### PR TITLE
Prevent crash when moderating deleted comments

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -181,6 +181,7 @@
     }
 
 	comment.status = status;
+    NSManagedObjectID *commentObjectID = comment.objectID;
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
     id <CommentServiceRemote> remote = [self remoteForBlog:comment.blog];
     RemoteComment *remoteComment = [self remoteCommentWithComment:comment];
@@ -191,8 +192,11 @@
                         }
                     } failure:^(NSError *error) {
                         [self.managedObjectContext performBlock:^{
-                            comment.status = prevStatus;
-                            [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+                            Comment *commentInContext = (Comment *)[self.managedObjectContext existingObjectWithID:commentObjectID error:nil];
+                            if (commentInContext) {
+                                commentInContext.status = prevStatus;
+                                [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+                            }
                             if (failure) {
                                 dispatch_async(dispatch_get_main_queue(), ^{
                                     failure(error);


### PR DESCRIPTION
If we pass the Comment object instead of the ID, and then try to change
the status, the app will crash because we're trying to change a faulted
object.

Fixes #2372
