### PR TITLE
Enabled assertions for internal releases.

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3161,7 +3161,6 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
-					NS_BLOCK_ASSERTIONS,
 					INTERNAL_BUILD,
 					"${inherited}",
 				);


### PR DESCRIPTION
Related to [this ticket](https://github.com/wordpress-mobile/WordPress-iOS/issues/2423).
