### PR TITLE
Specify post type when syncing a wpcom blog.

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -274,10 +274,13 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
                                    failure:nil];
 
     PostService *postService = [[PostService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    // FIXME: this is hacky, but XML-RPC doesn't support fetching "any" type of post
-    // Ideally we'd do a multicall and fetch both posts/pages, but it's out of scope for this commit
+    // FIXME: this is hacky, ideally we'd do a multicall and fetch both posts/pages, but it's out of scope for this commit
     if (blog.restApi) {
-        [postService syncPostsOfType:PostServiceTypeAny
+        [postService syncPostsOfType:PostServiceTypePost
+                             forBlog:blog
+                             success:nil
+                             failure:nil];
+        [postService syncPostsOfType:PostServiceTypePage
                              forBlog:blog
                              success:nil
                              failure:nil];

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -275,25 +275,15 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
 
     PostService *postService = [[PostService alloc] initWithManagedObjectContext:self.managedObjectContext];
     // FIXME: this is hacky, ideally we'd do a multicall and fetch both posts/pages, but it's out of scope for this commit
-    if (blog.restApi) {
-        [postService syncPostsOfType:PostServiceTypePost
-                             forBlog:blog
-                             success:nil
-                             failure:nil];
-        [postService syncPostsOfType:PostServiceTypePage
-                             forBlog:blog
-                             success:nil
-                             failure:nil];
-    } else {
-        [postService syncPostsOfType:PostServiceTypePost
-                             forBlog:blog
-                             success:nil
-                             failure:nil];
-        [postService syncPostsOfType:PostServiceTypePage
-                             forBlog:blog
-                             success:nil
-                             failure:nil];
-    }
+    [postService syncPostsOfType:PostServiceTypePost
+                         forBlog:blog
+                         success:nil
+                         failure:nil];
+    [postService syncPostsOfType:PostServiceTypePage
+                         forBlog:blog
+                         success:nil
+                         failure:nil];
+
 }
 
 - (void)syncBlogStaggeringRequests:(Blog *)blog


### PR DESCRIPTION
Avoids fetching revisions and other unwanted post types.

Closes #3428 