### PR TITLE
Sets the image picker navbar to blue.

### DIFF
--- a/WordPress/Classes/PostMediaViewController.m
+++ b/WordPress/Classes/PostMediaViewController.m
@@ -337,10 +337,16 @@
 	DDLogVerbose(@"scaling and rotating image...");
 }
 
+- (void)resetStatusBarColor {
+    // On iOS7 Beta 6 the image picker seems to override our preferred setting so we force the status bar color back.
+    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
+}
+
 #pragma mark -
 #pragma mark UIPopover Delegate Methods
 
 - (void)popoverControllerDidDismissPopover:(UIPopoverController *)popoverController {
+    [self resetStatusBarColor]; // incase the popover is dismissed after the image picker is presented.
     _addPopover.delegate = nil;
     _addPopover = nil;
 }
@@ -487,6 +493,7 @@
     _picker.navigationBar.translucent = NO;
 	_picker.delegate = self;
 	_picker.allowsEditing = NO;
+    _picker.navigationBar.barStyle = UIBarStyleBlack;
     return _picker;
 }
 
@@ -837,8 +844,7 @@
 }
 
 - (void)imagePickerController:(UIImagePickerController *)thePicker didFinishPickingMediaWithInfo:(NSDictionary *)info {
-    // On iOS7 Beta 6 the image picker seems to override our preferred setting so we force the status bar color back.
-    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
+    [self resetStatusBarColor];
 
 	if([[info valueForKey:@"UIImagePickerControllerMediaType"] isEqualToString:@"public.movie"]) {
 		self.currentVideo = [info mutableCopy];

--- a/WordPress/Classes/PostSettingsViewController.m
+++ b/WordPress/Classes/PostSettingsViewController.m
@@ -1860,6 +1860,7 @@ static NSString *const RemoveGeotagCellIdentifier = @"RemoveGeotagCellIdentifier
 	picker.allowsEditing = NO;
     picker.navigationBar.translucent = NO;
     picker.modalPresentationStyle = UIModalPresentationCurrentContext;
+    picker.navigationBar.barStyle = UIBarStyleBlack;
     
     if (IS_IPAD) {
         self.popover = [[UIPopoverController alloc] initWithContentViewController:picker];


### PR DESCRIPTION
Fixes #1019 
Also makes sure the status bar color doesn't stay black if the popover is dismissed by a tap. 

After:
![ios simulator screen shot jan 7 2014 10 03 18 am](https://f.cloud.github.com/assets/1435271/1860555/4b9ebdd2-77b5-11e3-9642-c65c892fa2fc.png)
