### PR TITLE
Use read/menu instead of read/tags to retrieve tags and lists for Reader

### DIFF
--- a/WordPress/Classes/ReaderPost.h
+++ b/WordPress/Classes/ReaderPost.h
@@ -16,7 +16,7 @@ extern NSInteger const ReaderPostsToSync;
 extern NSString *const ReaderLastSyncDateKey;
 extern NSString *const ReaderCurrentTopicKey;
 extern NSString *const ReaderTopicsArrayKey;
-extern NSString *const ReaderExtrasArrayKey;
+extern NSString *const ReaderListsArrayKey;
 
 
 extern NSString * const ReaderPostStoredCommentIDKey;
@@ -147,10 +147,13 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 @interface ReaderPost (WordPressComApi)
 
 /**
- Gets the list of recommended topics for the Reader.
+ Gets the list of tags & lists for the Reader.
+ 
+ @param success a block called if the REST API call is successful.
+ @param failure a block called if there is any error. `error` can be any underlying network error
  */
-+ (void)getReaderTopicsWithSuccess:(WordPressComApiRestSuccessResponseBlock)success
-						   failure:(WordPressComApiRestSuccessFailureBlock)failure;
++ (void)getReaderMenuItemsWithSuccess:(WordPressComApiRestSuccessResponseBlock)success
+                              failure:(WordPressComApiRestSuccessFailureBlock)failure;
 
 /**
  Gets the list of comments for the specified post, on the specified site.

--- a/WordPress/Classes/ReaderPost.m
+++ b/WordPress/Classes/ReaderPost.m
@@ -23,7 +23,7 @@ NSInteger const ReaderPostsToSync = 20;
 NSString *const ReaderLastSyncDateKey = @"ReaderLastSyncDate";
 NSString *const ReaderCurrentTopicKey = @"ReaderCurrentTopicKey";
 NSString *const ReaderTopicsArrayKey = @"ReaderTopicsArrayKey";
-NSString *const ReaderExtrasArrayKey = @"ReaderExtrasArrayKey";
+NSString *const ReaderListsArrayKey = @"ReaderListsArrayKey";
 
 // These keys are used in the getStoredComment method
 NSString * const ReaderPostStoredCommentIDKey = @"commentID";
@@ -765,14 +765,16 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
 
 @implementation ReaderPost (WordPressComApi)
 
-+ (void)getReaderTopicsWithSuccess:(WordPressComApiRestSuccessResponseBlock)success
-                           failure:(WordPressComApiRestSuccessFailureBlock)failure {
++ (void)getReaderMenuItemsWithSuccess:(WordPressComApiRestSuccessResponseBlock)success
+                         failure:(WordPressComApiRestSuccessFailureBlock)failure {
     
-    NSString *path = @"read/tags";
+    NSString *path = @"read/menu";
+    WPAccount *account = [WPAccount defaultWordPressComAccount];
+    WordPressComApi *api = [account restApi];
     
     // There should probably be a better check here
-    if ([[WPAccount defaultWordPressComAccount] restApi].authToken) {
-        [[WPAccount defaultWordPressComAccount].restApi getPath:path parameters:nil success:success failure:failure];
+    if ([api hasCredentials]) {
+        [api getPath:path parameters:nil success:success failure:failure];
     } else {
         [[WordPressComApi anonymousApi] getPath:path parameters:nil success:success failure:failure];
     }

--- a/WordPress/Classes/ReaderTopicsViewController.m
+++ b/WordPress/Classes/ReaderTopicsViewController.m
@@ -19,12 +19,8 @@
 
 @property (nonatomic, assign) BOOL topicsLoaded;
 @property (nonatomic, strong) NSArray *topicsArray;
-@property (nonatomic, strong) NSArray *defaultTopicsArray;
+@property (nonatomic, strong) NSArray *listsArray;
 @property (nonatomic, strong) NSDictionary *currentTopic;
-
-- (NSArray *)fetchDefaultTopics;
-- (void)loadTopics;
-- (void)handleFriendFinderButtonTapped:(id)sender;
 
 @end
 
@@ -36,18 +32,9 @@
 - (id)initWithStyle:(UITableViewStyle)style {
 	self = [super initWithStyle:style];
 	if (self) {
-		self.defaultTopicsArray = [self fetchDefaultTopics];
+		self.listsArray = [self fetchLists];
         
-        NSArray *arr = [[NSUserDefaults standardUserDefaults] arrayForKey:ReaderExtrasArrayKey];
-        if (arr != nil) {
-            self.defaultTopicsArray = [_defaultTopicsArray arrayByAddingObjectsFromArray:arr];
-        }
-        
-		arr = [[NSUserDefaults standardUserDefaults] arrayForKey:ReaderTopicsArrayKey];
-		if (arr == nil) {
-			arr = @[];
-		}
-		self.topicsArray = arr;
+		self.topicsArray = [[NSUserDefaults standardUserDefaults] arrayForKey:ReaderTopicsArrayKey] ?: @[];
 		
         self.currentTopic = [ReaderPost currentTopic];
     }
@@ -72,15 +59,21 @@
 																		  action:@selector(handleFriendFinderButtonTapped:)];
 	self.navigationItem.leftBarButtonItem = friendFinderButton;
     
-    [self loadTopics];
+    [self fetchTagsAndLists];
 	
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 
 #pragma mark - Instance Methods
 
-- (NSArray *)fetchDefaultTopics {
-    NSArray *arr = [ReaderPost readerEndpoints];
+- (NSArray *)fetchLists {
+    NSArray *arr = [[NSUserDefaults standardUserDefaults] arrayForKey:ReaderListsArrayKey];
+    
+    if (arr.count > 0) {
+        return arr;
+    }
+    
+    arr = [ReaderPost readerEndpoints];
     NSIndexSet *indexSet = [arr indexesOfObjectsPassingTest:^BOOL(id obj, NSUInteger idx, BOOL *stop) {
         NSDictionary *dict = (NSDictionary *)obj;
         return [[dict objectForKey:@"default"] boolValue];
@@ -93,7 +86,7 @@
 }
 
 
-- (void)loadTopics {
+- (void)fetchTagsAndLists {
 	
 	if ([self.topicsArray count] == 0) {
 		CGFloat width = self.tableView.frame.size.width;
@@ -109,24 +102,35 @@
 		[activityView startAnimating];
 	}
 	
-	[ReaderPost getReaderTopicsWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
+	[ReaderPost getReaderMenuItemsWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
         [self.tableView setTableFooterView:nil];
         NSDictionary *dict = (NSDictionary *)responseObject;
 		
-        NSDictionary *tagsDict = [dict dictionaryForKey:@"tags"];
-        NSMutableArray *tags = [NSMutableArray arrayWithCapacity:[tagsDict count]];
+        NSDictionary *listsDict = dict[@"default"];
+        NSDictionary *tagsDict = dict[@"subscribed"];
+        NSMutableArray *lists = [NSMutableArray arrayWithCapacity:listsDict.count];
+        NSMutableArray *tags = [NSMutableArray arrayWithCapacity:tagsDict.count];
 		
-        for (id key in tagsDict) {
-            NSDictionary *dict = [tagsDict objectForKey:key];
-            
-            NSString *title = [dict objectForKey:@"title"];
+        [listsDict enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+            NSString *title = [obj objectForKey:@"title"];
             title = [title stringByDecodingXMLCharacters];
-            NSString *endpoint = [dict objectForKey:@"URL"];
+            NSString *endpoint = [obj objectForKey:@"URL"];
+            [lists addObject:@{@"title": title, @"endpoint":endpoint}];
+        }];
+		
+        [tagsDict enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+            NSString *title = [obj objectForKey:@"title"];
+            title = [title stringByDecodingXMLCharacters];
+            NSString *endpoint = [obj objectForKey:@"URL"];
             [tags addObject:@{@"title": title, @"endpoint":endpoint}];
-        }
-        
+        }];
+
+        self.listsArray = lists;
         self.topicsArray = tags;
-        [[NSUserDefaults standardUserDefaults] setObject:tags forKey:ReaderTopicsArrayKey];
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        [defaults setObject:tags forKey:ReaderTopicsArrayKey];
+        [defaults setObject:lists forKey:ReaderListsArrayKey];
+        [defaults synchronize];
         
         [self.tableView reloadData];
     } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
@@ -181,7 +185,7 @@
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
 	if (section == 0) {
-		return [_defaultTopicsArray count];
+		return [_listsArray count];
 	}
 	return [_topicsArray count];
 }
@@ -197,7 +201,7 @@
 	
 	NSArray *arr = nil;
 	if (indexPath.section == 0) {
-		arr = _defaultTopicsArray;
+		arr = _listsArray;
 	} else {
 		arr = _topicsArray;
 	}
@@ -219,7 +223,7 @@
 	// Selected topics yo.
 	NSArray *arr = nil;
 	if (indexPath.section == 0) {
-		arr = _defaultTopicsArray;
+		arr = _listsArray;
 	} else {
 		arr = _topicsArray;
 	}


### PR DESCRIPTION
Fixes #1289 

Switched from read/tags to read/menu to retrieve both lists (defaults) and tags (subscribed) items for the Reader.  This effectively restores the missing list items considered to be "extras" using previous endpoints.
