### PR TITLE
Don't include pending changes on note prune

### DIFF
--- a/WordPress/Classes/NoteService.m
+++ b/WordPress/Classes/NoteService.m
@@ -83,6 +83,7 @@ const NSUInteger NoteKeepCount = 20;
     
     NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"Note"];
     request.fetchOffset = keepCount;
+    request.includesPendingChanges = NO;
     NSSortDescriptor *dateSortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"timestamp" ascending:NO];
     request.sortDescriptors = @[ dateSortDescriptor ];
     NSArray *notes = [self.managedObjectContext executeFetchRequest:request error:&error];


### PR DESCRIPTION
For some weird reason, core data includes objects with pending changes,
even if they don't match the fetchLimit/fetchOffset conditions

Fixes #1623
