### PR TITLE
Fixes the footer color for the assets picker.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ pod 'EmailChecker', :podspec => 'https://raw.github.com/wordpress-mobile/EmailCh
 pod 'CrashlyticsLumberjack', '~>1.0.0'
 pod 'HockeySDK', '~>3.5.0'
 pod 'Helpshift', '~>4.8.0'
-pod 'CTAssetsPickerController', '~> 2.6'
+pod 'CTAssetsPickerController', '~> 2.7.0'
 pod 'WordPress-iOS-Shared', '0.1.3'
 pod 'WordPress-iOS-Editor', :git => 'git://github.com/wordpress-mobile/WordPress-iOS-Editor', :commit => '39a0ddb1e0b2913d3002398f203fe0285e6c0d45'
 pod 'WordPressCom-Stats-iOS', '0.1.4'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
     - CocoaLumberjack/Core
   - CrashlyticsLumberjack (1.0.1):
     - CocoaLumberjack/Core
-  - CTAssetsPickerController (2.6.0)
+  - CTAssetsPickerController (2.7.0)
   - DTCoreText (1.6.13):
     - DTFoundation/Core (~> 1.7.1)
     - DTFoundation/DTAnimatedGIF (~> 1.7.1)
@@ -98,7 +98,7 @@ DEPENDENCIES:
   - AFNetworking (~> 2.3.1)
   - CocoaLumberjack (~> 1.8.1)
   - CrashlyticsLumberjack (~> 1.0.0)
-  - CTAssetsPickerController (~> 2.6)
+  - CTAssetsPickerController (~> 2.7.0)
   - DTCoreText (= 1.6.13)
   - EmailChecker (from `https://raw.github.com/wordpress-mobile/EmailChecker/master/ios/EmailChecker.podspec`)
   - google-plus-ios-sdk (~> 1.5)
@@ -148,7 +148,7 @@ SPEC CHECKSUMS:
   AFNetworking: 6d7b76aa5d04c8c37daad3eef4b7e3f2a7620da3
   CocoaLumberjack: 9d198d6e19909b3b113a38c5f06f7bb8eedd0427
   CrashlyticsLumberjack: b2a184319db06a070ccc176c07c503720ebedf81
-  CTAssetsPickerController: 1dadc633ca90bcd7797222199fcd7f9047b93386
+  CTAssetsPickerController: 319a91106b7b323446b39ab944a3f14db0a1ca46
   DTCoreText: 84eb8ba2e70448fdd9d837540e371f9f587b65ba
   DTFoundation: 360bc65ab44f588611f47324b8cfb0f18e04b263
   EmailChecker: e909e6d113fac7ad5e3c304fabce30fc4a79c80e

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -390,6 +390,10 @@ static NSDictionary *EnabledButtonBarStyle;
     CTAssetsPickerController *picker = [[CTAssetsPickerController alloc] init];
 	picker.delegate = self;
     
+    UIBarButtonItem *barButtonItem = [UIBarButtonItem appearanceWhenContainedIn:[UIToolbar class], [CTAssetsPickerController class], nil];
+    [barButtonItem setTitleTextAttributes:@{NSForegroundColorAttributeName: [UIColor whiteColor]} forState:UIControlStateNormal];
+    [barButtonItem setTitleTextAttributes:@{NSForegroundColorAttributeName: [UIColor whiteColor]} forState:UIControlStateDisabled];
+    
     // Only show photos for now (not videos)
     picker.assetsFilter = [ALAssetsFilter allPhotos];
     


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/112).

There was [a previous (failed) PR for this](https://github.com/wordpress-mobile/WordPress-iOS/pull/2717).  The author of CTAssetsPickerController [modified the library and proposed a new and supported way to change the picker's footer text color](https://github.com/chiunam/CTAssetsPickerController/pull/57).

/cc @aerych since you reviewed the original PR.
