### PR TITLE
Added title placeholder for the pages screen.

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/EditPageViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/EditPageViewController.m
@@ -12,7 +12,7 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    self.titlePlaceholderText = NSLocalizedString(@"Page title", @"Placeholder text for the title field on Pages screen.");;
+    self.titlePlaceholderText = NSLocalizedString(@"Page title", @"Placeholder text for the title field on Pages screen.");
 }
 
 - (NSString *)editorTitle


### PR DESCRIPTION
Title has it.

Fixes https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/373:

![screen shot 2014-11-13 at 12 10 30 pm](https://cloud.githubusercontent.com/assets/154014/5033739/2025f6a8-6b2e-11e4-9ccf-187705806ae1.png)

/cc @diegoreymendez 
