### PR TITLE
Fixes a restoration edge-case.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -15,6 +15,7 @@
 #import "WPUploadStatusButton.h"
 #import "WPTabBarController.h"
 #import "WPMediaProgressTableViewController.h"
+#import "WPPostViewController.h"
 #import "WPProgressTableViewCell.h"
 #import <AssetsLibrary/AssetsLibrary.h>
 #import <WordPress-iOS-Shared/UIImage+Util.h>
@@ -44,6 +45,11 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 + (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
 {
+    BOOL dontRestoreIfNewEditorIsEnabled = [WPPostViewController isNewEditorEnabled];
+    
+    if (dontRestoreIfNewEditorIsEnabled) {
+        return nil;
+    }
 
     if ([[identifierComponents lastObject] isEqualToString:WPLegacyEditorNavigationRestorationID]) {
         UINavigationController *navController = [[UINavigationController alloc] init];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -362,7 +362,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     return navController;
 }
 
-+ (UIViewController*)restoreViewControllerWithIdentifierPath:(NSArray*)identifierComponents
++ (UIViewController*)restoreViewControllerWithIdentifierPath:(NSArray *)identifierComponents
                                                        coder:(NSCoder *)coder
 {
     UIViewController *restoredViewController = nil;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -340,26 +340,30 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 															coder:(NSCoder *)coder
 {
     UIViewController* restoredViewController = nil;
-
-    if ([self isParentNavigationControllerIdentifierPath:identifierComponents]) {
-        
-        UINavigationController *navController = [[UINavigationController alloc] init];
-        navController.restorationIdentifier = WPEditorNavigationRestorationID;
-        navController.restorationClass = self;
-        
-        restoredViewController = navController;
-        
-    } else if ([self isSelfIdentifierPath:identifierComponents]) {
-        
-        AbstractPost* restoredPost = [self decodePostFromCoder:coder];
-        
-        if (restoredPost) {
-            WPPostViewControllerMode mode = [self decodeEditModeFromCoder:coder];
+    
+    BOOL restoreOnlyIfNewEditorIsEnabled = [WPPostViewController isNewEditorEnabled];
+    
+    if (restoreOnlyIfNewEditorIsEnabled) {
+        if ([self isParentNavigationControllerIdentifierPath:identifierComponents]) {
             
-            restoredViewController = [[self alloc] initWithPost:restoredPost
-                                                           mode:mode];
-        } else {
-            restoredViewController = [[self alloc] initInFailedStateRestorationMode];
+            UINavigationController *navController = [[UINavigationController alloc] init];
+            navController.restorationIdentifier = WPEditorNavigationRestorationID;
+            navController.restorationClass = self;
+            
+            restoredViewController = navController;
+            
+        } else if ([self isSelfIdentifierPath:identifierComponents]) {
+            
+            AbstractPost* restoredPost = [self decodePostFromCoder:coder];
+            
+            if (restoredPost) {
+                WPPostViewControllerMode mode = [self decodeEditModeFromCoder:coder];
+                
+                restoredViewController = [[self alloc] initWithPost:restoredPost
+                                                               mode:mode];
+            } else {
+                restoredViewController = [[self alloc] initInFailedStateRestorationMode];
+            }
         }
     }
     

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -344,27 +344,51 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     BOOL restoreOnlyIfNewEditorIsEnabled = [WPPostViewController isNewEditorEnabled];
     
     if (restoreOnlyIfNewEditorIsEnabled) {
-        if ([self isParentNavigationControllerIdentifierPath:identifierComponents]) {
-            
-            UINavigationController *navController = [[UINavigationController alloc] init];
-            navController.restorationIdentifier = WPEditorNavigationRestorationID;
-            navController.restorationClass = self;
-            
-            restoredViewController = navController;
-            
-        } else if ([self isSelfIdentifierPath:identifierComponents]) {
-            
-            AbstractPost* restoredPost = [self decodePostFromCoder:coder];
-            
-            if (restoredPost) {
-                WPPostViewControllerMode mode = [self decodeEditModeFromCoder:coder];
-                
-                restoredViewController = [[self alloc] initWithPost:restoredPost
-                                                               mode:mode];
-            } else {
-                restoredViewController = [[self alloc] initInFailedStateRestorationMode];
-            }
-        }
+        restoredViewController = [self restoreViewControllerWithIdentifierPath:identifierComponents
+                                                                         coder:coder];
+    }
+    
+    return restoredViewController;
+}
+
+#pragma mark - Restoration helpers
+
++ (UIViewController*)restoreParentNavigationController
+{
+    UINavigationController *navController = [[UINavigationController alloc] init];
+    navController.restorationIdentifier = WPEditorNavigationRestorationID;
+    navController.restorationClass = self;
+    
+    return navController;
+}
+
++ (UIViewController*)restoreViewControllerWithIdentifierPath:(NSArray*)identifierComponents
+                                                       coder:(NSCoder *)coder
+{
+    UIViewController *restoredViewController = nil;
+    
+    if ([self isParentNavigationControllerIdentifierPath:identifierComponents]) {
+        
+        restoredViewController = [self restoreParentNavigationController];
+    } else if ([self isSelfIdentifierPath:identifierComponents]) {
+        restoredViewController = [self restoreViewControllerWithCoder:coder];
+    }
+    
+    return restoredViewController;
+}
+
++ (UIViewController*)restoreViewControllerWithCoder:(NSCoder *)coder
+{
+    UIViewController *restoredViewController = nil;
+    AbstractPost *restoredPost = [self decodePostFromCoder:coder];
+    
+    if (restoredPost) {
+        WPPostViewControllerMode mode = [self decodeEditModeFromCoder:coder];
+        
+        restoredViewController = [[self alloc] initWithPost:restoredPost
+                                                       mode:mode];
+    } else {
+        restoredViewController = [[self alloc] initInFailedStateRestorationMode];
     }
     
     return restoredViewController;


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/560).

It seems there's some strange problem with the legacy restoration code, when the new editor is enabled.  In order to fix this issue in a secure manner I disabled the legacy editor restoration if the new editor should be used instead - the result is that the post will be saved as draft but the legacy editor window will not be restored.

/cc @SergioEstevao 