### PR TITLE
Fixes the location of the signout popover.

### DIFF
--- a/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
@@ -366,7 +366,14 @@ CGFloat const blavatarImageViewSize = 43.f;
                                                  cancelButtonTitle:NSLocalizedString(@"Cancel", @"")
                                             destructiveButtonTitle:NSLocalizedString(@"Sign Out", @"")otherButtonTitles:nil, nil ];
                 actionSheet.actionSheetStyle = UIActionSheetStyleDefault;
-                [actionSheet showInView:self.view];
+
+                if (IS_IPAD) {
+                    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+                    [actionSheet showFromRect:[cell bounds] inView:cell animated:YES];
+                } else {
+                    [actionSheet showInView:self.view];
+                }
+
             } else if (indexPath.row == [self rowForNotifications]) {
                 NotificationSettingsViewController *notificationSettingsViewController = [[NotificationSettingsViewController alloc] initWithStyle:UITableViewStyleGrouped];
                 [self.navigationController pushViewController:notificationSettingsViewController animated:YES];


### PR DESCRIPTION
Fixes #2334 

After:
![ios simulator screen shot sep 4 2014 2 15 32 pm](https://cloud.githubusercontent.com/assets/1435271/4155234/793b13e2-3468-11e4-952b-4d72f79f4b07.png)
