### PR TITLE
Skip fetching a new image from the cache and just copy instead.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -352,8 +352,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
     NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
     ReaderPost *post = (ReaderPost *)[self.resultsController objectAtIndexPath:indexPath];
 
-    CGSize imageSize = postView.featuredImageView.image.size;
-    UIImage *image = [self.featuredImageSource imageForURL:post.featuredImageURL withSize:imageSize];
+    UIImage *image = [cell.postView.featuredImageView.image copy];
     UIImage *avatarImage = [post cachedAvatarWithSize:CGSizeMake(WPContentAttributionViewAvatarSize, WPContentAttributionViewAvatarSize)];
 
     RebloggingViewController *controller = [[RebloggingViewController alloc] initWithPost:post featuredImage:image avatarImage:avatarImage];
@@ -820,8 +819,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
 	ReaderPost *post = [self.resultsController.fetchedObjects objectAtIndex:indexPath.row];
     ReaderPostTableViewCell *cell = (ReaderPostTableViewCell *)[self.tableView cellForRowAtIndexPath:indexPath];
 
-    CGSize imageSize = cell.postView.featuredImageView.image.size;
-    UIImage *image = [_featuredImageSource imageForURL:post.featuredImageURL withSize:imageSize];
+    UIImage *image = [cell.postView.featuredImageView.image copy];
     UIImage *avatarImage = [cell.post cachedAvatarWithSize:CGSizeMake(32.0, 32.0)];
 // TODO: the detail controller should just fetch the cached versions of these resources vs passing them around here. :P
 	self.detailController = [[ReaderPostDetailViewController alloc] initWithPost:post featuredImage:image avatarImage:avatarImage];


### PR DESCRIPTION
This is a work around for an issue retriving some images from the cache.

Fixes #1908 

The issue seems to be `WPTableImageSource` `imageForURL:withSize:` returning nil if `cachedImageForURL:withSize:` doesn't find a match. If `resizesImagesSynchronously` is true, `WPTableImageSource` attempts to fetch and resize an image from the cache. This also ends up returning nil in some cases. 

Digging deeper, the `CGSize` passed to MGImageUtils's UIImage+ProportionalFill `imageCroppedToSize:ignoreAlpha:` has a zero height (nothing visible for core graphic to draw so no image). The zero height comes from `cachedImageForURL:withSize:` setting the size to zero when searching the cache. 

An alternate fix would be to pass the original height to the UIImage category methods but I'm not sure if that edit would have its own consequences. 

Since this needs to be a simple fix for 4.2, just copying and passing the existing image seems the safe path and was the approach prior to the view refactor.  Ideally the reader detail should request its own images so a more robust fix can be scoped for 4.3. 
