### PR TITLE
Restore Jetpack API base URL

### DIFF
--- a/WordPress/Classes/Models/Blog+Jetpack.m
+++ b/WordPress/Classes/Models/Blog+Jetpack.m
@@ -66,7 +66,7 @@ NSString * const BlogJetpackApiPath = @"get-user-blogs/1.0";
         }
     }
 
-	AFHTTPRequestOperationManager* operationManager = [[AFHTTPRequestOperationManager alloc] init];
+	AFHTTPRequestOperationManager* operationManager = [[AFHTTPRequestOperationManager alloc] initWithBaseURL:[NSURL URLWithString:BlogJetpackApiBaseUrl]];
 
 	NSString* userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
 


### PR DESCRIPTION
Since the migration to AFNetworking 2, the Jetpack login screen was broken, and users received an "unsupported URL" error.

We were trying to use "get-user-blogs/1.0" as the URL, which is unsupported.
