### PR TITLE
Tweaking App Review Prompt

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -634,9 +634,14 @@ static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracki
 - (void)initializeAppTracking
 {
     NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-    [AppRatingUtility registerSection:@"Notifications" withSignificantEventCount:5];
+    [AppRatingUtility registerSection:@"notifications" withSignificantEventCount:5];
     [AppRatingUtility setSystemWideSignificantEventsCount:10];
     [AppRatingUtility initializeForVersion:version];
+    [AppRatingUtility checkIfAppReviewPromptsHaveBeenDisabled:^{
+        DDLogVerbose(@"Was able to successfully retrieve data about whether to disable the app review prompts");
+    } failure:^{
+        DDLogError(@"Was unable to retrieve data about whether to disable the app review prompts");
+    }];
 }
 
 - (void)trackLowMemory

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -634,8 +634,9 @@ static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracki
 - (void)initializeAppTracking
 {
     NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+    [AppRatingUtility registerSection:@"Notifications" withSignificantEventCount:5];
+    [AppRatingUtility setSystemWideSignificantEventsCount:10];
     [AppRatingUtility initializeForVersion:version];
-    [AppRatingUtility setNumberOfSignificantEventsRequiredForPrompt:5];
 }
 
 - (void)trackLowMemory

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+typedef void (^AppRatingCompletionBlock)();
+
 /**
  This class will help track whether or not a user should be prompted for an app 
  review. This class is loosely based on Appirater 
@@ -22,7 +24,7 @@
  *  @param success called on successfully retrieving the details
  *  @param failure called when we were unable to retrieve the details
  */
-+ (void)checkIfAppReviewPromptsHaveBeenDisabled:(void (^)(void))success failure:(void (^)(void))failure;
++ (void)checkIfAppReviewPromptsHaveBeenDisabled:(AppRatingCompletionBlock)success failure:(AppRatingCompletionBlock)failure;
 
 /**
  *  Registers a granular section to be tracked.

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
@@ -13,6 +13,14 @@
 + (void)initializeForVersion:(NSString *)version;
 
 /**
+ *  This checks if we've disabled app review prompts for a feature or at a global level
+ *
+ *  @param success called on successfully retrieving the details
+ *  @param failure called when we were unable to retrieve the details
+ */
++ (void)checkIfAppReviewPromptsHaveBeenDisabled:(void (^)(void))success failure:(void (^)(void))failure;
+
+/**
  *  Registers a granular section to be tracked.
  *
  *  @param section               section name, e.g. "Notifications"

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
@@ -1,19 +1,23 @@
 #import <Foundation/Foundation.h>
 
 /**
- This class will help track whether or not a user should be prompted for an app review. This class is loosely based on Appirater (https://github.com/arashpayan/appirater)
+ This class will help track whether or not a user should be prompted for an app 
+ review. This class is loosely based on Appirater 
+ (https://github.com/arashpayan/appirater)
  */
 @interface AppRatingUtility : NSObject
 
 /**
- *  This should be called with the current App Version so as to setup internal tracking.
+ *  This should be called with the current App Version so as to setup internal 
+    tracking.
  *
  *  @param version version number of the app, e.g. CFBundleShortVersionString
  */
 + (void)initializeForVersion:(NSString *)version;
 
 /**
- *  This checks if we've disabled app review prompts for a feature or at a global level
+ *  This checks if we've disabled app review prompts for a feature or at a 
+    global level
  *
  *  @param success called on successfully retrieving the details
  *  @param failure called when we were unable to retrieve the details
@@ -41,14 +45,18 @@
 + (void)incrementSignificantEventForSection:(NSString *)section;
 
 /**
- *  Sets the number of system wide significant events are required when calling `shouldPromptForAppReview`. Ideally this number should be a number less than the total of all the signficant event counts for each section so as to trigger the review prompt for a fairly active user who uses the app in a broad fashion.
+ *  Sets the number of system wide significant events are required when calling `shouldPromptForAppReview`. Ideally this number should be a number less 
+    than the total of all the signficant event counts for each section so as to
+    trigger the review prompt for a fairly active user who uses the app in a 
+    broad fashion.
  *
  *  @param numberOfEvents number of events required to trigger the generic check for an app review.
  */
 + (void)setSystemWideSignificantEventsCount:(NSUInteger)numberOfEvents;
 
 /**
- *  Indicates that the user didn't want to review the app or leave feedback for this version.
+ *  Indicates that the user didn't want to review the app or leave feedback for 
+    this version.
  */
 + (void)declinedToRateCurrentVersion;
 
