### PR TITLE
Headers are no longer precompiled for WPiOS.

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3827,7 +3827,6 @@
 					"$(SRCROOT)",
 				);
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -3885,7 +3884,6 @@
 					"\"$(SRCROOT)/Classes\"",
 					"$(SRCROOT)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -3961,7 +3959,6 @@
 					"\"$(SRCROOT)/Classes\"",
 					"$(SRCROOT)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -4038,7 +4035,6 @@
 					"\"$(SRCROOT)/Classes\"",
 					"$(SRCROOT)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",


### PR DESCRIPTION
Precompiles headers are making some fake-errors pop up when building WPiOS, that makes spotting real errors more difficult.  I'm disabling precompiled headers for now.

**How to test:**
- Just make sure the build times are reasonable with this setting off.

/cc @sendhil, @astralbodies 