### PR TITLE
Convert blogid to number for new sites

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -720,7 +720,7 @@ CGFloat const CreateAccountAndBlogButtonHeight = 40.0;
                 blog = [accountService createBlogWithAccount:defaultAccount];
                 blog.xmlrpc = blogOptions[@"xmlrpc"];
             }
-            blog.blogID = blogOptions[@"blogid"];
+            blog.blogID = [blogOptions numberForKey:@"blogid"];
             blog.blogName = [blogOptions[@"blogname"] stringByDecodingXMLCharacters];
             blog.url = blogOptions[@"url"];
 


### PR DESCRIPTION
Since `sites/new` is an undocumented endpoint, I mistakenly expected
blogid to be a number and ditched the conversion in 19d76d217bff6edb39fbbf7ad845abb88d0d2ffa

Fixes #2047
