### PR TITLE
Summarize all blogs on the device for future debugging purposes

### DIFF
--- a/WordPress/Classes/BlogService.h
+++ b/WordPress/Classes/BlogService.h
@@ -59,12 +59,13 @@
 
 - (void)checkVideoPressEnabledForBlog:(Blog *)blog success:(void (^)(BOOL enabled))success failure:(void (^)(NSError *error))failure;
 
-#pragma mark -
-#pragma mark Class methods
 - (NSInteger)blogCountForAllAccounts;
+
 - (NSInteger)blogCountSelfHosted;
+
 - (NSInteger)blogCountVisibleForAllAccounts;
 
+- (NSArray *)blogsForAllAccounts;
 
 
 @end

--- a/WordPress/Classes/BlogService.m
+++ b/WordPress/Classes/BlogService.m
@@ -352,6 +352,25 @@ NSString *const LastUsedBlogURLDefaultsKey = @"LastUsedBlogURLDefaultsKey";
     return [self blogCountWithPredicate:predicate];
 }
 
+- (NSArray *)blogsForAllAccounts
+{
+    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"blogName" ascending:YES];
+    
+    NSFetchRequest *request = [[NSFetchRequest alloc] init];
+    [request setEntity:[NSEntityDescription entityForName:@"Blog" inManagedObjectContext:self.managedObjectContext]];
+    [request setSortDescriptors:@[sortDescriptor]];
+    
+    NSError *error;
+    NSArray *blogs = [self.managedObjectContext executeFetchRequest:request error:&error];
+
+    if (error) {
+        DDLogError(@"Error while retrieving all blogs");
+        return nil;
+    }
+    
+    return blogs;
+}
+
 #pragma mark - Private methods
 
 - (NSInteger)blogCountWithPredicate:(NSPredicate *)predicate

--- a/WordPress/Classes/WordPressAppDelegate.m
+++ b/WordPress/Classes/WordPressAppDelegate.m
@@ -857,6 +857,8 @@ static NSInteger const IndexForMeTab = 2;
     NSArray *languages = [[NSUserDefaults standardUserDefaults] objectForKey:@"AppleLanguages"];
     NSString *currentLanguage = [languages objectAtIndex:0];
     BOOL extraDebug = [[NSUserDefaults standardUserDefaults] boolForKey:@"extra_debug"];
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
+    NSArray *blogs = [blogService blogsForAllAccounts];
     
     DDLogInfo(@"===========================================================================");
 	DDLogInfo(@"Launching WordPress for iOS %@...", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"]);
@@ -873,6 +875,16 @@ static NSInteger const IndexForMeTab = 2;
     DDLogInfo(@"UDID:      %@", [device wordpressIdentifier]);
     DDLogInfo(@"APN token: %@", [[NSUserDefaults standardUserDefaults] objectForKey:NotificationsDeviceToken]);
     DDLogInfo(@"Launch options: %@", launchOptions);
+    
+    if (blogs.count > 0) {
+        DDLogInfo(@"All blogs on device:");
+        for (Blog *blog in blogs) {
+            DDLogInfo(@"Name: %@ URL: %@ XML-RPC: %@ isWpCom: %@ blogId: %@ jetpackAccount: %@", blog.blogName, blog.url, blog.xmlrpc, blog.account.isWpcom ? @"YES" : @"NO", blog.blogID, !!blog.jetpackAccount ? @"PRESENT" : @"NONE");
+        }
+    } else {
+        DDLogInfo(@"No blogs configured on device.");
+    }
+    
     DDLogInfo(@"===========================================================================");
 }
 


### PR DESCRIPTION
Closes #682 

Went for the simplest approach - just dump to the log file right now.  We're not providing e-mail support at the moment so this will help us with crash reports at least.
