### PR TITLE
New User-Agent module

### DIFF
--- a/WordPress/Classes/Categories/UIDevice+Helpers.h
+++ b/WordPress/Classes/Categories/UIDevice+Helpers.h
@@ -1,6 +1,5 @@
 #import <UIKit/UIKit.h>
 
 @interface UIDevice (Helpers)
-- (NSString *)wordPressUserAgent;
 - (NSString *)wordPressIdentifier;
 @end

--- a/WordPress/Classes/Categories/UIDevice+Helpers.m
+++ b/WordPress/Classes/Categories/UIDevice+Helpers.m
@@ -4,18 +4,6 @@ static NSString * const WordPressIdentifierDefaultsKey = @"WordPressIdentifier";
 
 @implementation UIDevice (Helpers)
 
-- (NSString *)wordPressUserAgent
-{
-    NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-    NSString *userAgent = [NSString stringWithFormat:@"wp-iphone/%@ (%@ %@, %@) Mobile",
-                           appVersion,
-                           self.systemName,
-                           self.systemVersion,
-                           self.model];
-    
-    return userAgent;
-}
-
 - (NSString *)wordPressIdentifier
 {
     NSString *uuid;

--- a/WordPress/Classes/Models/Blog+Jetpack.m
+++ b/WordPress/Classes/Models/Blog+Jetpack.m
@@ -78,7 +78,7 @@ NSString * const BlogJetpackApiPath = @"get-user-blogs/1.0";
 
     AFHTTPRequestOperationManager* operationManager = [[AFHTTPRequestOperationManager alloc] initWithBaseURL:[NSURL URLWithString:BlogJetpackApiBaseUrl]];
 
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent currentUserAgent];
 
     operationManager.requestSerializer = [[AFJSONRequestSerializer alloc] init];
     [operationManager.requestSerializer setAuthorizationHeaderFieldWithUsername:username password:password];

--- a/WordPress/Classes/Models/Blog+Jetpack.m
+++ b/WordPress/Classes/Models/Blog+Jetpack.m
@@ -7,6 +7,7 @@
 #import "WordPressComOAuthClient.h"
 #import "AccountService.h"
 #import "BlogService.h"
+#import "WPUserAgent.h"
 
 NSString * const BlogJetpackErrorDomain = @"BlogJetpackError";
 NSString * const BlogJetpackApiBaseUrl = @"https://public-api.wordpress.com/";
@@ -77,7 +78,7 @@ NSString * const BlogJetpackApiPath = @"get-user-blogs/1.0";
 
     AFHTTPRequestOperationManager* operationManager = [[AFHTTPRequestOperationManager alloc] initWithBaseURL:[NSURL URLWithString:BlogJetpackApiBaseUrl]];
 
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
 
     operationManager.requestSerializer = [[AFJSONRequestSerializer alloc] init];
     [operationManager.requestSerializer setAuthorizationHeaderFieldWithUsername:username password:password];

--- a/WordPress/Classes/System/WordPressAppDelegate.h
+++ b/WordPress/Classes/System/WordPressAppDelegate.h
@@ -7,6 +7,7 @@
 @class AbstractPost;
 @class Simperium;
 @class Blog;
+@class WPUserAgent;
 
 @interface WordPressAppDelegate : NSObject <UIApplicationDelegate>
 
@@ -17,15 +18,9 @@
 @property (nonatomic, strong,  readonly) Simperium                      *simperium;
 @property (nonatomic, assign,  readonly) BOOL                           connectionAvailable;
 @property (nonatomic, assign,  readonly) BOOL                           wpcomAvailable;
+@property (nonatomic, strong,  readonly) WPUserAgent                    *userAgent;
 
 + (WordPressAppDelegate *)sharedWordPressApplicationDelegate;
-
-///---------------------------
-/// @name User agent switching
-///---------------------------
-- (void)useDefaultUserAgent;
-- (void)useAppUserAgent;
-- (NSString *)applicationUserAgent;
 
 ///-----------
 /// @name NUX

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -164,7 +164,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     // Networking setup
     [[AFNetworkActivityIndicatorManager sharedManager] setEnabled:YES];
     [self setupReachability];
