### PR TITLE
Removing usage of [WPStyleGuide baseLighterBlue].

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/NotificationsFollowTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/NotificationsFollowTableViewCell.m
@@ -21,7 +21,7 @@
         [self.textLabel setFont:[WPStyleGuide tableviewSectionHeaderFont]];
 
         [self.detailTextLabel setFont:[WPStyleGuide subtitleFont]];
-        [self.detailTextLabel setTextColor:[WPStyleGuide baseDarkerBlue]];
+        [self.detailTextLabel setTextColor:[WPStyleGuide wordPressBlue]];
         [self.detailTextLabel setBackgroundColor:[UIColor clearColor]];
         [self.detailTextLabel setNumberOfLines:1];
         [self.detailTextLabel setAdjustsFontSizeToFitWidth:NO];

--- a/WordPress/Classes/ViewRelated/Themes/ThemeDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeDetailsViewController.m
@@ -61,7 +61,7 @@
     self.livePreviewButton.titleLabel.text = NSLocalizedString(@"Live Preview", nil);
     self.activateButton.titleLabel.text = NSLocalizedString(@"Activate", nil);
     [self.livePreviewButton setBackgroundColor:[WPStyleGuide whisperGrey]];
-    [self.activateButton setBackgroundColor:[WPStyleGuide baseDarkerBlue]];
+    [self.activateButton setBackgroundColor:[WPStyleGuide wordPressBlue]];
     self.livePreviewButton.layer.cornerRadius = 3.0f;
     self.activateButton.layer.cornerRadius = 3.0f;
     self.livePreviewButton.exclusiveTouch = YES;

--- a/WordPress/Classes/ViewRelated/Views/InlineComposeView.m
+++ b/WordPress/Classes/ViewRelated/Views/InlineComposeView.m
@@ -40,8 +40,7 @@ const CGFloat InlineComposeViewMaxHeight = 88.f;
 
         [self addSubview:_proxyTextView];
 
-        self.sendButton.tintColor = [WPStyleGuide baseDarkerBlue];
-
+        self.sendButton.tintColor = [WPStyleGuide wordPressBlue];
     }
     return self;
 }


### PR DESCRIPTION
This [WPStyleGuide baseLighterBlue]is basically a duplicated color from
[WPStyleGuide wordPressBlue]. Removing all instances of it so we can
remove baseLighterBlue from the shared repo and cut down on confusion.

cc @drw158 
