### PR TITLE
Flagging if users have seen leagcy editor

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -39,7 +39,7 @@ NSString *const CheckedIfUserHasSeenLegacyEditor = @"checked_if_user_has_seen_le
         return;
     }
     
-    NSInteger sessionCount = [[[[Mixpanel sharedInstance] currentSuperProperties] numberForKey:@"session_count"] integerValue];
+    NSInteger sessionCount = [self sessionCount];
     if ([[Mixpanel sharedInstance].currentSuperProperties[@"created_account_on_mobile"] boolValue]) {
         // We want to differentiate between users who created pre 4.6 and those who created after and the way we do this
         // is by checking if the editor is enabled. The editor would only be enabled for users who created an account after 4.6.
@@ -710,7 +710,7 @@ NSString *const CheckedIfUserHasSeenLegacyEditor = @"checked_if_user_has_seen_le
 
 - (void)incrementSessionCount
 {
-    NSInteger sessionCount = [[[[Mixpanel sharedInstance] currentSuperProperties] numberForKey:@"session_count"] integerValue];
+    NSInteger sessionCount = [self sessionCount];
     sessionCount++;
     
     if (sessionCount == 1) {
@@ -720,6 +720,11 @@ NSString *const CheckedIfUserHasSeenLegacyEditor = @"checked_if_user_has_seen_le
     NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:[Mixpanel sharedInstance].currentSuperProperties];
     superProperties[@"session_count"] = @(sessionCount);
     [[Mixpanel sharedInstance] registerSuperProperties:superProperties];
+}
+
+- (NSInteger)sessionCount
+{
+    return [[[[Mixpanel sharedInstance] currentSuperProperties] numberForKey:@"session_count"] integerValue];
 }
 
 @end

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -15,6 +15,7 @@
 
 NSString *const EmailAddressRetrievedKey = @"email_address_retrieved";
 NSString *const CheckedIfUserHasSeenLegacyEditor = @"checked_if_user_has_seen_legacy_editor";
+NSString *const SeenLegacyEditor = @"seen_legacy_editor";
 
 - (instancetype)init
 {
@@ -43,12 +44,12 @@ NSString *const CheckedIfUserHasSeenLegacyEditor = @"checked_if_user_has_seen_le
     if ([self didUserCreateAccountOnMobile]) {
         // We want to differentiate between users who created pre 4.6 and those who created after and the way we do this
         // is by checking if the editor is enabled. The editor would only be enabled for users who created an account after 4.6.
-        [self setSuperProperty:@"seen_legacy_editor" toValue:@(![WPPostViewController isNewEditorEnabled])];
+        [self setSuperProperty:SeenLegacyEditor toValue:@(![WPPostViewController isNewEditorEnabled])];
     } else if (sessionCount == 0) {
         // First time users whether they have created an account or are signing in have never seen the legacy editor.
-        [self setSuperProperty:@"seen_legacy_editor" toValue:@NO];
+        [self setSuperProperty:SeenLegacyEditor toValue:@NO];
     } else {
-        [self setSuperProperty:@"seen_legacy_editor" toValue:@YES];
+        [self setSuperProperty:SeenLegacyEditor toValue:@YES];
     }
     
     [standardDefaults setBool:@YES forKey:CheckedIfUserHasSeenLegacyEditor];

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -40,7 +40,7 @@ NSString *const CheckedIfUserHasSeenLegacyEditor = @"checked_if_user_has_seen_le
     }
     
     NSInteger sessionCount = [self sessionCount];
-    if ([[Mixpanel sharedInstance].currentSuperProperties[@"created_account_on_mobile"] boolValue]) {
+    if ([self didUserCreateAccountOnMobile]) {
         // We want to differentiate between users who created pre 4.6 and those who created after and the way we do this
         // is by checking if the editor is enabled. The editor would only be enabled for users who created an account after 4.6.
         [self setSuperProperty:@"seen_legacy_editor" toValue:@(![WPPostViewController isNewEditorEnabled])];
@@ -53,6 +53,11 @@ NSString *const CheckedIfUserHasSeenLegacyEditor = @"checked_if_user_has_seen_le
     
     [standardDefaults setBool:@YES forKey:CheckedIfUserHasSeenLegacyEditor];
     [standardDefaults synchronize];
+}
+
+- (BOOL)didUserCreateAccountOnMobile
+{
+    return [[Mixpanel sharedInstance].currentSuperProperties[@"created_account_on_mobile"] boolValue];
 }
 
 - (void)track:(WPAnalyticsStat)stat


### PR DESCRIPTION
Adding a super property `seen_legacy_editor` which indicates whether a user has seen the legacy editor or not.  The code runs a one time check that will execute for WPiOS 4.8 and the logic behind detecting if a user has seen the legacy editor is:

```
if a user has created an account
  if a user has the new editor active
    flag the user as having not seen the legacy editor since in this case the user has created their account after 4.6 when the editor was enabled for new users
  else
    flag the user as having seen the legacy editor as they created their account before 4.6
 end if
else if the user has a session count of zero indicating this is the first time they've opened the app
  flag the user as having never seen the legacy editor since the visual editor is enabled for all users starting in 4.8
else
  flag the user as having seen the legacy editor
end if
```

cc @diegoreymendez @bummytime - would you guys mind taking a peek at this and letting me know if the logic stacks up?
cc @meremagee as an fyi
