### PR TITLE
Added a temporary fix to prevent the Whats New dialog from showing multiple times.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -82,6 +82,13 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 @property (nonatomic, assign, readwrite) BOOL                           listeningForBlogChanges;
 @property (nonatomic, strong, readwrite) NSDate                         *applicationOpenedTime;
 
+/**
+ *  @brief      Flag that signals wether Whats New is on screen or not.
+ *  @details    Won't be necessary once WPWhatsNew is changed to inherit from UIViewController
+ *              https://github.com/wordpress-mobile/WordPress-iOS/issues/3218
+ */
+@property (nonatomic, assign, readwrite) BOOL                           isShowingWhatsNew;
+
 @end
 
 @implementation WordPressAppDelegate
@@ -1275,11 +1282,21 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
             if (!whatsNewAlreadyShown) {
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(WhatsNewShowDelay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                     
-                    WPWhatsNew* whatsNew = [[WPWhatsNew alloc] init];
-                    
-                    [whatsNew showWithDismissBlock:^{
-                        [userDefaults setBool:YES forKey:WhatsNewUserDefaultsKey];
-                    }];
+                    // TODO: this method should be improved to have a single method to know wether
+                    // the whats new popup should be shown or not.
+                    //
+                    // https://github.com/wordpress-mobile/WordPress-iOS/issues/3218
+                    //
+                    if (!self.isShowingWhatsNew) {
+                        self.isShowingWhatsNew = YES;
+                        
+                        WPWhatsNew* whatsNew = [[WPWhatsNew alloc] init];
+                        
+                        [whatsNew showWithDismissBlock:^{
+                            [userDefaults setBool:YES forKey:WhatsNewUserDefaultsKey];
+                            self.isShowingWhatsNew = NO;
+                        }];
+                    }
                 });
             }
         }

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -87,7 +87,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
  *  @details    Won't be necessary once WPWhatsNew is changed to inherit from UIViewController
  *              https://github.com/wordpress-mobile/WordPress-iOS/issues/3218
  */
-@property (nonatomic, assign, readwrite) BOOL                           isShowingWhatsNew;
+@property (nonatomic, assign, readwrite) BOOL                           wasWhatsNewShown;
 
 @end
 
@@ -1267,37 +1267,30 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
  */
 - (void)showWhatsNewIfNeeded
 {
-    BOOL userIsLoggedIn = ![self noBlogsAndNoWordPressDotComAccount];
-    
-    if (userIsLoggedIn) {
-        if ([self mustShowWhatsNewPopup]) {
-            
-            static NSString* const WhatsNewUserDefaultsKey = @"WhatsNewUserDefaultsKey";
-            static const CGFloat WhatsNewShowDelay = 1.0f;
-            
-            NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
-            
-            BOOL whatsNewAlreadyShown = [userDefaults boolForKey:WhatsNewUserDefaultsKey];
-            
-            if (!whatsNewAlreadyShown) {
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(WhatsNewShowDelay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                    
-                    // TODO: this method should be improved to have a single method to know wether
-                    // the whats new popup should be shown or not.
-                    //
-                    // https://github.com/wordpress-mobile/WordPress-iOS/issues/3218
-                    //
-                    if (!self.isShowingWhatsNew) {
-                        self.isShowingWhatsNew = YES;
+    if (!self.wasWhatsNewShown) {
+        BOOL userIsLoggedIn = ![self noBlogsAndNoWordPressDotComAccount];
+        
+        if (userIsLoggedIn) {
+            if ([self mustShowWhatsNewPopup]) {
+                
+                static NSString* const WhatsNewUserDefaultsKey = @"WhatsNewUserDefaultsKey";
+                static const CGFloat WhatsNewShowDelay = 1.0f;
+                
+                NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+                
+                BOOL whatsNewAlreadyShown = [userDefaults boolForKey:WhatsNewUserDefaultsKey];
+                
+                if (!whatsNewAlreadyShown) {
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(WhatsNewShowDelay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                        self.wasWhatsNewShown = YES;
                         
                         WPWhatsNew* whatsNew = [[WPWhatsNew alloc] init];
                         
                         [whatsNew showWithDismissBlock:^{
                             [userDefaults setBool:YES forKey:WhatsNewUserDefaultsKey];
-                            self.isShowingWhatsNew = NO;
                         }];
-                    }
-                });
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/3232).

The chosen fix is not the most elegant solution.  I added notes on how the whole code can be improved [in this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/3218).

/cc @bummytime 