### PR TITLE
Switching days should only reset expanded link groups for that one section

### DIFF
--- a/WordPress/Classes/StatsViewController.m
+++ b/WordPress/Classes/StatsViewController.m
@@ -673,7 +673,7 @@ typedef NS_ENUM(NSInteger, TotalFollowersShareRow) {
     // Only reload section if the selection changed
     if (todayCurrentlySelected != todaySelected) {
         [self.showingToday setObject:@(todaySelected) forKey:@(section)];
-        [self.expandedLinkGroups removeAllObjects];
+        [self.expandedLinkGroups removeObjectForKey:@(section)];
         [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:section] withRowAnimation:UITableViewRowAnimationFade];
     }
 }


### PR DESCRIPTION
Fixes #1469 

When a link group is expanded (referrers or clicks) and then today/yesterday is tapped in another section, the app would crash.  The switching of days was erasing the entire dictionary managing which links groups are expanded rather than just erasing the current section's data.
