### PR TITLE
Added logic to determine if status bar should be displayed on post options

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
@@ -3,7 +3,7 @@
 
 @interface PostSettingsViewController : UITableViewController
 
-- (id)initWithPost:(AbstractPost *)aPost;
+- (instancetype)initWithPost:(AbstractPost *)aPost shouldHideStatusBar:(BOOL)shouldHideStatusBar;
 - (void)endEditingAction:(id)sender;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -60,6 +60,7 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
 @property (nonatomic, strong) PublishDatePickerView *datePicker;
 @property (assign) BOOL *textFieldDidHaveFocusBeforeOrientationChange;
 @property (nonatomic, strong) UIPopoverController *popover;
+@property (nonatomic, assign) BOOL *shouldHideStatusBar;
 
 @end
 
@@ -72,12 +73,13 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
     [self removePostPropertiesObserver];
 }
 
-- (id)initWithPost:(AbstractPost *)aPost
+- (instancetype)initWithPost:(AbstractPost *)aPost shouldHideStatusBar:(BOOL)shouldHideStatusBar
 {
     self = [super initWithStyle:UITableViewStyleGrouped];
     if (self) {
         self.apost = aPost;
         _mediaUploader = [[WPMediaUploader alloc] init];
+        _shouldHideStatusBar = shouldHideStatusBar;
     }
     return self;
 }
@@ -122,7 +124,7 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
     [self.navigationController setToolbarHidden:YES];
     
     // Do not hide the status bar on iPads
-    if (!IS_IPAD) {
+    if (self.shouldHideStatusBar && !IS_IPAD) {
         [[UIApplication sharedApplication] setStatusBarHidden:YES
                                                 withAnimation:nil];
     }

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -311,7 +311,7 @@ static NSInteger const MaximumNumberOfPictures = 4;
 - (void)showSettings
 {
     Post *post = (Post *)self.post;
-    UIViewController *vc = [[[self classForSettingsViewController] alloc] initWithPost:post];
+    UIViewController *vc = [[[self classForSettingsViewController] alloc] initWithPost:post shouldHideStatusBar:NO];
     UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Back", nil) style:UIBarButtonItemStyleBordered target:nil action:nil];
     self.navigationItem.backBarButtonItem = backButton;
     [self.navigationController pushViewController:vc animated:YES];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -343,7 +343,7 @@ static NSUInteger const kWPPostViewControllerSaveOnExitActionSheetTag = 201;
 - (void)showSettings
 {
     Post *post = (Post *)self.post;
-    PostSettingsViewController *vc = [[[self classForSettingsViewController] alloc] initWithPost:post];
+    PostSettingsViewController *vc = [[[self classForSettingsViewController] alloc] initWithPost:post shouldHideStatusBar:YES];
 	vc.hidesBottomBarWhenPushed = YES;
     [self.navigationController pushViewController:vc animated:YES];
 }


### PR DESCRIPTION
Title has it.

Fixes https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/279

/cc @diegoreymendez 
