### PR TITLE
Removed Lookback from being compiled for all builds except Internal

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -31,7 +31,7 @@ pod 'WordPressCom-Analytics-iOS', '0.0.11'
 pod 'NSObject-SafeExpectations', '0.0.2'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :branch => 'master'
 pod 'Simperium', '0.7.2'
-pod 'Lookback', '0.6.5'
+pod 'Lookback', '0.6.5', :configurations => ['Release-Internal']
 
 target 'WordPressTodayWidget', :exclusive => true do
     pod 'WordPressCom-Stats-iOS', '0.1.4'

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -9,7 +9,6 @@
 #import <UIDeviceIdentifier/UIDeviceHardware.h>
 #import <Simperium/Simperium.h>
 #import <Helpshift/Helpshift.h>
-#import <Lookback/Lookback.h>
 #import <WordPress-iOS-Shared/WPFontManager.h>
 
 #import "WordPressAppDelegate.h"
@@ -50,6 +49,10 @@
 
 #import "Reachability.h"
 #import "WordPress-Swift.h"
+
+#ifdef LOOKBACK_ENABLED
+#import <Lookback/Lookback.h>
+#endif
 
 #if DEBUG
 #import "DDTTYLogger.h"
@@ -231,9 +234,11 @@ static NSString* const kWPNewPostURLParamImageKey = @"image";
 
 - (void)lookbackGestureRecognized:(UILongPressGestureRecognizer *)sender
 {
+#ifdef LOOKBACK_ENABLED
     if (sender.state == UIGestureRecognizerStateBegan) {
         [LookbackRecordingViewController presentOntoScreenAnimated:YES];
     }
+#endif
 }
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation

--- a/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
@@ -38,7 +38,10 @@
 #import "WPImageOptimizer.h"
 #import "Constants.h"
 #import "Mediaservice.h"
+
+#ifdef LOOKBACK_ENABLED
 #import <Lookback/Lookback.h>
+#endif
 
 typedef enum {
     SettingsSectionWpcom = 0,
@@ -202,10 +205,12 @@ static CGFloat const SettingsRowHeight = 44.0;
 
 - (void)handleShakeToPullUpFeedbackChanged:(id)sender
 {
+#ifdef LOOKBACK_ENABLED
     UISwitch *aSwitch = (UISwitch *)sender;
     BOOL shakeForFeedback = aSwitch.on;
     [[NSUserDefaults standardUserDefaults] setBool:shakeForFeedback forKey:WPInternalBetaShakeToPullUpFeedbackKey];
     [Lookback lookback].shakeToRecord = shakeForFeedback;
+#endif
 }
 
 - (void)dismiss {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3595,7 +3595,6 @@
 					"BITHOCKEY_C_BUILD=\"\\\"32\\\"\"",
 					"${inherited}",
 					"NSLOGGER_BUILD_USERNAME=\"${USER}\"",
-					LOOKBACK_ENABLED,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_THUMB_SUPPORT = NO;


### PR DESCRIPTION
Closes #2675 

Will cherry-pick into release/4.5 to support submitting to Apple.
