### PR TITLE
Prevents CoreData NSObjectInaccessibleException Crash

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -780,7 +780,10 @@ NSInteger const kMeTabIndex = 2;
             NSString *filepath = [documentsDirectory stringByAppendingPathComponent:currentPath];
 
             if (![pathsToKeep containsObject:filepath]) {
-                [[NSFileManager defaultManager] removeItemAtPath:filepath error:nil];
+                NSError *nukeError = nil;
+                if ([[NSFileManager defaultManager] removeItemAtPath:filepath error:&nukeError] == NO) {
+                    DDLogError(@"Error [%@] while nuking Unused Media at path [%@]", nukeError.localizedDescription, filepath);
+                }
             }
         }
     }];


### PR DESCRIPTION
Fixes #2122

I've been unable to directly reproduce this crash directly. This is caused by Media deletion, on another thread, while the `cleanUnusedMediaFileFromTmpDir` method is executed.

In this commit, we're switching the NSFetchRequest's resultType to `NSDictionaryResultType`. Which means that: instead of retrieving Media entities, we're just getting an array of dictionaries, containing just the value we need -in this case, that'd be the `localURL` property value-.

This way, we'd be preventing any Faulting exceptions altogether.

The RegEx that we used to have, to check file extensions, has been nuked, in favor of `pathExtension` selector. Plus, we're now considering other media types, rather than just `png`.

/cc @astralbodies || @bummytime || @aerych 

Ready for review, thanks in advance!
