### PR TITLE
Prevent crash on MediaService createMediaWithAsset

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -78,16 +78,19 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
         DDLogError(@"Error writing media to %@", imagePath);
     }
     [self.managedObjectContext performBlock:^{
-        AbstractPost *post = (AbstractPost *)[self.managedObjectContext objectWithID:postObjectID];
-        Media *media = [self newMediaForPost:post];
-        media.filename = [imagePath lastPathComponent];
-        media.localURL = imagePath;
-        media.thumbnail = thumbnailData;
-        // This is kind of lame, but we've been storing file size as KB so far
-        // We should store size in bytes or rename the property to avoid confusion
-        media.filesize = @(optimizedImageData.length / 1024);
-        media.width = width;
-        media.height = height;
+        Media *media;
+        AbstractPost *post = (AbstractPost *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
+        if (post) {
+            media = [self newMediaForPost:post];
+            media.filename = [imagePath lastPathComponent];
+            media.localURL = imagePath;
+            media.thumbnail = thumbnailData;
+            // This is kind of lame, but we've been storing file size as KB so far
+            // We should store size in bytes or rename the property to avoid confusion
+            media.filesize = @(optimizedImageData.length / 1024);
+            media.width = width;
+            media.height = height;
+        }
         //make sure that we only return when object is properly created and saved
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
             if (completion) {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1055,6 +1055,10 @@ static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCell
     [assetsLibrary assetForURL:assetURL resultBlock:^(ALAsset *asset){
         MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
         [mediaService createMediaWithAsset:asset forPostObjectID:self.post.objectID completion:^(Media *media) {
+            if (!media) {
+                weakSelf.isUploadingMedia = NO;
+                return;
+            }
             media.mediaType = MediaTypeFeatured;
             [mediaService uploadMedia:media success:^{
                 weakSelf.isUploadingMedia = NO;

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -963,6 +963,10 @@ static NSInteger const MaximumNumberOfPictures = 4;
         if ([[asset valueForProperty:ALAssetPropertyType] isEqualToString:ALAssetTypePhoto]) {
             MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
             [mediaService createMediaWithAsset:asset forPostObjectID:self.post.objectID completion:^(Media *media) {
+                if (!media) {
+                    return;
+                }
+
                 AFHTTPRequestOperation *operation = [mediaService operationToUploadMedia:media withSuccess:^{
                     [self insertMedia:media];
                 } failure:^(NSError *error) {

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1329,6 +1329,9 @@ static NSDictionary *EnabledButtonBarStyle;
             } else if ([[asset valueForProperty:ALAssetPropertyType] isEqualToString:ALAssetTypePhoto]) {
                 MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
                 [mediaService createMediaWithAsset:asset forPostObjectID:self.post.objectID completion:^(Media *media) {
+                    if (!media) {
+                        return;
+                    }
                     NSString* imageUniqueId = [self uniqueId];
                     
                     NSURL* url = [[NSURL alloc] initFileURLWithPath:media.localURL];


### PR DESCRIPTION
Uses existingObjectWithID instead of objectID, and checks that there's
an actual post to attach the media too.

If there is no post, `completion` will be called with a `nil` media
object.

Fixes #2719
