### PR TITLE
Fix compiler warning by using parent class of post and page.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.h
@@ -3,6 +3,6 @@
 
 @interface FeaturedImageViewController : WPImageViewController
 
-- (id)initWithPost:(Post *)post;
+- (id)initWithPost:(AbstractPost *)post;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
@@ -6,7 +6,7 @@
 @interface FeaturedImageViewController () <UIActionSheetDelegate>
 
 @property (nonatomic, strong) UIBarButtonItem *deleteButton;
-@property (nonatomic, strong) Post *post;
+@property (nonatomic, strong) AbstractPost *post;
 @property (nonatomic, strong) UIBarButtonItem *activityItem;
 
 @end
@@ -20,7 +20,7 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (id)initWithPost:(Post *)post
+- (id)initWithPost:(AbstractPost *)post
 {
     self = [super init];
     if (self) {


### PR DESCRIPTION
Fix for this https://github.com/wordpress-mobile/WordPress-iOS/issues/3040

/cc @sendhil or @bummytime 