### PR TITLE
Issue/468 remove failed media on drafts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1493,6 +1493,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         [self.editorView removeImage:key];
     }];
     [self.mediaInProgress removeAllObjects];
+    [self autosaveContent];
 }
 
 - (void)stopTrackingProgressOfMediaWithId:(NSString *)uniqueMediaId

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -666,13 +666,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     [failedMediaBeforeEditAlertView show];
 }
 
-- (void)cancelMediaUploads
-{
-    [self.mediaGlobalProgress cancel];
-    [self.mediaInProgress removeAllObjects];
-    [self refreshNavigationBarButtons:NO];
-}
-
 - (void)showSettings
 {
     if ([self isMediaUploading]) {
@@ -1476,6 +1469,13 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (BOOL)isMediaUploading
 {
     return (self.mediaGlobalProgress.totalUnitCount > self.mediaGlobalProgress.completedUnitCount) && !self.mediaGlobalProgress.cancelled;
+}
+
+- (void)cancelMediaUploads
+{
+    [self.mediaGlobalProgress cancel];
+    [self.mediaInProgress removeAllObjects];
+    [self refreshNavigationBarButtons:NO];
 }
 
 - (void)cancelUploadOfMediaWithId:(NSString *)uniqueMediaId

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -657,8 +657,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)showMediaFailedRemovalAlert
 {
-    UIAlertView * failedMediaAlertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Failed media", @"Title for alert when trying to edit html post with failed media items")
-                                                                              message:NSLocalizedString(@"Some media uploads failed. saving this post will remove them from the post. Save anyway?", @"Confirms with the user if they save the post all media that failed to upload will be removed from it.")
+    UIAlertView * failedMediaAlertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Failed media", @"Title for alert when trying to save post with failed media items")
+                                                                              message:NSLocalizedString(@"Some media uploads failed. Saving this post will remove them from the post. Save anyway?", @"Confirms with the user if they save the post all media that failed to upload will be removed from it.")
                                                                              delegate:self
                                                                     cancelButtonTitle:NSLocalizedString(@"No", @"")
                                                                     otherButtonTitles:NSLocalizedString(@"Yes", @""), nil];
@@ -671,7 +671,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)showFailedMediaBeforeEditAlert
 {
     UIAlertView * failedMediaBeforeEditAlertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Failed media", @"Title for alert when trying to edit html post with failed media items")
-                                                           message:NSLocalizedString(@"There are media items in this post that failed to upload to the server. Do you want to remove them?", @"Asks the user if they want to remove their failed media from the post before editing the html")
+                                                           message:NSLocalizedString(@"Some media uploads failed. Manual HTML editing  this post will remove them from the post. Edit anyway?", @"Confirms with the user if they manul edit the post html all media that failed to upload will be removed from it.")
                                                           delegate:self
                                                  cancelButtonTitle:NSLocalizedString(@"No", @"")
                                                  otherButtonTitles:NSLocalizedString(@"Yes", @""), nil];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -645,9 +645,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)showFailedMediaRemovalAlert
 {
     UIAlertView * failedMediaAlertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Failed media", @"Title for alert when trying to save post with failed media items")
-                                                                              message:NSLocalizedString(@"Some media uploads failed. Saving this post will remove them from the post. Save anyway?", @"Confirms with the user if they save the post all media that failed to upload will be removed from it.")
+                                                                              message:NSLocalizedString(@"Some media uploads failed. This action will remove all failed media from the post.\nSave anyway?", @"Confirms with the user if they save the post all media that failed to upload will be removed from it.")
                                                                              delegate:self
-                                                                    cancelButtonTitle:NSLocalizedString(@"No", @"")
+                                                                    cancelButtonTitle:NSLocalizedString(@"Not Now", @"")
                                                                     otherButtonTitles:NSLocalizedString(@"Yes", @""), nil];
     failedMediaAlertView.tag = EditPostViewControllerAlertTagFailedMediaBeforeSave;
     [failedMediaAlertView show];
