### PR TITLE
Issue/498 editor airplane mode add image

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -1055,6 +1055,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         if (buttonIndex == 1) {
             DDLogInfo(@"Saving post even after some media failed to upload");
             [self savePost:YES];
+            [self dismissEditView];
         }
         _failedMediaAlertView = nil;
     } else if (alertView.tag == EditPostViewControllerAlertTagSwitchBlogs) {

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -19,6 +19,7 @@
 #import <AssetsLibrary/AssetsLibrary.h>
 #import <WordPress-iOS-Shared/UIImage+Util.h>
 #import <WordPress-iOS-Shared/WPFontManager.h>
+#import "WordPress-Swift.h"
 
 NSString *const WPLegacyEditorNavigationRestorationID = @"WPLegacyEditorNavigationRestorationID";
 NSString *const WPLegacyAbstractPostRestorationKey = @"WPLegacyAbstractPostRestorationKey";
@@ -33,9 +34,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 @property (nonatomic, strong) UIPopoverController *mediaProgressPopover;
 @property (nonatomic) BOOL dismissingBlogPicker;
 @property (nonatomic) CGPoint scrollOffsetRestorePoint;
-@property (nonatomic, strong) NSProgress * mediaProgress;
+@property (nonatomic, strong) NSProgress * mediaGlobalProgress;
 @property (nonatomic, strong) UIProgressView * mediaProgressView;
-@property (nonatomic, strong) NSMutableArray * childrenMediaProgress;
+@property (nonatomic, strong) NSMutableDictionary *mediaInProgress;
 
 @end
 
@@ -80,7 +81,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)dealloc
 {
     _failedMediaAlertView.delegate = nil;
-    [self.mediaProgress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted))];
+    [_mediaGlobalProgress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted))];
     _mediaProgressPopover.delegate = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
@@ -137,7 +138,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    self.childrenMediaProgress = [NSMutableArray array];
     [self setupNavbar];
     [self createRevisionOfPost];
     [self removeIncompletelyUploadedMediaFilesAsAResultOfACrash];
@@ -147,6 +147,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(removeMedia:) name:@"ShouldRemoveMedia" object:nil];
 
     [self geotagNewPost];
+    self.mediaInProgress = [NSMutableDictionary dictionary];
     self.mediaProgressView = [[UIProgressView alloc] initWithProgressViewStyle:UIProgressViewStyleBar];
     self.delegate = self;
 }
@@ -196,7 +197,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     
     self.mediaProgressView.hidden = ![self isMediaUploading];
     if ([self isMediaUploading]) {
-        self.mediaProgressView.progress = MIN((float)(self.mediaProgress.completedUnitCount+1)/(float)self.mediaProgress.totalUnitCount,self.mediaProgress.fractionCompleted);
+        [self refreshMediaProgress];
         UIButton *titleButton = self.uploadStatusButton;
         NSMutableAttributedString *titleText = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@", NSLocalizedString(@"Media Uploading...", @"Message to indicate progress of uploading media to server")]                                                                                      attributes:@{ NSFontAttributeName : [WPFontManager openSansBoldFontOfSize:14.0] }];
         [titleButton setAttributedTitle:titleText forState:UIControlStateNormal];
@@ -744,11 +745,17 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 #pragma mark - Media State Methods
 
-- (BOOL)isMediaUploading
+- (NSString*)uniqueIdForMedia
 {
-    return self.mediaProgress &&
-    ![self.mediaProgress isCancelled] &&
-    self.mediaProgress.completedUnitCount < self.mediaProgress.totalUnitCount;
+    NSUUID * uuid = [[NSUUID alloc] init];
+    return [uuid UUIDString];
+}
+
+- (void)refreshMediaProgress
+{
+    self.mediaProgressView.hidden = ![self isMediaUploading];
+    float fractionOfUploadsCompleted = (float)(self.mediaGlobalProgress.completedUnitCount+1)/(float)self.mediaGlobalProgress.totalUnitCount;
+    self.mediaProgressView.progress = MIN(fractionOfUploadsCompleted ,self.mediaGlobalProgress.fractionCompleted);
 }
 
 - (void)showMediaProgress
@@ -758,7 +765,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         self.blogSelectorPopover = nil;
     }
     
-    WPMediaProgressTableViewController *vc = [[WPMediaProgressTableViewController alloc] initWithMasterProgress:self.mediaProgress childrenProgress:self.childrenMediaProgress];
+    WPMediaProgressTableViewController *vc = [[WPMediaProgressTableViewController alloc] initWithMasterProgress:self.mediaGlobalProgress childrenProgress:self.mediaInProgress.allValues];
     
     vc.title = NSLocalizedString(@"Media Uploading", @"Title for view that shows progress of multiple uploads");
     
