### PR TITLE
Updating version number usage throughout app

### DIFF
--- a/WordPress/Classes/Categories/NSBundle+VersionNumberHelper.h
+++ b/WordPress/Classes/Categories/NSBundle+VersionNumberHelper.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface NSBundle (VersionNumberHelper)
+
+- (NSString *)detailedVersionNumber;
+
+@end

--- a/WordPress/Classes/Categories/NSBundle+VersionNumberHelper.m
+++ b/WordPress/Classes/Categories/NSBundle+VersionNumberHelper.m
@@ -1,0 +1,12 @@
+#import "NSBundle+VersionNumberHelper.h"
+
+@implementation NSBundle (VersionNumberHelper)
+
+- (NSString *)detailedVersionNumber
+{
+    NSBundle *mainBundle = [NSBundle mainBundle];
+    NSString *versionNumberString = [NSString stringWithFormat:@"%@ (%@)", [mainBundle.infoDictionary objectForKey:@"CFBundleShortVersionString"], [mainBundle.infoDictionary objectForKey:@"CFBundleVersion"]];
+    return versionNumberString;
+}
+
+@end

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -45,6 +45,7 @@
 #import "StatsViewController.h"
 #import "Constants.h"
 #import "UIImage+Util.h"
+#import "NSBundle+VersionNumberHelper.h"
 
 #import "WPAnalyticsTrackerMixpanel.h"
 #import "WPAnalyticsTrackerWPCom.h"
@@ -845,7 +846,7 @@ static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracki
     UIWebView *webView = [[UIWebView alloc] init];
     NSString *defaultUA = [webView stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
 
-    NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
+    NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
     [[NSUserDefaults standardUserDefaults] setObject:appVersion forKey:@"version_preference"];
     NSString *appUA = [NSString stringWithFormat:@"wp-iphone/%@ (%@ %@, %@) Mobile",
                        appVersion,
@@ -1060,7 +1061,7 @@ static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracki
     NSArray *blogs = [blogService blogsForAllAccounts];
 
     DDLogInfo(@"===========================================================================");
-    DDLogInfo(@"Launching WordPress for iOS %@...", [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"]);
+    DDLogInfo(@"Launching WordPress for iOS %@...", [[NSBundle mainBundle] detailedVersionNumber]);
     DDLogInfo(@"Crash count:       %d", crashCount);
 #ifdef DEBUG
     DDLogInfo(@"Debug mode:  Debug");

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -13,6 +13,7 @@
 #import "AccountService.h"
 #import "BlogService.h"
 #import "Blog.h"
+#import "NSBundle+VersionNumberHelper.h"
 #import "WordPress-Swift.h"
 #import "AboutViewController.h"
 #import "WPTabBarController.h"
@@ -330,11 +331,11 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
         if (indexPath.row == 0) {
             // App Version
             cell.textLabel.text = NSLocalizedString(@"Version", @"");
-            NSString *appversion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
+            NSString *appVersion = [[NSBundle mainBundle] detailedVersionNumber];
 #if DEBUG
-            appversion = [appversion stringByAppendingString:@" (DEV)"];
+            appVersion = [appVersion stringByAppendingString:@" (DEV)"];
 #endif
-            cell.detailTextLabel.text = appversion;
+            cell.detailTextLabel.text = appVersion;
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
         } else if (indexPath.row == 1) {
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
@@ -441,7 +442,7 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
 
 - (MFMailComposeViewController *)feedbackMailViewController
 {
-    NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString*)kCFBundleVersionKey];
+    NSString *appVersion = [[NSBundle mainBundle] detailedVersionNumber];
     NSString *device = [UIDeviceHardware platformString];
     NSString *locale = [[NSLocale currentLocale] localeIdentifier];
     NSString *iosVersion = [[UIDevice currentDevice] systemVersion];

--- a/WordPress/Classes/ViewRelated/System/AboutViewController.m
+++ b/WordPress/Classes/ViewRelated/System/AboutViewController.m
@@ -1,6 +1,7 @@
 #import "AboutViewController.h"
 #import "ReachabilityUtils.h"
 #import "WPWebViewController.h"
+#import "NSBundle+VersionNumberHelper.h"
 
 @interface AboutViewController()
 
@@ -33,7 +34,7 @@ CGFloat const AboutViewPortraitButtonsY = 90.0f;
     self.titleLabel.font = [WPStyleGuide largePostTitleFont];
     self.titleLabel.textColor = [WPStyleGuide whisperGrey];
 
-    self.versionLabel.text = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
+    self.versionLabel.text = [[NSBundle mainBundle] detailedVersionNumber];
     self.versionLabel.font = [WPStyleGuide postTitleFont];
     self.versionLabel.textColor = [WPStyleGuide whisperGrey];
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 		85B6F74F1742DA1E00CE7F3A /* WPNUXMainButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 85B6F74E1742DA1D00CE7F3A /* WPNUXMainButton.m */; };
 		85B6F7521742DAE800CE7F3A /* WPNUXBackButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 85B6F7511742DAE800CE7F3A /* WPNUXBackButton.m */; };
 		85C720B11730CEFA00460645 /* WPWalkthroughTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 85C720B01730CEFA00460645 /* WPWalkthroughTextField.m */; };
+		85CE4C201A703CF200780DFE /* NSBundle+VersionNumberHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 85CE4C1F1A703CF200780DFE /* NSBundle+VersionNumberHelper.m */; };
 		85D08A7117342ECE00E2BBCA /* AddUsersBlogCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D08A7017342ECE00E2BBCA /* AddUsersBlogCell.m */; };
 		85D2275918F1EB8A001DA8DA /* WPAnalyticsTrackerMixpanel.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D2275818F1EB8A001DA8DA /* WPAnalyticsTrackerMixpanel.m */; };
 		85D80558171630B30075EEAC /* DotCom-Languages.plist in Resources */ = {isa = PBXBuildFile; fileRef = 85D80557171630B30075EEAC /* DotCom-Languages.plist */; };
