### PR TITLE
Scroll the current view to top when current tab is selected again.

### DIFF
--- a/WordPress/Classes/WordPressAppDelegate.m
+++ b/WordPress/Classes/WordPressAppDelegate.m
@@ -527,12 +527,6 @@ static NSInteger const IndexForMeTab = 2;
     return YES;
 }
 
-- (void)tabBarController:(UITabBarController *)tabBarController didSelectViewController:(UIViewController *)viewController
-{
-    
-}
-
-
 #pragma mark - Application directories
 
 - (void)changeCurrentDirectory {


### PR DESCRIPTION
Fixes #1103 

Determines if the current tab is first showing it's root/top view controller (if it's a navigation controller) and if it is and it's showing a UITableView, then scroll to the top.  Prevents the tab bar controller from having yet again another set of hard-coded indices.

Rejoice, @melchoyce!
