### PR TITLE
Make all buttons in notes mute non-destructive (no red text)

### DIFF
--- a/WordPress/Classes/NotificationSettingsViewController.m
+++ b/WordPress/Classes/NotificationSettingsViewController.m
@@ -419,8 +419,8 @@ BOOL hasChanges;
             actionSheet = [[UIActionSheet alloc] initWithTitle:NSLocalizedString(@"Notifications", @"")
                                                       delegate:self
                                              cancelButtonTitle:NSLocalizedString(@"Cancel", @"")
-                                        destructiveButtonTitle:NSLocalizedString(@"Turn Off", @"")
-                                             otherButtonTitles:NSLocalizedString(@"Turn Off for 1hr", @""), NSLocalizedString(@"Turn Off Until 8am", @""), nil ];
+                                        destructiveButtonTitle:nil
+                                             otherButtonTitles:NSLocalizedString(@"Turn Off", @""), NSLocalizedString(@"Turn Off for 1hr", @""), NSLocalizedString(@"Turn Off Until 8am", @""), nil ];
             actionSheet.tag = 101;
             
         }


### PR DESCRIPTION
Fixes #1396 

None of the notification mute options are "destructive" so a user shouldn't feel any apprehension about tapping Turn Off.
