### PR TITLE
Add note about running `pod install` when building

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,6 @@ http://make.wordpress.org/mobile/handbook/pathways/ios/how-to-contribute/
 
 Starting with changeset 3633 version 3.2, WordPress for iOS uses Cocoapods (http://cocoapods.org/) to manage third party libraries.  Trying to build the project by itself (WordPress.xcproj) after launching will result in an error, as the resources managed by cocoapods are not included.  Instead, launch the workspace by either double clicking on WordPress.xcworkspace file, or launch Xcode and choose File > Open and browse to WordPress.xcworkspace. 
 
+Run `pod install` from the command line to install dependencies for the project.
+
 In order to login to a WordPress.com account, you will need to create an account over at https://developer.wordpress.com. The only account you will be able to login in with is the one affiliated with your developer account. Once you have an account and a corresponding app id and app secret, you will need to setup a ~/.wpcom_app_credentials file as detailed [here](http://make.wordpress.org/mobile/handbook/pathways/ios/tutorials-guides/#3-%c2%a0setup-wpcom_app_credentials). For more details see http://developer.wordpress.com/2014/07/04/authentication-improvements-for-testing-your-apps/.


### PR DESCRIPTION
Need to do it when setting up the project otherwise you get build errors.