### PR TITLE
Notifications to merge changes aren't required when using parent/child

### DIFF
--- a/WordPress/Classes/AbstractPost.m
+++ b/WordPress/Classes/AbstractPost.m
@@ -67,7 +67,7 @@
 }
 
 + (void)mergeNewPosts:(NSArray *)newObjects forBlog:(Blog *)blog {
-    NSManagedObjectContext *backgroundContext = [[ContextManager sharedInstance] backgroundContext];
+    NSManagedObjectContext *backgroundContext = [[ContextManager sharedInstance] newDerivedContext];
     [backgroundContext performBlock:^{
         NSMutableArray *objectsToKeep = [NSMutableArray array];
         Blog *contextBlog = (Blog *)[backgroundContext existingObjectWithID:blog.objectID error:nil];
@@ -115,7 +115,7 @@
             }
         }
         
-        [[ContextManager sharedInstance] saveContext:backgroundContext];
+        [[ContextManager sharedInstance] saveDerivedContext:backgroundContext];
     }];
 }
 

--- a/WordPress/Classes/Comment.m
+++ b/WordPress/Classes/Comment.m
@@ -56,7 +56,7 @@ NSString * const CommentStatusDraft = @"draft";
 }
 
 + (void)mergeNewComments:(NSArray *)newComments forBlog:(Blog *)blog {
-    NSManagedObjectContext *backgroundMOC = [[ContextManager sharedInstance] backgroundContext];
+    NSManagedObjectContext *backgroundMOC = [[ContextManager sharedInstance] newDerivedContext];
     [backgroundMOC performBlock:^{
         NSMutableArray *commentsToKeep = [NSMutableArray array];
         Blog *contextBlog = (Blog *)[backgroundMOC existingObjectWithID:blog.objectID error:nil];
@@ -81,7 +81,7 @@ NSString * const CommentStatusDraft = @"draft";
             }
         }
         
-        [[ContextManager sharedInstance] saveContext:backgroundMOC];
+        [[ContextManager sharedInstance] saveDerivedContext:backgroundMOC];
     }];
 }
 

--- a/WordPress/Classes/ContextManager.h
+++ b/WordPress/Classes/ContextManager.h
@@ -5,17 +5,11 @@
 ///----------------------------------------------
 ///@name Persistent Contexts
 ///
-/// The backgroundContext has concurrency type
-/// NSPrivateQueueConcurrencyType and should be
-/// used for any background tasks. Its parent is
-/// the persistentStoreCoordinator.
-///
 /// The mainContext has concurrency type
 /// NSMainQueueConcurrencyType and should be used
 /// for UI elements and fetched results controllers.
 /// Its parent is the backgroundContext.
 ///----------------------------------------------
-@property (nonatomic, readonly, strong) NSManagedObjectContext *backgroundContext;
 @property (nonatomic, readonly, strong) NSManagedObjectContext *mainContext;
 
 ///-------------------------------------------------------------