-    self.userAgent = [WPUserAgent init];
+    self.userAgent = [[WPUserAgent alloc] init];
     [self setupSingleSignOn];
 
     [self customizeAppearance];

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -48,6 +48,7 @@
 #import "UIImage+Util.h"
 #import "NSBundle+VersionNumberHelper.h"
 #import "NSProcessInfo+Util.h"
+#import "WPUserAgent.h"
 
 #import "WPAnalyticsTrackerMixpanel.h"
 #import "WPAnalyticsTrackerWPCom.h"
@@ -81,6 +82,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 @property (nonatomic, assign, readwrite) BOOL                           connectionAvailable;
 @property (nonatomic, assign, readwrite) BOOL                           wpcomAvailable;
 @property (nonatomic, strong, readwrite) NSDate                         *applicationOpenedTime;
+@property (nonatomic, strong, readwrite) WPUserAgent                    *userAgent;
 
 /**
  *  @brief      Flag that signals wether Whats New is on screen or not.
@@ -162,7 +164,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     // Networking setup
     [[AFNetworkActivityIndicatorManager sharedManager] setEnabled:YES];
     [self setupReachability];
-    [self setupUserAgent];
+    self.userAgent = [WPUserAgent init];
     [self setupSingleSignOn];
 
     [self customizeAppearance];
@@ -808,49 +810,6 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
         }
     }];
 }
-
-
-
-#pragma mark - User agents
-
-- (void)setupUserAgent
-{
-    // Keep a copy of the original userAgent for use with certain webviews in the app.
-    NSString *defaultUA = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
-    NSString *wordPressUserAgent = [[UIDevice currentDevice] wordPressUserAgent];
-
-    NSDictionary *dictionary = @{
-        @"UserAgent"        : wordPressUserAgent,
-        @"DefaultUserAgent" : defaultUA,
-        @"AppUserAgent"     : wordPressUserAgent
-    };
-    [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
-}
-
-- (void)useDefaultUserAgent
-{
-    NSString *ua = [[NSUserDefaults standardUserDefaults] stringForKey:@"DefaultUserAgent"];
-    NSDictionary *dictionary = [[NSDictionary alloc] initWithObjectsAndKeys:ua, @"UserAgent", nil];
-    // We have to call registerDefaults else the change isn't picked up by UIWebViews.
-    [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
-    DDLogVerbose(@"User-Agent set to: %@", ua);
-}
-
-- (void)useAppUserAgent
-{
-    NSString *ua = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppUserAgent"];
-    NSDictionary *dictionary = [[NSDictionary alloc] initWithObjectsAndKeys:ua, @"UserAgent", nil];
-    // We have to call registerDefaults else the change isn't picked up by UIWebViews.
-    [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
-    
-    DDLogVerbose(@"User-Agent set to: %@", ua);
-}
-
-- (NSString *)applicationUserAgent
-{
-    return [[NSUserDefaults standardUserDefaults] objectForKey:@"UserAgent"];
-}
-
 
 #pragma mark - Networking setup
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerWPCom.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerWPCom.m
@@ -31,7 +31,7 @@
 {
     int x = arc4random();
     NSString *statsURL = [NSString stringWithFormat:@"%@%@%@%@%d" , WPMobileReaderURL, @"&template=stats&stats_name=", statName, @"&rnd=", x];
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent currentUserAgent];
     
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:statsURL]];
     [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerWPCom.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerWPCom.m
@@ -1,5 +1,6 @@
 #import "WPAnalyticsTrackerWPCom.h"
 #import "WordPressAppDelegate.h"
+#import "WPUserAgent.h"
 #import "Constants.h"
 
 @implementation WPAnalyticsTrackerWPCom
@@ -30,7 +31,7 @@
 {
     int x = arc4random();
     NSString *statsURL = [NSString stringWithFormat:@"%@%@%@%@%d" , WPMobileReaderURL, @"&template=stats&stats_name=", statName, @"&rnd=", x];
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
     
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:statsURL]];
     [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];

--- a/WordPress/Classes/Utility/WPUserAgent.h
+++ b/WordPress/Classes/Utility/WPUserAgent.h
@@ -1,0 +1,26 @@
+#import <Foundation/Foundation.h>
+
+/**
+ *  @class  WPUserAgent
+ *  @brief  Takes care of the user-agent logic for WPiOS.
+ */
+@interface WPUserAgent : NSObject
+
+/**
+ *  @brief      Sets the App's user agent to be the default one.
+ */
+- (void)useDefaultUserAgent;
+
+/**
+ *  @brief      Sets the App's user agent to be the WordPress one.
+ */
+- (void)useAppUserAgent;
+
+/**
+ *  @brief      Call this method to get the current user agent.
+ *
+ *  @returns    The current user agent.
+ */
+- (NSString *)applicationUserAgent;
+
+@end

