### PR TITLE
updates run-oclint.sh to allow for linting a specific file

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2371,7 +2371,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "sh ../run-oclint.sh";
+			shellScript = "# sh ../run-oclint.sh <optional: filename to lint>\nsh ../run-oclint.sh";
 		};
 		E16AB92814D978240047A2E5 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/run-oclint.sh
+++ b/run-oclint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
-
 source ~/.bash_profile
+
+check_file="$1"
+oclint_args="-rc LONG_LINE=120 -rc SHORT_VARIABLE_NAME=1 -rc LONG_METHOD=75"
 
 hash oclint &> /dev/null
 if [ $? -eq 1 ]; then
@@ -10,25 +12,22 @@ fi
 
 temp_dir="/tmp"
 build_dir="${temp_dir}/WPiOS_linting"
+compile_commands_path=${temp_dir}/compile_commands.json
+xcodebuild_log_path=${temp_dir}/xcodebuild.log
 
 echo "[*] cleaning up generated files"
-if [ -f ${temp_dir}/compile_commands.json ]; then
-    rm ${temp_dir}/compile_commands.json
-fi
-if [ -f ${temp_dir}/xcodebuild.log ]; then
-    rm ${temp_dir}/xcodebuild.log
-fi
+[[ -f $compile_commands_path ]] && rm ${compile_commands_path}
+[[ -f $xcodebuild_log_path ]] && rm ${xcodebuild_log_path}
 
 echo "[*] starting xcodebuild to build the project.."
-
 if [ -d WordPress.xcworkspace ]; then
     # we're running the script from the CLI
-    is_xcode=0
     xcode_workspace="WordPress.xcworkspace"
+    pipe_command=""
 elif [ -d ../WordPress.xcworkspace ]; then
     # we're running the script from Xcode
-    is_xcode=1
     xcode_workspace="../WordPress.xcworkspace"
+    pipe_command="| sed 's/\\(.*\\.\\m\\{1,2\\}:[0-9]*:[0-9]*:\\)/\\1 warning:/'"
 else
     # error!
     echo >&2 "workspace not found, analyzing stopped"
@@ -39,18 +38,21 @@ xcodebuild -sdk "iphonesimulator7.1" \
            CONFIGURATION_BUILD_DIR=$build_dir \
            -workspace $xcode_workspace -configuration Debug -scheme WordPress clean build \
            DSTROOT=$build_dir OBJROOT=$build_dir SYMROOT=$build_dir \
-           | tee ${temp_dir}/xcodebuild.log
+           | tee ${xcodebuild_log_path}
 
 echo "[*] transforming xcodebuild.log into compile_commands.json..."
 cd ${temp_dir}
-oclint-xcodebuild -e Pods/
+oclint-xcodebuild -e Pods/ -o ${compile_commands_path}
 
 echo "[*] starting analyzing"
-if [ is_xcode -eq 1 ]; then
-    # if we're inside of Xcode then the oclint output should be cleaned up a little. enter sed!
-    oclint-json-compilation-database -e Pods/ oclint_args "-rc LONG_LINE=120 SHORT_VARIABLE_NAME=1" | sed 's/\\(.*\\.\\m\\{1,2\\}:[0-9]*:[0-9]*:\\)/\\1 warning:/'
+
+if [ $check_file ]; then
+    include_files="-i $check_file"
+    exclude_files="-e *"
 else
-    oclint-json-compilation-database -e Pods/ oclint_args "-rc LONG_LINE=120 SHORT_VARIABLE_NAME=1"
+    include_files=""
+    exclude_files="-e Pods/ -e Vendor/"
 fi
 
-rm -rf ${build_dir}
+eval "oclint-json-compilation-database $exclude_files oclint_args \"$oclint_args\" $include_files $pipe_command"
+exit 0


### PR DESCRIPTION
Adds an optional parameter to run-oclint.sh for a single file to run through the linter.  Add this in the scripting build phase on the OCLint target.  Also cleans up some of the extra conditionals in the shell script.

![wordpress wordpress](https://cloud.githubusercontent.com/assets/1220715/3788128/3b9b88e8-1a53-11e4-87a9-728ae6e824cf.jpg)

refs #2158 
