### PR TITLE
Don't change self hosted section on blogs list.

### DIFF
--- a/WordPress/Classes/BlogListViewController.m
+++ b/WordPress/Classes/BlogListViewController.m
@@ -494,6 +494,18 @@ NSString * const WPBlogListRestorationID = @"WPBlogListID";
 }
 
 - (void)controller:(NSFetchedResultsController *)controller didChangeSection:(id<NSFetchedResultsSectionInfo>)sectionInfo atIndex:(NSUInteger)sectionIndex forChangeType:(NSFetchedResultsChangeType)type {
+    /*
+     The section for self hosted is always present, since it includes the
+     'Add Site' row.
+
+     If we tried to add/remove the section when the results controller changed,
+     it would crash, as the table's data source section count would remain the
+     same.
+     */
+    if (sectionIndex == [self sectionForSelfHosted]) {
+        return;
+    }
+
     switch (type) {
         case NSFetchedResultsChangeInsert:
             [self.tableView insertSections:[NSIndexSet indexSetWithIndex:sectionIndex] withRowAnimation:UITableViewRowAnimationFade];


### PR DESCRIPTION
The section for self hosted is always present, since it includes the 'Add Site' row.

If we tried to add/remove the section when the results controller changed, it would crash, as the table's data source section count would remain the same.

Fixes #813 
/cc @tomwitkin 
