### PR TITLE
Added in ability to open certain screens when triggered by a Mixpanel push notification

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.h
+++ b/WordPress/Classes/System/WordPressAppDelegate.h
@@ -43,6 +43,7 @@ extern NSInteger const kMeTabIndex;
 - (void)showTabForIndex:(NSInteger)tabIndex;
 - (void)showPostTab;
 - (void)switchTabToPostsListForPost:(AbstractPost *)post;
+- (void)switchMeTabToStatsViewForBlog:(Blog *)blog;
 - (BOOL)isNavigatingMeTab;
 
 ///-----------

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -747,6 +747,24 @@ static NSString* const kWPNewPostURLParamImageKey = @"image";
     [blogListNavController setViewControllers:@[blogListViewController, blogDetailsViewController, postsViewController]];
 }
 
+- (void)switchMeTabToStatsViewForBlog:(Blog *)blog
+{
+    // Make sure the desired tab is selected.
+    [self showTabForIndex:kMeTabIndex];
+    
+    // Build and set the navigation heirarchy for the Me tab.
+    UINavigationController *blogListNavController = [self.tabBarController.viewControllers objectAtIndex:kMeTabIndex];
+    BlogListViewController *blogListViewController = [blogListNavController.viewControllers objectAtIndex:0];
+
+    BlogDetailsViewController *blogDetailsViewController = [BlogDetailsViewController new];
+    blogDetailsViewController.blog = blog;
+    
+    StatsViewController *statsViewController = [StatsViewController new];
+    statsViewController.blog = blog;
+    
+    [blogListNavController setViewControllers:@[blogListViewController, blogDetailsViewController, statsViewController]];
+}
+
 - (BOOL)isNavigatingMeTab
 {
     return (self.tabBarController.selectedIndex == kMeTabIndex && [self.blogListViewController.navigationController.viewControllers count] > 1);

--- a/WordPress/Classes/Utility/NotificationsManager.m
+++ b/WordPress/Classes/Utility/NotificationsManager.m
@@ -11,6 +11,7 @@
 #import "AccountService.h"
 #import "WPAccount.h"
 #import "CommentService.h"
+#import "BlogService.h"
 
 #import <Helpshift/Helpshift.h>
 #import <Simperium/Simperium.h>
@@ -413,7 +414,17 @@ NSString *const NotificationActionCommentApprove                    = @"COMMENT_
     } else if ([targetToOpen isEqualToString:@"notifications"]) {
         [appDelegate showTabForIndex:kNotificationsTabIndex];
     } else if ([targetToOpen isEqualToString:@"stats"]) {
-        // Open Stats
+        [self openStatsForLastUsedOrFirstWPComBlog];
+    }
+}
+
++ (void)openStatsForLastUsedOrFirstWPComBlog
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+    Blog *blog = [blogService lastUsedOrFirstWPcomBlog];
+    if (blog != nil && [blog isWPcom]) {
+        [[WordPressAppDelegate sharedWordPressApplicationDelegate] switchMeTabToStatsViewForBlog:blog];
     }
 }
 


### PR DESCRIPTION
This enables the app to open up the Reader, Notifications and Stats from a Mixpanel push notification. In order for this to work the push notification should have the following payload:

```
{ "origin":"mp", "open":"notifications"} // Opens Notifications
{ "origin":"mp", "open":"reader"} // Opens Reader
{ "origin":"mp", "open":"stats"} // Opens Stats

```

cc @mikejohnstn 