--- a/WordPress/Classes/Utility/WPUserAgent.h
+++ b/WordPress/Classes/Utility/WPUserAgent.h
@@ -6,6 +6,8 @@
  */
 @interface WPUserAgent : NSObject
 
+#pragma mark - Changing the user agent
+
 /**
  *  @brief      Sets the App's user agent to be the default one.
  */
@@ -14,7 +16,9 @@
 /**
  *  @brief      Sets the App's user agent to be the WordPress one.
  */
-- (void)useAppUserAgent;
+- (void)useWordPressUserAgent;
+
+#pragma mark - Getting the user agent
 
 /**
  *  @brief      Call this method to get the current user agent.

--- a/WordPress/Classes/Utility/WPUserAgent.h
+++ b/WordPress/Classes/Utility/WPUserAgent.h
@@ -25,6 +25,6 @@
  *
  *  @returns    The current user agent.
  */
-- (NSString *)applicationUserAgent;
+- (NSString *)currentUserAgent;
 
 @end

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -35,7 +35,7 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
     [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
 }
 
-#pragma mark -
+#pragma mark - WordPress User-Agent
 
 - (NSString *)wordPressUserAgent
 {
@@ -50,7 +50,7 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
     return userAgent;
 }
 
-#pragma mark - User agents
+#pragma mark - Changing the user agent
 
 - (void)useDefaultUserAgent
 {
@@ -59,19 +59,12 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
     [self setUserAgent:ua];
 }
 
-- (void)useAppUserAgent
+- (void)useWordPressUserAgent
 {
     NSString *ua = [[NSUserDefaults standardUserDefaults] stringForKey:WPUserAgentKeyWordPressUserAgent];
     
     [self setUserAgent:ua];
 }
