### PR TITLE
Adding checks to `gencredentials.rb` for missing keys

### DIFF
--- a/WordPress/WordPressApi/gencredentials.rb
+++ b/WordPress/WordPressApi/gencredentials.rb
@@ -251,4 +251,46 @@ if secret.nil?
   exit 3
 end
 
+configuration = ENV["CONFIGURATION"]
+if !configuration.nil? && ["Release", "Release-Internal"].include?(configuration)
+
+  if mixpanel_dev.nil? || mixpanel_prod.nil?
+    $stderr.puts "warning: Mixpanel keys not found"
+  end
+
+  if crashlytics.nil?
+    $stderr.puts "warning: Crashlytics API key not found"
+  end
+
+  if pocket.nil?
+    $stderr.puts "warning: Pocket API key not found"
+  end
+
+  if googleplus.nil?
+    $stderr.puts "warning: Google Plus API key not found"
+  end
+
+  if simperium_api_key.nil? || simperium_app_id.nil?
+    $stderr.puts "warning: Simperium keys not found"
+  end
+
+  if helpshift_api_key.nil? || helpshift_domain_name.nil? || helpshift_app_id.nil?
+    $stderr.puts "warning: Helpshift keys not found"
+  end
+
+  if lookback_token.nil?
+    $stderr.puts "warning: Lookback token not found"
+  end
+
+  if appbotx_api_key.nil?
+    $stderr.puts "warning: AppbotX API key not found"
+  end
+
+  if configuration == "Release-Internal"
+    if hockeyapp.nil?
+      $stderr.puts "warning: HockeyApp App Id not found"
+    end 
+  end
+end
+
 print_class(client, secret, pocket, mixpanel_dev, mixpanel_prod, crashlytics, hockeyapp, googleplus, helpshift_api_key, helpshift_domain_name, helpshift_app_id, simperium_api_key, simperium_app_id, debugging_key, lookback_token, appbotx_api_key)

--- a/WordPress/WordPressApi/gencredentials.rb
+++ b/WordPress/WordPressApi/gencredentials.rb
@@ -221,9 +221,9 @@ File.open(path) do |f|
       hockeyapp = v.chomp
     elsif k == "GOOGLE_PLUS_CLIENT_ID"
       googleplus = v.chomp
-	elsif k == "SIMPERIUM_API_KEY"
+    elsif k == "SIMPERIUM_API_KEY"
       simperium_api_key = v.chomp
-	elsif k == "SIMPERIUM_APP_ID"
+    elsif k == "SIMPERIUM_APP_ID"
       simperium_app_id = v.chomp
     elsif k == "HELPSHIFT_API_KEY"
       helpshift_api_key = v.chomp


### PR DESCRIPTION
I added a few checks to `gencredentials.rb` file that will spit out warnings when archiving the app when it detects missing keys. I figure this way we can make sure we don't send out a version of the app that's missing a critical key.

cc @diegoreymendez 