### PR TITLE
Listen for WP default account changes and refresh blogs accordingly

### DIFF
--- a/WordPress/Classes/ReaderPostsViewController.m
+++ b/WordPress/Classes/ReaderPostsViewController.m
@@ -968,7 +968,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
     authToken = account.authToken;
     
     WPXMLRPCClient *api = [WPXMLRPCClient clientWithXMLRPCEndpoint:xmlrpc];
-    [api setAuthorizationHeaderWithToken:[[[WPAccount defaultWordPressComAccount] restApi] authToken]];
+    [api setAuthorizationHeaderWithToken:authToken];
     [api callMethod:@"wp.getUsersBlogs"
          parameters:[NSArray arrayWithObjects:username, password, nil]
             success:^(AFHTTPRequestOperation *operation, id responseObject) {


### PR DESCRIPTION
Fixes #1174 

Blog list for reader is now refetched after WP default account changes.  This is a temporary solution - the Reader should be using Core Data and not that NSUserDefaults array.
