### PR TITLE
Fix invalid credentails warning when creating a wpcom site via Settings.

### DIFF
--- a/WordPress/Classes/CreateWPComAccountViewController.m
+++ b/WordPress/Classes/CreateWPComAccountViewController.m
@@ -15,6 +15,7 @@
 #import "SelectWPComLanguageViewController.h"
 #import "WPAsyncBlockOperation.h"
 #import "WPTableViewSectionFooterView.h"
+#import "WPAccount.h"
 
 @interface CreateWPComAccountViewController () <
     UITextFieldDelegate> {
@@ -440,6 +441,8 @@ CGSize const CreateAccountHeaderSize = { 320.0, 70.0 };
         void (^createBlogSuccess)(id) = ^(id responseObject){
             [operation didSucceed];
             if (self.delegate != nil) {
+                WPAccount *account = [WPAccount createOrUpdateWordPressComAccountWithUsername:_usernameTextField.text andPassword:_passwordTextField.text];
+                [WPAccount setDefaultWordPressComAccount:account];
                 [self.delegate createdAndSignedInAccountWithUserName:_usernameTextField.text];
             }
         };


### PR DESCRIPTION
All the API calls were completing successfully but a WPAccount instance was never created.
Users would get an invalid credentails error when trying to add the newly created blog to the app.
Fixes #664
