### PR TITLE
Correctly layout the follow button.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostView.m
@@ -299,7 +299,7 @@ static NSInteger const MaxNumberOfLinesForTitleForSummary = 3;
         self.followButton.hidden = NO;
         CGFloat followX = bylineX - 4; // Fudge factor for image alignment
         CGFloat followY = RPVAuthorPadding + self.bylineLabel.frame.size.height - 2;
-        height = ceil([self.followButton.titleLabel suggestedSizeForWidth:innerContentWidth].height);
+        height = ceil([self.followButton.titleLabel suggestSizeForString:[self.followButton titleForState:UIControlStateNormal] width:innerContentWidth].height);
         self.followButton.frame = CGRectMake(followX, followY, RPVFollowButtonWidth, height);
     } else {
         self.followButton.hidden = YES;


### PR DESCRIPTION
Correctly gets the value for height without relying on the button's internal label having text.
Fixes #1758 