@@ -73,14 +81,21 @@
 + (void)likedCurrentVersion;
 
 /**
- *  Checks if the user should be prompted for an app review based on `systemWideSignificantEventsCount` and also if the user hasn't been configured to skip being prompted for this release.  Note that this method will check to see if app review prompts on a global basis have been shut off.
+ *  Checks if the user should be prompted for an app review based on `systemWideSignificantEventsCount` and also if the user hasn't been
+    configured to skip being prompted for this release.  Note that this method 
+    will check to see if app review prompts on a global basis have been shut 
+    off.
  *
  *  @return returns true when the user has performed enough significant events and isn't configured to skip being prompted for this release.
  */
 + (BOOL)shouldPromptForAppReview;
 
 /**
- *  Checks if the user should be prompted for an app review based on the number of significant events configured for this particular section and if the user hasn't been configured to skip being prompted for this release. Note that this method will check to see if prompts for this section have been shut off entirely.
+ *  Checks if the user should be prompted for an app review based on the number 
+    of significant events configured for this particular section and if the user 
+    hasn't been configured to skip being prompted for this release. Note that 
+    this method will check to see if prompts for this section have been shut 
+    off entirely.
  *
  *  @param section section name, e.g. "Notifications"
  *

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
@@ -13,5 +13,7 @@
 + (void)ratedCurrentVersion;
 + (void)doesntLikeCurrentVersion;
 + (void)likedCurrentVersion;
++ (BOOL)hasUserEverLikedApp;
++ (BOOL)hasUserEverDislikedApp;
 
 @end

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
@@ -11,5 +11,7 @@
 + (void)declinedToRateCurrentVersion;
 + (void)gaveFeedbackForCurrentVersion;
 + (void)ratedCurrentVersion;
++ (void)doesntLikeCurrentVersion;
++ (void)likedCurrentVersion;
 
 @end

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
@@ -1,25 +1,97 @@
 #import <Foundation/Foundation.h>
 
-// Based loosely on Appirater (https://github.com/arashpayan/appirater)
-
+/**
+ This class will help track whether or not a user should be prompted for an app review. This class is loosely based on Appirater (https://github.com/arashpayan/appirater)
+ */
 @interface AppRatingUtility : NSObject
 
+/**
+ *  This should be called with the current App Version so as to setup internal tracking.
+ *
+ *  @param version version number of the app, e.g. CFBundleShortVersionString
+ */
 + (void)initializeForVersion:(NSString *)version;
+
+/**
+ *  Registers a granular section to be tracked.
+ *
+ *  @param section               section name, e.g. "Notifications"
+ *  @param significantEventCount the number of significant events required to trigger an app rating prompt for this particular section
+ */
 + (void)registerSection:(NSString *)section withSignificantEventCount:(NSUInteger)significantEventCount;
 
+/**
+ *  Increments significant events app wide
+ */
 + (void)incrementSignificantEvent;
+
+/**
+ *  Increments significant events for just this particular section
+ *
+ *  @param section section name, e.g. "Notifications"
+ */
 + (void)incrementSignificantEventForSection:(NSString *)section;
+
+/**
+ *  Sets the number of system wide significant events are required when calling `shouldPromptForAppReview`. Ideally this number should be a number less than the total of all the signficant event counts for each section so as to trigger the review prompt for a fairly active user who uses the app in a broad fashion.
+ *
+ *  @param numberOfEvents number of events required to trigger the generic check for an app review.
+ */
 + (void)setSystemWideSignificantEventsCount:(NSUInteger)numberOfEvents;
 
+/**
+ *  Indicates that the user didn't want to review the app or leave feedback for this version.
+ */
 + (void)declinedToRateCurrentVersion;
+
+/**
+ *  Indicates that the user decided to give feedback for this version.
+ */
 + (void)gaveFeedbackForCurrentVersion;
+
+/**
+ *  Indicates the the use rated the current version of the app.
+ */
 + (void)ratedCurrentVersion;
+
+/**
+ *  Indicates that the user didn't like the current version of the app.
+ */
 + (void)dislikedCurrentVersion;
+
+/**
+ *  Indicates the user did like the current version of the app.
+ */
 + (void)likedCurrentVersion;
 
+/**
+ *  Checks if the user should be prompted for an app review based on `systemWideSignificantEventsCount` and also if the user hasn't been configured to skip being prompted for this release.  Note that this method will check to see if app review prompts on a global basis have been shut off.
+ *
+ *  @return returns true when the user has performed enough significant events and isn't configured to skip being prompted for this release.
+ */
 + (BOOL)shouldPromptForAppReview;
+
+/**
+ *  Checks if the user should be prompted for an app review based on the number of significant events configured for this particular section and if the user hasn't been configured to skip being prompted for this release. Note that this method will check to see if prompts for this section have been shut off entirely.
+ *
+ *  @param section section name, e.g. "Notifications"
+ *
+ *  @return returns true when the user has performed enough significant events for this section and isn't configured to skip being prompted for this release.
+ */
 + (BOOL)shouldPromptForAppReviewForSection:(NSString *)section;
+
+/**
+ *  Checks if the user has ever indicated that they like the app.
+ *
+ *  @return true if the user has ever indicated they like the app.
+ */
 + (BOOL)hasUserEverLikedApp;
+
+/**
+ *  Checks if the user has ever indicated they dislike the app.
+ *
+ *  @return true if the user has ever indicated they don't like the app.
+ */
 + (BOOL)hasUserEverDislikedApp;
 
 @end

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
@@ -11,7 +11,7 @@
 + (void)declinedToRateCurrentVersion;
 + (void)gaveFeedbackForCurrentVersion;
 + (void)ratedCurrentVersion;
-+ (void)doesntLikeCurrentVersion;
++ (void)dislikedCurrentVersion;
 + (void)likedCurrentVersion;
 + (BOOL)hasUserEverLikedApp;
 + (BOOL)hasUserEverDislikedApp;

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
@@ -4,15 +4,21 @@
 
 @interface AppRatingUtility : NSObject
 
-+ (BOOL)shouldPromptForAppReview;
 + (void)initializeForVersion:(NSString *)version;
++ (void)registerSection:(NSString *)section withSignificantEventCount:(NSUInteger)significantEventCount;
+
 + (void)incrementSignificantEvent;
