### PR TITLE
Fixed the precompiled header for WPiOS.

### DIFF
--- a/WordPress/WordPress_Prefix.pch
+++ b/WordPress/WordPress_Prefix.pch
@@ -15,14 +15,14 @@
     #import <AFNetworking/AFNetworking.h>
 	#import <CocoaLumberjack/DDLog.h>
     #import <NSObject+SafeExpectations.h>
-    #import "DDLog.h"
+    #import <CocoaLumberjack/DDLog.h>
+    #import <WordPressCom-Analytics-iOS/WPAnalytics.h>
+    #import <WordPress-iOS-Shared/WPStyleGuide.h>
 
 	// Project-specific
     #import "NSString+Util.h"
     #import "WPError.h"
     #import "UIColor+Helpers.h"
-    #import <WordPressCom-Analytics-iOS/WPAnalytics.h>
-    #import "WPStyleGuide.h"
 
 #ifndef IS_IPAD
 #define IS_IPAD   ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)


### PR DESCRIPTION
Some includes in the main .pch file were outdated.  I updated them to fix some compilation issues in 4.5.

/cc @jleandroperez 
