### PR TITLE
Editor: Use UITextView instead of IOS7CorrectedTextView.

### DIFF
--- a/WordPress/Classes/EditPostViewController.m
+++ b/WordPress/Classes/EditPostViewController.m
@@ -293,7 +293,7 @@ CGFloat const EPVCTextViewTopPadding = 7.0f;
     // Shows the post body.
     // Height should never be smaller than what is required to display its text.
     if (!self.textView) {
-        self.textView = [[IOS7CorrectedTextView alloc] initWithFrame:frame];
+        self.textView = [[UITextView alloc] initWithFrame:frame];
         self.textView.autoresizingMask = mask;
         self.textView.delegate = self;
         self.textView.typingAttributes = [WPStyleGuide regularTextAttributes];

--- a/WordPress/Classes/EditPostViewController_Internal.h
+++ b/WordPress/Classes/EditPostViewController_Internal.h
@@ -11,7 +11,6 @@
 #import "PostMediaViewController.h"
 #import "PostPreviewViewController.h"
 #import "AbstractPost.h"
-#import "IOS7CorrectedTextView.h"
 #import "WPKeyboardToolbarBase.h"
 #import "WPKeyboardToolbarDone.h"
 
@@ -43,7 +42,7 @@ typedef NS_ENUM(NSUInteger, EditPostViewControllerMode) {
 @property (nonatomic, strong) UIView *optionsSeparatorView;
 @property (nonatomic, strong) UIView *optionsView;
 @property (nonatomic, strong) UIButton *optionsButton;
-@property (nonatomic, strong) IOS7CorrectedTextView *textView;
+@property (nonatomic, strong) UITextView *textView;
 @property (nonatomic, strong) WPKeyboardToolbarBase *editorToolbar;
 @property (nonatomic, strong) WPKeyboardToolbarDone *titleToolbar;
 @property (nonatomic, strong) UILabel *tapToStartWritingLabel;


### PR DESCRIPTION
Fixes #1458 and #1460

Seems like iOS 7.1 fixes some of the more frustrating bugs Apple introduced to `UITextView` in the 7.0 SDK. Just making the change for the editor for now. 
