### PR TITLE
Hide action buttons for anonymous users.

### DIFF
--- a/WordPress/Classes/ReaderPostView.m
+++ b/WordPress/Classes/ReaderPostView.m
@@ -8,6 +8,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 #import "ReaderPostView.h"
+#import "WPAccount.h"
 #import "WPContentViewSubclass.h"
 #import "ContentActionButton.h"
 #import "UILabel+SuggestSize.h"
@@ -273,7 +274,7 @@ static NSInteger const MaxNumberOfLinesForTitleForSummary = 3;
         self.tagButton.hidden = YES;
     }
     
-	if ([[self.post isWPCom] boolValue]) {
+	if ([[self.post isWPCom] boolValue] && [WPAccount defaultWordPressComAccount] != nil) {
 		self.likeButton.hidden = NO;
 		self.reblogButton.hidden = NO;
         self.commentButton.hidden = NO;


### PR DESCRIPTION
Fixes #1324 
We should cycle back to show these for unauthed users and have a nice path to auth inorder to use the feature.
