### PR TITLE
Add timezone to blog sync and fix options retrieval so it works.

### DIFF
--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -89,6 +89,8 @@
                                     @"image_default_link_type",
                                     @"software_version",
                                     @"videopress_enabled",
+                                    @"timezone",
+                                    @"gmt_offset"
                                     ];
 
         for (NSString *key in optionsDirectMapKeys) {

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -606,8 +606,8 @@ NSString *const LastUsedBlogURLDefaultsKey = @"LastUsedBlogURLDefaultsKey";
 
 - (NSTimeZone *)timeZoneForBlog:(Blog *)blog
 {
-    NSString *timeZoneName = [blog.options stringForKey:@"timezone"];
-    NSNumber *gmtOffSet = [blog.options numberForKey:@"gmt_offset"];
+    NSString *timeZoneName = [blog getOptionValue:@"timezone"];
+    NSNumber *gmtOffSet = [blog getOptionValue:@"gmt_offset"];
     id optionValue = [blog getOptionValue:@"time_zone"];
     
     NSTimeZone *timeZone = nil;

--- a/WordPress/WordPressTest/BlogServiceTest.m
+++ b/WordPress/WordPressTest/BlogServiceTest.m
@@ -103,7 +103,7 @@
 
 - (void)testTimeZoneForBlogRESTTimeZoneOption
 {
-    self.blog.options = @{ @"timezone" : @"America/Chicago" };
+    self.blog.options = @{ @"timezone" : @{ @"value" : @"America/Chicago" }};
     
     NSTimeZone *timeZone = [self.blogService timeZoneForBlog:self.blog];
     
@@ -113,7 +113,7 @@
 
 - (void)testTimeZoneForBlogRESTGMTOffsetOption
 {
-    self.blog.options = @{ @"gmt_offset" : @-5 };
+    self.blog.options = @{ @"gmt_offset" : @{ @"value" : @-5 }};
     
     NSTimeZone *timeZone = [self.blogService timeZoneForBlog:self.blog];
     


### PR DESCRIPTION
Fixes #3266 

Adds timezone and gmt_offset to REST API call and properly retrieves the value from the gnarly options dictionary.