### PR TITLE
Discard the transient noteData property when Note is faulted

### DIFF
--- a/WordPress/Classes/Note.m
+++ b/WordPress/Classes/Note.m
@@ -212,6 +212,12 @@ const NSUInteger NoteKeepCount = 20;
     return _noteData;
 }
 
+#pragma mark - NSManagedObject methods
+
+- (void)didTurnIntoFault {
+    _noteData = nil;
+}
+
 #pragma mark - Comment HTML parsing
 
 /*


### PR DESCRIPTION
Fixes #1098 #1198 
Related #1151 

_noteData is a transient property that should be set to nil when the NSManagedObject "Note" is faulted.  This prevents stale data from being kept around.  The nil check for initialization in the overridden property getter was the culprit.
