### PR TITLE
Avoid apostrophe in two strings by not using a contraction.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
@@ -109,7 +109,7 @@ static CGFloat const FollowSitesRowHeight = 54.0;
     }
 
     NSString *title = NSLocalizedString(@"No Sites", @"Title of a message explaining that the user is not currently following any blogs in their reader.");
-    NSString *message = NSLocalizedString(@"You're not following any sites yet.  Why not follow one now?", @"A suggestion to the user that they try following a site in their reader.");
+    NSString *message = NSLocalizedString(@"You are not following any sites yet. Why not follow one now?", @"A suggestion to the user that they try following a site in their reader.");
     _noResultsView = [WPNoResultsView noResultsViewWithTitle:title
                                                      message:message
                                                accessoryView:nil

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -611,7 +611,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
 
     NSRange range = [self.currentTopic.path rangeOfString:@"following"];
     if (range.location != NSNotFound) {
-        return NSLocalizedString(@"You're not following any sites yet.", @"");
+        return NSLocalizedString(@"You are not following any sites yet.", @"");
     }
 
     range = [self.currentTopic.path rangeOfString:@"liked"];


### PR DESCRIPTION
Closes #1134

Instead of using a correct apostrophe unicode character, avoid it altogether in two strings by using "you are" instead of "you're".
