### PR TITLE
#780 - present reader detail view sharing options via popover on iPad

### DIFF
--- a/WordPress/Classes/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ReaderPostDetailViewController.m
@@ -38,7 +38,8 @@ typedef enum {
 } ReaderDetailSection;
 
 
-@interface ReaderPostDetailViewController ()<UIActionSheetDelegate, MFMailComposeViewControllerDelegate, ReaderTextFormDelegate> {
+@interface ReaderPostDetailViewController ()<UIActionSheetDelegate, MFMailComposeViewControllerDelegate, ReaderTextFormDelegate, UIPopoverControllerDelegate> {
+    UIPopoverController *_popover;
 }
 
 @property (nonatomic, strong) ReaderPostView *postView;
@@ -417,7 +418,17 @@ typedef enum {
             return;
         [WPActivityDefaults trackActivityType:activityType withPrefix:@"ReaderDetail"];
     };
-    [self presentViewController:activityViewController animated:YES completion:nil];
+    if (IS_IPAD) {
+        if (_popover) {
+            [self dismissPopover];
+            return;
+        }
+        _popover = [[UIPopoverController alloc] initWithContentViewController:activityViewController];
+        _popover.delegate = self;
+        [_popover presentPopoverFromBarButtonItem:self.shareButton permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+    } else {
+        [self presentViewController:activityViewController animated:YES completion:nil];
+    }
 }
 
 - (void)handleDismissForm:(id)sender {
@@ -536,6 +547,17 @@ typedef enum {
     }
     
     return tabBarSize;
+}
+
+- (void)dismissPopover {
+    if (_popover) {
+        [_popover dismissPopoverAnimated:YES];
+        _popover = nil;
+    }
+}
+
+- (void)popoverControllerDidDismissPopover:(UIPopoverController *)popoverController {
+    _popover = nil;
 }
 
 - (void)handleKeyboardDidShow:(NSNotification *)notification {


### PR DESCRIPTION
#780

Old vs. New:

![ios simulator screen shot dec 11 2013 9 33 46 am](https://f.cloud.github.com/assets/3904502/1726138/8a02c298-628a-11e3-90d3-e1cf05b07597.png)
![ios simulator screen shot dec 11 2013 9 29 07 am](https://f.cloud.github.com/assets/3904502/1726139/8b480bae-628a-11e3-8729-d60038969df4.png)
