### PR TITLE
NSJSONSerialization not deserializing with mutable collections

### DIFF
--- a/WordPress/Classes/Note.m
+++ b/WordPress/Classes/Note.m
@@ -164,7 +164,7 @@ const NSUInteger NoteKeepCount = 20;
 
 - (void)syncAttributes:(NSDictionary *)noteData {
     self.payload = [NSJSONSerialization dataWithJSONObject:noteData options:0 error:nil];
-    self.noteData = [NSJSONSerialization JSONObjectWithData:self.payload options:0 error:nil];
+    self.noteData = [NSJSONSerialization JSONObjectWithData:self.payload options:NSJSONReadingMutableContainers error:nil];
     if ([noteData objectForKey:@"type"]) {
         self.type = [noteData objectForKey:@"type"];
     }
@@ -217,7 +217,7 @@ const NSUInteger NoteKeepCount = 20;
 
 - (id)noteData {
     if (_noteData == nil) {
-        _noteData = [NSJSONSerialization JSONObjectWithData:self.payload options:0 error:nil];
+        _noteData = [NSJSONSerialization JSONObjectWithData:self.payload options:NSJSONReadingMutableContainers error:nil];
     }
     return _noteData;
 }

--- a/WordPress/Classes/NotificationsFollowDetailViewController.m
+++ b/WordPress/Classes/NotificationsFollowDetailViewController.m
@@ -224,8 +224,8 @@
     NSInteger row = button.tag;
     
     NSMutableDictionary *selectedNote = [_noteData objectAtIndex:row];
-    NSDictionary *noteAction = [selectedNote objectForKey:@"action"];
-    NSDictionary *noteDetails;
+    NSMutableDictionary *noteAction = [selectedNote objectForKey:@"action"];
+    NSMutableDictionary *noteDetails;
     if ([noteAction isKindOfClass:[NSDictionary class]])
         noteDetails = [noteAction objectForKey:@"params"];
 


### PR DESCRIPTION
Issue #738 

Previously we were using JSON Framework (I think) previously and it apparently deserialized JSON into collections that were mutable.  We recently removed the old framework in lieu of the built-in NSJSONSerialization framework.  By default, none of those collections are mutable unless NSJSONReadingMutableContainers is set in the options.

We were setting a value in the dictionary after receiving the Foundation objects in the Note Detail Viewer (for what purpose is unknown).  I fixed the collections to be mutable to get back to the original behavior.  I think some time could be spent improving Note.
