### PR TITLE
Re-enabled the visual editor for new user accounts

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -698,6 +698,9 @@ CGFloat const CreateAccountAndBlogButtonHeight = 40.0;
 
     WPAsyncBlockOperation *userCreation = [WPAsyncBlockOperation operationWithBlock:^(WPAsyncBlockOperation *operation){
         void (^createUserSuccess)(id) = ^(id responseObject){
+            // Turn on the new editor only for users that create a new account within the iOS app
+            [WPPostViewController setNewEditorAvailable:YES];
+            [WPPostViewController setNewEditorEnabled:YES];
             [operation didSucceed];
         };
         void (^createUserFailure)(NSError *) = ^(NSError *error) {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/326

/cc @diegoreymendez 
