### PR TITLE
The onboarding tip will keep showing until dismissed.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -1275,9 +1275,9 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
                     
                     WPWhatsNew* whatsNew = [[WPWhatsNew alloc] init];
                     
-                    [whatsNew show];
-                    
-                    [userDefaults setBool:YES forKey:WhatsNewUserDefaultsKey];
+                    [whatsNew showWithDismissBlock:^{
+                        [userDefaults setBool:YES forKey:WhatsNewUserDefaultsKey];
+                    }];
                 });
             }
         }

--- a/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNew.h
+++ b/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNew.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+typedef void(^WPWhatsNewDismissBlock)();
+
 /**
  *  @class      WPWhatsNew
  *  @brief      This class is a module that can be used to contain the logic to show the What's New
@@ -16,7 +18,10 @@
  *  @brief      Shows the What's New popup.
  *  @details    If this version of the application does not have the required title and details
  *              glotpress strings, then nothing will be shown.
+ *
+ *  @param      dismissBlock    This block will be executed when the WPWhatsNewView is dismissed.
+ *                              Can be nil.
  */
-- (void)show;
+- (void)showWithDismissBlock:(WPWhatsNewDismissBlock)dismissBlock;
 
 @end

--- a/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNew.m
+++ b/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNew.m
@@ -23,7 +23,7 @@
 
 #pragma mark - Showing
 
-- (void)show
+- (void)showWithDismissBlock:(WPWhatsNewDismissBlock)dismissBlock
 {
     NSString *versionString = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
     NSAssert(versionString,
@@ -38,7 +38,10 @@
         
         UIImage* image = [UIImage imageNamed:@"icon-tab-newpost"];
         
-        [self showWithTitle:whatsNewTitle details:whatsNewDetails image:image];
+        [self showWithTitle:whatsNewTitle
+                    details:whatsNewDetails
+                      image:image
+               dismissBlock:dismissBlock];
     }
 }
 
@@ -46,13 +49,15 @@
  *  @brief      Shows the What's New popup with the specified title, details and image.
  *  @details    Should not be called directly in most cases.  Use method "show" instead.
  *
- *  @param      title       The title to display.  Cannot be nil or zero length.
- *  @param      details     The details to display.  Cannot be nil or zero length.
- *  @param      image       The image to show.  Cannot be nil.
+ *  @param      title           The title to display.  Cannot be nil or zero length.
+ *  @param      details         The details to display.  Cannot be nil or zero length.
+ *  @param      image           The image to show.  Cannot be nil.
+ *  @param      dismissBlock    The dismiss block for the whats new view.  Can be nil.
  */
 - (void)showWithTitle:(NSString*)title
               details:(NSString*)details
                 image:(UIImage*)image
+         dismissBlock:(WPWhatsNewDismissBlock)dismissBlock
 {
     NSParameterAssert([title isKindOfClass:[NSString class]]);
     NSParameterAssert([title length] > 0);
@@ -92,6 +97,8 @@
             [dimmerView removeFromSuperview];
         }];
     };
+    
+    whatsNewView.didDismissBlock = dismissBlock;
     
     [dimmerView showAnimated:YES completion:nil];
     [whatsNewView showAnimated:YES completion:nil];


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/510).

/cc @aerych or @SergioEstevao, since you guys are online.