### PR TITLE
Fixing bug where we weren't properly aliasing new users in Mixpanel

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -118,12 +118,14 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
 - (void)aliasNewUser
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
-    WPAccount *account = [accountService defaultWordPressComAccount];
-    NSString *username = account.username;
-    
-    [[Mixpanel sharedInstance] createAlias:username forDistinctID:[Mixpanel sharedInstance].distinctId];
-    [[Mixpanel sharedInstance] identify:[Mixpanel sharedInstance].distinctId];
+    [context performBlockAndWait:^{
+        AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+        WPAccount *account = [accountService defaultWordPressComAccount];
+        NSString *username = account.username;
+        
+        [[Mixpanel sharedInstance] createAlias:username forDistinctID:[Mixpanel sharedInstance].distinctId];
+        [[Mixpanel sharedInstance] identify:[Mixpanel sharedInstance].distinctId];
+    }];
 }
 
 - (void)retrieveAndRegisterEmailAddressIfApplicable

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -115,6 +115,17 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
     [self retrieveAndRegisterEmailAddressIfApplicable];
 }
 
+- (void)aliasNewUser
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+    WPAccount *account = [accountService defaultWordPressComAccount];
+    NSString *username = account.username;
+    
+    [[Mixpanel sharedInstance] createAlias:username forDistinctID:[Mixpanel sharedInstance].distinctId];
+    [[Mixpanel sharedInstance] identify:[Mixpanel sharedInstance].distinctId];
+}
+
 - (void)retrieveAndRegisterEmailAddressIfApplicable
 {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
@@ -504,6 +515,7 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
             [instructions setCurrentDateForPeopleProperty:@"$created"];
             [instructions addSuperPropertyToFlag:@"created_account_on_mobile"];
             [instructions setSuperProperty:@"created_account_on_app_version" toValue:[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"]];
+            [self aliasNewUser];
             break;
         case WPAnalyticsStatEditorEnabledNewVersion:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Enabled New Version"];


### PR DESCRIPTION
We weren't properly aliasing new users before so when a user would create an account we'd always lose that event in any funnel because it would be associated with the randomly generated id Mixpanel would assign them. 

cc @astralbodies 