### PR TITLE
WhatsNewView: Setting OpenSans font via code

### DIFF
--- a/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNewView.h
+++ b/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNewView.h
@@ -42,6 +42,11 @@ typedef void(^WPWhatsNewDismissBlock)();
  */
 @property (nonatomic, weak, readonly) IBOutlet UITextView *title;
 
+/**
+ *  @brief      The accept button that dismissess the popup.
+ */
+@property (nonatomic, weak, readonly) IBOutlet UIButton *acceptButton;
+
 #pragma mark - Properties: Blocks
 
 /**

--- a/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNewView.m
+++ b/WordPress/Classes/ViewRelated/WhatsNew/WPWhatsNewView.m
@@ -16,6 +16,7 @@ static const CGFloat WPWhatsNewShowAnimationMagnificationScale = 1.1;
 @property (nonatomic, weak, readwrite) IBOutlet NSLayoutConstraint *detailsHeightConstraint;
 @property (nonatomic, weak, readwrite) IBOutlet UIImageView* imageView;
 @property (nonatomic, weak, readwrite) IBOutlet UITextView* title;
+@property (nonatomic, weak, readwrite) IBOutlet UIButton* acceptButton;
 @end
 
 @implementation WPWhatsNewView
@@ -44,15 +45,19 @@ static const CGFloat WPWhatsNewShowAnimationMagnificationScale = 1.1;
              @"ImageView outlet not wired.");
     NSAssert([_title isKindOfClass:[UITextView class]],
              @"Title outlet not wired.");
+    NSAssert([_acceptButton isKindOfClass:[UIButton class]],
+             @"Button outlet not wired.");
     
     self.details.scrollEnabled = NO;
     [self setTranslatesAutoresizingMaskIntoConstraints:NO];
     
     UIFont *titleFont = [WPFontManager openSansBoldFontOfSize:18.0f];
     UIFont *detailsFont = [WPFontManager openSansLightFontOfSize:15.0f];
+    UIFont *buttonFont = [WPFontManager openSansLightFontOfSize:16.0f];
     
     self.title.font = titleFont;
     self.details.font = detailsFont;
+    self.acceptButton.titleLabel.font = buttonFont;
 }
 
 #pragma mark - Showing & hiding

--- a/WordPress/Resources/WhatsNew/WPWhatsNewView.xib
+++ b/WordPress/Resources/WhatsNew/WPWhatsNewView.xib
@@ -111,6 +111,7 @@
                 </mask>
             </variation>
             <connections>
+                <outlet property="acceptButton" destination="JiN-6m-R2d" id="2CR-1f-n6a"/>
                 <outlet property="details" destination="7Yo-lx-1UL" id="eEq-ir-BGX"/>
                 <outlet property="detailsHeightConstraint" destination="d06-w8-7sQ" id="buX-Kv-Rll"/>
                 <outlet property="imageView" destination="rZt-IM-vJ7" id="JGZ-vj-KV2"/>

--- a/WordPress/Resources/WhatsNew/WPWhatsNewView.xib
+++ b/WordPress/Resources/WhatsNew/WPWhatsNewView.xib
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6246"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <mutableArray key="OpenSans-Bold.ttf">
-            <string>OpenSans-Bold</string>
-        </mutableArray>
-        <mutableArray key="OpenSans-Light.ttf">
-            <string>OpenSans-Light</string>
-        </mutableArray>
-        <mutableArray key="OpenSans-Regular.ttf">
-            <string>OpenSans</string>
-        </mutableArray>
-    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -28,7 +17,7 @@
                     <constraints>
                         <constraint firstAttribute="height" constant="34" id="sug-n5-6nx"/>
                     </constraints>
-                    <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="18"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                 </textView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vcP-jy-MXs" userLabel="Separator Line View">
@@ -44,7 +33,7 @@
                     <constraints>
                         <constraint firstAttribute="height" constant="60" id="q6a-Ez-UNQ"/>
                     </constraints>
-                    <fontDescription key="fontDescription" name="OpenSans-Light" family="Open Sans" pointSize="16"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
                     <state key="normal" title="Great, thanks!">
                         <color key="titleColor" red="0.054901960784313725" green="0.45098039215686275" blue="0.69803921568627447" alpha="1" colorSpace="calibratedRGB"/>
                         <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
@@ -73,7 +62,7 @@
                         <constraint firstAttribute="height" constant="100" id="d06-w8-7sQ"/>
                         <constraint firstAttribute="width" constant="200" id="qKj-0j-rfx"/>
                     </constraints>
-                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="15"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                     <connections>
                         <outlet property="delegate" destination="iN0-l3-epB" id="vib-OP-dB5"/>


### PR DESCRIPTION
This PR aims at fixing an exception we've been getting on launch, before the AppDelegate is even initialized (stack trace pasted below).

The issue has been tracked down to WPWhatsNewView.nib. Apparently, UIKit performs an internal initialization as soon as you launch the app, and an exception is thrown (+ captured), due to a font that's not available in the *Resources* folder.

@bummytime may i bother you with a quick review Matt?.

Thanks in advance!

![screen shot 2015-02-25 at 5 32 04 pm](https://cloud.githubusercontent.com/assets/1195260/6380028/7bb6683e-bd15-11e4-8de7-780f6a6a84ac.png)
