### PR TITLE
issues/1647-NUX-create-account-title-shifted

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -382,7 +382,7 @@ CGFloat const CreateAccountAndBlogButtonHeight = 40.0;
     CGFloat x,y;
 
     CGFloat viewWidth = CGRectGetWidth(self.view.bounds);
-    CGFloat viewHeight = CGRectGetHeight(self.view.bounds);
+    CGFloat viewHeight = CGRectGetHeight([UIScreen mainScreen].bounds);
 
     // Layout Help Button
     UIImage *helpButtonImage = [UIImage imageNamed:@"btn-help"];


### PR DESCRIPTION
reworked PR #1853 from @jstart, always set viewHeight to [UIScreen mainScreen].bounds height so that WPNUXUtility can center controls vertically, otherwise controls are shifted up when returning from another view, fixes #1647 
