### PR TITLE
NotificationDetails: Implements crash failsafe

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -79,6 +79,17 @@ static CGFloat NotificationSectionSeparator     = 10;
 
 @implementation NotificationDetailsViewController
 
+- (void)dealloc
+{
+    // Failsafe: Manually nuke the tableView dataSource and delegate. Make sure not to force a loadView event!
+    if (!self.isViewLoaded) {
+        return;
+    }
+    
+    self.tableView.delegate = nil;
+    self.tableView.dataSource = nil;
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];


### PR DESCRIPTION
I've been unable to directly reproduce this crash.

However, code has been pushed, to make sure whenever a `NotificationDetailsViewController` instance gets nuked, its tableView doesn't keep an invalid reference to a dead object (dataSource + delegate properties).

/cc @sendhil 

Closes #2567
