### PR TITLE
fixed: resize dialogue still pops up when uploading images

### DIFF
--- a/WordPress/Classes/PostMediaViewController.h
+++ b/WordPress/Classes/PostMediaViewController.h
@@ -75,6 +75,7 @@ static inline double radians(double degrees) {
 @property (nonatomic, strong) WPAlertView *customSizeAlert;
 @property (nonatomic, strong) UIActionSheet *currentActionSheet;
 @property (nonatomic, strong) NSString *statsPrefix;
+@property BOOL shouldShowResizeActionSheet;
 
 - (id)initWithPost:(AbstractPost *)aPost;
 

--- a/WordPress/Classes/PostMediaViewController.m
+++ b/WordPress/Classes/PostMediaViewController.m
@@ -863,12 +863,18 @@
 		
         if (IS_IOS7) {
             if (IS_IPAD) {
-                [resizeActionSheet showFromBarButtonItem:[self.navigationItem.rightBarButtonItems objectAtIndex:1] animated:YES];
+                if (self.shouldShowResizeActionSheet) {
+                    [resizeActionSheet showFromBarButtonItem:[self.navigationItem.rightBarButtonItems objectAtIndex:1] animated:YES];
+                }
             } else {
-                [resizeActionSheet showInView:self.view];
+                if (self.shouldShowResizeActionSheet) {
+                    [resizeActionSheet showInView:self.view];
+                }
             }
         } else {
-            [resizeActionSheet showInView:postDetailViewController.view];
+            if (self.shouldShowResizeActionSheet) {
+                [resizeActionSheet showInView:postDetailViewController.view];
+            }
         }
 	}
 }
@@ -1089,11 +1095,11 @@
 		NSNumber *resizePreference = [NSNumber numberWithInt:-1];
 		if([[NSUserDefaults standardUserDefaults] objectForKey:@"media_resize_preference"] != nil)
 			resizePreference = [nf numberFromString:[[NSUserDefaults standardUserDefaults] objectForKey:@"media_resize_preference"]];
-		BOOL showResizeActionSheet = NO;
+        self.shouldShowResizeActionSheet = NO;
 		switch ([resizePreference intValue]) {
 			case 0:
             {
-                showResizeActionSheet = YES;
+                self.shouldShowResizeActionSheet = YES;
 				break;
             }
 			case 1:
@@ -1119,7 +1125,7 @@
             }
 			default:
             {
-                showResizeActionSheet = YES;
+                self.shouldShowResizeActionSheet = NO;
 				break;
             }
 		}
@@ -1131,7 +1137,7 @@
             [self showResizeActionSheet];
         } else {
             [postDetailViewController.navigationController dismissViewControllerAnimated:YES completion:^{
-                if (showResizeActionSheet) {
+                if (self.shouldShowResizeActionSheet) {
                     [self showResizeActionSheet];
                 }
             }];


### PR DESCRIPTION
Quick follow up on this issue: https://github.com/wordpress-mobile/WordPress-iOS/commit/7955c4a71eb2995e763cf0671a3d6db0eb0833a6

Koke's fix almost worked, all we needed was a property and an additional check before the resize sheet is shown. Works fine now on iPads running iOS 6 and iOS 7

PS:
This is my first ever pull request (or contribution)... I hope I've done this correctly - let me know if I haven't, or if you need more info.
