### PR TITLE
Issues/1326 reset reader when acct changes

### DIFF
--- a/WordPress/Classes/ReaderPostsViewController.m
+++ b/WordPress/Classes/ReaderPostsViewController.m
@@ -925,6 +925,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
     [defaults removeObjectForKey:ReaderLastSyncDateKey];
     [NSUserDefaults resetStandardUserDefaults];
     [self resetResultsController];
+    [self.tableView reloadData];
     [self.navigationController popToViewController:self animated:NO];
     
     if ([WPAccount defaultWordPressComAccount] && [self isViewLoaded]) {


### PR DESCRIPTION
Fixes #1326 
When the user changes accounts, reset old content, current topic and last synced date.  Removes any detail controllers on the reader's nav stack.
