### PR TITLE
NotificationsViewController: Loading matcher post on the mainMOC

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/NotificationsViewController.m
@@ -285,11 +285,10 @@ typedef void (^NotificationsLoadPostBlock)(BOOL success, ReaderPost *post);
 
 - (void)loadPostWithId:(NSNumber *)postID fromSite:(NSNumber *)siteID block:(NotificationsLoadPostBlock)block
 {
-    ContextManager *contextManager = [ContextManager sharedInstance];
-    NSManagedObjectContext *context = [contextManager newDerivedContext];
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context];
-    [service fetchPost:[postID integerValue] forSite:[siteID integerValue] success:^(ReaderPost *post) {
-        [contextManager saveDerivedContext:context];
+    [service fetchPost:postID.integerValue forSite:siteID.integerValue success:^(ReaderPost *post) {
+        [[ContextManager sharedInstance] saveContext:context];
         block(YES, post);
     } failure:^(NSError *error) {
         DDLogError(@"[RestAPI] %@", error);


### PR DESCRIPTION
Fixes #1944

Tapping over a Matcher Notification was pushing ReaderPostDetailViewController, but the post itself was being faulted into a derived MOC, when we actually needed / expected a post faulted in the main MOC.
