### PR TITLE
Small change to make a method less-verbose.

### DIFF
--- a/WordPress/Classes/Models/Blog+Jetpack.m
+++ b/WordPress/Classes/Models/Blog+Jetpack.m
@@ -77,7 +77,7 @@ NSString * const BlogJetpackApiPath = @"get-user-blogs/1.0";
 
     AFHTTPRequestOperationManager* operationManager = [[AFHTTPRequestOperationManager alloc] initWithBaseURL:[NSURL URLWithString:BlogJetpackApiBaseUrl]];
 
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedInstance] applicationUserAgent];
 
     operationManager.requestSerializer = [[AFJSONRequestSerializer alloc] init];
     [operationManager.requestSerializer setAuthorizationHeaderFieldWithUsername:username password:password];

--- a/WordPress/Classes/Services/SuggestionService.m
+++ b/WordPress/Classes/Services/SuggestionService.m
@@ -95,7 +95,7 @@ NSString * const SuggestionListUpdatedNotification = @"SuggestionListUpdatedNoti
         return NO;
     }
     
-    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
+    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedInstance];
     
     NSArray *suggestions = [self.suggestionsCache objectForKey:siteID];
     

--- a/WordPress/Classes/System/WordPressAppDelegate.h
+++ b/WordPress/Classes/System/WordPressAppDelegate.h
@@ -18,7 +18,7 @@
 @property (nonatomic, assign,  readonly) BOOL                           connectionAvailable;
 @property (nonatomic, assign,  readonly) BOOL                           wpcomAvailable;
 
-+ (WordPressAppDelegate *)sharedWordPressApplicationDelegate;
++ (WordPressAppDelegate *)sharedInstance;
 
 ///---------------------------
 /// @name User agent switching

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -93,7 +93,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 
 @implementation WordPressAppDelegate
 
-+ (WordPressAppDelegate *)sharedWordPressApplicationDelegate
++ (WordPressAppDelegate *)sharedInstance
 {
     return (WordPressAppDelegate *)[[UIApplication sharedApplication] delegate];
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerWPCom.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerWPCom.m
@@ -30,7 +30,7 @@
 {
     int x = arc4random();
     NSString *statsURL = [NSString stringWithFormat:@"%@%@%@%@%d" , WPMobileReaderURL, @"&template=stats&stats_name=", statName, @"&rnd=", x];
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedInstance] applicationUserAgent];
     
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:statsURL]];
     [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];

