### PR TITLE
If there's only one blog show it in My Blogs

### DIFF
--- a/WordPress/Classes/BlogListViewController.m
+++ b/WordPress/Classes/BlogListViewController.m
@@ -75,6 +75,15 @@ CGFloat const blavatarImageSize = 50.f;
     self.resultsController.delegate = self;
     [self.resultsController performFetch:nil];
     [self.tableView reloadData];
+
+    if ([[self.resultsController fetchedObjects] count] == 1) {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            NSIndexPath *firstIndexPath = [NSIndexPath indexPathForRow:0 inSection:0];
+            [self.tableView selectRowAtIndexPath:firstIndexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+            [self tableView:self.tableView didSelectRowAtIndexPath:firstIndexPath];
+        });
+    }
 }
 
 - (void)viewWillDisappear:(BOOL)animated {


### PR DESCRIPTION
Instead of showing the lists of blogs by default with just one blog and
the "Add site" option, push that blog controller by default.

You can still go back and when you tap "My Blogs" again it'll pop

Related to #333 / #388. @mikejohnstn 

![my-blogs](https://f.cloud.github.com/assets/8739/1556454/bcbefec0-4ed2-11e3-8981-4954c8fcc82d.gif)
