### PR TITLE
Fixing bug where all users were flagged as being from WordPress.com.

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -22,7 +22,6 @@
 - (void)beginSession
 {
     [Mixpanel sharedInstanceWithToken:[WordPressComApiCredentials mixpanelAPIToken]];
-    
     // Tracking session count will help us isolate users who just installed the app
     NSUInteger sessionCount = [[[[Mixpanel sharedInstance] currentSuperProperties] objectForKey:@"session_count"] intValue];
     sessionCount++;
@@ -32,11 +31,12 @@
     WPAccount *account = [accountService defaultWordPressComAccount];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
     
-    BOOL dotcom_user, jetpack_user;
+    BOOL dotcom_user = NO;
+    BOOL jetpack_user = NO;
     if (account != nil) {
-        dotcom_user = true;
+        dotcom_user = YES;
         if ([[account jetpackBlogs] count] > 0) {
-            jetpack_user = true;
+            jetpack_user = YES;
         }
     }
     


### PR DESCRIPTION
BOOL isn't initialized to zero when it's a variable within a method(it gets initialized to zero when it's an instance variable though):
![32 bit](https://cloud.githubusercontent.com/assets/437043/3548398/25d459b6-08ad-11e4-9d82-a0fbeb9def9e.png)

Fixes #1956 
