### PR TITLE
Issues/149

### DIFF
--- a/WordPress/Classes/ReaderMediaQueue.h
+++ b/WordPress/Classes/ReaderMediaQueue.h
@@ -1,0 +1,37 @@
+//
+//  ReaderMediaQueue.h
+//  WordPress
+//
+//  Created by aerych on 11/6/13.
+//  Copyright (c) 2013 WordPress. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "ReaderMediaView.h"
+
+@class ReaderMediaQueue;
+
+@protocol ReaderMediaQueueDelegate <NSObject>
+@optional
+- (void)readerMediaQueue:(ReaderMediaQueue *)mediaQueue didLoadMedia:(ReaderMediaView *)media;
+- (void)readerMediaQueue:(ReaderMediaQueue *)mediaQueue didLoadBatch:(NSArray *)batch;
+- (void)readerMediaQueueDidFinish:(ReaderMediaQueue *)mediaQueue;
+
+@end
+
+@interface ReaderMediaQueue : NSObject
+
+@property (nonatomic, weak) id<ReaderMediaQueueDelegate> delegate;
+@property (nonatomic) NSInteger batchSize;
+
+- (id)initWithDelegate:(id<ReaderMediaQueueDelegate>)delegate;
+
+- (void)enqueueMedia:(ReaderMediaView *)mediaView
+             withURL:(NSURL *)url
+    placeholderImage:(UIImage *)image
+                size:(CGSize)size
+           isPrivate:(BOOL)isPrivate
+             success:(void (^)(ReaderMediaView *))success
+             failure:(void (^)(ReaderMediaView *, NSError *))failure;
+
+@end

