### PR TITLE
Avoid redrawing cells when setting separator style.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -232,7 +232,6 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
-
 }
 
 - (void)configureCellForLayout


### PR DESCRIPTION
Fixes #1934 

Setting the `cellSeparatorStyle` causes the table view to redraw its cells. Due to the way the underlying `WPTableViewController` is wired up, this also triggers calls to core data to populate the results controller and a lot of stuff we're not interested in during `viewDidLoad`. 

A work around is to temporarily unset the table view's delegate and data source while assigning the separator style.  This avoids a noticeable lag when switching to the reader tab. 
