### PR TITLE
Fix no result message cut off

### DIFF
--- a/WordPress/Classes/StatsNoResultsCell.h
+++ b/WordPress/Classes/StatsNoResultsCell.h
@@ -13,7 +13,7 @@
 
 @interface StatsNoResultsCell : WPTableViewCell
 
-+ (CGFloat)heightForRow;
++ (CGFloat)heightForRowForSection:(StatsSection)section withWidth:(CGFloat)width;
 
 - (void)configureForSection:(StatsSection)section;
 

--- a/WordPress/Classes/StatsViewController.m
+++ b/WordPress/Classes/StatsViewController.m
@@ -307,7 +307,7 @@ typedef NS_ENUM(NSInteger, TotalFollowersShareRow) {
                 case StatsDataRowTitle:
                     return [StatsTwoColumnCell heightForRow];
                 default:
-                    return [self resultsForSection:indexPath.section].count > 0 ? [StatsTwoColumnCell heightForRow] : [StatsNoResultsCell heightForRow];
+                    return [self resultsForSection:indexPath.section].count > 0 ? [StatsTwoColumnCell heightForRow] : [StatsNoResultsCell heightForRowForSection:(StatsSection)indexPath.section withWidth:CGRectGetWidth(self.view.bounds)];
             }
         case StatsSectionLinkToWebview:
             return [StatsLinkToWebviewCell heightForRow];


### PR DESCRIPTION
Fixes #1338 

Before:
![image](https://f.cloud.github.com/assets/437043/2361995/829d0292-a638-11e3-92b7-f05242800b7e.png)
After:
![image](https://f.cloud.github.com/assets/437043/2361984/5ba5280e-a638-11e3-9fb0-312fa81247cc.png)

Before:
![image](https://f.cloud.github.com/assets/437043/2361998/9cfea352-a638-11e3-9e30-2a78b6cfe4cc.png)
After:
![image](https://f.cloud.github.com/assets/437043/2361986/5f2d078a-a638-11e3-84bb-69c321556477.png)
