### PR TITLE
Fix post settings photo popover position

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -47,7 +47,6 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
 
 @interface PostSettingsViewController () <UITextFieldDelegate, WPTableImageSourceDelegate, WPPickerViewDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate, UIPopoverControllerDelegate> {
     WPMediaUploader *_mediaUploader;
-    UIPopoverController *_popover;
 }
 
 @property (nonatomic, strong) AbstractPost *apost;
@@ -60,6 +59,7 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
 @property (nonatomic, strong) UIImage *featuredImage;
 @property (nonatomic, strong) PublishDatePickerView *datePicker;
 @property (assign) BOOL *textFieldDidHaveFocusBeforeOrientationChange;
+@property (nonatomic, strong) UIPopoverController *popover;
 
 @end
 
@@ -824,10 +824,10 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
     picker.navigationBar.barStyle = UIBarStyleBlack;
     
     if (IS_IPAD) {
-        _popover = [[UIPopoverController alloc] initWithContentViewController:picker];
+        self.popover = [[UIPopoverController alloc] initWithContentViewController:picker];
         CGRect frame = [self.tableView rectForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:PostSettingsSectionFeaturedImage]];
-        _popover.delegate = self;
-        [_popover presentPopoverFromRect:frame inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+        self.popover.delegate = self;
+        [self.popover presentPopoverFromRect:frame inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
     } else {
         [self.navigationController presentViewController:picker animated:YES completion:nil];
     }
@@ -962,7 +962,7 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
         }];
 
         if (IS_IPAD) {
-            [_popover dismissPopoverAnimated:YES];
+            [self.popover dismissPopoverAnimated:YES];
         } else {
             [self.navigationController dismissViewControllerAnimated:YES completion:nil];
         }
@@ -977,6 +977,13 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
 - (void)popoverController:(UIPopoverController *)popoverController willRepositionPopoverToRect:(inout CGRect *)rect inView:(inout UIView *__autoreleasing *)view
 {
     *rect = [self.tableView rectForRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:PostSettingsSectionFeaturedImage]];
+}
+
+- (void)popoverControllerDidDismissPopover:(UIPopoverController *)popoverController
+{
+    // Reset delegate and nil popover property
+    self.popover.delegate = nil;
+    self.popover = nil;
 }
 
 @end


### PR DESCRIPTION
Fixed #1918 by implementing UIPopoverControllerDelegate's popoverController:willRepositionPopoverToRect:inView: method.

Popover is now well centered after rotation.
