### PR TITLE
Crash when tapping first row of group stats cells section

### DIFF
--- a/WordPress/Classes/StatsLinkToWebviewCell.m
+++ b/WordPress/Classes/StatsLinkToWebviewCell.m
@@ -19,7 +19,7 @@ static CGFloat const LabelVerticalOffset = 2.0f;
 {
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
-        self.selectionStyle = UITableViewCellSelectionStyleNone;
+        self.selectionStyle = UITableViewCellSelectionStyleDefault;
         self.contentView.userInteractionEnabled = YES;
     }
     return self;

--- a/WordPress/Classes/StatsTwoColumnCell.m
+++ b/WordPress/Classes/StatsTwoColumnCell.m
@@ -80,6 +80,7 @@ static CGFloat const RowIconWidth = 20.0f;
     if ([cellData isKindOfClass:[StatsViewByCountry class]]) {
         [self setLeft:left withImageUrl:[(StatsViewByCountry *)cellData imageUrl] right:right titleCell:NO];
     } else if ([cellData isKindOfClass:[StatsGroup class]]) {
+        self.selectionStyle = UITableViewCellSelectionStyleDefault;
         [self setLeft:left withImageUrl:[(StatsGroup *)cellData iconUrl] right:right titleCell:NO];
     } else {
         [self setLeft:left withImageUrl:nil right:right titleCell:NO];
@@ -92,6 +93,11 @@ static CGFloat const RowIconWidth = 20.0f;
     _linkEnabled = linkEnabled;
     
     UIColor *color = linkEnabled ? [WPStyleGuide baseDarkerBlue] : [WPStyleGuide whisperGrey];
+    
+    if (_linkEnabled) {
+        self.selectionStyle = UITableViewCellSelectionStyleDefault;
+    }
+    
     [self titleLabel].textColor = color;
 }
 

--- a/WordPress/Classes/StatsViewController.m
+++ b/WordPress/Classes/StatsViewController.m
@@ -513,7 +513,7 @@ typedef NS_ENUM(NSInteger, TotalFollowersShareRow) {
 
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath {
     StatsTitleCountItem *item = [self itemSelectedAtIndexPath:indexPath];
-    return [item isKindOfClass:[StatsGroup class]] || item.URL != nil;
+    return [item isKindOfClass:[StatsGroup class]] || item.URL != nil || indexPath.section == StatsSectionLinkToWebview;
 }
 
 - (StatsTitleCountItem *)itemSelectedAtIndexPath:(NSIndexPath *)indexPath {
@@ -574,6 +574,8 @@ typedef NS_ENUM(NSInteger, TotalFollowersShareRow) {
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+    
     StatsTitleCountItem *item = [self itemSelectedAtIndexPath:indexPath];
     if ([item isKindOfClass:[StatsGroup class]]) {
         [self toggleGroupExpanded:indexPath childCount:[(StatsGroup *)item children].count];


### PR DESCRIPTION
Fixes #1592 & #1556 

Header row cell was originally not tappable due to the UIButtons taking up the entire frame of the first row's cell.  Edge around UISegmentedControl could potentially be tapped and it'll crash the app.  Also with this fix #1556 is resolved because the row highlighting logic (which was crashing) was ineffective.
