### PR TITLE
Link in comment leads to actual comment

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/NotificationsCommentDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/NotificationsCommentDetailViewController.m
@@ -582,7 +582,17 @@ NSString *const WPNotificationCommentRestorationKey = @"WPNotificationCommentRes
 }
 
 - (void)contentView:(WPContentView *)contentView didReceiveLinkAction:(id)sender {
-    [self pushToURL:((DTLinkButton *)sender).URL];
+    NSURL *url = ((DTLinkButton *)sender).URL;
+    
+    // Putting the link into format that will not be discarded by WebViewController
+    NSString *correctUrl = [NSString stringWithFormat:
+                            @"%@://%@%@/#%@",
+                            url.scheme,
+                            url.host,
+                            url.path,
+                            url.fragment];
+
+    [self pushToURL:[NSURL URLWithString:correctUrl]];
 }
 
 


### PR DESCRIPTION
Fixes #1962

I had to fix the link format so it will be accepted by WebViewController and will point to comment mentioned in section.
