### PR TITLE
Prevents crash due to emtpy settings dictionary

### DIFF
--- a/WordPress/Classes/Utility/NotificationsManager.m
+++ b/WordPress/Classes/Utility/NotificationsManager.m
@@ -297,6 +297,7 @@ NSString *const NotificationActionCommentApprove                    = @"COMMENT_
 {
     NSDictionary *settings          = [NotificationsManager notificationSettingsDictionary];
     if (!settings) {
+        DDLogError(@"%@ %@ returning early because of blank notifications setting dictionary", self, NSStringFromSelector(_cmd));
         return;
     }
     


### PR DESCRIPTION
Fixes #2777

This PR will just prevent crashes due to empty Notification Settings dictionary (which can have multiple reasons). 

In an upcoming iteration we'll be killing this code, entirely, and replacing this with a Simperium-backed component (_NotificationsManager_ is up for a full refactor).

/cc @sendhil 
