### PR TITLE
Properly manage observers added to NSNotificationCenter

### DIFF
--- a/WordPress/Classes/BlogListViewController.m
+++ b/WordPress/Classes/BlogListViewController.m
@@ -40,6 +40,10 @@ NSString * const WPBlogListRestorationID = @"WPBlogListID";
     return self;
 }
 
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 - (NSString *)modelIdentifierForElementAtIndexPath:(NSIndexPath *)indexPath inView:(UIView *)view {
     if (!indexPath || !view)
         return nil;
@@ -78,12 +82,8 @@ NSString * const WPBlogListRestorationID = @"WPBlogListID";
                                                           action:@selector(showSettings:)];
     self.navigationItem.rightBarButtonItem = self.settingsButton;
     
-    [[NSNotificationCenter defaultCenter] addObserverForName:WordPressComApiDidLoginNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
-        [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationFade];
-    }];
-    [[NSNotificationCenter defaultCenter] addObserverForName:WordPressComApiDidLogoutNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
-        [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationFade];
-    }];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(wordPressComApiDidLogin:) name:WordPressComApiDidLoginNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(wordPressComApiDidLogout:) name:WordPressComApiDidLogoutNotification object:nil];
 
     // Remove one-pixel gap resulting from a top-aligned grouped table view
     if (IS_IPHONE) {
@@ -120,6 +120,18 @@ NSString * const WPBlogListRestorationID = @"WPBlogListID";
 - (BOOL)hasDotComAndSelfHosted {
     return ([[self.resultsController sections] count] > 1);
 }
+
+
+#pragma mark - Notifications
+
+- (void)wordPressComApiDidLogin:(NSNotification *)notification {
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationFade];
+}
+
+- (void)wordPressComApiDidLogout:(NSNotification *)notification {
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationFade];
+}
+
 
 #pragma mark - Actions
 

--- a/WordPress/Classes/ReaderPostsViewController.m
+++ b/WordPress/Classes/ReaderPostsViewController.m
@@ -69,8 +69,8 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
 
 - (void)dealloc {
     _featuredImageSource.delegate = nil;
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
 	self.readerReblogFormView = nil;
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (id)init {
@@ -81,9 +81,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
 		self.infiniteScrollEnabled = YES;
         self.incrementalLoadingSupported = YES;
         
-        [[NSNotificationCenter defaultCenter] addObserverForName:ReaderTopicDidChangeNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
-            [self readerTopicDidChange];
-        }];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(readerTopicDidChange:) name:ReaderTopicDidChangeNotification object:nil];        
 	}
 	return self;
 }
@@ -388,7 +386,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
     
 	[[NSUserDefaults standardUserDefaults] setObject:dict forKey:ReaderCurrentTopicKey];
 	[[NSUserDefaults standardUserDefaults] synchronize];
-    [self readerTopicDidChange];
+    [self readerTopicDidChange:nil];
 }
 
 
@@ -800,9 +798,9 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
 }
 
 
-#pragma mark - ReaderTopicsDelegate Methods
+#pragma mark - Notifications
 
-- (void)readerTopicDidChange {
+- (void)readerTopicDidChange:(NSNotification *)notification {
 	if (IS_IPAD){
         [self dismissPopover];
 	}

--- a/WordPress/Classes/SettingsViewController.m
+++ b/WordPress/Classes/SettingsViewController.m
@@ -70,11 +70,7 @@ CGFloat const blavatarImageViewSize = 43.f;
     self.doneButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Done", @"") style:[WPStyleGuide barButtonStyleForBordered] target:self action:@selector(dismiss)];
     self.navigationItem.rightBarButtonItem = self.doneButton;
     
-    [[NSNotificationCenter defaultCenter] addObserverForName:WPAccountDefaultWordPressComAccountChangedNotification object:nil queue:nil usingBlock:^(NSNotification *note) {
-        NSMutableIndexSet *sections = [NSMutableIndexSet indexSet];
-        [sections addIndex:SettingsSectionWpcom];
-        [self.tableView reloadSections:sections withRowAnimation:UITableViewRowAnimationFade];
-    }];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(defaultAccountDidChange:) name:WPAccountDefaultWordPressComAccountChangedNotification object:nil];
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
@@ -84,6 +80,16 @@ CGFloat const blavatarImageViewSize = 43.f;
     [self.navigationController setNavigationBarHidden:NO animated:animated];
     [self.tableView reloadData];
 }
+
+
+#pragma mark - Notifications
+
+- (void)defaultAccountDidChange:(NSNotification *)notification {
+    NSMutableIndexSet *sections = [NSMutableIndexSet indexSet];
+    [sections addIndex:SettingsSectionWpcom];
+    [self.tableView reloadSections:sections withRowAnimation:UITableViewRowAnimationFade];
+}
+
 
 #pragma mark - Custom Getter
 

