### PR TITLE
Fix for private images

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -209,7 +209,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         _changedToEditModeDueToUnsavedChanges = changeToEditModeDueToUnsavedChanges;
         _post = post;
         
-        if (post.blog.isPrivate) {
+        if (post.blog.isWPcom) {
             [PrivateSiteURLProtocol registerPrivateSiteURLProtocol];
         }
     }


### PR DESCRIPTION
This should fix #3082.

The ```post.blog.isPrivate``` call was returning ```NO``` randomly when the user really was on a private site, thus causing the loading of private images to fail. This is most likely because the blog options dictionary is getting wiped out for some reason before isPrivate is called.

After discussions with @aerych, we decided the best course for now was to enable the PrivateSiteURLProtocol  for all .com blogs (and not .org blogs).

/cc @aerych for a quick review