### PR TITLE
Use correct width for section headers when displayed in a modal window.

### DIFF
--- a/WordPress/Classes/WPTableViewSectionHeaderView.m
+++ b/WordPress/Classes/WPTableViewSectionHeaderView.m
@@ -50,7 +50,10 @@ CGFloat const WPTableViewSectionHeaderViewBottomVerticalPadding = 8.0;
 {
     [super layoutSubviews];
     
-    CGFloat width = self.fixedWidth > 0 ? self.fixedWidth : CGRectGetWidth(self.superview.frame);
+    CGFloat width = CGRectGetWidth(self.superview.frame);
+    if (self.fixedWidth > 0) {
+        width = MIN(self.fixedWidth, width);
+    }
     CGSize titleSize = [[self class] sizeForTitle:_titleLabel.text andWidth:CGRectGetWidth(self.bounds)];
     _titleLabel.frame = CGRectIntegral(CGRectMake(WPTableViewSectionHeaderViewStandardOffset + (CGRectGetWidth(self.superview.frame) - width) / 2.0, WPTableViewSectionHeaderViewTopVerticalPadding, width, titleSize.height));
 }


### PR DESCRIPTION
Fixes #1035 

![img_0106](https://f.cloud.github.com/assets/1435271/1883249/6c6ae368-7983-11e3-80a0-9826c95f8401.PNG)
