### PR TITLE
Fixes a problem with a constraint.

### DIFF
--- a/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNew.m
+++ b/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNew.m
@@ -73,15 +73,13 @@
     
     WPBackgroundDimmerView* dimmerView = [[WPBackgroundDimmerView alloc] init];
     
-    UIWindow* keyWindow = [[UIApplication sharedApplication] keyWindow];
-    NSAssert([keyWindow isKindOfClass:[UIWindow class]],
-             @"We're expecting the application window to exist when this method is called.");
+    UIView *keyView = [self keyView];
     
-    [keyWindow addSubview:dimmerView];
+    [keyView addSubview:dimmerView];
     [dimmerView addSubview:whatsNewView];
     
-    [self configureConstraintsBetweenKeyWindow:keyWindow
-                                 andDimmerView:dimmerView];
+    [self configureConstraintsBetweenKeyView:keyView
+                               andDimmerView:dimmerView];
     
     [self configureConstraintsBetweenDimmerView:dimmerView
                                 andWhatsNewView:whatsNewView];
@@ -103,6 +101,31 @@
     [dimmerView showAnimated:YES completion:nil];
     [whatsNewView showAnimated:YES completion:nil];
 }
+
+#pragma mark - Key View
+
+/**
+ *  @brief      Gets the key view.
+ *  @details    The key view is the view the what's new dialog should be added to.  It's the first
+ *              subview of the key window.
+ *
+ *  @returns    The key view.
+ */
+- (UIView*)keyView
+{
+    UIWindow* keyWindow = [[UIApplication sharedApplication] keyWindow];
+    NSAssert([keyWindow isKindOfClass:[UIWindow class]],
+             @"We're expecting the application window to exist when this method is called.");
+    
+    NSAssert([keyWindow.subviews count] > 0,
+             @"We should only call this method when there's something on-screen.");
+    UIView* keyView = [keyWindow.subviews objectAtIndex:0];
+    NSAssert([keyView isKindOfClass:[UIView class]],
+             @"We're expecting to have a keyView at this point.");
+    
+    return keyView;
+}
+
 
 #pragma mark - Localizable data
 
@@ -221,17 +244,17 @@
     [dimmerView addConstraints:@[xAlignment, yAlignment]];
 }
 
-- (void)configureConstraintsBetweenKeyWindow:(UIWindow*)keyWindow
-                               andDimmerView:(WPBackgroundDimmerView*)dimmerView
+- (void)configureConstraintsBetweenKeyView:(UIView*)keyView
+                             andDimmerView:(WPBackgroundDimmerView*)dimmerView
 {
-    NSParameterAssert([keyWindow isKindOfClass:[UIWindow class]]);
+    NSParameterAssert([keyView isKindOfClass:[UIView class]]);
     NSParameterAssert([dimmerView isKindOfClass:[WPBackgroundDimmerView class]]);
-    NSAssert([keyWindow.subviews containsObject:dimmerView],
+    NSAssert([keyView.subviews containsObject:dimmerView],
              @"The key window should already contain the dimmer view at this point.");
     
     [dimmerView setTranslatesAutoresizingMaskIntoConstraints:NO];
     
-    NSLayoutConstraint* dimmerLeft = [NSLayoutConstraint constraintWithItem:keyWindow
+    NSLayoutConstraint* dimmerLeft = [NSLayoutConstraint constraintWithItem:keyView
                                                                   attribute:NSLayoutAttributeLeft
                                                                   relatedBy:NSLayoutRelationEqual
                                                                      toItem:dimmerView
@@ -239,7 +262,7 @@
                                                                  multiplier:1.0f
                                                                    constant:0.0f];
     
-    NSLayoutConstraint* dimmerRight = [NSLayoutConstraint constraintWithItem:keyWindow
+    NSLayoutConstraint* dimmerRight = [NSLayoutConstraint constraintWithItem:keyView
                                                                    attribute:NSLayoutAttributeRight
                                                                    relatedBy:NSLayoutRelationEqual
                                                                       toItem:dimmerView
@@ -247,7 +270,7 @@
                                                                   multiplier:1.0f
                                                                     constant:0.0f];
     
-    NSLayoutConstraint* dimmerTop = [NSLayoutConstraint constraintWithItem:keyWindow
+    NSLayoutConstraint* dimmerTop = [NSLayoutConstraint constraintWithItem:keyView
                                                                  attribute:NSLayoutAttributeTop
                                                                  relatedBy:NSLayoutRelationEqual
                                                                     toItem:dimmerView
@@ -255,7 +278,7 @@
                                                                 multiplier:1.0f
                                                                   constant:0.0f];
     
-    NSLayoutConstraint* dimmerBottom = [NSLayoutConstraint constraintWithItem:keyWindow
+    NSLayoutConstraint* dimmerBottom = [NSLayoutConstraint constraintWithItem:keyView
                                                                     attribute:NSLayoutAttributeBottom
                                                                     relatedBy:NSLayoutRelationEqual
                                                                        toItem:dimmerView
@@ -263,7 +286,7 @@
                                                                    multiplier:1.0f
                                                                      constant:0.0f];
 
-    [keyWindow addConstraints:@[dimmerLeft, dimmerRight, dimmerTop, dimmerBottom]];
+    [keyView addConstraints:@[dimmerLeft, dimmerRight, dimmerTop, dimmerBottom]];
 }
 
 @end

--- a/WordPress/Resources/WhatsNew/WPWhatsNewView.xib
+++ b/WordPress/Resources/WhatsNew/WPWhatsNewView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
@@ -74,11 +74,6 @@
                     </constraints>
                     <fontDescription key="fontDescription" name="OpenSans-Light" family="Open Sans" pointSize="15"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                    <variation key="default">
-                        <mask key="constraints">
-                            <exclude reference="d06-w8-7sQ"/>
-                        </mask>
-                    </variation>
                     <connections>
                         <outlet property="delegate" destination="iN0-l3-epB" id="vib-OP-dB5"/>
                     </connections>


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/512).

@bummytime - I opened [a separate issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/548) for the bug you reported about showing the onboarding tip on top of the state restored editor.

/cc @bummytime @SergioEstevao 