### PR TITLE
Fixes an issue where comment cells heights were not updated during rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
+++ b/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
@@ -95,11 +95,11 @@ static const UIEdgeInsets ReplyAndLikeButtonEdgeInsets = {0.0f, 4.0f, 0.0f, -4.0
                                                                    views:views]];
 
     // Author and date
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-offsetLeft-[_authorButton]-(>=1@200)-|"
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-offsetLeft-[_authorButton]-|"
                                                                  options:0
                                                                  metrics:metrics
                                                                    views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-offsetLeft-[_timeButton]-(>=1@200)-|"
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-offsetLeft-[_timeButton]-|"
                                                                  options:0
                                                                  metrics:metrics
                                                                    views:views]];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -185,27 +185,6 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
     [self.tableViewHandler refreshCachedRowHeightsForWidth:width];
 }
 
-- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
-{
-    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    
-    // TODO:
-    // This snippet prevents an AutoLayout constraint error message, due to an 'Out of Bounds' bottom constraint.
-    // We can't really calculate the exact bottom padding required  before the error is printed, since the target NavBar's height
-    // and KeyboardHeight are unknown.
-    // During the rotation sequence, the OS itself will quickly post the 'KeyboardWillHide' / 'KeyboardWillShow' notifications,
-    // and the exact bottom inset will be properly calculated. Please, nuke this if we (ever) find a better approach.
-    //
-    if (!self.replyTextView.isFirstResponder) {
-        return;
-    }
-    
-    CGFloat delta = size.height - PostHeaderHeight - self.replyTextViewBottomConstraint.constant;
-    if (delta < 0) {
-        self.replyTextViewBottomConstraint.constant += delta;
-    }
-}
-
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
 {
     // Remove the no results view or else the position will abruptly adjust after rotation
@@ -437,7 +416,8 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
                                                                       attribute:NSLayoutAttributeBottom
                                                                      multiplier:1.0
                                                                        constant:0.0];
-    
+    self.replyTextViewBottomConstraint.priority = UILayoutPriorityDefaultHigh;
+
     [self.view addConstraint:self.replyTextViewBottomConstraint];
     
     if ([UIDevice isPad]) {


### PR DESCRIPTION
Removes iOS8 transition method. This restores calls to depreciated orientation change methods (for now).
Sets constraint priority to high instead of required.

Closes #3378 