### PR TITLE
Remove app update check

### DIFF
--- a/WordPress/Classes/WordPressAppDelegate.m
+++ b/WordPress/Classes/WordPressAppDelegate.m
@@ -555,6 +555,14 @@ static NSInteger const IndexForMeTab = 2;
 }
 
 
+#pragma mark - Notifications
+
+- (void)defaultAccountDidChange:(NSNotification *)notification {
+    [Crashlytics setUserName:[[WPAccount defaultWordPressComAccount] username]];
+    [self setCommonCrashlyticsParameters];
+}
+
+
 #pragma mark - Crash reporting
 
 - (void)configureCrashlytics {


### PR DESCRIPTION
Fixes #1016 

Removing unnecessary app update check as iOS 7 does auto-updates by default.  Also took the time to clean up unused code in the App Delegate.
