### PR TITLE
Possible fix for #279.

### DIFF
--- a/WordPress/Classes/SettingsViewController.m
+++ b/WordPress/Classes/SettingsViewController.m
@@ -193,7 +193,7 @@ typedef enum {
         if (_isSigningOut) {
             return;
         } else {
-            _isSigningOut = true;
+            _isSigningOut = YES;
         }
         
         if (IS_IPAD) {


### PR DESCRIPTION
The issues creeping up in #279 were related to the fact that the
settings controller would display multiple
GeneralWalkthroughViewController classes. This code ensures that only
one GeneralWalkthroughViewController gets displayed.