@@ -658,9 +658,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)showFailedMediaBeforeEditAlert
 {
     UIAlertView * failedMediaBeforeEditAlertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Failed media", @"Title for alert when trying to edit html post with failed media items")
-                                                           message:NSLocalizedString(@"Some media uploads failed. Manual HTML editing  this post will remove them from the post. Edit anyway?", @"Confirms with the user if they manul edit the post html all media that failed to upload will be removed from it.")
+                                                           message:NSLocalizedString(@"Some media uploads failed. Switching to the HTML view of this post will remove failed media.\nSwitch anyway?", @"Confirms with the user if they manually edit the post HTML all media that failed to upload will be removed from it.")
                                                           delegate:self
-                                                 cancelButtonTitle:NSLocalizedString(@"No", @"")
+                                                 cancelButtonTitle:NSLocalizedString(@"Not Now", @"")
                                                  otherButtonTitles:NSLocalizedString(@"Yes", @""), nil];
     failedMediaBeforeEditAlertView.tag = EditPostViewControllerAlertTagFailedMediaBeforeEdit;
     [failedMediaBeforeEditAlertView show];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1497,10 +1497,14 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)removeAllFailedMedia
 {
-    [self.mediaInProgress enumerateKeysAndObjectsUsingBlock:^(NSString * key, NSProgress * obj, BOOL *stop) {
-        [self.editorView removeImage:key];
+    NSMutableArray * keys = [NSMutableArray array];
+    [self.mediaInProgress enumerateKeysAndObjectsUsingBlock:^(NSString * key, NSProgress * progress, BOOL *stop) {
+        if (progress.totalUnitCount == 0){
+            [self.editorView removeImage:key];
+            [keys addObject:key];
+        }
     }];
-    [self.mediaInProgress removeAllObjects];
+    [self.mediaInProgress removeObjectsForKeys:keys];
     [self autosaveContent];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1763,7 +1763,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         case (EditPostViewControllerAlertTagFailedMediaBeforeSave): {
             if (buttonIndex == alertView.firstOtherButtonIndex) {
                 [self removeAllFailedMedia];
-                [self stopEditing];
                 [self savePostAndDismissVC];
             }
         } break;
@@ -1826,8 +1825,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)actionSheetSaveDraftButtonPressed
 {
-    [self stopEditing];
-    
     if (![self.post hasRemote] && [self.post.status isEqualToString:@"publish"]) {
         self.post.status = @"draft";
     }

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1627,6 +1627,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
                     if (error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled) {
                         [strongSelf stopTrackingProgressOfMediaWithId:imageUniqueId];
                         [strongSelf.editorView removeImage:imageUniqueId];
+                        [strongSelf autosaveContent];
                         [media remove];
                     } else {
                         [self dismissAssociatedActionSheetIfVisible:imageUniqueId];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1474,7 +1474,15 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)cancelMediaUploads
 {
     [self.mediaGlobalProgress cancel];
-    [self.mediaInProgress removeAllObjects];
+    NSMutableArray * keys = [NSMutableArray array];
+    [self.mediaInProgress enumerateKeysAndObjectsUsingBlock:^(NSString * key, NSProgress * progress, BOOL *stop) {
+        if (progress.isCancelled){
+            [self.editorView removeImage:key];
+            [keys addObject:key];
+        }
+    }];
+    [self.mediaInProgress removeObjectsForKeys:keys];
+    [self autosaveContent];
     [self refreshNavigationBarButtons:NO];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -631,19 +631,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     [alertView show];
 }
 
-- (void)showFailedMediaAlert
-{
-    if (self.failedMediaAlertView)
-        return;
-    self.failedMediaAlertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Pending media", @"Title for alert when trying to publish a post with failed media items")
-                                                       message:NSLocalizedString(@"There are media items in this post that aren't uploaded to the server. Do you want to continue?", @"")
-                                                      delegate:self
-                                             cancelButtonTitle:NSLocalizedString(@"No", @"")
-                                             otherButtonTitles:NSLocalizedString(@"Post anyway", @""), nil];
-    self.failedMediaAlertView.tag = EditPostViewControllerAlertTagFailedMedia;
-    [self.failedMediaAlertView show];
-}
-
 - (void)showMediaUploadingAlert
 {
     //the post is using the network connection and cannot be stoped, show a message to the user
@@ -655,7 +642,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     [blogIsCurrentlyBusy show];
 }
 
-- (void)showMediaFailedRemovalAlert
+- (void)showFailedMediaRemovalAlert
 {
     UIAlertView * failedMediaAlertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Failed media", @"Title for alert when trying to save post with failed media items")
                                                                               message:NSLocalizedString(@"Some media uploads failed. Saving this post will remove them from the post. Save anyway?", @"Confirms with the user if they save the post all media that failed to upload will be removed from it.")
@@ -742,11 +729,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 {
     if ([self isMediaUploading]) {
         [self showMediaUploadingAlert];
-        return;
-    }
-    
-    if ([self hasFailedMedia]) {
-        [self showMediaFailedRemovalAlert];
         return;
     }
     
@@ -1316,11 +1298,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 		return;
 	}
     
-    if ([self hasFailedMedia]) {
-        [self showFailedMediaAlert];
-        return;
-    }
-    
     [self stopEditing];
 	[self savePostAndDismissVC];
 }
@@ -1330,7 +1307,11 @@ static void *ProgressObserverContext = &ProgressObserverContext;
  */
 - (void)savePostAndDismissVC
 {
-	[self savePost];
+    if ([self hasFailedMedia]) {
+        [self showFailedMediaRemovalAlert];
+        return;
+    }
+    [self savePost];
     [self dismissEditView];
 }
 
@@ -1784,7 +1765,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
                 [self stopEditing];
                 [self savePostAndDismissVC];
             }
-        }
+        } break;
     }
     
     return;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -622,8 +622,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)showCancelMediaUploadPrompt
 {
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Cancel Media Uploads", "Dialog box title for when the user is cancelling an upload.")
-                                                        message:NSLocalizedString(@"You are currently uploading media. This action will cancel uploads in progress.\n\nAre you sure?", @"This prompt is displayed when the user attempts to stop media uploads in the post editor.")
+    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Cancel images uploads", "Dialog box title for when the user is cancelling an upload.")
+                                                        message:NSLocalizedString(@"You are currently uploading images. This action will cancel uploads in progress.\n\nAre you sure?", @"This prompt is displayed when the user attempts to stop images uploads in the post editor.")
                                                        delegate:self
                                               cancelButtonTitle:NSLocalizedString(@"Not Now", "Nicer dialog answer for \"No\".")
                                               otherButtonTitles:NSLocalizedString(@"Yes", "Yes"), nil];
