### PR TITLE
Highlight comments from the post author

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentTableViewCell.m
@@ -156,7 +156,7 @@ const CGFloat RPVAuthorBadgeHeight = 12.0f;
         self.authorBadgeLabel.textColor = [UIColor whiteColor];
         self.authorBadgeLabel.textAlignment = NSTextAlignmentCenter;
         self.authorBadgeLabel.font = [WPFontManager openSansBoldFontOfSize:6.0];
-        self.authorBadgeLabel.text = @"Author";
+        self.authorBadgeLabel.text = NSLocalizedString(@"Author", @"Author badge text in Reader comment");
         [self.contentView addSubview:self.authorBadgeLabel];
 
         // Make sure the text view doesn't overlap any of the other views.


### PR DESCRIPTION
Fixes #1360

I did create small badge to highlight the post author in comments displayed by Reader. Don't know what is the process for localisation so I just made the NSLocalized string for the badge name.

![ios simulator screen shot 23 jul 2014 11 24 21](https://cloud.githubusercontent.com/assets/151760/3671175/d868224e-124c-11e4-919f-2a3f06bcc4e4.png)