-+ (void)setNumberOfSignificantEventsRequiredForPrompt:(NSUInteger)numberOfEvents;
++ (void)incrementSignificantEventForSection:(NSString *)section;
++ (void)setSystemWideSignificantEventsCount:(NSUInteger)numberOfEvents;
+
 + (void)declinedToRateCurrentVersion;
 + (void)gaveFeedbackForCurrentVersion;
 + (void)ratedCurrentVersion;
 + (void)dislikedCurrentVersion;
 + (void)likedCurrentVersion;
+
++ (BOOL)shouldPromptForAppReview;
++ (BOOL)shouldPromptForAppReviewForSection:(NSString *)section;
 + (BOOL)hasUserEverLikedApp;
 + (BOOL)hasUserEverDislikedApp;
 

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
@@ -57,7 +57,7 @@ NSString *const AppReviewPromptDisabledUrl = @"http://api.wordpress.org/iphoneap
     }];
 }
 
-+ (void)checkIfAppReviewPromptsHaveBeenDisabled:(void (^)(void))success failure:(void (^)(void))failure;
++ (void)checkIfAppReviewPromptsHaveBeenDisabled:(AppRatingCompletionBlock)success failure:(AppRatingCompletionBlock)failure;
 {
     NSURL *url = [NSURL URLWithString:AppReviewPromptDisabledUrl];
     NSURLRequest *request = [[NSURLRequest alloc] initWithURL:url];

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
@@ -11,8 +11,8 @@ NSString *const AppRatingNumberOfVersionsToSkipPrompting = @"AppRatingsNumberOfV
 NSString *const AppRatingRatedCurrentVersion = @"AppRatingRatedCurrentVersion";
 NSString *const AppRatingDeclinedToRateCurrentVersion = @"AppRatingDeclinedToRateCurrentVersion";
 NSString *const AppRatingGaveFeedbackForCurrentVersion = @"AppRatingGaveFeedbackForCurrentVersion";
-NSString *const AppRatingDidntLikeCurrentVersion = @"AppRatingDidntLikeCurrentVersion";
-NSString *const AppRatingLikedCurrentVersion = @"AppRatingDidntLikeCurrentVersion";
+NSString *const AppRatingDislikedCurrentVersion = @"AppRatingDislikedCurrentVersion";
+NSString *const AppRatingLikedCurrentVersion = @"AppRatingLikedCurrentVersion";
 NSString *const AppRatingUserLikeCount = @"AppRatingUserLikeCount";
 NSString *const AppRatingUserDislikeCount = @"AppRatingUserDislikeCount";
 
@@ -36,7 +36,7 @@ NSString *const AppRatingUserDislikeCount = @"AppRatingUserDislikeCount";
 + (BOOL)interactedWithAppReviewPrompt
 {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    return [userDefaults boolForKey:AppRatingRatedCurrentVersion] || [userDefaults boolForKey:AppRatingDeclinedToRateCurrentVersion] || [userDefaults boolForKey:AppRatingGaveFeedbackForCurrentVersion] || [userDefaults boolForKey:AppRatingLikedCurrentVersion] || [userDefaults boolForKey:AppRatingDidntLikeCurrentVersion];
+    return [userDefaults boolForKey:AppRatingRatedCurrentVersion] || [userDefaults boolForKey:AppRatingDeclinedToRateCurrentVersion] || [userDefaults boolForKey:AppRatingGaveFeedbackForCurrentVersion] || [userDefaults boolForKey:AppRatingLikedCurrentVersion] || [userDefaults boolForKey:AppRatingDislikedCurrentVersion];
 }
 
 + (void)initializeForVersion:(NSString *)version
@@ -67,7 +67,7 @@ NSString *const AppRatingUserDislikeCount = @"AppRatingUserDislikeCount";
         [userDefaults setBool:NO forKey:AppRatingRatedCurrentVersion];
         [userDefaults setBool:NO forKey:AppRatingDeclinedToRateCurrentVersion];
         [userDefaults setBool:NO forKey:AppRatingGaveFeedbackForCurrentVersion];
-        [userDefaults setBool:NO forKey:AppRatingDidntLikeCurrentVersion];
+        [userDefaults setBool:NO forKey:AppRatingDislikedCurrentVersion];
         [userDefaults setBool:NO forKey:AppRatingLikedCurrentVersion];
         
         if (interactedWithAppReviewPromptInPreviousVersion) {
@@ -128,13 +128,13 @@ NSString *const AppRatingUserDislikeCount = @"AppRatingUserDislikeCount";
     [userDefaults synchronize];
 }
 
-+ (void)doesntLikeCurrentVersion
++ (void)dislikedCurrentVersion
 {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     NSUInteger userDislikeCount = [userDefaults integerForKey:AppRatingUserDislikeCount];
     userDislikeCount++;
     [userDefaults setInteger:userDislikeCount forKey:AppRatingUserDislikeCount];
-    [userDefaults setBool:YES forKey:AppRatingDidntLikeCurrentVersion];
+    [userDefaults setBool:YES forKey:AppRatingDislikedCurrentVersion];
     [userDefaults setInteger:2 forKey:AppRatingNumberOfVersionsToSkipPrompting];
     [userDefaults synchronize];
 }

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
@@ -13,6 +13,8 @@ NSString *const AppRatingDeclinedToRateCurrentVersion = @"AppRatingDeclinedToRat
 NSString *const AppRatingGaveFeedbackForCurrentVersion = @"AppRatingGaveFeedbackForCurrentVersion";
 NSString *const AppRatingDidntLikeCurrentVersion = @"AppRatingDidntLikeCurrentVersion";
 NSString *const AppRatingLikedCurrentVersion = @"AppRatingDidntLikeCurrentVersion";
+NSString *const AppRatingUserLikeCount = @"AppRatingUserLikeCount";
+NSString *const AppRatingUserDislikeCount = @"AppRatingUserDislikeCount";
 
 + (BOOL)shouldPromptForAppReview
 {
@@ -99,41 +101,64 @@ NSString *const AppRatingLikedCurrentVersion = @"AppRatingDidntLikeCurrentVersio
 
 + (void)setNumberOfSignificantEventsRequiredForPrompt:(NSUInteger)numberOfEvents
 {
-    [[NSUserDefaults standardUserDefaults] setInteger:numberOfEvents forKey:AppRatingNumberOfSignificantEventsRequiredForPrompt];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    [userDefaults setInteger:numberOfEvents forKey:AppRatingNumberOfSignificantEventsRequiredForPrompt];
+    [userDefaults synchronize];
 }
 
 + (void)declinedToRateCurrentVersion
 {
-    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:AppRatingDeclinedToRateCurrentVersion];
-    [[NSUserDefaults standardUserDefaults] setInteger:2 forKey:AppRatingNumberOfVersionsToSkipPrompting];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    [userDefaults setBool:YES forKey:AppRatingDeclinedToRateCurrentVersion];
+    [userDefaults setInteger:2 forKey:AppRatingNumberOfVersionsToSkipPrompting];
+    [userDefaults synchronize];
 }
 
 + (void)gaveFeedbackForCurrentVersion
 {
-    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:AppRatingGaveFeedbackForCurrentVersion];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    [userDefaults setBool:YES forKey:AppRatingGaveFeedbackForCurrentVersion];
+    [userDefaults synchronize];
 }
 
 + (void)ratedCurrentVersion
 {
-    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:AppRatingRatedCurrentVersion];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    [userDefaults setBool:YES forKey:AppRatingRatedCurrentVersion];
+    [userDefaults synchronize];
 }
 
 + (void)doesntLikeCurrentVersion
 {
-    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:AppRatingDidntLikeCurrentVersion];
-    [[NSUserDefaults standardUserDefaults] setInteger:2 forKey:AppRatingNumberOfVersionsToSkipPrompting];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    NSUInteger userDislikeCount = [userDefaults integerForKey:AppRatingUserDislikeCount];
+    userDislikeCount++;
+    [userDefaults setInteger:userDislikeCount forKey:AppRatingUserDislikeCount];
+    [userDefaults setBool:YES forKey:AppRatingDidntLikeCurrentVersion];
+    [userDefaults setInteger:2 forKey:AppRatingNumberOfVersionsToSkipPrompting];
+    [userDefaults synchronize];
 }
 
 + (void)likedCurrentVersion
 {
-    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:AppRatingLikedCurrentVersion];
-    [[NSUserDefaults standardUserDefaults] setInteger:1 forKey:AppRatingNumberOfVersionsToSkipPrompting];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
+    
+    NSUInteger userLikeCount = [userDefaults integerForKey:AppRatingUserLikeCount];
+    userLikeCount++;
+    [userDefaults setInteger:userLikeCount forKey:AppRatingUserLikeCount];
+    [userDefaults setBool:YES forKey:AppRatingLikedCurrentVersion];
+    [userDefaults setInteger:1 forKey:AppRatingNumberOfVersionsToSkipPrompting];
+    [userDefaults synchronize];
+}
+
++ (BOOL)hasUserEverLikedApp
+{
+    return [[NSUserDefaults standardUserDefaults] integerForKey:AppRatingUserLikeCount] > 0;
+}
+
++ (BOOL)hasUserEverDislikedApp
+{
+    return [[NSUserDefaults standardUserDefaults] integerForKey:AppRatingUserDislikeCount] > 0;
 }
 
 @end

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
@@ -17,6 +17,7 @@ NSString *const AppRatingSignificantEventCount = @"AppRatingSignificantEventCoun
 NSString *const AppRatingUseCount = @"AppRatingUseCount";
 NSString *const AppRatingNumberOfVersionsSkippedPrompting = @"AppRatingsNumberOfVersionsSkippedPrompt";
 NSString *const AppRatingNumberOfVersionsToSkipPrompting = @"AppRatingsNumberOfVersionsToSkipPrompting";