--- a/WordPress/Classes/ReaderMediaQueue.m
+++ b/WordPress/Classes/ReaderMediaQueue.m
@@ -1,0 +1,199 @@
+//
+//  ReaderMediaQueue.m
+//  WordPress
+//
+//  Created by aerych on 11/6/13.
+//  Copyright (c) 2013 WordPress. All rights reserved.
+//
+
+#import "ReaderMediaQueue.h"
+#import "WPTableImageSource.h"
+
+// Barebones storage class for items in the queues.
+typedef void (^ReaderMediaViewSuccessBlock)(ReaderMediaView *readerMediaView);
+typedef void (^ReaderMediaViewFailureBlock)(ReaderMediaView *readerMediaView, NSError *error);
+
+@interface ReaderMediaQueueItem : NSObject
+
+@property (nonatomic, strong) ReaderMediaView *mediaView;
+@property (nonatomic, strong) NSURL *url;
+@property (nonatomic) CGSize size;
+@property (nonatomic) BOOL isPrivate;
+@property (nonatomic, copy) ReaderMediaViewSuccessBlock success;
+@property (nonatomic, copy) ReaderMediaViewFailureBlock failure;
+@property (nonatomic, strong) UIImage *image;
+@property (nonatomic) BOOL failedToLoad;
+
+@end
+
+@implementation ReaderMediaQueueItem
+
+- (id)initWithMediaView:(ReaderMediaView *)mediaView
+                    url:(NSURL *)url
+                   size:(CGSize)size
+              isPrivate:(BOOL)isPrivate
+                success:(void (^)(ReaderMediaView *readerMediaView))success
+                failure:(void (^)(ReaderMediaView *readerMediaView, NSError *error))failure {
+    self = [super init];
+    if (self) {
+        _mediaView = mediaView;
+        _url = url;
+        _isPrivate = isPrivate;
+        _size = size;
+        _success = success;
+        _failure = failure;
+    }
+    return self;
+}
+
+@end
+
+
+@interface ReaderMediaQueue()<WPTableImageSourceDelegate>
+
+@property (nonatomic) NSInteger counter;
+@property (nonatomic, strong) NSMutableArray *holdingQueue;
+@property (nonatomic, strong) NSMutableArray *activeQueue;
+@property (nonatomic, strong) WPTableImageSource *imageSource;
+
+@end
+
+@implementation ReaderMediaQueue
+
+- (id)init {
+    self = [super init];
+    if (self) {
+        _activeQueue = [NSMutableArray array];
+        _holdingQueue = [NSMutableArray array];
+        _batchSize = 10;
+        _counter = 0;
+        _imageSource = [[WPTableImageSource alloc] init];
+        _imageSource.delegate = self;
+    }
+    return self;
+}
+
+
+- (id)initWithDelegate:(id<ReaderMediaQueueDelegate>)delegate {
+    self = [self init];
+    if (self) {
+        _delegate = delegate;
+    }
+    return self;
+}
+
+
+- (void)setBatchSize:(NSInteger)batchSize {
+    _batchSize = MAX(MIN(batchSize, 20), 1);
+}
+
+
+- (void)enqueueMedia:(ReaderMediaView *)mediaView
+             withURL:(NSURL *)url
+    placeholderImage:(UIImage *)image
+                size:(CGSize)size
+           isPrivate:(BOOL)isPrivate
+             success:(void (^)(ReaderMediaView *))success
+             failure:(void (^)(ReaderMediaView *, NSError *))failure {
+
+    mediaView.contentURL = url;
+    if (image) {
+        [mediaView setPlaceholder:image];
+    }
+
+    ReaderMediaQueueItem *item = [[ReaderMediaQueueItem alloc] initWithMediaView:mediaView
+                                                                             url:url
+                                                                            size:size
+                                                                       isPrivate:isPrivate
+                                                                         success:success
+                                                                         failure:failure];
+    
+    if ([self.activeQueue count] < self.batchSize) {
+        [self addToActiveQueue:item];
+    } else {
+        [self addToHoldingQueue:item];
+    }
+}
+
+
+- (void)addToActiveQueue:(ReaderMediaQueueItem *)item {
+    [self.activeQueue addObject:item];
+    
+    NSIndexPath *indexPath = [NSIndexPath indexPathForRow:[self.activeQueue count]-1 inSection:0];
+    [self.imageSource fetchImageForURL:item.url withSize:item.size indexPath:indexPath isPrivate:item.isPrivate];
+}
+
+
+- (void)addToHoldingQueue:(ReaderMediaQueueItem *)item {
+    [self.holdingQueue addObject:item];
+}
+
+
+#pragma mark - WPTableImageSourceDelegate Methods
+
+- (void)tableImageSource:(WPTableImageSource *)tableImageSource imageFailedForIndexPath:(NSIndexPath *)indexPath {
+    self.counter++;
+    ReaderMediaQueueItem *item = [self.activeQueue objectAtIndex:indexPath.row];
+    item.failedToLoad = YES;
+}
+
+- (void)tableImageSource:(WPTableImageSource *)tableImageSource
+              imageReady:(UIImage *)image
+            forIndexPath:(NSIndexPath *)indexPath {
+    self.counter++;
+    
+    ReaderMediaQueueItem *item = [self.activeQueue objectAtIndex:indexPath.row];
+    item.image = image;
+    
+    if ([self.delegate respondsToSelector:@selector(readerMediaQueue:didLoadMedia::)]) {
+        [self.delegate readerMediaQueue:self didLoadMedia:item.mediaView];
+    }
+    
+    // Did we load everything in the active queue?
+    if (self.counter < [self.activeQueue count]) {
+        return;
+    }
+    
+    // Batch loaded
+    NSMutableArray *mediaArray = [NSMutableArray array];
+    for (NSInteger i = 0; i < [self.activeQueue count]; i++) {
+        ReaderMediaQueueItem *item = [self.activeQueue objectAtIndex:i];
+        if (item.failedToLoad) {
+            if (item.failure) {
+                item.failure(item.mediaView, nil); //TODO: return the actual error as well?
+            }
+        } else if (item.success) {
+            [item.mediaView setImage:item.image];
+            item.success(item.mediaView);
+        }
+        // clear blocks because paranoid
+        item.success = nil;
+        item.failure = nil;
+
+        [mediaArray addObject:item.mediaView];
+    }
+
+    if ([self.delegate respondsToSelector:@selector(readerMediaQueue:didLoadBatch:)]) {
+        [self.delegate readerMediaQueue:self didLoadBatch:mediaArray];
+    }
+    
+    // Reset for the next batch.
+    self.counter = 0;
+    [self.activeQueue removeAllObjects];
+    
+    // Are there more to load?
+    if ([self.holdingQueue count] == 0) {
+        if ([self.delegate respondsToSelector:@selector(readerMediaQueueDidFinish:)]) {
+            [self.delegate readerMediaQueueDidFinish:self];
+        }
+        return;
+    }
+    
+    NSInteger num = MIN(self.batchSize, [self.holdingQueue count]);
+    for (NSInteger i = 0; i < num; i++) {
+        [self addToActiveQueue:[self.holdingQueue objectAtIndex:0]];
+        [self.holdingQueue removeObjectAtIndex:0];
+    }
+}
+
+@end

