### PR TITLE
Don't use kSecAttrAccessible to search keychain

### DIFF
--- a/WordPress/Classes/SFHFKeychainUtils.m
+++ b/WordPress/Classes/SFHFKeychainUtils.m
@@ -209,8 +209,8 @@ static NSString *SFHFKeychainUtilsErrorDomain = @"SFHFKeychainUtilsErrorDomain";
 
 	// Set up a query dictionary with the base query attributes: item type (generic), username, and service
 
-	NSArray *keys = [[[NSArray alloc] initWithObjects: (NSString *) kSecClass, kSecAttrAccount, kSecAttrService, kSecAttrAccessible, nil] autorelease];
-	NSArray *objects = [[[NSArray alloc] initWithObjects: (NSString *) kSecClassGenericPassword, username, serviceName, kSecAttrAccessibleAfterFirstUnlock, nil] autorelease];
+	NSArray *keys = [[[NSArray alloc] initWithObjects: (NSString *) kSecClass, kSecAttrAccount, kSecAttrService, nil] autorelease];
+	NSArray *objects = [[[NSArray alloc] initWithObjects: (NSString *) kSecClassGenericPassword, username, serviceName, nil] autorelease];
 
 	NSMutableDictionary *query = [[[NSMutableDictionary alloc] initWithObjects: objects forKeys: keys] autorelease];
 


### PR DESCRIPTION
On 3.8.3 we were storing passwords with
`kSecAttrAccessibleAfterWhenUnlocked`. Even if the keychain migration
fix should turn these into `kSecAttrAccessibleAfterFirstUnlock`, it runs
async so the first launch after an upgrade it would appear that the
credentials were invalid.

fixes #306 
