### PR TITLE
Add password hints to the error presented to the user during account creation

### DIFF
--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -651,7 +651,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
     } else if ([errorCode isEqualToString:@"blog_name_reserved_but_may_be_available"]) {
         return NSLocalizedString(@"That site is currently reserved but may be available in a couple days.", nil);
     } else if ([errorCode isEqualToString:@"password_invalid"]) {
-        return NSLocalizedString(@"Sorry, that password does not meet our security guidelines. Please choose a password with a mix of uppercase letters, lowercase letters, numbers and symbols.", @"");
+        return NSLocalizedString(@"Sorry, that password does not meet our security guidelines. Please choose a password with a mix of uppercase letters, lowercase letters, numbers and symbols.", @"This error message occurs when a user tries to create an account with a weak password.");
     } else if ([errorCode isEqualToString:@"blog_title_invalid"]) {
         return NSLocalizedString(@"Invalid Site Title", @"");
     } else if ([errorCode isEqualToString:@"username_illegal_wpcom"]) {


### PR DESCRIPTION
Adds hints to the weak password error presented to users to improve the likelihood that the password scoring algorithm will accept the proposed password.  See issue #2497 
