### PR TITLE
Changed tapping the 'Me' tab behavior for users with a single site.

### DIFF
--- a/WordPress/Classes/BlogListViewController.h
+++ b/WordPress/Classes/BlogListViewController.h
@@ -10,4 +10,7 @@
 
 @interface BlogListViewController : UITableViewController <NSFetchedResultsControllerDelegate, UIDataSourceModelAssociation>
 
+- (void)bypassBlogListViewController;
+- (BOOL)shouldBypassBlogListViewControllerWhenSelectedFromTabBar;
+
 @end

--- a/WordPress/Classes/BlogListViewController.m
+++ b/WordPress/Classes/BlogListViewController.m
@@ -125,6 +125,24 @@ NSString * const WPBlogListRestorationID = @"WPBlogListID";
     return ([[self.resultsController sections] count] > 1);
 }
 
+- (BOOL)shouldBypassBlogListViewControllerWhenSelectedFromTabBar
+{
+    return [self numSites] == 1;
+}
+
+- (void)bypassBlogListViewController
+{
+    if ([self shouldBypassBlogListViewControllerWhenSelectedFromTabBar]) {
+        // We do a delay of 0.0 so that way this doesn't kick off until the next run loop.
+        [self performSelector:@selector(selectFirstSite) withObject:nil afterDelay:0.0];
+    }
+}
+
+- (void)selectFirstSite
+{
+    [self tableView:self.tableView didSelectRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:0]];
+}
+
 
 #pragma mark - Notifications
 

--- a/WordPress/Classes/WordPressAppDelegate.m
+++ b/WordPress/Classes/WordPressAppDelegate.m
@@ -551,6 +551,22 @@ static NSString *const CameraPlusImagesNotification = @"CameraPlusImagesNotifica
             [self showPostTab];
         }
         return NO;
+    } else if ([tabBarController.viewControllers indexOfObject:viewController] == 2) {
+        // If the user has one blog then we don't want to present them with the main "me"
+        // screen where they can see all their blogs. In the case of only one blog just show
+        // the main blog details screen
+
+        // Don't kick of this auto selecting behavior if the user taps the the active tab as it
+        // would break from standard iOS UX
+        if (tabBarController.selectedIndex != 2) {
+            UINavigationController *navController = (UINavigationController *)viewController;
+            BlogListViewController *blogListViewController = (BlogListViewController *)navController.viewControllers[0];
+            if ([blogListViewController shouldBypassBlogListViewControllerWhenSelectedFromTabBar]) {
+                if ([navController.visibleViewController isKindOfClass:[blogListViewController class]]) {
+                    [blogListViewController bypassBlogListViewController];
+                }
+            }
+        }
     }
     return YES;
 }


### PR DESCRIPTION
Modified the tapping of the 'Me' tab to bypass the main blog selection
screen and just show the individual blog details as the vast majority
of our users will only have one blog and adding an extra click is a
bit redundant for them. If the user taps the 'Me' tab while the tab
is currently active it'll pull up the blog list, but if they select
the 'Me' tab while the tab isn't active it'll pull up their blog's
detail screen.

Fixes #1208
