### PR TITLE
Fixing AppRatingUtility crash

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -113,6 +113,7 @@ static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracki
     [self configureHockeySDK];
     [self configureNewRelic];
     [self configureCrashlytics];
+    [self initializeAppTracking];
 
     // Start Simperium
     [self loginSimperium];
@@ -412,7 +413,6 @@ static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracki
 {
     DDLogInfo(@"%@ %@", self, NSStringFromSelector(_cmd));
     [self trackApplicationOpened];
-    [self initializeAppTracking];
     
     [self showWhatsNewIfNeeded];
 }


### PR DESCRIPTION
This PR fixes this crash in the latest internal beta:
```
0   CoreFoundation                       0x000000018458a59c __exceptionPreprocess + 132
1   libobjc.A.dylib                      0x0000000194c880e4 objc_exception_throw + 56
2   CoreFoundation                       0x000000018458a45c +[NSException raise:format:arguments:] + 112
3   Foundation                           0x00000001854114f4 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 108
4   WordPress                            0x00000001001b75ec +[AppRatingUtility assertValidSection:] (AppRatingUtility.m:319)
5   WordPress                            0x00000001001b6838 +[AppRatingUtility incrementSignificantEventForSection:] (AppRatingUtility.m:178)
6   WordPress                            0x0000000100245450 -[NotificationDetailsViewController viewDidLoad] (NotificationDetailsViewController.m:138)
7   WordPress                            0x00000001006416dc NRMA__voidParamHandler (NRMAMethodProfiler.m:707)
8   UIKit                                0x0000000188d39184 -[UIViewController loadViewIfRequired] + 688
9   UIKit                                0x0000000188d38e94 -[UIViewController view] + 28
10  UIKit                                0x0000000188eabaac -[UIApplication(StateRestoration) _restoreApplicationPreservationStateWithSessionIdentifier:beginHandler:completionHandler:] + 4872
11  UIKit                                0x0000000188daa8a8 -[UIApplication(StateRestoration) _doRestorationIfNecessary] + 228
12  UIKit                                0x0000000188daa6ac -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] + 232
13  UIKit                                0x0000000188fc1688 -[UIApplication _callInitializationDelegatesForMainScene:transitionContext:] + 2280
14  UIKit                                0x0000000188fc3e08 -[UIApplication _runWithMainScene:transitionContext:completion:] + 1476
15  UIKit                                0x0000000188fc24a0 -[UIApplication workspaceDidEndTransaction:] + 180
16  FrontBoardServices                   0x000000018c7f962c __31-[FBSSerialQueue performAsync:]_block_invoke + 24
17  CoreFoundation                       0x0000000184542a28 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 16
18  CoreFoundation                       0x0000000184541b30 __CFRunLoopDoBlocks + 308
19  CoreFoundation                       0x0000000184540154 __CFRunLoopRun + 1752
20  CoreFoundation                       0x000000018446d0a4 CFRunLoopRunSpecific + 392
21  UIKit                                0x0000000188da3aac -[UIApplication _run] + 548
22  UIKit                                0x0000000188d9eaa4 UIApplicationMain + 1484
23  WordPress                            0x00000001000db1dc main (main.m:5)
24  libdyld.dylib                        0x00000001952f6a08 start + 0
```

Basically the assert was failing because the code to register the App Review sections was firing after the code to increment the significant event during state restoration.