### PR TITLE
Blog picker now acts as back button when a single site is displayed.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -568,8 +568,19 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 #pragma mark - Actions
 
-- (void)showBlogSelectorPrompt
+- (void)showBlogSelectorPrompt:(WPBlogSelectorButton*)sender
 {
+    // If we are editing an existing post, we need to simply exit
+    // the screen we are currently on and return.
+    if (sender.buttonMode == WPBlogSelectorButtonSingleSite) {
+        if (self.isEditing) {
+            [self cancelEditing];
+        } else {
+            [self dismissEditView];
+        }
+        return;
+    }
+    
     if (![self.post hasSiteSpecificChanges]) {
         [self showBlogSelector];
         return;
@@ -1234,13 +1245,13 @@ static void *ProgressObserverContext = &ProgressObserverContext;
             [blogButton sizeToFit];
         }
         
-        // The blog picker is read-only if one of the following is true:
+        // The blog picker is in single site mode if one of the following is true:
         // editor screen is in preview mode, there is only 1 blog, or the user
-        // is editing an existing post
+        // is editing an existing post.
         if (self.currentBlogCount <= 1 || !self.isEditing || (self.isEditing && self.post.hasRemote)) {
-            blogButton.isReadOnly = YES;
+            blogButton.buttonMode = WPBlogSelectorButtonSingleSite;
         } else {
-            blogButton.isReadOnly = NO;
+            blogButton.buttonMode = WPBlogSelectorButtonMultipleSite;
         }
         aUIButtonBarItem = [[UIBarButtonItem alloc] initWithCustomView:blogButton];
     }
@@ -1254,7 +1265,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     if (!_blogPickerButton) {
         CGFloat titleButtonWidth = (IS_IPAD) ? 300.0f : 170.0f;
         UIButton *button = [WPBlogSelectorButton buttonWithFrame:CGRectMake(0.0f, 0.0f, titleButtonWidth , 30.0f) buttonStyle:WPBlogSelectorButtonTypeSingleLine];
-        [button addTarget:self action:@selector(showBlogSelectorPrompt) forControlEvents:UIControlEventTouchUpInside];
+        [button addTarget:self action:@selector(showBlogSelectorPrompt:) forControlEvents:UIControlEventTouchUpInside];
         _blogPickerButton = button;
     }
     

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -568,16 +568,22 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 #pragma mark - Actions
 
+/**
+ *	@brief      Handles the UIControlEventTouchUpInside event for the blog selector button.
+ *	@details    This method handles a the touch up inside event for the blog selector button.
+                Since there are two different modes this button can have, we have a few
+                different scenarios to consider:  1) If the user is editing an existing post 
+                exit the screen we are currently on and return. 2) If the user is creating a
+                new post and the post does not have site-specific changes, show the blog selector
+                3) If the user is creating a new post and the post does have site-specific 
+                changes, display a blog change warning.
+ *
+ *	@param      sender The WPBlogSelectorButton triggering this action.
+ */
 - (void)showBlogSelectorPrompt:(WPBlogSelectorButton*)sender
 {
-    // If we are editing an existing post, we need to simply exit
-    // the screen we are currently on and return.
     if (sender.buttonMode == WPBlogSelectorButtonSingleSite) {
-        if (self.isEditing) {
-            [self cancelEditing];
-        } else {
-            [self dismissEditView];
-        }
+        [self cancelEditingOrDismiss];
         return;
     }
     
@@ -883,6 +889,15 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 }
 
 #pragma mark - Instance Methods
+
+- (void)cancelEditingOrDismiss
+{
+    if (self.isEditing) {
+        [self cancelEditing];
+    } else {
+        [self dismissEditView];
+    }
+}
 
 - (UIImage *)tintedImageWithColor:(UIColor *)tintColor image:(UIImage *)image
 {

--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.h
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.h
@@ -6,10 +6,15 @@ typedef NS_ENUM(NSUInteger, WPBlogSelectorButtonStyle)
     WPBlogSelectorButtonTypeSingleLine
 };
 
+typedef NS_ENUM(NSUInteger, WPBlogSelectorButtonMode) {
+    WPBlogSelectorButtonSingleSite,
+    WPBlogSelectorButtonMultipleSite,
+};
+
 @interface WPBlogSelectorButton : UIButton
 
 @property (nonatomic, assign) WPBlogSelectorButtonStyle buttonStyle;
-@property (nonatomic, assign) BOOL isReadOnly;
+@property (nonatomic, assign) WPBlogSelectorButtonMode buttonMode;
 
 + (id)buttonWithFrame:(CGRect)frame buttonStyle:(WPBlogSelectorButtonStyle)buttonStyle;
 

--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
@@ -63,20 +63,14 @@
     return frame;
 }
 
-- (void)setIsReadOnly:(BOOL)isReadOnly
+- (void)setButtonMode:(WPBlogSelectorButtonMode)value
 {
-    self.enabled = !isReadOnly;
-    self.userInteractionEnabled = !isReadOnly;
-    if (isReadOnly) {
+    _buttonMode = value;
+    if (self.buttonMode == WPBlogSelectorButtonSingleSite) {
         [self setImage:nil forState:UIControlStateNormal];
     } else {
         [self setImage:[UIImage imageNamed:@"icon-navbar-dropdown.png"] forState:UIControlStateNormal];
     }
-}
-
-- (BOOL)isReadOnly
-{
-    return !self.enabled;
 }
 
 @end


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/526

This fix makes the ```WPBlogSelectorButton``` act as a back button when displaying a single site in the editor (e.g. we are editing a post). If there is more than one site the blog selector screen should appear as normal.

/cc @diegoreymendez would you mind reviewing?