### PR TITLE
Adjusted when we increment 'Application Opened' people property.

### DIFF
--- a/WordPress/Classes/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/WPAnalyticsTrackerMixpanel.m
@@ -51,7 +51,6 @@
     NSString *username = account.username;
     if (account && [username length] > 0) {
         [[Mixpanel sharedInstance] identify:username];
-        [[Mixpanel sharedInstance].people increment:@"Application Opened" by:@(1)];
         [[Mixpanel sharedInstance].people set:@{ @"$username": username, @"$first_name" : username }];
     }
 }
@@ -158,6 +157,7 @@
     switch (stat) {
         case WPAnalyticsStatApplicationOpened:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Application Opened"];
+            [instructions setPeoplePropertyToIncrement:@"Application Opened"];
             break;
         case WPAnalyticsStatApplicationClosed:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Application Closed"];


### PR DESCRIPTION
Moved the incrementing of the 'Application Opened' people property from initialization of Mixpanel to the corresponding instructions that go along side the Application Opened event.
