### PR TITLE
Shows an alert if the user opens in preview mode a post with unsaved changes.

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -28,4 +28,18 @@
 - (BOOL)hasCategories;
 - (BOOL)hasTags;
 
+/**
+ *  @brief      Call this method to know whether this post has a revision or not.
+ *
+ *  @returns    YES if this post has a revision, NO otherwise.
+ */
+- (BOOL)hasRevision;
+
+/**
+ *  @brief      Call this method to know whether this post has unsaved changes or not.
+ *
+ *  @returns    YES if the post has unsaved changes.  NO otherwise.
+ */
+- (BOOL)hasUnsavedChanges;
+
 @end

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -247,6 +247,16 @@
     return NO;
 }
 
+- (BOOL)hasRevision
+{
+    return self.revision != nil;
+}
+
+- (BOOL)hasUnsavedChanges
+{
+    return [self hasRevision] && [self.revision hasChanged];
+}
+
 - (void)findComments
 {
     NSSet *comments = [self.blog.comments filteredSetUsingPredicate:


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/426).

Known issues:
- (Low Priority) [This](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/429).
- (High Priority) [This](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/430).  I'm going to be working on this one next.  We have seen similar issues already so I feel this problem is not really introduced by this PR.

/cc @bummytime 
