### PR TITLE
User can close a new, empty post without a warning

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -277,6 +277,7 @@
     AbstractPost *original = (AbstractPost *)self.original;
     
     // We need the extra check since [nil isEqual:nil] returns NO
+    // and because @"" != nil
     if (!([self.postTitle length] == 0 && [original.postTitle length] == 0)
         && (![self.postTitle isEqualToString:original.postTitle])) {
         return YES;

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -279,7 +279,7 @@
     // We need the extra check since [nil isEqual:nil] returns NO
     // and because @"" != nil
     if (!([self.postTitle length] == 0 && [original.postTitle length] == 0)
-        && (![self.postTitle isEqualToString:original.postTitle])) {
+        && (![self.postTitle isEqual:original.postTitle])) {
         return YES;
     }
     

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -277,27 +277,33 @@
     AbstractPost *original = (AbstractPost *)self.original;
     
     // We need the extra check since [nil isEqual:nil] returns NO
-    if ((self.postTitle != original.postTitle) && (![self.postTitle isEqual:original.postTitle])) {
+    if (!([self.postTitle length] == 0 && [original.postTitle length] == 0)
+        && (![self.postTitle isEqualToString:original.postTitle])) {
         return YES;
     }
     
-    if ((self.content != original.content) && (![self.content isEqual:original.content])) {
+    if (!([self.content length] == 0 && [original.content length] == 0)
+        && (![self.content isEqual:original.content])) {
         return YES;
     }
     
-    if ((self.status != original.status) && (![self.status isEqual:original.status])) {
+    if (!([self.status length] == 0 && [original.status length] == 0)
+        && (![self.status isEqual:original.status])) {
         return YES;
     }
     
-    if ((self.password != original.password) && (![self.password isEqual:original.password])) {
+    if (!([self.password length] == 0 && [original.password length] == 0)
+        && (![self.password isEqual:original.password])) {
         return YES;
     }
     
-    if ((self.dateCreated != original.dateCreated) && (![self.dateCreated isEqual:original.dateCreated])) {
+    if ((self.dateCreated != original.dateCreated)
+        && (![self.dateCreated isEqual:original.dateCreated])) {
         return YES;
     }
     
-    if ((self.permaLink != original.permaLink) && (![self.permaLink  isEqual:original.permaLink])) {
+    if (!([self.permaLink length] == 0 && [original.permaLink length] == 0)
+        && (![self.permaLink isEqual:original.permaLink])) {
         return YES;
     }
     

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -824,7 +824,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     [self.editorView saveSelection];
     [self.editorView.focusedField blur];
 	
-    if ([self.post hasUnsavedChanges]) {
+    if ([self.post hasLocalChanges]) {
         [self showPostHasChangesActionSheet];
     } else {
         [self stopEditing];


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/531

This PR fixes a few minor logic flaws in ```AbstractPost.hasLocalChanges``` and also now calls ```hasLocalChanges ``` in ```cancelEditing``` because ```hasUnsavedChanges``` will always return YES on new, empty posts.

/cc @SergioEstevao for PR review please and thank you! :-)

