### PR TITLE
Disabled Jetpack + REST for internal builds.

### DIFF
--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -28,7 +28,7 @@ NSString *const WPStatsTodayWidgetUserDefaultsVisitorCountKey = @"TodayVisitorCo
 
 NSString *const WPInternalBetaShakeToPullUpFeedbackKey = @"InternalBetaShakeToPullUpFeedback";
 
-#if defined(INTERNAL_BUILD) || defined(DEBUG)
+#if defined(DEBUG)
 BOOL const WPJetpackRESTSupported = YES;
 #else
 BOOL const WPJetpackRESTSupported = NO;


### PR DESCRIPTION
Disables Jetpack + REST for internal builds until [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/2705) is fixed.

/cc @sendhil 
