### PR TITLE
Set the merge policy to not throw an error if there is a conflict

### DIFF
--- a/WordPress/Classes/ContextManager.m
+++ b/WordPress/Classes/ContextManager.m
@@ -40,6 +40,7 @@ static ContextManager *instance;
 - (NSManagedObjectContext *const)newDerivedContext {
     NSManagedObjectContext *derived = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
     derived.parentContext = self.mainContext;
+    derived.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
     return derived;
 }
 
@@ -49,6 +50,7 @@ static ContextManager *instance;
     }
     _mainContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
     _mainContext.persistentStoreCoordinator = [self persistentStoreCoordinator];
+    _mainContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(mergeChangesIntoBackgroundContext:) name:NSManagedObjectContextDidSaveNotification object:_mainContext];
     return _mainContext;


### PR DESCRIPTION
Fixes #1182 

Continue to use NSMergeByPropertyObjectTrumpMergePolicy in every context.  Need to test heavily and try to reproduce the merging.
