### PR TITLE
Fixing typo with StatsSummary variable name.

### DIFF
--- a/WordPress/Classes/StatsSummary.h
+++ b/WordPress/Classes/StatsSummary.h
@@ -9,7 +9,7 @@
 
 @interface StatsSummary : NSObject
 
-@property (nonatomic, strong) NSNumber *totalCatagories;
+@property (nonatomic, strong) NSNumber *totalCategories;
 @property (nonatomic, strong) NSNumber *totalComments;
 @property (nonatomic, strong) NSNumber *totalFollowersBlog;
 @property (nonatomic, strong) NSNumber *totalFollowersComments;

--- a/WordPress/Classes/StatsSummary.m
+++ b/WordPress/Classes/StatsSummary.m
@@ -15,7 +15,7 @@
     self = [super init];
     if (self) {
         NSDictionary *stats = summary[@"stats"];
-        self.totalCatagories = stats[@"categories"];
+        self.totalCategories = stats[@"categories"];
         self.totalComments = stats[@"comments"];
         self.totalFollowersBlog = stats[@"followers_blog"];
         self.totalFollowersComments = stats[@"followers_comments"];

--- a/WordPress/Classes/StatsViewController.m
+++ b/WordPress/Classes/StatsViewController.m
@@ -389,7 +389,7 @@ typedef NS_ENUM(NSInteger, TotalFollowersShareRow) {
             break;
         case TotalFollowersShareRowContentCategoryTag:
             leftLabel = @"Categories";
-            leftCount = summary.totalCatagories;
+            leftCount = summary.totalCategories;
             rightLabel = @"Tags";
             rightCount = summary.totalTags;
             break;


### PR DESCRIPTION
Renamed totalCatagories to totalCategories.
