### PR TITLE
Replace dup call to saved topic & fetch default topic.

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -82,7 +82,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     }
 
     if (!topic) {
-        topic = [self currentTopicFromSavedURIString];
+        topic = [self currentTopicFromDefaultTopic];
         [self setCurrentTopic:topic];
     }
 


### PR DESCRIPTION
Fixes an [issue fetching a default topic](https://github.com/wordpress-mobile/WordPress-iOS/pull/2800#issuecomment-63941364). 
cc @astralbodies @sendhil 
