### PR TITLE
Use xcodebuild instead of xctool to build and run tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ notifications:
   email: true
 install:
 - gem install cocoapods && pod install
+- gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 - ./Scripts/install-oclint.sh
 before_script:
 - xctool --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ install:
 - ./Scripts/install-oclint.sh
 before_script:
 - xctool --version
+script:
+- ./Scripts/build.sh
 after_success:
 - ./Scripts/run-oclint.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ install:
 - ./Scripts/install-oclint.sh
 before_script:
 - xctool --version
-script:
-- ./Scripts/build.sh
 after_success:
 - ./Scripts/run-oclint.sh
 

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -16,5 +16,6 @@ set -o pipefail && xcodebuild test \
 	-destination "platform=iOS Simulator,name=iPhone 4s,OS=8.1" \
 	-workspace "$TRAVIS_XCODE_WORKSPACE" \
 	-scheme "$TRAVIS_XCODE_SCHEME" \
+	-configuration Debug \
 	-sdk "$TRAVIS_XCODE_SDK" | ${pretty}
 	

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,20 +1,28 @@
-#checking if xcpretty is available to use
-command -v xcpretty >/dev/null
-if [ $? -eq 1 ]; then
-echo >&2 "xcpretty not found don't use it."
-exit 0
-fi
-
 if [ ! $TRAVIS ]; then
 	TRAVIS_XCODE_WORKSPACE=WordPress.xcworkspace
 	TRAVIS_XCODE_SCHEME=WordPress
     TRAVIS_XCODE_SDK=iphonesimulator8.1
 fi
 
+#checking if xcpretty is available to use
+command -v xcpretty >/dev/null
+if [ $? -eq 1 ]; then
+echo >&2 "xcpretty not found don't use it."
+xcodebuild build test \
+	-destination "platform=iOS Simulator,name=iPhone 4s,OS=8.1" \
+	-workspace "$TRAVIS_XCODE_WORKSPACE" \
+	-scheme "$TRAVIS_XCODE_SCHEME" \
+	-configuration Debug
+else
 xcodebuild build test \
 	-destination "platform=iOS Simulator,name=iPhone 4s,OS=8.1" \
 	-workspace "$TRAVIS_XCODE_WORKSPACE" \
 	-scheme "$TRAVIS_XCODE_SCHEME" \
 	-configuration Debug \
 	-sdk "$TRAVIS_XCODE_SDK" | xcpretty -c && exit ${PIPESTATUS[0]}
+fi
+
+
+
+
 	

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -12,10 +12,10 @@ if [ ! $TRAVIS ]; then
     TRAVIS_XCODE_SDK=iphonesimulator8.1
 fi
 
-set -o pipefail && xcodebuild test \
+xcodebuild build test \
 	-destination "platform=iOS Simulator,name=iPhone 4s,OS=8.1" \
 	-workspace "$TRAVIS_XCODE_WORKSPACE" \
 	-scheme "$TRAVIS_XCODE_SCHEME" \
 	-configuration Debug \
-	-sdk "$TRAVIS_XCODE_SDK" | ${pretty}
+	-sdk "$TRAVIS_XCODE_SDK"
 	

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -17,5 +17,5 @@ xcodebuild build test \
 	-workspace "$TRAVIS_XCODE_WORKSPACE" \
 	-scheme "$TRAVIS_XCODE_SCHEME" \
 	-configuration Debug \
-	-sdk "$TRAVIS_XCODE_SDK"
+	-sdk "$TRAVIS_XCODE_SDK" | xcpretty -c
 	

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,2 +1,20 @@
-echo "xcodebuild build -workspace $TRAVIS_XCODE_WORKSPACE -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK"
-xctool build test -workspace "$TRAVIS_XCODE_WORKSPACE" -scheme "$TRAVIS_XCODE_SCHEME" -sdk "$TRAVIS_XCODE_SDK"
+#checking if xcpretty is available to use
+pretty="xcpretty -c"
+command -v xcpretty >/dev/null
+if [ $? -eq 1 ]; then
+echo >&2 "xcpretty not found don't use it."
+pretty="&>";
+fi
+
+if [ ! $TRAVIS ]; then
+	TRAVIS_XCODE_WORKSPACE=WordPress.xcworkspace
+	TRAVIS_XCODE_SCHEME=WordPress
+    TRAVIS_XCODE_SDK=iphonesimulator8.1
+fi
+
+set -o pipefail && xcodebuild test \
+	-destination "platform=iOS Simulator,name=iPhone 4s,OS=8.1" \
+	-workspace "$TRAVIS_XCODE_WORKSPACE" \
+	-scheme "$TRAVIS_XCODE_SCHEME" \
+	-sdk "$TRAVIS_XCODE_SDK" | ${pretty}
+	

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,9 +1,8 @@
 #checking if xcpretty is available to use
-pretty="xcpretty -c"
 command -v xcpretty >/dev/null
 if [ $? -eq 1 ]; then
 echo >&2 "xcpretty not found don't use it."
-pretty="&>";
+exit 0
 fi
 
 if [ ! $TRAVIS ]; then
@@ -17,5 +16,5 @@ xcodebuild build test \
 	-workspace "$TRAVIS_XCODE_WORKSPACE" \
 	-scheme "$TRAVIS_XCODE_SCHEME" \
 	-configuration Debug \
-	-sdk "$TRAVIS_XCODE_SDK" | xcpretty -c
+	-sdk "$TRAVIS_XCODE_SDK" | xcpretty -c && exit ${PIPESTATUS[0]}
 	


### PR DESCRIPTION
The reason sometimes out unit tests where failing while running on Travis was because of the use of xctool instead of xcodebuid to build and run unit tests.

When using xctool locally to build and test started to got the same errors has Travis. After I converted the build script to use xcodebuild the test errors stop happening.

/cc @sendhil can you please review?