### PR TITLE
Use GMT dates for relative dates

### DIFF
--- a/WordPress/Classes/ReaderPostView.m
+++ b/WordPress/Classes/ReaderPostView.m
@@ -700,7 +700,7 @@ const CGFloat RPVControlButtonBorderSize = 0.0f;
 }
 
 - (void)refreshDate:(NSTimer *)timer {
-    [self.timeButton setTitle:[self.post.dateCreated shortString] forState:UIControlStateNormal];
+    [self.timeButton setTitle:[self.post.date_created_gmt shortString] forState:UIControlStateNormal];
 }
 
 


### PR DESCRIPTION
The `shortString` method will calculate using GMT, so pass a GMT date

Fixes #833 
