### PR TITLE
Modularize app tracking

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.h
+++ b/WordPress/Classes/System/WordPressAppDelegate.h
@@ -7,9 +7,11 @@
 @class AbstractPost;
 @class Simperium;
 @class Blog;
+@class WPAppAnalytics;
 
 @interface WordPressAppDelegate : NSObject <UIApplicationDelegate>
 
+@property (nonatomic, strong,  readonly) WPAppAnalytics                 *analytics;
 @property (nonatomic, strong, readwrite) IBOutlet UIWindow              *window;
 @property (nonatomic, strong,  readonly) Reachability                   *internetReachability;
 @property (nonatomic, strong,  readonly) Reachability                   *wpcomReachability;

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -116,7 +116,9 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     [self initializeAppRatingUtility];
     
     // Analytics
-    self.analytics = [[WPAppAnalytics alloc] init];
+    self.analytics = [[WPAppAnalytics alloc] initWithLastVisibleScreenBlock:^NSString*{
+        return [self currentlySelectedScreen];
+    }];
 
     // Start Simperium
     [self loginSimperium];
@@ -338,8 +340,6 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
     DDLogInfo(@"%@ %@", self, NSStringFromSelector(_cmd));
-    
-    [self.analytics trackApplicationClosed:[self currentlySelectedScreen]];
 
     // Let the app finish any uploads that are in progress
     UIApplication *app = [UIApplication sharedApplication];
@@ -390,7 +390,6 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
     DDLogInfo(@"%@ %@", self, NSStringFromSelector(_cmd));
-    [self.analytics trackApplicationOpened];
     
     [self showWhatsNewIfNeeded];
 }

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -20,7 +20,7 @@ extern NSString* const WPAppAnalyticsDefaultsKeyUsageTracking;
  */
 @interface WPAppAnalytics : NSObject
 
-#pragma mark - App Tracking
+#pragma mark - App Tracking Events
 
 /**
  *  @brief      Tracks that the application has been closed.
@@ -33,5 +33,21 @@ extern NSString* const WPAppAnalyticsDefaultsKeyUsageTracking;
  *  @brief      Tracks that the application has been opened.
  */
 - (void)trackApplicationOpened;
+
+#pragma mark - Usage tracking
+
+/**
+ *  @brief      Call this method to know if usage is being tracked.
+ *
+ *  @returns    YES if usage is being tracked, NO otherwise.
+ */
+- (BOOL)isTrackingUsage;
+
+/**
+ *  @brief      Sets usage tracking ON or OFF
+ *
+ *  @param      trackingUsage   The new status for usage tracking.
+ */
+- (void)setTrackingUsage:(BOOL)trackingUsage;
 
 @end

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -24,6 +24,15 @@ extern NSString* const WPAppAnalyticsDefaultsKeyUsageTracking;
 
 #pragma mark - Init
 
+/**
+ *  @brief      Default initializer.
+ *
+ *  @param      lastVisibleScreenCallback       This block will be executed whenever this object
+ *                                              needs to know the last visible screen for tracking
+ *                                              purposes.
+ *
+ *  @returns    The initialized object.
+ */
 - (instancetype)initWithLastVisibleScreenBlock:(WPAppAnalyticsLastVisibleScreenCallback)lastVisibleScreenCallback;
 
 #pragma mark - Usage tracking

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NSString*(^WPAppAnalyticsLastVisibleScreenCallback)();
+
 extern NSString* const WPAppAnalyticsDefaultsKeyUsageTracking;
 
 /**
@@ -19,6 +21,10 @@ extern NSString* const WPAppAnalyticsDefaultsKeyUsageTracking;
  *              our app delegate class.
  */
 @interface WPAppAnalytics : NSObject
