### PR TITLE
Removing duplicated image generation code and using pre existing category.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -404,15 +404,7 @@ NSInteger const kMeTabIndex = 2;
 
     // Create a background
     // (not strictly needed when white, but left here for possible customization)
-    UIColor *backgroundColor = [UIColor whiteColor];
-    CGRect rect = CGRectMake(0.0f, 0.0f, 1.0f, 1.0f);
-    UIGraphicsBeginImageContext(rect.size);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    CGContextSetFillColorWithColor(context, [backgroundColor CGColor]);
-    CGContextFillRect(context, rect);
-    UIImage *tabBackgroundImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    _tabBarController.tabBar.backgroundImage = tabBackgroundImage;
+    _tabBarController.tabBar.backgroundImage = [UIImage imageWithColor:[UIColor whiteColor]];
     
     self.readerPostsViewController = [[ReaderPostsViewController alloc] init];
     UINavigationController *readerNavigationController = [[UINavigationController alloc] initWithRootViewController:self.readerPostsViewController];


### PR DESCRIPTION
I noticed that the code over here - https://github.com/wordpress-mobile/WordPress-iOS/blob/0489596182504e091d4ff803d01e5c7275233a68/WordPress/Classes/System/WordPressAppDelegate.m#L405-L415 was using code that we already have in a category that @aerych wrote sometime back. Just updating this portion of the code to use the pre existing category(https://github.com/wordpress-mobile/WordPress-iOS-Shared/blob/8679c488284d6ebb5ed5c826e487256fd4850eee/WordPress-iOS-Shared/UIImage%2BUtil.m#L5) to eliminate some duplication.
