### PR TITLE
Restore correct state to featured image when returning to post settings.

### DIFF
--- a/WordPress/Classes/PostSettingsViewController.m
+++ b/WordPress/Classes/PostSettingsViewController.m
@@ -149,7 +149,17 @@
     id supportsFeaturedImages = [self.post.blog getOptionValue:@"post_thumbnail"];
     if (supportsFeaturedImages != nil) {
         blogSupportsFeaturedImage = [supportsFeaturedImages boolValue];
-        if (blogSupportsFeaturedImage && self.post.post_thumbnail != nil) {
+        
+        if (blogSupportsFeaturedImage && [self.post.media count] > 0) {
+            for (Media *media in self.post.media) {
+                NSInteger status = [media.remoteStatusNumber integerValue];
+                if ([media.mediaType isEqualToString:@"featured"] && (status == MediaRemoteStatusPushing || status == MediaRemoteStatusProcessing)){
+                    [self showFeaturedImageUploader:nil];
+                }
+            }
+        }
+        
+        if (!isUploadingFeaturedImage && (blogSupportsFeaturedImage && self.post.post_thumbnail != nil)) {
             // Download the current featured image
             [featuredImageView setHidden:YES];
             [featuredImageLabel setText:NSLocalizedString(@"Loading Featured Image", @"Loading featured image in post settings")];


### PR DESCRIPTION
Fixes #217 

I think part of the problem described in the issue is that there was nothing to indicate you're previously chosen featured image was still loading when returning to the settings view. A better fix would be to git rid of the modal alert and to handle all the uploading/syncing in the background but I think this works for a short term fix. 
