### PR TITLE
Only reload today/yesterday sections when segmented control changes

### DIFF
--- a/WordPress/Classes/StatsViewController.m
+++ b/WordPress/Classes/StatsViewController.m
@@ -612,9 +612,14 @@ typedef NS_ENUM(NSInteger, TotalFollowersShareRow) {
 #pragma mark - StatsTodayYesterdayButtonCellDelegate
 
 - (void)statsDayChangedForSection:(StatsSection)section todaySelected:(BOOL)todaySelected {
-    [_showingToday setObject:@(todaySelected) forKey:@(section)];
-    [_expandedLinkGroups removeAllObjects];
-    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:section] withRowAnimation:UITableViewRowAnimationFade];
+    BOOL todayCurrentlySelected = [self.showingToday[@(section)] boolValue];
+    
+    // Only reload section if the selection changed
+    if (todayCurrentlySelected != todaySelected) {
+        [self.showingToday setObject:@(todaySelected) forKey:@(section)];
+        [self.expandedLinkGroups removeAllObjects];
+        [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:section] withRowAnimation:UITableViewRowAnimationFade];
+    }
 }
 
 


### PR DESCRIPTION
Fixes #1221 

Compare the previous value (today or yesterday) to the new value and only update the table section if the value is changing.
