### PR TITLE
Just show an arrow for the back button, no title.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
@@ -134,7 +134,7 @@ typedef enum {
 
     self.tableView.tableHeaderView = self.inlineComposeView;
 
-    // Let pushed view controllers just show an error for the back button, not title.
+    // Let pushed view controllers just show an arrow for the back button, not title.
     UIBarButtonItem *backButton = [[UIBarButtonItem alloc] init];
     backButton.title = @"";
     self.navigationItem.backBarButtonItem = backButton;


### PR DESCRIPTION
Fixes #1045 
Setting a custom back button with a zero length title prevents both an ellipsed title, and the default "Back" button text from showing. 
