### PR TITLE
Don't clear Jetpack password field on entry.

### DIFF
--- a/WordPress/Classes/JetpackSettingsViewController.m
+++ b/WordPress/Classes/JetpackSettingsViewController.m
@@ -175,7 +175,6 @@ CGFloat const JetpackSignInButtonHeight = 41.0;
         _passwordField.delegate = self;
         _passwordField.secureTextEntry = YES;
         _passwordField.text = _blog.jetpackPassword;
-        _passwordField.clearsOnBeginEditing = YES;
         _passwordField.showTopLineSeparator = YES;
         [self.view addSubview:_passwordField];
     }


### PR DESCRIPTION
The jetpack password field shouldn't clear when going between username and password. Copies the behaviour of Site password field.
