### PR TITLE
Refresh textView after insert to fix visual glitch on iOS 7

### DIFF
--- a/WordPress/Classes/EditPostViewController.m
+++ b/WordPress/Classes/EditPostViewController.m
@@ -1587,7 +1587,7 @@ CGFloat const EditPostViewControllerTextViewOffset = 10.0;
     }
     dispatch_async(dispatch_get_main_queue(), ^{
         textView.scrollEnabled = NO;
-        [textView setTextAlignment:textView.textAlignment];
+        [textView setNeedsDisplay];
         textView.scrollEnabled = YES;
     });
 }


### PR DESCRIPTION
Fixes #280 

I took a stab at finding a fix for the visual glitch we're seeing with blockquotes. Best guess at a cause is the UITextView isn't updating its `contentSize` after an insert while `scrollEnabled = NO`. Scrolling has to be disabled while inserting else the scrollOffset can change. Since a UITextView manages its contentSize itself it didn't seem like a good idea to set it manually, so I looked at other options.

This patch functions as a work around by getting the UITextView to update without affecting scrollOffset.  It would be great to fix the underlying problem, but I'm out of ideas and this could work in the meantime. 
