### PR TITLE
Hides a password field that was visible.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -555,6 +555,7 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
         textCell.textField.attributedPlaceholder = nil;
         textCell.textField.placeholder = NSLocalizedString(@"Enter a password", @"");
         textCell.textField.clearButtonMode = UITextFieldViewModeWhileEditing;
+        textCell.textField.secureTextEntry = YES;
 
         cell = textCell;
         cell.tag = PostSettingsRowPassword;


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/286).

/cc @bummytime 
