### PR TITLE
Fix collapsed rows in activity log and support views on iOS7

### DIFF
--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
@@ -4,8 +4,10 @@
 #import <DDFileLogger.h>
 #import "WPTableViewSectionHeaderView.h"
 #import "WPTableViewSectionFooterView.h"
+#import "WordPress-Swift.h"
 
 static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
+static CGFloat const ActivityLogRowHeight = 44.0f;
 
 @interface ActivityLogViewController ()
 
@@ -41,9 +43,13 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
 {
     [super viewDidLoad];
     
-    [self.tableView setEstimatedRowHeight:50.f];
-    [self.tableView setRowHeight:UITableViewAutomaticDimension];
-
+    if ([UIDevice isOS8]) { // iOS8 or higher
+        [self.tableView setEstimatedRowHeight:ActivityLogRowHeight];
+        [self.tableView setRowHeight:UITableViewAutomaticDimension];
+    } else {
+        [self.tableView setRowHeight:ActivityLogRowHeight];
+    }
+    
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self loadLogFiles];
 

--- a/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
@@ -77,9 +77,6 @@ static CGFloat const SettingsRowHeight = 44.0;
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-
-    [self.tableView setEstimatedRowHeight:50.f];
-    [self.tableView setRowHeight:UITableViewAutomaticDimension];
     
     self.title = NSLocalizedString(@"Settings", @"App Settings");
     self.doneButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Done", @"") style:[WPStyleGuide barButtonStyleForBordered] target:self action:@selector(dismiss)];

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -14,6 +14,7 @@
 #import "BlogService.h"
 #import "Blog.h"
 #import <Mixpanel/MPTweakInline.h>
+#import "WordPress-Swift.h"
 
 static NSString *const UserDefaultsFeedbackEnabled = @"wp_feedback_enabled";
 static NSString *const UserDefaultsHelpshiftEnabled = @"wp_helpshift_enabled";
@@ -25,6 +26,8 @@ int const kHelpshiftWindowTypeFAQs = 1;
 int const kHelpshiftWindowTypeConversation = 2;
 
 static NSString *const FeedbackCheckUrl = @"http://api.wordpress.org/iphoneapp/feedback-check/1.0/";
+
+static CGFloat const SupportRowHeight = 44.0f;
 
 @interface SupportViewController ()
 
@@ -139,8 +142,12 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
 {
     [super viewDidLoad];
     
-    [self.tableView setEstimatedRowHeight:50.f];
-    [self.tableView setRowHeight:UITableViewAutomaticDimension];
+    if ([UIDevice isOS8]) { // iOS8 or higher
+        [self.tableView setEstimatedRowHeight:SupportRowHeight];
+        [self.tableView setRowHeight:UITableViewAutomaticDimension];
+    } else {
+        [self.tableView setRowHeight:SupportRowHeight];
+    }
 
     [self checkIfHelpshiftShouldBeEnabled];
 


### PR DESCRIPTION
Using UITableViewAutomaticDimension on the activity log and support views on iOS7 results in collapsed rows - so we need to test for iOS8 (or higher) before using it.  Also changed row height from 50 back to 44 to match the rest of the application.  Lastly, removed using automatic dimension from the settings view controller since it recently added heightForRowAtIndexPath (if/when we start doing DynamicText across the app, we may want to update the settings view controller to allow for automatic dimensions.)  Tested on iPhone 5 iOS7.1 sim and iPhone 6 Plus iOS8 sim.  Fixes #2694 