+
+#pragma mark - Init
+
+- (instancetype)initWithLastVisibleScreenBlock:(WPAppAnalyticsLastVisibleScreenCallback)lastVisibleScreenCallback;
 
 #pragma mark - App Tracking Events
 

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -1,0 +1,37 @@
+//
+//  WPAppAnalytics.h
+//  WordPress
+//
+//  Created by Diego E. Rey Mendez on 3/16/15.
+//  Copyright (c) 2015 WordPress. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+extern NSString* const WPAppAnalyticsDefaultsKeyUsageTracking;
+
+/**
+ *  @class      WPAppAnalytics
+ *  @brief      This is a container for the app-specific analytics logic.
+ *  @details    WPAnalytics is a generic component.  This component acts as a container for all
+ *              of the WPAnalytics code that's specific to WordPress, interfacing with WPAnalytics
+ *              where appropiate.  This is mostly useful to remove such app-specific logic from
+ *              our app delegate class.
+ */
+@interface WPAppAnalytics : NSObject
+
+#pragma mark - App Tracking
+
+/**
+ *  @brief      Tracks that the application has been closed.
+ *  
+ *  @param      lastVisibleScreen       The name of the last visible screen.  Can be nil.
+ */
+- (void)trackApplicationClosed:(NSString*)lastVisibleScreen;
+
+/**
+ *  @brief      Tracks that the application has been opened.
+ */
+- (void)trackApplicationOpened;
+
+@end

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -26,20 +26,6 @@ extern NSString* const WPAppAnalyticsDefaultsKeyUsageTracking;
 
 - (instancetype)initWithLastVisibleScreenBlock:(WPAppAnalyticsLastVisibleScreenCallback)lastVisibleScreenCallback;
 
-#pragma mark - App Tracking Events
-
-/**
- *  @brief      Tracks that the application has been closed.
- *  
- *  @param      lastVisibleScreen       The name of the last visible screen.  Can be nil.
- */
-- (void)trackApplicationClosed:(NSString*)lastVisibleScreen;
-
-/**
- *  @brief      Tracks that the application has been opened.
- */
-- (void)trackApplicationOpened;
-
 #pragma mark - Usage tracking
 
 /**

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -38,6 +38,9 @@ static NSString* const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 
 #pragma mark - Init helpers
 
+/**
+ *  @brief      Initializes analytics tracking for WPiOS.
+ */
 - (void)initializeAppTracking
 {
     NSNumber* usageTracking = [[NSUserDefaults standardUserDefaults] valueForKey:WPAppAnalyticsDefaultsKeyUsageTracking];

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -14,6 +14,8 @@
 #import "WordPressComApiCredentials.h"
 
 NSString* const WPAppAnalyticsDefaultsKeyUsageTracking = @"usage_tracking_enabled";
+static NSString* const WPAppAnalyticsKeyLastVisibleScreen = @"last_visible_screen";
+static NSString* const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 
 @interface WPAppAnalytics ()
 @property (nonatomic, strong, readwrite) NSDate* applicationOpenedTime;
@@ -65,13 +67,13 @@ NSString* const WPAppAnalyticsDefaultsKeyUsageTracking = @"usage_tracking_enable
     NSMutableDictionary *analyticsProperties = [NSMutableDictionary new];
     
     if (lastVisibleScreen) {
-        analyticsProperties[@"last_visible_screen"] = lastVisibleScreen;
+        analyticsProperties[WPAppAnalyticsKeyLastVisibleScreen] = lastVisibleScreen;
     }
     
     if (self.applicationOpenedTime != nil) {
         NSDate *applicationClosedTime = [NSDate date];
         NSTimeInterval timeInApp = round([applicationClosedTime timeIntervalSinceDate:self.applicationOpenedTime]);
-        analyticsProperties[@"time_in_app"] = @(timeInApp);
+        analyticsProperties[WPAppAnalyticsKeyTimeInApp] = @(timeInApp);
         self.applicationOpenedTime = nil;
     }
     

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -1,0 +1,88 @@
+//
+//  WPAppAnalytics.m
+//  WordPress
+//
+//  Created by Diego E. Rey Mendez on 3/16/15.
+//  Copyright (c) 2015 WordPress. All rights reserved.
+//
+
+#import "WPAppAnalytics.h"
+
+#import "WPAnalyticsTrackerMixpanel.h"
+#import "WPAnalyticsTrackerWPCom.h"
+#import "WPTabBarController.h"
+#import "WordPressComApiCredentials.h"
+
+NSString* const WPAppAnalyticsDefaultsKeyUsageTracking = @"usage_tracking_enabled";
+
+@interface WPAppAnalytics ()
+@property (nonatomic, strong, readwrite) NSDate* applicationOpenedTime;
+@end
+
+@implementation WPAppAnalytics
+
+#pragma mark - Init
+
+- (instancetype)init
+{
+    self = [super init];
+    
+    if (self) {
+        [self initializeAppTracking];
+    }
+    
+    return self;
+}
+
+#pragma mark - Init helpers
+
+- (void)initializeAppTracking
+{
+    NSNumber* usageTracking = [[NSUserDefaults standardUserDefaults] valueForKey:WPAppAnalyticsDefaultsKeyUsageTracking];
+    
+    if (usageTracking == nil) {        
+        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WPAppAnalyticsDefaultsKeyUsageTracking];
+        [NSUserDefaults resetStandardUserDefaults];
+    }
+    
+    if ([WordPressComApiCredentials mixpanelAPIToken].length > 0) {
+        [WPAnalytics registerTracker:[[WPAnalyticsTrackerMixpanel alloc] init]];
+    }
+    
+    [WPAnalytics registerTracker:[[WPAnalyticsTrackerWPCom alloc] init]];
+    
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsKeyUsageTracking]) {
+        DDLogInfo(@"WPAnalytics session started");
+        
+        [WPAnalytics beginSession];
+    }
+}
+
+#pragma mark - App Tracking
+
+- (void)trackApplicationClosed:(NSString*)lastVisibleScreen
+{
+    NSMutableDictionary *analyticsProperties = [NSMutableDictionary new];
+    
+    if (lastVisibleScreen) {
+        analyticsProperties[@"last_visible_screen"] = lastVisibleScreen;
+    }
+    
+    if (self.applicationOpenedTime != nil) {
+        NSDate *applicationClosedTime = [NSDate date];
+        NSTimeInterval timeInApp = round([applicationClosedTime timeIntervalSinceDate:self.applicationOpenedTime]);
+        analyticsProperties[@"time_in_app"] = @(timeInApp);
+        self.applicationOpenedTime = nil;
+    }
+    
+    [WPAnalytics track:WPAnalyticsStatApplicationClosed withProperties:analyticsProperties];
+    [WPAnalytics endSession];
+}
+
+- (void)trackApplicationOpened
+{
+    self.applicationOpenedTime = [NSDate date];
+    [WPAnalytics track:WPAnalyticsStatApplicationOpened];
+}
+
+@end

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -120,6 +120,11 @@ static NSString* const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 
 #pragma mark - App Tracking
 
