### PR TITLE
Prime the share activity when its safe.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
@@ -168,7 +168,15 @@ static CGFloat const SectionHeaderHeight = 25.0f;
     if ((lastSynced == nil || ABS([lastSynced timeIntervalSinceNow]) > ReaderPostDetailViewControllerRefreshTimeout) && self.post.isWPCom) {
 		[self syncWithUserInteraction:NO];
     }
-    
+
+    // The first time the activity view controller is loaded, there is a bit of
+    // processing that happens under the hood. This can cause a stutter
+    // if the user taps the share button while scrolling. A work around is to
+    // prime the activity controller when there is no animation occuring.
+    // The performance hit only happens once so its fine to discard the controller
+    // after it loads its view.
+    [[self activityViewControllerForSharing] view];
+
     [self.tableView reloadData];
 }
 
@@ -388,7 +396,7 @@ static CGFloat const SectionHeaderHeight = 25.0f;
 	});
 }
 
-- (void)handleShareButtonTapped:(id)sender
+- (UIActivityViewController *)activityViewControllerForSharing
 {
     NSString *title = self.post.postTitle;
     NSString *summary = self.post.summary;
@@ -396,7 +404,7 @@ static CGFloat const SectionHeaderHeight = 25.0f;
 
     NSMutableArray *activityItems = [NSMutableArray array];
 	NSMutableDictionary *postDictionary = [NSMutableDictionary dictionary];
-	
+
     if (title) {
         postDictionary[@"title"] = title;
     }
@@ -421,7 +429,12 @@ static CGFloat const SectionHeaderHeight = 25.0f;
         }
         [WPActivityDefaults trackActivityType:activityType];
     };
+    return activityViewController;
+}
 
+- (void)handleShareButtonTapped:(id)sender
+{
+    UIActivityViewController *activityViewController = [self activityViewControllerForSharing];
     if (IS_IPAD) {
         if (self.popover) {
             [self dismissPopover];


### PR DESCRIPTION
Avoid a visible performance hit later if scrolling.
Spent some time trying to track the exact cause down in the Time Profiler but I hit a dead end with Apple's frameworks.  This patch is just a work around for the underlying problem until we can coax it into showing its self. 

Fixes #1650 
