### PR TITLE
Remove slicing data from btn-primary-tap asset

### DIFF
--- a/WordPress/Resources/AppImages.xcassets/btn-primary-tap.imageset/Contents.json
+++ b/WordPress/Resources/AppImages.xcassets/btn-primary-tap.imageset/Contents.json
@@ -6,20 +6,9 @@
       "filename" : "btn-primary-tap.png"
     },
     {
-      "resizing" : {
-        "mode" : "3-part-horizontal",
-        "center" : {
-          "mode" : "fill",
-          "width" : 1
-        },
-        "capInsets" : {
-          "right" : 9,
-          "left" : 8
-        }
-      },
       "idiom" : "universal",
-      "filename" : "btn-primary-tap@2x.png",
-      "scale" : "2x"
+      "scale" : "2x",
+      "filename" : "btn-primary-tap@2x.png"
     }
   ],
   "info" : {


### PR DESCRIPTION
We're slicing in code anyway, and it was crashing for some reason

Fixes #1946
