### PR TITLE
Fix for issue #1043, content cut off after rotation

### DIFF
--- a/WordPress/Classes/ReaderPostView.h
+++ b/WordPress/Classes/ReaderPostView.h
@@ -2,6 +2,9 @@
 
 @class ReaderPostView;
 
+extern NSString * const ReaderPostViewDidFinishLayoutNotification;
+
+
 @protocol ReaderPostViewDelegate <WPContentViewDelegate>
 - (void)postView:(ReaderPostView *)postView didReceiveLikeAction:(id)sender;
 - (void)postView:(ReaderPostView *)postView didReceiveReblogAction:(id)sender;

--- a/WordPress/Classes/ReaderPostView.m
+++ b/WordPress/Classes/ReaderPostView.m
@@ -10,6 +10,7 @@
 #import "AccountService.h"
 
 static NSInteger const MaxNumberOfLinesForTitleForSummary = 3;
+NSString * const ReaderPostViewDidFinishLayoutNotification = @"ReaderPostViewDidFinishLayoutNotification";
 
 @interface ReaderPostView()
 
@@ -380,6 +381,11 @@ static NSInteger const MaxNumberOfLinesForTitleForSummary = 3;
     
     ownFrame.size.height = nextY + RPVMetaViewHeight - 1;
     self.frame = ownFrame;
+    
+    // Notify others that our layout has changed.
+    // This is needed because the layout would change after a containing tableViewCell's height was determined based on old values
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObject:[NSValue valueWithCGRect:ownFrame] forKey:@"OptimalFrame"];
+    [[NSNotificationCenter defaultCenter] postNotificationName:ReaderPostViewDidFinishLayoutNotification object:self userInfo:userInfo];
 }
 
 - (void)reset {


### PR DESCRIPTION
The problem in issue #1043 was the ReaderPostView changed its layout after the cell's height was determined.

Also fixes a related but slightly different bug where the content width would get weird if you rotated the device while scrolled down to the comments, with the content cell off screen.
