### PR TITLE
Cleaned up navbar in editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -30,7 +30,7 @@ NSString *const kWPEditorConfigURLParamAvailable = @"available";
 NSString *const kWPEditorConfigURLParamEnabled = @"enabled";
 
 static NSInteger const MaximumNumberOfPictures = 5;
-static NSInteger const kNavigationBarButtonSpacer = 15;
+static CGFloat const kNavigationBarButtonSpacer = 15.0;
 static NSUInteger const kWPPostViewControllerSaveOnExitActionSheetTag = 201;
 
 @interface WPPostViewController ()<UIPopoverControllerDelegate> {


### PR DESCRIPTION
- Fixes https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/259
- Added some breathing room between navbar icons

/cc @diegoreymendez 
