### PR TITLE
Tooltip popover fix for pages

### DIFF
--- a/WordPress/Classes/Utility/WPTooltip.h
+++ b/WordPress/Classes/Utility/WPTooltip.h
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+
+/**
+ *  @class      WPTooltip
+ *  @brief      This class allows the implementer to display a simple, animated popover.
+ *  @details    This class was added to simplify the creation & display of tooltips using
+ *              designer-approved defaults.
+ *  @todo       Currently, the tooltip only animates from the bottom of a frame. More display
+ *              options should be added (as needed).
+ */
+@interface WPTooltip : NSObject
+
+/**
+ *  @brief      Shows the tooltip.
+ *  @param      view    The view which contains the tooltip.
+ *  @param      frame   The frame to animate out of.
+ *  @param      text    The text to display.
+ */
++ (void)displayToolTipInView:(UIView *)view fromFrame:(CGRect)frame withText:(NSString *)text;
+
+@end

--- a/WordPress/Classes/Utility/WPTooltip.m
+++ b/WordPress/Classes/Utility/WPTooltip.m
@@ -1,0 +1,31 @@
+#import "WPTooltip.h"
+#import <AMPopTip/AMPopTip.h>
+
+@implementation WPTooltip
+
++ (void)displayToolTipInView:(UIView *)view fromFrame:(CGRect)frame withText:(NSString *)text
+{
+    NSParameterAssert([view isKindOfClass:[UIView class]]);
+    NSParameterAssert([text isKindOfClass:[NSString class]]);
+    NSParameterAssert([text length] > 0);
+    
+    AMPopTip *popTip = [AMPopTip popTip];
+    [[AMPopTip appearance] setFont:[WPStyleGuide regularTextFont]];
+    [[AMPopTip appearance] setTextColor:[UIColor whiteColor]];
+    [[AMPopTip appearance] setPopoverColor:[WPStyleGuide littleEddieGrey]];
+    [[AMPopTip appearance] setArrowSize:CGSizeMake(12.0, 8.0)];
+    [[AMPopTip appearance] setEdgeMargin:5.0];
+    [[AMPopTip appearance] setDelayIn:0.5];
+    UIEdgeInsets insets = {6,5,6,5};
+    [[AMPopTip appearance] setEdgeInsets:insets];
+    popTip.shouldDismissOnTap = YES;
+    popTip.shouldDismissOnTapOutside = YES;
+    [popTip showText:text
+           direction:AMPopTipDirectionDown
+            maxWidth:200
+              inView:view
+           fromFrame:frame
+            duration:3];
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Pages/EditPageViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/EditPageViewController.m
@@ -55,7 +55,12 @@
 
 - (void)showOnboardingTips
 {
-    CGFloat xValue = IS_IPAD ? CGRectGetMaxX(self.view.frame)-NavigationBarButtonRect.size.width-20.0 : CGRectGetMaxX(self.view.frame)-NavigationBarButtonRect.size.width-10.0;
+    CGFloat xValue = CGRectGetMaxX(self.view.frame) - NavigationBarButtonRect.size.width;
+    if (IS_IPAD) {
+        xValue -= 20.0;
+    } else {
+        xValue -= 10.0;
+    }
     CGRect targetFrame = CGRectMake(xValue, 0.0, NavigationBarButtonRect.size.width, 0.0);
     NSString *tooltipText = NSLocalizedString(@"Tap to edit page", @"Tooltip for the button that allows the user to edit the current page.");
     [WPTooltip displayToolTipInView:self.view fromFrame:targetFrame withText:tooltipText];

--- a/WordPress/Classes/ViewRelated/Pages/EditPageViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/EditPageViewController.m
@@ -5,7 +5,7 @@
 #import "Page.h"
 #import "Blog.h"
 #import "PageSettingsViewController.h"
-#import <AMPopTip/AMPopTip.h>
+#import "WPTooltip.h"
 
 @implementation EditPageViewController
 
@@ -55,25 +55,10 @@
 
 - (void)showOnboardingTips
 {
-    AMPopTip *popTip = [AMPopTip popTip];
     CGFloat xValue = IS_IPAD ? CGRectGetMaxX(self.view.frame)-NavigationBarButtonRect.size.width-20.0 : CGRectGetMaxX(self.view.frame)-NavigationBarButtonRect.size.width-10.0;
     CGRect targetFrame = CGRectMake(xValue, 0.0, NavigationBarButtonRect.size.width, 0.0);
-    [[AMPopTip appearance] setFont:[WPStyleGuide regularTextFont]];
-    [[AMPopTip appearance] setTextColor:[UIColor whiteColor]];
-    [[AMPopTip appearance] setPopoverColor:[WPStyleGuide littleEddieGrey]];
-    [[AMPopTip appearance] setArrowSize:CGSizeMake(12.0, 8.0)];
-    [[AMPopTip appearance] setEdgeMargin:5.0];
-    [[AMPopTip appearance] setDelayIn:0.5];
-    UIEdgeInsets insets = {6,5,6,5};
-    [[AMPopTip appearance] setEdgeInsets:insets];
-    popTip.shouldDismissOnTap = YES;
-    popTip.shouldDismissOnTapOutside = YES;
-    [popTip showText:NSLocalizedString(@"Tap to edit page", @"Tooltip for the button that allows the user to edit the current page.")
-           direction:AMPopTipDirectionDown
-            maxWidth:200
-              inView:self.view
-           fromFrame:targetFrame
-            duration:3];
+    NSString *tooltipText = NSLocalizedString(@"Tap to edit page", @"Tooltip for the button that allows the user to edit the current page.");
+    [WPTooltip displayToolTipInView:self.view fromFrame:targetFrame withText:tooltipText];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Pages/EditPageViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/EditPageViewController.m
@@ -5,6 +5,7 @@
 #import "Page.h"
 #import "Blog.h"
 #import "PageSettingsViewController.h"
+#import <AMPopTip/AMPopTip.h>
 
 @implementation EditPageViewController
 
@@ -48,6 +49,31 @@
 
 - (AbstractPost *)createNewDraftForBlog:(Blog *)blog {
     return [PostService createDraftPageInMainContextForBlog:blog];
+}
+
+#pragma mark - Onboarding
+
+- (void)showOnboardingTips
+{
+    AMPopTip *popTip = [AMPopTip popTip];
+    CGFloat xValue = IS_IPAD ? CGRectGetMaxX(self.view.frame)-NavigationBarButtonRect.size.width-20.0 : CGRectGetMaxX(self.view.frame)-NavigationBarButtonRect.size.width-10.0;
+    CGRect targetFrame = CGRectMake(xValue, 0.0, NavigationBarButtonRect.size.width, 0.0);
+    [[AMPopTip appearance] setFont:[WPStyleGuide regularTextFont]];
+    [[AMPopTip appearance] setTextColor:[UIColor whiteColor]];
+    [[AMPopTip appearance] setPopoverColor:[WPStyleGuide littleEddieGrey]];
+    [[AMPopTip appearance] setArrowSize:CGSizeMake(12.0, 8.0)];
+    [[AMPopTip appearance] setEdgeMargin:5.0];
+    [[AMPopTip appearance] setDelayIn:0.5];
+    UIEdgeInsets insets = {6,5,6,5};
+    [[AMPopTip appearance] setEdgeInsets:insets];
+    popTip.shouldDismissOnTap = YES;
+    popTip.shouldDismissOnTapOutside = YES;
+    [popTip showText:NSLocalizedString(@"Tap to edit page", @"Tooltip for the button that allows the user to edit the current page.")
+           direction:AMPopTipDirectionDown
+            maxWidth:200
+              inView:self.view
+           fromFrame:targetFrame
+            duration:3];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
@@ -13,6 +13,8 @@ typedef enum
 }
 WPPostViewControllerMode;
 
+extern const CGRect NavigationBarButtonRect;
+
 extern NSString* const WPEditorNavigationRestorationID;
 extern NSString* const kUserDefaultsNewEditorEnabled;
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -8,7 +8,6 @@
 #import <WordPress-iOS-Shared/WPFontManager.h>
 #import <WordPress-iOS-Shared/WPStyleGuide.h>
 #import <WordPressCom-Analytics-iOS/WPAnalytics.h>
-#import <AMPopTip/AMPopTip.h>
 #import <SVProgressHUD.h>
 #import "BlogSelectorViewController.h"
 #import "BlogService.h"
@@ -35,6 +34,7 @@
 #import "WPTabBarController.h"
 #import "WPUploadStatusButton.h"
 #import "WordPress-Swift.h"
+#import "WPTooltip.h"
 
 typedef NS_ENUM(NSInteger, EditPostViewControllerAlertTag) {
     EditPostViewControllerAlertTagNone,
@@ -558,25 +558,10 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)showOnboardingTips
 {
-    AMPopTip *popTip = [AMPopTip popTip];
     CGFloat xValue = IS_IPAD ? CGRectGetMaxX(self.view.frame)-NavigationBarButtonRect.size.width-20.0 : CGRectGetMaxX(self.view.frame)-NavigationBarButtonRect.size.width-10.0;
     CGRect targetFrame = CGRectMake(xValue, 0.0, NavigationBarButtonRect.size.width, 0.0);
-    [[AMPopTip appearance] setFont:[WPStyleGuide regularTextFont]];
-    [[AMPopTip appearance] setTextColor:[UIColor whiteColor]];
-    [[AMPopTip appearance] setPopoverColor:[WPStyleGuide littleEddieGrey]];
-    [[AMPopTip appearance] setArrowSize:CGSizeMake(12.0, 8.0)];
-    [[AMPopTip appearance] setEdgeMargin:5.0];
-    [[AMPopTip appearance] setDelayIn:0.5];
-    UIEdgeInsets insets = {6,5,6,5};
-    [[AMPopTip appearance] setEdgeInsets:insets];
-    popTip.shouldDismissOnTap = YES;
-    popTip.shouldDismissOnTapOutside = YES;
-    [popTip showText:NSLocalizedString(@"Tap to edit post", @"Tooltip for the button that allows the user to edit the current post.")
-           direction:AMPopTipDirectionDown
-            maxWidth:200
-              inView:self.view
-           fromFrame:targetFrame
-            duration:3];
+    NSString *tooltipText = NSLocalizedString(@"Tap to edit post", @"Tooltip for the button that allows the user to edit the current post.");
+    [WPTooltip displayToolTipInView:self.view fromFrame:targetFrame withText:tooltipText];
 }
 
 #pragma mark - Actions

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -558,7 +558,12 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)showOnboardingTips
 {
-    CGFloat xValue = IS_IPAD ? CGRectGetMaxX(self.view.frame)-NavigationBarButtonRect.size.width-20.0 : CGRectGetMaxX(self.view.frame)-NavigationBarButtonRect.size.width-10.0;
+    CGFloat xValue = CGRectGetMaxX(self.view.frame) - NavigationBarButtonRect.size.width;
+    if (IS_IPAD) {
+        xValue -= 20.0;
+    } else {
+        xValue -= 10.0;
+    }
     CGRect targetFrame = CGRectMake(xValue, 0.0, NavigationBarButtonRect.size.width, 0.0);
     NSString *tooltipText = NSLocalizedString(@"Tap to edit post", @"Tooltip for the button that allows the user to edit the current post.");
     [WPTooltip displayToolTipInView:self.view fromFrame:targetFrame withText:tooltipText];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		74C1C306199170930077A7DC /* PostDetailViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 74C1C305199170930077A7DC /* PostDetailViewController.xib */; };
 		74C1C30E199170EA0077A7DC /* PostDetailViewController~ipad.xib in Resources */ = {isa = PBXBuildFile; fileRef = 74C1C30D199170EA0077A7DC /* PostDetailViewController~ipad.xib */; };
 		74D5FFD619ACDF6700389E8F /* WPLegacyEditPostViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 74D5FFD519ACDF6700389E8F /* WPLegacyEditPostViewController.m */; };
+		74F313EF1A9B97A200AA8B45 /* WPTooltip.m in Sources */ = {isa = PBXBuildFile; fileRef = 74F313EE1A9B97A200AA8B45 /* WPTooltip.m */; };
 		83043E55126FA31400EC9953 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83043E54126FA31400EC9953 /* MessageUI.framework */; };
 		8333FE0E11FF6EF200A495C1 /* EditSiteViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8333FE0D11FF6EF200A495C1 /* EditSiteViewController.xib */; };
 		83418AAA11C9FA6E00ACF00C /* Comment.m in Sources */ = {isa = PBXBuildFile; fileRef = 83418AA911C9FA6E00ACF00C /* Comment.m */; };
