### PR TITLE
Fixes editor style bar background color for iOS 7.1 and later.

### DIFF
--- a/WordPress/Classes/EditPostViewController.m
+++ b/WordPress/Classes/EditPostViewController.m
@@ -344,10 +344,7 @@ CGFloat const EPVCTextViewTopPadding = 7.0f;
     if (self.editorToolbar == nil) {
         frame = CGRectMake(0.0f, 0.0f, viewWidth, WPKT_HEIGHT_PORTRAIT);
         self.editorToolbar = [[WPKeyboardToolbarBase alloc] initWithFrame:frame];
-        self.editorToolbar.backgroundColor = [UIColor UIColorFromHex:(0xdcdfe2)];
-        if (IS_IPAD) {
-            self.editorToolbar.backgroundColor = [UIColor UIColorFromHex:(0xcfd2d5)];
-        }
+        self.editorToolbar.backgroundColor = [WPStyleGuide keyboardColor];
         self.editorToolbar.delegate = self;
         self.textView.inputAccessoryView = self.editorToolbar;
     }

--- a/WordPress/Classes/WPStyleGuide.m
+++ b/WordPress/Classes/WPStyleGuide.m
@@ -251,10 +251,25 @@
 }
 
 + (UIColor *)keyboardColor {
+    // Pre iOS 7.1 uses a the lighter keyboard background.
+    // There doesn't seem to be a good way to get the keyboard background color
+    // programatically so we'll rely on checking the OS version.
+    // Approach based on http://stackoverflow.com/a/5337804
+    NSString *versionStr = [[UIDevice currentDevice] systemVersion];
+    BOOL hasLighterKeyboard = [versionStr compare:@"7.1" options:NSNumericSearch] == NSOrderedAscending;
+    
+    if (hasLighterKeyboard) {
+        if (IS_IPAD) {
+            return [UIColor colorWithRed:207.0f/255.0f green:210.0f/255.0f blue:213.0f/255.0f alpha:1.0];
+        } else {
+            return [UIColor colorWithRed:220.0f/255.0f green:223.0f/255.0f blue:226.0f/255.0f alpha:1.0];
+        }
+    }
+    
     if (IS_IPAD) {
-        return [UIColor colorWithRed:207.0f/255.0f green:210.0f/255.0f blue:213.0f/255.0f alpha:1.0];
+        return [UIColor colorWithRed:217.0f/255.0f green:220.0f/255.0f blue:223.0f/255.0f alpha:1.0];
     } else {
-        return [UIColor colorWithRed:220.0f/255.0f green:223.0f/255.0f blue:226.0f/255.0f alpha:1.0];
+        return [UIColor colorWithRed:204.0f/255.0f green:208.0f/255.0f blue:214.0f/255.0f alpha:1.0];
     }
 }
 


### PR DESCRIPTION
Fixes #1369 
Before: 
![ios simulator screen shot mar 18 2014 2 29 59 pm](https://f.cloud.github.com/assets/1435271/2452661/2183b1e6-aed4-11e3-8573-dc69c89211af.png)

After:
![ios simulator screen shot mar 18 2014 2 31 57 pm](https://f.cloud.github.com/assets/1435271/2452663/260b9e22-aed4-11e3-8cae-7d0f7048e3d5.png)
