### PR TITLE
Update to stats pod 0.2.5 which includes Jetpack stats crash fix

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -28,7 +28,7 @@ pod 'Helpshift', '~>4.8.0'
 pod 'CTAssetsPickerController', '~> 2.7.0'
 pod 'WordPress-iOS-Shared', '0.2.2'
 pod 'WordPress-iOS-Editor', '0.5'
-pod 'WordPressCom-Stats-iOS', '0.2.0'
+pod 'WordPressCom-Stats-iOS', '0.2.5'
 pod 'WordPressCom-Analytics-iOS', '0.0.28'
 pod 'NSObject-SafeExpectations', '0.0.2'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
@@ -38,7 +38,7 @@ pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.gi
 pod 'MRProgress', '~>0.7.0'
 
 target 'WordPressTodayWidget', :exclusive => true do
-  pod 'WordPressCom-Stats-iOS', '0.2.0'
+  pod 'WordPressCom-Stats-iOS', '0.2.5'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -114,11 +114,11 @@ PODS:
     - AFNetworking (~> 2.5.1)
     - wpxmlrpc (~> 0.7)
   - WordPressCom-Analytics-iOS (0.0.28)
-  - WordPressCom-Stats-iOS (0.2.0):
+  - WordPressCom-Stats-iOS (0.2.5):
     - AFNetworking (~> 2.5.1)
     - CocoaLumberjack (~> 1.9)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.2.0)
+    - WordPress-iOS-Shared (~> 0.2)
     - WordPressCom-Analytics-iOS
   - wpxmlrpc (0.8)
 
@@ -154,7 +154,7 @@ DEPENDENCIES:
   - WordPress-iOS-Shared (= 0.2.2)
   - WordPressApi (= 0.3.1)
   - WordPressCom-Analytics-iOS (= 0.0.28)
-  - WordPressCom-Stats-iOS (= 0.2.0)
+  - WordPressCom-Stats-iOS (= 0.2.5)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -224,7 +224,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Shared: f66cc48dae11681d24c9abf36724a6ec28014409
   WordPressApi: 95a1b20372c3a5052f4d3bc4d333f72009c3d986
   WordPressCom-Analytics-iOS: 5895f5e051da1f8ada3d861182229b7d8cef350a
-  WordPressCom-Stats-iOS: bb023fc4c623cb77c9baa43db228df3a0394a558
+  WordPressCom-Stats-iOS: 69e9198e1581cd7815b2faad961ddab8c3391d02
   wpxmlrpc: 5bd349b9894755c05d868b3518b217e496ae1b05
 
 COCOAPODS: 0.35.0


### PR DESCRIPTION
Closes #3458 

Adds a safety check for the class of responseObject to make sure its not assumed to be an NSDictionary. Added unit tests to ensure a nil response is acceptable.