### PR TITLE
Implement restoration for StatsViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -102,8 +102,9 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 + (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder {
     NSURL *blogObjectURL = [coder decodeObjectForKey:StatsBlogObjectURLRestorationKey];
-    if (!blogObjectURL)
+    if (!blogObjectURL) {
         return nil;
+    }
 
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     NSManagedObjectID *blogObjectID = [context.persistentStoreCoordinator managedObjectIDForURIRepresentation:blogObjectURL];


### PR DESCRIPTION
The WPStatsViewController class already implemented view controller
restoration, but the subclass didn't.

When a StatsViewController was restored, `self.blog` was `nil`, which
would cause it to prompt to install Jetpack, as `[nil hasJetpack]`
evaluates to false.

Fixes #1958
