### PR TITLE
Issue #1658: Comments: Replying to a comment from the comment's list does not reflect success/failure

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -12,6 +12,7 @@
 #import "WPFixedWidthScrollView.h"
 #import "WPTableViewCell.h"
 #import "DTLinkButton.h"
+#import "WPToast.h"
 
 CGFloat const CommentViewDeletePromptActionSheetTag = 501;
 CGFloat const CommentViewReplyToCommentViewControllerHasChangesActionSheetTag = 401;
@@ -356,25 +357,31 @@ CGFloat const CommentViewUnapproveButtonTag = 701;
 #pragma mark - InlineComposeViewDelegate methods
 
 - (void)composeView:(InlineComposeView *)view didSendText:(NSString *)text {
-
     self.reply.content = text;
+    
     // try to save it
-
     [[ContextManager sharedInstance] saveContext:self.reply.managedObjectContext];
 
-    [self.inlineComposeView clearText];
-    [self.inlineComposeView dismissComposer];
-
-    self.reply.status = CommentStatusApproved;
+    self.inlineComposeView.enabled = NO;
     self.transientReply = NO;
 
     CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:self.reply.managedObjectContext];
     [commentService uploadComment:self.reply success:^{
-        // the current modal experience shows success by dismissising the editor
-        // ideally we switch to an optimistic experience
+        self.reply.status = CommentStatusApproved;
+        
+        [self.inlineComposeView clearText];
+        self.inlineComposeView.enabled = YES;
+        [self.inlineComposeView dismissComposer];
+        
+        [WPToast showToastWithMessage:NSLocalizedString(@"Replied", @"User replied to a comment")
+                             andImage:[UIImage imageNamed:@"action_icon_replied"]];
+        
     } failure:^(NSError *error) {
         // reset to draft status, AppDelegate automatically shows UIAlert when comment fails
         self.reply.status = CommentStatusDraft;
+        
+        self.inlineComposeView.enabled = YES;
+        [self.inlineComposeView displayComposer];
 
         DDLogError(@"Could not reply to comment: %@", error);
     }];


### PR DESCRIPTION
#1658

Replying on the comment details now communicate the current status: Sending comment, Success/Failure same way the comment notification view do it. 