+NSString *const AppRatingSkipRatingCurrentVersion = @"AppRatingsSkipRatingCurrentVersion";
 NSString *const AppRatingRatedCurrentVersion = @"AppRatingRatedCurrentVersion";
 NSString *const AppRatingDeclinedToRateCurrentVersion = @"AppRatingDeclinedToRateCurrentVersion";
 NSString *const AppRatingGaveFeedbackForCurrentVersion = @"AppRatingGaveFeedbackForCurrentVersion";
@@ -113,6 +114,7 @@ NSString *const AppReviewPromptDisabledUrl = @"http://api.wordpress.org/iphoneap
     {
         // Restarting tracking for new version of app
         BOOL interactedWithAppReviewPromptInPreviousVersion = [self interactedWithAppReviewPrompt];
+        BOOL skippedRatingPreviousVersion = [self skipRatingCurrentVersion];
         
         [userDefaults setObject:version forKey:AppRatingCurrentVersion];
         [userDefaults setInteger:0 forKey:AppRatingSignificantEventCount];
@@ -124,10 +126,11 @@ NSString *const AppReviewPromptDisabledUrl = @"http://api.wordpress.org/iphoneap
         [userDefaults setBool:NO forKey:AppRatingGaveFeedbackForCurrentVersion];
         [userDefaults setBool:NO forKey:AppRatingDislikedCurrentVersion];
         [userDefaults setBool:NO forKey:AppRatingLikedCurrentVersion];
+        [userDefaults setBool:NO forKey:AppRatingSkipRatingCurrentVersion];
         
         [self resetReviewPromptDisabledStatus];
         
-        if (interactedWithAppReviewPromptInPreviousVersion) {
+        if (interactedWithAppReviewPromptInPreviousVersion || skippedRatingPreviousVersion) {
             NSInteger numberOfVersionsSkippedPrompting = [userDefaults integerForKey:AppRatingNumberOfVersionsSkippedPrompting];
             NSInteger numberOfVersionsToSkipPrompting = [userDefaults integerForKey:AppRatingNumberOfVersionsToSkipPrompting];
             
@@ -136,7 +139,7 @@ NSString *const AppReviewPromptDisabledUrl = @"http://api.wordpress.org/iphoneap
                     // We haven't skipped enough versions, skip this one
                     numberOfVersionsSkippedPrompting++;
                     [userDefaults setInteger:numberOfVersionsSkippedPrompting forKey:AppRatingNumberOfVersionsSkippedPrompting];
-                    [userDefaults setBool:YES forKey:AppRatingRatedCurrentVersion];
+                    [userDefaults setBool:YES forKey:AppRatingSkipRatingCurrentVersion];
                 } else {
                     // We have skipped enough, reset data
                     [userDefaults setInteger:0 forKey:AppRatingNumberOfVersionsSkippedPrompting];
@@ -236,7 +239,7 @@ NSString *const AppReviewPromptDisabledUrl = @"http://api.wordpress.org/iphoneap
 
 + (BOOL)shouldPromptForAppReview
 {
-    if ([self interactedWithAppReviewPrompt]) {
+    if ([self interactedWithAppReviewPrompt] || [self skipRatingCurrentVersion]) {
         return NO;
     }
     
@@ -269,7 +272,7 @@ NSString *const AppReviewPromptDisabledUrl = @"http://api.wordpress.org/iphoneap
 {
     [self assertValidSection:section];
     
-    if ([self interactedWithAppReviewPrompt]) {
+    if ([self interactedWithAppReviewPrompt] || [self skipRatingCurrentVersion]) {
         return NO;
     }
     
@@ -296,6 +299,11 @@ NSString *const AppReviewPromptDisabledUrl = @"http://api.wordpress.org/iphoneap
 {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     return [userDefaults boolForKey:AppRatingRatedCurrentVersion] || [userDefaults boolForKey:AppRatingDeclinedToRateCurrentVersion] || [userDefaults boolForKey:AppRatingGaveFeedbackForCurrentVersion] || [userDefaults boolForKey:AppRatingLikedCurrentVersion] || [userDefaults boolForKey:AppRatingDislikedCurrentVersion];
+}
+
++ (BOOL)skipRatingCurrentVersion
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:AppRatingSkipRatingCurrentVersion];
 }
 
 + (BOOL)hasUserEverLikedApp

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -135,7 +135,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
                                                  name:NSManagedObjectContextObjectsDidChangeNotification
                                                object:context];
 
-    [AppRatingUtility incrementSignificantEventForSection:@"Notifications"];
+    [AppRatingUtility incrementSignificantEventForSection:@"notifications"];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -135,7 +135,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
                                                  name:NSManagedObjectContextObjectsDidChangeNotification
                                                object:context];
 
-    [AppRatingUtility incrementSignificantEvent];
+    [AppRatingUtility incrementSignificantEventForSection:@"Notifications"];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -750,7 +750,7 @@ static NSTimeInterval NotificationsSyncTimeout          = 10;
 
 - (void)appbotPromptDidntLike
 {
-    [AppRatingUtility doesntLikeCurrentVersion];
+    [AppRatingUtility dislikedCurrentVersion];
     [WPAnalytics track:WPAnalyticsStatAppReviewsDidntLikeApp];
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -744,11 +744,13 @@ static NSTimeInterval NotificationsSyncTimeout          = 10;
 
 - (void)appbotPromptLiked
 {
+    [AppRatingUtility likedCurrentVersion];
     [WPAnalytics track:WPAnalyticsStatAppReviewsLikedApp];
 }
 
 - (void)appbotPromptDidntLike
 {
+    [AppRatingUtility doesntLikeCurrentVersion];
     [WPAnalytics track:WPAnalyticsStatAppReviewsDidntLikeApp];
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -184,7 +184,7 @@ static NSTimeInterval NotificationsSyncTimeout          = 10;
 
 - (void)showRatingViewIfApplicable
 {
-    if ([AppRatingUtility shouldPromptForAppReview]) {
+    if ([AppRatingUtility shouldPromptForAppReviewForSection:@"Notifications"]) {
         if ([self.tableView.tableHeaderView isKindOfClass:[ABXPromptView class]]) {
             // Rating View is already visible, don't bother to do anything
             return;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -184,7 +184,7 @@ static NSTimeInterval NotificationsSyncTimeout          = 10;
 
 - (void)showRatingViewIfApplicable
 {
-    if ([AppRatingUtility shouldPromptForAppReviewForSection:@"Notifications"]) {
+    if ([AppRatingUtility shouldPromptForAppReviewForSection:@"notifications"]) {
         if ([self.tableView.tableHeaderView isKindOfClass:[ABXPromptView class]]) {
             // Rating View is already visible, don't bother to do anything
             return;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -203,6 +203,9 @@
 		852416CF1A12EBDD0030700C /* AppRatingUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 852416CE1A12EBDD0030700C /* AppRatingUtility.m */; };
 		852416D21A12ED690030700C /* AppRatingUtilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 852416D11A12ED690030700C /* AppRatingUtilityTests.m */; };
 		8525398B171761D9003F6B32 /* WPComLanguages.m in Sources */ = {isa = PBXBuildFile; fileRef = 8525398A171761D9003F6B32 /* WPComLanguages.m */; };
+		855408861A6F105700DDBD79 /* app-review-prompt-all-enabled.json in Resources */ = {isa = PBXBuildFile; fileRef = 855408851A6F105700DDBD79 /* app-review-prompt-all-enabled.json */; };
+		855408881A6F106800DDBD79 /* app-review-prompt-notifications-disabled.json in Resources */ = {isa = PBXBuildFile; fileRef = 855408871A6F106800DDBD79 /* app-review-prompt-notifications-disabled.json */; };
+		8554088A1A6F107D00DDBD79 /* app-review-prompt-global-disable.json in Resources */ = {isa = PBXBuildFile; fileRef = 855408891A6F107D00DDBD79 /* app-review-prompt-global-disable.json */; };
 		857610D618C0377300EDF406 /* StatsWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 857610D518C0377300EDF406 /* StatsWebViewController.m */; };
 		858DE40F1730384F000AC628 /* LoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 858DE40E1730384F000AC628 /* LoginViewController.m */; };
 		859CFD46190E3198005FB217 /* WPMediaUploader.m in Sources */ = {isa = PBXBuildFile; fileRef = 859CFD45190E3198005FB217 /* WPMediaUploader.m */; };
@@ -850,6 +853,9 @@
 		8527B15717CE98C5001CBA2E /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		852CD8AB190E0BC4006C9AED /* WPMediaSizing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPMediaSizing.h; sourceTree = "<group>"; };
 		852CD8AC190E0BC4006C9AED /* WPMediaSizing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPMediaSizing.m; sourceTree = "<group>"; };
+		855408851A6F105700DDBD79 /* app-review-prompt-all-enabled.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "app-review-prompt-all-enabled.json"; sourceTree = "<group>"; };
+		855408871A6F106800DDBD79 /* app-review-prompt-notifications-disabled.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "app-review-prompt-notifications-disabled.json"; sourceTree = "<group>"; };
+		855408891A6F107D00DDBD79 /* app-review-prompt-global-disable.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "app-review-prompt-global-disable.json"; sourceTree = "<group>"; };
 		857610D418C0377300EDF406 /* StatsWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsWebViewController.h; sourceTree = "<group>"; };
 		857610D518C0377300EDF406 /* StatsWebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsWebViewController.m; sourceTree = "<group>"; };
 		858DE40D1730384F000AC628 /* LoginViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoginViewController.h; sourceTree = "<group>"; };
@@ -2667,6 +2673,9 @@
 				E15618FE16DBA983006532C4 /* xmlrpc-response-newpost.xml */,
 				93594BD4191D2F5A0079E6B2 /* stats-batch.json */,
 				E11330501A13BAA300D36D84 /* me-sites-with-jetpack.json */,
+				855408851A6F105700DDBD79 /* app-review-prompt-all-enabled.json */,
+				855408871A6F106800DDBD79 /* app-review-prompt-notifications-disabled.json */,
+				855408891A6F107D00DDBD79 /* app-review-prompt-global-disable.json */,
 			);
 			path = "Test Data";
 			sourceTree = "<group>";
@@ -3030,8 +3039,11 @@
 				93594BD5191D2F5A0079E6B2 /* stats-batch.json in Resources */,
 				93CD939319099BE70049096E /* authtoken.json in Resources */,
 				E1E4CE0F1774563F00430844 /* misteryman.jpg in Resources */,
+				855408881A6F106800DDBD79 /* app-review-prompt-notifications-disabled.json in Resources */,
+				8554088A1A6F107D00DDBD79 /* app-review-prompt-global-disable.json in Resources */,
 				E1E4CE0617739FAB00430844 /* test-image.jpg in Resources */,
 				E11330511A13BAA300D36D84 /* me-sites-with-jetpack.json in Resources */,
+				855408861A6F105700DDBD79 /* app-review-prompt-all-enabled.json in Resources */,
 				E131CB5616CACF1E004B0314 /* get-user-blogs_has-blog.json in Resources */,
 				E131CB5816CACFB4004B0314 /* get-user-blogs_doesnt-have-blog.json in Resources */,
 				E15618FF16DBA983006532C4 /* xmlrpc-response-newpost.xml in Resources */,

--- a/WordPress/WordPressTest/AppRatingUtilityTests.m
+++ b/WordPress/WordPressTest/AppRatingUtilityTests.m
@@ -103,7 +103,7 @@
 {
     [AppRatingUtility initializeForVersion:@"4.7"];
     XCTAssertFalse([AppRatingUtility shouldPromptForAppReview]);
-    [AppRatingUtility doesntLikeCurrentVersion];
+    [AppRatingUtility dislikedCurrentVersion];
     
     [AppRatingUtility initializeForVersion:@"4.8"];
     [AppRatingUtility incrementSignificantEvent];
@@ -130,7 +130,7 @@
     XCTAssertTrue([AppRatingUtility hasUserEverLikedApp]);
     
     [AppRatingUtility initializeForVersion:@"4.9"];
-    [AppRatingUtility doesntLikeCurrentVersion];
+    [AppRatingUtility dislikedCurrentVersion];
     XCTAssertTrue([AppRatingUtility hasUserEverLikedApp]);
 }
 
@@ -142,7 +142,7 @@
     
     [AppRatingUtility initializeForVersion:@"4.8"];
     XCTAssertFalse([AppRatingUtility hasUserEverDislikedApp]);
-    [AppRatingUtility doesntLikeCurrentVersion];
+    [AppRatingUtility dislikedCurrentVersion];
     XCTAssertTrue([AppRatingUtility hasUserEverDislikedApp]);
     
     [AppRatingUtility initializeForVersion:@"4.9"];

--- a/WordPress/WordPressTest/AppRatingUtilityTests.m
+++ b/WordPress/WordPressTest/AppRatingUtilityTests.m
@@ -221,7 +221,7 @@
     } failure:^{
         [NSException raise:@"Error" format:@"Shouldn't get here..."];
     }];
-    [self waitForExpectationsWithTimeout:0.1 handler:nil];
+    [self waitForExpectationsWithTimeout:0.5 handler:nil];
     
     // We shouldn't disable the check when the remote check indicates everything is enabled
     XCTAssertTrue([AppRatingUtility shouldPromptForAppReviewForSection:@"notifications"]);
@@ -241,7 +241,7 @@
     } failure:^{
         [NSException raise:@"Error" format:@"Shouldn't get here..."];
     }];
-    [self waitForExpectationsWithTimeout:0.1 handler:nil];
+    [self waitForExpectationsWithTimeout:0.5 handler:nil];
     
     // We should disable the check when the remote check indicates notifications is disabled
     XCTAssertFalse([AppRatingUtility shouldPromptForAppReviewForSection:@"notifications"]);
@@ -261,7 +261,7 @@
     } failure:^{
         [NSException raise:@"Error" format:@"Shouldn't get here..."];
     }];
-    [self waitForExpectationsWithTimeout:0.1 handler:nil];
+    [self waitForExpectationsWithTimeout:0.5 handler:nil];
     
     // We should disable the check when the remote check indicates notifications is disabled
     XCTAssertFalse([AppRatingUtility shouldPromptForAppReviewForSection:@"notifications"]);
@@ -283,7 +283,7 @@
     } failure:^{
         [NSException raise:@"Error" format:@"Shouldn't get here..."];
     }];
