### PR TITLE
Adjusting update-translations.rb for redirection

### DIFF
--- a/update-translations.rb
+++ b/update-translations.rb
@@ -68,7 +68,7 @@ LANGS.each do |code,local|
   lang_dir = File.join('WordPress', 'Resources', "#{local}.lproj")
   puts "Updating #{code}"
   system "cp #{lang_dir}/Localizable.strings #{lang_dir}/Localizable.strings.bak"
-  system "curl -Lso #{lang_dir}/Localizable.strings http://translate.wordpress.org/projects/ios/dev/#{code}/default/export-translations?format=strings" or begin
+  system "curl -so #{lang_dir}/Localizable.strings https://translate.wordpress.org/projects/ios/dev/#{code}/default/export-translations?format=strings" or begin
     puts "Error downloading #{code}"
   end
   system "php fix-translation.php #{lang_dir}/Localizable.strings"


### PR DESCRIPTION
The URL we were hitting on Glotpress now sends a 302 so I adjusted the curl command we use to account for this.

cc @koke 