-
-- (NSString *)applicationUserAgent
-{
-    return [[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent];
-}
-
-#pragma mark - Setter
 
 - (void)setUserAgent:(NSString*)userAgent
 {
@@ -82,6 +75,13 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
     [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
     
     DDLogVerbose(@"User-Agent set to: %@", userAgent);
+}
+
+#pragma mark - Getting the user agent
+
+- (NSString *)applicationUserAgent
+{
+    return [[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent];
 }
 
 

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -70,7 +70,7 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
 {
     NSParameterAssert([userAgent isKindOfClass:[NSString class]]);
     
-    NSDictionary *dictionary = [[NSDictionary alloc] initWithObjectsAndKeys:userAgent, WPUserAgentKeyUserAgent, nil];
+    NSDictionary *dictionary = @{WPUserAgentKeyUserAgent: userAgent};
     // We have to call registerDefaults else the change isn't picked up by UIWebViews.
     [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
     

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -79,7 +79,7 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
 
 #pragma mark - Getting the user agent
 
-- (NSString *)applicationUserAgent
+- (NSString *)currentUserAgent
 {
     return [[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent];
 }

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -1,0 +1,88 @@
+#import "WPUserAgent.h"
+
+static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
+static NSString* const WPUserAgentKeyDefaultUserAgent = @"DefaultUserAgent";
+static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
+
+@implementation WPUserAgent
+
+#pragma mark - Init
+
+- (instancetype)init
+{
+    self = [super init];
+    
+    if (self) {
+        [self setupUserAgent];
+    }
+    
+    return self;
+}
+
+#pragma mark - One time setup
+
+- (void)setupUserAgent
+{
+    // Keep a copy of the original userAgent for use with certain webviews in the app.
+    NSString *defaultUA = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    NSString *wordPressUserAgent = [self wordPressUserAgent];
+
+    NSDictionary *dictionary = @{
+                                 WPUserAgentKeyUserAgent : wordPressUserAgent,
+                                 WPUserAgentKeyDefaultUserAgent : defaultUA,
+                                 WPUserAgentKeyWordPressUserAgent : wordPressUserAgent
+                                 };
+    [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
+}
+
+#pragma mark -
+
+- (NSString *)wordPressUserAgent
+{
+    UIDevice *device = [UIDevice currentDevice];
+    NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+    NSString *userAgent = [NSString stringWithFormat:@"wp-iphone/%@ (%@ %@, %@) Mobile",
+                           appVersion,
+                           device.systemName,
+                           device.systemVersion,
+                           device.model];
+    
+    return userAgent;
+}
+
+#pragma mark - User agents
+
+- (void)useDefaultUserAgent
+{
+    NSString *ua = [[NSUserDefaults standardUserDefaults] stringForKey:WPUserAgentKeyDefaultUserAgent];
+    
+    [self setUserAgent:ua];
+}
+
+- (void)useAppUserAgent
+{
+    NSString *ua = [[NSUserDefaults standardUserDefaults] stringForKey:WPUserAgentKeyWordPressUserAgent];
+    
+    [self setUserAgent:ua];
+}
+
+- (NSString *)applicationUserAgent
+{
+    return [[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent];
+}
+
+#pragma mark - Setter
+
+- (void)setUserAgent:(NSString*)userAgent
+{
+    NSParameterAssert([userAgent isKindOfClass:[NSString class]]);
+    
+    NSDictionary *dictionary = [[NSDictionary alloc] initWithObjectsAndKeys:userAgent, WPUserAgentKeyUserAgent, nil];
+    // We have to call registerDefaults else the change isn't picked up by UIWebViews.
+    [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
+    
+    DDLogVerbose(@"User-Agent set to: %@", userAgent);
+}
+
+
+@end

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -580,7 +580,7 @@
 
 - (NSURLRequest *)newRequestForWebsite
 {
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent currentUserAgent];
     if (!self.needsLogin) {
         return [WPURLRequest requestWithURL:self.url userAgent:userAgent];
     }

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -5,6 +5,7 @@
 #import "NSString+Helpers.h"
 #import "UIDevice+Helpers.h"
 #import "WPURLRequest.h"
+#import "WPUserAgent.h"
 #import "WPCookie.h"
 #import "Constants.h"
 #import "WPError.h"
@@ -579,7 +580,7 @@
 
 - (NSURLRequest *)newRequestForWebsite
 {
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
     if (!self.needsLogin) {
         return [WPURLRequest requestWithURL:self.url userAgent:userAgent];
     }

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -22,7 +22,7 @@
 
 - (void)dealloc
 {
-    [[WordPressAppDelegate sharedWordPressApplicationDelegate] useAppUserAgent];
+    [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent useWordPressUserAgent];
     [self.webView stopLoading];
     self.webView.delegate = nil;
 }
@@ -66,7 +66,7 @@
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent useAppUserAgent];
+    [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent useWordPressUserAgent];
     [self.webView stopLoading];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -3,6 +3,7 @@
 #import "WPURLRequest.h"
 #import "Post.h"
 #import "PostCategory.h"
+#import "WPUserAgent.h"
 
 @interface PostPreviewViewController ()
 
@@ -55,7 +56,7 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [[WordPressAppDelegate sharedWordPressApplicationDelegate] useDefaultUserAgent];
+    [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent useDefaultUserAgent];
     if (self.shouldHideStatusBar && !IS_IPAD) {
         [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:nil];
     }
@@ -65,7 +66,7 @@
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    [[WordPressAppDelegate sharedWordPressApplicationDelegate] useAppUserAgent];
+    [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent useAppUserAgent];
     [self.webView stopLoading];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/WPWebAppViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPWebAppViewController.m
@@ -97,7 +97,7 @@
     }
 
     NSHTTPCookieStorage *cookies = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent currentUserAgent];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
     NSDictionary *cookieHeader = [NSHTTPCookie requestHeaderFieldsWithCookies:[cookies cookiesForURL:request.URL]];
     [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];

--- a/WordPress/Classes/ViewRelated/Reader/WPWebAppViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPWebAppViewController.m
@@ -1,6 +1,7 @@
 #import "WPWebAppViewController.h"
 #import "WordPressAppDelegate.h"
 #import "ReachabilityUtils.h"
+#import "WPUserAgent.h"
 
 @implementation WPWebAppViewController {
     BOOL _pullToRefreshEnabled;
@@ -96,7 +97,7 @@
     }
 
     NSHTTPCookieStorage *cookies = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url]];
     NSDictionary *cookieHeader = [NSHTTPCookie requestHeaderFieldsWithCookies:[cookies cookiesForURL:request.URL]];
     [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];

--- a/WordPress/Classes/ViewRelated/Views/WPWebView.m
+++ b/WordPress/Classes/ViewRelated/Views/WPWebView.m
@@ -124,7 +124,7 @@ NSString *refreshedWithOutValidRequestNotification = @"refreshedWithOutValidRequ
     [self setDefaultHeader:@"Accept-Language" value:[NSString stringWithFormat:@"%@, en-us;q=0.8", preferredLanguageCodes]];
 
     // User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent currentUserAgent];
     [self setDefaultHeader:@"User-Agent" value:userAgent];
 }
 

--- a/WordPress/Classes/ViewRelated/Views/WPWebView.m
+++ b/WordPress/Classes/ViewRelated/Views/WPWebView.m
@@ -5,6 +5,7 @@
 #import "WordPressAppDelegate.h"
 #import "UIColor+Helpers.h"
 #import "UIDevice+Helpers.h"
+#import "WPUserAgent.h"
 
 NSString *refreshedWithOutValidRequestNotification = @"refreshedWithOutValidRequestNotification";
 
@@ -123,7 +124,7 @@ NSString *refreshedWithOutValidRequestNotification = @"refreshedWithOutValidRequ
     [self setDefaultHeader:@"Accept-Language" value:[NSString stringWithFormat:@"%@, en-us;q=0.8", preferredLanguageCodes]];
 
     // User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
-    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
     [self setDefaultHeader:@"User-Agent" value:userAgent];
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		5903AE1B19B60A98009D5354 /* WPButtonForNavigationBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 5903AE1A19B60A98009D5354 /* WPButtonForNavigationBar.m */; };
 		591A428C1A6DC1B0003807A6 /* WPBackgroundDimmerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */; };
 		591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */; };
+		594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = 594DB2941AB891A200E2E456 /* WPUserAgent.m */; };
 		595B02221A6C4ECD00415A30 /* WPWhatsNewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */; };
 		595B02271A6C504400415A30 /* WPWhatsNewView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 595B02261A6C504400415A30 /* WPWhatsNewView.xib */; };
 		598351AE1A704E7A00B6DD4F /* WPWhatsNew.m in Sources */ = {isa = PBXBuildFile; fileRef = 598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */; };
