### PR TITLE
Fix future date issue on months for stats.

### DIFF
--- a/WordPress/Classes/StatsViewsVisitors.m
+++ b/WordPress/Classes/StatsViewsVisitors.m
@@ -81,7 +81,7 @@ NSString *const StatsPointCountKey = @"count";
         {
             self.dateFormatter.dateFormat = @"yyyy-MM-dd";
             NSDate *d = [self.dateFormatter dateFromString:name];
-            self.dateFormatter.dateFormat = @"LLL yy"; // L is stand-alone month
+            self.dateFormatter.dateFormat = @"LLL yyyy"; // L is stand-alone month
             return [self.dateFormatter stringFromDate:d];
         }
         default:


### PR DESCRIPTION
If the user clicked on the months filter of the visitors and views
section it could appear like the final month was a future date as the
months would display like "Mar 14" with just two digits on the year.
If the year digits were greater than the current date it could
possibly confuse the user. To fix this I just adjusted the label to
print out four digits for the year.

Fixes #1337 

Here's what it looks like now:
![image](https://f.cloud.github.com/assets/437043/2362319/6ba84854-a63c-11e3-9acf-5ca0e313a352.png)
