### PR TITLE
Adding scripts for screenshot generation/upload

### DIFF
--- a/Scripts/fastlane/.gitignore
+++ b/Scripts/fastlane/.gitignore
@@ -1,0 +1,2 @@
+screenshots
+*.itmsp

--- a/Scripts/fastlane/Deliverfile
+++ b/Scripts/fastlane/Deliverfile
@@ -1,0 +1,80 @@
+load "wordpress_translation_retrieval.rb"
+#
+# For more information about each property, visit the GitHub documentation: https://github.com/krausefx/deliver
+# Everything next to a # is a comment and will be ignored
+
+# hide_transporter_output # remove the '#' in the beginning of the line, to hide the output while uploading
+
+########################################
+# App Metadata
+########################################
+
+# This folder has to include one folder for each language
+# More information about automatic screenshot upload: 
+# https://github.com/KrauseFx/deliver#upload-screenshots-to-itunes-connect
+screenshots_path "./screenshots/"
+app_identifier "org.wordpress"
+
+# Make sure to update these keys for a new version
+version "4.8"
+glotpress_whats_new_key = "v4.8-whats-new"
+
+changelog({
+    "en-US" => WordPressTranslationRetrieval.get_version_text("en-US", glotpress_whats_new_key),
+    "en-CA" => WordPressTranslationRetrieval.get_version_text("en-CA", glotpress_whats_new_key),
+    "en-AU" => WordPressTranslationRetrieval.get_version_text("en-AU", glotpress_whats_new_key),
+    "es-ES" => WordPressTranslationRetrieval.get_version_text("es-ES", glotpress_whats_new_key),
+    "fr-FR" => WordPressTranslationRetrieval.get_version_text("fr-FR", glotpress_whats_new_key),
+    "it-IT" => WordPressTranslationRetrieval.get_version_text("it-IT", glotpress_whats_new_key),
+    "ja-JP" => WordPressTranslationRetrieval.get_version_text("ja-JP", glotpress_whats_new_key),
+    "sv-SE" => WordPressTranslationRetrieval.get_version_text("sv-SE", glotpress_whats_new_key),
+    "pt-BR" => WordPressTranslationRetrieval.get_version_text("pt-BR", glotpress_whats_new_key),
+    "nl-NL" => WordPressTranslationRetrieval.get_version_text("nl-NL", glotpress_whats_new_key),
+    "de-DE" => WordPressTranslationRetrieval.get_version_text("de-DE", glotpress_whats_new_key),
+    "id-ID" => WordPressTranslationRetrieval.get_version_text("id-ID", glotpress_whats_new_key),
+    "ko-KR" => WordPressTranslationRetrieval.get_version_text("ko-KR", glotpress_whats_new_key),
+    "ru-RU" => WordPressTranslationRetrieval.get_version_text("ru-RU", glotpress_whats_new_key),
+    "cmn-Hans" => WordPressTranslationRetrieval.get_version_text("cmn-Hans", glotpress_whats_new_key),
+    "th-TH" => WordPressTranslationRetrieval.get_version_text("th-TH", glotpress_whats_new_key),
+    "cmn-Hant" => WordPressTranslationRetrieval.get_version_text("cmn-Hant", glotpress_whats_new_key),
+    "tr-TR" => WordPressTranslationRetrieval.get_version_text("tr-TR", glotpress_whats_new_key),
+    "en-GB" => WordPressTranslationRetrieval.get_version_text("en-GB", glotpress_whats_new_key),
+})
+
+# version '1.2' # you can pass this if you want to verify the version number with the ipa file
+
+config_json_folder './deliver'
+
+########################################
+# Building and Testing
+########################################
+
+# Dynamic generation of the ipa file
+# I'm using Shenzhen by Mattt, but you can use any build tool you want
+# Remove the whole block if you do not want to upload an ipa file
+# ipa do
+    # Add any code you want, like incrementing the build 
+    # number or changing the app identifier
+
+    # Attention: When you return a valid ipa file, this file will get uploaded and released
+    # If you only want to upload app metadata, remove the complete ipa block.
+
+    # system("ipa build --verbose") # build your project using Shenzhen
+    "./WordPress-Deliver-iOS.ipa" # Tell 'Deliver' where it can find the finished ipa file
+# end
+
+# ipa "./latest.ipa" # this can be used instead of the `do` block, if you prefer manually building the ipa file
+
+# beta_ipa do
+    # system("ipa build --verbose") # customize this to build beta version
+    # "./ad_hoc_build.ipa" # upload ipa file using `deliver --beta`
+# end
+
+# unit_tests do
+#   If you use fastlane (http://github.com/krausefx/fastlane), run the tests there
+#   system("xctool test")
+# end
+
+success do
+  # system("say 'Successfully deployed a new version.'")
+end

