### PR TITLE
Removing the media spinner titleView after media download is complete.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.m
@@ -174,6 +174,7 @@ static NSInteger const MaximumNumberOfPictures = 4;
     if (_mediaUploadQueue.operationCount > 0) {
         self.navigationItem.titleView = self.uploadStatusView;
     } else if(blogCount <= 1 || self.editMode == EditPostViewControllerModeEditPost || [[WordPressAppDelegate sharedWordPressApplicationDelegate] isNavigatingMeTab]) {
+        self.navigationItem.titleView = nil;
         self.navigationItem.title = [self editorTitle];
     } else {
         UIButton *titleButton = self.titleBarButton;


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/100

/cc @sendhil 