@@ -791,27 +798,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     [alertView show];
 }
 
-- (void)cancelMediaUploads
-{
-    [self.mediaProgress cancel];
-}
-
-- (BOOL)hasFailedMedia
-{
-    BOOL hasFailedMedia = NO;
-
-    NSSet *mediaFiles = self.post.media;
-    for (Media *media in mediaFiles) {
-        if (media.remoteStatus == MediaRemoteStatusFailed) {
-            hasFailedMedia = YES;
-            break;
-        }
-    }
-    mediaFiles = nil;
-
-    return hasFailedMedia;
-}
-
 - (void)showFailedMediaAlert
 {
     if (_failedMediaAlertView) {
@@ -836,41 +822,137 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     [blogIsCurrentlyBusy show];
 }
 
-- (void) insertMediaAssets:(NSArray *)assets
+- (BOOL)hasFailedMedia
 {
-    if (self.mediaProgress.isCancelled || self.mediaProgress.completedUnitCount >= self.mediaProgress.totalUnitCount){
-        [self.mediaProgress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted))];
-        self.mediaProgress = nil;
-        [self.childrenMediaProgress removeAllObjects];
-    }
+    __block BOOL hasFailedMedia = NO;
+    [self.mediaInProgress enumerateKeysAndObjectsUsingBlock:^(NSString * key, NSProgress * progress, BOOL *stop) {
+        if (progress.totalUnitCount == 0){
+            hasFailedMedia = YES;
+        }
+    }];
+    return hasFailedMedia;
+}
 
