### PR TITLE
issues/1649-noResultsView-refresh-flicker

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTableViewController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTableViewController.m
@@ -432,7 +432,6 @@ NSString *const DefaultCellIdentifier = @"DefaultCellIdentifier";
     }
 
     _didTriggerRefresh = YES;
-    [self.noResultsView removeFromSuperview];
     [self syncItemsViaUserInteraction];
 }
 
@@ -539,12 +538,11 @@ NSString *const DefaultCellIdentifier = @"DefaultCellIdentifier";
     if (!self.isViewLoaded) {
         return;
     }
-
-    [self.noResultsView removeFromSuperview];
     [self.noResultsActivityIndicator stopAnimating];
     [self.noResultsActivityIndicator removeFromSuperview];
 
     if (self.resultsController.fetchedObjects.count) {
+        [self.noResultsView removeFromSuperview];
         return;
     }
 


### PR DESCRIPTION
only remove noResultsView from superview when there are results to show, Fixes #1649
