### PR TITLE
LoginViewController uses dismissBlock after successful login.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -568,7 +568,7 @@ static NSString* const kWPNewPostURLParamImageKey = @"image";
 {
     LoginViewController *loginViewController = [[LoginViewController alloc] init];
     loginViewController.showEditorAfterAddingSites = thenEditor;
-    loginViewController.cancelButtonDisabled = YES;
+    loginViewController.cancellable = NO;
     loginViewController.dismissBlock = ^{
         [self.window.rootViewController dismissViewControllerAnimated:YES completion:nil];
     };

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -400,6 +400,7 @@ CGFloat const blavatarImageSize = 50.f;
     if ([indexPath isEqual:[self indexPathForAddSite]]) {
         [self setEditing:NO animated:NO];
         LoginViewController *loginViewController = [[LoginViewController alloc] init];
+        loginViewController.cancellable = YES;
 
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
         AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.h
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.h
@@ -4,6 +4,6 @@
 @property (nonatomic, assign) BOOL onlyDotComAllowed;
 @property (nonatomic, assign) BOOL prefersSelfHosted;
 @property (nonatomic, assign) BOOL showEditorAfterAddingSites;
-@property (nonatomic, assign) BOOL cancelButtonDisabled;
+@property (nonatomic, assign) BOOL cancellable;
 @property (nonatomic, copy) void (^dismissBlock)();
 @end

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -500,7 +500,7 @@ CGFloat const GeneralWalkthroughStatusBarOffset = 20.0;
     [_signInButton setTitle:signInTitle forState:UIControlStateNormal];
 
     // Add Cancel Button
-    if (!self.cancelButtonDisabled && _cancelButton == nil) {
+    if (self.cancellable && _cancelButton == nil) {
         _cancelButton = [[WPNUXSecondaryButton alloc] init];
         [_cancelButton setTitle:NSLocalizedString(@"Cancel", nil) forState:UIControlStateNormal];
         [_cancelButton addTarget:self action:@selector(cancelButtonAction:) forControlEvents:UIControlEventTouchUpInside];

--- a/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
@@ -534,6 +534,7 @@ static CGFloat const SettingsRowHeight = 44.0;
         } else {
             LoginViewController *loginViewController = [[LoginViewController alloc] init];
             loginViewController.onlyDotComAllowed = YES;
+            loginViewController.cancellable = YES;
             loginViewController.dismissBlock = ^{
                 [self.navigationController popToViewController:self animated:YES];
             };


### PR DESCRIPTION
`cancelButtonDisabled` flag added to LoginViewController so it doesn't depend on the existence of dismissBlock anymore to decide whether to show the cancel button or not.

Fixes #2882. @koke can I bother you with a quick review?

> Right now LoginViewController always uses dismissViewControllerAnimated after a successful login which assumes that we will only use it as a modal view controller. In order to have a better control, we should use the dismissBlock after a successful login so the calling controller can decide whether to dismiss the modal view or pop to a previous controller.
