### PR TITLE
Prevent crash if blog name can't be extracted from subject & is nil

### DIFF
--- a/WordPress/Classes/Note.m
+++ b/WordPress/Classes/Note.m
@@ -199,6 +199,10 @@ const NSUInteger NoteKeepCount = 20;
         [scanner scanUpToString:@"\"" intoString:&blogName];
         [scanner scanString:@"\"" intoString:NULL];
     }
+    
+    if (blogName.length == 0) {
+        return nil;
+    }
 
     NSPredicate *subjectPredicate = [NSPredicate predicateWithFormat:@"self.blogName CONTAINS[cd] %@", blogName];
     NSPredicate *wpcomPredicate = [NSPredicate predicateWithFormat:@"self.account.isWpcom == YES"];


### PR DESCRIPTION
Fixes #1452 

The real question is what was the Note subject that crashed the algorithm...
