### PR TITLE
Fixes crash. Removes tableview from storyboard.

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6249" systemVersion="14A379a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="MbC-cA-c9S">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="13F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="MbC-cA-c9S">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6243"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
     </dependencies>
     <scenes>
         <!--Notification List Controller-->
@@ -33,15 +33,6 @@
         <scene sceneID="ET8-9p-ZLz">
             <objects>
                 <tableViewController id="xj3-6N-2Jy" userLabel="Reader Post Details" customClass="ReaderPostDetailViewController" sceneMemberID="viewController">
-                    <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="7Cm-An-fV3">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <connections>
-                            <outlet property="dataSource" destination="xj3-6N-2Jy" id="Jol-xd-D0x"/>
-                            <outlet property="delegate" destination="xj3-6N-2Jy" id="TFz-fd-42p"/>
-                        </connections>
-                    </tableView>
                     <navigationItem key="navigationItem" id="sWj-Rg-m3q"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="h51-jr-fqU" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -91,13 +82,13 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QIf-EO-cFO">
-                                                    <rect key="frame" x="54" y="9" width="254" height="14.5"/>
+                                                    <rect key="frame" x="54" y="9" width="254" height="15"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Snippet" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LeI-iE-lkn">
-                                                    <rect key="frame" x="54" y="23" width="254" height="14.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Snippet" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LeI-iE-lkn">
+                                                    <rect key="frame" x="54" y="23" width="254" height="15"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <nil key="highlightedColor"/>
@@ -179,7 +170,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uYt-ov-kC3">
-                                                    <rect key="frame" x="54" y="8" width="188" height="14.5"/>
+                                                    <rect key="frame" x="54" y="8" width="188" height="15"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="188" id="tqG-8i-PGz"/>
                                                     </constraints>
@@ -188,12 +179,12 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sed-4I-XCW">
-                                                    <rect key="frame" x="242" y="8" width="64" height="14.5"/>
+                                                    <rect key="frame" x="242" y="8" width="64" height="15"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="N7y-ge-mMq" customClass="WPDynamicHeightTextView" customModule="WordPress" customModuleProvider="target">
+                                                <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="N7y-ge-mMq" customClass="WPDynamicHeightTextView" customModule="WordPress" customModuleProvider="target">
                                                     <rect key="frame" x="12" y="20" width="296" height="29"/>
                                                     <color key="backgroundColor" red="0.9215686917" green="0.93333339689999995" blue="0.94901967050000002" alpha="1" colorSpace="deviceRGB"/>
                                                     <constraints>
@@ -207,8 +198,8 @@
                                                         <constraint firstAttribute="height" constant="1" id="BUp-fs-LKw"/>
                                                     </constraints>
                                                 </view>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kdg-f8-pBH" userLabel="Reply" customClass="VerticallyStackedButton">
-                                                    <rect key="frame" x="120" y="69.5" width="20" height="30"/>
+                                                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kdg-f8-pBH" userLabel="Reply" customClass="VerticallyStackedButton">
+                                                    <rect key="frame" x="120" y="70" width="20" height="30"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="20" id="Jbk-z2-z1U"/>
                                                     </constraints>
@@ -223,8 +214,8 @@
                                                         <action selector="replyWasPressed:" destination="FtC-SI-oJr" eventType="touchUpInside" id="HJw-Pe-Axk"/>
                                                     </connections>
                                                 </button>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e1p-ec-Dn3" customClass="VerticallyStackedButton">
-                                                    <rect key="frame" x="160" y="69.5" width="20" height="30"/>
+                                                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e1p-ec-Dn3" customClass="VerticallyStackedButton">
+                                                    <rect key="frame" x="160" y="70" width="20" height="30"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="20" id="jzW-8y-eL4"/>
                                                     </constraints>
@@ -239,8 +230,8 @@
                                                         <action selector="likeWasPressed:" destination="FtC-SI-oJr" eventType="touchUpInside" id="c0t-Kd-Ydq"/>
                                                     </connections>
                                                 </button>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dZU-ho-dbu" customClass="VerticallyStackedButton">
-                                                    <rect key="frame" x="200" y="69.5" width="20" height="30"/>
+                                                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dZU-ho-dbu" customClass="VerticallyStackedButton">
+                                                    <rect key="frame" x="200" y="70" width="20" height="30"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="20" id="oj5-pk-p8y"/>
                                                     </constraints>
@@ -255,8 +246,8 @@
                                                         <action selector="approveWasPressed:" destination="FtC-SI-oJr" eventType="touchUpInside" id="YLu-SY-nNP"/>
                                                     </connections>
                                                 </button>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q3a-Aa-VqY" customClass="VerticallyStackedButton">
-                                                    <rect key="frame" x="240" y="69.5" width="20" height="30"/>
+                                                <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q3a-Aa-VqY" customClass="VerticallyStackedButton">
+                                                    <rect key="frame" x="240" y="70" width="20" height="30"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="20" id="aqK-WO-00U"/>
                                                     </constraints>
@@ -382,12 +373,12 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog URL" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8yY-Q0-7Ra" userLabel="BlogUrlLabel">
-                                                    <rect key="frame" x="70" y="19" width="238" height="14.5"/>
+                                                    <rect key="frame" x="70" y="19" width="238" height="15"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rba-We-3uT" userLabel="FollowButton">
-                                                    <rect key="frame" x="66" y="31.5" width="100" height="22"/>
+                                                    <rect key="frame" x="66" y="32" width="100" height="22"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="100" id="8Qz-7K-TV1"/>
                                                     </constraints>


### PR DESCRIPTION
Re-targets #2702
The reader detail view controller is no longer a UITableViewController. This PR removes the obsolete UITableView + delegate outlets from the notifications storyboard, which was causing a crash when viewing a post detail from a comment notification.

cc @jleandroperez 
