### PR TITLE
Force saving of derived contexts to use alternate save method

### DIFF
--- a/WordPress/Classes/ContextManager.m
+++ b/WordPress/Classes/ContextManager.m
@@ -101,6 +101,8 @@ static ContextManager *instance;
 
 - (void)saveContext:(NSManagedObjectContext *)context {
     // Save derived contexts a little differently
+    // TODO - When the service refactor is complete, remove this - calling methods to Services should know what kind of context
+    //        it is and call the saveDerivedContext at the end of the work
     if (context.parentContext == self.mainContext) {
         [self saveDerivedContext:context];
         return;


### PR DESCRIPTION
Related #1608 

Derived contexts should use alternate method - put a check in to force this behavior to prevent having Services know what kind of context it is to pick the alternate method.

@jleandroperez 
