### PR TITLE
Make the background context primary and set up inheritance correctly

### DIFF
--- a/WordPress/Classes/ContextManager.m
+++ b/WordPress/Classes/ContextManager.m
@@ -81,6 +81,9 @@ static ContextManager *instance;
     [self.backgroundContext performBlock:^{
         DDLogVerbose(@"Merging changes into background context");
         [self.backgroundContext mergeChangesFromContextDidSaveNotification:notification];
+        
+        // Changes are not saved out to the persistent store coordinator until the root context is saved
+        [self saveContext:self.backgroundContext];
     }];
 }
 


### PR DESCRIPTION
Resolves #1480 

Derived contexts saves should probably be merged in using the notification system as well.  Right now there is no way to "unregister" a context from the NSNotificationCenter system, hence the explicit call to save the main context.  I don't think this works exactly right.
