### PR TITLE
State restoration fix for WPPostViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
@@ -34,6 +34,15 @@ typedef void (^EditPostCompletionHandler)(void);
 - (id)initWithDraftForLastUsedBlog;
 
 /*
+ Initialize the editor with the specified post and default to preview mode.
+ 
+ @param		post		The post to edit.  Cannot be nil.
+ 
+ @returns	The initialized object.
+ */
+- (id)initWithPost:(AbstractPost *)post;
+
+/*
  Initialize the editor with the specified post.
  
  @param		post		The post to edit.  Cannot be nil.

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -91,6 +91,12 @@ static NSDictionary *EnabledButtonBarStyle;
 }
 
 - (id)initWithPost:(AbstractPost *)post
+{
+    return [self initWithPost:post
+                         mode:kWPPostViewControllerModePreview];
+}
+
+- (id)initWithPost:(AbstractPost *)post
 			  mode:(WPPostViewControllerMode)mode
 {
     self = [super initWithMode:mode];


### PR DESCRIPTION
This should fix https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/320

/cc @diegoreymendez 
