### PR TITLE
Don't show placeholders for images on the reader detail.

### DIFF
--- a/WordPress/Classes/ReaderMediaQueue.m
+++ b/WordPress/Classes/ReaderMediaQueue.m
@@ -166,9 +166,11 @@ typedef void (^ReaderMediaViewFailureBlock)(ReaderMediaView *readerMediaView, NS
             if (item.failure) {
                 item.failure(item.mediaView, nil); //TODO: return the actual error as well?
             }
-        } else if (item.success) {
+        } else {
             [item.mediaView setImage:item.image];
-            item.success(item.mediaView);
+            if (item.success) {
+                item.success(item.mediaView);
+            }
         }
         // clear blocks because paranoid
         item.success = nil;

--- a/WordPress/Classes/ReaderMediaView.h
+++ b/WordPress/Classes/ReaderMediaView.h
@@ -14,7 +14,6 @@
 @property (nonatomic, assign) UIEdgeInsets edgeInsets;
 @property (nonatomic, strong) NSURL *contentURL;
 @property (nonatomic) BOOL isShowingPlaceholder;
-@property (nonatomic) CGFloat placeholderRatio;
 
 - (UIImage *)image;
 - (void)setImage:(UIImage *)image;

--- a/WordPress/Classes/ReaderMediaView.m
+++ b/WordPress/Classes/ReaderMediaView.m
@@ -74,7 +74,6 @@
 - (void)setPlaceholder:(UIImage *)image {
 	_imageView.image = image;
 	self.isShowingPlaceholder = YES;
-    self.placeholderRatio = self.frame.size.width / self.frame.size.height;
 }
 
 

--- a/WordPress/Classes/ReaderVideoView.m
+++ b/WordPress/Classes/ReaderVideoView.m
@@ -130,7 +130,7 @@
 											   NSDictionary *thumb = [thumbs objectAtIndex:3];
 											   NSString *url = [thumb objectForKey:@"url"];
 											   [selfRef setImageWithURL:[NSURL URLWithString:url]
-													   placeholderImage:[UIImage imageNamed:@"wp_vid_placeholder.png"]
+													   placeholderImage:nil
 																success:success
 																failure:failure];
 											   
@@ -172,7 +172,7 @@
 											 selfRef.title = [dict objectForKey:@"title"];
 											 NSString *url = [dict objectForKey:@"thumbnail_large"];
 											 [selfRef setImageWithURL:[NSURL URLWithString:url]
-													 placeholderImage:[UIImage imageNamed:@"wp_vid_placeholder.png"]
+													 placeholderImage:nil
 															  success:success
 															  failure:failure];
 											 
@@ -197,7 +197,7 @@
 												   NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:responseObject options:0 error:nil];
 												   NSString *url = [dict objectForKey:@"thumbnail_large_url"];
 												   [selfRef setImageWithURL:[NSURL URLWithString:url]
-														   placeholderImage:[UIImage imageNamed:@"wp_vid_placeholder.png"]
+														   placeholderImage:nil 
 																	success:success
 																	failure:failure];
 												   


### PR DESCRIPTION
Starting width and height is 1px instead of 0px to avoid graphics context warnings.
Clarifies variable name.
Fixes an issue where not specifying a success block for a ReaderMediaQueueItem would prevent the downloaded image from showing.
Removes obsolete placholder specific code.

Fixes #981 
