### PR TITLE
Temporarily disable REST for Jetpack sites

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -12,6 +12,8 @@ static NSInteger const ImageSizeMediumHeight = 360;
 static NSInteger const ImageSizeLargeWidth = 640;
 static NSInteger const ImageSizeLargeHeight = 480;
 
+static BOOL const JetpackRESTSupported = NO;
+
 @implementation Blog {
     WPXMLRPCClient *_api;
     NSString *_blavatarUrl;
@@ -373,7 +375,7 @@ static NSInteger const ImageSizeLargeHeight = 480;
 {
     if (self.isWPcom) {
         return self.account.restApi;
-    } else if (self.jetpackAccount) {
+    } else if (JetpackRESTSupported && self.jetpackAccount) {
         return self.jetpackAccount.restApi;
     }
     return nil;


### PR DESCRIPTION
It just doesn't work when the JSON API module is disabled.
Also, there are some issues where failed uploads don't show any error.

Failed upload before:

![img_0609](https://cloud.githubusercontent.com/assets/8739/4012519/8ad2c3d4-2a0e-11e4-8b25-f949750cdda6.PNG)

Failed upload after:

![img_0608](https://cloud.githubusercontent.com/assets/8739/4012523/93579624-2a0e-11e4-974a-8e451d73d205.PNG)

refs #2258 
