### PR TITLE
Small cleanup on the recently added WPAppAnalytics.

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -1,11 +1,3 @@
-//
-//  WPAppAnalytics.h
-//  WordPress
-//
-//  Created by Diego E. Rey Mendez on 3/16/15.
-//  Copyright (c) 2015 WordPress. All rights reserved.
-//
-
 #import <Foundation/Foundation.h>
 
 typedef NSString*(^WPAppAnalyticsLastVisibleScreenCallback)();

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -1,11 +1,3 @@
-//
-//  WPAppAnalytics.m
-//  WordPress
-//
-//  Created by Diego E. Rey Mendez on 3/16/15.
-//  Copyright (c) 2015 WordPress. All rights reserved.
-//
-
 #import "WPAppAnalytics.h"
 
 #import "WPAnalyticsTrackerMixpanel.h"

--- a/WordPress/WordPressTest/WPAppAnalyticsTests.m
+++ b/WordPress/WordPressTest/WPAppAnalyticsTests.m
@@ -1,11 +1,3 @@
-//
-//  WPAppAnalyticsTests.m
-//  WordPress
-//
-//  Created by Diego E. Rey Mendez on 3/16/15.
-//  Copyright (c) 2015 WordPress. All rights reserved.
-//
-
 #import <OCMock/OCMock.h>
 #import <WordPressCom-Analytics-iOS/WPAnalytics.h>
 #import <XCTest/XCTest.h>
@@ -23,7 +15,7 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
 
 @implementation WPAppAnalyticsTests
 
-- (void)testInitializationWithMixPanelAndWPComTracker
+- (void)testInitializationWithMixpanelAndWPComTracker
 {
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WPAppAnalyticsDefaultsKeyUsageTracking];
     
@@ -99,7 +91,7 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     [analyticsMock verify];
 }
 
-- (void)testInitializationWithMixPanelAndWPComTrackerButNoUsageTracking
+- (void)testInitializationWithMixpanelAndWPComTrackerButNoUsageTracking
 {
     [[NSUserDefaults standardUserDefaults] setBool:NO forKey:WPAppAnalyticsDefaultsKeyUsageTracking];
     


### PR DESCRIPTION
Cleans up `WPAppAnalytics` and its unit tests following @sendhil's notes [to a previous PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/3419/files).

/cc @sendhil 