### PR TITLE
Refresh me page gravatar once the email for the account is updated

### DIFF
--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -4,6 +4,7 @@
 @class WPAccount, Blog;
 
 extern NSString *const WPAccountDefaultWordPressComAccountChangedNotification;
+extern NSString *const WPAccountWordPressComAccountEmailAndDefaultBlogUpdatedNotification;
 
 @interface AccountService : NSObject <LocalCoreDataService>
 

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -4,7 +4,7 @@
 @class WPAccount, Blog;
 
 extern NSString *const WPAccountDefaultWordPressComAccountChangedNotification;
-extern NSString *const WPAccountWordPressComAccountEmailAndDefaultBlogUpdatedNotification;
+extern NSString *const WPAccountEmailAndDefaultBlogUpdatedNotification;
 
 @interface AccountService : NSObject <LocalCoreDataService>
 

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -20,7 +20,7 @@ static NSString * const DefaultDotcomAccountUUIDDefaultsKey = @"AccountDefaultDo
 
 static NSString * const WordPressDotcomXMLRPCKey = @"https://wordpress.com/xmlrpc.php";
 NSString * const WPAccountDefaultWordPressComAccountChangedNotification = @"WPAccountDefaultWordPressComAccountChangedNotification";
-NSString * const WPAccountWordPressComAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountWordPressComAccountEmailAndDefaultBlogUpdatedNotification";
+NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEmailAndDefaultBlogUpdatedNotification";
 
 @implementation AccountService
 
@@ -244,7 +244,7 @@ NSString * const WPAccountWordPressComAccountEmailAndDefaultBlogUpdatedNotificat
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
 
         dispatch_async(dispatch_get_main_queue(), ^{
-            [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountWordPressComAccountEmailAndDefaultBlogUpdatedNotification object:account];
+            [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountEmailAndDefaultBlogUpdatedNotification object:account];
         });
     } failure:^(NSError *error) {
         DDLogError(@"Failed to retrieve /me endpoint while updating email and default blog");

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -20,6 +20,7 @@ static NSString * const DefaultDotcomAccountUUIDDefaultsKey = @"AccountDefaultDo
 
 static NSString * const WordPressDotcomXMLRPCKey = @"https://wordpress.com/xmlrpc.php";
 NSString * const WPAccountDefaultWordPressComAccountChangedNotification = @"WPAccountDefaultWordPressComAccountChangedNotification";
+NSString * const WPAccountWordPressComAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountWordPressComAccountEmailAndDefaultBlogUpdatedNotification";
 
 @implementation AccountService
 
@@ -232,12 +233,19 @@ NSString * const WPAccountDefaultWordPressComAccountChangedNotification = @"WPAc
 
 - (void)updateEmailAndDefaultBlogForWordPressComAccount:(WPAccount *)account
 {
+    if (!account) {
+        return;
+    }
     AccountServiceRemoteREST *remote = [[AccountServiceRemoteREST alloc] initWithApi:account.restApi];
     [remote getDetailsWithSuccess:^(NSDictionary *userDetails) {
         account.email = userDetails[@"email"];
         NSNumber *primaryBlogId = userDetails[@"primary_blog"];
         account.defaultBlog = [[account.blogs filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"blogID = %@", primaryBlogId]] anyObject];
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountWordPressComAccountEmailAndDefaultBlogUpdatedNotification object:account];
+        });
     } failure:^(NSError *error) {
         DDLogError(@"Failed to retrieve /me endpoint while updating email and default blog");
     }];

--- a/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
@@ -104,6 +104,8 @@ const CGFloat MeHeaderViewVerticalMargin = 10.0;
 {
     CGRect gravatarFrame = CGRectMake(0.0f, 0.0f, MeHeaderViewGravatarSize, MeHeaderViewGravatarSize);
     UIImageView *imageView = [[UIImageView alloc] initWithFrame:gravatarFrame];
+    imageView.layer.cornerRadius = MeHeaderViewGravatarSize / 2.0;
+    imageView.clipsToBounds = YES;
     imageView.translatesAutoresizingMaskIntoConstraints = NO;
     return imageView;
 }

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -100,7 +100,7 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(accountEmailUpdated:)
-                                                 name:WPAccountWordPressComAccountEmailAndDefaultBlogUpdatedNotification
+                                                 name:WPAccountEmailAndDefaultBlogUpdatedNotification
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:self


### PR DESCRIPTION
We trigger an update on the email and default blog when the Me page loads for the first time, updating the email will now trigger an update on the gravatar. This is especially important for the initial update the 4.8 version, since we are starting to store the email in this version. The gravatar is also changed to be round.

@aerych May I bother you with another review?