### PR TITLE
Check for a nil topic before loading more.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -714,6 +714,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
         if (failure) {
             failure(nil);
         }
+        return;
     }
 
 	self.loadingMore = YES;


### PR DESCRIPTION
Avoids a rare crash at launch in certain situations.
Minor code style fix and removes a commented method.
Fixes #1903 
