### PR TITLE
Added Manage button to Notifications screen

### DIFF
--- a/WordPress/Classes/NotificationsViewController.m
+++ b/WordPress/Classes/NotificationsViewController.m
@@ -18,6 +18,8 @@
 #import "WPAccount.h"
 #import "WPWebViewController.h"
 #import "Note.h"
+#import "NotificationsManager.h"
+#import "NotificationSettingsViewController.h"
 
 NSString * const NotificationsLastSyncDateKey = @"NotificationsLastSyncDate";
 NSString * const NotificationsJetpackInformationURL = @"http://jetpack.me/about/";
@@ -101,6 +103,14 @@ NSString * const NotificationsJetpackInformationURL = @"http://jetpack.me/about/
     
     self.tableView.separatorInset = UIEdgeInsetsMake(0, 25, 0, 0);
     self.infiniteScrollEnabled = YES;
+    
+    if ([NotificationsManager deviceRegisteredForPushNotifications]) {
+        UIBarButtonItem *pushSettings = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Manage", @"")
+                                                                         style:UIBarButtonItemStylePlain
+                                                                        target:self
+                                                                        action:@selector(showNotificationSettings)];
+        self.navigationItem.rightBarButtonItem = pushSettings;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -169,6 +179,24 @@ NSString * const NotificationsJetpackInformationURL = @"http://jetpack.me/about/
         }
     }
     [Note pruneOldNotesBefore:pruneBefore withContext:self.resultsController.managedObjectContext];
+}
+
+- (void)showNotificationSettings {
+    [WPMobileStats trackEventForWPCom:StatsEventNotificationsClickedManageNotifications];
+    
+    NotificationSettingsViewController *notificationSettingsViewController = [[NotificationSettingsViewController alloc] initWithStyle:UITableViewStyleGrouped];
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:notificationSettingsViewController];
+    navigationController.navigationBar.translucent = NO;
+    navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
+    
+    UIBarButtonItem *closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(closeNotificationSettings)];
+    notificationSettingsViewController.navigationItem.rightBarButtonItem = closeButton;
+    
+    [self presentViewController:navigationController animated:YES completion:nil];
+}
+
+- (void)closeNotificationSettings {
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - Public methods

--- a/WordPress/Classes/WPMobileStats.h
+++ b/WordPress/Classes/WPMobileStats.h
@@ -60,6 +60,7 @@ extern NSString *const StatsEventWebviewSentArticleToGooglePlus;
 // Notifications
 extern NSString *const StatsPropertyNotificationsOpened;
 extern NSString *const StatsPropertyNotificationsOpenedDetails;
+extern NSString *const StatsEventNotificationsClickedManageNotifications;
 
 // Notifications Detail
 extern NSString *const StatsEventNotificationsDetailClickedReplyButton;

--- a/WordPress/Classes/WPMobileStats.m
+++ b/WordPress/Classes/WPMobileStats.m
@@ -73,6 +73,7 @@ NSString *const StatsEventWebviewSentArticleToGooglePlus = @"Sent Article to Goo
 // Notifications
 NSString *const StatsPropertyNotificationsOpened = @"notifications_opened";
 NSString *const StatsPropertyNotificationsOpenedDetails = @"notifications_opened_details";
+NSString *const StatsEventNotificationsClickedManageNotifications = @"Notifications - Manage Button";
 
 // Notifications Detail
 NSString *const StatsEventNotificationsDetailClickedReplyButton = @"Notifications Detail - Clicked Reply Button";


### PR DESCRIPTION
Fixes #1167 

Added a "Manage" button to the top of the Notifications window to get right to the settings for push notifications.

![img_0001](https://f.cloud.github.com/assets/373903/2224720/683de590-9a82-11e3-971c-bd0ca5db4d82.PNG)

![img_0042](https://f.cloud.github.com/assets/373903/2224734/8a1697fc-9a82-11e3-9f27-c48a9853c339.PNG)