-    [self waitForExpectationsWithTimeout:0.1 handler:nil];
+    [self waitForExpectationsWithTimeout:0.5 handler:nil];
     
     // We should disable the check when the remote check indicates notifications is disabled
     XCTAssertFalse([AppRatingUtility shouldPromptForAppReviewForSection:@"notifications"]);

--- a/WordPress/WordPressTest/AppRatingUtilityTests.m
+++ b/WordPress/WordPressTest/AppRatingUtilityTests.m
@@ -118,4 +118,36 @@
     XCTAssertTrue([AppRatingUtility shouldPromptForAppReview], @"should prompt for a review two versions later");
 }
 
+- (void)testHasUserEverLikedApp
+{
+    [AppRatingUtility initializeForVersion:@"4.7"];
+    XCTAssertFalse([AppRatingUtility hasUserEverLikedApp]);
+    [AppRatingUtility declinedToRateCurrentVersion];
+    
+    [AppRatingUtility initializeForVersion:@"4.8"];
+    XCTAssertFalse([AppRatingUtility hasUserEverLikedApp]);
+    [AppRatingUtility likedCurrentVersion];
+    XCTAssertTrue([AppRatingUtility hasUserEverLikedApp]);
+    
+    [AppRatingUtility initializeForVersion:@"4.9"];
+    [AppRatingUtility doesntLikeCurrentVersion];
+    XCTAssertTrue([AppRatingUtility hasUserEverLikedApp]);
+}
+
+- (void)testHasUserEverDislikedTheApp
+{
+    [AppRatingUtility initializeForVersion:@"4.7"];
+    XCTAssertFalse([AppRatingUtility hasUserEverDislikedApp]);
+    [AppRatingUtility declinedToRateCurrentVersion];
+    
+    [AppRatingUtility initializeForVersion:@"4.8"];
+    XCTAssertFalse([AppRatingUtility hasUserEverDislikedApp]);
+    [AppRatingUtility doesntLikeCurrentVersion];
+    XCTAssertTrue([AppRatingUtility hasUserEverDislikedApp]);
+    
+    [AppRatingUtility initializeForVersion:@"4.9"];
+    [AppRatingUtility likedCurrentVersion];
+    XCTAssertTrue([AppRatingUtility hasUserEverDislikedApp]);
+}
+
 @end