--- a/WordPress/Classes/WordPressAppDelegate.m
+++ b/WordPress/Classes/WordPressAppDelegate.m
@@ -67,6 +67,10 @@ NSString * const WPNotificationsNavigationRestorationID = @"WPNotificationsNavig
     return (WordPressAppDelegate *)[[UIApplication sharedApplication] delegate];
 }
 
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 
 #pragma mark - UIApplicationDelegate
 
@@ -624,6 +628,14 @@ NSString * const WPNotificationsNavigationRestorationID = @"WPNotificationsNavig
 }
 
 
+#pragma mark - Notifications
+
+- (void)defaultAccountDidChange:(NSNotification *)notification {
+    [Crashlytics setUserName:[[WPAccount defaultWordPressComAccount] username]];
+    [self setCommonCrashlyticsParameters];
+}
+
+
 #pragma mark - Crash reporting
 
 - (void)configureCrashlytics {
@@ -647,12 +659,8 @@ NSString * const WPNotificationsNavigationRestorationID = @"WPNotificationsNavig
     if (hasCredentials && [[WPAccount defaultWordPressComAccount] username] != nil) {
         [Crashlytics setUserName:[[WPAccount defaultWordPressComAccount] username]];
     }
-    
-    void (^accountChangedBlock)(NSNotification *) = ^(NSNotification *note) {
-        [Crashlytics setUserName:[[WPAccount defaultWordPressComAccount] username]];
-        [self setCommonCrashlyticsParameters];
-    };
-    [[NSNotificationCenter defaultCenter] addObserverForName:WPAccountDefaultWordPressComAccountChangedNotification object:nil queue:nil usingBlock:accountChangedBlock];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(defaultAccountDidChange:) name:WPAccountDefaultWordPressComAccountChangedNotification object:nil];
 }
 
 - (void)crashlytics:(Crashlytics *)crashlytics didDetectCrashDuringPreviousExecution:(id<CLSCrashReport>)crash

--- a/WordPress/WordPressTest/EditPostViewControllerTest.m
+++ b/WordPress/WordPressTest/EditPostViewControllerTest.m
@@ -24,6 +24,10 @@
     Post *_post;
 }
 
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 - (void)setUp {
     [super setUp];
     NSDictionary *blogDict = @{
@@ -102,19 +106,28 @@
     }];
 
     ATHStart();
-    [[NSNotificationCenter defaultCenter] addObserverForName:EditPostViewControllerDidAutosaveNotification object:_controller queue:nil usingBlock:^(NSNotification *note) {
-        ATHNotify();
-    }];
-    [[NSNotificationCenter defaultCenter] addObserverForName:EditPostViewControllerAutosaveDidFailNotification object:_controller queue:nil usingBlock:^(NSNotification *note) {
-        NSError *error = [[note userInfo] objectForKey:@"error"];
-        XCTFail(@"Autosave failed: %@", error);
-        ATHNotify();
-    }];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(controllerDidAutosave:) name:EditPostViewControllerDidAutosaveNotification object:_controller];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(controllerAutosaveDidFail:) name:EditPostViewControllerAutosaveDidFailNotification object:_controller];
+    
     [titleTextField typeText:@"This is a very long title, which should trigger the autosave methods. Just in case... Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc est neque, adipiscing vitae euismod ut, elementum nec nibh. In hac habitasse platea dictumst. Mauris eu est lectus, sed elementum nunc. Praesent elit enim, facilisis eu tincidunt imperdiet, iaculis eu elit. In hac habitasse platea dictumst. Pellentesque feugiat elementum nulla, vitae pellentesque urna porttitor quis. Quisque et libero leo. Vestibulum ut erat ut ligula aliquet iaculis. Morbi egestas justo id nunc feugiat viverra vel sed risus. Nunc non ligula erat, eu ullamcorper purus. Nullam vitae erat velit, semper congue nibh. Vestibulum pulvinar mi a justo tincidunt venenatis in nec tortor. Curabitur tortor risus, consequat eget sollicitudin gravida, vestibulum vitae lacus. Aenean ut magna adipiscing mauris iaculis sollicitudin at id nisi."];
     ATHEnd();
     XCTAssertEqualObjects(_post.postID, @123);
     XCTAssertEqualObjects(_post.status, @"draft");
 }
+
+
+#pragma mark - Notifications
+
+- (void)controllerDidAutosave:(NSNotification *)notification {
+    ATHNotify();
+}
+
+- (void)controllerAutosaveDidFail:(NSNotification *)notification {
+    NSError *error = [[notification userInfo] objectForKey:@"error"];
+    XCTFail(@"Autosave failed: %@", error);
+    ATHNotify();
+}
+
 
 #pragma mark - Helpers
 


### PR DESCRIPTION
For #735 we learned `addObserverForName:object:queue:usingBlock:` isn't all that handy, and we weren't properly managing the observers it returns. This pull replaces all uses of that method with the more typical `addObserver:selector:name:object:` and adds `dealloc` cleanup where necessary.
