### PR TITLE
Fix for "Sheet can not be presented..." crash

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -118,7 +118,7 @@ DEPENDENCIES:
   - SocketRocket (from `https://github.com/jleandroperez/SocketRocket.git`, branch `master`)
   - SVProgressHUD (~> 1.0)
   - UIDeviceIdentifier (~> 0.1)
-  - WordPress-iOS-Editor (from `git://github.com/wordpress-mobile/WordPress-iOS-Editor`, commit `c4960f85531b02fa22cb0b78bce50620872010ea`)
+  - WordPress-iOS-Editor (from `git://github.com/wordpress-mobile/WordPress-iOS-Editor`, commit `7116f1fb9ea3471d5bbd73c3779fc4c8fe401ab0`)
   - WordPress-iOS-Shared (= 0.1.3)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPressApi.git`, tag `0.2.0`)
   - WordPressCom-Analytics-iOS (= 0.0.12)
@@ -138,7 +138,7 @@ EXTERNAL SOURCES:
     :branch: master
     :git: https://github.com/jleandroperez/SocketRocket.git
   WordPress-iOS-Editor:
-    :commit: c4960f85531b02fa22cb0b78bce50620872010ea
+    :commit: 7116f1fb9ea3471d5bbd73c3779fc4c8fe401ab0
     :git: git://github.com/wordpress-mobile/WordPress-iOS-Editor
   WordPressApi:
     :git: https://github.com/wordpress-mobile/WordPressApi.git

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -488,7 +488,7 @@ static NSDictionary *EnabledButtonBarStyle;
     if (IS_IPAD) {
         [actionSheet showFromBarButtonItem:self.cancelButton animated:YES];
     } else {
-        [actionSheet showFromToolbar:self.navigationController.toolbar];
+        [actionSheet showInView:[UIApplication sharedApplication].keyWindow];
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/371. I was not able to repro this issue, however given the error, I think it is safe to assume the toolbar is not in the window and displaying the actionsheet with it in that state is bad news. :grinning: 

There may be some relation to this bug: https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/372 but for now, this fix should alleviate some of the crashers.

/cc @sendhil 

P.S. it looks like the `Podfile.lock` file was out of date too...updated to correct commit hash.
