### PR TITLE
#863 - comments view section titles

### DIFF
--- a/WordPress/Classes/BlogDetailsViewController.m
+++ b/WordPress/Classes/BlogDetailsViewController.m
@@ -79,13 +79,14 @@ NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
+    
     if (IS_IPHONE) {
+        // Account for 1 pixel header height
         UIEdgeInsets tableInset = [self.tableView contentInset];
         tableInset.top = -1;
         self.tableView.contentInset = tableInset;
     }
-    
-    [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:BlogDetailsCellIdentifier];
 }

--- a/WordPress/Classes/CommentsViewController.m
+++ b/WordPress/Classes/CommentsViewController.m
@@ -167,7 +167,7 @@ CGFloat const CommentsSectionHeaderHeight = 24.0;
     
     // Don't show a section title if there's only one section
     if ([tableView numberOfSections] <= 1) {
-        return 1.0;
+        return IS_IPHONE ? 1 : WPTableViewTopMargin;
     }
     
     NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];

--- a/WordPress/Classes/PostsViewController.m
+++ b/WordPress/Classes/PostsViewController.m
@@ -45,11 +45,6 @@
     [button addTarget:self action:@selector(showAddPostView) forControlEvents:UIControlEventTouchUpInside];
     UIBarButtonItem *composeButtonItem = [[UIBarButtonItem alloc] initWithCustomView:button];
 
-    // Account for 1 pixel header height
-    UIEdgeInsets tableInset = [self.tableView contentInset];
-    tableInset.top = -1;
-    self.tableView.contentInset = tableInset;
-
     [WPStyleGuide setRightBarButtonItemWithCorrectSpacing:composeButtonItem forNavigationItem:self.navigationItem];
     
     self.infiniteScrollEnabled = YES;

--- a/WordPress/Classes/WPTableViewController.m
+++ b/WordPress/Classes/WPTableViewController.m
@@ -98,6 +98,13 @@ NSString *const DefaultCellIdentifier = @"DefaultCellIdentifier";
     self.tableView.allowsSelectionDuringEditing = YES;
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self.tableView registerClass:[self cellClass] forCellReuseIdentifier:DefaultCellIdentifier];
+    
+    if (IS_IPHONE) {
+        // Account for 1 pixel header height
+        UIEdgeInsets tableInset = [self.tableView contentInset];
+        tableInset.top = -1;
+        self.tableView.contentInset = tableInset;
+    }
 
     if (self.infiniteScrollEnabled) {
         [self enableInfiniteScrolling];


### PR DESCRIPTION
#863

This was a regression from 3.8.5. Before and after:

![1](https://f.cloud.github.com/assets/3904502/1768353/4729609a-6761-11e3-951f-4a3ebefca42d.png)
