### PR TITLE
Notifications comments blanking around during scrolling

### DIFF
--- a/WordPress/Classes/NotificationsCommentDetailViewController.m
+++ b/WordPress/Classes/NotificationsCommentDetailViewController.m
@@ -57,7 +57,6 @@ NS_ENUM(NSUInteger, NotifcationCommentCellType){
 @property NSDictionary *followAction;
 @property NSURL *headerURL;
 @property BOOL hasScrollBackView;
-@property (nonatomic, strong) NSCache *contentCache;
 
 @property (nonatomic, strong) UIBarButtonItem *approveBarButton;
 @property (nonatomic, strong) UIBarButtonItem *unapproveBarButton;
@@ -176,13 +175,6 @@ NS_ENUM(NSUInteger, NotifcationCommentCellType){
                                                  name:UIKeyboardWillHideNotification
                                                object:nil];
 
-}
-
-- (NSCache *)contentCache {
-    if (!_contentCache) {
-        _contentCache = [[NSCache alloc] init];
-    }
-    return _contentCache;
 }
 
 - (void)displayNote {


### PR DESCRIPTION
Fixes #954 

Blanks rows were appearing erratically while scrolling around a notification comment thread.  It looks like the NSCache originally used was completely unnecessary and was overriding the behavior of register cells with the table view.  If someone knows better about this, please chime in.

cc: @aerych @xtreme-rebecca-putinski @mikejohnstn 
