### PR TITLE
Move custom post button into tabbar so it hides when the tabbar hides.

### DIFF
--- a/WordPress/Classes/WPMainTabBarController.m
+++ b/WordPress/Classes/WPMainTabBarController.m
@@ -25,7 +25,6 @@
     CGFloat y = CGRectGetHeight(self.view.frame) - (image.size.height + 2);
     
     self.postButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    _postButton.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleLeftMargin;
     _postButton.frame = CGRectMake(x, y, image.size.width, image.size.height);
     [_postButton setImage:image forState:UIControlStateNormal];
     [_postButton setImage:[UIImage imageNamed:@"icon-tab-newpost-highlighted"] forState:UIControlStateHighlighted];
@@ -37,7 +36,7 @@
     // wrong place the first time viewWillAppear: is called, but not subsequent times.
     // This seems to be because the layer transform due to rotation has not yet ben applied.
     _postButton.hidden = YES;
-    [self.view addSubview:_postButton];
+    [self.tabBar addSubview:_postButton];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -77,6 +76,9 @@
     NSArray *tabBarButtonItems = self.tabBar.subviews;
     for (NSInteger i = 0; i < [tabBarButtonItems count]; i++) {
         UIView *tabBarButton = [tabBarButtonItems objectAtIndex:i];
+        if ([_postButton isEqual:tabBarButton]) {
+            continue;
+        }
         CGFloat x = CGRectGetMinX(tabBarButton.frame);
         if (x > lastX) {
             lastX = x;
@@ -84,24 +86,8 @@
         }
     }
 
-    tabFrame = [self.view convertRect:tabFrame fromView:self.tabBar];
-
-    // Since the button uses contentMode UIViewContentModeCenter, adjust the frame
-    // to make sure we don't crop any of the image.
-    CGFloat diff;
-    CGSize imageSize = _postButton.imageView.image.size;
-    if (tabFrame.size.height < imageSize.height) {
-        diff = imageSize.height - tabFrame.size.height;
-        tabFrame.size.height  = imageSize.height;
-        tabFrame.origin.y -= ceilf(diff / 2.0f);
-    }
-    if (tabFrame.size.width < imageSize.width) {
-        diff = imageSize.width - tabFrame.size.width;
-        tabFrame.size.width  = imageSize.width;
-        tabFrame.origin.x -= ceilf(diff / 2.0f);
-    }
-    
     _postButton.frame = tabFrame;
+    [self.tabBar bringSubviewToFront:_postButton];
 }
 
 - (void)postButtonTapped {


### PR DESCRIPTION
Remove autoresizing masks and other position code and just use the tabBarButton's frame.

Fixes #859 
