### PR TITLE
Issue/3374 reblog crash with no visible WPCom blogs

### DIFF
--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -65,6 +65,8 @@
 
 - (NSInteger)blogCountSelfHosted;
 
+- (NSInteger)blogCountVisibleForWPComAccounts;
+
 - (NSInteger)blogCountVisibleForAllAccounts;
 
 - (NSArray *)blogsForAllAccounts;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -343,6 +343,12 @@ NSString *const LastUsedBlogURLDefaultsKey = @"LastUsedBlogURLDefaultsKey";
     return [self blogCountWithPredicate:predicate];
 }
 
+- (NSInteger)blogCountVisibleForWPComAccounts
+{
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"visible = %@ AND account.isWpcom = %@" argumentArray:@[@(YES), @(YES)]];
+    return [self blogCountWithPredicate:predicate];
+}
+
 - (NSInteger)blogCountVisibleForAllAccounts
 {
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"visible = %@" argumentArray:@[@(YES)]];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -28,6 +28,7 @@
 #import "WPNoResultsView.h"
 #import "WPTableImageSource.h"
 #import "WPTabBarController.h"
+#import "BlogService.h"
 
 #import "WPTableViewHandler.h"
 #import "WordPress-Swift.h"
@@ -208,7 +209,8 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
 
 - (void)checkWPComAccountExists
 {
-    self.hasWPComAccount = ([[[AccountService alloc] initWithManagedObjectContext:self.managedObjectContext] defaultWordPressComAccount] != nil);
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    self.hasWPComAccount = [blogService blogCountVisibleForWPComAccounts] > 0;
 }
 
 - (void)configureRefreshControl


### PR DESCRIPTION
The BOOL hasWPComAccount now reflects whether there are any visible blogs. This prevents the action buttons from showing up if there are no visible WPCom blogs, even if the user is logged in.