@@ -877,6 +878,8 @@
 		85B6F7511742DAE800CE7F3A /* WPNUXBackButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPNUXBackButton.m; sourceTree = "<group>"; };
 		85C720AF1730CEFA00460645 /* WPWalkthroughTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPWalkthroughTextField.h; sourceTree = "<group>"; };
 		85C720B01730CEFA00460645 /* WPWalkthroughTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPWalkthroughTextField.m; sourceTree = "<group>"; };
+		85CE4C1E1A703CF200780DFE /* NSBundle+VersionNumberHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSBundle+VersionNumberHelper.h"; sourceTree = "<group>"; };
+		85CE4C1F1A703CF200780DFE /* NSBundle+VersionNumberHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+VersionNumberHelper.m"; sourceTree = "<group>"; };
 		85D08A6F17342ECE00E2BBCA /* AddUsersBlogCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AddUsersBlogCell.h; sourceTree = "<group>"; };
 		85D08A7017342ECE00E2BBCA /* AddUsersBlogCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AddUsersBlogCell.m; sourceTree = "<group>"; };
 		85D2275718F1EB8A001DA8DA /* WPAnalyticsTrackerMixpanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAnalyticsTrackerMixpanel.h; sourceTree = "<group>"; };
@@ -2485,6 +2488,8 @@
 				B57B99DD19A2DBF200506504 /* NSObject+Helpers.m */,
 				31EC15061A5B6675009FC8B3 /* WPStyleGuide+Suggestions.h */,
 				31EC15071A5B6675009FC8B3 /* WPStyleGuide+Suggestions.m */,
+				85CE4C1E1A703CF200780DFE /* NSBundle+VersionNumberHelper.h */,
+				85CE4C1F1A703CF200780DFE /* NSBundle+VersionNumberHelper.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -3564,6 +3569,7 @@
 				E1F5A1BC1771C90A00E0495F /* WPTableImageSource.m in Sources */,
 				851734431798C64700A30E27 /* NSURL+Util.m in Sources */,
 				5DF738971965FACD00393584 /* RecommendedTopicsViewController.m in Sources */,
+				85CE4C201A703CF200780DFE /* NSBundle+VersionNumberHelper.m in Sources */,
 				E1D95EB817A28F5E00A3E9F3 /* WPActivityDefaults.m in Sources */,
 				857610D618C0377300EDF406 /* StatsWebViewController.m in Sources */,
 				5D08B90419648C3400D5B381 /* ReaderSubscriptionViewController.m in Sources */,


### PR DESCRIPTION
Updating the usage of the version number throughout the app since we now use a separate build number for CFBundleVersion.

Note - this is a result of a discussion from #3007.
Note - this is a re-do of https://github.com/wordpress-mobile/WordPress-iOS/pull/3039

cc @astralbodies