### PR TITLE
Post Settings: Add padding for iPad

### DIFF
--- a/WordPress/Classes/PostSettingsViewController.m
+++ b/WordPress/Classes/PostSettingsViewController.m
@@ -129,7 +129,7 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
 
     [self.tableView registerNib:[UINib nibWithNibName:@"WPTableViewActivityCell" bundle:nil] forCellReuseIdentifier:TableViewActivityCellIdentifier];
     
-    self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, 0.0, 44.0)]; // add some verticle padding
+    self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, 0.0, 44.0)]; // add some vertical padding
 }
 
 - (void)viewWillAppear:(BOOL)animated {


### PR DESCRIPTION
Closes #1297 

Adds a top margin for the iPad.  Adds a bottom margin for both iPad and iPhone screens.
