### PR TITLE
Issue/864 empty reader

### DIFF
--- a/WordPress/Classes/ReaderPostsViewController.m
+++ b/WordPress/Classes/ReaderPostsViewController.m
@@ -176,11 +176,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
 }
 
 - (void)viewDidAppear:(BOOL)animated {
-    // WPTableViewController's viewDidAppear triggers a sync, but only do it if authenticated
-    // (this prevents an attempted sync when the app launches for the first time before authenticating)
-    if ([[WordPressAppDelegate sharedWordPressApplicationDelegate] isWPcomAuthenticated]) {
-        [super viewDidAppear:animated];
-    }
+    [super viewDidAppear:animated];
 
     NSIndexPath *selectedIndexPath = [self.tableView indexPathForSelectedRow];
     if (selectedIndexPath) {


### PR DESCRIPTION
Fixes #864 (an outdated check was preventing refresh) and a couple related problems:
- Sync time wasn't being cleared after sign out (which could prevent a refresh after changing accounts).
- Found another use of `NSNotificationCenter` with a block, and removed it.
