### PR TITLE
better handles cells for Helpshift enabled status

### DIFF
--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -160,7 +160,7 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
     if (section == SettingsSectionFAQForums) {
-        return 1;
+        return 2;
     }
     
     if (section == SettingsSectionActivityLog) {
@@ -216,25 +216,42 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
     cell.textLabel.textAlignment = NSTextAlignmentLeft;
     [WPStyleGuide configureTableViewCell:cell];
     
-    if (indexPath.section == SettingsSectionFAQForums && indexPath.row == 0) {
-        cell.textLabel.text = (self.helpshiftEnabled) ? NSLocalizedString(@"Contact Us", nil)
-                                                      : NSLocalizedString(@"WordPress Help Center", @"");
+    if (indexPath.section == SettingsSectionFAQForums) {
+        switch (indexPath.row) {
+            case 0:
+                cell.textLabel.text = NSLocalizedString(@"WordPress Help Center", @"");
+                cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
 
-        if (self.helpshiftUnreadCount > 0) {
-            UILabel *helpshiftUnreadCountLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 50, 30)];
-            helpshiftUnreadCountLabel.layer.masksToBounds = YES;
-            helpshiftUnreadCountLabel.layer.cornerRadius = 15;
-            helpshiftUnreadCountLabel.textAlignment = NSTextAlignmentCenter;
-            helpshiftUnreadCountLabel.backgroundColor = [WPStyleGuide newKidOnTheBlockBlue];
-            helpshiftUnreadCountLabel.textColor = [UIColor whiteColor];
-
-            helpshiftUnreadCountLabel.text = [NSString stringWithFormat:@"%i", self.helpshiftUnreadCount];
-            cell.accessoryView = helpshiftUnreadCountLabel;
-
-            cell.accessoryType = UITableViewCellAccessoryNone;
-        } else {
-            cell.accessoryView = nil;
-            cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                break;
+            case 1:
+                if (self.helpshiftEnabled) {
+                    cell.textLabel.text = NSLocalizedString(@"Contact Us", nil);
+                    
+                    if (self.helpshiftUnreadCount > 0) {
+                        UILabel *helpshiftUnreadCountLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 50, 30)];
+                        helpshiftUnreadCountLabel.layer.masksToBounds = YES;
+                        helpshiftUnreadCountLabel.layer.cornerRadius = 15;
+                        helpshiftUnreadCountLabel.textAlignment = NSTextAlignmentCenter;
+                        helpshiftUnreadCountLabel.backgroundColor = [WPStyleGuide newKidOnTheBlockBlue];
+                        helpshiftUnreadCountLabel.textColor = [UIColor whiteColor];
+                        
+                        helpshiftUnreadCountLabel.text = [NSString stringWithFormat:@"%i", self.helpshiftUnreadCount];
+                        cell.accessoryView = helpshiftUnreadCountLabel;
+                        
+                        cell.accessoryType = UITableViewCellAccessoryNone;
+                    } else {
+                        cell.accessoryView = nil;
+                        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                    }
+                } else {
+                    cell.textLabel.text = NSLocalizedString(@"WordPress Forums", @"");
+                    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+                }
+                
+                break;
+            default:
+                // should never get here
+                break;
         }
     } else if (indexPath.section == SettingsSectionFeedback) {
         cell.textLabel.text = NSLocalizedString(@"E-mail Support", @"");
@@ -296,11 +313,29 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
 {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
-    if (indexPath.section == SettingsSectionFAQForums && !self.helpshiftEnabled && indexPath.row == 0) {
-        [[Helpshift sharedInstance] showFAQs:self withOptions:nil];
-    } else if (indexPath.section == SettingsSectionFAQForums && self.helpshiftEnabled && indexPath.row == 0) {
-        [Taplytics goalAchieved:@"Helpshift opened"];
-        [[Helpshift sharedInstance] showConversation:self withOptions:nil];
+    if (indexPath.section == SettingsSectionFAQForums) {
+        switch (indexPath.row) {
+            case 0:
+                if (self.helpshiftEnabled) {
+                    [[Helpshift sharedInstance] showFAQs:self withOptions:nil];
+                } else {
+                    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://ios.wordpress.org/faq"]];
+                }
+                
+                break;
+            case 1:
+                if (self.helpshiftEnabled) {
+                    [Taplytics goalAchieved:@"Helpshift opened"];
+                    [[Helpshift sharedInstance] showConversation:self withOptions:nil];
+                } else {
+                    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:@"http://ios.forums.wordpress.org"]];
+                }
+                
+                break;
+            default:
+                // should never get here
+                break;
+        }
     } else if (indexPath.section == SettingsSectionFeedback) {
         if ([MFMailComposeViewController canSendMail]) {
             MFMailComposeViewController *mailComposeViewController = [self feedbackMailViewController];


### PR DESCRIPTION
This should fix the case where Helpshift was always loaded.  On the baseline, SupportViewController was displaying the FAQ from Helpshift (which also includes a button for Contact Us).  On the experiment, it was showing only the Contact Us cell.

This PR brings back the FAQ and Help Center pages if on the baseline and adds a FAQ cell on the Helpshift experiment.

fixes #1866 
