### PR TITLE
v1 of the code that enables the new editor for all users.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -72,7 +72,7 @@
 
 int ddLogLevel                                                  = LOG_LEVEL_INFO;
 static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracking_enabled";
-static NSString * const MustShowWhatsNewPopup = @"MustShowWhatsNewPopup";
+static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhatsNewPopup";
 
 @interface WordPressAppDelegate () <UITabBarControllerDelegate, CrashlyticsDelegate, UIAlertViewDelegate, BITHockeyManagerDelegate>
 

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -72,6 +72,7 @@
 
 int ddLogLevel                                                  = LOG_LEVEL_INFO;
 static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracking_enabled";
+static NSString * const MustShowWhatsNewPopup = @"MustShowWhatsNewPopup";
 
 @interface WordPressAppDelegate () <UITabBarControllerDelegate, CrashlyticsDelegate, UIAlertViewDelegate, BITHockeyManagerDelegate>
 
@@ -169,6 +170,10 @@ static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracki
     // Configure Today Widget
     [self determineIfTodayWidgetIsConfiguredAndShowAppropriately];
 
+    if ([WPPostViewController makeNewEditorAvailable]) {
+        [self setMustShowWhatsNewPopup:YES];
+    }
+    
     CGRect bounds = [[UIScreen mainScreen] bounds];
     [self.window setFrame:bounds];
     [self.window setBounds:bounds]; // for good measure.
@@ -329,23 +334,7 @@ static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracki
                     }
                 }
             }
-		} else if ([[url host] isEqualToString:@"editor"]) {
-			NSDictionary* params = [[url query] dictionaryFromQueryString];
-			
-			if (params.count > 0) {
-				BOOL available = [[params objectForKey:kWPEditorConfigURLParamAvailable] boolValue];
-				BOOL enabled = [[params objectForKey:kWPEditorConfigURLParamEnabled] boolValue];
-				
-				[WPPostViewController setNewEditorAvailable:available];
-				[WPPostViewController setNewEditorEnabled:enabled];
-                
-                if (available) {
-                    [WPAnalytics track:WPAnalyticsStatEditorEnabledNewVersion];
-                }
-				
-				[self showVisualEditorAvailableInSettingsAnimation:available];
-			}
-        }
+		}
     }
 
     return returnValue;
@@ -1260,40 +1249,6 @@ static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracki
     [service removeTodayWidgetConfiguration];
 }
 
-#pragma mark - GUI animations
-
-- (void)showVisualEditorAvailableInSettingsAnimation:(BOOL)available
-{
-	UIView* notificationView = [[UIView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-	notificationView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.5f];
-	notificationView.alpha = 0.0f;
-	
-	[self.window addSubview:notificationView];
-	
-	[UIView animateWithDuration:0.2f animations:^{
-		notificationView.alpha = 1.0f;
-	} completion:^(BOOL finished) {
-		
-		NSString* statusString = nil;
-		
-		if (available) {
-			statusString = NSLocalizedString(@"Visual Editor added to Settings", nil);
-		} else {
-			statusString = NSLocalizedString(@"Visual Editor removed from Settings", nil);
-		}
-        
-        [SVProgressHUD showSuccessWithStatus:statusString maskType:SVProgressHUDMaskTypeNone];
-		
-		dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-			[UIView animateWithDuration:0.2f animations:^{
-				notificationView.alpha = 0.0f;
-			} completion:^(BOOL finished) {
-				[notificationView removeFromSuperview];
-			}];
-		});
-	}];
-}
-
 #pragma mark - What's new
 
 /**
@@ -1304,26 +1259,40 @@ static NSString * const kUsageTrackingDefaultsKey               = @"usage_tracki
  */
 - (void)showWhatsNewIfNeeded
 {
-    if (![self noBlogsAndNoWordPressDotComAccount]) {
-        
-        static NSString* const WhatsNewUserDefaultsKey = @"WhatsNewUserDefaultsKey";
-        static const CGFloat WhatsNewShowDelay = 1.0f;
-        
-        NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-        
-        BOOL whatsNewAlreadyShown = [userDefaults boolForKey:WhatsNewUserDefaultsKey];
-        
-        if (!whatsNewAlreadyShown) {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(WhatsNewShowDelay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                
-                WPWhatsNew* whatsNew = [[WPWhatsNew alloc] init];
-                
-                [whatsNew show];
-                
-                [userDefaults setBool:YES forKey:WhatsNewUserDefaultsKey];
-            });
+    BOOL userIsLoggedIn = ![self noBlogsAndNoWordPressDotComAccount];
+    
+    if (userIsLoggedIn) {
+        if ([self mustShowWhatsNewPopup]) {
+            
+            static NSString* const WhatsNewUserDefaultsKey = @"WhatsNewUserDefaultsKey";
+            static const CGFloat WhatsNewShowDelay = 1.0f;
+            
+            NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+            
+            BOOL whatsNewAlreadyShown = [userDefaults boolForKey:WhatsNewUserDefaultsKey];
+            
+            if (!whatsNewAlreadyShown) {
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(WhatsNewShowDelay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    
+                    WPWhatsNew* whatsNew = [[WPWhatsNew alloc] init];
+                    
+                    [whatsNew show];
+                    
+                    [userDefaults setBool:YES forKey:WhatsNewUserDefaultsKey];
+                });
+            }
         }
     }
+}
+
+- (BOOL)mustShowWhatsNewPopup
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:MustShowWhatsNewPopup];
+}
+
+- (void)setMustShowWhatsNewPopup:(BOOL)mustShow
+{
+    [[NSUserDefaults standardUserDefaults] setBool:mustShow forKey:MustShowWhatsNewPopup];
 }
 
 @end

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -453,6 +453,10 @@ NSString *const EmailAddressRetrievedKey = @"email_address_retrieved";
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Enabled New Version"];
             [instructions addSuperPropertyToFlag:@"enabled_new_editor"];
             break;
