### PR TITLE
Me page sign-in/out label and section header changed

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -268,7 +268,8 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
 
             if (defaultAccount) {
                 // Present the Sign out ActionSheet
-                NSString *signOutTitle = NSLocalizedString(@"You are logged in as %@", @"");
+                NSString *signOutTitle = NSLocalizedString(@"Signing out removes all of your sites associated with %@",
+                                                           @"Label for disconnecting WordPress.com account. The %@ is a placeholder for the user's screen name.");
                 signOutTitle = [NSString stringWithFormat:signOutTitle, [defaultAccount username]];
                 UIActionSheet *actionSheet;
                 actionSheet = [[UIActionSheet alloc] initWithTitle:signOutTitle

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -17,6 +17,7 @@
 #import "WPAccount.h"
 #import "LoginViewController.h"
 #import <WordPress-iOS-Shared/WPTableViewCell.h>
+#import <WordPress-iOS-Shared/WPTableViewSectionHeaderView.h>
 #import "HelpshiftUtils.h"
 
 const typedef enum {
@@ -200,22 +201,43 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
             AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
             WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
 
-            cell.textLabel.textAlignment = NSTextAlignmentCenter;
             cell.accessoryType = UITableViewCellAccessoryNone;
 
             if (defaultAccount) {
-                NSString *signOutString = NSLocalizedString(@"Sign Out", @"Sign out from WordPress.com");
+                NSString *signoutFromAccunt = [NSString stringWithFormat:@"Unlink %@", defaultAccount.username];
+                NSString *signOutString = NSLocalizedString(signoutFromAccunt, @"Sign out from WordPress.com");
                 cell.textLabel.text = signOutString;
                 cell.accessibilityIdentifier = signOutString;
             }
             else {
-                NSString *signInString = NSLocalizedString(@"Sign In", @"Sign in to WordPress.com");
+                NSString *signInString = NSLocalizedString(@"Sign in to WordPress.com", @"Sign in to WordPress.com");
                 cell.textLabel.text = signInString;
                 cell.accessibilityIdentifier = signInString;
             }
         }
     }
     return cell;
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+{
+    WPTableViewSectionHeaderView *header = [[WPTableViewSectionHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 0)];
+    header.title = [self titleForHeaderInSection:section];
+    return header;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    NSString *title = [self titleForHeaderInSection:section];
+    return [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
+}
+
+- (NSString *)titleForHeaderInSection:(NSInteger)section
+{
+    if (section == MeSectionWpCom) {
+        return NSLocalizedString(@"WORDPRESS.COM LINKED ACCOUNT", @"WordPress.com sign-in/sign-out section header title");
+    }
+    return nil;
 }
 
 #pragma mark - UITableViewDelegate methods

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -201,16 +201,18 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
             AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
             WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
 
+            cell.textLabel.textAlignment = NSTextAlignmentCenter;
             cell.accessoryType = UITableViewCellAccessoryNone;
 
             if (defaultAccount) {
-                NSString *signoutFromAccunt = [NSString stringWithFormat:@"Unlink %@", defaultAccount.username];
-                NSString *signOutString = NSLocalizedString(signoutFromAccunt, @"Sign out from WordPress.com");
+                NSString *signOutString = NSLocalizedString(@"Disconnect from WordPress.com",
+                                                            @"Label for disconnecting from WordPress.com account");
                 cell.textLabel.text = signOutString;
                 cell.accessibilityIdentifier = signOutString;
             }
             else {
-                NSString *signInString = NSLocalizedString(@"Sign in to WordPress.com", @"Sign in to WordPress.com");
+                NSString *signInString = NSLocalizedString(@"Connect to WordPress.com Account",
+                                                           @"Label for connecting to WordPress.com account");
                 cell.textLabel.text = signInString;
                 cell.accessibilityIdentifier = signInString;
             }
@@ -235,7 +237,7 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
 - (NSString *)titleForHeaderInSection:(NSInteger)section
 {
     if (section == MeSectionWpCom) {
-        return NSLocalizedString(@"WORDPRESS.COM LINKED ACCOUNT", @"WordPress.com sign-in/sign-out section header title");
+        return NSLocalizedString(@"WordPress.com Account", @"WordPress.com sign-in/sign-out section header title");
     }
     return nil;
 }


### PR DESCRIPTION
We wanted to make it more obvious that when you sign-out, you're actually signing out from your main WordPress.com account. So, we (with Davide) have came up with this design: https://cloudup.com/cyju4iomQb2

I am a little concerned about the "link" phrase but don't really have a better suggestion. @aerych May I bother you with a review?

Closes #3265.

/cc @astralbodies 