### PR TITLE
Explicitly setting the SettingsVC tableView rowHeight

### DIFF
--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
@@ -40,6 +40,9 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    
+    [self.tableView setEstimatedRowHeight:50.f];
+    [self.tableView setRowHeight:UITableViewAutomaticDimension];
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self loadLogFiles];

--- a/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
@@ -68,7 +68,9 @@ CGFloat const blavatarImageViewSize = 43.f;
 {
     [super viewDidLoad];
 
-    [self.tableView setRowHeight:50.f];
+    [self.tableView setEstimatedRowHeight:50.f];
+    [self.tableView setRowHeight:UITableViewAutomaticDimension];
+    
     self.title = NSLocalizedString(@"Settings", @"App Settings");
     self.doneButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Done", @"") style:[WPStyleGuide barButtonStyleForBordered] target:self action:@selector(dismiss)];
     self.navigationItem.rightBarButtonItem = self.doneButton;

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -138,6 +138,9 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    
+    [self.tableView setEstimatedRowHeight:50.f];
+    [self.tableView setRowHeight:UITableViewAutomaticDimension];
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     self.feedbackEnabled = [defaults boolForKey:UserDefaultsFeedbackEnabled];


### PR DESCRIPTION
to avoid the rowHeight changing unexpectedly during transition to the AboutVC.  See #2558 
