### PR TITLE
Added more descriptive error message to WPComLoginViewController.

### DIFF
--- a/WordPress/Classes/WPcomLoginViewController.m
+++ b/WordPress/Classes/WPcomLoginViewController.m
@@ -351,7 +351,7 @@
                                     }
                                 } failure:^(NSError *error) {
                                     DDLogError(@"Login failed with username %@: %@", username, error);
-                                    loginController.footerText = NSLocalizedString(@"Sign in failed. Please try again.", @"");
+                                    loginController.footerText = [error localizedDescription];
                                     loginController.buttonText = NSLocalizedString(@"Sign In", @"");
                                     loginController.isSigningIn = NO;
                                     [loginController.tableView reloadData];


### PR DESCRIPTION
Users who would login through this screen(when prompted by say the
Reader) wouldn't see the error message regarding 2FA that the user
should generate a app specific password because we had a hard coded
error message. Fixes #1314 

Here's what it looks like now:
![image](https://f.cloud.github.com/assets/437043/2341861/118f6a8a-a4e5-11e3-9ef1-b2be22aa5c94.png)
