### PR TITLE
State preservation requires controllers to be set on UIWindow in willFinishLaunchingWithOptions

### DIFF
--- a/WordPress/Classes/WordPressAppDelegate.m
+++ b/WordPress/Classes/WordPressAppDelegate.m
@@ -118,6 +118,12 @@ static NSString *const CameraPlusImagesNotification = @"CameraPlusImagesNotifica
         [self cleanUnusedMediaFileFromTmpDir];
     });
     
+    CGRect bounds = [[UIScreen mainScreen] bounds];
+    [self.window setFrame:bounds];
+    [self.window setBounds:bounds]; // for good measure.
+    self.window.backgroundColor = [UIColor blackColor];
+    self.window.rootViewController = self.tabBarController;
+    
     return YES;
 }
 
@@ -129,12 +135,6 @@ static NSString *const CameraPlusImagesNotification = @"CameraPlusImagesNotifica
         [NotificationsManager handleNotificationForApplicationLaunch:launchOptions];
     }
 
-    CGRect bounds = [[UIScreen mainScreen] bounds];
-    [self.window setFrame:bounds];
-    [self.window setBounds:bounds]; // for good measure.
-    
-    self.window.backgroundColor = [UIColor blackColor];
-    self.window.rootViewController = self.tabBarController;
     [self.window makeKeyAndVisible];
     
     [self showWelcomeScreenIfNeededAnimated:NO];


### PR DESCRIPTION
Fixes #1132 

When I was fixing notifications I didn’t realize moving to didFinishLaunchingWithOptions would break state preservation.  All back :).
