### PR TITLE
#774 - fixed floating title-less table view section headers

### DIFF
--- a/WordPress/Classes/PostsViewController.m
+++ b/WordPress/Classes/PostsViewController.m
@@ -60,6 +60,11 @@
         [button addTarget:self action:@selector(showAddPostView) forControlEvents:UIControlEventTouchUpInside];
         composeButtonItem = [[UIBarButtonItem alloc] initWithCustomView:button];
     }
+    
+    // Account for 1 pixel header height
+    UIEdgeInsets tableInset = [self.tableView contentInset];
+    tableInset.top = -1;
+    self.tableView.contentInset = tableInset;
 
     [WPStyleGuide setRightBarButtonItemWithCorrectSpacing:composeButtonItem forNavigationItem:self.navigationItem];
     

--- a/WordPress/Classes/WPTableViewController.m
+++ b/WordPress/Classes/WPTableViewController.m
@@ -68,7 +68,7 @@ NSString *const DefaultCellIdentifier = @"DefaultCellIdentifier";
 }
 
 - (id)initWithStyle:(UITableViewStyle)style {
-    self = [super initWithStyle:style];
+    self = [super initWithStyle:UITableViewStyleGrouped];
     
     if (self) {
         self.restorationIdentifier = NSStringFromClass([self class]);


### PR DESCRIPTION
#774

iOS 7 changed the style of table views, which made using grouped table views often more appropriate than plain.

![2](https://f.cloud.github.com/assets/3904502/1718662/ec67cc62-61e0-11e3-9296-8e49fd68a93d.png)