@@ -621,6 +622,8 @@
 		591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPBackgroundDimmerView.m; sourceTree = "<group>"; };
 		591A428D1A6DC6F2003807A6 /* WPGUIConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPGUIConstants.h; sourceTree = "<group>"; };
 		591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPGUIConstants.m; sourceTree = "<group>"; };
+		594DB2931AB891A200E2E456 /* WPUserAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUserAgent.h; sourceTree = "<group>"; };
+		594DB2941AB891A200E2E456 /* WPUserAgent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUserAgent.m; sourceTree = "<group>"; };
 		595B02201A6C4ECD00415A30 /* WPWhatsNewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPWhatsNewView.h; path = WhatsNew/WPWhatsNewView.h; sourceTree = "<group>"; };
 		595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNewView.m; path = WhatsNew/WPWhatsNewView.m; sourceTree = "<group>"; };
 		595B02261A6C504400415A30 /* WPWhatsNewView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = WPWhatsNewView.xib; path = Resources/WhatsNew/WPWhatsNewView.xib; sourceTree = "<group>"; };
@@ -2178,6 +2181,8 @@
 				FFAB7CAF1A0BD83A00765942 /* WPAssetExporter.h */,
 				74F313ED1A9B97A200AA8B45 /* WPTooltip.h */,
 				74F313EE1A9B97A200AA8B45 /* WPTooltip.m */,
