### PR TITLE
Hide password edit field for WordPress.com blogs

### DIFF
--- a/WordPress/Classes/EditSiteViewController.m
+++ b/WordPress/Classes/EditSiteViewController.m
@@ -134,7 +134,7 @@ static NSString *const JetpackConnectedCellIdentifier = @"JetpackConnectedCellId
             return 3;
 		case 1:
             // Settings: Geolocation, [ Push Notifications ]
-            if (self.blog && ( [self.blog isWPcom] || [self.blog hasJetpack] ) && [[WordPressComApi sharedApi] hasCredentials] && [[NSUserDefaults standardUserDefaults] objectForKey:NotificationsDeviceToken] != nil)
+            if ([self canTogglePushNotifications])
                 return 2;
             else
                 return 1;	
@@ -370,6 +370,13 @@ static NSString *const JetpackConnectedCellIdentifier = @"JetpackConnectedCellId
     } else {
         textField.returnKeyType = UIReturnKeyNext;
     }
+}
+
+- (BOOL)canTogglePushNotifications {
+    return self.blog &&
+        ([self.blog isWPcom] || [self.blog hasJetpack]) &&
+        [[WordPressComApi sharedApi] hasCredentials] &&
+        [[NSUserDefaults standardUserDefaults] objectForKey:NotificationsDeviceToken] != nil;
 }
 
 - (void)toggleGeolocation:(id)sender {


### PR DESCRIPTION
For #944. Includes a tiny bit of bonus code cleanup.
