### PR TITLE
NoteBlockText: Prevents default UITextView openURL behavior

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -79,6 +79,11 @@ import Foundation
     }
         
     // MARK: - RichTextView Data Source
+    public func textView(textView: UITextView, shouldInteractWithURL URL: NSURL, inRange characterRange: NSRange) -> Bool {
+        onUrlClick?(URL)
+        return false
+    }
+    
     public func textView(textView: UITextView, didPressLink link: NSURL) {
         onUrlClick?(link)
     }


### PR DESCRIPTION
Fixes #3292

/cc @astralbodies (Thanks in advance!)
