### PR TITLE
visually group blog details instead of long list

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -160,15 +160,15 @@ NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
                 cell.imageView.image = [UIImage imageNamed:@"icon-menu-stats"];
                 break;
             case BlogDetailsRowEditSettings:
-                cell.textLabel.text = NSLocalizedString(@"Edit Site Settings", nil);
+                cell.textLabel.text = NSLocalizedString(@"Edit Site", nil);
                 cell.imageView.image = [UIImage imageNamed:@"icon-menu-settings"];
                 break;
             case BlogDetailsRowViewSite:
-                cell.textLabel.text = NSLocalizedString(@"View Web Site", nil);
+                cell.textLabel.text = NSLocalizedString(@"View Site", nil);
                 cell.imageView.image = [UIImage imageNamed:@"icon-menu-viewsite"];
                 break;
             case BlogDetailsRowViewAdmin:
-                cell.textLabel.text = NSLocalizedString(@"View Web Admin", nil);
+                cell.textLabel.text = NSLocalizedString(@"View Admin", nil);
                 cell.imageView.image = [UIImage imageNamed:@"icon-menu-viewadmin"];
                 break;
             default:


### PR DESCRIPTION
fixes #1634 

This also adjusts the titles of the cells to be more descriptive for what they are.

![ios simulator screen shot jul 22 2014 5 03 31 pm](https://cloud.githubusercontent.com/assets/1220715/3665232/f4975c28-11e3-11e4-8297-440e39d28b3c.png)
