### PR TITLE
#721 — Fixed animation of box when Reader is empty

### DIFF
--- a/WordPress/Classes/WPAnimatedBox.m
+++ b/WordPress/Classes/WPAnimatedBox.m
@@ -38,10 +38,10 @@ static CGFloat const WPAnimatedBoxAnimationTolerance = 5.0;
     _page1 = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"animatedBoxPage1"]];
     [_page1 sizeToFit];
     
-    _page2 = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"animatedBox_page2"]];
+    _page2 = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"animatedBoxPage2"]];
     [_page2 sizeToFit];
     
-    _page3 = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"animatedBox_page3"]];
+    _page3 = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"animatedBoxPage3"]];
     [_page3 sizeToFit];
     
     // view's are laid out by pixels for accuracy


### PR DESCRIPTION
#721

![ios simulator screen shot dec 5 2013 8 59 21 am](https://f.cloud.github.com/assets/3904502/1684718/982f002c-5dce-11e3-9d0e-137401e75d1c.png)