--- a/WordPress/WordPressTest/AppRatingUtilityTests.m
+++ b/WordPress/WordPressTest/AppRatingUtilityTests.m
@@ -84,26 +84,38 @@
     XCTAssertTrue([AppRatingUtility shouldPromptForAppReview]);
 }
 
-- (void)testUserIsntPromptedForAnAppReviewFor461IfPromptedIn46
+- (void)testUserIsNotPromptedForAReviewForOneVersionIfTheyLikedTheApp;
 {
-    [AppRatingUtility initializeForVersion:@"4.6"];
-    [self createConditionsForPositiveAppReviewPrompt];
-    XCTAssertTrue([AppRatingUtility shouldPromptForAppReview]);
-    [AppRatingUtility ratedCurrentVersion];
-    [AppRatingUtility initializeForVersion:@"4.6.1"];
+    [AppRatingUtility initializeForVersion:@"4.7"];
     XCTAssertFalse([AppRatingUtility shouldPromptForAppReview]);
-    [self createConditionsForPositiveAppReviewPrompt];
-    XCTAssertFalse([AppRatingUtility shouldPromptForAppReview]);
+    [AppRatingUtility likedCurrentVersion];
+    
+    [AppRatingUtility initializeForVersion:@"4.8"];
+    [AppRatingUtility incrementSignificantEvent];
+    XCTAssertFalse([AppRatingUtility shouldPromptForAppReview], @"should not prompt for a review after liking last version");
+    
+    [AppRatingUtility initializeForVersion:@"4.9"];
+    [AppRatingUtility incrementSignificantEvent];
+    XCTAssertTrue([AppRatingUtility shouldPromptForAppReview], @"should prompt for a review after skipping a version");
 }
 
