### PR TITLE
#1645 Added nil check to settings when adding flags to build files

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -60,11 +60,16 @@ post_install do |installer|
         if build_files.length > 0
             build_files.each { |build_file|
                 settings = build_file.settings
-                compiler_flags = settings[compiler_flags_key]
-                compiler_flags = (compiler_flags.nil?) ?
-                    new_compiler_flags :
-                    (compiler_flags + " " + new_compiler_flags)
-                settings[compiler_flags_key] = compiler_flags
+                if settings.nil?
+                  # If we don't have settings for the file we create a new hash
+                  settings = Hash[compiler_flags_key, new_compiler_flags]
+                else
+                  compiler_flags = settings[compiler_flags_key]
+                  compiler_flags = (compiler_flags.nil?) ?
+                      new_compiler_flags :
+                      (compiler_flags + " " + new_compiler_flags)
+                  settings[compiler_flags_key] = compiler_flags
+                end
                 build_file.settings = settings
             }
         else


### PR DESCRIPTION
This fixes an issue when doing a `pod install` which causes a `undefined method '[]' for nil:NilClass` due to the post install hook not checking for nil on the settings object.
