### PR TITLE
Removing incorrect analytics for sharing.

### DIFF
--- a/WordPress/Classes/Utility/Sharing/WPActivityDefaults.m
+++ b/WordPress/Classes/Utility/Sharing/WPActivityDefaults.m
@@ -40,11 +40,7 @@
         stat = WPAnalyticsStatSentItemToGooglePlus;
     } else if ([activityType isEqualToString:NSStringFromClass([WordPressActivity class])]) {
         stat = WPAnalyticsStatSentItemToWordPress;
-    } else if ([activityType isEqualToString:UIActivityTypeCopyToPasteboard]) {
-        return;
-    } else if ([activityType isEqualToString:UIActivityTypeAddToReadingList]) {
-        return;
-    } else if ([activityType isEqualToString:NSStringFromClass([SafariActivity class])]) {
+    } else if ([activityType isEqualToString:UIActivityTypeCopyToPasteboard] || [activityType isEqualToString:UIActivityTypeAddToReadingList] || [activityType isEqualToString:NSStringFromClass([SafariActivity class])]) {
         return;
     } else {
         [WPAnalytics track:WPAnalyticsStatSharedItem];


### PR DESCRIPTION
Was incorrectly flagging:
- Adding an item to Reading List.
- Copying an item's link.
- Opening an item in Safari.

Fixes #2010.
