### PR TITLE
Add in people properties to track last time users performed key actions

### DIFF
--- a/WordPress/Classes/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/WPAnalyticsTrackerMixpanel.m
@@ -172,7 +172,7 @@
         case WPAnalyticsStatThemesAccessedThemeBrowser:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Themes - Accessed Theme Browser"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_theme_browser"];
-            [instructions setPeoplePropertyWithCurrentDate:@"last_time_accessed_theme_browser"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_theme_browser"];
             break;
         case WPAnalyticsStatThemesChangedTheme:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Themes - Changed Theme"];
@@ -181,7 +181,7 @@
         case WPAnalyticsStatReaderAccessed:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Reader - Accessed"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_reader"];
-            [instructions setPeoplePropertyWithCurrentDate:@"last_time_accessed_reader"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_reader"];
             break;
         case WPAnalyticsStatReaderOpenedArticle:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Reader - Opened Article"];
@@ -190,12 +190,12 @@
         case WPAnalyticsStatReaderLikedArticle:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Reader - Liked Article"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_liked_article"];
-            [instructions setPeoplePropertyWithCurrentDate:@"last_time_liked_reader_article"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_liked_reader_article"];
             break;
         case WPAnalyticsStatReaderRebloggedArticle:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Reader - Reblogged Article"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_reblogged_article"];
-            [instructions setPeoplePropertyWithCurrentDate:@"last_time_reblogged_article"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_reblogged_article"];
             break;
         case WPAnalyticsStatReaderInfiniteScroll:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Reader - Infinite Scroll"];
@@ -215,17 +215,17 @@
         case WPAnalyticsStatReaderLoadedFreshlyPressed:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Reader - Loaded Freshly Pressed"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_loaded_freshly_pressed"];
-            [instructions setPeoplePropertyWithCurrentDate:@"last_time_loaded_freshly_pressed"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_loaded_freshly_pressed"];
             break;
         case WPAnalyticsStatReaderCommentedOnArticle:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Reader - Commented on Article"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_commented_on_reader_article"];
-            [instructions setPeoplePropertyWithCurrentDate:@"last_time_commented_on_article"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_commented_on_article"];
             break;
         case WPAnalyticsStatStatsAccessed:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Stats - Accessed"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_stats"];
-            [instructions setPeoplePropertyWithCurrentDate:@"last_time_accessed_stats"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_stats"];
             break;
         case WPAnalyticsStatEditorCreatedPost:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Created Post"];
@@ -242,7 +242,7 @@
         case WPAnalyticsStatEditorPublishedPost:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Published Post"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_editor_published_post"];
-            [instructions setPeoplePropertyWithCurrentDate:@"last_time_published_post"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_published_post"];
             break;
         case WPAnalyticsStatEditorUpdatedPost:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Updated Post"];
@@ -251,7 +251,7 @@
         case WPAnalyticsStatNotificationsAccessed:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Notifications - Accessed"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_notifications"];
-            [instructions setPeoplePropertyWithCurrentDate:@"last_time_accessed_notifications"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_notifications"];
             break;
         case WPAnalyticsStatNotificationsOpenedNotificationDetails:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Notifications - Opened Notification Details"];
@@ -281,7 +281,7 @@
             break;
         case WPAnalyticsStatCreatedAccount:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Created Account"];
-            [instructions setPeoplePropertyWithCurrentDate:@"$created"];
+            [instructions setCurrentDateForPeopleProperty:@"$created"];
             break;
         case WPAnalyticsStatSharedItemViaEmail:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsWithSuperPropertyAndPeoplePropertyIncrementor:@"number_of_items_shared_via_email"];
@@ -309,7 +309,7 @@
             break;
         case WPAnalyticsStatSharedItem:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsWithSuperPropertyAndPeoplePropertyIncrementor:@"number_of_items_shared"];
-            [instructions setPeoplePropertyWithCurrentDate:@"last_time_shared_article"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_shared_article"];
             break;
         case WPAnalyticsStatNotificationPerformedAction:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsWithSuperPropertyAndPeoplePropertyIncrementor:@"number_of_notifications_performed_action_against"];

--- a/WordPress/Classes/WPAnalyticsTrackerMixpanelInstructionsForStat.h
+++ b/WordPress/Classes/WPAnalyticsTrackerMixpanelInstructionsForStat.h
@@ -19,6 +19,6 @@
 
 - (void)setSuperPropertyAndPeoplePropertyToIncrement:(NSString *)property;
 - (void)addSuperPropertyToFlag:(NSString *)property;
-- (void)setPeoplePropertyWithCurrentDate:(NSString *)property;
+- (void)setCurrentDateForPeopleProperty:(NSString *)property;
 
 @end

--- a/WordPress/Classes/WPAnalyticsTrackerMixpanelInstructionsForStat.m
+++ b/WordPress/Classes/WPAnalyticsTrackerMixpanelInstructionsForStat.m
@@ -68,7 +68,7 @@
     self.peoplePropertyToIncrement = property;
 }
 
-- (void)setPeoplePropertyWithCurrentDate:(NSString *)property{
+- (void)setCurrentDateForPeopleProperty:(NSString *)property{
     [self setPeopleProperty:property toValue:[NSDate date]];
 }
 


### PR DESCRIPTION
Added in people properties to track the last time users performed the following key actions:
- Last Time Accessed Reader
- Last Time Accessed Theme Browser
- Last Time Liked Article
- Last Time Reblogged Article
- Last Time Loaded Freshly Pressed
- Last Time Commented on an Article
- Last Time Stats Accessed
- Last Time Published Post
- Last Time Notifications Accessed
- Last Time Shared item

Fixes #1585
