### PR TITLE
Fixes a duplicate declaration warning.

### DIFF
--- a/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNew.h
+++ b/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNew.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-typedef void(^WPWhatsNewDismissBlock)();
+#import "WPWhatsNewView.h"
 
 /**
  *  @class      WPWhatsNew


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/3187).

/cc @jleandroperez 