--- a/WordPress/Classes/Utility/NotificationsManager.m
+++ b/WordPress/Classes/Utility/NotificationsManager.m
@@ -189,7 +189,7 @@ static NSString *const NotificationActionCommentApprove             = @"COMMENT_
         [[WPTabBarController sharedInstance] showNotificationsTabForNoteWithID:notificationID];
     } else if (state == UIApplicationStateBackground) {
         if (completionHandler) {
-            Simperium *simperium = [[WordPressAppDelegate sharedWordPressApplicationDelegate] simperium];
+            Simperium *simperium = [[WordPressAppDelegate sharedInstance] simperium];
             [simperium backgroundFetchWithCompletion:^(UIBackgroundFetchResult result) {
                 if (result == UIBackgroundFetchResultNewData) {
                     DDLogVerbose(@"Background Fetch Completed with New Data!");

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -579,7 +579,7 @@
 
 - (NSURLRequest *)newRequestForWebsite
 {
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedInstance] applicationUserAgent];
     if (!self.needsLogin) {
         return [WPURLRequest requestWithURL:self.url userAgent:userAgent];
     }

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -320,7 +320,7 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
 
                 if (!defaultAccount) {
                     [WPAnalytics track:WPAnalyticsStatLogout];
-                    [[WordPressAppDelegate sharedWordPressApplicationDelegate] showWelcomeScreenIfNeededAnimated:YES];
+                    [[WordPressAppDelegate sharedInstance] showWelcomeScreenIfNeededAnimated:YES];
                 }
             });
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -310,7 +310,7 @@ static NSTimeInterval NotificationsSyncTimeout          = 10;
 
 - (void)showDetailsForNoteWithID:(NSString *)notificationID
 {
-    Simperium *simperium        = [[WordPressAppDelegate sharedWordPressApplicationDelegate] simperium];
+    Simperium *simperium        = [[WordPressAppDelegate sharedInstance] simperium];
     SPBucket *notesBucket       = [simperium bucketForName:self.entityName];
     Notification *notification  = [notesBucket objectForKey:notificationID];
     
@@ -337,7 +337,7 @@ static NSTimeInterval NotificationsSyncTimeout          = 10;
 - (void)startSyncTimeoutTimer
 {
     // Don't proceed if we're not even connected
-    BOOL isConnected = [[WordPressAppDelegate sharedWordPressApplicationDelegate] connectionAvailable];
+    BOOL isConnected = [[WordPressAppDelegate sharedInstance] connectionAvailable];
     if (!isConnected) {
         return;
     }
@@ -361,7 +361,7 @@ static NSTimeInterval NotificationsSyncTimeout          = 10;
 
 - (void)setupNotificationsBucketDelegate
 {
-    Simperium *simperium            = [[WordPressAppDelegate sharedWordPressApplicationDelegate] simperium];
+    Simperium *simperium            = [[WordPressAppDelegate sharedInstance] simperium];
     SPBucket *notesBucket           = [simperium bucketForName:self.entityName];
     notesBucket.delegate            = self;
     notesBucket.notifyWhileIndexing = YES;
@@ -392,7 +392,7 @@ static NSTimeInterval NotificationsSyncTimeout          = 10;
     }
 
     NSString *bucketName    = NSStringFromClass([Meta class]);
-    Simperium *simperium    = [[WordPressAppDelegate sharedWordPressApplicationDelegate] simperium];
+    Simperium *simperium    = [[WordPressAppDelegate sharedInstance] simperium];
     Meta *metadata          = [[simperium bucketForName:bucketName] objectForKey:bucketName.lowercaseString];
     if (!metadata) {
         return;
@@ -418,7 +418,7 @@ static NSTimeInterval NotificationsSyncTimeout          = 10;
 {
     // This is only required for debugging:
     // If we're sync'ing against a custom bucket, we should let the user know about it!
-    Simperium *simperium    = [[WordPressAppDelegate sharedWordPressApplicationDelegate] simperium];
+    Simperium *simperium    = [[WordPressAppDelegate sharedInstance] simperium];
     NSString *name          = simperium.bucketOverrides[NSStringFromClass([Notification class])];
     if ([name isEqualToString:WPNotificationsBucketName]) {
         return;

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -21,7 +21,7 @@
 
 - (void)dealloc
 {
-    [[WordPressAppDelegate sharedWordPressApplicationDelegate] useAppUserAgent];
+    [[WordPressAppDelegate sharedInstance] useAppUserAgent];
     [self.webView stopLoading];
     self.webView.delegate = nil;
 }
@@ -55,7 +55,7 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [[WordPressAppDelegate sharedWordPressApplicationDelegate] useDefaultUserAgent];
+    [[WordPressAppDelegate sharedInstance] useDefaultUserAgent];
     if (self.shouldHideStatusBar && !IS_IPAD) {
         [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:nil];
     }
@@ -65,7 +65,7 @@
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    [[WordPressAppDelegate sharedWordPressApplicationDelegate] useAppUserAgent];
+    [[WordPressAppDelegate sharedInstance] useAppUserAgent];
     [self.webView stopLoading];
 }
 
@@ -207,7 +207,7 @@
 
     NSString *link = self.apost.permaLink;
 
-    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
+    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedInstance];
 
     if (appDelegate.connectionAvailable == NO) {
         [self showSimplePreviewWithMessage:[NSString stringWithFormat:@"<div class=\"page\"><p>%@ %@</p>", NSLocalizedString(@"The internet connection appears to be offline.", @""), NSLocalizedString(@"A simple preview is shown below.", @"")]];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -691,7 +691,7 @@ NSString * const ReaderDetailTypePreviewSite = @"preview-site";
 - (void)syncIfAppropriate
 {
     // Do not start auto-sync if connection is down
-    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
+    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedInstance];
     if (appDelegate.connectionAvailable == NO) {
         return;
     }

--- a/WordPress/Classes/ViewRelated/Reader/WPWebAppViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPWebAppViewController.m
@@ -96,7 +96,7 @@
     }
 
     NSHTTPCookieStorage *cookies = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedInstance] applicationUserAgent];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
     NSDictionary *cookieHeader = [NSHTTPCookie requestHeaderFieldsWithCookies:[cookies cookiesForURL:request.URL]];
     [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];

--- a/WordPress/Classes/ViewRelated/Settings/NotificationSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/NotificationSettingsViewController.m
@@ -361,7 +361,7 @@ static CGFloat NotificationFooterExtraPadding       = 10.0f;
         return nil;
     }
     
-    Simperium *simperium = [[WordPressAppDelegate sharedWordPressApplicationDelegate] simperium];
+    Simperium *simperium = [[WordPressAppDelegate sharedInstance] simperium];
     NSString *lastSeen = [simperium.networkLastSeenTime shortString] ?: [NSString string];
     NSString *status = [NSString stringWithFormat:@"Network Last Seen: %@ [%@]", lastSeen, simperium.networkStatus];
     return status;

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -75,7 +75,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 - (void)initStats
 {
-    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
+    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedInstance];
     if (!appDelegate.connectionAvailable) {
         [self showNoResultsWithTitle:NSLocalizedString(@"No Connection", @"") message:NSLocalizedString(@"An active internet connection is required to view stats", @"")];
         return;

--- a/WordPress/Classes/ViewRelated/Stats/StatsWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsWebViewController.m
@@ -92,7 +92,7 @@ NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
     // Bypass AFNetworking for ajax stats.
     webView.useWebViewLoading = YES;
 
-    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
+    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedInstance];
     if ( appDelegate.connectionAvailable == YES ) {
         [self.webView showRefreshingState];
     }
@@ -190,7 +190,7 @@ NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
     if (blog) {
         DDLogInfo(@"Loading Stats for the following blog: %@", [blog url]);
 
-        WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
+        WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedInstance];
         if ( !appDelegate.connectionAvailable ) {
             [webView hideRefreshingState];
             __weak StatsWebViewController *weakSelf = self;
@@ -336,7 +336,7 @@ NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
         return;
     }
 
-    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
+    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedInstance];
     if ( !appDelegate.connectionAvailable ) {
         __weak StatsWebViewController *weakSelf = self;
         [ReachabilityUtils showAlertNoInternetConnectionWithRetryBlock:^{

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -351,7 +351,7 @@ NSString * const kWPNewPostURLParamImageKey = @"image";
 
         // Ignore taps on the post tab and instead show the modal.
         if ([blogService blogCountVisibleForAllAccounts] == 0) {
-            [[WordPressAppDelegate sharedWordPressApplicationDelegate] showWelcomeScreenAnimated:YES thenEditor:YES];
+            [[WordPressAppDelegate sharedInstance] showWelcomeScreenAnimated:YES thenEditor:YES];
         } else {
             [self showPostTab];
         }

--- a/WordPress/Classes/ViewRelated/System/WPTableViewController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTableViewController.m
@@ -190,7 +190,7 @@ NSString *const DefaultCellIdentifier = @"DefaultCellIdentifier";
 
     self.resultsController = nil;
     [self.tableView reloadData];
-    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
+    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedInstance];
     if (!(appDelegate.connectionAvailable == YES && [self.resultsController.fetchedObjects count] == 0 && ![self isSyncing])) {
         [self configureNoResultsView];
     }
@@ -515,7 +515,7 @@ NSString *const DefaultCellIdentifier = @"DefaultCellIdentifier";
     }
 
     // Do not start auto-sync if connection is down
-    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedWordPressApplicationDelegate];
+    WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedInstance];
     if (appDelegate.connectionAvailable == NO) {
         return;
     }

