### PR TITLE
#158 - Fixed layout of AboutViewController

### DIFF
--- a/WordPress/Classes/AboutViewController.m
+++ b/WordPress/Classes/AboutViewController.m
@@ -12,8 +12,7 @@
 
 @interface AboutViewController()
 
-@property (nonatomic, strong) IBOutlet UIView *logoView;
-@property (nonatomic, strong) IBOutlet UIView *buttonsView;
+@property (strong, nonatomic) IBOutlet UIScrollView *scrollView;
 @property (nonatomic, strong) IBOutlet UILabel *titleLabel;
 @property (nonatomic, strong) IBOutlet UILabel *versionLabel;
 @property (nonatomic, strong) IBOutlet UILabel *publisherLabel;
@@ -24,9 +23,6 @@
 @end
 
 @implementation AboutViewController
-
-@synthesize buttonsView;
-@synthesize logoView;
 
 CGFloat const AboutViewLandscapeButtonsY = -20.0f;
 CGFloat const AboutViewPortraitButtonsY = 90.0f;
@@ -74,6 +70,8 @@ CGFloat const AboutViewPortraitButtonsY = 90.0f;
     [self.privacyPolicyButton setTitle:NSLocalizedString(@"Privacy Policy", nil) forState:UIControlStateNormal];
     self.privacyPolicyButton.titleLabel.font = [WPStyleGuide postTitleFont];
     
+    self.scrollView.contentSize = CGSizeMake(CGRectGetWidth(self.scrollView.frame), CGRectGetMaxY(self.viewWebsiteButton.frame));
+    
     if([self.navigationController.viewControllers count] == 1) {
         self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Close", @"") style:[WPStyleGuide barButtonStyleForBordered] target:self action:@selector(dismiss)];
     }
@@ -83,21 +81,6 @@ CGFloat const AboutViewPortraitButtonsY = 90.0f;
 {
     return [super shouldAutorotateToInterfaceOrientation:interfaceOrientation];
 }
-
-- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
-    if (IS_IPHONE) {
-        CGRect frame = buttonsView.frame;
-        if (UIInterfaceOrientationIsLandscape(toInterfaceOrientation)) {
-            self.logoView.hidden = YES;
-            frame.origin.y = AboutViewLandscapeButtonsY;
-        } else {
-            self.logoView.hidden = NO;
-            frame.origin.y = AboutViewPortraitButtonsY;
-        }
-        self.buttonsView.frame = frame;
-    }
-}
-
 
 #pragma mark - Custom methods
 

--- a/WordPress/Resources/AboutViewController.xib
+++ b/WordPress/Resources/AboutViewController.xib
@@ -2,34 +2,60 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
         <deployment defaultVersion="1536" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3746"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AboutViewController">
             <connections>
-                <outlet property="buttonsView" destination="46" id="51"/>
-                <outlet property="logoView" destination="47" id="52"/>
                 <outlet property="privacyPolicyButton" destination="21" id="zIe-IN-36Z"/>
                 <outlet property="publisherLabel" destination="36" id="tOV-vQ-RbK"/>
+                <outlet property="scrollView" destination="dxy-8e-g3D" id="5lb-0C-Jxf"/>
                 <outlet property="titleLabel" destination="33" id="0Y9-bB-C8A"/>
                 <outlet property="tosButton" destination="20" id="kmw-cy-Hkd"/>
                 <outlet property="versionLabel" destination="53" id="54"/>
-                <outlet property="view" destination="1" id="3"/>
+                <outlet property="view" destination="T6I-j2-k2C" id="UXU-So-Ac5"/>
                 <outlet property="viewWebsiteButton" destination="41" id="4aS-dM-vMm"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="1">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+        <view contentMode="scaleToFill" id="T6I-j2-k2C">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" id="46">
