### PR TITLE
 Show secure text entry toggle on Jetpack password field

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -653,6 +653,7 @@ CGFloat const GeneralWalkthroughStatusBarOffset = 20.0;
 {
     [self setAuthenticating:NO withStatusMessage:nil];
     JetpackSettingsViewController *jetpackSettingsViewController = [[JetpackSettingsViewController alloc] initWithBlog:_blog];
+    
     jetpackSettingsViewController.canBeSkipped = YES;
     [jetpackSettingsViewController setCompletionBlock:^(BOOL didAuthenticate) {
         if (didAuthenticate) {

--- a/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
@@ -176,6 +176,7 @@ CGFloat const JetpackSignInButtonHeight = 41.0;
         _passwordField.delegate = self;
         _passwordField.secureTextEntry = YES;
         _passwordField.text = _blog.jetpackPassword;
+        _passwordField.showSecureTextEntryToggle = NO;
         _passwordField.clearsOnBeginEditing = YES;
         _passwordField.showTopLineSeparator = YES;
         [self.view addSubview:_passwordField];
@@ -346,6 +347,14 @@ CGFloat const JetpackSignInButtonHeight = 41.0;
     [self updateSaveButton];
 }
 
+- (void)textFieldDidBeginEditing:(UITextField *)textField {
+    
+    if (textField == _passwordField) {
+        _passwordField.showSecureTextEntryToggle = YES;
+    }
+
+}
+
 - (void)keyboardWillShow:(NSNotification *)notification {
     NSDictionary *keyboardInfo = notification.userInfo;
     CGFloat animationDuration = [[keyboardInfo objectForKey:UIKeyboardAnimationDurationUserInfoKey] floatValue];
@@ -415,7 +424,7 @@ CGFloat const JetpackSignInButtonHeight = 41.0;
 
 
 - (BOOL)saveEnabled {
-    return (!_authenticating && _usernameField.text.length && _passwordField.text.length);
+    return (!_authenticating && _usernameField.text.length && _passwordField.text.length && _passwordField.showSecureTextEntryToggle);
 }
 
 - (void)setAuthenticating:(BOOL)authenticating {
@@ -428,7 +437,7 @@ CGFloat const JetpackSignInButtonHeight = 41.0;
 
 - (void)updateSaveButton {
 	if (![self isViewLoaded]) return;
-	
+
     _signInButton.enabled = [self saveEnabled];
 }
 


### PR DESCRIPTION
Fixes #1108 

The toggle is hidden when loaded until the password textfield has begun editing, which would clear the field. 
The save button will be disabled until the field has been edited.