+        case WPAnalyticsStatEditorDisabledNewVersion:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Disabled New Version"];
+            [instructions addSuperPropertyToFlag:@"disabled_new_editor"];
+            break;
         case WPAnalyticsStatSharedItemViaEmail:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsWithSuperPropertyAndPeoplePropertyIncrementor:@"number_of_items_shared_via_email"];
             [instructions setCurrentDateForPeopleProperty:@"last_time_shared_item_via_email"];

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -699,8 +699,6 @@ CGFloat const CreateAccountAndBlogButtonHeight = 40.0;
     WPAsyncBlockOperation *userCreation = [WPAsyncBlockOperation operationWithBlock:^(WPAsyncBlockOperation *operation){
         void (^createUserSuccess)(id) = ^(id responseObject){
             // Turn on the new editor only for users that create a new account within the iOS app
-            [WPPostViewController setNewEditorAvailable:YES];
-            [WPPostViewController setNewEditorEnabled:YES];
             [WPAnalytics track:WPAnalyticsStatEditorEnabledNewVersion];
             [operation didSucceed];
         };

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -698,8 +698,6 @@ CGFloat const CreateAccountAndBlogButtonHeight = 40.0;
 
     WPAsyncBlockOperation *userCreation = [WPAsyncBlockOperation operationWithBlock:^(WPAsyncBlockOperation *operation){
         void (^createUserSuccess)(id) = ^(id responseObject){
-            // Turn on the new editor only for users that create a new account within the iOS app
-            [WPAnalytics track:WPAnalyticsStatEditorEnabledNewVersion];
             [operation didSucceed];
         };
         void (^createUserFailure)(NSError *) = ^(NSError *error) {

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
@@ -103,6 +103,7 @@ typedef void (^EditPostCompletionHandler)(void);
             andTags:(NSString *)tags
            andImage:(NSString *)image;
 
+
 #pragma mark - Visual editor in settings
 
 /**
@@ -118,6 +119,13 @@ typedef void (^EditPostCompletionHandler)(void);
  *	@return		YES if the new editor is enabled, NO otherwise.
  */
 + (BOOL)isNewEditorEnabled;
+
+/**
+ *  @brief      Makes sure the new editor is available.
+ *
+ *  @returns    YES if the editor was made available, NO otherwise.
+ */
++ (BOOL)makeNewEditorAvailable;
 
 /**
  *	@brief		Makes the new editor available in the app settings.

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -842,6 +842,21 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     [defaults synchronize];
 }
 
++ (BOOL)makeNewEditorAvailable
+{
+    BOOL result = NO;
+    BOOL newVisualEditorNotAvailable = ![WPPostViewController isNewEditorAvailable];
+    
+    if (newVisualEditorNotAvailable) {
+        
+        result = YES;
+        [WPPostViewController setNewEditorAvailable:YES];
+        [WPPostViewController setNewEditorEnabled:YES];
+    }
+    
+    return result;
+}
+
 + (BOOL)isNewEditorAvailable
 {
 	return [[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsNewEditorAvailable];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -840,6 +840,12 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults setBool:isEnabled forKey:kUserDefaultsNewEditorEnabled];
     [defaults synchronize];
+    
+    if (isEnabled) {
+        [WPAnalytics track:WPAnalyticsStatEditorEnabledNewVersion];
+    } else {
+        [WPAnalytics track:WPAnalyticsStatEditorDisabledNewVersion];
+    }
 }
 
 + (BOOL)makeNewEditorAvailable


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/497).
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/509).
Improves the code we had for [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/466).

This was implemented using the minimum possible logic to turn the new editor on by default.  In my opinion we should consider in the next few versions cleaning up some of the code and removing the old visual editor - also removing some of the code that was introduced in this PR, since it won't be needed anymore.

How it works, please review the logic:
- **For users who didn't have the editor in earlier versions:** the new editor is enabled as default.  The onboarding tip is shown.
- **For users who had the editor in earlier versions:** the editor is still available in settings but not force enabled.  The onboarding tip is _not_ shown.

/cc @bummytime 