### PR TITLE
Prevents pushing ReaderPostDetailVC when the caller is not the top VC

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/NotificationsViewController.m
@@ -246,11 +246,11 @@ typedef void (^NotificationsLoadPostBlock)(BOOL success, ReaderPost *post);
             [self.navigationController pushViewController:commentDetailViewController animated:YES];
         } else if ([note isMatcher] && [note metaPostID] && [note metaSiteID]) {
             [self loadPostWithId:[note metaPostID] fromSite:[note metaSiteID] block:^(BOOL success, ReaderPost *post) {
-                if (!success) {
+                if (!success || ![self.navigationController.topViewController isEqual:self]) {
                     [self.tableView deselectRowAtIndexPath:indexPath animated:YES];
                     return;
                 }
-                
+            
                 ReaderPostDetailViewController *controller = [[ReaderPostDetailViewController alloc] initWithPost:post featuredImage:nil avatarImage:nil];
                 [self.navigationController pushViewController:controller animated:YES];
             }];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -500,6 +500,10 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
     ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context];
     [service deletePostsWithNoTopic];
     [service fetchPost:postId forSite:blogId success:^(ReaderPost *post) {
+        if (![self.navigationController.topViewController isEqual:self]) {
+            return;
+        }
+        
         ReaderPostDetailViewController *controller = [[ReaderPostDetailViewController alloc] initWithPost:post
                                                                                             featuredImage:nil
                                                                                               avatarImage:nil];


### PR DESCRIPTION
I've been unable to directly reproduce this. One possibility is that this is caused by multiple nested calls to `pushViewController:`.

I've found two potential spots that would allow that to happen: multiple taps on a cell + network lag.

Fixes #1955
