### PR TITLE
Fixes a crash when Jetpack authentication fails

### DIFF
--- a/WordPress/Classes/Models/Blog+Jetpack.m
+++ b/WordPress/Classes/Models/Blog+Jetpack.m
@@ -172,16 +172,23 @@ NSString * const BlogJetpackApiPath = @"get-user-blogs/1.0";
                              } failure:^(NSError *error) {
                                  DDLogError(@"Error while obtaining OAuth2 token after enabling JetPack: %@", error);
 
-                                 // OAuth2 login failed - we can still create the WPAccount without the token
-                                 // TODO: This is the behavior prior to 3.9 and could get removed
+                                 /*
+                                  If we're using a WordPress.com account that was already set up in the app
+                                  and authenticated, we can use that one. Otherwise, we fail.
+                                  */
                                  AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:self.managedObjectContext];
-                                 WPAccount *account = [accountService createOrUpdateWordPressComAccountWithUsername:username password:password authToken:nil];
-                                 self.jetpackAccount = account;
-                                 [self dataSave];
+                                 WPAccount *account = [accountService findWordPressComAccountWithUsername:username];
 
-                                 // If the default 3.9 behavior is removed above, this should call the failure block, not success
-                                 if (success) {
-                                     success();
+                                 if (account) {
+                                     self.jetpackAccount = account;
+                                     [self dataSave];
+                                     if (success) {
+                                         success();
+                                     }
+                                 } else {
+                                     if (failure) {
+                                         failure(error);
+                                     }
                                  }
                              }];
 }

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -96,7 +96,7 @@
                                   andServiceName:WordPressComOAuthKeychainServiceName
                                            error:&error];
         if (error) {
-            DDLogError(@"Error while retrieving WordPressComOAuthKeychainServiceName token: %@", error);
+            DDLogError(@"Error while deleting WordPressComOAuthKeychainServiceName token: %@", error);
         }
     }
 }

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -78,4 +78,12 @@ extern NSString *const WPAccountDefaultWordPressComAccountChangedNotification;
 
 - (NSUInteger)numberOfAccounts;
 
+/**
+ Returns a WordPress.com account with the specified username, if it exists
+
+ @param username the account's username
+ @return a `WPAccount` object if there's one for the specified username. Otherwise it returns nil
+ */
+- (WPAccount *)findWordPressComAccountWithUsername:(NSString *)username;
+
 @end

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -184,16 +184,9 @@ NSString * const WPAccountDefaultWordPressComAccountChangedNotification = @"WPAc
                                                 username:(NSString *)username
                                              andPassword:(NSString *)password
 {
-    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"Account"];
-    [request setPredicate:[NSPredicate predicateWithFormat:@"xmlrpc like %@ AND username like %@", xmlrpc, username]];
-    [request setIncludesPendingChanges:YES];
+    WPAccount *account = [self findAccountWithUsername:username andXmlrpc:xmlrpc];
 
-    WPAccount *account;
-
-    NSArray *results = [self.managedObjectContext executeFetchRequest:request error:nil];
-    if ([results count] > 0) {
-        account = [results objectAtIndex:0];
-    } else {
+    if (!account) {
         account = [NSEntityDescription insertNewObjectForEntityForName:@"Account" inManagedObjectContext:self.managedObjectContext];
         account.uuid = [[NSUUID new] UUIDString];
         account.xmlrpc = xmlrpc;
@@ -206,8 +199,6 @@ NSString * const WPAccountDefaultWordPressComAccountChangedNotification = @"WPAc
     return account;
 
 }
-
-#pragma mark - Private methods
 
 - (NSUInteger)numberOfAccounts
 {
@@ -222,5 +213,21 @@ NSString * const WPAccountDefaultWordPressComAccountChangedNotification = @"WPAc
     }
     return count;
 }
+
+- (WPAccount *)findWordPressComAccountWithUsername:(NSString *)username
+{
+    return [self findAccountWithUsername:username andXmlrpc:WordPressDotcomXMLRPCKey];
+}
+
+- (WPAccount *)findAccountWithUsername:(NSString *)username andXmlrpc:(NSString *)xmlrpc
+{
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"Account"];
+    [request setPredicate:[NSPredicate predicateWithFormat:@"xmlrpc like %@ AND username like %@", xmlrpc, username]];
+    [request setIncludesPendingChanges:YES];
+
+    NSArray *results = [self.managedObjectContext executeFetchRequest:request error:nil];
+    return [results firstObject];
+}
+
 
 @end


### PR DESCRIPTION
For reasons I can't remember or understand, when the OAuth2 request
failed, we would still create the account as if nothing happened. The
code would even overwrite a perfectly valid account with wrong
credentials, leaving the app in a bad state.

The simplest way would be to just call `failure` if the OAuth2 request
failed, but some times, the first API request might succeed and the
OAuth2 request fails. In those cases, if we already have a WordPress.com
account which matches the one we're trying to add, we reuse that one,
but not try to replace password or auth token.

In fact, if there's already a valid account we shouldn't even call
OAuth2 to get a new token. But this is a hotfix for 3.6, and the whole
Jetpack authentication flow is going to change very soon anyway.

Fixes #2748
