### PR TITLE
Don't replace wp.com account on Jetpack login

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -162,7 +162,9 @@ NSString * const WPAccountDefaultWordPressComAccountChangedNotification = @"WPAc
     account.isWpcom = YES;
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
 
-    [self setDefaultWordPressComAccount:account];
+    if (![self defaultWordPressComAccount]) {
+        [self setDefaultWordPressComAccount:account];
+    }
 
     return account;
 }

--- a/WordPress/WordPressTest/BlogJetpackTest.m
+++ b/WordPress/WordPressTest/BlogJetpackTest.m
@@ -143,4 +143,17 @@
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
+- (void)testJetpackSetupDoesntReplaceDotcomAccount {
+    ATHStart();
+    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:[ContextManager sharedInstance].mainContext];
+    WPAccount *wpComAccount = [accountService createOrUpdateWordPressComAccountWithUsername:@"user" password:@"pass" authToken:@"token"];
+    ATHWait();
+    XCTAssertEqualObjects(wpComAccount, [accountService defaultWordPressComAccount]);
+
+    [accountService createOrUpdateWordPressComAccountWithUsername:@"test1" password:@"test1" authToken:@"token1"];
+    ATHWait();
+
+    XCTAssertEqualObjects(wpComAccount, [accountService defaultWordPressComAccount]);
+}
+
 @end


### PR DESCRIPTION
If there's already a wp.com account set up in the app, let's respect
that instead of replacing it.

Fixes #2259