@@ -41,7 +35,9 @@
 ///--------------------------
 
 /**
- For usage as a 'scratch pad' context
+ For usage as a 'scratch pad' context or for doing background work.
+ 
+ Make sure to save using saveDerivedContext:
  
  @return a new MOC with NSPrivateQueueConcurrencyType, 
  with the parent context as the background writer context

--- a/WordPress/Classes/Media.m
+++ b/WordPress/Classes/Media.m
@@ -70,7 +70,7 @@
     if ([blog isDeleted] || blog.managedObjectContext == nil)
         return;
     
-    NSManagedObjectContext *backgroundMOC = [[ContextManager sharedInstance] backgroundContext];
+    NSManagedObjectContext *backgroundMOC = [[ContextManager sharedInstance] newDerivedContext];
     [backgroundMOC performBlock:^{
         Blog *contextBlog = (Blog *)[backgroundMOC objectWithID:blog.objectID];
         NSMutableArray *mediaToKeep = [NSMutableArray array];
@@ -88,7 +88,7 @@
             }
         }
         
-        [[ContextManager sharedInstance] saveContext:backgroundMOC];
+        [[ContextManager sharedInstance] saveDerivedContext:backgroundMOC];
     }];
 }
 

--- a/WordPress/Classes/NotificationsManager.m
+++ b/WordPress/Classes/NotificationsManager.m
@@ -113,7 +113,7 @@ NSString *const NotificationsDeviceToken = @"apnsDeviceToken";
             
         case UIApplicationStateBackground:
             if (completionHandler) {
-                NoteService *noteService = [[NoteService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] backgroundContext]];
+                NoteService *noteService = [[NoteService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
                 
                 [noteService fetchNewNotificationsWithSuccess:^(BOOL hasNewNotes) {
                     DDLogVerbose(@"notification fetch completion handler completed with new notes: %@", hasNewNotes ? @"YES" : @"NO");

--- a/WordPress/Classes/ReaderPost.m
+++ b/WordPress/Classes/ReaderPost.m
@@ -118,7 +118,7 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
         return;
     }
     
-    NSManagedObjectContext *backgroundMOC = [[ContextManager sharedInstance] backgroundContext];
+    NSManagedObjectContext *backgroundMOC = [[ContextManager sharedInstance] newDerivedContext];
     [backgroundMOC performBlock:^{
         for (NSDictionary *postData in arr) {
             if (![postData isKindOfClass:[NSDictionary class]]) {
@@ -127,7 +127,7 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
             [self createOrUpdateWithDictionary:postData forEndpoint:endpoint withContext:backgroundMOC];
         }
         
-        [[ContextManager sharedInstance] saveContext:backgroundMOC];
+        [[ContextManager sharedInstance] saveDerivedContext:backgroundMOC];
         if (success) {
             dispatch_async(dispatch_get_main_queue(), success);
         }
@@ -137,7 +137,7 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
 
 + (void)deletePostsSyncedEarlierThan:(NSDate *)syncedDate {
     DDLogMethod();
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] backgroundContext];
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
     [context performBlock:^{
         NSFetchRequest *request = [[NSFetchRequest alloc] init];
         [request setEntity:[NSEntityDescription entityForName:@"ReaderPost" inManagedObjectContext:context]];
@@ -154,7 +154,7 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
                 [context deleteObject:post];
             }
         }
-        [[ContextManager sharedInstance] saveContext:context];
+        [[ContextManager sharedInstance] saveDerivedContext:context];
     }];
 }
 

--- a/WordPress/Classes/Theme.m
+++ b/WordPress/Classes/Theme.m
@@ -72,7 +72,7 @@ static NSDateFormatter *dateFormatter;
     WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
 
     [[defaultAccount restApi] fetchThemesForBlogId:blog.blogID.stringValue success:^(AFHTTPRequestOperation *operation, id responseObject) {
-        NSManagedObjectContext *backgroundMOC = [[ContextManager sharedInstance] backgroundContext];
+        NSManagedObjectContext *backgroundMOC = [[ContextManager sharedInstance] newDerivedContext];
         [backgroundMOC performBlock:^{
             NSMutableArray *themesToKeep = [NSMutableArray array];
             for (NSDictionary *t in responseObject[@"themes"]) {
@@ -87,7 +87,7 @@ static NSDateFormatter *dateFormatter;
                 }
             }
             
-            [[ContextManager sharedInstance] saveContext:backgroundMOC];
+            [[ContextManager sharedInstance] saveDerivedContext:backgroundMOC];
             
             dateFormatter = nil;
             

--- a/WordPress/Classes/WordPressAppDelegate.m
+++ b/WordPress/Classes/WordPressAppDelegate.m
@@ -636,7 +636,7 @@ static NSInteger const IndexForMeTab = 2;
 - (void)cleanUnusedMediaFileFromTmpDir {
     DDLogInfo(@"%@ %@", self, NSStringFromSelector(_cmd));
 
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] backgroundContext];
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     [context performBlock:^{
         NSError *error;
         NSMutableArray *mediaToKeep = [NSMutableArray array];


### PR DESCRIPTION
Fixes #1608 

The notifications with merging were causing conflicts when background changes happened.  Made the background context totally private and renamed to root context to prevent any confusion.  Any background work that needs to be performed should be done with a newDerivedContext.  Changes made in the main thread context will force a save on the root context so they're persisted to disk.
