### PR TITLE
If there is no gravatar use an identicon instead of 404ing.

### DIFF
--- a/WordPress/Classes/WPAvatarSource.m
+++ b/WordPress/Classes/WPAvatarSource.m
@@ -262,7 +262,7 @@ static NSString *const GravatarBaseUrl = @"http://gravatar.com";
             break;
     }
 
-    url = [url stringByAppendingFormat:@"%@?s=%d&d=404", hash, (int)(size.width * [[UIScreen mainScreen] scale])];
+    url = [url stringByAppendingFormat:@"%@?s=%d&d=identicon", hash, (int)(size.width * [[UIScreen mainScreen] scale])];
     return [NSURL URLWithString:url];
 }
 

--- a/WordPress/Classes/WPContentView.m
+++ b/WordPress/Classes/WPContentView.m
@@ -7,7 +7,6 @@
 #import "WPWebViewController.h"
 #import "UIImageView+AFNetworkingExtra.h"
 #import "UILabel+SuggestSize.h"
-#import "WPAvatarSource.h"
 #import "ContentActionButton.h"
 #import "NSDate+StringFormatting.h"
 #import "UIColor+Helpers.h"


### PR DESCRIPTION
Removes an unnecessary reference to WPAvatarSource

Fixes #1664
