### PR TITLE
Selecting image from photostream problems

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -81,7 +81,10 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
                                  stripGeoLocation:!geoLocationEnabled
                                 completionHandler:^(BOOL success, CGSize resultingSize, NSData * thumbnailData, NSError *error) {
         if (!success) {
-            completion(nil, error);
+            if (completion){
+                completion(nil, error);
+            }
+            return;
         }
         [self.managedObjectContext performBlock:^{
             

--- a/WordPress/Classes/Utility/WPAssetExporter.m
+++ b/WordPress/Classes/Utility/WPAssetExporter.m
@@ -43,7 +43,7 @@ const NSInteger WPAssetExportErrorCodeMissingAsset = 1;
 {
     if (!asset.defaultRepresentation) {
         if (handler) {
-            NSDictionary * userInfo = @{NSLocalizedDescriptionKey:NSLocalizedString(@"This image belongs to a Photo Stream and is not available at the moment to be added to your site. Try opening it full screen in the Photos app before trying to using it again.", @"Message that explains to a user that the current asset they selected is not available on the device. This normally happens when user selects a media that belogns to a photostream that needs to be downloaded locally first.")};
+            NSDictionary * userInfo = @{NSLocalizedDescriptionKey:NSLocalizedString(@"This Photo Stream image cannot be added to your WordPress. Try saving it to your Camera Roll before uploading.", @"Message that explains to a user that the current asset they selected is not available on the device. This normally happens when user selects a media that belogns to a photostream that needs to be downloaded locally first.")};
             NSError * error = [NSError errorWithDomain:WPAssetExportErrorDomain
                                                   code:WPAssetExportErrorCodeMissingAsset
                                               userInfo:userInfo];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1007,8 +1007,7 @@ static NSString *const TableViewProgressCellIdentifier = @"TableViewProgressCell
         strongSelf.featuredImageProgress.completedUnitCount++;
         if (error) {
             DDLogError(@"Couldn't export image: %@", [error localizedDescription]);
-            [WPError showAlertWithTitle:NSLocalizedString(@"Failed to export feature image", @"The title for an alert that says to the user that the featured image he selected couldn't be exported.") message:error.localizedDescription];
-            strongSelf.isUploadingMedia = NO;
+            [WPError showAlertWithTitle:NSLocalizedString(@"Image unavailable", @"The title for an alert that says to the user the media (image or video) he selected couldn't be used on the post.") message:error.localizedDescription];strongSelf.isUploadingMedia = NO;
             return;
         }
         media.mediaType = MediaTypeFeatured;
@@ -1113,6 +1112,11 @@ static NSString *const TableViewProgressCellIdentifier = @"TableViewProgressCell
     NSURL *assetURL = [info objectForKey:UIImagePickerControllerReferenceURL];
     ALAssetsLibrary *assetsLibrary = [[ALAssetsLibrary alloc] init];
     [assetsLibrary assetForURL:assetURL resultBlock:^(ALAsset *asset){
+        if (!asset.defaultRepresentation) {
+            [WPError showAlertWithTitle:NSLocalizedString(@"Image unavailable", @"The title for an alert that says the image the user selected isn't available.")
+                                message:NSLocalizedString(@"This Photo Stream image cannot be added to your WordPress. Try saving it to your Camera Roll before uploading.", @"User information explaining that the image is not available locally. This is normally related to share photo stream images.")  withSupportButton:NO];
+            return;
+        }
         [weakSelf uploadFeatureImage:asset];
         if (IS_IPAD) {
             [weakSelf.popover dismissPopoverAnimated:YES];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1007,7 +1007,8 @@ static NSString *const TableViewProgressCellIdentifier = @"TableViewProgressCell
         strongSelf.featuredImageProgress.completedUnitCount++;
         if (error) {
             DDLogError(@"Couldn't export image: %@", [error localizedDescription]);
-            [WPError showAlertWithTitle:NSLocalizedString(@"Image unavailable", @"The title for an alert that says to the user the media (image or video) he selected couldn't be used on the post.") message:error.localizedDescription];strongSelf.isUploadingMedia = NO;
+            [WPError showAlertWithTitle:NSLocalizedString(@"Image unavailable", @"The title for an alert that says to the user the media (image or video) he selected couldn't be used on the post.") message:error.localizedDescription];
+            strongSelf.isUploadingMedia = NO;
             return;
         }
         media.mediaType = MediaTypeFeatured;

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -1164,8 +1164,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     if ([asset valueForProperty:ALAssetPropertyType] == ALAssetTypePhoto) {
         // If the image is from a shared photo stream it may not be available locally to be used
         if (!asset.defaultRepresentation) {
-            [WPError showAlertWithTitle:NSLocalizedString(@"Cannot select this image", @"The title for an alert that says the image the user selected isn't available.")
-                                message:NSLocalizedString(@"This image belongs to a Photo Stream and is not available at the moment to be added to your site. Try opening it full screen in the Photos app before trying to using it again.", @"User information explaining that the image is not available locally. This is normally related to share photo stream images.") withSupportButton:NO];
+            [WPError showAlertWithTitle:NSLocalizedString(@"Image unavailable", @"The title for an alert that says the image the user selected isn't available.")
+                                message:NSLocalizedString(@"This Photo Stream image cannot be added to your WordPress. Try saving it to your Camera Roll before uploading.", @"User information explaining that the image is not available locally. This is normally related to share photo stream images.")  withSupportButton:NO];
             return NO;
         }
         if (picker.selectedAssets.count >= MaximumNumberOfPictures) {

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -2133,8 +2133,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     if ([asset valueForProperty:ALAssetPropertyType] == ALAssetTypePhoto) {
         // If the image is from a shared photo stream it may not be available locally to be used
         if (!asset.defaultRepresentation) {
-            [WPError showAlertWithTitle:NSLocalizedString(@"Cannot select this image", @"The title for an alert that says the image the user selected isn't available.")
-                                message:NSLocalizedString(@"This image belongs to a Photo Stream and is not available at the moment to be added to your site. Try opening it full screen in the Photos app before trying to using it again.", @"User information explaining that the image is not available locally. This is normally related to share photo stream images.")  withSupportButton:NO];
+            [WPError showAlertWithTitle:NSLocalizedString(@"Image unavailable", @"The title for an alert that says the image the user selected isn't available.")
+                                message:NSLocalizedString(@"This Photo Stream image cannot be added to your WordPress. Try saving it to your Camera Roll before uploading.", @"User information explaining that the image is not available locally. This is normally related to share photo stream images.")  withSupportButton:NO];
             return NO;
         }
         if (picker.selectedAssets.count >= MaximumNumberOfPictures) {


### PR DESCRIPTION
This fix a bug where selecting a image from a photostream not available on the device make the app crash if trying to do it in self-hosted blog (using XML-RPC).

It also updates the error messages according to this: https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/567

cc @diegoreymendez, please review.