--- a/WordPress/Classes/ReaderMediaView.h
+++ b/WordPress/Classes/ReaderMediaView.h
@@ -19,7 +19,7 @@
 - (UIImage *)image;
 - (void)setImage:(UIImage *)image;
 - (NSURL *)contentURL;
-
+- (void)setPlaceholder:(UIImage *)image;
 - (void)setImageWithURL:(NSURL *)url
 	   placeholderImage:(UIImage *)image
 				success:(void (^)(ReaderMediaView *readerMediaView))success

--- a/WordPress/Classes/ReaderMediaView.m
+++ b/WordPress/Classes/ReaderMediaView.m
@@ -71,13 +71,19 @@
 }
 
 
+- (void)setPlaceholder:(UIImage *)image {
+	_imageView.image = image;
+	self.isShowingPlaceholder = YES;
+    self.placeholderRatio = self.frame.size.width / self.frame.size.height;
+}
+
+
 - (void)setImageWithURL:(NSURL *)url
 	   placeholderImage:(UIImage *)image
 				success:(void (^)(ReaderMediaView *))success
 				failure:(void (^)(ReaderMediaView *, NSError *))failure {
 	if (image) {
-		self.isShowingPlaceholder = YES;
-        self.placeholderRatio = self.frame.size.width / self.frame.size.height;
+        [self setPlaceholder:image];
 	}
 	// Weak refs to avoid retain loop.
 	__weak ReaderMediaView *selfRef = self;
@@ -93,7 +99,6 @@
 								failure(selfRef, error);
 							}
 						}];
-	
 }
 
 

--- a/WordPress/Classes/WPTableImageSource.h
+++ b/WordPress/Classes/WPTableImageSource.h
@@ -63,6 +63,7 @@
  Downloads an image at the specified URL
 
  If `size` is smaller than the `maxSize` property, the larger one will be downloaded and resized
+ If `size.height` is zero its assumed the image width is known and height should be calculated after the image is downloaded.
 
  @param url the URL for the image.
  @param size what size you are planning to display the image.
@@ -70,6 +71,7 @@
  @param isPrivate if the image is hosted on a private blog. photon will be skipped for private blogs. 
 */
 - (void)fetchImageForURL:(NSURL *)url withSize:(CGSize)size indexPath:(NSIndexPath *)indexPath isPrivate:(BOOL)isPrivate;
+
 
 /**
  Invalidates stored index paths.
@@ -93,5 +95,16 @@
  @param indexPath the indexPath passed in fetchImageForURL:withSize:indexPath:.
 */
 - (void)tableImageSource:(WPTableImageSource *)tableImageSource imageReady:(UIImage *)image forIndexPath:(NSIndexPath *)indexPath;
+
+@optional
+
+/**
+ Sent if the requested image download fails
+ 
+ @param tableImageSource the image source sending the message.
+ @param indexPath the indexPath passed in fetchImageForURL:withSize:indexPath:.
+ @param error the error, if any.
+ */
+- (void)tableImageSource:(WPTableImageSource *)tableImageSource imageFailedforIndexPath:(NSIndexPath *)indexPath error:(NSError *)error;
 
 @end

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		4526DC561148072F0090C99D /* Default-Landscape.png in Resources */ = {isa = PBXBuildFile; fileRef = 4526DC541148072F0090C99D /* Default-Landscape.png */; };
 		45C73C25113C36F70024D0D2 /* MainWindow-iPad.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45C73C24113C36F70024D0D2 /* MainWindow-iPad.xib */; };
 		45F45B3611614BA50022D394 /* CPopoverManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 45F45B3511614BA50022D394 /* CPopoverManager.m */; };
