### PR TITLE
Added Content-Security-Policy to the default preview HTML template

### DIFF
--- a/WordPress/Resources/HTML/defaultPostTemplate.html
+++ b/WordPress/Resources/HTML/defaultPostTemplate.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 	<meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no">
+    <meta http-equiv="Content-Security-Policy" content="script-src none">
 	<style type="text/css">
 		html {font-family:Helvetica;padding:10px}
 		body {


### PR DESCRIPTION
Adding the Content-Security-Policy meta tag disables javascript in the local post/page preview.

h/t to this guy: http://philkast.com/2013/12/10/using-content-security-policy-from-a-meta-tag.html