+				594DB2931AB891A200E2E456 /* WPUserAgent.h */,
+				594DB2941AB891A200E2E456 /* WPUserAgent.m */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -3381,6 +3386,7 @@
 				ACBAB6860E1247F700F38795 /* PostPreviewViewController.m in Sources */,
 				E1A6DBE519DC7D230071AC1E /* PostService.m in Sources */,
 				C58349C51806F95100B64089 /* IOS7CorrectedTextView.m in Sources */,
+				594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */,
 				C56636E91868D0CE00226AAB /* StatsViewController.m in Sources */,
 				313AE4A019E3F20400AAFABE /* CommentViewController.m in Sources */,
 				93A379DB19FE6D3000415023 /* DDLogSwift.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = 594DB2941AB891A200E2E456 /* WPUserAgent.m */; };
 		595B02221A6C4ECD00415A30 /* WPWhatsNewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */; };
 		595B02271A6C504400415A30 /* WPWhatsNewView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 595B02261A6C504400415A30 /* WPWhatsNewView.xib */; };
+		5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */; };
 		598351AE1A704E7A00B6DD4F /* WPWhatsNew.m in Sources */ = {isa = PBXBuildFile; fileRef = 598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */; };
 		5D0431AE1A7C31AB0025BDFD /* ReaderBrowseSiteViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D0431AD1A7C31AB0025BDFD /* ReaderBrowseSiteViewController.m */; };
 		5D08B90419648C3400D5B381 /* ReaderSubscriptionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D08B90319648C3400D5B381 /* ReaderSubscriptionViewController.m */; };
@@ -627,6 +628,7 @@
 		595B02201A6C4ECD00415A30 /* WPWhatsNewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPWhatsNewView.h; path = WhatsNew/WPWhatsNewView.h; sourceTree = "<group>"; };
 		595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNewView.m; path = WhatsNew/WPWhatsNewView.m; sourceTree = "<group>"; };
 		595B02261A6C504400415A30 /* WPWhatsNewView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = WPWhatsNewView.xib; path = Resources/WhatsNew/WPWhatsNewView.xib; sourceTree = "<group>"; };
+		5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUserAgentTests.m; sourceTree = "<group>"; };
 		598351AC1A704E7A00B6DD4F /* WPWhatsNew.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPWhatsNew.h; path = WhatsNew/WPWhatsNew.h; sourceTree = "<group>"; };
 		598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNew.m; path = WhatsNew/WPWhatsNew.m; sourceTree = "<group>"; };
 		5D0431AC1A7C31AB0025BDFD /* ReaderBrowseSiteViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReaderBrowseSiteViewController.h; sourceTree = "<group>"; };
@@ -2656,6 +2658,7 @@
 				5D2BEB4819758102005425F7 /* WPTableImageSourceTest.m */,
 				93A379EB19FFBF7900415023 /* KeychainTest.m */,
 				FFAB7CB21A14D1AC00765942 /* ProgressTest.m */,
+				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -3675,6 +3678,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */,
 				931D26F519ED7E6D00114F17 /* BlogJetpackTest.m in Sources */,
 				5D12FE1E1988243700378BD6 /* RemoteReaderPost.m in Sources */,
 				5D12FE221988245B00378BD6 /* RemoteReaderSite.m in Sources */,

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -5,6 +5,7 @@
 #import "UIDevice+Helpers.h"
 #import "WordPressAppDelegate.h"
 #import "NotificationsManager.h"
+#import "WPUserAgent.h"
 
 static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.wordpress.com/rest/v1.1/";
 static NSString *const WordPressComApiOauthBaseUrl = @"https://public-api.wordpress.com/oauth2";
@@ -72,7 +73,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 		
         [self setAuthorizationHeaderWithToken:_authToken];
 		
-        NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+        NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
 		[self.requestSerializer setValue:userAgent forHTTPHeaderField:@"User-Agent"];
 	}
 	
