### PR TITLE
Fixing errors in today extension caused by XCode 6.1

### DIFF
--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -85,8 +85,8 @@ class TodayViewController: UIViewController, NCWidgetProviding {
             numberFormatter.numberStyle = NSNumberFormatterStyle.DecimalStyle
             numberFormatter.maximumFractionDigits = 0
             
-            self.visitorCount = numberFormatter.stringFromNumber(wpStatsSummary.visitorCountToday)!
-            self.viewCount = numberFormatter.stringFromNumber(wpStatsSummary.viewCountToday)!
+            self.visitorCount = numberFormatter.stringFromNumber(wpStatsSummary.visitorCountToday) ?? ""
+            self.viewCount = numberFormatter.stringFromNumber(wpStatsSummary.viewCountToday) ?? ""
             
             self.siteNameLabel?.text = self.siteName
             self.visitorsCountLabel?.text = self.visitorCount


### PR DESCRIPTION
XCode 6.1 introduced this idea of "failable inits" which broke a bunch of things in the today extension.

You can see more details on failable inits here - https://github.com/ksm/SwiftInFlux#failable-initializers-in-objective-c-frameworks.

cc @astralbodies 
