### PR TITLE
Update the Terms of Service button color when creating a WordPress.com account

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -332,7 +332,7 @@ CGFloat const CreateAccountAndBlogButtonHeight = 40.0;
         
         // Build the string in two parts so the coloring of "Terms of Service." doesn't break when it gets translated
         NSString *plainTosText = NSLocalizedString(@"By creating an account you agree to the fascinating Terms of Service.", @"NUX Create Account TOS Label");
-        NSString *tosFindText = NSLocalizedString(@"Terms of Service", @"NUX Create Account TOS");
+        NSString *tosFindText = NSLocalizedString(@"Terms of Service", @"'Terms of Service' should be the same text that is in 'NUX Create Account TOS Label'");
         
         NSMutableAttributedString *tosText = [[NSMutableAttributedString alloc] initWithString:plainTosText];
         [tosText addAttribute:NSForegroundColorAttributeName


### PR DESCRIPTION
I am not totally sure this is the right way to attack this keeping in mind that the string needs to be translatable.
cc @astralbodies 
Fixes #1645

![ios simulator screen shot sep 19 2014 5 03 02 pm](https://cloud.githubusercontent.com/assets/363753/4343218/63afd702-4051-11e4-9b26-29cfb361f3f4.png)
