### PR TITLE
Post status not updated if post is scheduled

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1416,7 +1416,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 }
 
 /**
- *	@brief		Saves the post being edited and uploads it.  If the post is changing from 'draft' status to 'publish' set the date to now.
+ *  @brief      Saves the post being edited and uploads it.
+ *  @details    Saves the post being edited and uploads it. If the post is NOT already scheduled, 
+ *              changing from 'draft' status to 'publish' will set the date to now.
  */
 - (void)savePost
 {
@@ -1425,7 +1427,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
     [self.view endEditing:YES];
     
-    if ([self.post.original.status isEqualToString:@"draft"]  && [self.post.status isEqualToString:@"publish"]) {
+    if (!self.post.isScheduled && [self.post.original.status isEqualToString:@"draft"]  && [self.post.status isEqualToString:@"publish"]) {
         self.post.dateCreated = [NSDate date];
     }
     self.post = self.post.original;


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/50 (and should not break the fix here: https://github.com/wordpress-mobile/WordPress-iOS/issues/3032)

@diegoreymendez would you mind reviewing?