--- a/WordPress/Classes/ViewRelated/Views/WPWebView.m
+++ b/WordPress/Classes/ViewRelated/Views/WPWebView.m
@@ -123,7 +123,7 @@ NSString *refreshedWithOutValidRequestNotification = @"refreshedWithOutValidRequ
     [self setDefaultHeader:@"Accept-Language" value:[NSString stringWithFormat:@"%@, en-us;q=0.8", preferredLanguageCodes]];
 
     // User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedInstance] applicationUserAgent];
     [self setDefaultHeader:@"User-Agent" value:userAgent];
 }
 

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -72,7 +72,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 		
         [self setAuthorizationHeaderWithToken:_authToken];
 		
-        NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+        NSString *userAgent = [[WordPressAppDelegate sharedInstance] applicationUserAgent];
 		[self.requestSerializer setValue:userAgent forHTTPHeaderField:@"User-Agent"];
 	}
 	
@@ -121,7 +121,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
         DDLogVerbose(@"Initializing anonymous API");
         _anonymousApi = [[self alloc] initWithBaseURL:[NSURL URLWithString:WordPressComApiClientEndpointURL] ];
 
-        NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+        NSString *userAgent = [[WordPressAppDelegate sharedInstance] applicationUserAgent];
 		[_anonymousApi.requestSerializer setValue:userAgent forHTTPHeaderField:@"User-Agent"];
     });
 


### PR DESCRIPTION
`WordPressAppDelegate` has a method called `sharedWordPressAppDelegate` that was too verbose.  I renamed the method to the also-standard variant `sharedInstance` to make the code more readable.

/cc @sendhil 

