### PR TITLE
Fixing crash where comment can sometimes be nil.

### DIFF
--- a/WordPress/Classes/Models/AbstractComment.m
+++ b/WordPress/Classes/Models/AbstractComment.m
@@ -41,6 +41,9 @@
 - (NSString *)contentForDisplay {
     // Unescape HTML characters and add <br /> tags
     NSString *commentContent = [[self.content stringByDecodingXMLCharacters] trim];
+    if (commentContent == nil) {
+        return @"";
+    }
     // Don't add <br /> tags after an HTML tag, as DTCoreText will handle that spacing for us
     NSRegularExpression *removeNewlinesAfterHtmlTags = [NSRegularExpression regularExpressionWithPattern:@"(?<=\\>)\n\n" options:0 error:nil];
     commentContent = [removeNewlinesAfterHtmlTags stringByReplacingMatchesInString:commentContent options:0 range:NSMakeRange(0, [commentContent length]) withTemplate:@""];


### PR DESCRIPTION
There was a crash reported in the internal beta where the regular expression manipulation below this line was crashing because  we were sending in a nil value. Just added a nil check for sanity and to avert this crash in the highly unlikely case the `commentContent` is nil.
