### PR TITLE
iPad logout issue resolved

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -514,7 +514,9 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 {
     if ([self noBlogsAndNoWordPressDotComAccount]) {
         UIViewController *presenter = self.window.rootViewController;
-        if (presenter.presentedViewController) {
+        // Check if the presentedVC is UIAlertController because in iPad we show a Sign-out button in UIActionSheet
+        // and it's not dismissed before the check and `dismissViewControllerAnimated` does not work for it
+        if (presenter.presentedViewController && ![presenter.presentedViewController isKindOfClass:[UIAlertController class]]) {
             [presenter dismissViewControllerAnimated:animated completion:^{
                 [self showWelcomeScreenAnimated:animated thenEditor:NO];
             }];


### PR DESCRIPTION
In iPad we are showing a `UIActionSheet` for the Sign-out button and it acts as a `presentedViewController` for the `WPTabBarController`. Since we check `presentedViewController` and dismiss it in the `AppDelegate` before the login screen appears, that UIActionSheet was preventing login page from showing up. This case is now ignored and login page should appear even if the action sheet is not dismissed yet. Fixes #3114.

This was an interesting bug. I am not absolutely sure if this is the best way to prevent it. @jleandroperez Can I bother you with a review? Let me know if you have a better idea than checking for the `UIAlertController`.