### PR TITLE
Force notes to fully refresh if table is refreshed manually (user interaction)

### DIFF
--- a/WordPress/Classes/NotificationsViewController.m
+++ b/WordPress/Classes/NotificationsViewController.m
@@ -279,12 +279,13 @@ NSString * const NotificationsJetpackInformationURL = @"http://jetpack.me/about/
     
     NSNumber *timestamp;
     NSArray *notes = [self.resultsController fetchedObjects];
-    if ([notes count] > 0) {
+    if (userInteraction == NO && [notes count] > 0) {
         Note *note = [notes objectAtIndex:0];
         timestamp = note.timestamp;
     } else {
         timestamp = nil;
     }
+    
     [self.user getNotificationsSince:timestamp success:^(AFHTTPRequestOperation *operation, id responseObject) {
         [self updateSyncDate];
         if (success) {


### PR DESCRIPTION
Fixes #869 

The Android app always pulls the current Note list from the REST API - should we just do the same across the board?
