### PR TITLE
Moved action sheet display on iPhone in edit post controller to toolbar

### DIFF
--- a/WordPress/Classes/EditPostViewController.m
+++ b/WordPress/Classes/EditPostViewController.m
@@ -623,7 +623,7 @@ CGFloat const EPVCTextViewTopPadding = 7.0f;
     if (IS_IPAD) {
         [actionSheet showFromBarButtonItem:self.navigationItem.leftBarButtonItem animated:YES];
     } else {
-        [actionSheet showInView:self.view];
+        [actionSheet showFromToolbar:self.navigationController.toolbar];
     }
 }
 


### PR DESCRIPTION
Fixes #956 

Prevents the action sheet from being displayed outside the bounds of the main view, making the cancel (keep editing) button untappable.
