### PR TITLE
#1154 - Nil check on image after successful avatar download

### DIFF
--- a/WordPress/Classes/WPAvatarSource.m
+++ b/WordPress/Classes/WPAvatarSource.m
@@ -115,8 +115,12 @@ static NSString *const GravatarBaseUrl = @"http://gravatar.com";
     CGSize maxSize = [self maxSizeForType:type];
     [[WPImageSource sharedSource] downloadImageForURL:url
                                           withSuccess:^(UIImage *image) {
-                                              [self setCachedImage:image forHash:hash type:type size:maxSize];
-                                              [self processImage:image forHash:hash type:type size:size success:success];
+                                              if (image != nil) {
+                                                  [self setCachedImage:image forHash:hash type:type size:maxSize];
+                                                  [self processImage:image forHash:hash type:type size:size success:success];
+                                              } else if (success) {
+                                                  success(nil);
+                                              }
                                           } failure:^(NSError *error) {
                                               if (success) {
                                                   success(nil);


### PR DESCRIPTION
#1154

Nil check on image after successful avatar download to prevent app from crashing.