@@ -121,7 +122,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
         DDLogVerbose(@"Initializing anonymous API");
         _anonymousApi = [[self alloc] initWithBaseURL:[NSURL URLWithString:WordPressComApiClientEndpointURL] ];
 
-        NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
+        NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
 		[_anonymousApi.requestSerializer setValue:userAgent forHTTPHeaderField:@"User-Agent"];
     });
 

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -73,7 +73,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 		
         [self setAuthorizationHeaderWithToken:_authToken];
 		
-        NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
+        NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent currentUserAgent];
 		[self.requestSerializer setValue:userAgent forHTTPHeaderField:@"User-Agent"];
 	}
 	
@@ -122,7 +122,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
         DDLogVerbose(@"Initializing anonymous API");
         _anonymousApi = [[self alloc] initWithBaseURL:[NSURL URLWithString:WordPressComApiClientEndpointURL] ];
 
-        NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent applicationUserAgent];
+        NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate].userAgent currentUserAgent];
 		[_anonymousApi.requestSerializer setValue:userAgent forHTTPHeaderField:@"User-Agent"];
     });
 

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -1,11 +1,3 @@
-//
-//  WPUserAgentTests.m
-//  WordPress
-//
-//  Created by Diego E. Rey Mendez on 3/17/15.
-//  Copyright (c) 2015 WordPress. All rights reserved.
-//
-
 #import <XCTest/XCTest.h>
 
 #import "WPUserAgent.h"

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -1,0 +1,67 @@
+//
+//  WPUserAgentTests.m
+//  WordPress
+//
+//  Created by Diego E. Rey Mendez on 3/17/15.
+//  Copyright (c) 2015 WordPress. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "WPUserAgent.h"
+
+static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
+static NSString* const WPUserAgentKeyDefaultUserAgent = @"DefaultUserAgent";
+static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
+
+@interface WPUserAgentTests : XCTestCase
+@end
+
+@implementation WPUserAgentTests
+
+/**
+ *  @brief      Calculates the wordpress UA for this device.
+ *  @details    This method is duplicated on purpose since we want to make sure that any change to
+ *              the WP UA in the app makes this test show an error unless updated.  This way we
+ *              ensure the change is intentional.
+ */
+- (NSString *)wordPressUserAgent
+{
+    UIDevice *device = [UIDevice currentDevice];
+    NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+    NSString *userAgent = [NSString stringWithFormat:@"wp-iphone/%@ (%@ %@, %@) Mobile",
+                           appVersion,
+                           device.systemName,
+                           device.systemVersion,
+                           device.model];
+    
+    return userAgent;
+}
+
+- (void)testUseDefaultUserAgent
+{
+    NSString *defaultUA = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    WPUserAgent *userAgent = nil;
+    
+    XCTAssertNoThrow(userAgent = [[WPUserAgent alloc] init]);
+    XCTAssertTrue([userAgent isKindOfClass:[WPUserAgent class]]);
+    
+    [userAgent useDefaultUserAgent];
+    
+    XCTAssertTrue([[userAgent currentUserAgent] isEqualToString:defaultUA]);
+}
+
+- (void)testUseWordPressUserAgent
+{
+    NSString *wordPressUA = [self wordPressUserAgent];
+    WPUserAgent *userAgent = nil;
+    
+    XCTAssertNoThrow(userAgent = [[WPUserAgent alloc] init]);
+    XCTAssertTrue([userAgent isKindOfClass:[WPUserAgent class]]);
+    
+    [userAgent useDefaultUserAgent];
+    
+    XCTAssertTrue([[userAgent currentUserAgent] isEqualToString:wordPressUA]);
+}
+
+@end


### PR DESCRIPTION
`WordPressAppDelegate` was dealing with some code to handle the user agent for the app.  Since this was outside of the scope of what the app delegate should be doing I created a module to take care of it.

A method from a `UIDevice` extension was also moved into this class as it was inside of it's domain.

**Test:**
- Run the unit tests.

Unfortunately, testing this is difficult, but I added unit tests that should ensure a certain level of assurance.  Please make sure the lines that were replaced were replaced correctly.

/cc @bummytime 