### PR TITLE
Remove "Themes" item from BlogDetailsViewController.

### DIFF
--- a/WordPress/Classes/BlogDetailsViewController.m
+++ b/WordPress/Classes/BlogDetailsViewController.m
@@ -18,7 +18,6 @@ typedef enum {
     BlogDetailsRowPages,
     BlogDetailsRowComments,
     BlogDetailsRowStats,
-    BlogDetailsRowThemes,
     BlogDetailsRowMedia,
     BlogDetailsRowViewSite,
     BlogDetailsRowViewAdmin,
@@ -111,7 +110,7 @@ NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return [self shouldShowThemesOption] ? BlogDetailsRowCount : BlogDetailsRowCount - 1;
+    return BlogDetailsRowCount;
 }
 
 - (void)configureCell:(UITableViewCell *)cell atIndexPath:(NSIndexPath *)indexPath {
@@ -131,9 +130,6 @@ NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
     } else if (indexPath.row == BlogDetailsRowStats) {
         cell.textLabel.text = NSLocalizedString(@"Stats", nil);
         cell.imageView.image = [UIImage imageNamed:@"icon-menu-stats"];
-    } else if ([self shouldShowThemesOption] && indexPath.row == BlogDetailsRowThemes) {
-        cell.textLabel.text = NSLocalizedString(@"Themes", nil);
-        cell.imageView.image = [UIImage imageNamed:@"icon-menu-themes"];
     } else if ([self isRowForMedia:indexPath.row]) {
         cell.textLabel.text = NSLocalizedString(@"Media", nil);
         cell.imageView.image = [UIImage imageNamed:@"icon-menu-media"];
@@ -179,8 +175,6 @@ NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
     } else if (indexPath.row == BlogDetailsRowStats) {
         [WPAnalytics track:WPAnalyticsStatStatsAccessed];
         controllerClass =  [StatsViewController class];
-    } else if ([self shouldShowThemesOption] && indexPath.row == BlogDetailsRowThemes) {
-        controllerClass = [ThemeBrowserViewController class];
     } else if ([self isRowForMedia:indexPath.row]) {
         [WPAnalytics track:WPAnalyticsStatOpenedMediaLibrary];
         controllerClass = [MediaBrowserViewController class];
@@ -260,23 +254,19 @@ NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
 }
 
 - (BOOL)isRowForMedia:(NSUInteger)index {
-    return index == ([self shouldShowThemesOption] ? BlogDetailsRowMedia : BlogDetailsRowMedia - 1);
+    return index == BlogDetailsRowMedia;
 }
 
 - (BOOL)isRowForViewSite:(NSUInteger)index {
-    return index == ([self shouldShowThemesOption] ? BlogDetailsRowViewSite : BlogDetailsRowViewSite - 1);
+    return index == BlogDetailsRowViewSite;
 }
 
 - (BOOL)isRowForViewAdmin:(NSUInteger)index {
-    return index == ([self shouldShowThemesOption] ? BlogDetailsRowViewAdmin : BlogDetailsRowViewAdmin - 1);
+    return index == BlogDetailsRowViewAdmin;
 }
 
 - (BOOL)isRowForEditBlog:(NSUInteger)index {
-    return index == ([self shouldShowThemesOption] ? BlogDetailsRowEdit : BlogDetailsRowEdit - 1);
-}
-
-- (BOOL)shouldShowThemesOption {
-    return self.blog.isWPcom;
+    return index == BlogDetailsRowEdit;
 }
 
 /*


### PR DESCRIPTION
This just removes the ability to select "Themes" from the blog details view. I think we should keep the Themes code in there for now incase we can improve it and release it at a later date rather than just dumping it from the codebase entirely.

Fixes #1580.
