### PR TITLE
Add clang format file.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,62 @@
+---
+Language:        Cpp
+# BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+ConstructorInitializerIndentWidth: 4
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AlwaysBreakAfterDefinitionReturnType: false
+AlwaysBreakTemplateDeclarations: false
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: All
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+BinPackParameters: true
+BinPackArguments: true
+ColumnLimit:     0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+DerivePointerAlignment: false
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: false
+IndentWrappedFunctionNames: false
+IndentFunctionDeclarationAfterType: false
+MaxEmptyLinesToKeep: 1
+KeepEmptyLinesAtTheStartOfBlocks: true
+NamespaceIndentation: Inner
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakString: 1000
+PenaltyBreakFirstLessLess: 120
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+SpacesBeforeTrailingComments: 1
+Cpp11BracedListStyle: false
+Standard:        Cpp03
+IndentWidth:     4
+TabWidth:        8
+UseTab:          Never
+BreakBeforeBraces: Linux
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: false
+SpacesInContainerLiterals: false
+SpaceBeforeAssignmentOperators: true
+ContinuationIndentWidth: 4
+CommentPragmas:  '^ IWYU pragma:'
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+SpaceBeforeParens: ControlStatements
+DisableFormat:   false
+...
+


### PR DESCRIPTION
Clang Format is a tool that is part of the <a href="http://clang.llvm.org">Clang toolset</a> and it helps to automatically format Objective-C code. Out of the box, clang-format is a command-line tool that you can run directly on your source files. It doesn’t add/remove code from your source, instead focusing on adjusting the whitespace characters within your source to make code more consistent.

With a little bit of extra effort, you can make clang-format available from within Xcode. <a href="http://ClangFormat-Xcode">ClangFormat-Xcode</a> is an Xcode plugin developed by Travis Jeffery that makes Clang’s format tools available within Xcode.

Travis has made the plugin available via Alcatraz. Alternately if you don't want to install <a href="http://alcatraz.io">Alcatraz</a> and prefer to install the plugin manually follow the instructions on the repository.

After you install it there will be a new menu item under Edit → Clang Format where you can configure and trigger automatic formatting of code in your project.

You can format the current file, selected text within the current file or more than one file selected in the Xcode project navigator. The style used to format is also available on this menu, there is a set of pre-configures styles (LLVM, Google, WebKit) but there is also the possibility to create our own style trough a configuration file.

To make our life easier I already created a <a href="https://gist.githubusercontent.com/SergioEstevao/fcacf0ba6dacdced4113/raw/89f61047db6fe83c2016769083b77d6839287247/.clang-format" target="_blank">configuration file</a> for clang-format that follows WordPress code formatting guidelines and add it to our WordPress repo. So you just need to configure the plugin to use the File configuration option.

To make the process of formatting quicker I’ve assigned keystrokes to these using System Preferences → Keyboard → Shortcuts → App Shortcuts. Ctrl+F to format selected text and Ctrl+Shif+F for the all file.

cc @sendhil, please review