### PR TITLE
Allow topic tag button to be tapped after dismissal on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -445,7 +445,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
 - (void)topicsAction:(id)sender {
 	ReaderTopicsViewController *controller = [[ReaderTopicsViewController alloc] initWithStyle:UITableViewStyleGrouped];
     if (IS_IPAD) {
-        if (_popover) {
+        if (_popover && [_popover isPopoverVisible]) {
             [self dismissPopover];
             return;
         }


### PR DESCRIPTION
Fixes #1763 

When the popover is dismissed on the iPad, the dismiss action isn't called.  Instead of only looking at if _popover is nil to determine whether or not to show the popover, also send the isPopoverVisible message.  If it's not visible then just create the new popover.
