### PR TITLE
Call the delegate super method to restore load-more.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -917,6 +917,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    [super tableView:tableView willDisplayCell:cell forRowAtIndexPath:indexPath];
     // Preload here to avoid unnecessary preload calls when fetching cells for reasons other than for display.
     [self preloadImagesForCellsAfterIndexPath:indexPath];
 }


### PR DESCRIPTION
Missed that the super class was also using the delegate method in #1996 
This restores that behavior.
