### PR TITLE
Fixes a problem with the Whats New popup.

### DIFF
--- a/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNew.m
+++ b/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNew.m
@@ -75,6 +75,8 @@
     
     UIView *keyView = [self keyView];
     
+    [keyView.superview endEditing:YES];
+    
     [keyView addSubview:dimmerView];
     [dimmerView addSubview:whatsNewView];
     


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/548).
Also mitigates [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/569) considerably, since it becomes a minor issue rather than a blocker.

If the Whats Up popup is shown on top of something with first responder status, its forced to resign it.

/cc @bummytime 