### PR TITLE
Bumping appbotx version

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -33,7 +33,7 @@ pod 'NSObject-SafeExpectations', '0.0.2'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'Simperium', '0.7.7'
 pod 'Lookback', '0.9.2', :configurations => ['Release-Internal']
-pod "WordPress-AppbotX", :git => "https://github.com/wordpress-mobile/appbotx.git", :commit => "a0273598d22aac982bec5807e638050b0032a9c9"
+pod "WordPress-AppbotX", :git => "https://github.com/wordpress-mobile/appbotx.git", :commit => "303b8068530389ea87afde38b77466d685fe3210"
 pod 'MRProgress', '~>0.7.0'
 
 target 'WordPressTodayWidget', :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -147,7 +147,7 @@ DEPENDENCIES:
   - SocketRocket (from `https://github.com/jleandroperez/SocketRocket.git`, commit `3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927`)
   - SVProgressHUD (from `https://github.com/TransitApp/SVProgressHUD.git`, commit `2ac46ae2f2dd37db153ce1daea73b1273ac2bba3`)
   - UIDeviceIdentifier (~> 0.1)
-  - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `a0273598d22aac982bec5807e638050b0032a9c9`)
+  - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `303b8068530389ea87afde38b77466d685fe3210`)
   - WordPress-iOS-Editor (from `git://github.com/wordpress-mobile/WordPress-iOS-Editor`, commit `fac90a14bcf14440f7c80eee603e04e631f08a16`)
   - WordPress-iOS-Shared (= 0.1.6)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPressApi.git`, tag `0.2.1`)
@@ -168,7 +168,7 @@ EXTERNAL SOURCES:
     :commit: 2ac46ae2f2dd37db153ce1daea73b1273ac2bba3
     :git: https://github.com/TransitApp/SVProgressHUD.git
   WordPress-AppbotX:
-    :commit: a0273598d22aac982bec5807e638050b0032a9c9
+    :commit: 303b8068530389ea87afde38b77466d685fe3210
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-iOS-Editor:
     :commit: fac90a14bcf14440f7c80eee603e04e631f08a16
@@ -188,7 +188,7 @@ CHECKOUT OPTIONS:
     :commit: 2ac46ae2f2dd37db153ce1daea73b1273ac2bba3
     :git: https://github.com/TransitApp/SVProgressHUD.git
   WordPress-AppbotX:
-    :commit: a0273598d22aac982bec5807e638050b0032a9c9
+    :commit: 303b8068530389ea87afde38b77466d685fe3210
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-iOS-Editor:
     :commit: fac90a14bcf14440f7c80eee603e04e631f08a16


### PR DESCRIPTION
The latest version tweaks the email placeholder text to be "Email address" instead of "Email placeholder".