### PR TITLE
Modularizes the app delegate's crashlytic code

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -30,6 +30,7 @@
 #import "ReaderTopicService.h"
 #import "SVProgressHUD.h"
 #import "TodayExtensionService.h"
+#import "WPCrashlytics.h"
 
 #import "WPTabBarController.h"
 #import "BlogListViewController.h"
@@ -69,9 +70,10 @@
 int ddLogLevel                                                  = LOG_LEVEL_INFO;
 static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhatsNewPopup";
 
-@interface WordPressAppDelegate () <UITabBarControllerDelegate, CrashlyticsDelegate, UIAlertViewDelegate, BITHockeyManagerDelegate>
+@interface WordPressAppDelegate () <UITabBarControllerDelegate, UIAlertViewDelegate, BITHockeyManagerDelegate>
 
 @property (nonatomic, strong, readwrite) WPAppAnalytics                 *analytics;
+@property (nonatomic, strong, readwrite) WPCrashlytics                  *crashlytics;
 @property (nonatomic, strong, readwrite) Reachability                   *internetReachability;
 @property (nonatomic, strong, readwrite) DDFileLogger                   *fileLogger;
 @property (nonatomic, strong, readwrite) Simperium                      *simperium;
@@ -644,7 +646,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     [fileManager changeCurrentDirectoryPath:currentDirectoryPath];
 }
 
-#pragma mark - Crash reporting
+#pragma mark - Crashlytics configuration
 
 - (void)configureCrashlytics
 {
@@ -652,42 +654,11 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     return;
 #endif
 
-    if ([[WordPressComApiCredentials crashlyticsApiKey] length] == 0) {
-        return;
-    }
-
-    [Crashlytics startWithAPIKey:[WordPressComApiCredentials crashlyticsApiKey]];
-    [[Crashlytics sharedInstance] setDelegate:self];
-
-    [self setCommonCrashlyticsParameters];
-}
-
-- (void)crashlytics:(Crashlytics *)crashlytics didDetectCrashDuringPreviousExecution:(id<CLSCrashReport>)crash
-{
-    DDLogMethod();
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSInteger crashCount = [defaults integerForKey:@"crashCount"];
-    crashCount += 1;
-    [defaults setInteger:crashCount forKey:@"crashCount"];
-    [defaults synchronize];
-}
-
-- (void)setCommonCrashlyticsParameters
-{
-#if defined(INTERNAL_BUILD) || defined(DEBUG)
-    return;
-#endif
+    NSString* apiKey = [WordPressComApiCredentials crashlyticsApiKey];
     
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
-    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-
-    BOOL loggedIn = defaultAccount != nil;
-    [Crashlytics setUserName:defaultAccount.username];
-    [Crashlytics setObjectValue:@(loggedIn) forKey:@"logged_in"];
-    [Crashlytics setObjectValue:@(loggedIn) forKey:@"connected_to_dotcom"];
-    [Crashlytics setObjectValue:@([blogService blogCountForAllAccounts]) forKey:@"number_of_blogs"];
+    if (apiKey) {
+        self.crashlytics = [[WPCrashlytics alloc] initWithAPIKey:apiKey];
+    }
 }
 
 - (void)configureHockeySDK
@@ -870,7 +841,6 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     
     return name ?: WPNotificationsBucketName;
 }
-
 
 #pragma mark - Keychain
 
@@ -1138,7 +1108,6 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     }
     
     [self toggleExtraDebuggingIfNeeded];
-    [self setCommonCrashlyticsParameters];
     [self setupSingleSignOn];
     
     [WPAnalytics track:WPAnalyticsStatDefaultAccountChanged];

--- a/WordPress/Classes/Utility/WPCrashlytics.h
+++ b/WordPress/Classes/Utility/WPCrashlytics.h
@@ -1,0 +1,19 @@
+//
+//  WPCrashlytics.h
+//  WordPress
+//
+//  Created by Diego E. Rey Mendez on 3/26/15.
+//  Copyright (c) 2015 WordPress. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ *  @class      WPCrashlytics
+ *  @brief      This module contains the crashlytics logic for WPiOS.
+ */
+@interface WPCrashlytics : NSObject
+
+- (instancetype)initWithAPIKey:(NSString*)apiKey;
+
+@end

--- a/WordPress/Classes/Utility/WPCrashlytics.h
+++ b/WordPress/Classes/Utility/WPCrashlytics.h
@@ -1,11 +1,3 @@
-//
-//  WPCrashlytics.h
-//  WordPress
-//
-//  Created by Diego E. Rey Mendez on 3/26/15.
-//  Copyright (c) 2015 WordPress. All rights reserved.
-//
-
 #import <Foundation/Foundation.h>
 
 /**

--- a/WordPress/Classes/Utility/WPCrashlytics.h
+++ b/WordPress/Classes/Utility/WPCrashlytics.h
@@ -6,6 +6,6 @@
  */
 @interface WPCrashlytics : NSObject
 
