### PR TITLE
Removes unneeded constraint breaking on iOS7

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -158,11 +158,6 @@ NSInteger const BlogDetailsRowCountForSectionAdmin = 1;
                                                                   attribute:NSLayoutAttributeCenterX
                                                                  multiplier:1.f
                                                                    constant:0.f]];
-        // Then, horizontally constrain the headerWrapper
-        [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-[headerWrapper]-|"
-                                                                          options:0
-                                                                          metrics:metrics
-                                                                            views:views]];
         
     } else {
         // Pin the headerWrapper to its superview AND wrap the headerView in horizontal margins


### PR DESCRIPTION
While doing some iOS 7 iPad testing I noticed we had a constraint breaking somwhere.  I tracked it back to the one removed in this PR. Its actually an unneeded constraint since the other contraints for X centering and fixed width already ensure the correct layout. 

Tested in iOS 7 and iOS 8 iPad retina simulators