### PR TITLE
Fix for issue #1646, can’t dismiss comment reply keyboard

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/NotificationsCommentDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/NotificationsCommentDetailViewController.m
@@ -48,6 +48,7 @@ NSString *const WPNotificationCommentRestorationKey = @"WPNotificationCommentRes
 
 @property (nonatomic, strong) InlineComposeView *inlineComposeView;
 
+@property (nonatomic, strong) UITapGestureRecognizer *tapGesture;
 @end
 
 @implementation NotificationsCommentDetailViewController
@@ -114,6 +115,9 @@ NSString *const WPNotificationCommentRestorationKey = @"WPNotificationCommentRes
         scrollView.contentInset = UIEdgeInsetsMake(WPTableViewTopMargin, 0, WPTableViewTopMargin, 0);
         scrollView.contentWidth = WPTableViewFixedWidth;
     };
+
+    scrollView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+
     self.view = scrollView;
     self.view.backgroundColor = [UIColor whiteColor];
     
@@ -146,6 +150,8 @@ NSString *const WPNotificationCommentRestorationKey = @"WPNotificationCommentRes
     self.inlineComposeView = [[InlineComposeView alloc] initWithFrame:CGRectZero];
     self.inlineComposeView.delegate = self;
     [self.view addSubview:self.inlineComposeView];
+    
+    self.tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(onShowKeyboard:)
@@ -333,7 +339,11 @@ NSString *const WPNotificationCommentRestorationKey = @"WPNotificationCommentRes
 }
 
 - (void)replyAction:(id)sender {
-    [self.inlineComposeView becomeFirstResponder];
+    if(self.inlineComposeView.isDisplayed) {
+        [self.inlineComposeView dismissComposer];
+    } else {
+        [self.inlineComposeView becomeFirstResponder];
+    }
 }
 
 - (void)performCommentAction:(NSDictionary *)commentAction {
@@ -417,6 +427,14 @@ NSString *const WPNotificationCommentRestorationKey = @"WPNotificationCommentRes
     [_postBanner setBackgroundColor:[UIColor UIColorFromHex:0xF2F2F2]];
 }
 
+#pragma mark - Gesture Actions
+
+- (void)handleTap:(UITapGestureRecognizer *)gesture
+{
+    if(self.inlineComposeView.isDisplayed) {
+        [self.inlineComposeView dismissComposer];
+    }
+}
 
 #pragma mark - REST API
 
@@ -487,11 +505,13 @@ NSString *const WPNotificationCommentRestorationKey = @"WPNotificationCommentRes
     CGRect keyboardRect = [[notification.userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
     UIScrollView *scrollView = (UIScrollView *)self.view;
     scrollView.contentInset = UIEdgeInsetsMake(0.f, 0.f, CGRectGetHeight(keyboardRect), 0.f);
+    [self.view addGestureRecognizer:self.tapGesture];
 }
 
 - (void)onHideKeyboard:(NSNotification *)notification {
     UIScrollView *scrollView = (UIScrollView *)self.view;
     scrollView.contentInset = UIEdgeInsetsMake(0.f, 0.f, 0.f, 0.f);
+    [self.view removeGestureRecognizer:self.tapGesture];
 }
 
 


### PR DESCRIPTION
This fixes not being able to dismiss the keyboard when replying to a comment from the CommentViewController. Adds a tap gesture to dismiss, and the UIScrollView pan down to dismiss.

Also fixes scrolling issues in CommentViewController when the keyboard is shown over long comments.

I think it also fixes the same problem when replying in Notifications (#1646), but it's hard for me to test without being able to link up Jetpack.
