### PR TITLE
Issue #1611: Notifications Cell Crashes if Title is nil

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/NewNotificationsTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/NewNotificationsTableViewCell.m
@@ -18,7 +18,7 @@
     // combine author and title
     NSString *title = [contentProvider titleForDisplay];
     NSString *content = [[contentProvider contentPreviewForDisplay] stringByNormalizingWhitespace];
-    if (!(title.length > 0)) {
+    if (title.length == 0) {
         title = NSLocalizedString(@"(No Title)", nil);
     }
     


### PR DESCRIPTION
#1611

Fixes the problem when title is nil. 