+/**
+ *  @brief      Tracks that the application has been closed.
+ *
+ *  @param      lastVisibleScreen       The name of the last visible screen.  Can be nil.
+ */
 - (void)trackApplicationClosed:(NSString*)lastVisibleScreen
 {
     NSMutableDictionary *analyticsProperties = [NSMutableDictionary new];
@@ -139,6 +144,9 @@ static NSString* const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
     [WPAnalytics endSession];
 }
 
+/**
+ *  @brief      Tracks that the application has been opened.
+ */
 - (void)trackApplicationOpened
 {
     self.applicationOpenedTime = [NSDate date];

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -113,25 +113,19 @@ static NSString* const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 
 - (void)applicationDidEnterBackground:(NSNotification*)notification
 {
-    NSString* lastVisibleScreen = self.lastVisibleScreenCallback();
-    
-    [self trackApplicationClosed:lastVisibleScreen];
+    [self trackApplicationClosed];
 }
 
 #pragma mark - App Tracking
 
 /**
  *  @brief      Tracks that the application has been closed.
- *
- *  @param      lastVisibleScreen       The name of the last visible screen.  Can be nil.
  */
-- (void)trackApplicationClosed:(NSString*)lastVisibleScreen
+- (void)trackApplicationClosed
 {
     NSMutableDictionary *analyticsProperties = [NSMutableDictionary new];
     
-    if (lastVisibleScreen) {
-        analyticsProperties[WPAppAnalyticsKeyLastVisibleScreen] = lastVisibleScreen;
-    }
+    analyticsProperties[WPAppAnalyticsKeyLastVisibleScreen] = self.lastVisibleScreenCallback();
     
     if (self.applicationOpenedTime != nil) {
         NSDate *applicationClosedTime = [NSDate date];

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -347,7 +347,7 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
             cell.textLabel.text = NSLocalizedString(@"Anonymous Usage Tracking", @"Setting for enabling anonymous usage tracking");
             UISwitch *aSwitch = (UISwitch *)cell.accessoryView;
-            aSwitch.on = [[NSUserDefaults standardUserDefaults] boolForKey:kUsageTrackingDefaultsKey];
+            aSwitch.on = [[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsKeyUsageTracking];
         } else if (indexPath.row == 3) {
             cell.textLabel.text = NSLocalizedString(@"Activity Logs", @"");
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
@@ -425,16 +425,16 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
 - (void)handleCellSwitchChanged:(id)sender
 {
     UISwitch *aSwitch = (UISwitch *)sender;
-    NSString *key = (aSwitch.tag == 1) ? kExtraDebugDefaultsKey : kUsageTrackingDefaultsKey;
+    NSString *key = (aSwitch.tag == 1) ? kExtraDebugDefaultsKey : WPAppAnalyticsDefaultsKeyUsageTracking;
 
     [[NSUserDefaults standardUserDefaults] setBool:aSwitch.on forKey:key];
     [NSUserDefaults resetStandardUserDefaults];
 
-    if ([key isEqualToString:kUsageTrackingDefaultsKey] && aSwitch.on) {
+    if ([key isEqualToString:WPAppAnalyticsDefaultsKeyUsageTracking] && aSwitch.on) {
         DDLogInfo(@"WPAnalytics session started");
 
         [WPAnalytics beginSession];
-    } else if ([key isEqualToString:kUsageTrackingDefaultsKey] && !aSwitch.on) {
+    } else if ([key isEqualToString:WPAppAnalyticsDefaultsKeyUsageTracking] && !aSwitch.on) {
         DDLogInfo(@"WPAnalytics session stopped");
 
         [WPAnalytics endSession];

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -17,10 +17,10 @@
 #import "WordPress-Swift.h"
 #import "AboutViewController.h"
 #import "WPTabBarController.h"
+#import "WPAppAnalytics.h"
 #import "HelpshiftUtils.h"
 
 static NSString *const UserDefaultsFeedbackEnabled = @"wp_feedback_enabled";
-static NSString * const kUsageTrackingDefaultsKey = @"usage_tracking_enabled";
 static NSString * const kExtraDebugDefaultsKey = @"extra_debug";
 int const kActivitySpinnerTag = 101;
 int const kHelpshiftWindowTypeFAQs = 1;

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -347,7 +347,7 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
             cell.selectionStyle = UITableViewCellSelectionStyleNone;
             cell.textLabel.text = NSLocalizedString(@"Anonymous Usage Tracking", @"Setting for enabling anonymous usage tracking");
             UISwitch *aSwitch = (UISwitch *)cell.accessoryView;
-            aSwitch.on = [[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsKeyUsageTracking];
+            aSwitch.on = [[WordPressAppDelegate sharedWordPressApplicationDelegate].analytics isTrackingUsage];
         } else if (indexPath.row == 3) {
             cell.textLabel.text = NSLocalizedString(@"Activity Logs", @"");
             cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
@@ -425,19 +425,12 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
 - (void)handleCellSwitchChanged:(id)sender
 {
     UISwitch *aSwitch = (UISwitch *)sender;
-    NSString *key = (aSwitch.tag == 1) ? kExtraDebugDefaultsKey : WPAppAnalyticsDefaultsKeyUsageTracking;
 
-    [[NSUserDefaults standardUserDefaults] setBool:aSwitch.on forKey:key];
-    [NSUserDefaults resetStandardUserDefaults];
-
-    if ([key isEqualToString:WPAppAnalyticsDefaultsKeyUsageTracking] && aSwitch.on) {
-        DDLogInfo(@"WPAnalytics session started");
-
-        [WPAnalytics beginSession];
-    } else if ([key isEqualToString:WPAppAnalyticsDefaultsKeyUsageTracking] && !aSwitch.on) {
-        DDLogInfo(@"WPAnalytics session stopped");
-
-        [WPAnalytics endSession];
+    if (aSwitch.tag == 1) {
+        [[NSUserDefaults standardUserDefaults] setBool:aSwitch.on forKey:kExtraDebugDefaultsKey];
+        [NSUserDefaults resetStandardUserDefaults];
+    } else {
+        [[WordPressAppDelegate sharedWordPressApplicationDelegate].analytics setTrackingUsage:aSwitch.on];
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		5903AE1B19B60A98009D5354 /* WPButtonForNavigationBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 5903AE1A19B60A98009D5354 /* WPButtonForNavigationBar.m */; };
 		591A428C1A6DC1B0003807A6 /* WPBackgroundDimmerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */; };
 		591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */; };
+		5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */; };
 		595B02221A6C4ECD00415A30 /* WPWhatsNewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */; };
 		595B02271A6C504400415A30 /* WPWhatsNewView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 595B02261A6C504400415A30 /* WPWhatsNewView.xib */; };
 		598351AE1A704E7A00B6DD4F /* WPWhatsNew.m in Sources */ = {isa = PBXBuildFile; fileRef = 598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */; };
@@ -621,6 +622,8 @@
 		591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPBackgroundDimmerView.m; sourceTree = "<group>"; };
 		591A428D1A6DC6F2003807A6 /* WPGUIConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPGUIConstants.h; sourceTree = "<group>"; };
 		591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPGUIConstants.m; sourceTree = "<group>"; };
+		5948AD0C1AB734F2006E8882 /* WPAppAnalytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAppAnalytics.h; sourceTree = "<group>"; };
+		5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAppAnalytics.m; sourceTree = "<group>"; };
 		595B02201A6C4ECD00415A30 /* WPWhatsNewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPWhatsNewView.h; path = WhatsNew/WPWhatsNewView.h; sourceTree = "<group>"; };
 		595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNewView.m; path = WhatsNew/WPWhatsNewView.m; sourceTree = "<group>"; };
 		595B02261A6C504400415A30 /* WPWhatsNewView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = WPWhatsNewView.xib; path = Resources/WhatsNew/WPWhatsNewView.xib; sourceTree = "<group>"; };
@@ -2221,6 +2224,8 @@
 		85A1B6721742E7DB00BA5E35 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				5948AD0C1AB734F2006E8882 /* WPAppAnalytics.h */,
+				5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */,
 				85D2275718F1EB8A001DA8DA /* WPAnalyticsTrackerMixpanel.h */,
 				85D2275818F1EB8A001DA8DA /* WPAnalyticsTrackerMixpanel.m */,
 				859F761B18F2159800EF8D5D /* WPAnalyticsTrackerMixpanelInstructionsForStat.h */,
@@ -3635,6 +3640,7 @@
 				5D119DA3176FBE040073D83A /* UIImageView+AFNetworkingExtra.m in Sources */,
 				5DF59C0B1770AE3A00171208 /* UILabel+SuggestSize.m in Sources */,
 				E1F5A1BC1771C90A00E0495F /* WPTableImageSource.m in Sources */,
+				5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */,
 				851734431798C64700A30E27 /* NSURL+Util.m in Sources */,
 				5DF738971965FACD00393584 /* RecommendedTopicsViewController.m in Sources */,
 				85CE4C201A703CF200780DFE /* NSBundle+VersionNumberHelper.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		591A428C1A6DC1B0003807A6 /* WPBackgroundDimmerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */; };
 		591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */; };
 		5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */; };
+		5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */; };
 		595B02221A6C4ECD00415A30 /* WPWhatsNewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */; };
 		595B02271A6C504400415A30 /* WPWhatsNewView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 595B02261A6C504400415A30 /* WPWhatsNewView.xib */; };
 		598351AE1A704E7A00B6DD4F /* WPWhatsNew.m in Sources */ = {isa = PBXBuildFile; fileRef = 598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */; };
