### PR TITLE
Make notification like view look consistent to comment view

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/NotificationsFollowDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/NotificationsFollowDetailViewController.m
@@ -171,7 +171,8 @@ typedef void (^NoteToggleFollowBlock)(BOOL success);
         
         cell.textLabel.text				= [NSString decodeXMLCharactersIn:_note.subjectText];
         cell.textLabel.numberOfLines	= 0;
-        cell.textLabel.textAlignment	= NSTextAlignmentCenter;
+        cell.textLabel.textColor		= [UIColor blackColor];
+		cell.textLabel.font				= [WPStyleGuide regularTextFont];
         cell.accessoryType				= UITableViewCellAccessoryDisclosureIndicator;
 
         // Note that we're using this cell as a section header. Since 'didPressCellAtIndex:' method isn't gonna get called,
@@ -214,7 +215,8 @@ typedef void (^NoteToggleFollowBlock)(BOOL success);
 			cell.actionButton.hidden	= YES;
 		}
         
-        cell.textLabel.text = noteItem.headerText;
+        cell.textLabel.text       = noteItem.headerText;
+        cell.detailTextLabel.text = [noteItem.headerLink stringByReplacingOccurrencesOfString:@"http://" withString:@""];;
 
 		// Handle the Icon
 		NSURL *iconURL = noteItem.iconURL;
@@ -306,7 +308,7 @@ typedef void (^NoteToggleFollowBlock)(BOOL success);
 {
     if (indexPath.section == WPNotificationSectionsFollow) {
 		NoteBodyItem *item = self.filteredBodyItems[indexPath.row];
-		NSURL *blogURL = item.action.blogURL;
+        NSURL *blogURL =  [[NSURL alloc]initWithString:item.headerLink];
         if (blogURL) {
             WPWebViewController *webViewController = [[WPWebViewController alloc] init];
             if ([blogURL isWordPressDotComUrl]) {

--- a/WordPress/Resources/NotificationsFollowDetailViewController.xib
+++ b/WordPress/Resources/NotificationsFollowDetailViewController.xib
@@ -16,10 +16,10 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="548"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" allowsSelectionDuringEditing="YES" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="3">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" allowsSelectionDuringEditing="YES" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="3">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="548"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="13"/>
                         <outlet property="delegate" destination="-1" id="14"/>


### PR DESCRIPTION
Fixes #1913

I did update the view of like notification to make it looks more like comment counterpart. The results looks like this:

![ios simulator screen shot 20 jul 2014 21 07 47](https://cloud.githubusercontent.com/assets/151760/3638284/4814f2a6-1041-11e4-9d4c-3131afcf5b97.png)
![ios simulator screen shot 20 jul 2014 21 07 36](https://cloud.githubusercontent.com/assets/151760/3638283/48145e2c-1041-11e4-9eec-1acbe7f01220.png)
