### PR TITLE
Matched stats colors from WordPress.com

### DIFF
--- a/WordPress/Classes/StatsViewsVisitorsBarGraphCell.m
+++ b/WordPress/Classes/StatsViewsVisitorsBarGraphCell.m
@@ -247,8 +247,8 @@ CGFloat heightFromRangeToRange(NSUInteger height, CGFloat maxOldRange, CGFloat m
     NSDictionary *categoryData = [_viewsVisitorsData viewsVisitorsForUnit:_currentUnit];
     WPBarGraphView *barGraph = [[WPBarGraphView alloc] initWithFrame:self.bounds];
     self.barGraph = barGraph;
-    [self.barGraph addCategory:StatsViewsCategory color:[WPStyleGuide baseLighterBlue]];
-    [self.barGraph addCategory:StatsVisitorsCategory color:[WPStyleGuide midnightBlue]];
+    [self.barGraph addCategory:StatsViewsCategory color:[WPStyleGuide statsLighterBlue]];
+    [self.barGraph addCategory:StatsVisitorsCategory color:[WPStyleGuide statsDarkerBlue]];
     if (categoryData) {
         [self.barGraph setBarsWithCount:categoryData[StatsViewsCategory] forCategory:StatsViewsCategory];
         [self.barGraph setBarsWithCount:categoryData[StatsVisitorsCategory] forCategory:StatsVisitorsCategory];

--- a/WordPress/Classes/WPStyleGuide.h
+++ b/WordPress/Classes/WPStyleGuide.h
@@ -51,6 +51,8 @@
 + (UIColor *)darkAsNightGrey;
 + (UIColor *)textFieldPlaceholderGrey;
 + (UIColor *)validationErrorRed;
++ (UIColor *)statsLighterBlue;
++ (UIColor *)statsDarkerBlue;
 
 + (UIColor *)tableViewActionColor;
 + (UIColor *)buttonActionColor;

--- a/WordPress/Classes/WPStyleGuide.m
+++ b/WordPress/Classes/WPStyleGuide.m
@@ -242,6 +242,14 @@
     return [WPStyleGuide baseLighterBlue];
 }
 
++ (UIColor *)statsLighterBlue {
+    return [UIColor colorWithRed:143.0f/255.0f green:186.0f/255.0f blue:203.0f/255.0f alpha:1.0f];
+}
+
++ (UIColor *)statsDarkerBlue {
+    return [UIColor colorWithRed:25.0f/255.0f green:88.0f/255.0f blue:137.0f/255.0f alpha:1.0f];
+}
+
 + (UIColor *)keyboardColor {
     if (IS_IPAD) {
         return [UIColor colorWithRed:207.0f/255.0f green:210.0f/255.0f blue:213.0f/255.0f alpha:1.0];


### PR DESCRIPTION
Fixes #1226 

Before and After
![issue1226](https://f.cloud.github.com/assets/373903/2259608/0d58f8b4-9e37-11e3-9576-2adabd022c78.png)

WordPress.com example:

![2014-02-25_09-38-05](https://f.cloud.github.com/assets/373903/2259613/20f976be-9e37-11e3-82a0-c17ff3dde29a.png)