@@ -634,8 +634,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)showMediaUploadingAlert
 {
     //the post is using the network connection and cannot be stoped, show a message to the user
-    UIAlertView *blogIsCurrentlyBusy = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Uploading media", @"Title for alert when trying to save/exit a post before media upload process is complete.")
-                                                                  message:NSLocalizedString(@"You are currently uploading media. Please wait until this completes.", @"This is a notification the user receives if they are trying to save a post (or exit) before the media upload process is complete.")
+    UIAlertView *blogIsCurrentlyBusy = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Uploading images", @"Title for alert when trying to save/exit a post before image upload process is complete.")
+                                                                  message:NSLocalizedString(@"You are currently uploading images. Please wait until this completes.", @"This is a notification the user receives if they are trying to save a post (or exit) before the image upload process is complete.")
                                                                  delegate:nil
                                                         cancelButtonTitle:NSLocalizedString(@"OK", @"")
                                                         otherButtonTitles:nil];
@@ -644,8 +644,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)showFailedMediaRemovalAlert
 {
-    UIAlertView * failedMediaAlertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Failed media", @"Title for alert when trying to save post with failed media items")
-                                                                              message:NSLocalizedString(@"Some media uploads failed. This action will remove all failed media from the post.\nSave anyway?", @"Confirms with the user if they save the post all media that failed to upload will be removed from it.")
+    UIAlertView * failedMediaAlertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Uploads failed", @"Title for alert when trying to save post with failed media items")
+                                                                              message:NSLocalizedString(@"Some images uploads failed. This action will remove all failed images from the post.\nSave anyway?", @"Confirms with the user if they save the post all images that failed to upload will be removed from it.")
                                                                              delegate:self
                                                                     cancelButtonTitle:NSLocalizedString(@"Not Now", @"")
                                                                     otherButtonTitles:NSLocalizedString(@"Yes", @""), nil];
@@ -657,8 +657,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)showFailedMediaBeforeEditAlert
 {
-    UIAlertView * failedMediaBeforeEditAlertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Failed media", @"Title for alert when trying to edit html post with failed media items")
-                                                           message:NSLocalizedString(@"Some media uploads failed. Switching to the HTML view of this post will remove failed media.\nSwitch anyway?", @"Confirms with the user if they manually edit the post HTML all media that failed to upload will be removed from it.")
+    UIAlertView * failedMediaBeforeEditAlertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Uploads failed", @"Title for alert when trying to edit html post with failed media items")
+                                                           message:NSLocalizedString(@"Some images uploads failed. Switching to the HTML view of this post will remove failed media.\nSwitch anyway?", @"Confirms with the user if they manually edit the post HTML all images that failed to upload will be removed from it.")
                                                           delegate:self
                                                  cancelButtonTitle:NSLocalizedString(@"Not Now", @"")
                                                  otherButtonTitles:NSLocalizedString(@"Yes", @""), nil];


### PR DESCRIPTION
Fix for this https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/468

Centralizes the test for failed media on savePostAndDismissVC

cc @bummytime 