### PR TITLE
Watch for badge count changes and update tab bar badge count accordingly

### DIFF
--- a/WordPress/Classes/NotificationsManager.m
+++ b/WordPress/Classes/NotificationsManager.m
@@ -87,18 +87,20 @@ NSString *const NotificationsDeviceToken = @"apnsDeviceToken";
 + (void)handleNotification:(NSDictionary *)userInfo forState:(UIApplicationState)state completionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     DDLogVerbose(@"Received push notification:\nPayload: %@\nCurrent Application state: %d", userInfo, state);
     
+    // Try to pull the badge number from the notification object
+    // Badge count does not normally update when the app is active
+    // And this forces KVO to be fired
+    NSDictionary *apsObject = [userInfo dictionaryForKey:@"aps"];
+    if (apsObject) {
+        NSNumber *badgeCount = [apsObject numberForKey:@"badge"];
+        if (badgeCount) {
+            [UIApplication sharedApplication].applicationIconBadgeNumber = [badgeCount intValue];
+        }
+    }
+    
     if ([userInfo stringForKey:@"type"]) { //check if it is the badge reset PN
         NSString *notificationType = [userInfo stringForKey:@"type"];
         if ([notificationType isEqualToString:@"badge-reset"]) {
-            [UIApplication sharedApplication].applicationIconBadgeNumber = 0;
-            //Try to pull the badge number from the notification object
-            NSDictionary *apsObject = [userInfo dictionaryForKey:@"aps"];
-            if (apsObject) {
-                NSNumber *badgeCount = [apsObject numberForKey:@"badge"];
-                if (badgeCount) {
-                    [UIApplication sharedApplication].applicationIconBadgeNumber = [badgeCount intValue];
-                }
-            }
             return;
         }
     }

--- a/WordPress/Classes/NotificationsViewController.m
+++ b/WordPress/Classes/NotificationsViewController.m
@@ -92,6 +92,7 @@ NSString * const NotificationsJetpackInformationURL = @"http://jetpack.me/about/
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [[UIApplication sharedApplication] removeObserver:self forKeyPath:@"applicationIconBadgeNumber"];
 }
 
 - (void)viewDidLoad
@@ -111,6 +112,14 @@ NSString * const NotificationsJetpackInformationURL = @"http://jetpack.me/about/
                                                                         action:@selector(showNotificationSettings)];
         self.navigationItem.rightBarButtonItem = pushSettings;
     }
+    
+    // Watch for application badge number changes
+    UIApplication *application = [UIApplication sharedApplication];
+    [application addObserver:self
+                  forKeyPath:@"applicationIconBadgeNumber"
+                     options:NSKeyValueObservingOptionNew
+                     context:nil];
+    [self updateTabBarBadgeNumber];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -140,8 +149,26 @@ NSString * const NotificationsJetpackInformationURL = @"http://jetpack.me/about/
         [self pruneOldNotes];
 }
 
+#pragma mark - NSObject(NSKeyValueObserving) methods
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context {
+    if ([keyPath isEqualToString:@"applicationIconBadgeNumber"]) {
+        [self updateTabBarBadgeNumber];
+    }
+}
 
 #pragma mark - Custom methods
+
+- (void)updateTabBarBadgeNumber {
+    UIApplication *application = [UIApplication sharedApplication];
+    NSInteger count = application.applicationIconBadgeNumber;
+    
+    NSString *countString = count == 0 ? nil : [NSString stringWithFormat:@"%d", count];
+    self.navigationController.tabBarItem.badgeValue = countString;
+}
 
 - (void)refreshUnreadNotes {
     [Note refreshUnreadNotesWithContext:self.resultsController.managedObjectContext];


### PR DESCRIPTION
Closes #674 

Force badge count to be updated even if the app is active.  Watch for changes in the badge count and update the tab bar item for the notifications view accordingly.

There is a discrepancy between the unread count being pushed and the seen status on push notifications.  Will file an additional issue.  cc: @daniloercoli 
