### PR TITLE
Fix scroll-to-top gesture in views with inline commenting

### DIFF
--- a/WordPress/Classes/InlineComposeView.m
+++ b/WordPress/Classes/InlineComposeView.m
@@ -35,6 +35,10 @@ const CGFloat InlineComposeViewMaxHeight = 88.f;
         _proxyTextView = [[UITextView alloc] initWithFrame:CGRectZero];
         _proxyTextView.delegate = self;
         _proxyTextView.inputAccessoryView = self.inputAccessoryView;
+        
+        // Ensure scroll-to-top gesture is disabled so it still works in parent views
+        _proxyTextView.scrollsToTop = NO;
+        _toolbarTextView.scrollsToTop = NO;
 
         self.placeholderLabel.text = NSLocalizedString(@"Write a reply…", @"Placeholder text for inline compose view");
 


### PR DESCRIPTION
The new inline commenting interface uses embedded `UITextView` instances. These were interfering with the scroll-to-top gesture in parent scroll views and table views (tapping the status bar sends the view to the top). 

Fixes #908  by disabling `scrollsToTop` on these views.