--- a/Scripts/fastlane/Snapfile
+++ b/Scripts/fastlane/Snapfile
@@ -1,0 +1,63 @@
+# Uncomment the lines below you want to change by removing the # in the beginning
+# Verify script has credentials
+
+script = File.read("shoot_the_screens.js")
+if script.include?("FILL-IN-USERNAME") || script.include?("FILL-IN-PASSWORD")
+  puts <<-eos
+
+Make sure to change the following lines:
+  var username = "FILL-IN-USERNAME";
+  var password = "FILL-IN-PASSWORD";
+
+  eos
+
+  raise "Invalid Script File"
+end
+
+# A list of devices you want to take the screenshots from
+devices([
+  "iPhone 6",
+  "iPhone 6 Plus",
+  "iPhone 5",
+  "iPhone 4s",
+  "iPad Air"
+])
+
+languages("en-US en-CA en-AU es-ES fr-FR it-IT ja-JP sv-SE pt-BR nl-NL de-DE id-ID ko-KR ru-RU cmn-Hans th-TH cmn-Hant tr-TR en-GB".split(" "))
+
+# Where should the resulting screenshots be stored?
+screenshots_path "./screenshots"
+
+# clear_previous_screenshots # remove the '#'' to clear all previously generated screenshots before creating new ones
+
+# JavaScript UIAutomation file
+js_file './shoot_the_screens.js'
+
+# The name of the project's scheme
+scheme 'WordPress'
+
+# Where is your project (or workspace)? Provide the full path here
+project_path '../../WordPress.xcworkspace'
+
+# By default, the latest version should be used automatically. If you want to change it, do it here
+# ios_version '8.1'
+
+# Custom Callbacks
+
+# setup_for_device_change do |device| 
+#   puts "Preparing device: #{device}"
+# end
+
+# setup_for_language_change do |lang, device|
+#   puts "Running #{lang} on #{device}"
+#   system("./popuplateDatabase.sh")
+# end
+
+# teardown_language do |lang, device|
+#   puts "Finished with #{lang} on #{device}"
+# end
+
+# teardown_device do |device|
+#   puts "Cleaning device #{device}"
+#   system("./cleanup.sh")
+# end

--- a/Scripts/fastlane/SnapshotHelper.js
+++ b/Scripts/fastlane/SnapshotHelper.js
@@ -1,0 +1,58 @@
+function wait_for_loading_indicator_to_be_finished()
+{
+  try {
+    re = UIATarget.localTarget().frontMostApp().statusBar().elements()[2].rect()
+    re2 = UIATarget.localTarget().frontMostApp().statusBar().elements()[3].rect()
+    while ((re['size']['width'] == 10 && re['size']['height'] == 20) ||
+           (re2['size']['width'] == 10 && re2['size']['height'] == 20))
+     {
+      UIALogger.logMessage("Loading indicator is visible... waiting")
+      UIATarget.localTarget().delay(1)
+      re = UIATarget.localTarget().frontMostApp().statusBar().elements()[2].rect()
+      re2 = UIATarget.localTarget().frontMostApp().statusBar().elements()[3].rect()
+    }
+  } catch (e) {}
+}
+
+function captureLocalizedScreenshot(name) {
+  wait_for_loading_indicator_to_be_finished();
+
+  var target = UIATarget.localTarget();
+  var model = target.model();
+  var rect = target.rect();
+  var deviceOrientation = target.deviceOrientation();
+  
+  var theSize = (rect.size.width > rect.size.height) ? rect.size.width.toFixed() : rect.size.height.toFixed();
+
+  if (model.match(/iPhone/)) 
+  {
+    if (theSize > 667) {
+      model = "iPhone6Plus";
+    } else if (theSize == 667) {
+      model = "iPhone6";
+    } else if (theSize == 568){
+      model = "iPhone5";
+    } else {
+    model = "iPhone4";
+    }
+  } 
+  else 
+  {
+    model = "iOS-iPad";
+  }
+
+  var orientation = "portrait";
+  if (deviceOrientation == UIA_DEVICE_ORIENTATION_LANDSCAPELEFT) {
+    orientation = "landscapeleft";
+  } else if (deviceOrientation == UIA_DEVICE_ORIENTATION_LANDSCAPERIGHT) {
+    orientation = "landscaperight";
+  } else if (deviceOrientation == UIA_DEVICE_ORIENTATION_PORTRAIT_UPSIDEDOWN) {
+    orientation = "portrait_upsidedown";
+  }
+
+  var result = target.host().performTaskWithPathArgumentsTimeout("/usr/bin/printenv" , ["SNAPSHOT_LANGUAGE"], 5);
+  var language = result.stdout.substring(0, result.stdout.length - 1);
+
+  var parts = [language, model, name, orientation];
+  target.captureScreenWithName(parts.join("-"));
+}

