### PR TITLE
Force deviceId to be a string after registering for push notifications

### DIFF
--- a/WordPress/Classes/NotificationsManager.m
+++ b/WordPress/Classes/NotificationsManager.m
@@ -195,7 +195,7 @@ NSString *const NotificationsDeviceToken = @"apnsDeviceToken";
 
 + (void)saveNotificationSettings {
     NSDictionary *settings = [NotificationsManager notificationSettingsDictionary];
-    NSString *deviceId = [[NSUserDefaults standardUserDefaults] objectForKey:NotificationsDeviceIdKey];
+    NSString *deviceId = [[NSUserDefaults standardUserDefaults] stringForKey:NotificationsDeviceIdKey];
     WPAccount *account = [WPAccount defaultWordPressComAccount];
     [[account restApi] saveNotificationSettings:settings
                                        deviceId:deviceId
@@ -207,7 +207,7 @@ NSString *const NotificationsDeviceToken = @"apnsDeviceToken";
 }
 
 + (void)fetchNotificationSettingsWithSuccess:(void (^)())success failure:(void (^)(NSError *))failure {
-    NSString *deviceId = [[NSUserDefaults standardUserDefaults] objectForKey:NotificationsDeviceIdKey];
+    NSString *deviceId = [[NSUserDefaults standardUserDefaults] stringForKey:NotificationsDeviceIdKey];
     
     WPAccount *account = [WPAccount defaultWordPressComAccount];
     [[account restApi] fetchNotificationSettingsWithDeviceId:deviceId

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -389,8 +389,8 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
                NSAssert([responseObject isKindOfClass:[NSDictionary class]], @"Response should be a dictionary");
                
                if (success) {
-                   NSString *deviceId = responseObject[@"ID"];
-                   NSDictionary *settings = responseObject[@"settings"];
+                   NSString *deviceId = [responseObject stringForKey:@"ID"];
+                   NSDictionary *settings = [responseObject dictionaryForKey:@"settings"];
                    
                    success(deviceId, settings);
                }


### PR DESCRIPTION
Fixes #1307 

Uses some of the safe setters to make sure device ID is an NSString throughout NotificationsManager and WordPress.com API.
