### PR TITLE
Make page editor show in fullscreen.

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PagesViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/PagesViewController.m
@@ -102,7 +102,7 @@
         WPLegacyEditPageViewController *editPageViewController = [[WPLegacyEditPageViewController alloc] initWithPost:apost];
         UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:editPageViewController];
         [navController setToolbarHidden:NO]; // Fixes incorrect toolbar animation.
-        navController.modalPresentationStyle = UIModalPresentationCurrentContext;
+        navController.modalPresentationStyle = UIModalPresentationFullScreen;
         navController.restorationIdentifier = WPLegacyEditorNavigationRestorationID;
         navController.restorationClass = [WPLegacyEditPageViewController class];
         


### PR DESCRIPTION
Fix https://github.com/wordpress-mobile/WordPress-iOS/issues/3017

/cc @aerych can you review this? It's a quick one..