### PR TITLE
Added a "Signed In" event to tracking.

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics.h
@@ -60,6 +60,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatAddedSelfHostedSiteButJetpackNotConnectedToWPCom,
     WPAnalyticsStatSkippedConnectingToJetpack,
     WPAnalyticsStatSignedInToJetpack,
+    WPAnalyticsStatSignedIn,
     WPAnalyticsStatSelectedLearnMoreInConnectToJetpackScreen,
     WPAnalyticsStatPerformedJetpackSignInFromStatsScreen,
     WPAnalyticsStatSelectedInstallJetpack,

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -388,6 +388,9 @@
             [instructions addSuperPropertyToFlag:@"jetpack_user"];
             [instructions addSuperPropertyToFlag:@"dotcom_user"];
             break;
+        case WPAnalyticsStatSignedIn:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Signed In"];
+            break;
         case WPAnalyticsStatSelectedLearnMoreInConnectToJetpackScreen:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Selected Learn More in Connect to Jetpack Screen"];
             break;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -886,6 +886,7 @@ CGFloat const GeneralWalkthroughStatusBarOffset = 20.0;
                                 success:^{
                                     [self setAuthenticating:NO withStatusMessage:nil];
                                     [self dismiss];
+                                    [WPAnalytics track:WPAnalyticsStatSignedIn withProperties:@{ @"dotcom_user" : @(YES) }];
                                     [WPAnalytics refreshMetadata];
                                 }
                                 failure:^(NSError *error) {
@@ -933,6 +934,7 @@ CGFloat const GeneralWalkthroughStatusBarOffset = 20.0;
         [self dismiss];
     }
     
+    [WPAnalytics track:WPAnalyticsStatSignedIn withProperties:@{ @"dotcom_user" : @(NO) }];
     [WPAnalytics refreshMetadata];
 }
 


### PR DESCRIPTION
We didn't previously have an event to track generic user sign ins. This pull request adds it.
