### PR TITLE
Show no connection error & push web view for stats

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -27,17 +27,17 @@ pod 'Helpshift', '~>4.8.0'
 pod 'CTAssetsPickerController', '~> 2.7.0'
 pod 'WordPress-iOS-Shared', '0.2.0'
 pod 'WordPress-iOS-Editor', :git => 'git://github.com/wordpress-mobile/WordPress-Editor-iOS', :commit => 'c7a2ef6ef77e892bba430efd923592f4d6200d00'
-pod 'WordPressCom-Stats-iOS', :git => 'git://github.com/wordpress-mobile/WordPressCom-Stats-iOS', :commit => 'fe29b5d6000b5a01037d130e65c870985b60363b'
+pod 'WordPressCom-Stats-iOS', :git => 'git://github.com/wordpress-mobile/WordPressCom-Stats-iOS', :commit => 'bd37321189ad3de9343cb2761d6ec5fbef06c72a'
 pod 'WordPressCom-Analytics-iOS', '0.0.25'
 pod 'NSObject-SafeExpectations', '0.0.2'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'Simperium', '0.7.8'
 pod 'Lookback', '0.9.2', :configurations => ['Release-Internal']
-pod "WordPress-AppbotX", :git => "https://github.com/wordpress-mobile/appbotx.git", :commit => "303b8068530389ea87afde38b77466d685fe3210"
+pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '303b8068530389ea87afde38b77466d685fe3210'
 pod 'MRProgress', '~>0.7.0'
 
 target 'WordPressTodayWidget', :exclusive => true do
-    pod 'WordPressCom-Stats-iOS', :git => 'git://github.com/wordpress-mobile/WordPressCom-Stats-iOS', :commit => 'fe29b5d6000b5a01037d130e65c870985b60363b'
+    pod 'WordPressCom-Stats-iOS', :git => 'git://github.com/wordpress-mobile/WordPressCom-Stats-iOS', :commit => 'bd37321189ad3de9343cb2761d6ec5fbef06c72a'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -152,7 +152,7 @@ DEPENDENCIES:
   - WordPress-iOS-Shared (= 0.2.0)
   - WordPressApi (~> 0.3.1)
   - WordPressCom-Analytics-iOS (= 0.0.25)
-  - WordPressCom-Stats-iOS (from `git://github.com/wordpress-mobile/WordPressCom-Stats-iOS`, commit `fe29b5d6000b5a01037d130e65c870985b60363b`)
+  - WordPressCom-Stats-iOS (from `git://github.com/wordpress-mobile/WordPressCom-Stats-iOS`, commit `bd37321189ad3de9343cb2761d6ec5fbef06c72a`)
   - wpxmlrpc (~> 0.7)
 
 EXTERNAL SOURCES:
@@ -174,7 +174,7 @@ EXTERNAL SOURCES:
     :commit: c7a2ef6ef77e892bba430efd923592f4d6200d00
     :git: git://github.com/wordpress-mobile/WordPress-Editor-iOS
   WordPressCom-Stats-iOS:
-    :commit: fe29b5d6000b5a01037d130e65c870985b60363b
+    :commit: bd37321189ad3de9343cb2761d6ec5fbef06c72a
     :git: git://github.com/wordpress-mobile/WordPressCom-Stats-iOS
 
 CHECKOUT OPTIONS:
@@ -194,7 +194,7 @@ CHECKOUT OPTIONS:
     :commit: c7a2ef6ef77e892bba430efd923592f4d6200d00
     :git: git://github.com/wordpress-mobile/WordPress-Editor-iOS
   WordPressCom-Stats-iOS:
-    :commit: fe29b5d6000b5a01037d130e65c870985b60363b
+    :commit: bd37321189ad3de9343cb2761d6ec5fbef06c72a
     :git: git://github.com/wordpress-mobile/WordPressCom-Stats-iOS
 
 SPEC CHECKSUMS:

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -36,6 +36,8 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+ 
+    self.view.backgroundColor = [WPStyleGuide itsEverywhereGrey];
     
     self.statsVC = [[UIStoryboard storyboardWithName:@"SiteStats" bundle:nil] instantiateInitialViewController];
     self.statsVC.statsDelegate = self;

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -56,11 +56,6 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 {
     _blog = blog;
     DDLogInfo(@"Loading Stats for the following blog: %@", [blog url]);
-    
-    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
-    if (!appDelegate.connectionAvailable) {
-        [self showNoResultsWithTitle:NSLocalizedString(@"No Connection", @"") message:NSLocalizedString(@"An active internet connection is required to view stats", @"")];
-    }
 }
 
 - (void)addStatsViewControllerToView
@@ -78,6 +73,12 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 - (void)initStats
 {
+    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
+    if (!appDelegate.connectionAvailable) {
+        [self showNoResultsWithTitle:NSLocalizedString(@"No Connection", @"") message:NSLocalizedString(@"An active internet connection is required to view stats", @"")];
+        return;
+    }
+
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -3,6 +3,7 @@
 #import "WordPressAppDelegate.h"
 #import "JetpackSettingsViewController.h"
 #import "StatsWebViewController.h"
+#import "WPChromelessWebViewController.h"
 #import "WPAccount.h"
 #import "ContextManager.h"
 #import "BlogService.h"
@@ -143,6 +144,14 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 {
     StatsWebViewController *vc = [[StatsWebViewController alloc] init];
     vc.blog = self.blog;
+    [self.navigationController pushViewController:vc animated:YES];
+}
+
+
+- (void)statsViewController:(WPStatsViewController *)controller openURL:(NSURL *)url
+{
+    WPChromelessWebViewController *vc = [[WPChromelessWebViewController alloc] init];
+    [vc loadPath:url.absoluteString];
     [self.navigationController pushViewController:vc animated:YES];
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -10,6 +10,7 @@
 #import "SFHFKeychainUtils.h"
 #import "TodayExtensionService.h"
 #import <WPStatsViewController.h>
+#import <WPNoResultsView.h>
 
 static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
@@ -17,6 +18,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 @property (nonatomic, assign) BOOL showingJetpackLogin;
 @property (nonatomic, strong) WPStatsViewController *statsVC;
+@property (nonatomic, weak) WPNoResultsView *noResultsView;
 
 @end
 
@@ -56,7 +58,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     
     WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
     if (!appDelegate.connectionAvailable) {
-//        [self showNoResultsWithTitle:NSLocalizedString(@"No Connection", @"") message:NSLocalizedString(@"An active internet connection is required to view stats", @"")];
+        [self showNoResultsWithTitle:NSLocalizedString(@"No Connection", @"") message:NSLocalizedString(@"An active internet connection is required to view stats", @"")];
     }
 }
 
@@ -165,6 +167,15 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     if (self.dismissBlock) {
         self.dismissBlock();
     }
+}
+
+
+- (void)showNoResultsWithTitle:(NSString *)title message:(NSString *)message
+{
+    [self.noResultsView removeFromSuperview];
+    WPNoResultsView *noResultsView = [WPNoResultsView noResultsViewWithTitle:title message:message accessoryView:nil buttonTitle:nil];
+    self.noResultsView = noResultsView;
+    [self.view addSubview:self.noResultsView];
 }
 
 


### PR DESCRIPTION
1. Show connection error message as was done before 0.2.0.
2. Push chromeless web view when a URL is loaded from stats UI instead of launching out to Safari.
3. Resolved iOS 7 loading problems with Storyboard and call made to NSCalendar that doesn't exist until iOS 8.