### PR TITLE
Forward declaration error fix in NotificationsManager

### DIFF
--- a/WordPress/Classes/Utility/NotificationsManager.m
+++ b/WordPress/Classes/Utility/NotificationsManager.m
@@ -16,6 +16,7 @@
 #import <Helpshift/Helpshift.h>
 #import <Simperium/Simperium.h>
 #import <Mixpanel/Mixpanel.h>
+#import "Blog.h"
 
 
 


### PR DESCRIPTION
Fixes forward declaration error in NotificationsManager by importing `Blog.h`.

/cc @astralbodies 