@@ -624,6 +625,7 @@
 		591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPGUIConstants.m; sourceTree = "<group>"; };
 		5948AD0C1AB734F2006E8882 /* WPAppAnalytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAppAnalytics.h; sourceTree = "<group>"; };
 		5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAppAnalytics.m; sourceTree = "<group>"; };
+		5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAppAnalyticsTests.m; sourceTree = "<group>"; };
 		595B02201A6C4ECD00415A30 /* WPWhatsNewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPWhatsNewView.h; path = WhatsNew/WPWhatsNewView.h; sourceTree = "<group>"; };
 		595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNewView.m; path = WhatsNew/WPWhatsNewView.m; sourceTree = "<group>"; };
 		595B02261A6C504400415A30 /* WPWhatsNewView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = WPWhatsNewView.xib; path = Resources/WhatsNew/WPWhatsNewView.xib; sourceTree = "<group>"; };
@@ -2651,6 +2653,7 @@
 				F1564E5A18946087009F8F97 /* NSStringHelpersTest.m */,
 				5DF94E351962BA5F00359241 /* Reader */,
 				E10675C7183F82E900E5CE5C /* SettingsViewControllerTest.m */,
+				5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */,
 				E1E4CE0C177439D100430844 /* WPAvatarSourceTest.m */,
 				5DA3EE191925111700294E0B /* WPImageOptimizerTest.m */,
 				5D2BEB4819758102005425F7 /* WPTableImageSourceTest.m */,