-    if (!self.mediaProgress){
-        self.mediaProgress = [[NSProgress alloc] initWithParent:[NSProgress currentProgress]
-                                                       userInfo:nil];
-        self.mediaProgress.totalUnitCount = assets.count;
-        [self.mediaProgress addObserver:self
-                             forKeyPath:NSStringFromSelector(@selector(fractionCompleted))
-                                options:NSKeyValueObservingOptionInitial
-                                context:ProgressObserverContext];
-    } else {
-        self.mediaProgress.totalUnitCount += assets.count;
+- (BOOL)isMediaUploading
+{
+    return (self.mediaGlobalProgress.totalUnitCount > self.mediaGlobalProgress.completedUnitCount) && !self.mediaGlobalProgress.cancelled;
+}
+
+- (void)cancelMediaUploads
+{
+    [self.mediaGlobalProgress cancel];
+    NSMutableArray * keys = [NSMutableArray array];
+    [self.mediaInProgress enumerateKeysAndObjectsUsingBlock:^(NSString * key, NSProgress * progress, BOOL *stop) {
+        if (progress.isCancelled){
+            [keys addObject:key];
+        }
+    }];
+    [self.mediaInProgress removeObjectsForKeys:keys];
+    [self autosaveContent];
+    [self setupNavbar];
+}
+
+- (void)cancelUploadOfMediaWithId:(NSString *)uniqueMediaId
+{
+    NSProgress * progress = self.mediaInProgress[uniqueMediaId];
+    if (!progress) {
+        return;
     }
+    [progress cancel];
+}
+
+- (void)removeAllFailedMedia
+{
+    NSMutableArray * keys = [NSMutableArray array];
+    [self.mediaInProgress enumerateKeysAndObjectsUsingBlock:^(NSString * key, NSProgress * progress, BOOL *stop) {
+        if (progress.totalUnitCount == 0){
+            [keys addObject:key];
+        }
+    }];
+    [self.mediaInProgress removeObjectsForKeys:keys];
+    [self autosaveContent];
+}
+
+- (void)stopTrackingProgressOfMediaWithId:(NSString *)uniqueMediaId
+{
+    NSParameterAssert(uniqueMediaId != nil);
+    if (!uniqueMediaId) {
+        return;
+    }
+    NSProgress * progress = self.mediaInProgress[uniqueMediaId];
+    [self.mediaInProgress removeObjectForKey:uniqueMediaId];
+    if (progress.isCancelled){
+        //on iOS 7 cancelled sub progress don't update the parent progress properly so we need to do it
+        if ( ![UIDevice isOS8] ) {
+            self.mediaGlobalProgress.completedUnitCount++;
+        }
+    }
+}
+
+- (void)trackMediaWithId:(NSString *)uniqueMediaId usingProgress:(NSProgress *)progress
+{
+    NSParameterAssert(uniqueMediaId != nil);
+    if (!uniqueMediaId) {
+        return;
+    }
+    
+    self.mediaInProgress[uniqueMediaId] = progress;
+}
+
+- (void)prepareMediaProgressForNumberOfAssets:(NSUInteger)count
+{
+    if (self.mediaGlobalProgress.isCancelled ||
+        self.mediaGlobalProgress.completedUnitCount >= self.mediaGlobalProgress.totalUnitCount){
+        [self.mediaGlobalProgress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted))];
+        self.mediaGlobalProgress = nil;
+    }
+    
+    if (!self.mediaGlobalProgress){
+        self.mediaGlobalProgress = [[NSProgress alloc] initWithParent:[NSProgress currentProgress]
+                                                             userInfo:nil];
+        self.mediaGlobalProgress.totalUnitCount = count;
+        [self.mediaGlobalProgress addObserver:self
+                                   forKeyPath:NSStringFromSelector(@selector(fractionCompleted))
+                                      options:NSKeyValueObservingOptionInitial
+                                      context:ProgressObserverContext];
+    } else {
+        self.mediaGlobalProgress.totalUnitCount += count;
+    }
+}
+
+- (void) addMediaAssets:(NSArray *)assets
+{
+    [self prepareMediaProgressForNumberOfAssets:assets.count];
 
     for (ALAsset *asset in assets) {
         if ([[asset valueForProperty:ALAssetPropertyType] isEqualToString:ALAssetTypePhoto]) {
             MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
+            __weak __typeof__(self) weakSelf = self;
+            NSString* imageUniqueId = [self uniqueIdForMedia];
+            NSProgress *createMediaProgress = [[NSProgress alloc] initWithParent:nil userInfo:nil];
+            createMediaProgress.totalUnitCount = 2;
+            [self trackMediaWithId:imageUniqueId usingProgress:createMediaProgress];
+            
             [mediaService createMediaWithAsset:asset forPostObjectID:self.post.objectID completion:^(Media *media, NSError * error) {
                 if (error){
                     [WPError showAlertWithTitle:NSLocalizedString(@"Failed to export media", @"The title for an alert that says to the user the media (image or video) he selected couldn't be used on the post.") message:error.localizedDescription];
                     return;
                 }
-                [self.mediaProgress becomeCurrentWithPendingUnitCount:1];
+                __typeof__(self) strongSelf = weakSelf;
+                if (!strongSelf) {
+                    return;
+                }
+                createMediaProgress.completedUnitCount++;
+                
+                [strongSelf.mediaGlobalProgress becomeCurrentWithPendingUnitCount:1];
                 NSProgress *uploadProgress = nil;
                 [mediaService uploadMedia:media progress:&uploadProgress success:^{
-                    [self insertMedia:media];
+                    [strongSelf insertMedia:media];
+                    [strongSelf stopTrackingProgressOfMediaWithId:imageUniqueId];
                 } failure:^(NSError *error) {
                     // the progress was completed event if it was an error state
-                    self.mediaProgress.completedUnitCount++;
+                    strongSelf.mediaGlobalProgress.completedUnitCount++;
+                    [strongSelf stopTrackingProgressOfMediaWithId:imageUniqueId];
                     if (error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled) {
                         DDLogWarn(@"Media uploader failed with cancelled upload: %@", error.localizedDescription);
                         return;
@@ -879,8 +961,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
                 }];
                 UIImage * image = [UIImage imageWithCGImage:asset.thumbnail];
                 [uploadProgress setUserInfoObject:image forKey:WPProgressImageThumbnailKey];
-                [self.childrenMediaProgress addObject:uploadProgress];
-                [self.mediaProgress resignCurrent];
+                [strongSelf trackMediaWithId:imageUniqueId usingProgress:uploadProgress];
+                [strongSelf.mediaGlobalProgress resignCurrent];
             }];
         }
     }
@@ -1066,7 +1148,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)assetsPickerController:(CTAssetsPickerController *)picker didFinishPickingAssets:(NSArray *)assets
 {
     [self dismissViewControllerAnimated:YES completion:^{
-        [self insertMediaAssets:assets];
+        [self addMediaAssets:assets];
     }];
 }
 
@@ -1097,7 +1179,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
                         change:(NSDictionary *)change
                        context:(void *)context
 {
-    if (context == ProgressObserverContext && object == self.mediaProgress) {        
+    if (context == ProgressObserverContext && object == self.mediaGlobalProgress) {
         [[NSOperationQueue mainQueue] addOperationWithBlock:^{
             [self setupNavbar];
         }];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1342,7 +1342,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 		return;
 	}
     
-    [self stopEditing];
 	[self savePostAndDismissVC];
 }
 
@@ -1355,6 +1354,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         [self showFailedMediaRemovalAlert];
         return;
     }
+    [self stopEditing];
     [self savePost];
     [self dismissEditView];
 }


### PR DESCRIPTION
Fix for this https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/498

For the legacy editor the main work was copying code from the new editor to update the save logic when media was pending.

For the new editor the fix was to change the moment where the stop editing was done. It's now done after all possible changes on the post content can happen.

can you please review @diegoreymendez or @bummytime 