### PR TITLE
Removed warning for unknown keys

### DIFF
--- a/WordPress/WordPressApi/gencredentials.rb
+++ b/WordPress/WordPressApi/gencredentials.rb
@@ -249,8 +249,6 @@ File.open(path) do |f|
       appbotx_api_key = v.chomp
     elsif k == "NEWRELIC_APPLICATION_TOKEN"
       newrelic_application_token = v.chomp
-    else
-      $stderr.puts "warning: Unknown key #{k}"
     end
   end
 end


### PR DESCRIPTION
Removed the warning that was spit out by `gencredentials.rb` if it didn't know what to do with a key. Some people remove keys by renaming them or have extra keys for other things they are testing so it's annoying to see warnings appear all the time that aren't really needed.