### PR TITLE
Data detectors issue fixed for comment page

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentTableViewCell.swift
@@ -8,6 +8,7 @@ import Foundation
         super.awakeFromNib()
 
         dataDetectors = .All
+        isTextViewSelectable = true
     }
 
     public var commentText: String? {

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -39,6 +39,11 @@ import Foundation
     public var labelPadding: UIEdgeInsets {
         return privateLabelPadding
     }
+    public var isTextViewSelectable: Bool = false {
+        didSet {
+            textView.selectable = isTextViewSelectable
+        }
+    }
     
     
     //  TODO:


### PR DESCRIPTION
Fixes #2534 

It turns out that links weren't working because textView was not selectable. @jleandroperez can you give me the go to merge this in? Thanks!