-- (instancetype)initWithAPIKey:(NSString*)apiKey;
+- (instancetype)initWithAPIKey:(NSString *)apiKey;
 
 @end

--- a/WordPress/Classes/Utility/WPCrashlytics.m
+++ b/WordPress/Classes/Utility/WPCrashlytics.m
@@ -1,11 +1,3 @@
-//
-//  WPCrashlytics.m
-//  WordPress
-//
-//  Created by Diego E. Rey Mendez on 3/26/15.
-//  Copyright (c) 2015 WordPress. All rights reserved.
-//
-
 #import "WPCrashlytics.h"
 
 #import <Crashlytics/Crashlytics.h>

--- a/WordPress/Classes/Utility/WPCrashlytics.m
+++ b/WordPress/Classes/Utility/WPCrashlytics.m
@@ -20,7 +20,7 @@
 
 #pragma mark - Initialization
 
-- (instancetype)initWithAPIKey:(NSString*)apiKey
+- (instancetype)initWithAPIKey:(NSString *)apiKey
 {
     NSParameterAssert(apiKey);
     
@@ -57,7 +57,7 @@
     [notificationCenter removeObserver:self];
 }
 
-- (void)handleDefaultAccountChangedNotification:(NSNotification*)notification
+- (void)handleDefaultAccountChangedNotification:(NSNotification *)notification
 {
     [self setCommonCrashlyticsParameters];
 }

--- a/WordPress/Classes/Utility/WPCrashlytics.m
+++ b/WordPress/Classes/Utility/WPCrashlytics.m
@@ -74,10 +74,6 @@
 
 - (void)setCommonCrashlyticsParameters
 {
-#if defined(INTERNAL_BUILD) || defined(DEBUG)
-    return;
-#endif
-    
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];

--- a/WordPress/Classes/Utility/WPCrashlytics.m
+++ b/WordPress/Classes/Utility/WPCrashlytics.m
@@ -1,0 +1,106 @@
+//
+//  WPCrashlytics.m
+//  WordPress
+//
+//  Created by Diego E. Rey Mendez on 3/26/15.
+//  Copyright (c) 2015 WordPress. All rights reserved.
+//
+
+#import "WPCrashlytics.h"
+
+#import <Crashlytics/Crashlytics.h>
+#import "AccountService.h"
+#import "BlogService.h"
+#import "ContextManager.h"
+#import "WPAccount.h"
+
+@interface WPCrashlytics () <CrashlyticsDelegate>
+@end
+
+@implementation WPCrashlytics
+
+#pragma mark - Dealloc
+
+- (void)dealloc
+{
+    [self stopObservingNotifications];
+}
+
+#pragma mark - Initialization
+
+- (instancetype)initWithAPIKey:(NSString*)apiKey
+{
+    NSParameterAssert(apiKey);
+    
+    self = [super init];
+    
+    if (self) {
+        [Crashlytics startWithAPIKey:apiKey];
+        [[Crashlytics sharedInstance] setDelegate:self];
+        
+        [self setCommonCrashlyticsParameters];
+        
+        [self startObservingNotifications];
+    }
+    
+    return self;
+}
+
+#pragma mark - Notifications
+
+- (void)startObservingNotifications
+{
+    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+    
+    [notificationCenter addObserver:self
+                           selector:@selector(handleDefaultAccountChangedNotification:)
+                               name:WPAccountDefaultWordPressComAccountChangedNotification
+                             object:nil];
+}
+
+- (void)stopObservingNotifications
+{
+    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+    
+    [notificationCenter removeObserver:self];
+}
+
+- (void)handleDefaultAccountChangedNotification:(NSNotification*)notification
+{
+    [self setCommonCrashlyticsParameters];
+}
+
+#pragma mark - Common crashlytics parameters
+
+- (void)setCommonCrashlyticsParameters
+{
+#if defined(INTERNAL_BUILD) || defined(DEBUG)
+    return;
+#endif
+    
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
+    
+    BOOL loggedIn = defaultAccount != nil;
+    [Crashlytics setUserName:defaultAccount.username];
+    [Crashlytics setObjectValue:@(loggedIn) forKey:@"logged_in"];
+    [Crashlytics setObjectValue:@(loggedIn) forKey:@"connected_to_dotcom"];
+    [Crashlytics setObjectValue:@([blogService blogCountForAllAccounts]) forKey:@"number_of_blogs"];
+}
+
+#pragma mark - CrashlyticsDelegate
+
+- (void)crashlytics:(Crashlytics *)crashlytics didDetectCrashDuringPreviousExecution:(id<CLSCrashReport>)crash
+{
+    DDLogMethod();
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSInteger crashCount = [defaults integerForKey:@"crashCount"];
+    crashCount += 1;
+    [defaults setInteger:crashCount forKey:@"crashCount"];
+    [defaults synchronize];
+}
+
+
+@end

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -73,9 +73,10 @@
 		5903AE1B19B60A98009D5354 /* WPButtonForNavigationBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 5903AE1A19B60A98009D5354 /* WPButtonForNavigationBar.m */; };
 		591A428C1A6DC1B0003807A6 /* WPBackgroundDimmerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */; };
 		591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */; };
