### PR TITLE
ReaderPost now shows sortDate for Freshly Pressed posts

### DIFF
--- a/WordPress/Classes/ReaderPost.h
+++ b/WordPress/Classes/ReaderPost.h
@@ -117,18 +117,13 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 - (void)reblogPostToSite:(id)site note:(NSString *)note success:(void (^)())success failure:(void (^)(NSError *error))failure;
 
 
-- (NSString *)prettyDateString;
-
 - (BOOL)isFollowable;
 
 - (BOOL)isFreshlyPressed;
 
-
 - (BOOL)isBlogsIFollow;
 
-
 - (BOOL)isPrivate;
-
 
 - (BOOL)isWPCom;
 

--- a/WordPress/Classes/ReaderPost.m
+++ b/WordPress/Classes/ReaderPost.m
@@ -606,22 +606,6 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
 	}];
 }
 
-
-- (NSString *)prettyDateString {
-	NSDate *date = [self isFreshlyPressed] ? self.sortDate : self.date_created_gmt;
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-	NSTimeInterval diff = [[NSDate date] timeIntervalSinceDate:date];
-    if (diff < 86400) {
-        formatter.dateStyle = NSDateFormatterNoStyle;
-        formatter.timeStyle = NSDateFormatterShortStyle;
-    } else {
-        formatter.dateStyle = NSDateFormatterShortStyle;
-        formatter.timeStyle = NSDateFormatterNoStyle;
-    }
-    formatter.doesRelativeDateFormatting = YES;
-    return [formatter stringFromDate:date];
-}
-
 - (BOOL)isFollowable {
     return self.siteID != nil;
 }
@@ -879,5 +863,18 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
                            }
 					   }];
 }
+
+#pragma mark - WPContentViewProvider protocol
+
+- (NSDate *)dateForDisplay {
+    BOOL isFreshlyPressed = [self isFreshlyPressed];
+    
+    if (isFreshlyPressed) {
+        return [self sortDate];
+    }
+    
+    return [self dateCreated];
+}
+
 
 @end


### PR DESCRIPTION
Fixes #1081 

ReaderPost was not fully set up with the new WPContentViewProvider delegate method to account for Freshly Pressed.
