### PR TITLE
Present videos full screen

### DIFF
--- a/WordPress/Classes/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ReaderPostDetailViewController.m
@@ -690,7 +690,7 @@ typedef enum {
                                                    object:controller.moviePlayer];
 
 		controller.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
-		controller.modalPresentationStyle = UIModalPresentationFormSheet;
+		controller.modalPresentationStyle = UIModalPresentationFullScreen;
         [self.navigationController presentViewController:controller animated:YES completion:nil];
 
 	} else {


### PR DESCRIPTION
Using a form sheet caused the media controls to have the wrong layout on
iPad.

Fixes #465.
