### PR TITLE
Changed spinnner color to white for all cases

### DIFF
--- a/WordPress/Classes/WPWebViewController.m
+++ b/WordPress/Classes/WPWebViewController.m
@@ -333,14 +333,8 @@
         if (IS_IPHONE) {
             // Build a spinner button if we don't have one
             if (self.spinnerButton == nil) {
-                UIActivityIndicatorView *spinner = nil;
-                UIActivityIndicatorViewStyle style;
-                if ([[UIToolbar class] respondsToSelector:@selector(appearance)]) {
-                    style = UIActivityIndicatorViewStyleGray;
-                } else {
-                    style = UIActivityIndicatorViewStyleWhite;
-                }
-                spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:style];
+                UIActivityIndicatorView *spinner = [[UIActivityIndicatorView alloc]
+                                                    initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
                 UIView *customView = [[UIView alloc] initWithFrame:CGRectMake(10.0f, 0.0f, 32.0f, 32.0f)];
                 [spinner setCenter:customView.center];
                 


### PR DESCRIPTION
Previously toolbar appears on the view after keyboard disappears, hide
it when the keyboard disappears on the view.
Fixes #176 

( Squashs into one the commits in https://github.com/wordpress-mobile/WordPress-iOS/pull/979 ) Props @intoxicated https://github.com/intoxicated
