### PR TITLE
Setting the locale in the DateUtils to POSIX to prevent [silent] conversion failures

### DIFF
--- a/WordPress/Classes/DateUtils.m
+++ b/WordPress/Classes/DateUtils.m
@@ -45,6 +45,7 @@
 		}
 	}
 	NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
 	for (NSString *dateFormat in formats) {
 		[dateFormatter setDateFormat:dateFormat];
 		date = [dateFormatter dateFromString:dateString];
@@ -58,6 +59,7 @@
 
 + (NSString *)isoStringFromDate:(NSDate *)date {
 	NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
 	[dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZZZ"];
 	return [dateFormatter stringFromDate:date];
 }


### PR DESCRIPTION
Fixes #960 

Using date strings in the date formatter is tricky - when interpreting dates from XML (or wherever) the formatter has to be locked to a locale so the letters used mean the right thing.  Device locale can affect what the letters mean - in this case setting to 12hr en_GB fails when converting a date over the wire.

Related: wordpress-mobile/wpxmlrpc#2
