### PR TITLE
Do not pass wp_post_thumbnail if it has not changed.

### DIFF
--- a/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
@@ -244,7 +244,9 @@
         if (existingPost) {
             [postParams setValue:@"" forKey:@"wp_post_thumbnail"];
         }
-    } else {
+    } else if (!existingPost || post.isFeaturedImageChanged) {
+        // Do not add this param to existing posts when the featured image has not changed.
+        // Doing so results in a XML-RPC fault: Invalid attachment ID.
         [postParams setValue:post.postThumbnailID forKey:@"wp_post_thumbnail"];
     }
 

--- a/WordPress/Classes/Networking/Remote Objects/RemotePost.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemotePost.h
@@ -23,7 +23,7 @@
 
 @property (nonatomic, strong) NSArray *categories;
 @property (nonatomic, strong) NSArray *tags;
-@property (nonatomic) BOOL isFeaturedImageChanged;
+@property (nonatomic, assign) BOOL isFeaturedImageChanged;
 
 /**
  Array of custom fields. Each value is a dictionary containing {ID, key, value}

--- a/WordPress/Classes/Networking/Remote Objects/RemotePost.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemotePost.h
@@ -23,6 +23,7 @@
 
 @property (nonatomic, strong) NSArray *categories;
 @property (nonatomic, strong) NSArray *tags;
+@property (nonatomic) BOOL isFeaturedImageChanged;
 
 /**
  Array of custom fields. Each value is a dictionary containing {ID, key, value}

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -369,6 +369,8 @@ NSString * const PostServiceErrorDomain = @"PostServiceErrorDomain";
         remotePost.metadata = [self remoteMetadataForPost:postPost];
     }
 
+    remotePost.isFeaturedImageChanged = post.isFeaturedImageChanged;
+
     return remotePost;
 }
 


### PR DESCRIPTION
Closes #3045 
Restores the check to see if a featured image was changed. If there is no change then the `wp_post_thumbnail` param is not included in the XML-RPC request.  This avoids an odd fault returned in cases where the param is included, but there was no change. 