### PR TITLE
Capitalize title when switching reader topics.

### DIFF
--- a/WordPress/Classes/ReaderPostsViewController.m
+++ b/WordPress/Classes/ReaderPostsViewController.m
@@ -902,7 +902,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
     [self syncItems];
 	[self configureNoResultsView];
     
-	self.title = [[ReaderPost currentTopic] stringForKey:@"title"];
+	self.title = [[[ReaderPost currentTopic] stringForKey:@"title"] capitalizedString];
 
     if ([WordPressAppDelegate sharedWordPressApplicationDelegate].connectionAvailable == YES && ![self isSyncing] ) {
 		[[NSUserDefaults standardUserDefaults] removeObjectForKey:ReaderLastSyncDateKey];


### PR DESCRIPTION
Fixes #1291 
