### PR TITLE
Blog picker popover has the right header color and shows its title.

### DIFF
--- a/WordPress/Classes/BlogSelectorViewController.m
+++ b/WordPress/Classes/BlogSelectorViewController.m
@@ -54,19 +54,23 @@ static CGFloat const blavatarImageSize = 50.f;
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    UIBarButtonItem *cancelButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
-                                                                                      target:self
-                                                                                      action:@selector(cancelButtonTapped:)];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(wordPressComAccountChanged)
+                                                 name:WPAccountDefaultWordPressComAccountChangedNotification
+                                               object:nil];
     
-    self.navigationItem.leftBarButtonItem = cancelButtonItem;
-    
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(wordPressComAccountChanged) name:WPAccountDefaultWordPressComAccountChangedNotification object:nil];
-    
-    // Remove one-pixel gap resulting from a top-aligned grouped table view
     if (IS_IPHONE) {
+        // Remove one-pixel gap resulting from a top-aligned grouped table view
         UIEdgeInsets tableInset = [self.tableView contentInset];
         tableInset.top = -1;
         self.tableView.contentInset = tableInset;
+        
+        // Cancel button
+        UIBarButtonItem *cancelButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
+                                                                                          target:self
+                                                                                          action:@selector(cancelButtonTapped:)];
+        
+        self.navigationItem.leftBarButtonItem = cancelButtonItem;
     }
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];

--- a/WordPress/Classes/EditPostViewController.m
+++ b/WordPress/Classes/EditPostViewController.m
@@ -583,20 +583,23 @@ CGFloat const EPVCTextViewTopPadding = 7.0f;
                                                                                    selectedCompletion:selectedCompletion
                                                                                      cancelCompletion:dismissHandler];
     vc.title = NSLocalizedString(@"Select Blog", @"");
+
+    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];
+    navController.navigationBar.translucent = NO;
+    navController.navigationBar.barStyle = UIBarStyleBlack;
     
     if (IS_IPAD) {
         vc.preferredContentSize = CGSizeMake(320.0, 500);
         
         CGRect titleRect = self.navigationItem.titleView.frame;
         titleRect = [self.navigationController.view convertRect:titleRect fromView:self.navigationItem.titleView.superview];
-        
-        self.blogSelectorPopover = [[UIPopoverController alloc] initWithContentViewController:vc];
+
+        self.blogSelectorPopover = [[UIPopoverController alloc] initWithContentViewController:navController];
         self.blogSelectorPopover.backgroundColor = [WPStyleGuide newKidOnTheBlockBlue];
         self.blogSelectorPopover.delegate = self;
         [self.blogSelectorPopover presentPopoverFromRect:titleRect inView:self.navigationController.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+
     } else {
-        UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];
-        navController.navigationBar.translucent = NO;
         navController.modalPresentationStyle = UIModalPresentationPageSheet;
         navController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
         


### PR DESCRIPTION
Fixes #1102 
The grey we were seeing is actually the background of the BlogSelectorViewController.
I'm changing it up so the picker displays a UINavigationController who's root vc is the BlogSelectorViewController.  This way we get the right color + the title which wasn't previously being displayed. 

After:
![ios simulator screen shot jan 31 2014 5 19 00 pm](https://f.cloud.github.com/assets/1435271/2055939/1dcecc4a-8ace-11e3-95d5-f23560f39ab6.png)
