### PR TITLE
We're hiding the bottom toolbar when the editor is on screen.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostsViewController.m
@@ -244,6 +244,7 @@
     if ([WPPostViewController isNewEditorEnabled]) {
         WPPostViewController *postViewController = [[WPPostViewController alloc] initWithPost:apost
                                                                                          mode:kWPPostViewControllerModePreview];
+        postViewController.hidesBottomBarWhenPushed = YES;
         [self.navigationController pushViewController:postViewController animated:YES];
     } else {
         // In legacy mode, view means edit


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/382).

/cc @bummytime 
