### PR TITLE
Issues/2029 fix preloading reader images

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -600,7 +600,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
             } else {
                 [self.featuredImageSource fetchImageForURL:imageURL
                                                   withSize:[self sizeForFeaturedImage]
-                                                 indexPath:indexPath
+                                                 indexPath:nextIndexPath
                                                  isPrivate:post.isPrivate];
             }
         }


### PR DESCRIPTION
Fixes [WordPress-iOS/issues/2029](https://github.com/wordpress-mobile/WordPress-iOS/issues/2029)

Also fixes using the wrong indexPath for preloading the images.