-- (void)testUserIsPromptedForAnReviewIn461IfWasntPromptedin46
+- (void)testUserIsNotPromptedForAReviewForTwoVersionsIfTheyDeclineToRate
 {
-    [AppRatingUtility initializeForVersion:@"4.6"];
+    [AppRatingUtility initializeForVersion:@"4.7"];
     XCTAssertFalse([AppRatingUtility shouldPromptForAppReview]);
-    [AppRatingUtility initializeForVersion:@"4.6.1"];
-    XCTAssertFalse([AppRatingUtility shouldPromptForAppReview]);
-    [self createConditionsForPositiveAppReviewPrompt];
-    XCTAssertTrue([AppRatingUtility shouldPromptForAppReview]);
+    [AppRatingUtility doesntLikeCurrentVersion];
+    
+    [AppRatingUtility initializeForVersion:@"4.8"];
+    [AppRatingUtility incrementSignificantEvent];
+    XCTAssertFalse([AppRatingUtility shouldPromptForAppReview], @"should not prompt for a review after declining on this first upgrade");
+    
+    [AppRatingUtility initializeForVersion:@"4.9"];
+    [AppRatingUtility incrementSignificantEvent];
+    XCTAssertFalse([AppRatingUtility shouldPromptForAppReview], @"should not prompt for a review after declining on this second upgrade");
+    
+    [AppRatingUtility initializeForVersion:@"5.0"];
+    [AppRatingUtility incrementSignificantEvent];
+    XCTAssertTrue([AppRatingUtility shouldPromptForAppReview], @"should prompt for a review two versions later");
 }
 
 @end

