### PR TITLE
Use GCD to reload reader comments

### DIFF
--- a/WordPress/Classes/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ReaderPostDetailViewController.m
@@ -401,7 +401,10 @@ NSTimeInterval const ReaderPostDetailViewControllerRefreshTimeout = 300; // 5 mi
 		for (ReaderComment *comment in _comments) {
 			comment.attributedContent = [ReaderCommentTableViewCell convertHTMLToAttributedString:comment.content withOptions:nil];
 		}
-	   [self.tableView performSelectorOnMainThread:@selector(reloadData) withObject:nil waitUntilDone:NO];
+        __weak ReaderPostDetailViewController *weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.tableView reloadData];
+        });
 	});
 }
 


### PR DESCRIPTION
Using performSelector was causing a crash since the controller was being
released but the table was not.

Fixes #661
