### PR TITLE
Adjust WPContentActionView time button edge insets to better align title

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPContentActionView.m
+++ b/WordPress/Classes/ViewRelated/Views/WPContentActionView.m
@@ -196,7 +196,7 @@ const CGFloat WPContentActionViewButtonSpacing = 12.0;
     button.translatesAutoresizingMaskIntoConstraints = NO;
     button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
     button.titleLabel.font = [WPStyleGuide subtitleFont];
-    [button setTitleEdgeInsets: UIEdgeInsetsMake(0, 2, 0, -2)];
+    [button setTitleEdgeInsets: UIEdgeInsetsMake(1, 2, -1, -2)];
 
     // Disable it for now (could be used for permalinks in the future)
     [button setImage:[UIImage imageNamed:@"reader-postaction-time"] forState:UIControlStateDisabled];


### PR DESCRIPTION
See #1485 
