### PR TITLE
Notifications: Represent a blank comment author as 'Someone'

### DIFF
--- a/WordPress/Classes/NotificationsCommentDetailViewController.m
+++ b/WordPress/Classes/NotificationsCommentDetailViewController.m
@@ -380,7 +380,7 @@ const CGFloat NotificationsCommentDetailViewControllerReplyTextViewDefaultHeight
 
             NSString *author = [comment.commentData valueForKeyPath:@"author.name"];
             if ([[author trim] length] == 0) {
-                author = NSLocalizedString(@"Someone", @"");
+                author = NSLocalizedString(@"Someone", @"Identifies the author of a comment that chose to be anonymous. Should match the wpcom translation for 'Someone' who left a comment, as opposed to an 'anonymous' author.");
             }
             NSString *authorLink = [comment.commentData valueForKeyPath:@"author.URL"];
             [self.commentView setAuthorDisplayName:author authorLink:authorLink];


### PR DESCRIPTION
Fixes #1301 
Stopgap until the API is updated.
