### PR TITLE
Date format for week labels based on LLL dd rather than Week dd

### DIFF
--- a/WordPress/Classes/StatsViewsVisitors.m
+++ b/WordPress/Classes/StatsViewsVisitors.m
@@ -70,9 +70,13 @@ NSString *const StatsPointCountKey = @"count";
             return [self.dateFormatter stringFromDate:d];
         }
         case StatsViewsVisitorsUnitWeek:
-            // Assumes format: yyyyWxx where xx is the week number with leading zero
-            return [NSLocalizedString(@"Week", @"Stats 'nice' name prefix for week unit")
-                    stringByAppendingFormat:@" %@",[name substringWithRange:NSMakeRange(name.length-2, 2)]];
+        {
+            // Assumes format: yyyyWxxWxx first xx is month, second xx is first day of that week
+            self.dateFormatter.dateFormat = @"yyyy'W'MM'W'dd";
+            NSDate *d = [self.dateFormatter dateFromString:name];
+            self.dateFormatter.dateFormat = @"LLL dd";
+            return [self.dateFormatter stringFromDate:d];
+        }
         case StatsViewsVisitorsUnitMonth:
         {
             self.dateFormatter.dateFormat = @"yyyy-MM-dd";


### PR DESCRIPTION
Fixes #1227 

Matches WordPress.com stats page - should be fine localized as well since I am using a NSDateFormatter.

Before and After
![2014-02-25_09-38-12](https://f.cloud.github.com/assets/373903/2259239/3ae6c922-9e33-11e3-988f-d56cec0f5cba.png)

WordPress.com Stats
![2014-02-25_09-38-05](https://f.cloud.github.com/assets/373903/2259242/3fe8d988-9e33-11e3-83bf-dc32d25e3fe5.png)
