### PR TITLE
Prevents NSRangeException

### DIFF
--- a/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
@@ -14,7 +14,7 @@ extension NotificationBlock
 
         for notificationRange in ranges as [NotificationRange] {
             
-            // Make sure this range is not ouf bounds!
+            // Make sure this range is not of bounds!
             let range = notificationRange.range
             if range.location + range.length > theString.length {
                 continue


### PR DESCRIPTION
Fixes #2664

This crash was caused by invalid backend data (still a pending issue). Nevertheless, i'm adding code so the client doesn't break violently.

/cc @diegoreymendez 
