### PR TITLE
Changing minimum required version of WordPress to 3.6.

### DIFF
--- a/WordPress/Classes/Blog.m
+++ b/WordPress/Classes/Blog.m
@@ -580,7 +580,7 @@ static NSInteger const ImageSizeLargeHeight = 480;
                 return;
             
             self.options = [NSDictionary dictionaryWithDictionary:(NSDictionary *)responseObject];
-            NSString *minimumVersion = @"3.5";
+            NSString *minimumVersion = @"3.6";
             float version = [[self version] floatValue];
             if (version < [minimumVersion floatValue]) {
                 if (self.lastUpdateWarning == nil || [self.lastUpdateWarning floatValue] < [minimumVersion floatValue]) {


### PR DESCRIPTION
Fixes #1417 
