### PR TITLE
Restore category parent comparision to check int values since the number...

### DIFF
--- a/WordPress/Classes/WPCategoryTree.m
+++ b/WordPress/Classes/WPCategoryTree.m
@@ -23,7 +23,8 @@
     for (NSUInteger i = 0; i < count; i++) {
         Category *category = [collection objectAtIndex:i];
 
-        if ([category.parentID isEqualToNumber:self.parent.categoryID]) {
+        // self.parent can be nil, so compare int values to avoid badness
+        if ([category.parentID intValue] == [self.parent.categoryID intValue]) {
             WPCategoryTree *child = [[WPCategoryTree alloc] initWithParent:category];
             [child getChildrenFromObjects:collection];
             [self.children addObject:child];


### PR DESCRIPTION
... can be nil.
Fixes #1261 
