### PR TITLE
Fixes #165. Don't apply iOS7 font style to iOS6 publish/update button.

### DIFF
--- a/WordPress/Classes/EditPostViewController.m
+++ b/WordPress/Classes/EditPostViewController.m
@@ -588,11 +588,14 @@ CGFloat const EditPostViewControllerTextViewOffset = 10.0;
     [self.navigationItem.rightBarButtonItem setEnabled:updateEnabled];
 
     // Seems to be a bug with UIBarButtonItem respecting the UIControlStateDisabled text color
-    if (updateEnabled) {
-        [self.navigationItem.rightBarButtonItem setTitleTextAttributes:@{UITextAttributeFont: [WPStyleGuide regularTextFont], UITextAttributeTextColor : [UIColor whiteColor]} forState:UIControlStateNormal];
+    NSDictionary *titleTextAttributes;
+    UIColor *color = updateEnabled ? [UIColor whiteColor] : [UIColor lightGrayColor];
+    if (IS_IOS7) {
+        titleTextAttributes = @{UITextAttributeFont: [WPStyleGuide regularTextFont], UITextAttributeTextColor : color};
     } else {
-        [self.navigationItem.rightBarButtonItem setTitleTextAttributes:@{UITextAttributeFont: [WPStyleGuide regularTextFont], UITextAttributeTextColor : [UIColor lightGrayColor]}  forState:UIControlStateNormal];
+        titleTextAttributes = @{UITextAttributeTextColor : color};
     }
+    [self.navigationItem.rightBarButtonItem setTitleTextAttributes:titleTextAttributes forState:UIControlStateNormal];
 }
 
 - (void)refreshUIForCurrentPost {


### PR DESCRIPTION
Before: 

![screen shot 2013-11-08 at 1 27 15 pm](https://f.cloud.github.com/assets/1435271/1503496/d3d7f530-48ab-11e3-893f-fd1a037de5a4.png)

After: 

![screen shot 2013-11-08 at 1 12 37 pm](https://f.cloud.github.com/assets/1435271/1503468/8245f4e2-48ab-11e3-94a1-c2440d8e4a7a.png)