@@ -3684,6 +3687,7 @@
 				FFAB7CB31A14D1AC00765942 /* ProgressTest.m in Sources */,
 				93E9050719E6F3D8005513C9 /* TestContextManager.m in Sources */,
 				5D2BEB4919758102005425F7 /* WPTableImageSourceTest.m in Sources */,
+				5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */,
 				9363113F19FA996700B0C739 /* AccountServiceTests.swift in Sources */,
 				F1564E5B18946087009F8F97 /* NSStringHelpersTest.m in Sources */,
 				93EF094C19ED533500C89770 /* ContextManagerTests.swift in Sources */,

--- a/WordPress/WordPressTest/WPAppAnalyticsTests.m
+++ b/WordPress/WordPressTest/WPAppAnalyticsTests.m
@@ -10,26 +10,138 @@
 #import <WordPressCom-Analytics-iOS/WPAnalytics.h>
 #import <XCTest/XCTest.h>
 
+#import "WordPressComApiCredentials.h"
 #import "WPAppAnalytics.h"
+#import "WPAnalyticsTrackerMixpanel.h"
+#import "WPAnalyticsTrackerWPCom.h"
+
+typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
 
 @interface WPAppAnalyticsTests : XCTestCase
 @end
 
 @implementation WPAppAnalyticsTests
 
