### PR TITLE
Present the modal from the rootViewController.

### DIFF
--- a/WordPress/Classes/PagesViewController.m
+++ b/WordPress/Classes/PagesViewController.m
@@ -38,7 +38,7 @@
     EditPageViewController *editPostViewController = [[EditPageViewController alloc] initWithPost:apost];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:editPostViewController];
     navController.modalPresentationStyle = UIModalPresentationCurrentContext;
-    [self.navigationController presentViewController:navController animated:YES completion:nil];
+    [self.view.window.rootViewController presentViewController:navController animated:YES completion:nil];
 }
 
 - (void)showAddPostView {


### PR DESCRIPTION
Fixes #797 
On the iPad, the page editor would appear behind the tab bar.
Fix is to show the editor modal from the rootViewController.
