### PR TITLE
Rolls back 2612 due to issues related to kerning.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichTextView.m
+++ b/WordPress/Classes/ViewRelated/Views/WPRichTextView.m
@@ -434,7 +434,6 @@ static CGFloat WPRichTextDefaultEmbedRatio = 1.778;
     button.GUID = identifier;
 
     // get image with normal link text
-    frame.size.width = frame.size.width + 2; // slight padding to avoid cropping italic characters
     UIImage *normalImage = [attributedTextContentView contentImageWithBounds:frame options:DTCoreTextLayoutFrameDrawingDefault];
     [button setImage:normalImage forState:UIControlStateNormal];
 


### PR DESCRIPTION
While #2612 worked for preventing italic characters from being cropped, it created an issue where closely kerned punctuation following a link would be partially captured and included as part of the link image. This leads to some undesired visual artifacts.  Since the font attributes for the specified attributed string do not specify if the font is italic (wtf?) its preferable to rollback #2612 and just clip a few pixels off the occasional italicized link. 