-- (void)testInitialization
+- (void)testInitializationWithMixPanelAndWPComTracker
 {
-    id analyticsClassMock = [OCMockObject mockForClass:[WPAnalytics class]];
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WPAppAnalyticsDefaultsKeyUsageTracking];
     
-    [[analyticsClassMock expect] registerTracker:OCMOCK_ANY];
+    id analyticsMock = [OCMockObject mockForClass:[WPAnalytics class]];
+    id apiCredentialsMock = [OCMockObject mockForClass:[WordPressComApiCredentials class]];
+    
+    OCMockInvocationBlock firstRegisterTrackerInvocationBlock = ^(NSInvocation *invocation) {
+        __unsafe_unretained id<WPAnalyticsTracker> tracker = nil;
+        [invocation getArgument:&tracker atIndex:2];
+        
+        NSAssert([tracker isKindOfClass:[WPAnalyticsTrackerMixpanel class]],
+                 @"Expected to have a mixpanel tracker.");
+    };
+    
+    OCMockInvocationBlock secondRegisterTrackerInvocationBlock = ^(NSInvocation *invocation) {
+        __unsafe_unretained id<WPAnalyticsTracker> tracker = nil;
+        [invocation getArgument:&tracker atIndex:2];
+        
+        NSAssert([tracker isKindOfClass:[WPAnalyticsTrackerWPCom class]],
+                 @"Expected to have a WPCom tracker.");
+    };
+    
+    [[[apiCredentialsMock expect] andReturn:@"NON_EMPTY_TOKEN"] mixpanelAPIToken];
+    [[[analyticsMock expect] andDo:firstRegisterTrackerInvocationBlock] registerTracker:OCMOCK_ANY];
+    [[[analyticsMock expect] andDo:secondRegisterTrackerInvocationBlock] registerTracker:OCMOCK_ANY];
+    [[analyticsMock expect] beginSession];
     
     WPAppAnalytics *analytics = nil;
+    WPAppAnalyticsLastVisibleScreenCallback lastVisibleScreenCallback = ^NSString*{
+        return @"TEST";
+    };
     
-    XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] init],
+    XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] initWithLastVisibleScreenBlock:lastVisibleScreenCallback],
                      @"Allocating or initializing this object shouldn't throw an exception");
     XCTAssert([analytics isKindOfClass:[WPAppAnalytics class]]);
     
