### PR TITLE
Status bar fix for preview screen in new editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.h
@@ -3,6 +3,6 @@
 
 @interface PostPreviewViewController : UIViewController <UIWebViewDelegate>
 
-- (instancetype)initWithPost:(AbstractPost *)aPost;
+- (instancetype)initWithPost:(AbstractPost *)aPost shouldHideStatusBar:(BOOL)shouldHideStatusBar;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -10,6 +10,7 @@
 @property (nonatomic, strong) UIView *loadingView;
 @property (nonatomic, strong) NSMutableData *receivedData;
 @property (nonatomic, strong) AbstractPost *apost;
+@property (nonatomic, assign) BOOL *shouldHideStatusBar;
 
 @end
 
@@ -25,12 +26,13 @@
     self.webView.delegate = nil;
 }
 
-- (instancetype)initWithPost:(AbstractPost *)aPost
+- (instancetype)initWithPost:(AbstractPost *)aPost shouldHideStatusBar:(BOOL)shouldHideStatusBar
 {
     self = [super init];
     if (self) {
         self.apost = aPost;
         self.navigationItem.title = NSLocalizedString(@"Preview", @"Post Editor / Preview screen title.");
+        self.shouldHideStatusBar = shouldHideStatusBar;
     }
     return self;
 }
@@ -53,6 +55,10 @@
 {
     [super viewWillAppear:animated];
     [[WordPressAppDelegate sharedWordPressApplicationDelegate] useDefaultUserAgent];
+    if (self.shouldHideStatusBar && !IS_IPAD) {
+        [[UIApplication sharedApplication] setStatusBarHidden:YES
+                                                withAnimation:nil];
+    }
     [self refreshWebView];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -319,7 +319,7 @@ static NSInteger const MaximumNumberOfPictures = 4;
 
 - (void)showPreview
 {
-    PostPreviewViewController *vc = [[PostPreviewViewController alloc] initWithPost:self.post];
+    PostPreviewViewController *vc = [[PostPreviewViewController alloc] initWithPost:self.post shouldHideStatusBar:NO];
     UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Back", nil) style:UIBarButtonItemStyleBordered target:nil action:nil];
     self.navigationItem.backBarButtonItem = backButton;
     [self.navigationController pushViewController:vc animated:YES];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -350,7 +350,7 @@ static NSUInteger const kWPPostViewControllerSaveOnExitActionSheetTag = 201;
 
 - (void)showPreview
 {
-    PostPreviewViewController *vc = [[PostPreviewViewController alloc] initWithPost:self.post];
+    PostPreviewViewController *vc = [[PostPreviewViewController alloc] initWithPost:self.post shouldHideStatusBar:self.isEditing];
 	vc.hidesBottomBarWhenPushed = YES;
     [self.navigationController pushViewController:vc animated:YES];
 }


### PR DESCRIPTION
This commit simply hides the status bar for the preview screen on new editor while editing. Old editor remains the same.

Fixes https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/263

/cc @diegoreymendez 
