### PR TITLE
Fixes 1069: Make content in "Make a Link" screen narrower on iPad

### DIFF
--- a/WordPress/Classes/WPAlertView.m
+++ b/WordPress/Classes/WPAlertView.m
@@ -24,12 +24,14 @@
 @property (nonatomic, weak) IBOutlet WPNUXSecondaryButton *leftButton;
 @property (nonatomic, weak) IBOutlet WPNUXPrimaryButton *rightButton;
 @property (nonatomic, strong) NSLayoutConstraint *originalFirstTextFieldConstraint;
+@property (nonatomic, weak) IBOutlet NSLayoutConstraint *firstTextFieldLabelWidthConstraint;
 
 @end
 
 @implementation WPAlertView
 
 CGFloat const WPAlertViewStandardOffset = 16.0;
+CGFloat const WPAlertViewDefaultTextFieldLabelWidth = 118.0f;
 
 - (void)dealloc
 {
@@ -64,9 +66,25 @@ CGFloat const WPAlertViewStandardOffset = 16.0;
             backgroundView = [[NSBundle mainBundle] loadNibNamed:@"WPAlertView" owner:self options:nil][0];
         }
         
-        backgroundView.frame = scrollView.frame;
-        backgroundView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        if (IS_IPAD) {
+            CGFloat backgroundViewWidth = CGRectGetWidth(scrollView.frame) / 2.0f;
+            CGFloat backgroundViewHeight = CGRectGetHeight(scrollView.frame) / 2.0f;
+            CGFloat backgroundViewX = CGRectGetMidX(scrollView.frame) / 2.0f;
+            CGFloat backgroundViewY = CGRectGetMidY(scrollView.frame) / 4.0f;
+            backgroundView.frame = CGRectMake(backgroundViewX,
+                                              backgroundViewY,
+                                              backgroundViewWidth,
+                                              backgroundViewHeight);
+            backgroundView.autoresizingMask = UIViewAutoresizingFlexibleHeight |
+                                              UIViewAutoresizingFlexibleLeftMargin |
+                                              UIViewAutoresizingFlexibleRightMargin;
+        } else {
+            backgroundView.frame = scrollView.frame;
+            backgroundView.autoresizingMask = UIViewAutoresizingFlexibleWidth |
+                                              UIViewAutoresizingFlexibleHeight;
+        }
         
+        [self adjustTextFieldLabelWidths];
         [scrollView addSubview:backgroundView];
         
         [self configureView];
@@ -146,6 +164,7 @@ CGFloat const WPAlertViewStandardOffset = 16.0;
     if (![_firstTextFieldLabelText isEqualToString:firstTextFieldLabelText]) {
         _firstTextFieldLabelText = firstTextFieldLabelText;
         _firstTextFieldLabel.text = _firstTextFieldLabelText;
+        [self adjustTextFieldLabelWidths];
         [self setNeedsUpdateConstraints];
     }
 }
@@ -173,6 +192,7 @@ CGFloat const WPAlertViewStandardOffset = 16.0;
     if (![_secondTextFieldLabelText isEqualToString:secondTextFieldLabelText]) {
         _secondTextFieldLabelText = secondTextFieldLabelText;
         _secondTextFieldLabel.text = _secondTextFieldLabelText;
+        [self adjustTextFieldLabelWidths];
         [self setNeedsUpdateConstraints];
     }
 }
@@ -380,6 +400,13 @@ CGFloat const WPAlertViewStandardOffset = 16.0;
     }
 }
 
+- (void)adjustTextFieldLabelWidths {
+    if (_firstTextFieldLabel.text.length == 0 && _secondTextFieldLabel.text.length == 0) {
+        _firstTextFieldLabelWidthConstraint.constant = 0.0f;
+    } else {
+        _firstTextFieldLabelWidthConstraint.constant = WPAlertViewDefaultTextFieldLabelWidth;
+    }
+}
 
 - (void)tappedOnView:(UITapGestureRecognizer *)gestureRecognizer
 {

--- a/WordPress/Classes/WPAlertView.xib
+++ b/WordPress/Classes/WPAlertView.xib
@@ -12,6 +12,7 @@
                 <outlet property="descriptionLabel" destination="jUH-h8-t6N" id="65h-hP-Zbi"/>
                 <outlet property="firstTextField" destination="QOp-w7-qQW" id="1RL-Eg-nY8"/>
                 <outlet property="firstTextFieldLabel" destination="his-1i-AHr" id="dtj-ta-o07"/>
+                <outlet property="firstTextFieldLabelWidthConstraint" destination="Zcn-mR-zzn" id="1vu-aM-mhF"/>
                 <outlet property="leftButton" destination="jIS-Eo-CLW" id="CF0-Sc-Ild"/>
                 <outlet property="rightButton" destination="sbI-dd-DIb" id="3lD-v5-GoT"/>
                 <outlet property="secondTextField" destination="Fqb-fm-JFc" id="ztH-Jz-XPo"/>


### PR DESCRIPTION
Fixes #1069 
In WPAlertView, if the device is an iPad, adjust the backgroundView's frame and autoresizingMask. If the device is an iPhone/iPod touch the backgroundView setup logic will function as it did previously. Some screen shots of the end result: 

![link_fixed_portrait](https://f.cloud.github.com/assets/154014/2211079/1f4e95fa-99a1-11e3-8c77-4515b6875fe6.png)
![link_fixed_landscape](https://f.cloud.github.com/assets/154014/2211082/296bdda4-99a1-11e3-9444-65272aaefdca.png)

This code also works with the WPAlertView's side-by-side mode:
![link_fixed_landscape2](https://f.cloud.github.com/assets/154014/2211097/4a9be49c-99a1-11e3-8ccb-e8f590fbe098.png)
![link_fixed_portrait2](https://f.cloud.github.com/assets/154014/2211092/4137696c-99a1-11e3-980c-c3a209ae2a82.png)

In addition, I addressed another issue where the UILabels that preceded both text fields are now hidden if both of the labels' text property are blank (this is a "before PR" screenshot FYI):

![link_not_fixed_portrait-2](https://f.cloud.github.com/assets/154014/2211161/11554bdc-99a2-11e3-98de-80f13e031a4e.png)
