### PR TITLE
Fixing validation warning

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
@@ -103,7 +103,7 @@ CGFloat const JetpackSignInButtonHeight = 41.0;
             _skipButton.accessibilityIdentifier = @"Skip";
             [self.view addSubview:_skipButton];
         } else {
-            UIBarButtonItem *skipButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Skip", @"") style:UIBarButtonItemStylePlain target:self action:@selector(skip:)];
+            UIBarButtonItem *skipButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Skip", @"") style:UIBarButtonItemStylePlain target:self action:@selector(skipAction:)];
             self.navigationItem.rightBarButtonItem = skipButton;
         }
 


### PR DESCRIPTION
Was getting this validation warning:
![image](https://cloud.githubusercontent.com/assets/437043/5747782/a7058944-9bef-11e4-8093-30eca00f8f79.png)

The source of it was this commit(https://github.com/wordpress-mobile/WordPress-iOS/commit/4e19cf7b470efa81216de4920cc5c435daead282#diff-e0107cd042ca5ace4c94361cfc5920edR126) which renamed a method but forgot to update all of the selectors that pointed to it.
