### PR TITLE
#457 - Unregister from push notifications before removing WP.com credentials

### DIFF
--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -221,10 +221,11 @@ NSString *const WordPressComApiErrorMessageKey = @"WordPressComApiErrorMessageKe
     WPFLogMethod();
     NSError *error = nil;
 
+    [[WordPressAppDelegate sharedWordPressApplicationDelegate] unregisterApnsToken];
+
     [SFHFKeychainUtils deleteItemForUsername:self.username andServiceName:@"WordPress.com" error:&error];
     [SFHFKeychainUtils deleteItemForUsername:self.username andServiceName:kWPcomXMLRPCUrl error:&error];
     
-    [[WordPressAppDelegate sharedWordPressApplicationDelegate] unregisterApnsToken];
     [WordPressAppDelegate sharedWordPressApplicationDelegate].isWPcomAuthenticated = NO;
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kApnsDeviceTokenPrefKey]; //Remove the token from Preferences, otherwise the token is never sent to the server on the next login
     [SFHFKeychainUtils deleteItemForUsername:self.username andServiceName:WordPressComApiOauthServiceName error:&error];


### PR DESCRIPTION
Unregister call to WP.com requires username and password to unregister a push token.  The app used to send NSArray arrayWithObjects and the null password would terminate the array, not causing a crash.  The unregister command would never work, however, and fail silently.  The recent change to how the array is created brought this to light - now unregistering for push notifications before the actual acccount is deleted from the app.
