### PR TITLE
Make native stats graph & links more accessible with VoiceOver

### DIFF
--- a/WordPress/Classes/StatsTwoColumnCell.m
+++ b/WordPress/Classes/StatsTwoColumnCell.m
@@ -89,6 +89,8 @@ static CGFloat const RowIconWidth = 20.0f;
 }
 
 - (void)setLinkEnabled:(BOOL)linkEnabled {
+    _linkEnabled = linkEnabled;
+    
     UIColor *color = linkEnabled ? [WPStyleGuide baseDarkerBlue] : [WPStyleGuide whisperGrey];
     [self titleLabel].textColor = color;
 }
@@ -170,5 +172,17 @@ static CGFloat const RowIconWidth = 20.0f;
 - (CGFloat)yValueToCenterViewVertically:(UIView *)view {
     return ([self.class heightForRow] - view.frame.size.height)/2;
 }
+
+#pragma mark - UIAccessibility items
+
+- (UIAccessibilityTraits)accessibilityTraits
+{
+    if (self.linkEnabled) {
+        return UIAccessibilityTraitLink;
+    }
+    
+    return [super accessibilityTraits];
+}
+
 
 @end

--- a/WordPress/Classes/StatsViewsVisitorsBarGraphCell.m
+++ b/WordPress/Classes/StatsViewsVisitorsBarGraphCell.m
@@ -208,7 +208,7 @@ CGFloat heightFromRangeToRange(NSUInteger height, CGFloat maxOldRange, CGFloat m
     return label;
 }
 
-#pragma mark - UIAccessibilityTraits
+#pragma mark - UIAccessibility methods
 
 - (BOOL)isAccessibilityElement
 {


### PR DESCRIPTION
Issue #652 

Make the visitors & views graph "visible" to VoiceOver.  Further improvements needed but this is a good first step.  Also make links that launch Safari have the accessibility trait of a link.
