### PR TITLE
No need to preserve offset when loading more.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -756,8 +756,7 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
     }
 
     [self.activityFooter startAnimating];
-    self.tableViewHandler.shouldRefreshTableViewPreservingOffset = YES;
-    
+
     ReaderPost *post = self.tableViewHandler.resultsController.fetchedObjects.lastObject;
     NSDate *earlierThan = post.sortDate;
     
@@ -847,8 +846,8 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
 
     if (self.shouldSkipRowAnimation) {
         // short circuit any row animation when loading more.
-        [self.tableView reloadData];
         self.shouldSkipRowAnimation = NO;
+        [self.tableView reloadData];
     }
 }
 


### PR DESCRIPTION
Fixes an issue where the post list could jump around or appear empty after loading more posts due. 
