### PR TITLE
Hack in the Pods/WordPress-iOS-Shared directory for strings files

### DIFF
--- a/localize.py
+++ b/localize.py
@@ -131,7 +131,7 @@ def localize(path):
 
     if os.path.isfile(original):
         os.rename(original, old)
-        os.system('genstrings -q -o "%s" `find . ../Pods/WordPress-iOS-Shared/ -name "*.m" | grep -v Vendor`' % language)
+        os.system('genstrings -q -o "%s" `find . ../Pods/WordPress* -name "*.m" | grep -v Vendor`' % language)
         os.rename(original, new)
         merge(merged, old, new)
         os.remove(new)


### PR DESCRIPTION
Closes #1783 

This pulls in the NSLocalizedString instances from WordPress-iOS-Shared which is now a component of the app.  This may not be the permanent solution, but it prevents strings from being lost in GlotPress immediately.
