### PR TITLE
Return an empty string when featured image is not set.

### DIFF
--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -471,9 +471,6 @@
     }
 
     featuredImage = [self sanitizeFeaturedImageString:featuredImage];
-    if ([featuredImage length] == 0) {
-        return nil;
-    }
     
     return featuredImage;
 }


### PR DESCRIPTION
Per the documentation and tests `ReaderPostServiceRemote featuredImageFromPostDictionary:` should return an empty string instead of `nil`

Fixes: #2444
