### PR TITLE
Fix toolbar animation when invoking from posts/pages list

### DIFF
--- a/WordPress/Classes/PagesViewController.m
+++ b/WordPress/Classes/PagesViewController.m
@@ -37,6 +37,7 @@
 - (void)editPost:(AbstractPost *)apost {
     EditPageViewController *editPostViewController = [[EditPageViewController alloc] initWithPost:apost];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:editPostViewController];
+    [navController setToolbarHidden:NO]; // Fixes wrong toolbar icon animation.
     navController.modalPresentationStyle = UIModalPresentationCurrentContext;
     [self.navigationController presentViewController:navController animated:YES completion:nil];
 }

--- a/WordPress/Classes/PostsViewController.m
+++ b/WordPress/Classes/PostsViewController.m
@@ -206,6 +206,7 @@
 - (void)editPost:(AbstractPost *)apost {
     EditPostViewController *editPostViewController = [[EditPostViewController alloc] initWithPost:apost];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:editPostViewController];
+    [navController setToolbarHidden:NO]; // Fixes incorrect toolbar animation.
     navController.modalPresentationStyle = UIModalPresentationCurrentContext;
     [self.view.window.rootViewController presentViewController:navController animated:YES completion:nil];
 }


### PR DESCRIPTION
Refs #814 
When displaying the editor from the posts or pages list, the toolbar icons would animate in from the right.  Making the toolbar visible from the presenting controller fixes the issue.