-                    <rect key="frame" x="0.0" y="90" width="320" height="376"/>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" id="dxy-8e-g3D">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="tailTruncation" id="41">
-                            <rect key="frame" x="22" y="245" width="276" height="47"/>
+                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="WordPress for iOS" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" minimumFontSize="10" adjustsFontSizeToFit="NO" id="33">
+                            <rect key="frame" x="20" y="20" width="278" height="51"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
+                            <fontDescription key="fontDescription" name="Georgia" family="Georgia" pointSize="24"/>
+                            <color key="textColor" red="0.1294117719" green="0.1294117719" blue="0.1294117719" alpha="1" colorSpace="deviceRGB"/>
+                            <color key="highlightedColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="shadowColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <size key="shadowOffset" width="0.0" height="1"/>
+                        </label>
+                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="53">
+                            <rect key="frame" x="20" y="79" width="278" height="21"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <fontDescription key="fontDescription" name="Georgia" family="Georgia" pointSize="15"/>
+                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" minimumFontSize="10" adjustsFontSizeToFit="NO" id="36">
+                            <rect key="frame" x="20" y="108" width="280" height="115"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES"/>
+                            <string key="text">Publisher: Automattic
+Copyright: Automattic</string>
+                            <fontDescription key="fontDescription" name="Georgia" family="Georgia" pointSize="16"/>
+                            <color key="textColor" red="0.1294117719" green="0.1294117719" blue="0.1294117719" alpha="1" colorSpace="deviceRGB"/>
+                            <color key="highlightedColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="shadowColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <size key="shadowOffset" width="0.0" height="1"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="tailTruncation" id="41">
+                            <rect key="frame" x="23" y="345" width="276" height="47"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Georgia" family="Georgia" pointSize="14"/>
                             <state key="normal" title="www.automattic.com">
                                 <color key="titleColor" red="0.25490197539999998" green="0.25490197539999998" blue="0.25490197539999998" alpha="1" colorSpace="deviceRGB"/>
@@ -43,8 +69,8 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="tailTruncation" id="21">
-                            <rect key="frame" x="19" y="174" width="282" height="44"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES"/>
+                            <rect key="frame" x="19" y="293" width="282" height="44"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="Privacy Policy" backgroundImage="welcome_button_bg_full.png">
                                 <color key="titleColor" red="0.1294117719" green="0.1294117719" blue="0.1294117719" alpha="1" colorSpace="deviceRGB"/>
@@ -59,8 +85,8 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="tailTruncation" id="20">
-                            <rect key="frame" x="19" y="113" width="282" height="44"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES"/>
+                            <rect key="frame" x="19" y="241" width="282" height="44"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <fontDescription key="fontDescription" name="Helvetica-Bold" family="Helvetica" pointSize="15"/>
                             <state key="normal" title="Terms of Service" backgroundImage="welcome_button_bg_full.png">
                                 <color key="titleColor" red="0.1294117719" green="0.1294117719" blue="0.1294117719" alpha="1" colorSpace="deviceRGB"/>
@@ -74,45 +100,11 @@
                                 <action selector="viewTermsOfService:" destination="-1" eventType="touchUpInside" id="43"/>
                             </connections>
                         </button>
-                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" minimumFontSize="10" adjustsFontSizeToFit="NO" id="36">
-                            <rect key="frame" x="20" y="0.0" width="280" height="115"/>
-                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES"/>
-                            <string key="text">Publisher: Automattic
-Copyright: Automattic</string>
-                            <fontDescription key="fontDescription" name="Georgia" family="Georgia" pointSize="16"/>
-                            <color key="textColor" red="0.1294117719" green="0.1294117719" blue="0.1294117719" alpha="1" colorSpace="deviceRGB"/>
-                            <color key="highlightedColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                            <color key="shadowColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                            <size key="shadowOffset" width="0.0" height="1"/>
-                        </label>
                     </subviews>
-                </view>
-                <view contentMode="scaleToFill" id="47">
-                    <rect key="frame" x="0.0" y="25" width="318" height="91"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    <subviews>
-                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="WordPress for iOS" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" minimumFontSize="10" adjustsFontSizeToFit="NO" id="33">
-                            <rect key="frame" x="20" y="20" width="278" height="51"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES"/>
-                            <fontDescription key="fontDescription" name="Georgia" family="Georgia" pointSize="24"/>
-                            <color key="textColor" red="0.1294117719" green="0.1294117719" blue="0.1294117719" alpha="1" colorSpace="deviceRGB"/>
-                            <color key="highlightedColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                            <color key="shadowColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                            <size key="shadowOffset" width="0.0" height="1"/>
-                        </label>
-                        <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="53">
-                            <rect key="frame" x="20" y="70" width="278" height="21"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                            <fontDescription key="fontDescription" name="Georgia" family="Georgia" pointSize="15"/>
-                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                </view>
+                </scrollView>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
-            <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
Issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/158

Moved contents to a scrollview:

![ios simulator screen shot nov 18 2013 9 19 41 am](https://f.cloud.github.com/assets/3904502/1564884/b6646b1a-5075-11e3-8e3d-75a6187f6c1d.png)
![ios simulator screen shot nov 18 2013 9 19 43 am](https://f.cloud.github.com/assets/3904502/1564885/b6d39f1c-5075-11e3-8c45-47973c8673cf.png)
