### PR TITLE
Add safety check if table has changed

### DIFF
--- a/WordPress/Classes/ReaderPostsViewController.m
+++ b/WordPress/Classes/ReaderPostsViewController.m
@@ -1018,11 +1018,17 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
 
 - (void)tableImageSource:(WPTableImageSource *)tableImageSource imageReady:(UIImage *)image forIndexPath:(NSIndexPath *)indexPath {
     ReaderPostTableViewCell *cell = (ReaderPostTableViewCell *)[self.tableView cellForRowAtIndexPath:indexPath];
+    
+    // Don't do anything if the cell is out of view or out of range
+    // (this is a safety check in case the Reader doesn't properly kill image requests when changing topics)
+    if (cell == nil)
+        return;
+
     [cell.postView setFeaturedImage:image];
     
+    // Update the detail view if it's open and applicable
     ReaderPost *post = [self.resultsController objectAtIndexPath:indexPath];
     
-    // Update the detail view if it's open and applicable
     if (post == self.detailController.post) {
         [self.detailController updateFeaturedImage:image];
     }


### PR DESCRIPTION
This should fix #832 with a quick check to handle images that are no longer valid for the current table. However, a more complete fix will be to properly cancel image requests when changing topics, which (to do well) requires a more thoughtful refactoring of how we do image loading and caching in the app (added as #904).
