### PR TITLE
Fix for issue #1575, preview not showing updates

### DIFF
--- a/WordPress/Classes/PostPreviewViewController.m
+++ b/WordPress/Classes/PostPreviewViewController.m
@@ -225,7 +225,7 @@
 #pragma mark Webkit View Delegate Methods
 
 - (void)refreshWebView {
-	BOOL edited = [self.apost hasChanges];
+	BOOL edited = [self.apost hasChanged];
     self.loadingView.hidden = NO;
 
 	if (edited) {


### PR DESCRIPTION
I'm not certain this is the same problem from #1575...? I wasn't able to reproduce it following those instructions, but maybe I misunderstood.

With a new post, I could enter content, tap Preview, and get the showSimplePreview, then go back, add more, and simple preview would show updates okay.

As soon as I tried to edit any saved post (published or draft) I could no longer see updates in the preview, because it would always do the showRealPreview.

I think `[self.apost hasChanges]` is supposed to be `hasChanged`, and that fixes this. Or, I found a slightly different bug and #1575 is something different that I couldn't reproduce. :)
