### PR TITLE
Removes call to layoutSubviewsIfNeeded when a media bach loads.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
@@ -481,11 +481,6 @@ static CGFloat const VerticalMargin = 40;
     }
 }
 
-- (void)richTextViewDidLoadMediaBatch:(WPRichTextView *)richTextView
-{
-    [self.postView layoutIfNeeded];
-}
-
 
 #pragma mark - WPTableImageSource Delegate
 


### PR DESCRIPTION
Closes #2869 

When viewing the example post in the simulator, it was consistently taking ~50 seconds for the post to be processed and rendered.  A significant amount of time stemmed from a call to `layoutSubviewsIfNeeded`.  This call originally existed to address some layout and rendering issues in an earlier approach to how the reader view displayed media.  Removing this call reduces time significantly, tho there is still a delay for the example post. My testing has not revealed any noticeable layout issues or glitching which leads me to feel this is a safe change, but I'd ask reviewers to triple check this.  Yay paranoia!
### Before

![screen shot 2014-12-02 at 2 27 20 pm](https://cloud.githubusercontent.com/assets/1435271/5270607/47317138-7a32-11e4-83b9-3ae6dbb9c760.png)
### After

![screen shot 2014-12-02 at 2 28 48 pm](https://cloud.githubusercontent.com/assets/1435271/5270615/502055b6-7a32-11e4-9059-d824b0923bab.png)
