### PR TITLE
Remove padding so label centers properly.

### DIFF
--- a/WordPress/Classes/WPNoResultsView.m
+++ b/WordPress/Classes/WPNoResultsView.m
@@ -42,17 +42,16 @@
 
 - (void)layoutSubviews {
     
-    CGFloat width = 250.0;
-    CGFloat messagePadding = 15.0;
+    CGFloat width = 250.0f;
     
     // Layout views
     _accessoryView.frame = CGRectMake((width - CGRectGetWidth(_accessoryView.frame)) / 2, 0, CGRectGetWidth(_accessoryView.frame), CGRectGetHeight(_accessoryView.frame));
     
     CGSize titleSize = [_titleLabel.text boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin attributes:@{NSFontAttributeName: _titleLabel.font} context:nil].size;
-    _titleLabel.frame = CGRectMake(0, (CGRectGetMaxY(_accessoryView.frame) > 0 && _accessoryView.hidden != YES ? CGRectGetMaxY(_accessoryView.frame) + 10.0 : 0) , width, titleSize.height);
+    _titleLabel.frame = CGRectMake(0.0f, (CGRectGetMaxY(_accessoryView.frame) > 0 && _accessoryView.hidden != YES ? CGRectGetMaxY(_accessoryView.frame) + 10.0 : 0) , width, titleSize.height);
     
     CGSize messageSize = [_messageLabel.text boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX) options:NSStringDrawingUsesLineFragmentOrigin attributes:@{NSFontAttributeName: _messageLabel.font} context:nil].size;
-    _messageLabel.frame = CGRectMake(messagePadding, CGRectGetMaxY(_titleLabel.frame) + 8.0, width - messagePadding, messageSize.height);
+    _messageLabel.frame = CGRectMake(0.0f, CGRectGetMaxY(_titleLabel.frame) + 8.0, width, messageSize.height);
     
     [_button sizeToFit];
     CGSize buttonSize = _button.frame.size;
@@ -94,7 +93,7 @@
     _titleLabel.numberOfLines = 0;
     [self setTitleText:titleText];
     [self addSubview:_titleLabel];
-    
+
     // Setup message text
     _messageLabel = [[UILabel alloc] init];
     _messageLabel.font = [UIFont fontWithName:@"OpenSans" size:14.0];
@@ -103,7 +102,7 @@
     _messageLabel.numberOfLines = 0;
     _messageLabel.textAlignment = NSTextAlignmentCenter;
     [self addSubview:_messageLabel];
-    
+
     // Setup button
     if (buttonTitle.length > 0) {
         _button = [UIButton buttonWithType:UIButtonTypeCustom];
@@ -129,8 +128,6 @@
         
         [self addSubview:_button];
     }
-    
-    
     
     // Register for orientation changes
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationDidChange:) name:UIDeviceOrientationDidChangeNotification object:nil];


### PR DESCRIPTION
Fixes #1003 

After: 
![ios simulator screen shot jan 3 2014 10 05 14 am](https://f.cloud.github.com/assets/1435271/1840352/dd3755f6-7490-11e3-883b-9ff176f5976c.png)
