### PR TITLE
Make sure the width of the postView matches its superview.

### DIFF
--- a/WordPress/Classes/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ReaderPostDetailViewController.m
@@ -881,6 +881,14 @@ typedef enum {
         postCell.selectionStyle = UITableViewCellSelectionStyleNone;
         [postCell.contentView addSubview:self.postView];
         
+        // Make the postView matches the width of its cell.
+        // When the postView is first created it matches the width of the tableView
+        // which may or may not be the same width as the cells when we get to this point.
+        // On the iPhone, when viewing in landscape orientation, there can be a 20px difference.
+        CGRect frame = self.postView.frame;
+        frame.size.width = postCell.frame.size.width;
+        self.postView.frame = frame;
+        
         return postCell;
     }
     


### PR DESCRIPTION
Fixes #1001 

On the iPhone, when `[ReaderPostDetailViewController viewDidLoad]` runs in landscape orientation, `self.view.frame.size.width` has a value of 300, and this is what the `postView` starts with. The first time `[ReaderPostDetailViewController tableView: cellForRowAtIndexPath:]` runs in landscape orientation, `postCell.frame.size.width` is 320, giving us a deficit of 20px. 
Weird, eh? 
