### PR TITLE
Removes subscription check when fetching current topic.

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -65,9 +65,6 @@ NSString *const ReaderTopicCurrentTopicURIKey = @"ReaderTopicCurrentTopicURIKey"
             if (error) {
                 DDLogError(@"%@ error fetching topic: %@", NSStringFromSelector(_cmd), error);
             }
-            if (topic.type == ReaderTopicTypeTag && topic.isSubscribed == NO) {
-                topic = nil;
-            }
         }
     }
 


### PR DESCRIPTION
Fixes #1847 
The reason for the check was to clear a topic that was unsubscribed via the web. However, self-hosted users are never subscribed per se and the side effect was they couldn't browse recommended tags. 
Props @jstart for catching this one.  
