### PR TITLE
Adding script to help with internal version numbers.

### DIFF
--- a/update-internal-version.rb
+++ b/update-internal-version.rb
@@ -7,12 +7,14 @@ rescue LoadError
   exit
 end
 
-print "Enter the version number to use as the base (i.e. 4.2.0) "
-base_version_number = gets.chomp
+internal_plist = Plist::parse_xml('./WordPress/WordPress-Internal-Info.plist')
 
+base_version_number = internal_plist["CFBundleVersion"]
+
+# Check if we need to add a .0 to the end(i.e. 4.2 -> 4.2.0)
+base_version_number = "#{base_version_number}.0" if base_version_number =~ /^\d+\.\d+$/
 version_number_with_date = "#{base_version_number}.#{Time.now.strftime("%Y%m%d")}"
 
-internal_plist = Plist::parse_xml('./WordPress/WordPress-Internal-Info.plist')
 internal_plist["CFBundleVersion"] = version_number_with_date
 internal_plist["CFBundleShortVersionString"] = version_number_with_date
 internal_plist.save_plist("./WordPress/WordPress-Internal-Info.plist")


### PR DESCRIPTION
Often times when generating new internal beta builds I have to go in by hand and attach the date to the version number. Wrote a simple script that helps automate this.
