### PR TITLE
Update nav bar buttons on new editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -205,7 +205,7 @@ static NSUInteger const kWPPostViewControllerSaveOnExitActionSheetTag = 201;
 - (void)viewDidAppear:(BOOL)animated
 {
 	[super viewDidAppear:animated];
-	
+	[self refreshNavigationBarButtons:NO];
 	if (self.isEditing) {
 		if ([self shouldHideStatusBarWhileTyping]) {
 			[[UIApplication sharedApplication] setStatusBarHidden:YES


### PR DESCRIPTION
Just a simple fix to refresh the new editor VC nav bar buttons when coming back from the post settings screen.

Fixes https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/251

/cc @diegoreymendez 
