### PR TITLE
Fixed bug where super properties weren't being incremented.

### DIFF
--- a/WordPress/Classes/WPAnalyticsTrackerMixpanelInstructionsForStat.m
+++ b/WordPress/Classes/WPAnalyticsTrackerMixpanelInstructionsForStat.m
@@ -64,7 +64,7 @@
 - (void)setSuperPropertyAndPeoplePropertyToIncrement:(NSString *)property
 {
     NSParameterAssert(property != nil);
-    [self addSuperPropertyToFlag:property];
+    self.superPropertyToIncrement = property;
     self.peoplePropertyToIncrement = property;
 }
 


### PR DESCRIPTION
Fixed a bug where some super properties in mixpanel that were meant to be counted ended up getting set as booleans instead.
