### PR TITLE
Adding session count to help track first time users.

### DIFF
--- a/WordPress/Classes/WPMobileStats.m
+++ b/WordPress/Classes/WPMobileStats.m
@@ -261,6 +261,7 @@ NSString *const StatsEventAddBlogsClickedAddSelected = @"Add Blogs - Clicked Add
     NSUInteger sessionCount = [[[NSUserDefaults standardUserDefaults] objectForKey:@"session_count"] intValue];
     sessionCount++;
     [[NSUserDefaults standardUserDefaults] setObject:@(sessionCount) forKey:@"session_count"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
 
     NSDictionary *properties = @{
                                  @"session_count": @(sessionCount),


### PR DESCRIPTION
Adding in session count so we can create funnels in Mixpanel that will let us isolate first time users.

FOR REVIEW
