### PR TITLE
Fixes Empty Notifications Legend Bug

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTableViewController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTableViewController.m
@@ -389,8 +389,8 @@ NSString *const DefaultCellIdentifier = @"DefaultCellIdentifier";
     }
     
     _didTriggerRefresh = YES;
-	[self syncItemsViaUserInteraction];
     [self.noResultsView removeFromSuperview];
+	[self syncItemsViaUserInteraction];
 }
 
 - (BOOL)userCanRefresh {


### PR DESCRIPTION
Since Simperium's sync call is no-op, and there is no delay in the `success` callback execution, the `[self.noResultsView removeFromSuperview]` instruction was actually removing the Empty Results view.

Fixes #2037 
