### PR TITLE
increases width of the date label for comments

### DIFF
--- a/WordPress/Classes/ReaderCommentTableViewCell.m
+++ b/WordPress/Classes/ReaderCommentTableViewCell.m
@@ -111,7 +111,7 @@
 		_textContentView.shouldLayoutCustomSubviews = YES;
 		[self.contentView addSubview:_textContentView];
 		
-		self.dateLabel = [[UILabel alloc] initWithFrame:CGRectMake(width - (10.0f + 30.0f), 10.0f, 30.0f, 20.0f)];
+		self.dateLabel = [[UILabel alloc] initWithFrame:CGRectMake(width - (10.0f + 40.0f), 10.0f, 40.0f, 20.0f)];
 		[_dateLabel setFont:[WPStyleGuide subtitleFont]];
 		_dateLabel.textColor = [WPStyleGuide littleEddieGrey];
 		_dateLabel.textAlignment = NSTextAlignmentRight;


### PR DESCRIPTION
#839

Before:

![ios simulator-1](https://f.cloud.github.com/assets/1220715/1758006/66682f6a-6688-11e3-8786-d70b936654f5.jpg)

After:

![ios simulator-2](https://f.cloud.github.com/assets/1220715/1758007/6abbf9e8-6688-11e3-8463-14e6abe68bbe.jpg)

Resolves #839 
