### PR TITLE
#338 - Fix for obscured password text field in NUX on iPad

### DIFF
--- a/WordPress/Classes/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/CreateAccountAndBlogViewController.m
@@ -131,13 +131,10 @@ CGFloat const CreateAccountAndBlogKeyboardOffset = 132.0;
     [self layoutPage2Controls];
     [self layoutPage3Controls];
     
-    if (!IS_IPAD) {
-        // We don't need to shift the controls up on the iPad as there's enough space.
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidShow) name:UIKeyboardDidShowNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidHide) name:UIKeyboardDidHideNotification object:nil];
-    }
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidShow) name:UIKeyboardDidShowNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidHide) name:UIKeyboardDidHideNotification object:nil];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -1114,10 +1111,18 @@ CGFloat const CreateAccountAndBlogKeyboardOffset = 132.0;
     NSDictionary *keyboardInfo = notification.userInfo;
     CGFloat animationDuration = [[keyboardInfo objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue];
     CGRect keyboardFrame = [[keyboardInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
+    keyboardFrame = [self.view convertRect:keyboardFrame fromView:nil];
+    
     if (_currentPage == 1) {
         _keyboardOffset = (CGRectGetMaxY(_page1NextButton.frame) - CGRectGetMinY(keyboardFrame)) + CGRectGetHeight(_page1NextButton.frame);
     } else {
         _keyboardOffset = (CGRectGetMaxY(_page2NextButton.frame) - CGRectGetMinY(keyboardFrame)) + CGRectGetHeight(_page2NextButton.frame);
+    }
+    
+    // make sure keyboard offset is greater than 0, otherwise do not move controls
+    if (_keyboardOffset < 0) {
+        _keyboardOffset = 0;
+        return;
     }
 
     [UIView animateWithDuration:animationDuration animations:^{


### PR DESCRIPTION
The NUX controls were set to not move in response to the keyboard when the app was running on an iPad. The NUX now always calculates whether there is room for the controls, and acts accordingly rather than assuming there is space on an iPad.

issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/338
