### PR TITLE
Prevents accessing an empty optional

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/RichTextView/RichTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/RichTextView/RichTextView.swift
@@ -92,11 +92,8 @@ import Foundation
     }
     
     public override var backgroundColor: UIColor? {
-        set {
-            textView.backgroundColor = newValue
-        }
-        get {
-            return textView.backgroundColor
+        didSet {
+            textView?.backgroundColor = backgroundColor
         }
     }
     


### PR DESCRIPTION
Fixes #2982

I've missed this scenario: 
- RichTextView gets instantiated from a storyboard. 
- The Nib-Loading-Mechanism will set the view's properties (backgroundColor)
- This happens before the `textView` gets alloc'ed
- As a result, an implicitly unwrapped optional is being accessed before it's ready.

Plus, the `backgroundColor` should not have custom getters and setters, since it's a UIView property.

/cc @aerych (Thanks!)