--- a/WordPress/WordPressTest/AppRatingUtilityTests.m
+++ b/WordPress/WordPressTest/AppRatingUtilityTests.m
@@ -221,7 +221,7 @@
     } failure:^{
         [NSException raise:@"Error" format:@"Shouldn't get here..."];
     }];
-    [self waitForExpectationsWithTimeout:0.5 handler:nil];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
     
     // We shouldn't disable the check when the remote check indicates everything is enabled
     XCTAssertTrue([AppRatingUtility shouldPromptForAppReviewForSection:@"notifications"]);
@@ -241,7 +241,7 @@
     } failure:^{
         [NSException raise:@"Error" format:@"Shouldn't get here..."];
     }];
-    [self waitForExpectationsWithTimeout:0.5 handler:nil];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
     
     // We should disable the check when the remote check indicates notifications is disabled
     XCTAssertFalse([AppRatingUtility shouldPromptForAppReviewForSection:@"notifications"]);
@@ -261,7 +261,7 @@
     } failure:^{
         [NSException raise:@"Error" format:@"Shouldn't get here..."];
     }];
-    [self waitForExpectationsWithTimeout:0.5 handler:nil];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
     
     // We should disable the check when the remote check indicates notifications is disabled
     XCTAssertFalse([AppRatingUtility shouldPromptForAppReviewForSection:@"notifications"]);
@@ -283,7 +283,7 @@
     } failure:^{
         [NSException raise:@"Error" format:@"Shouldn't get here..."];
     }];
-    [self waitForExpectationsWithTimeout:0.5 handler:nil];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
     
     // We should disable the check when the remote check indicates notifications is disabled
     XCTAssertFalse([AppRatingUtility shouldPromptForAppReviewForSection:@"notifications"]);

--- a/WordPress/WordPressTest/Test Data/app-review-prompt-all-enabled.json
+++ b/WordPress/WordPressTest/Test Data/app-review-prompt-all-enabled.json
@@ -1,0 +1,4 @@
+{
+    "notifications-disabled": "false",
+    "all-disabled": "false"
+}

--- a/WordPress/WordPressTest/Test Data/app-review-prompt-global-disable.json
+++ b/WordPress/WordPressTest/Test Data/app-review-prompt-global-disable.json
@@ -1,0 +1,4 @@
+{
+    "notifications-disabled": "false",
+    "all-disabled": "true"
+}

--- a/WordPress/WordPressTest/Test Data/app-review-prompt-notifications-disabled.json
+++ b/WordPress/WordPressTest/Test Data/app-review-prompt-notifications-disabled.json
@@ -1,0 +1,4 @@
+{
+    "notifications-disabled": "true",
+    "all-disabled": "false"
+}


### PR DESCRIPTION
Tweaking the App Review prompt to allow for more granularity. Also added ability for app review prompt to be disabled remotely on a feature by feature basis or for the entire app.

cc @diegoreymendez 