### PR TITLE
Prevent crash if delegate does not implement contentViewDidLoadAllMedia:

### DIFF
--- a/WordPress/Classes/WPContentView.m
+++ b/WordPress/Classes/WPContentView.m
@@ -466,7 +466,10 @@ const CGFloat RPVControlButtonBorderSize = 0.0f;
     // and correctly update. 
     dispatch_async(dispatch_get_main_queue(), ^{
         [self refreshMediaLayout];
-        [self.delegate contentViewDidLoadAllMedia:self]; // So the delegate can correct its size.
+        
+        if ([self.delegate respondsToSelector:@selector(contentViewDidLoadAllMedia:)]) {
+            [self.delegate contentViewDidLoadAllMedia:self]; // So the delegate can correct its size.
+        }
     });
 }
 


### PR DESCRIPTION
Fixes #1306 

WPContentView was not checking to see if an `@optional` delegate method was implemented before calling it.  Crash was the result.
