### PR TITLE
Fix gap under options cell after dismissing blog picker.

### DIFF
--- a/WordPress/Classes/EditPostViewController.m
+++ b/WordPress/Classes/EditPostViewController.m
@@ -373,7 +373,12 @@ CGFloat const EPVCTextViewTopPadding = 7.0f;
     CGFloat minHeight = self.view.frame.size.height;
     minHeight -= (EPVCTextfieldHeight + EPVCTextViewTopPadding);
     if (self.dismissingBlogPicker) {
-        minHeight -= 20.0f; // For some reason the frame/bounds hight includes the status bar.
+        // For some reason the frame/bounds hight includes the status bar.
+        if (UIInterfaceOrientationIsPortrait([UIApplication sharedApplication].statusBarOrientation)) {
+            minHeight -= [UIApplication sharedApplication].statusBarFrame.size.height;
+        } else {
+            minHeight -= [UIApplication sharedApplication].statusBarFrame.size.width;
+        }
     } else if (!self.tableView.window) {
         minHeight -= EPVCToolbarHeight;
     }


### PR DESCRIPTION
Two things led to the gap. 
First, when dismissing the blog picker the view's frame/bounds included the height of the status bar for some reason, adding 20px to the expected minHeight. 
Second, the view did not belong to a window so the height of the toolbar was subtracted, but it should not have been. 
Combined these two issues led to a 24px deficit in the minHeight resulting in a gap.

Fixes #871. 
