### PR TITLE
Reloads UITableView after dataSource switch

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -123,6 +123,10 @@ static NSTimeInterval NotificationsSyncTimeout          = 10;
     tableViewHandler.cacheRowHeights        = true;
     tableViewHandler.delegate               = self;
     self.tableViewHandler                   = tableViewHandler;
+    
+    // Reload the tableView right away: setting the new dataSource doesn't nuke the row + section count cache
+    [self.tableView reloadData];
+    
     // NOTE:
     // iOS 8 has a nice bug in which, randomly, the last cell per section was getting an extra separator.
     // For that reason, we draw our own separators.

--- a/WordPress/Classes/ViewRelated/Reader/WPTableViewHandler.h
+++ b/WordPress/Classes/ViewRelated/Reader/WPTableViewHandler.h
@@ -54,7 +54,6 @@
 @property (nonatomic) UITableViewRowAnimation moveRowAnimation;
 @property (nonatomic) UITableViewRowAnimation sectionRowAnimation;
 
-// Note: The tableView instance will be reloaded right during the handler initialization, in order to reset section and row caches.
 - (instancetype)initWithTableView:(UITableView *)tableView;
 - (void)updateTitleForSection:(NSUInteger)section;
 - (void)clearCachedRowHeights;

--- a/WordPress/Classes/ViewRelated/Reader/WPTableViewHandler.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPTableViewHandler.m
@@ -50,7 +50,6 @@ static CGFloat const DefaultCellHeight = 44.0;
         _tableView.delegate = self;
         _tableView.dataSource = self;
         [_tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:DefaultCellIdentifier];
-        [_tableView reloadData];
     }
     return self;
 }


### PR DESCRIPTION
Fixes #2932

(For the record) reason of this crash is:
- `[UITableView new]` creates a new tableView with _one_ section, by default.
- Setting a new dataSource doesn't reload the number of rows or sections.
- There are multiple actions that might trigger a "section view reload" (such as setting a footer!), and this is a source for crashes.

_Thank you all!!_

/cc @SergioEstevao + @koke + @aerych 