-		594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = 594DB2941AB891A200E2E456 /* WPUserAgent.m */; };
+		5926E1E31AC4468300964783 /* WPCrashlytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 5926E1E21AC4468300964783 /* WPCrashlytics.m */; };
 		5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */; };
 		5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */; };
+		594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = 594DB2941AB891A200E2E456 /* WPUserAgent.m */; };
 		595B02221A6C4ECD00415A30 /* WPWhatsNewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */; };
 		595B02271A6C504400415A30 /* WPWhatsNewView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 595B02261A6C504400415A30 /* WPWhatsNewView.xib */; };
 		5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */; };
@@ -625,11 +626,13 @@
 		591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPBackgroundDimmerView.m; sourceTree = "<group>"; };
 		591A428D1A6DC6F2003807A6 /* WPGUIConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPGUIConstants.h; sourceTree = "<group>"; };
 		591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPGUIConstants.m; sourceTree = "<group>"; };
-		594DB2931AB891A200E2E456 /* WPUserAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUserAgent.h; sourceTree = "<group>"; };
-		594DB2941AB891A200E2E456 /* WPUserAgent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUserAgent.m; sourceTree = "<group>"; };
+		5926E1E11AC4468300964783 /* WPCrashlytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPCrashlytics.h; sourceTree = "<group>"; };
+		5926E1E21AC4468300964783 /* WPCrashlytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPCrashlytics.m; sourceTree = "<group>"; };
 		5948AD0C1AB734F2006E8882 /* WPAppAnalytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAppAnalytics.h; sourceTree = "<group>"; };
 		5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAppAnalytics.m; sourceTree = "<group>"; };
 		5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAppAnalyticsTests.m; sourceTree = "<group>"; };
+		594DB2931AB891A200E2E456 /* WPUserAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUserAgent.h; sourceTree = "<group>"; };
+		594DB2941AB891A200E2E456 /* WPUserAgent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUserAgent.m; sourceTree = "<group>"; };
 		595B02201A6C4ECD00415A30 /* WPWhatsNewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPWhatsNewView.h; path = WhatsNew/WPWhatsNewView.h; sourceTree = "<group>"; };
 		595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNewView.m; path = WhatsNew/WPWhatsNewView.m; sourceTree = "<group>"; };
 		595B02261A6C504400415A30 /* WPWhatsNewView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = WPWhatsNewView.xib; path = Resources/WhatsNew/WPWhatsNewView.xib; sourceTree = "<group>"; };
@@ -2169,6 +2172,8 @@
 				8525398A171761D9003F6B32 /* WPComLanguages.m */,
 				E183BD7217621D85000B0822 /* WPCookie.h */,
 				E183BD7317621D86000B0822 /* WPCookie.m */,
+				5926E1E11AC4468300964783 /* WPCrashlytics.h */,
+				5926E1E21AC4468300964783 /* WPCrashlytics.m */,
 				E114D798153D85A800984182 /* WPError.h */,
 				E114D799153D85A800984182 /* WPError.m */,
 				5DA3EE0E192508F700294E0B /* WPImageOptimizer.h */,
@@ -3496,6 +3501,7 @@
 				E1D04D8419374F2C002FADD7 /* BlogServiceRemoteREST.m in Sources */,
 				A25EBD87156E330600530E3D /* WPTableViewController.m in Sources */,
 				5DEB61B4156FCD3400242C35 /* WPWebView.m in Sources */,
+				5926E1E31AC4468300964783 /* WPCrashlytics.m in Sources */,
 				B55853F31962337500FAF6C3 /* NSScanner+Helpers.m in Sources */,
 				5D49B03B19BE3CAD00703A9B /* SafeReaderTopicToReaderTopic.m in Sources */,
 				5DEB61B8156FCD5200242C35 /* WPChromelessWebViewController.m in Sources */,


### PR DESCRIPTION
Modularizes the app delegate's crashlytic code by creating a new class called WPCrashlytics.

The app delegate is still responsible for deciding whether crashlytics should be run or not (checks for debug or internal builds, checks for a crashlytics credential).

**Test 1:**
- Run the app in debug or internal mode, make sure `WPCrashlytics` is never instanced.

**Test 2:**
- Run the app in release mode, make sure `WPCrashlytics` is instanced

**Test 3:**
- Run the app in release mode, put a breakpoint in `WPCrashlytics`'s method `setCommonCrashlyticsParameters` and make sure it's called when the user account changes (logout, login).

**Test 4:**
- Run the app in release mode, make it crash by raising an exception.
- Place a breakpoint in `WPCrashlytics`'s method `crashlytics:didDetectCrashDuringPreviousExecution:`.
- Run the app in release mode again, and make sure the breakpoint is triggered.