### PR TITLE
Fixes typo in text field placeholder.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
@@ -437,7 +437,7 @@ typedef NS_ENUM(NSUInteger, ImageDetailsTextField) {
     UITableViewTextFieldCell *cell = [self getTextFieldCell];
     cell.tag = ImageDetailsRowLink;
     cell.textLabel.text = NSLocalizedString(@"Link To", @"Image link option title");
-    cell.textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:(NSLocalizedString(@"http://wwww.example.com/", @"Placeholder text for the link field.")) attributes:(@{NSForegroundColorAttributeName: [WPStyleGuide textFieldPlaceholderGrey]})];
+    cell.textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:(NSLocalizedString(@"http://www.example.com/", @"Placeholder text for the link field.")) attributes:(@{NSForegroundColorAttributeName: [WPStyleGuide textFieldPlaceholderGrey]})];
     cell.textField.accessibilityIdentifier = @"title value";
     cell.textField.text = self.imageDetails.linkURL;
     cell.textField.tag = 0;


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/518 

cc @bummytime 