### PR TITLE
Corrected logic used to find a Blog based upon a stats notification

### DIFF
--- a/WordPress/Classes/Note.m
+++ b/WordPress/Classes/Note.m
@@ -190,11 +190,37 @@ const NSUInteger NoteKeepCount = 20;
 }
 
 - (Blog *)blogForStatsEvent {
-    NSSet *blogs = [WPAccount defaultWordPressComAccount].blogs;
-    blogs = [blogs filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"%@ CONTAINS[cd] self.blogName", self.subject]];
-    if (blogs.count) {
-        return [blogs anyObject];
+    NSScanner *scanner = [NSScanner scannerWithString:self.subject];
+    NSString *blogName;
+    
+    while ([scanner isAtEnd] == NO) {
+        [scanner scanUpToString:@"\"" intoString:NULL];
+        [scanner scanString:@"\"" intoString:NULL];
+        [scanner scanUpToString:@"\"" intoString:&blogName];
+        [scanner scanString:@"\"" intoString:NULL];
     }
+
+    NSPredicate *subjectPredicate = [NSPredicate predicateWithFormat:@"self.blogName CONTAINS[cd] %@", blogName];
+    NSPredicate *wpcomPredicate = [NSPredicate predicateWithFormat:@"self.account.isWpcom == YES"];
+    NSPredicate *jetpackPredicate = [NSPredicate predicateWithFormat:@"self.jetpackAccount != nil"];
+    NSPredicate *statsBlogsPredicate = [NSCompoundPredicate orPredicateWithSubpredicates:@[wpcomPredicate, jetpackPredicate]];
+    NSPredicate *combinedPredicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[subjectPredicate, statsBlogsPredicate]];
+
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Blog"];
+    fetchRequest.predicate = combinedPredicate;
+    
+    NSError *error = nil;
+    NSArray *blogs = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
+    
+    if (error) {
+        DDLogError(@"Error while retrieving blogs with stats: %@", error);
+        return nil;
+    }
+
+    if (blogs.count > 0) {
+        return [blogs firstObject];
+    }
+    
     return nil;
 }
 

--- a/WordPress/Classes/NotificationsViewController.m
+++ b/WordPress/Classes/NotificationsViewController.m
@@ -267,8 +267,11 @@ NSString * const NotificationsJetpackInformationURL = @"http://jetpack.me/about/
     
     Note *note = [self.resultsController objectAtIndexPath:indexPath];
     BOOL hasDetailsView = [self noteHasDetailView:note];
-    if (!hasDetailsView) {
+    BOOL isStatsNote = [note statsEvent];
+    
+    if (!hasDetailsView && !isStatsNote) {
         cell.accessoryType = UITableViewCellAccessoryNone;
+        cell.selectionStyle = UITableViewCellSelectionStyleNone;
     }
 }
 

--- a/WordPress/Classes/WPContentCell.m
+++ b/WordPress/Classes/WPContentCell.m
@@ -98,6 +98,7 @@ CGFloat const WPContentCellDateImageSide = 16.0;
     _gravatarImageView.image = nil;
     _unreadView.hidden = YES;
 	self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    self.selectionStyle = UITableViewCellSelectionStyleDefault;
 }
 
 - (void)layoutSubviews


### PR DESCRIPTION
Fixes #1051 

NSPredicate used to filter set of blogs was incorrect.  The fact that Notes don't have an associated blog ID or something alike is making this logic very crappy.  I'm not even sure this logic will work in other languages, especially ones that use different diacritics for quotations - «like these».  

In any case, this matches the NSScanner logic used inside of `NewNotificationsTableViewCell` to find the blog name.  The one downfall to this method is that Notes for stats for Jetpack blogs not set up on the device will still appear tappable but will not bring up the stats.  An error message at some point would be useful but hopefully with the upcoming changes to Notes this will not be an issue.  The query to find the blog by name is not cheap and would make the table stutter something fierce just to turn on & off the accessory.
