### PR TITLE
#705 - Updated push notification parameters to use new app_secret_key

### DIFF
--- a/WordPress/Classes/NotificationsManager.m
+++ b/WordPress/Classes/NotificationsManager.m
@@ -66,20 +66,13 @@
     NSString *authURL = kNotificationAuthURL;
     WPAccount *account = [WPAccount defaultWordPressComAccount];
 	if (account) {
-#ifdef DEBUG
-        NSNumber *sandbox = [NSNumber numberWithBool:YES];
-#else
-        NSNumber *sandbox = [NSNumber numberWithBool:NO];
-#endif
         NSArray *parameters = @[account.username,
                                 account.password,
                                 token,
                                 [[UIDevice currentDevice] wordpressIdentifier],
                                 @"apple",
-                                sandbox,
-#ifdef INTERNAL_BUILD
-                                @"org.wordpress.internal"
-#endif
+                                @NO, // Sandbox parameter - deprecated
+                                WordPressComApiPushAppId
                                 ];
         
         WPXMLRPCClient *api = [[WPXMLRPCClient alloc] initWithXMLRPCEndpoint:[NSURL URLWithString:authURL]];

--- a/WordPress/WordPressApi/WordPressComApi.h
+++ b/WordPress/WordPressApi/WordPressComApi.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, WordPressComApiBlogVisibility) {
 extern NSString *const WordPressComApiErrorDomain;
 extern NSString *const WordPressComApiErrorCodeKey;
 extern NSString *const WordPressComApiErrorMessageKey;
-
+extern NSString *const WordPressComApiPushAppId;
 
 @interface WordPressComApi : AFHTTPClient
 @property (nonatomic,readonly,strong) NSString *username;

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -34,6 +34,15 @@ NSString *const WordPressComApiErrorDomain = @"com.wordpress.api";
 NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
 NSString *const WordPressComApiErrorMessageKey = @"WordPressComApiErrorMessageKey";
 
+#ifdef DEBUG
+NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore.dev";
+#elif
+#ifdef INTERNAL_BUILD
+NSString *const WordPressComApiPushAppId = @"org.wordpress.internal";
+#elif
+NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
+#endif
+#endif
 
 #define UnfollowedBlogEvent @"UnfollowedBlogEvent"
 
@@ -467,9 +476,7 @@ NSString *const WordPressComApiErrorMessageKey = @"WordPressComApiErrorMessageKe
                             updatedSettings,
                             token,
                             @"apple",
-#ifdef INTERNAL_BUILD
-                            @"org.wordpress.internal",
-#endif
+                            WordPressComApiPushAppId
                             ];
     WPXMLRPCClient *api = [[WPXMLRPCClient alloc] initWithXMLRPCEndpoint:[NSURL URLWithString:kWPcomXMLRPCUrl]];
     [api setAuthorizationHeaderWithToken:self.authToken];
@@ -497,9 +504,7 @@ NSString *const WordPressComApiErrorMessageKey = @"WordPressComApiErrorMessageKe
                             [self passwordForXmlrpc],
                             token,
                             @"apple",
-#ifdef INTERNAL_BUILD
-                            @"org.wordpress.internal",
-#endif
+                            WordPressComApiPushAppId
                             ];
     
     WPXMLRPCClient *api = [[WPXMLRPCClient alloc] initWithXMLRPCEndpoint:[NSURL URLWithString:kWPcomXMLRPCUrl]];
@@ -532,23 +537,15 @@ NSString *const WordPressComApiErrorMessageKey = @"WordPressComApiErrorMessageKe
     
     [api setAuthorizationHeaderWithToken:self.authToken];
     
-#ifdef DEBUG
-    NSNumber *production = @NO;
-#else
-    NSNumber *production = @YES;
-#endif
-
     NSDictionary *tokenOptions = @{
                                    @"device_family": @"apple",
                                    @"device_model": [UIDeviceHardware platform],
                                    @"device_name": [[UIDevice currentDevice] name],
                                    @"device_uuid": [[UIDevice currentDevice] wordpressIdentifier],
-                                   @"production": production,
+                                   @"production": @YES, // deprecated in favor of app_secret_key
                                    @"app_version": [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"],
                                    @"os_version": [[UIDevice currentDevice] systemVersion],
-#ifdef INTERNAL_BUILD
-                                   @"app_secret_key": @"org.wordpress.internal",
-#endif
+                                   @"app_secret_key": WordPressComApiPushAppId,
                                    };
     NSArray *parameters = @[
                             [self usernameForXmlrpc],
@@ -569,9 +566,7 @@ NSString *const WordPressComApiErrorMessageKey = @"WordPressComApiErrorMessageKe
                                     [self passwordForXmlrpc],
                                     token,
                                     @"apple",
-#ifdef INTERNAL_BUILD
-                                    @"org.wordpress.internal",
-#endif
+                                    WordPressComApiPushAppId
                                     ];
     WPXMLRPCRequest *settingsRequest = [api XMLRPCRequestWithMethod:@"wpcom.get_mobile_push_notification_settings" parameters:settingsParameters];
     WPXMLRPCRequestOperation *settingsOperation = [api XMLRPCRequestOperationWithRequest:settingsRequest success:^(AFHTTPRequestOperation *operation, id responseObject) {


### PR DESCRIPTION
Replaces previous calls to WordPress.com with a parameter indicating DEBUG mode (sandbox) with a app ID parameter.
