### PR TITLE
Issue/3374 no blog reblog crash

### DIFF
--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -4,8 +4,7 @@
 @class Blog;
 @class WPAccount;
 
-@interface BlogService : NSObject <LocalCoreDataService>
-
+@interface BlogService : NSObject<LocalCoreDataService>
 
 /**
  Returns the blog that matches with a given blogID
@@ -45,11 +44,17 @@
  */
 - (Blog *)firstWPComBlog;
 
+- (void)syncBlogsForAccount:(WPAccount *)account
+                    success:(void (^)())success
+                    failure:(void (^)(NSError *error))failure;
 
-- (void)syncBlogsForAccount:(WPAccount *)account success:(void (^)())success failure:(void (^)(NSError *error))failure;
+- (void)syncOptionsForBlog:(Blog *)blog
+                   success:(void (^)())success
+                   failure:(void (^)(NSError *error))failure;
 
-- (void)syncOptionsForBlog:(Blog *)blog success:(void (^)())success failure:(void (^)(NSError *error))failure;
-- (void)syncPostFormatsForBlog:(Blog *)blog success:(void (^)())success failure:(void (^)(NSError *error))failure;
+- (void)syncPostFormatsForBlog:(Blog *)blog
+                       success:(void (^)())success
+                       failure:(void (^)(NSError *error))failure;
 
 /*! Syncs an entire blog include posts, pages, comments, options, post formats and categories.
  *  Used for instances where the entire blog should be refreshed or initially downloaded.
@@ -57,9 +62,13 @@
  *  \param success Completion block called if the operation was a success
  *  \param failure Completion block called if the operation was a failure
  */
-- (void)syncBlog:(Blog *)blog success:(void (^)())success failure:(void (^)(NSError *error))failure;
+- (void)syncBlog:(Blog *)blog
+         success:(void (^)())success
+         failure:(void (^)(NSError *error))failure;
 
-- (void)checkVideoPressEnabledForBlog:(Blog *)blog success:(void (^)(BOOL enabled))success failure:(void (^)(NSError *error))failure;
+- (void)checkVideoPressEnabledForBlog:(Blog *)blog
+                              success:(void (^)(BOOL enabled))success
+                              failure:(void (^)(NSError *error))failure;
 
 - (NSInteger)blogCountForAllAccounts;
 
@@ -87,7 +96,8 @@
  @param account the account the blog belongs to
  @return the blog if one was found, otherwise it returns nil
  */
-- (Blog *)findBlogWithXmlrpc:(NSString *)xmlrpc inAccount:(WPAccount *)account;
+- (Blog *)findBlogWithXmlrpc:(NSString *)xmlrpc
+                   inAccount:(WPAccount *)account;
 
 /**
  Creates a blank `Blog` object for this account

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -70,6 +70,8 @@
                               success:(void (^)(BOOL enabled))success
                               failure:(void (^)(NSError *error))failure;
 
+- (BOOL)hasVisibleWPComAccounts;
+
 - (NSInteger)blogCountForAllAccounts;
 
 - (NSInteger)blogCountSelfHosted;

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -74,6 +74,8 @@
 
 - (NSInteger)blogCountSelfHosted;
 
+- (NSInteger)blogCountVisibleForWPComAccounts;
+
 - (NSInteger)blogCountVisibleForAllAccounts;
 
 - (NSArray *)blogsForAllAccounts;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -411,6 +411,13 @@ float const OneHourInSeconds = 60.0 * 60.0;
     return [self blogCountWithPredicate:predicate];
 }
 
+- (NSInteger)blogCountVisibleForWPComAccounts
+{
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:IsWPComAndVisiblePredicate];
+    
+    return [self blogCountWithPredicate:predicate];
+}
+
 - (NSInteger)blogCountVisibleForAllAccounts
 {
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"visible = %@"

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -399,6 +399,11 @@ float const OneHourInSeconds = 60.0 * 60.0;
     [blog.api enqueueXMLRPCRequestOperation:operation];
 }
 
+- (BOOL)hasVisibleWPComAccounts
+{
+    return [self blogCountVisibleForWPComAccounts] > 0;
+}
+
 - (NSInteger)blogCountForAllAccounts
 {
     return [self blogCountWithPredicate:nil];

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -24,8 +24,6 @@ NSString *const LastUsedBlogURLDefaultsKey = @"LastUsedBlogURLDefaultsKey";
 NSString *const BlogEntity = @"Blog";
 NSString *const EditPostViewControllerLastUsedBlogURLOldKey = @"EditPostViewControllerLastUsedBlogURL";
 NSString *const BlogName = @"blogName";
-NSString *const IsVisiblePredicate = @"visible = YES";
-NSString *const IsWPComAndVisiblePredicate = @"account.isWpcom = YES AND visible = YES";
 NSString *const GetFeatures = @"wpcom.getFeatures";
 NSString *const VideopressEnabled = @"videopress_enabled";
 NSString *const XmlRpc = @"xmlrpc";
@@ -36,7 +34,7 @@ NSString *const TimeZoneName = @"timezone";
 NSString *const GmtOffset = @"gmt_offset";
 NSString *const TimeZone = @"time_zone";
 NSString *const HttpsPrefix = @"https://";
-float const OneHourInSeconds = 60.0 * 60.0;
+CGFloat const OneHourInSeconds = 60.0 * 60.0;
 
 @interface BlogService ()
 
@@ -127,7 +125,7 @@ float const OneHourInSeconds = 60.0 * 60.0;
     }
 
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:BlogEntity];
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%@ AND url = %@", IsVisiblePredicate, url];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%@ AND url = %@", @"visible = YES", url];
     [fetchRequest setPredicate:predicate];
     fetchRequest.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:BlogName
                                                                    ascending:YES]];
@@ -152,7 +150,7 @@ float const OneHourInSeconds = 60.0 * 60.0;
 
 - (Blog *)firstBlog
 {
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:IsVisiblePredicate];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"visible = YES"];
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:BlogEntity];
     [fetchRequest setPredicate:predicate];
     fetchRequest.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:BlogName
@@ -171,7 +169,7 @@ float const OneHourInSeconds = 60.0 * 60.0;
 
 - (Blog *)firstWPComBlog
 {
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:IsWPComAndVisiblePredicate];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"account.isWpcom = YES AND visible = YES"];
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:BlogEntity];
     [fetchRequest setPredicate:predicate];
     fetchRequest.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:BlogName
@@ -418,7 +416,7 @@ float const OneHourInSeconds = 60.0 * 60.0;
 
 - (NSInteger)blogCountVisibleForWPComAccounts
 {
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:IsWPComAndVisiblePredicate];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"account.isWpcom = YES AND visible = YES"];
     
     return [self blogCountWithPredicate:predicate];
 }

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -125,7 +125,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     }
 
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:BlogEntity];
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%@ AND url = %@", @"visible = YES", url];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"visible = YES AND url = %@", url];
     [fetchRequest setPredicate:predicate];
     fetchRequest.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:BlogName
                                                                    ascending:YES]];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostContentView.h
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostContentView.h
@@ -64,7 +64,7 @@
 @property (nonatomic) BOOL shouldShowAttributionButton;
 
 /**
- A Boolean value specifying whether the view should display the reblog button.
+ A Boolean value specifying whether the view should hide the reblog button.
  Determined by there being a visible WPCom blog
  */
 @property (nonatomic) BOOL shouldHideReblogButton;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostContentView.h
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostContentView.h
@@ -64,6 +64,12 @@
 @property (nonatomic) BOOL shouldShowAttributionButton;
 
 /**
+ A Boolean value specifying whether the view should display the reblog button.
+ Determined by there being a visible WPCom blog
+ */
+@property (nonatomic) BOOL shouldHideReblogButton;
+
+/**
  A Boolean value specifying whether the comments button must be hidden, no matter what the post properties are.
  */
 @property (nonatomic) BOOL shouldHideComments;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostContentView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostContentView.m