--- a/Scripts/fastlane/deliver/metadata.json
+++ b/Scripts/fastlane/deliver/metadata.json
@@ -1,0 +1,341 @@
+{
+  "de-DE": {
+    "title": "WordPress",
+    "description": "Der Geistesblitz schlägt ein – jederzeit, überall. Verwalte deinen WordPress-Blog oder deine Website über dein iOS-Gerät von unterwegs: Zeige deine Statistiken an, moderiere Kommentare, erstelle und bearbeite Beiträge und Seiten, und lade Medien hoch. Alles, was du dafür benötigst, ist ein Blog bei WordPress.com oder eine selbst gehostete WordPress-Website, die unter Version 3.6 oder höher läuft.\n\nMit WordPress für iOS liegt das Veröffentlichen von Inhalten direkt in deiner Hand. Entwirf ein spontanes Haiku im Zug. Mache einen Schnappschuss bei einem Nachmittagsspaziergang für den Fotowettbewerb deiner Tageszeitung in der kommenden Woche. Antworte auf die neuesten Kommentare, oder überwache deine Statistiken, um zu sehen, woher die Leser heute kommen.\n\nVergiss nicht, die von der App veröffentlichten Beiträge mit #wponthego zu markieren, damit deine unterwegs von dir veröffentlichten Meisterwerke von anderen gefunden werden können.\n\nWordPress für iOS ist ein Open Source-Projekt. Auch du kannst dich demnach an der Entwicklung beteiligen. Weitere Informationen erhältst du unter http://ios.wordpress.org.\n\nDu benötigst Hilfe mit der App? Besuche die Foren unter http://ios.forums.wordpress.org, oder twittere uns @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social networking",
+      "blogging",
+      "blogs",
+      "photos",
+      "writing",
+      "geotagging",
+      "media",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "en-AU": {
+    "title": "WordPress",
+    "description": "Inspiration strikes — anytime, anywhere. Manage your WordPress blog or website on the go, from your iOS device: view your stats, moderate comments, create and edit posts and pages, and upload media. All you need is a WordPress.com blog or a self-hosted WordPress.org site running 3.6 or higher.\n\nWith WordPress for iOS, you have the power of publishing in the palm of your hand. Draft a spontaneous haiku on the train. Snap a photo on an afternoon stroll for the week’s photo challenge at The Daily Post. Respond to your latest comments, or monitor your stats to see where today’s readers are coming from.\n\nDon’t forget to tag your posts published from the app with #wponthego so the community can find your masterpieces on the move.\n\nWordPress for iOS is an Open Source project, which means you, too, can help contribute to its development. Learn more at http://ios.wordpress.org.\n\nNeed help with the app? Visit the forums at http://ios.forums.wordpress.org or tweet us @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social networking",
+      "blogging",
+      "blogs",
+      "photos",
+      "writing",
+      "geotagging",
+      "media",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "en-CA": {
+    "title": "WordPress",
+    "description": "Inspiration strikes — anytime, anywhere. Manage your WordPress blog or website on the go, from your iOS device: view your stats, moderate comments, create and edit posts and pages, and upload media. All you need is a WordPress.com blog or a self-hosted WordPress.org site running 3.6 or higher.\n\nWith WordPress for iOS, you have the power of publishing in the palm of your hand. Draft a spontaneous haiku on the train. Snap a photo on an afternoon stroll for the week’s photo challenge at The Daily Post. Respond to your latest comments, or monitor your stats to see where today’s readers are coming from.\n\nDon’t forget to tag your posts published from the app with #wponthego so the community can find your masterpieces on the move.\n\nWordPress for iOS is an Open Source project, which means you, too, can help contribute to its development. Learn more at http://ios.wordpress.org.\n\nNeed help with the app? Visit the forums at http://ios.forums.wordpress.org or tweet us @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social networking",
+      "blogging",
+      "blogs",
+      "photos",
+      "writing",
+      "geotagging",
+      "media",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "en-GB": {
+    "title": "WordPress",
+    "description": "Inspiration strikes — anytime, anywhere. Manage your WordPress blog or website on the go, from your iOS device: view your stats, moderate comments, create and edit posts and pages, and upload media. All you need is a WordPress.com blog or a self-hosted WordPress.org site running 3.6 or higher. With WordPress for iOS, you have the power of publishing in the palm of your hand. Draft a spontaneous haiku on the train. Snap a photo on an afternoon stroll for the week’s photo challenge at The Daily Post. Respond to your latest comments, or monitor your stats to see where today’s readers are coming from. Don’t forget to tag your posts published from the app with #wponthego so the community can find your masterpieces on the move. WordPress for iOS is an Open Source project, which means you, too, can help contribute to its development. Learn more at http://ios.wordpress.org. Need help with the app? Visit the forums at http://ios.forums.wordpress.org or tweet us @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social networking",
+      "blogging",
+      "blogs",
+      "photos",
+      "writing",
+      "geotagging",
+      "media",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "en-US": {
+    "title": "WordPress",
+    "description": "Inspiration strikes — anytime, anywhere. Manage your WordPress blog or website on the go, from your iOS device: view your stats, moderate comments, create and edit posts and pages, and upload media. All you need is a WordPress.com blog or a self-hosted WordPress.org site running 3.6 or higher.\n\nWith WordPress for iOS, you have the power of publishing in the palm of your hand. Draft a spontaneous haiku on the train. Snap a photo on an afternoon stroll for the week’s photo challenge at The Daily Post. Respond to your latest comments, or monitor your stats to see where today’s readers are coming from.\n\nDon’t forget to tag your posts published from the app with #wponthego so the community can find your masterpieces on the move.\n\nWordPress for iOS is an Open Source project, which means you, too, can help contribute to its development. Learn more at http://ios.wordpress.org.\n\nNeed help with the app? Visit the forums at http://ios.forums.wordpress.org or tweet us @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social networking",
+      "blogging",
+      "blogs",
+      "photos",
+      "writing",
+      "geotagging",
+      "media",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "es-ES": {
+    "title": "WordPress",
+    "description": "Es fácil gestionar tu blog o sitio de WordPress desde tu dispositivo iOS. Con WordPress para iOS puedes moderar comentarios, crear o editar entradas y páginas, ver estadísticas, y añadir images o vídeos fácilmente. Todo lo que necesitas es un blog en WordPress.com o en un alojamiento propio con WordPress 3.6 o superior\n\nWordPress para iOS es software libre. Puedes contribuir a su desarrollo en:\nhttp://ios.wordpress.org/.\n\nVisita el foro en http://ios.forums.wordpress.org para conseguir ayuda o envíanos un tweet a @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "Redes sociales",
+      "blogging",
+      "blogs",
+      "fotos",
+      "escribir",
+      "geolocalización",
+      "multimedia",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "fr-FR": {
+    "title": "WordPress",
+    "description": "Il est maintenant facile de gérer votre site ou blog WordPress depuis votre appareil iOS. Avec WordPress pour iOS, vous pouvez modérer vos commentaires, créer ou éditer des articles et pages, consulter vos statistiques, et ajouter des images et vidéos très simplement. Vous avez juste besoin d’un blog sur WordPress.com ou bien d’un blog WordPress auto-hébergé (version 3.6 minimum).\n\nWordPress pour iOS est un logiciel Open Source. Vous pouvez contribuer à son développement à cette adresse:\n\nhttp://ios.wordpress.org/\n\nSi vous avez besoin d’assistance (en anglais) pour cette application, rendez-vous sur le forum à l’adresse http://ios.forums.wordpress.org, ou envoyez un tweet à @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "réseau social",
+      "blogging",
+      "blogs",
+      "photos",
+      "écriture",
+      "géolocalisation",
+      "média",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "id-ID": {
+    "title": "WordPress",
+    "description": "Coretan inspirasi — kapan saja, di mana saja. Kelola blog WordPress Anda atau situs web Anda di mana saja, dari perangkat iOS Anda: lihat statistik, moderatori komentar, buat dan sunting kiriman dan halaman, serta unggah media. Semua yang ada butuhkan adalah blog WordPress.com atau situs WordPress.org yang Anda kelola sendiri yang menjalankan versi 3.6 atau lebih tinggi. Dengan WordPress untuk iOS, Anda memiliki kekuatan publikasi di jari tangan Anda. Buat draf haiku secara spontan selagi Anda sedang di kereta. Bidik foto selagi menikmati jalan-jalan sore untuk tantangan foto mingguan Anda di The Daily Post. Tanggapi komentar terbaru Anda, atau pantau statistik Anda untuk melihat berasal dari mana pembaca hari ini. Jangan lupa untuk menandai kiriman foto yang Anda publikasikan dari aplikasi dengan #wponthego sehingga komunitas dapat menemukan karya luar biasa Anda selagi dalam perjalanan. WordPress untuk iOS adalah proyek Sumber Terbuka, yang berarti Anda pun juga bisa memberikan kontribusi pengembangannya. Pelajari selengkapnya di http://ios.wordpress.org. Memerlukan bantuan berkaitan dengan aplikasi? Kunjungi forum di http://ios.forums.wordpress.org atau tweet kami @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social networking",
+      "blogging",
+      "blogs",
+      "photos",
+      "menulis",
+      "geotagging",
+      "media",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "it-IT": {
+    "title": "WordPress",
+    "description": "Gestire il tuo sito WordPress da un device Apple è da oggi ancora più semplice grazie a WordPress per iOS.\nCon WordPress per iOS è possibile moderare commenti, creare o editare articoli e pagine, visualizzare le statistiche del tuo sito, e condividere immagini e video con semplicità.\n\nTutto quello di cui hai bisogno è un blog su WordPress.com, oppure che il tuo sito sia stato creato con  WordPress.org 3.6 o superiore.\n\nWordPress per iOS è un progetto Open Source. Se desideri partecipare allo sviluppo di questa applicazione vieni a visitare il seguente sito: \nhttp://ios.wordpress.org/\n\nPer chiedere aiuto con l’applicazione visita il forum disponibile su http://ios.forums.wordpress.org, oppure invia un tweet a @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social network",
+      "blogging",
+      "blog",
+      "fotografie",
+      "scrittura",
+      "geotagging",
+      "media",
+      "wordpress"
+    ]
+  },
+  "ja-JP": {
+    "title": "WordPress",
+    "description": "WordPress ブログやサイトを iOS デバイスから管理するのは簡単です。WordPress for iOS アプリを使えばコメントの管理、投稿や固定ページの作成・編集、画像や動画の追加が楽にできます。WordPress.com レンタルブログ、またはバージョン 3.6 以降のインストール型 WordPress ブログに対応しています。\n\nWordPress for iOS はオープンソースプロジェクトです。開発に協力するには http://ios.wordpress.org/ をご覧ください。\n\nアプリに関するヘルプが必要な場合は http://ios.forums.wordpress.org をご利用いただくか、@WordPressiOS にツイートしてください。",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "ソーシャルネットワーキング",
+      "ブログ",
+      "写真",
+      "位置情報",
+      "メディア",
+      "wordpress"
+    ]
+  },
+  "ko-KR": {
+    "title": "WordPress",
+    "description": "영감은 언제 어디서나 떠오릅니다. 이동 중에 iOS 기기에서 WordPress 블로그 또는 웹사이트를 관리하세요. 통계 확인, 댓글 관리, 게시물 및 페이지 작성 및 편집 그리고 미디어를 업로드할 수 있습니다. 사용자는 3.6 버전 이상을 실행하는 WordPress.com 블로그 또는 독립 호스트 WordPress.org 사이트만 있으면 됩니다. iOS용 WordPress에서는 사용자가 직접 페이지에 게시할 수 있습니다. 기차로 여행하면서 즉흥적으로 짧은 시를 써 보세요. 오후 산책길에 사진을 찍어 The Daily Post의 이번 주 포토 챌린지에 올려보세요. 최근 댓글에 답글을 달거나, 통계를 모니터링하여 오늘 방문한 독자의 방문 경로를 확인해보세요. 앱에서 올린 게시물에 #wponthego 태그를 지정하면 커뮤니티에서 이동 중에 올린 작품을 쉽게 찾을 수 있습니다. iOS용 WordPress는 오픈 소스 프로젝트이므로 사용자도 개발에 참여할 수 있습니다. 자세한 내용은 http://ios.wordpress.org를 방문하세요. 앱 사용에 도움이 필요하세요? http://ios.forums.wordpress.org에서 포럼을 방문하거나 @WordPressiOS로 트윗하세요.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "소셜네트워크",
+      "블로깅",
+      "사진",
+      "글쓰기",
+      "지오태깅",
+      "미디어",
+      "워드프레스"
+    ]
+  },
+  "nl-NL": {
+    "title": "WordPress",
+    "description": "Inspiratie overkomt je — je weet nooit waar of wanneer. Vanaf je iOS-apparaat heb je altijd en overal toegang tot je WordPress-blog of -website; je kunt je statistieken bekijken, reageren op opmerkingen, berichten en pagina's maken en bewerken, en media uploaden. Je hebt alleen een WordPress.com-blog nodig of een eigen-gehoste WordPress.org-site waarop versie 3.6 of hoger wordt uitgevoerd. Met WordPress voor iOS heb je publicatiemogelijkheden in de palm van je hand. Schrijf een spontane haiku in de trein. Maak tijdens een ommetje een foto voor de wekelijkse fotowedstrijd van de krant. Reageer op de laatste opmerkingen of houd je statistieken in de gaten om te zien waar de lezers van vandaag vandaan komen. Vergeet je berichten die vanaf de app zijn gepubliceerd niet te taggen met #wponthego, zodat de community je artistieke creaties onderweg kan vinden. WordPress voor iOS is een Open Source-project; dat betekent dat ook jij kunt helpen bij de ontwikkeling ervan. Ga naar http://ios.wordpress.org voor meer informatie. Hulp nodig bij de app? Bezoek de forums op http://ios.forums.wordpress.org of twitter ons @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social networking",
+      "bloggen",
+      "blogs",
+      "foto's",
+      "schrijven",
+      "geotaggen",
+      "media",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "pt-BR": {
+    "title": "WordPress",
+    "description": "Às vezes a inspiração bate. Sem hora e sem lugar. Gerencie seu blog ou site do WordPress em movimento, usando seu aparelho iOS: verifique suas estatísticas, modere comentários, crie e edite posts e páginas, e faça upload de mídia. Tudo que você precisa é um blog do WordPress.com, ou um site auto-hospedado usando WordPress.org 3.7 ou superior. Com o WordPress para iOS, o poder de publicar está em suas mãos. Crie um haikai espontâneo quando estiver no ônibus ou no trem. Tire uma foto durante um passeio à tarde, e compartilhe com seus amigos. Responda aos seus últimos comentários ou monitore suas estatísticas para ver o que os leitores de hoje têm a dizer. Lembre-se de marcar seus posts no aplicativo com a tag #wponthego, para que outros possam encontrar suas publicações em movimento. O WordPress para iOS é um projeto de código aberto. Isso quer dizer que você também pode contribuir para seu desenvolvimento. Saiba mais em http://ios.wordpress.org. Precisa de ajuda com o aplicativo? Visite os fóruns em http://ios.forums.wordpress.org ou envie-nos um tweet @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social networking",
+      "blogging",
+      "blogs",
+      "photos",
+      "writing",
+      "geotagging",
+      "media",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "ru-RU": {
+    "title": "WordPress",
+    "description": "Вдохновение может прийти в любое время и в любом месте. Управляйте своим блогом или веб-сайтом WordPress на ходу, с устройства iOS: просматривайте статистику, модерируйте комментарии, создавайте и изменяйте сообщения и страницы, а также передавайте мультимедийные данные. Все, что для этого понадобится, — блог WordPress.com или резидентный сайт WordPress.org под управлением версии не ниже 3.6. Благодаря WordPress для iOS все возможности публикации оказываются прямо на вашей ладони. Набросать в поезде хайку, которое неожиданно сложилось в голове. Снять фото на дневной прогулке для еженедельного фотоконкурса в газете. Ответить на последние комментарии или посмотреть статистику, чтобы увидеть, откуда сегодня приходили читатели. Не забывайте помечать тегами #wponthego сообщения, опубликованные из приложения, чтобы ваше сообщество могло находить то, что создали на ходу. WordPress для iOS является проектом с открытым кодом, что позволяет и вам принять участие в разработке этой платформы. Дополнительные сведения см. по адресу http://ios.wordpress.org. Нужна помощь в использовании приложения? Посетите форумы по адресу http://ios.forums.wordpress.org или воспользуйтесь твиттером @WordPressiOS.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "социальные сети",
+      "блогинг",
+      "блоги",
+      "фото",
+      "написание",
+      "геопривязка",
+      "медиа",
+      "блог",
+      "wordpress"
+    ]
+  },
+  "sv-SE": {
+    "title": "WordPress",
+    "description": "Det är enkelt att uppdatera din WordPress-blogg från en iPhone, iPad, eller iPod Touch. Med WordPress för iOS kan du moderera kommentarer, skapa och ändra inlägg/sidor, se din statistik, och lägga till bilder samt video. Allt du behöver är en WordPress-blogg. Appen fungerar med WordPress 3.6 och högre.\n\nWordPress för iOS är ett Open Source-projekt. Du kan hjälpa till och utveckla appen på http://ios.wordpress.org/\n\nBesök forumet på http://ios.forums.wordpress.org eller twittra till @WordPressiOS för att få hjälp med appen.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "blogg",
+      "blog",
+      "blogga",
+      "bloggar",
+      "bloggläsare",
+      "foto",
+      "skriva",
+      "media",
+      "WordPress",
+      "hemsida",
+      "website",
+      "webbplats",
+      "reader"
+    ]
+  },
+  "th-TH": {
+    "title": "WordPress",
+    "description": "ทุกเมื่อที่เกิดแรงบันดาลใจ — ไม่ว่าจะเป็นที่ไหน เวลาใด คุณสามารถจัดการบล็อกเวิร์ดเพรสหรือเว็บไซต์ขณะกำลังเดินทางจากอุปกรณ์ iOS ของคุณ: ดูสถิติของคุณ จัดการความเห็น สร้างและแก้ไขเรื่องและหน้า และอัปโหลดไฟล์สื่อ สามารถทำได้ทั้งหมดไม่ว่าจะเป็นบล็อก WordPress.com หรือเว็บเวิร์ดเพรสที่ติดตั้งเองตั้งแต่รุ่น 3.6 ขึ้นไป ด้วยเวิร์ดเพรสสำหรับ iOS คุณก็มีความสามารถในการเผยแพร่เรื่องราวจากบนฝ่ามือของคุณ ไม่ว่าจะเป็นการเขียนบทกลอนสั้น ๆ เมื่ออยู่บนรถไฟ ถ่ายรูปเพื่อส่งประกวดรูปประจำสัปดาห์ที่เดย์ลี่โพสท์ เมื่อตอนคุณเดินเล่นยามบ่าย ตอบกลับความเห็นล่าสุดบนเว็บของคุณ หรือตรวจดูสถิติเว็ฐคุณเพื่อดูว่าผู้อ่านของคุณมาจากที่ไหนกันบ้าง อย่าลืมเพิ่มป้ายกำกับ #wponthego ให้กับเรื่องของคุณที่ทำการเผยแพร่จากแอพ เพื่อที่คนในชุมชนจะสามารถพบเรื่องของคุณที่บันทึกระหว่างการเดินทาง เวิร์ดเพรสสำหรับ iOS เป็นโครงการโอเพ่นซอร์ส ซึ่งหมายถึงคุณสามารถอุทิศตัวช่วยในการพัฒนาได้ เรื่อนรู้เพิ่มเติมได้ที่ http://ios.wordpress.org ต้องการความช่วยเหลือจากแอพ? เยี่ยมชมฟอรั่มที่ http://ios.forums.wordpress.org หรือทวีตหาเราที่ @WordPressiOS",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "แชร์เรื่องในเครือข่ายโซเชียล",
+      "เขียนบล็อก",
+      "บล็อก",
+      "รูปภาพ",
+      "การเขียน",
+      "ไฟล์สื่อ",
+      "บล็อก",
+      "เวิร์ดเพรส"
+    ]
+  },
+  "tr-TR": {
+    "title": "WordPress",
+    "description": "İlham geldiğinde aniden gelir. Yeri, zamanı hiç belli olmaz. WordPress blogunuzu veya web sitenizi iOS cihazınızdan hareket halindeyken yönetin: İstatistikleri görüntüleyin, yorumları yönetin, sayfalar ile iletileri oluşturup düzenleyin ve karşıya medya yükleyin. İhtiyacınız olan tek şey bir WordPress.com blogu ya da 3.6 veya daha yüksek sürümde çalışan bir kendini barındıran WordPress.org sitesi. WordPress for iOS ile yayımcılığın gücünü avucunuzda tutarsınız. Trende giderken hemen o anda bir haiku yazın. The Daily Post'taki haftanın fotoğrafı yarışması için akşamüzeri gezintinizde bir fotoğraf çekin. En son yorumlarınıza cevap verin veya bugünkü okuyucuların nereden geldiklerini görmek için durumunuzu takip edin. Topluluğun şaheserlerinizi hareket halindeyken de bulabilmeleri için uygulamadan yayımlanan iletilerinizi #wponthego ile etiketlemeyi unutmayın. WordPress for iOS bir Açık Kaynak projesidir; bu, geliştirilmesine sizin de yardımcı olabileceğiniz anlamına gelir. http://ios.wordpress.org adresinde daha fazlasını öğrenin. Uygulamayla ilgili yardım mı gerekli? http://ios.forums.wordpress.org adresinde forumları ziyaret edin veya @WordPressiOS adresinden bize tweet atın.",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social networking",
+      "blogging",
+      "blogs",
+      "photos",
+      "writing",
+      "geotagging",
+      "media",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "cmn-Hans": {
+    "title": "WordPress",
+    "description": "随时随地激发灵感。您可以在 iOS 设备上随心管理自己的 WordPress 博客或网站：查看统计数据、管好评论、创建和编辑文章和网页，以及上传媒体。您只需登录运行 3.6 或更高版本的 WordPress.com 博客或自托管 WordPress.org 站点即可。 借助 iOS 版 WordPress，您完全可以随时发布信息。在火车上草拟自发性俳句。拍一张午后漫步的照片，参与《每日邮报》的每周照片挑战。回复最新的评论或监控您的统计数据，看看今天的读者来自哪里。 别忘了为您从应用发布的文章添加标签“#wponthego”，这样，社区就可以随时找到您的作品。 iOS 版 WordPress 是开源项目，这还意味着您可以帮助我们促进其发展。要了解详情，请访问 http://ios.wordpress.org。 需要应用方面的帮助？请访问我们的论坛 (http://ios.forums.wordpress.org)，或 tweet 我们 (@WordPressiOS)。",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social networking",
+      "blogging",
+      "blogs",
+      "photos",
+      "writing",
+      "geotagging",
+      "media",
+      "blog",
+      "wordpress"
+    ]
+  },
+  "cmn-Hant": {
+    "title": "WordPress",
+    "description": "靈感隨時隨地都可能乍現。使用 iOS 裝置，外出時也可以管理 WordPress 網誌或網站：查看統計資料、審核回應、建立和編輯文章和頁面，以及上傳媒體。你只需要一個 WordPress.com 網誌，或是執行 3.6 版或更高版本的自助託管 WordPress.org 網站。 使用 iOS 版 WordPress，你就能夠在掌上輕鬆發佈文章。搭火車時信手創作幾行俳句；午後漫步時拍張照，投稿《每日郵報》的每週照片挑戰活動；回覆最新的回應；或者監控統計資料，查看今天的讀者來自哪些地方。 別忘了為從應用程式發佈的文章加註 #wponthego 標籤，讓社群可以隨時搜尋到你的傑作。 iOS 版 WordPress 是開放原始碼專案，這表示你也可以貢獻己力協助開發此程式。深入瞭解：http://ios.wordpress.org。 需要應用程式的說明嗎？請造訪論壇：http://ios.forums.wordpress.org 或使用 Twitter 推文給我們：@WordPressiOS",
+    "software_url": "http://ios.wordpress.org/",
+    "support_url": "http://ios.forums.wordpress.org/",
+    "privacy_url": "http://automattic.com/privacy/",
+    "keywords": [
+      "social networking",
+      "blogging",
+      "blogs",
+      "photos",
+      "writing",
+      "geotagging",
+      "media",
+      "blog",
+      "wordpress"
+    ]
+  }
+}

--- a/Scripts/fastlane/shoot_the_screens.js
+++ b/Scripts/fastlane/shoot_the_screens.js
@@ -1,0 +1,165 @@
+var target = UIATarget.localTarget();
+var app = target.frontMostApp();
+var win = app.mainWindow();
+var model = target.model();
+
+var type = function(text) {
+    app.keyboard().typeString(text);
+}
+var sleep = function(duration) {
+    target.delay(duration);
+}
+
+var kPortraitString = "portrait"
+var kLandscapeString = "landscape"
+
+var kMaxDimension4inch = 568;
+var kMaxDimension4point7inch = 667;
+var kMaxDimension5point5inch = 736;
+
+function rectMaxSizeMatchesPhoneWithMaxDimensionForOrientation(rect, maxDimension, orientation) {
+    return (orientation == kPortraitString && rect.size.height == maxDimension) || (orientation == kLandscapeString && rect.size.width == maxDimension)
+}
+
+function captureLocalizedScreenshot(name) {
+    var target = UIATarget.localTarget();
+    var model = target.model();
+    var rect = target.rect();
+    
+    var orientation = kPortraitString;
+    if (rect.size.height < rect.size.width) {
+        orientation = kLandscapeString;
+    }
+    
+    if (model.match(/iPhone/)) {
+        if (rectMaxSizeMatchesPhoneWithMaxDimensionForOrientation(rect, kMaxDimension4inch, orientation)) {
+            model = "iOS-4-in";
+        }
+        else if (rectMaxSizeMatchesPhoneWithMaxDimensionForOrientation(rect, kMaxDimension4point7inch, orientation)) {
+            model = "iOS-4.7-in";
+        }
+        else if (rectMaxSizeMatchesPhoneWithMaxDimensionForOrientation(rect, kMaxDimension5point5inch, orientation)) {
+            model = "iOS-5.5-in";
+        }
+        else {
+            model = "iOS-3.5-in";
+        }
+    } else {
+        model = "iOS-iPad";
+    }
+    
+    var parts = [model, orientation, name];
+    target.captureScreenWithName(parts.join("___"));
+}
+
+function isIpad() {
+    return model.match(/iPad/);
+}
+
+function dismissNewEditorModalIfApplicable() {
+  var newEditorButton = win.buttons()["new-editor-modal-dismiss-button"];
+  if (newEditorButton.isValid()) {
+    newEditorButton.tap();
+    sleep(1);
+  } 
+}
+
+UIALogger.logStart("screenshots");
+
+dismissNewEditorModalIfApplicable();
+
+if (app.tabBar().checkIsValid()) {
+    app.tabBar().buttons()[3].tap();
+    win.tableViews()[0].cells()[2].tap();
+    
+    if (model.match(/iPhone/)) {
+        app.actionSheet().elements()[1].tap();
+    } else {
+        win.popover().actionSheet().elements()[1].tap();
+    }
+}
+sleep(2);
+
+UIALogger.logMessage("Starting Sign In Process");
+
+var username = "FILL-IN-USERNAME";
+var password = "FILL-IN-PASSWORD";
+
+win.textFields()[0].tap(); sleep(1);
+win.textFields()[0].setValue(username); sleep(1);
+win.secureTextFields()[0].tap();sleep(1);
+win.secureTextFields()[0].setValue(password);
+win.textFields()[0].tap(); sleep(1);
+win.buttons()[1].tap();
+
+// Wait for "Brand New Editor" dialog
+sleep(5);
+dismissNewEditorModalIfApplicable();
+
+app.tabBar().buttons()[1].tap();
+if (isIpad()) {
+    app.navigationBar().buttons()[1].tap();    
+} else {
+    app.navigationBar().buttons()[0].tap();    
+}
+
+win.elements()["Pager View"].scrollViews()[0].tableViews()[0].cells()[0].tap(); sleep(5);
+
+UIALogger.logMessage("Capture Reader Screenshot");
+captureLocalizedScreenshot("1-reader"); sleep(1);
+
+// Get Notifications Screenshot
+app.tabBar().buttons()[4].tap(); sleep(3);
+UIALogger.logMessage("Capture Notifications Screenshot");
+captureLocalizedScreenshot("2-notifications"); sleep(1);
+
+// Get My Sites Screenshot
+app.tabBar().buttons()[0].tap(); sleep(1);
+UIALogger.logMessage("Capture My Sites");
+var blogsTableView = win.tableViews()["Blogs"];
+if (blogsTableView.isValid()) {
+    blogsTableView.cells()[0].tap();
+}
+sleep(1);
+UIALogger.logMessage("Capture My Sites Screenshot");
+captureLocalizedScreenshot("3-my-sites"); sleep(1);    
+
+// Get Editor Screenshot
+win.tableViews()[0].cells()[2].tap(); sleep(1);
+win.tableViews()[0].visibleCells()[2].tap(); sleep(1)
+app.navigationBar().rightButton().tap(); sleep(2);
+// Get the cursor to the end of the text before the image
+if (isIpad()) {
+    target.frontMostApp().mainWindow().scrollViews()[0].webViews()[0].textFields()[1].tapWithOptions({tapOffset:{x:0.95, y:0.04}}); sleep(1);    
+} else {
+    target.frontMostApp().mainWindow().scrollViews()[0].webViews()[0].textFields()[1].tapWithOptions({tapOffset:{x:0.95, y:0.10}}); sleep(1);        
+}
+
+target.frontMostApp().mainWindow().scrollViews()[0].webViews()[0].textFields()[1].scrollUp(); sleep(1);
+UIALogger.logMessage("Capture Editor Screenshot");
+captureLocalizedScreenshot("4-editor"); sleep(1);
+
+// Get Stats Screenshot
+target.frontMostApp().navigationBar().buttons()[0].tap(); sleep(1);
+if (isIpad()) {
+    if (app.popover().isValid()) {
+        win.popover().actionSheet().collectionViews()[0].cells()[0].buttons()[0].tap(); sleep(1);
+    }
+    app.navigationBar().buttons()[2].tap(); sleep(1);        
+} else {
+    if (app.actionSheet().isValid()) {
+        app.actionSheet().elements()[1].tap(); sleep(1);        
+    }
+    app.navigationBar().buttons()[0].tap(); sleep(1);    
+}
+
+// Load Stats
+target.frontMostApp().navigationBar().buttons()[0].tap(); sleep(1);
+win.tableViews()[0].visibleCells()[1].tap(); sleep(10);
+UIALogger.logMessage("Capture Stats Screenshot");
+captureLocalizedScreenshot("5-stats"); sleep(1);
+
+UIALogger.logPass("screenshots");
+
+
+

--- a/Scripts/fastlane/wordpress_translation_retrieval.rb
+++ b/Scripts/fastlane/wordpress_translation_retrieval.rb
@@ -1,0 +1,77 @@
+require 'rubygems'
+
+class WordPressTranslationRetrieval
+
+  LANGS = {
+    'en-US' => 'en-gb', # Technically this is a hack, but I don't think we can get the original english translations from Glotpress
+    'en-CA' => 'en-gb',
+    'en-AU' => 'en-au',
+    'es-ES' => 'es',
+    'en-GB' => 'en-gb',
+    'fr-FR' => 'fr',
+    'it-IT' => 'it',
+    'ja-JP' => 'ja',
+    'sv-SE' => 'sv',
+    'pt-BR' => 'pt-br',
+    'nl-NL' => 'nl',
+    'de-DE' => 'de',
+    'id-ID' => 'id',
+    'ko-KR' => 'ko',
+    'ru-RU' => 'ru',
+    'cmn-Hant' => 'zh-tw',
+    'th-TH' => 'th',
+    'cmn-Hans' => 'zh-cn',
+    'tr-TR' => 'tr',
+  }
+
+  class << self
+
+    def get_version_text_from_file_contents(file_contents, strings_file_key)
+      whats_new_text = nil
+
+      file_contents.each_with_index do |line, index|
+        if line =~ Regexp.new(strings_file_key)
+          whats_new_text = file_contents[index+2]
+        end
+      end
+
+      separator = "•"
+      matcher = Regexp.new("\"(.*)\"")
+      matches = whats_new_text.gsub("msgstr ", "").match(matcher)
+      version_text = matches[1].split(separator).select { |text| text.length > 0 }.map { |text| text.strip }.map { |text| "#{separator} #{text}"}.join("\n")
+
+      version_text
+    end
+
+    def retrieve_file_contents_from_glotpress(glotpress_language_code)
+      url = "https://translate.wordpress.org/projects/ios/release-notes/#{glotpress_language_code}/default/export-translations?format=po"
+      system "curl -so temp.po #{url}"
+      file_contents = File.readlines("temp.po")
+      system "rm temp.po"
+
+      file_contents
+    end
+
+    def get_version_text(deliver_language_code, strings_file_key)
+      glotpress_language_code = LANGS[deliver_language_code]
+      file_contents = retrieve_file_contents_from_glotpress(glotpress_language_code)
+      version_text = get_version_text_from_file_contents(file_contents, strings_file_key)
+
+      if version_text.length == 0
+        file_contents = retrieve_file_contents_from_glotpress("en-gb")
+        version_text = get_version_text_from_file_contents(file_contents, strings_file_key)
+      end
+
+      version_text
+    end
+  end
+
+end
+
+# Uncomment below and run the script from the command line to test
+# WordPressTranslationRetrieval::LANGS.each do |deliver_language_code, glotpress_language_code|
+#   puts "Version text for #{deliver_language_code}"
+#   puts WordPressTranslationRetrieval.get_version_text(deliver_language_code, "v4.8-whats-new")
+#   puts "\n"
+# end
+


### PR DESCRIPTION
Adding in scripts utilizing https://github.com/KrauseFx/deliver and https://github.com/KrauseFx/snapshot to help automate the process of generating screenshots and uploading them to iTunes connect. Let's hold off on merging this for now until we can verify this with 4.9. Right now 4.8 is still waiting to be approved so once it's approved and off to the app store we'll run this script with a new version to make sure everything works ok.

cc @diegoreymendez 