### PR TITLE
Don't save push settings if settings are nil

### DIFF
--- a/WordPress/Classes/NotificationsManager.h
+++ b/WordPress/Classes/NotificationsManager.h
@@ -12,6 +12,8 @@
  */
 extern NSString *const NotificationsDeviceToken;
 
+extern NSString *const NotificationsDeviceToken;
+
 @interface NotificationsManager : NSObject
 
 ///--------------------------------


### PR DESCRIPTION
Fixes #1153 

There is probably a bigger underlying issue with push settings being nil (lost credentials) but this method should be a bit more robust.