@@ -149,6 +149,7 @@
     [self.likeButton setSelected:self.post.isLiked];
     [self.reblogButton setSelected:self.post.isReblogged];
     [self.reblogButton setNeedsLayout];
+    [self.reblogButton setHidden:self.shouldHideReblogButton];
 
     // You can only reblog once.
     self.reblogButton.userInteractionEnabled = !self.post.isReblogged;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
@@ -15,6 +15,7 @@
 #import "WPTableImageSource.h"
 #import "WPWebViewController.h"
 #import "WordPress-Swift.h"
+#import "BlogService.h"
 
 static CGFloat const VerticalMargin = 40;
 static NSInteger const ReaderPostDetailImageQuality = 65;
@@ -140,7 +141,14 @@ static NSInteger const ReaderPostDetailImageQuality = 65;
     self.postView.canShowActionButtons = isLoggedIn;
     self.postView.shouldShowAttributionButton = isLoggedIn;
     
+    [self setReblogButtonVisibilityOfPostView:self.postView];
     [self.scrollView addSubview:self.postView];
+}
+
+- (void)setReblogButtonVisibilityOfPostView:(ReaderPostRichContentView *)postView
+{
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
+    postView.shouldHideReblogButton = ![blogService hasVisibleWPComAccounts];
 }
 
 - (void)configureConstraints

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -28,6 +28,7 @@
 #import "WPNoResultsView.h"
 #import "WPTableImageSource.h"
 #import "WPTabBarController.h"
+#import "BlogService.h"
 
 #import "WPTableViewHandler.h"
 #import "WordPress-Swift.h"
@@ -915,11 +916,19 @@ NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder
     cell.postView.shouldShowAttributionMenu = shouldShowAttributionMenu;
     cell.postView.canShowActionButtons = self.hasWPComAccount;
     cell.postView.shouldShowAttributionButton = self.hasWPComAccount;
+    
+    [self setReblogButtonVisibilityOfPostView:cell.postView];
     [cell configureCell:post];
     [self setImageForPost:post forCell:cell indexPath:indexPath];
     [self setAvatarForPost:post forCell:cell indexPath:indexPath];
 
     cell.postView.delegate = self;
+}
+
+- (void)setReblogButtonVisibilityOfPostView:(ReaderPostContentView *)postView
+{
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    postView.shouldHideReblogButton = ![blogService hasVisibleWPComAccounts];
 }
 
 - (void)configureBlockedCell:(ReaderBlockedTableViewCell *)cell atIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/WordPressTest/BlogServiceTest.m
+++ b/WordPress/WordPressTest/BlogServiceTest.m
@@ -46,7 +46,6 @@
 
 - (void)tearDown
 {
-    // Put teardown code here; it will be run once, after the last test case.
     [super tearDown];
     
     // Cleans up values saved in NSUserDefaults


### PR DESCRIPTION
#3374

@aerych, re-implemented with a base of release/4.9.

I went through and 'cleaned up' `BlogService`. This however has caused a giant pull request. The only functional changes are two new methods: `hasVisibleWPComAccounts` and `blogCountVisibleForWPComAccounts`. Everything else is functionally the same in that class.