### PR TITLE
Issue/473 editor adding images from photo stream

### DIFF
--- a/WordPress/Classes/Utility/WPAssetExporter.h
+++ b/WordPress/Classes/Utility/WPAssetExporter.h
@@ -1,6 +1,9 @@
 #import <Foundation/Foundation.h>
 #import <AssetsLibrary/AssetsLibrary.h>
 
+extern NSString * const WPAssetExportErrorDomain;
+extern const NSInteger WPAssetExportMissingAsset;
+
 /**
  WPAssetExporter handles a queue for exporting ALAsset to files.
  

--- a/WordPress/Classes/Utility/WPAssetExporter.h
+++ b/WordPress/Classes/Utility/WPAssetExporter.h
@@ -2,7 +2,7 @@
 #import <AssetsLibrary/AssetsLibrary.h>
 
 extern NSString * const WPAssetExportErrorDomain;
-extern const NSInteger WPAssetExportMissingAsset;
+extern const NSInteger WPAssetExportErrorCodeMissingAsset;
 
 /**
  WPAssetExporter handles a queue for exporting ALAsset to files.

--- a/WordPress/Classes/Utility/WPAssetExporter.m
+++ b/WordPress/Classes/Utility/WPAssetExporter.m
@@ -58,18 +58,23 @@ const NSInteger WPAssetExportErrorCodeMissingAsset = 1;
         WPImageOptimizer *imageOptimizer = [[WPImageOptimizer alloc] init];
         CGSize newSize = [imageOptimizer sizeForOriginalSize:targetSize fittingSize:targetSize];
         NSData *data = [imageOptimizer optimizedDataFromAsset:asset fittingSize:targetSize stripGeoLocation:stripGeoLocation];
-        if (!data && handler) {
-            handler(NO, newSize, thumbnailJPEGData, nil);
+        if (!data) {
+            if (handler) {
+                handler(NO, newSize, thumbnailJPEGData, nil);
+            }
             return;
         }
         NSError *error;
-        if (![data writeToFile:filePath options:NSDataWritingAtomic error:&error] && handler) {
-            handler(NO, newSize, thumbnailJPEGData, error);
+        if (![data writeToFile:filePath options:NSDataWritingAtomic error:&error]) {
+            if (handler){
+                handler(NO, newSize, thumbnailJPEGData, error);
+            }
             return;
         }
         
         if (handler){
             handler(YES, newSize, thumbnailJPEGData, nil);
+            return;
         }
     }];
 }

--- a/WordPress/Classes/Utility/WPAssetExporter.m
+++ b/WordPress/Classes/Utility/WPAssetExporter.m
@@ -43,7 +43,7 @@ const NSInteger WPAssetExportErrorCodeMissingAsset = 1;
 {
     if (!asset.defaultRepresentation) {
         if (handler) {
-            NSDictionary * userInfo = @{NSLocalizedDescriptionKey:NSLocalizedString(@"The media you are trying to use is not available locally at the moment. If it belongs to a photo stream please try again later.", @"Message that explains to a user that the current asset they selected is not available on the device. This normally happens when user selects a media that belogns to a photostream that needs to be downloaded locally first.")};
+            NSDictionary * userInfo = @{NSLocalizedDescriptionKey:NSLocalizedString(@"This image belongs to a Photo Stream and is not available at the moment to be added to your site. Try opening it full screen in the Photos app before trying to using it again.", @"Message that explains to a user that the current asset they selected is not available on the device. This normally happens when user selects a media that belogns to a photostream that needs to be downloaded locally first.")};
             NSError * error = [NSError errorWithDomain:WPAssetExportErrorDomain
                                                   code:WPAssetExportErrorCodeMissingAsset
                                               userInfo:userInfo];

--- a/WordPress/Classes/Utility/WPAssetExporter.m
+++ b/WordPress/Classes/Utility/WPAssetExporter.m
@@ -60,10 +60,12 @@ const NSInteger WPAssetExportMissingAsset = 1;
         NSData *data = [imageOptimizer optimizedDataFromAsset:asset fittingSize:targetSize stripGeoLocation:stripGeoLocation];
         if (!data && handler) {
             handler(NO, newSize, thumbnailJPEGData, nil);
+            return;
         }
         NSError *error;
         if (![data writeToFile:filePath options:NSDataWritingAtomic error:&error] && handler) {
             handler(NO, newSize, thumbnailJPEGData, error);
+            return;
         }
         
         if (handler){

--- a/WordPress/Classes/Utility/WPAssetExporter.m
+++ b/WordPress/Classes/Utility/WPAssetExporter.m
@@ -2,7 +2,7 @@
 #import "WPImageOptimizer.h"
 
 NSString * const WPAssetExportErrorDomain = @"org.wordpress.assetexporter";
-const NSInteger WPAssetExportMissingAsset = 1;
+const NSInteger WPAssetExportErrorCodeMissingAsset = 1;
 
 @interface WPAssetExporter ()
 

--- a/WordPress/Classes/Utility/WPAssetExporter.m
+++ b/WordPress/Classes/Utility/WPAssetExporter.m
@@ -45,7 +45,7 @@ const NSInteger WPAssetExportErrorCodeMissingAsset = 1;
         if (handler) {
             NSDictionary * userInfo = @{NSLocalizedDescriptionKey:NSLocalizedString(@"The media you are trying to use is not available locally at the moment. If it belongs to a photo stream please try again later.", @"Message that explains to a user that the current asset they selected is not available on the device. This normally happens when user selects a media that belogns to a photostream that needs to be downloaded locally first.")};
             NSError * error = [NSError errorWithDomain:WPAssetExportErrorDomain
-                                                  code:WPAssetExportMissingAsset
+                                                  code:WPAssetExportErrorCodeMissingAsset
                                               userInfo:userInfo];
             handler(NO, CGSizeZero, nil, error);
         }

--- a/WordPress/Classes/Utility/WPAssetExporter.m
+++ b/WordPress/Classes/Utility/WPAssetExporter.m
@@ -1,7 +1,8 @@
-
 #import "WPAssetExporter.h"
-
 #import "WPImageOptimizer.h"
+
+NSString * const WPAssetExportErrorDomain = @"org.wordpress.assetexporter";
+const NSInteger WPAssetExportMissingAsset = 1;
 
 @interface WPAssetExporter ()
 
@@ -40,7 +41,16 @@
    stripGeoLocation:(BOOL)stripGeoLocation
   completionHandler:(void (^)(BOOL success, CGSize resultingSize, NSData *thumbnailData, NSError *error)) handler
 {
-
+    if (!asset.defaultRepresentation) {
+        if (handler) {
+            NSDictionary * userInfo = @{NSLocalizedDescriptionKey:NSLocalizedString(@"The media you are trying to use is not available locally at the moment. If it belongs to a photo stream please try again later.", @"Message that explains to a user that the current asset they selected is not available on the device. This normally happens when user selects a media that belogns to a photostream that needs to be downloaded locally first.")};
+            NSError * error = [NSError errorWithDomain:WPAssetExportErrorDomain
+                                                  code:WPAssetExportMissingAsset
+                                              userInfo:userInfo];
+            handler(NO, CGSizeZero, nil, error);
+        }
+        return;
+    }
     [self.operationQueue addOperationWithBlock:^{
         UIImage *thumbnail = [UIImage imageWithCGImage:asset.thumbnail];
         NSData *thumbnailJPEGData = UIImageJPEGRepresentation(thumbnail, 1.0);

--- a/WordPress/Classes/Utility/WPImageOptimizer.m
+++ b/WordPress/Classes/Utility/WPImageOptimizer.m
@@ -12,6 +12,10 @@
 - (NSData *)optimizedDataFromAsset:(ALAsset *)asset fittingSize:(CGSize)targetSize stripGeoLocation:(BOOL) stripGeoLocation
 {
     ALAssetRepresentation *representation = asset.defaultRepresentation;
+    // If it's an asset from a shared photo stream it's image may not be available
+    if (!representation) {
+        return nil;
+    }
     // Can't optimize videos, so only try if asset is a photo
     // We can't resize an image to 0 height 0 width (there would be nothing to draw) so treat this as requesting the original image size by convention. 
     BOOL isImage = [[asset valueForProperty:ALAssetPropertyType] isEqual:ALAssetTypePhoto];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1963,6 +1963,12 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (BOOL)assetsPickerController:(CTAssetsPickerController *)picker shouldSelectAsset:(ALAsset *)asset
 {
     if ([asset valueForProperty:ALAssetPropertyType] == ALAssetTypePhoto) {
+        // If the image is from a shared photo stream it may not be available locally to be used
+        if (!asset.defaultRepresentation) {
+            [WPError showAlertWithTitle:NSLocalizedString(@"Cannot select this image", @"The title for an alert that says the image the user selected isn't available.")
+                                message:NSLocalizedString(@"This image is currently not available locally to be used in your post. Please try again later.", @"User information explaining that the image is not available locally. This is normally related to share photo stream images.")];
+            return NO;
+        }
         return picker.selectedAssets.count < MaximumNumberOfPictures;
     } else {
         return YES;


### PR DESCRIPTION
Introduced multiple checks for ALAsset that may not be available locally because they are part of shared photo stream. This caused crash because they return nil/empty images.

Fix for https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/473

cc @diegoreymendez, can you do a review?
cc @meremagee Do you want to check my wording for the alert messages.

