### PR TITLE
Make the Jetpack Account the default if no default WP.com account exists

### DIFF
--- a/WordPress/Classes/Blog+Jetpack.m
+++ b/WordPress/Classes/Blog+Jetpack.m
@@ -143,6 +143,7 @@ NSString * const BlogJetpackApiPath = @"get-user-blogs/1.0";
                                  // If there is no WP.com account on the device, make this the default
                                  if ([WPAccount defaultWordPressComAccount] == nil) {
                                      [WPAccount setDefaultWordPressComAccount:account];
+                                     [self dataSave];
                                      
                                      // Sadly we don't care if this succeeds or not
                                      [account syncBlogsWithSuccess:nil failure:nil];


### PR DESCRIPTION
Fixes #924 

Also fire off sync of all blogs and notifications.  This should eventually be centralized into a service to handle someone “logging on” to WordPress.com.
