### PR TITLE
Fixing comment moderation from notifications in iOS7

### DIFF
--- a/WordPress/Classes/NotificationsCommentDetailViewController.m
+++ b/WordPress/Classes/NotificationsCommentDetailViewController.m
@@ -212,26 +212,32 @@ NS_ENUM(NSUInteger, NotifcationCommentCellType){
             [indexedButtons setObject:self.approveBarButton forKey:actionType];
             self.approveBarButton.enabled = YES;
             self.approveBarButton.customView.tag = APPROVE_BUTTON_TAG;
+            self.approveBarButton.tag = APPROVE_BUTTON_TAG;
         } else if ([actionType isEqualToString:@"unapprove-comment"]){
             [indexedButtons setObject:self.unapproveBarButton forKey:actionType];
             self.unapproveBarButton.enabled = YES;
             self.unapproveBarButton.customView.tag = UNAPPROVE_BUTTON_TAG;
+            self.unapproveBarButton.tag = UNAPPROVE_BUTTON_TAG;
         } else if ([actionType isEqualToString:@"spam-comment"]){
             [indexedButtons setObject:self.spamBarButton forKey:actionType];
             self.spamBarButton.enabled = YES;
             self.spamBarButton.customView.tag = SPAM_BUTTON_TAG;
+            self.spamBarButton.tag = SPAM_BUTTON_TAG;
         } else if ([actionType isEqualToString:@"unspam-comment"]){
             [indexedButtons setObject:self.spamBarButton forKey:actionType];
             self.spamBarButton.enabled = YES;
             self.spamBarButton.customView.tag = UNSPAM_BUTTON_TAG;
+            self.spamBarButton.tag = UNSPAM_BUTTON_TAG;
         } else if ([actionType isEqualToString:@"trash-comment"]){
             [indexedButtons setObject:self.trashBarButton forKey:actionType];
             self.trashBarButton.enabled = YES;
             self.trashBarButton.customView.tag = TRASH_BUTTON_TAG;
+            self.trashBarButton.tag = TRASH_BUTTON_TAG;
         } else if ([actionType isEqualToString:@"untrash-comment"]){
             [indexedButtons setObject:self.trashBarButton forKey:actionType];
             self.trashBarButton.enabled = YES;
             self.trashBarButton.customView.tag = UNTRASH_BUTTON_TAG;
+            self.trashBarButton.tag = UNTRASH_BUTTON_TAG;
         } else if ([actionType isEqualToString:@"replyto-comment"]){
             [indexedButtons setObject:self.replyBarButton forKey:actionType];
             self.replyBarButton.enabled = YES;


### PR DESCRIPTION
See #357 for more details, but in iOS7 moderating comments was broken through the notifications. This fix isn’t ideal as it feels a little hacky, so lets revisit it after 3.8.4 is out.
