### PR TITLE
Keyboard on post settings now stays open on device rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -132,12 +132,15 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
 
 - (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
 {
+    [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
     if ([self.passwordTextField isFirstResponder] || [self.tagsTextField isFirstResponder]) {
         self.textFieldDidHaveFocusBeforeOrientationChange = YES;
     }
 }
 
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
+- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
+{
+    [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
     [self reloadData];
 }
 


### PR DESCRIPTION
Title has it.

Fixes https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/33

Also, the date picker will now close automatically (if open) when a UITextField on the settings screen gains focus.
