### PR TITLE
Fix reader toolbar visibility

### DIFF
--- a/WordPress/Classes/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ReaderPostDetailViewController.m
@@ -166,9 +166,8 @@ NSTimeInterval const ReaderPostDetailViewControllerRefreshTimeout = 300; // 5 mi
         [toolbar setBackgroundImage:nil forToolbarPosition:UIToolbarPositionBottom barMetrics:UIBarMetricsDefault];
         [toolbar setTintColor:[UIColor colorWithHexString:@"F1F1F1"]];
     }
-	
-	if (IS_IPAD)
-        [self.panelNavigationController setToolbarHidden:NO forViewController:self animated:NO];
+
+	[self.navigationController setToolbarHidden:NO animated:animated];
 
     [self.post addObserver:self forKeyPath:@"isReblogged" options:NSKeyValueObservingOptionNew context:@"reblogging"];
 
@@ -203,7 +202,7 @@ NSTimeInterval const ReaderPostDetailViewControllerRefreshTimeout = 300; // 5 mi
     self.panelNavigationController.delegate = nil;
     self.navigationController.navigationBar.translucent = NO;
     self.navigationController.toolbar.translucent = NO;
-	[self.navigationController setToolbarHidden:YES animated:YES];
+	[self.navigationController setToolbarHidden:YES animated:animated];
 }
 
 


### PR DESCRIPTION
After visiting a link, the toolbar would be gone. Using the default
`setToolbarHidden` method instead of the panel one works

fixes #311

![reader-toolbar](https://f.cloud.github.com/assets/8739/1540625/1faf8914-4d25-11e3-8ee5-fce06ad80aaa.gif)