-    [analyticsClassMock verify];
+    [apiCredentialsMock verify];
+    [analyticsMock verify];
+    
+    [apiCredentialsMock stopMocking];
+    [analyticsMock stopMocking];
+}
+
+
+- (void)testInitializationWithWPComTracker
+{
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WPAppAnalyticsDefaultsKeyUsageTracking];
+    
+    id analyticsMock = [OCMockObject mockForClass:[WPAnalytics class]];
+    id apiCredentialsMock = [OCMockObject mockForClass:[WordPressComApiCredentials class]];
+    
+    OCMockInvocationBlock registerTrackerInvocationBlock = ^(NSInvocation *invocation) {
+        __unsafe_unretained id<WPAnalyticsTracker> tracker = nil;
+        [invocation getArgument:&tracker atIndex:2];
+        
+        NSAssert([tracker isKindOfClass:[WPAnalyticsTrackerWPCom class]],
+                 @"Expected to have a WPCom tracker.");
+    };
+    
+    [[[apiCredentialsMock expect] andReturn:@""] mixpanelAPIToken];
+    [[[analyticsMock expect] andDo:registerTrackerInvocationBlock] registerTracker:OCMOCK_ANY];
+    [[analyticsMock expect] beginSession];
+    
+    WPAppAnalytics *analytics = nil;
+    WPAppAnalyticsLastVisibleScreenCallback lastVisibleScreenCallback = ^NSString*{
+        return @"TEST";
+    };
+    
+    XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] initWithLastVisibleScreenBlock:lastVisibleScreenCallback],
+                     @"Allocating or initializing this object shouldn't throw an exception");
+    XCTAssert([analytics isKindOfClass:[WPAppAnalytics class]]);
+    
+    [apiCredentialsMock verify];
+    [analyticsMock verify];
+}
+
+
+- (void)testInitializationWithMixPanelAndWPComTrackerButNoUsageTracking
+{
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:WPAppAnalyticsDefaultsKeyUsageTracking];
+    
+    id analyticsMock = [OCMockObject mockForClass:[WPAnalytics class]];
+    id apiCredentialsMock = [OCMockObject mockForClass:[WordPressComApiCredentials class]];
+    
+    OCMockInvocationBlock firstRegisterTrackerInvocationBlock = ^(NSInvocation *invocation) {
+        __unsafe_unretained id<WPAnalyticsTracker> tracker = nil;
+        [invocation getArgument:&tracker atIndex:2];
+        
+        NSAssert([tracker isKindOfClass:[WPAnalyticsTrackerMixpanel class]],
+                 @"Expected to have a mixpanel tracker.");
+    };
+    
+    OCMockInvocationBlock secondRegisterTrackerInvocationBlock = ^(NSInvocation *invocation) {
+        __unsafe_unretained id<WPAnalyticsTracker> tracker = nil;
+        [invocation getArgument:&tracker atIndex:2];
+        
+        NSAssert([tracker isKindOfClass:[WPAnalyticsTrackerWPCom class]],
+                 @"Expected to have a WPCom tracker.");
+    };
+    
+    [[[apiCredentialsMock expect] andReturn:@"NON_EMPTY_TOKEN"] mixpanelAPIToken];
+    [[[analyticsMock expect] andDo:firstRegisterTrackerInvocationBlock] registerTracker:OCMOCK_ANY];
+    [[[analyticsMock expect] andDo:secondRegisterTrackerInvocationBlock] registerTracker:OCMOCK_ANY];
+    [[analyticsMock reject] beginSession];
+    
+    WPAppAnalytics *analytics = nil;
+    WPAppAnalyticsLastVisibleScreenCallback lastVisibleScreenCallback = ^NSString*{
+        return @"TEST";
+    };
+    
+    XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] initWithLastVisibleScreenBlock:lastVisibleScreenCallback],
+                     @"Allocating or initializing this object shouldn't throw an exception");
+    XCTAssert([analytics isKindOfClass:[WPAppAnalytics class]]);
+    
+    [apiCredentialsMock verify];
+    [analyticsMock verify];
+    
+    [apiCredentialsMock stopMocking];
+    [analyticsMock stopMocking];
 }
 
 @end

