### PR TITLE
Set title for both normal and disabled modes on the time button

### DIFF
--- a/WordPress/Classes/WPContentView.m
+++ b/WordPress/Classes/WPContentView.m
@@ -447,7 +447,8 @@ const CGFloat RPVControlButtonBorderSize = 0.0f;
 }
 
 - (void)refreshDate:(NSTimer *)timer {
-    [self.timeButton setTitle:[self.contentProvider.dateForDisplay shortString] forState:UIControlStateNormal];
+    NSString *title = [self.contentProvider.dateForDisplay shortString];
+    [self.timeButton setTitle:title forState:UIControlStateNormal | UIControlStateDisabled];
 }
 
 - (void)refreshDate {


### PR DESCRIPTION
Fixes #1481 

The time when first set with `UIControlStateNormal` the title is set for all modes.  Subsequent title setting with `UIControlStateNormal` only replaces the title for that individual mode.  Since timeButtons are normally disabled controls, the mode needs to include `UIControlStateDisabled` when the cell is reused.
