### PR TITLE
Fix crash to to index being NSNotFound

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/WPTableViewHandler.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPTableViewHandler.m
@@ -693,6 +693,9 @@ static CGFloat const DefaultCellHeight = 44.0;
 - (NSIndexPath *)indexPathForFirstObjectPrecedingPreservedVisibleIndexPath:(NSIndexPath *)indexPath
 {
     NSInteger index = [self.fetchedResultsIndexPathsBeforeChange indexOfObject:indexPath];
+    if (NSNotFound == index) {
+        return nil;
+    }
     NSArray *arr = [self.fetchedResultsIndexPathsBeforeChange subarrayWithRange:NSMakeRange(0, index)];
     for (NSInteger  i = [arr count] -1; i > 0; i-- ) {
         NSManagedObject *obj = self.fetchedResultsBeforeChange[i];


### PR DESCRIPTION
Identified via crash log.  I have no idea how we'd reproduce this practically, but the fix for the crash seems obvious enough.
Crash log: 

> Last Exception Backtrace:
0   CoreFoundation                       0x000000018252e530 __exceptionPreprocess + 132
1   libobjc.A.dylib                      0x00000001935040e4 objc_exception_throw + 56
2   CoreFoundation                       0x000000018247a5c8 -[NSArray subarrayWithRange:] + 664
3   WordPress                            0x00000001001e7b08 -[WPTableViewHandler indexPathForFirstObjectPrecedingPreservedVisibleIndexPath:] (WPTableViewHandler.m:696)
4   WordPress                            0x00000001001e759c -[WPTableViewHandler refreshTableViewPreservingOffset] (WPTableViewHandler.m:638)
5   WordPress                            0x00000001001e5f18 -[WPTableViewHandler scrollViewDidEndDecelerating:] (WPTableViewHandler.m:400)
6   UIKit                                0x0000000186eea504 -[UIScrollView(UIScrollViewInternal) _stopScrollDecelerationNotify:] + 336
7   UIKit                                0x0000000186eea024 -[UIScrollView _smoothScrollWithUpdateTime:] + 2276

