### PR TITLE
Loading cached images as placeholders through sessions

### DIFF
--- a/WordPress/Classes/Categories/UIImageView+AFNetworkingExtra.h
+++ b/WordPress/Classes/Categories/UIImageView+AFNetworkingExtra.h
@@ -7,4 +7,6 @@
 				success:(void (^)(UIImage *image))success
 				failure:(void (^)(NSError *error))failure;
 
+- (void)setImageWithURL:(NSURL *)url emptyCachePlaceholderImage:(UIImage *)emptyCachePlaceholderImage;
+
 @end

--- a/WordPress/Classes/Categories/UIImageView+AFNetworkingExtra.m
+++ b/WordPress/Classes/Categories/UIImageView+AFNetworkingExtra.m
@@ -23,6 +23,33 @@
 						 }];
 }
 
+- (void)setImageWithURL:(NSURL *)url emptyCachePlaceholderImage:(UIImage *)emptyCachePlaceholderImage
+{
+    UIImage *placeholderImage = [self cachedImageForURL:url] ?: emptyCachePlaceholderImage;
+    [self setImageWithURL:url placeholderImage:placeholderImage];
+}
 
+- (UIImage *)cachedImageForURL:(NSURL *)url
+{
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    NSCachedURLResponse *cachedResponse = [[NSURLCache sharedURLCache] cachedResponseForRequest:request];
+    if (![cachedResponse            isKindOfClass:[NSCachedURLResponse class]]  ||
+        ![cachedResponse.response   isKindOfClass:[NSURLResponse class]]        ||
+        ![cachedResponse.data       isKindOfClass:[NSData class]]               ||
+        cachedResponse.data.length == 0) {
+        return nil;
+    }
+    
+    NSError *error = nil;
+    id responseObject = [[AFImageResponseSerializer serializer] responseObjectForResponse:cachedResponse.response
+                                                                                     data:cachedResponse.data
+                                                                                    error:&error];
+    
+    if (error || ![responseObject isKindOfClass:[UIImage class]]) {
+        return nil;
+    }
+    
+    return responseObject;
+}
 
 @end

--- a/WordPress/Classes/ViewRelated/Cells/WPContentCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/WPContentCell.m
@@ -1,6 +1,7 @@
 #import "WPContentCell.h"
 
 #import <AFNetworking/UIKit+AFNetworking.h>
+#import "UIImageView+AFNetworkingExtra.h"
 #import "WPComLanguages.h"
 #import "UIImageView+Gravatar.h"
 #import "NSDate+StringFormatting.h"
@@ -184,7 +185,7 @@ CGFloat const WPContentCellDefaultOrigin                    = 15.0f;
         NSString *url = [NSString stringWithFormat:@"%@", [contentProvider avatarURLForDisplay]];
         if (url) {
             url = [url stringByReplacingOccurrencesOfString:@"s=256" withString:[NSString stringWithFormat:@"s=%.0f", WPContentCellImageWidth * [[UIScreen mainScreen] scale]]];
-            [_gravatarImageView setImageWithURL:[NSURL URLWithString:url] placeholderImage:[UIImage imageNamed:@"gravatar"]];
+            [_gravatarImageView setImageWithURL:[NSURL URLWithString:url] emptyCachePlaceholderImage:[UIImage imageNamed:@"gravatar"] ];
         } else {
             [_gravatarImageView setImage:[UIImage imageNamed:@"gravatar"]];
         }


### PR DESCRIPTION
AFNetworking's UIImageView category relies on a NSCache in-memory based cache. After restarting the app, that cache gets nuked.

This patch will attempt to load the cached response for any given image. If found, that cache will be used as a placeholder.

Fixes #1942
