### PR TITLE
NotificationDetails: back button should be empty

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -87,6 +87,10 @@ static CGFloat NotificationSectionSeparator     = 10;
     self.restorationClass               = [self class];
     self.view.backgroundColor           = [WPStyleGuide itsEverywhereGrey];
     
+    // Don't show the notification title in the next-view's back button
+    UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:[NSString string] style:UIBarButtonItemStylePlain target:nil action:nil];
+    self.navigationItem.backBarButtonItem = backButton;
+    
     self.tableView.backgroundColor      = [WPStyleGuide itsEverywhereGrey];
 
     self.reuseIdentifierMap = @{


### PR DESCRIPTION
This PR prevents the NotificationDetails title to show up in `Back` button, of the next viewController that gets pushed.

Fixes #2332

Thanks @aerych for reporting this!

/cc @sendhil
