### PR TITLE
Show blog url when blog name is empty

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -42,7 +42,7 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     [self.blavatarImageView setImageWithBlavatarUrl:blog.blavatarUrl isWPcom:blog.isWPcom];
 
     // if the blog name is missing, we want to show the blog displayURL instead
-    [self.titleLabel setText:(blog.blogName ? blog.blogName : blog.displayURL)];
+    [self.titleLabel setText:((blog.blogName && !blog.blogName.isEmpty) ? blog.blogName : blog.displayURL)];
     [self.subtitleLabel setText:blog.displayURL];
 }
 


### PR DESCRIPTION
Fixes #3219.

![ios simulator screen shot feb 9 2015 19 57 43](https://cloud.githubusercontent.com/assets/662023/6112139/c6582a70-b096-11e4-8270-18d18e0b5358.png)

@jleandroperez Can I bother you with a review for a one-liner fix?