### PR TITLE
Fix date calculation to load more posts

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -147,7 +147,7 @@ NSString * const PostServiceErrorDomain = @"PostServiceErrorDomain";
         NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
         request.predicate = [NSPredicate predicateWithFormat:@"date_created_gmt != NULL"];
         NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"date_created_gmt" ascending:YES];
-        request.sortDescriptors = @[ sortDescriptor ];
+        request.sortDescriptors = @[sortDescriptor];
         Post *oldestPost = [[self.managedObjectContext executeFetchRequest:request error:nil] firstObject];
         if (oldestPost.date_created_gmt) {
             options[@"before"] = [oldestPost.date_created_gmt WordPressComJSONString];


### PR DESCRIPTION
`blog.posts` also includes pages, so let's use a fetch request with a
specific entity to calculate which post is the oldest

Fixes #2841
