### PR TITLE
Don't force a layout pass, just flag one is needed.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -231,7 +231,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
     UIEdgeInsets scrollInsets = self.tableView.scrollIndicatorInsets;
     scrollInsets.bottom = insets.bottom;
     self.tableView.scrollIndicatorInsets = scrollInsets;
-    [self.tableView layoutIfNeeded];
+    [self.tableView setNeedsLayout];
 }
 
 - (void)setTitle:(NSString *)title {


### PR DESCRIPTION
This is a candidate fix for #1838. The theory is calling `layoutIfNeeded` here catches the `UITableView` in an inconsistent state.  We've been unable to reproduce the crash on demand, so this is a guess based on what is contained in the logs. We'll judge the likelihood of success based on whether we see the crash still appearing in our beta builds, and revisit if the crash persists. 
