### PR TITLE
Filter out "Continue Reading" from summaries.

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -868,7 +868,10 @@ NSString * const ReaderPostServiceErrorDomain = @"ReaderPostServiceErrorDomain";
 {
     summary = [self makePlainText:summary];
 
-    NSRange rng = [summary rangeOfString:@"Continue reading →"];
+    NSString *continueReading = NSLocalizedString(@"Continue reading", @"Part of a prompt suggesting that there is more content for the user to read.");
+    continueReading = [NSString stringWithFormat:@"%@ →", continueReading];
+
+    NSRange rng = [summary rangeOfString:continueReading options:NSCaseInsensitiveSearch];
     if (rng.location != NSNotFound) {
         summary = [summary substringToIndex:rng.location];
     }


### PR DESCRIPTION
Removes some unnecessary parsing.
Closes #2226 