+		5D0077A7182AE9DF00F865DB /* ReaderMediaQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D0077A6182AE9DF00F865DB /* ReaderMediaQueue.m */; };
 		5D119DA3176FBE040073D83A /* UIImageView+AFNetworkingExtra.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D119DA2176FBE040073D83A /* UIImageView+AFNetworkingExtra.m */; };
 		5D1392A7157D4D92007D51B8 /* StatsWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D1392A6157D4D92007D51B8 /* StatsWebViewController.m */; };
 		5D15F4AF15B8C407001B14EA /* toolbarItalicHighlighted.png in Resources */ = {isa = PBXBuildFile; fileRef = 5D15F49715B8C407001B14EA /* toolbarItalicHighlighted.png */; };
@@ -1335,6 +1336,8 @@
 		45C73C24113C36F70024D0D2 /* MainWindow-iPad.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = "MainWindow-iPad.xib"; path = "Resources-iPad/MainWindow-iPad.xib"; sourceTree = "<group>"; };
 		45F45B3411614BA50022D394 /* CPopoverManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPopoverManager.h; sourceTree = "<group>"; };
 		45F45B3511614BA50022D394 /* CPopoverManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CPopoverManager.m; sourceTree = "<group>"; };
+		5D0077A5182AE9DF00F865DB /* ReaderMediaQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReaderMediaQueue.h; sourceTree = "<group>"; };
+		5D0077A6182AE9DF00F865DB /* ReaderMediaQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReaderMediaQueue.m; sourceTree = "<group>"; };
 		5D119DA1176FBE040073D83A /* UIImageView+AFNetworkingExtra.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+AFNetworkingExtra.h"; sourceTree = "<group>"; };
 		5D119DA2176FBE040073D83A /* UIImageView+AFNetworkingExtra.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+AFNetworkingExtra.m"; sourceTree = "<group>"; };
 		5D1392A5157D4D92007D51B8 /* StatsWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsWebViewController.h; sourceTree = "<group>"; };
@@ -3894,6 +3897,8 @@
 				5D8572B917611B36004CC20D /* ReaderUsersBlogsViewController.m */,
 				E1D062D2177C685700644185 /* ReaderButton.h */,
 				E1D062D3177C685700644185 /* ReaderButton.m */,
+				5D0077A5182AE9DF00F865DB /* ReaderMediaQueue.h */,
+				5D0077A6182AE9DF00F865DB /* ReaderMediaQueue.m */,
 			);
 			name = Reader;
 			sourceTree = "<group>";
@@ -5310,6 +5315,7 @@
 				5D42A3F7175E75EE005CFF05 /* ReaderCommentTableViewCell.m in Sources */,
 				5D42A3F8175E75EE005CFF05 /* ReaderImageView.m in Sources */,
 				E1D062D4177C685C00644185 /* ReaderButton.m in Sources */,
+				5D0077A7182AE9DF00F865DB /* ReaderMediaQueue.m in Sources */,
 				5D42A3F9175E75EE005CFF05 /* ReaderMediaView.m in Sources */,
 				5D42A3FA175E75EE005CFF05 /* ReaderPostDetailView.m in Sources */,
 				5D42A3FB175E75EE005CFF05 /* ReaderPostDetailViewController.m in Sources */,


### PR DESCRIPTION
Previously, every time an image would load in the reader detail, the text would be redrawn.  This is an expensive operation to improve performance I'm changing two things:

First: if the image's frame doesn't change after being loaded skip redrawing text because there is no need. 
Second: Queue up images to load in batches and only redraw the text after a batch of images has been loaded. 

Currently batches are loaded in 10s. 

So, with this change, a post that has 15 images will only redraw text 4 times instead of 17:
once on `viewWillAppear`
once for the timer workaround,
and twice for the two batches. 

The downside is that placeholders are visible longer than they otherwise would be. Maybe it makes sense to do away with the placeholders all together. 

Video items are not loaded via the queue because we fetch those thumbs after a call to the service API.  Large numbers of videos in a post is something that proabably happens rarely so I think its fine to leave them out for now. 
