### PR TITLE
NUX: check username, prmopt for self-hosted if reserved.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -751,7 +751,7 @@ CGFloat const GeneralWalkthroughStatusBarOffset = 20.0;
 
 - (void)displayReservedNameErrorMessage
 {
-    [WPError showAlertWithTitle:NSLocalizedString(@"Self-hosted site?", nil) message:NSLocalizedString(@"Please enter the URL of your self-hosted WordPress site.", nil) withSupportButton:NO];
+    [WPError showAlertWithTitle:NSLocalizedString(@"Self-hosted site?", nil) message:NSLocalizedString(@"Please enter the URL of your WordPress site.", nil) withSupportButton:NO];
 }
 
 - (void)setAuthenticating:(BOOL)authenticating withStatusMessage:(NSString *)status {


### PR DESCRIPTION
Fixes #1805 

The entered username is checked against a short, hardcoded list of reserved strings. If a match is found, a self-hosted site is assumed. The url field becomes first responder and the user is prompted. 

Since the actual list if names is small it doesn't seem necessary to make the round trip to wpcom and try to parse the returned error message.

Not 100% sure about the wording in the prompt. Thoughts there? 