--- a/WordPress/WordPressTest/WPAppAnalyticsTests.m
+++ b/WordPress/WordPressTest/WPAppAnalyticsTests.m
@@ -10,6 +10,7 @@
 #import <WordPressCom-Analytics-iOS/WPAnalytics.h>
 #import <XCTest/XCTest.h>
 
+#import "WordPressAppDelegate.h"
 #import "WordPressComApiCredentials.h"
 #import "WPAppAnalytics.h"
 #import "WPAnalyticsTrackerMixpanel.h"
@@ -66,7 +67,6 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     [analyticsMock stopMocking];
 }
 
-
 - (void)testInitializationWithWPComTracker
 {
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WPAppAnalyticsDefaultsKeyUsageTracking];
@@ -98,7 +98,6 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     [apiCredentialsMock verify];
     [analyticsMock verify];
 }
-
 
 - (void)testInitializationWithMixPanelAndWPComTrackerButNoUsageTracking
 {
@@ -142,6 +141,24 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     
     [apiCredentialsMock stopMocking];
     [analyticsMock stopMocking];
+}
+
+- (void)testIsTrackingUsage
+{
+    WPAppAnalytics* analytics = [WordPressAppDelegate sharedWordPressApplicationDelegate].analytics;
+    
+    [analytics setTrackingUsage:YES];
+    
+    XCTAssertTrue([analytics isTrackingUsage]);
+}
+
+- (void)testIsNotTrackingUsage
+{
+    WPAppAnalytics* analytics = [WordPressAppDelegate sharedWordPressApplicationDelegate].analytics;
+    
+    [analytics setTrackingUsage:NO];
+    
+    XCTAssertFalse([analytics isTrackingUsage]);
 }
 
 @end

--- a/WordPress/WordPressTest/WPAppAnalyticsTests.m
+++ b/WordPress/WordPressTest/WPAppAnalyticsTests.m
@@ -1,0 +1,22 @@
+//
+//  WPAppAnalyticsTests.m
+//  WordPress
+//
+//  Created by Diego E. Rey Mendez on 3/16/15.
+//  Copyright (c) 2015 WordPress. All rights reserved.
+//
+
+#import <OCMock/OCMock.h>
+#import "WPAppAnalytics.h"
+
+@interface WPAppAnalyticsTests : XCTestCase
+@end
+
+@implementation WPAppAnalyticsTests
+
+- (void)testInitialization
+{
+    //WPAppAnalytics* analytics = [[WPAppAnalytics alloc] init];
+}
+
+@end

--- a/WordPress/WordPressTest/WPAppAnalyticsTests.m
+++ b/WordPress/WordPressTest/WPAppAnalyticsTests.m
@@ -7,6 +7,9 @@
 //
 
 #import <OCMock/OCMock.h>
+#import <WordPressCom-Analytics-iOS/WPAnalytics.h>
+#import <XCTest/XCTest.h>
+
 #import "WPAppAnalytics.h"
 
 @interface WPAppAnalyticsTests : XCTestCase
@@ -16,7 +19,17 @@
 
 - (void)testInitialization
 {
-    //WPAppAnalytics* analytics = [[WPAppAnalytics alloc] init];
+    id analyticsClassMock = [OCMockObject mockForClass:[WPAnalytics class]];
+    
+    [[analyticsClassMock expect] registerTracker:OCMOCK_ANY];
+    
+    WPAppAnalytics *analytics = nil;
+    
+    XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] init],
+                     @"Allocating or initializing this object shouldn't throw an exception");
+    XCTAssert([analytics isKindOfClass:[WPAppAnalytics class]]);
+    
+    [analyticsClassMock verify];
 }
 
 @end


### PR DESCRIPTION
The app delegate was taking care of some app tracking tasks that did not belong to `WPAnalytics`.  Since they do not belong to the app delegate either, I created a new class to take care of it.

**Test 1:**
- Run the unit tests

**Test 2:**
- Set a breakpoint in `WPAppAnalytics - trackApplicationOpened`.
- Set a breakpoint in `WPAppAnalytics - trackApplicationClosed`.
- Run the app, and make sure both are triggered.
- `po analyticsProperties` in both to make sure the data is right.

/cc @jleandroperez 

PS: Travis seems to be still failing so you'll have to check this locally.