### PR TITLE
Hide the stats group headers when there are no results for the section

### DIFF
--- a/WordPress/Classes/StatsViewController.m
+++ b/WordPress/Classes/StatsViewController.m
@@ -329,7 +329,7 @@ typedef NS_ENUM(NSInteger, TotalFollowersShareRow) {
                 case StatsDataRowButtons:
                     return [StatsButtonCell heightForRow];
                 case StatsDataRowTitle:
-                    return [StatsTwoColumnCell heightForRow];
+                    return [self resultsForSection:indexPath.section].count > 0 ? [StatsTwoColumnCell heightForRow] : 0.0;
                 default:
                     return [self resultsForSection:indexPath.section].count > 0 ? [StatsTwoColumnCell heightForRow] : [StatsNoResultsCell heightForRowForSection:(StatsSection)indexPath.section withWidth:CGRectGetWidth(self.view.bounds)];
             }


### PR DESCRIPTION
Fixes #1465 

Hides the headers for the group when there are no results to be shown.