@@ -842,6 +843,8 @@
 		74D5FFD319ACDF6700389E8F /* WPLegacyEditPostViewController_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPLegacyEditPostViewController_Internal.h; sourceTree = "<group>"; usesTabs = 0; };
 		74D5FFD419ACDF6700389E8F /* WPLegacyEditPostViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPLegacyEditPostViewController.h; sourceTree = "<group>"; usesTabs = 0; };
 		74D5FFD519ACDF6700389E8F /* WPLegacyEditPostViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPLegacyEditPostViewController.m; sourceTree = "<group>"; usesTabs = 0; };
+		74F313ED1A9B97A200AA8B45 /* WPTooltip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPTooltip.h; sourceTree = "<group>"; };
+		74F313EE1A9B97A200AA8B45 /* WPTooltip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPTooltip.m; sourceTree = "<group>"; };
 		83043E54126FA31400EC9953 /* MessageUI.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		8333FE0D11FF6EF200A495C1 /* EditSiteViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = EditSiteViewController.xib; path = Resources/EditSiteViewController.xib; sourceTree = "<group>"; };
 		833AF259114575A50016DE8F /* PostAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostAnnotation.h; sourceTree = "<group>"; };
@@ -2171,6 +2174,8 @@
 				B5CC05FA196218E100975CAC /* XMLParserCollecter.h */,
 				B5CC05FB196218E100975CAC /* XMLParserCollecter.m */,
 				FFAB7CAF1A0BD83A00765942 /* WPAssetExporter.h */,
+				74F313ED1A9B97A200AA8B45 /* WPTooltip.h */,
+				74F313EE1A9B97A200AA8B45 /* WPTooltip.m */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -3458,6 +3463,7 @@
 				CCEF153114C9EA050001176D /* WPWebAppViewController.m in Sources */,
 				462F4E0A18369F0B0028D2F8 /* BlogDetailsViewController.m in Sources */,
 				B5CC05FC196218E100975CAC /* XMLParserCollecter.m in Sources */,
+				74F313EF1A9B97A200AA8B45 /* WPTooltip.m in Sources */,
 				85DA8C4418F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m in Sources */,
 				B55853FC19630E7900FAF6C3 /* Notification.m in Sources */,
 				5DF94E431962BAA700359241 /* WPContentAttributionView.m in Sources */,


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/511

Created a new class: ```WPTooltip``` that encapsulates the tooltip display logic along with the look & feel. Page and post VC's now call ```displayToolTipInView:fromFrame:withText:``` with the correct text.

/cc @diegoreymendez 