### PR TITLE
Set post settings tableview as grouped

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -310,7 +310,7 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
 - (NSString *)titleForHeaderInSection:(NSInteger)section {
     NSInteger sec = [[self.sections objectAtIndex:section] integerValue];
     if (sec == PostSettingsSectionTaxonomy) {
-        // No title
+        return NSLocalizedString(@"Taxonomy", @"Label for the Taxonomy area (categories, keywords, ...) in post settings.");
         
     } else if (sec == PostSettingsSectionMeta) {
         return NSLocalizedString(@"Publish", @"The grandiose Publish button in the Post Editor! Should use the same translation as core WP.");
@@ -338,13 +338,15 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
     if (IS_IPAD && section == 0) {
         return WPTableViewTopMargin;
-    } else if (section == 0) {
-        // Grouped table views don't allow 0.0f values
-        return 1.0f;
     }
     
     NSString *title = [self titleForHeaderInSection:section];
     return [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section {
+    // Remove extra padding caused by section footers in grouped table views
+    return 1.0f;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {


### PR DESCRIPTION
Fixed #1917

Grouped table views don't allow section heights of 0.0f so I had to do a simple hack with content inset. Is that OK?

The result looks good on both iPhone and iPad:
![ios simulator screen shot 16 jul 2014 01 49 38 pm](https://cloud.githubusercontent.com/assets/820515/3598383/04b1ca5a-0ce2-11e4-8bc7-25dc007ce83d.png)
![ios simulator screen shot 16 jul 2014 01 57 46 pm](https://cloud.githubusercontent.com/assets/820515/3598384/04b5d762-0ce2-11e4-90b1-c8594c6656e3.png)
