### PR TITLE
Updates Sync Timeout Metric

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -46,6 +46,7 @@ static CGFloat const NoteEstimatedHeight                = 70;
 static CGRect NotificationsTableHeaderFrame             = {0.0f, 0.0f, 0.0f, 40.0f};
 static CGRect NotificationsTableFooterFrame             = {0.0f, 0.0f, 0.0f, 48.0f};
 static NSTimeInterval NotificationsSyncTimeout          = 10;
+static NSString const *NotificationsNetworkStatusKey    = @"network_status";
 
 
 #pragma mark ====================================================================================
@@ -353,7 +354,10 @@ static NSTimeInterval NotificationsSyncTimeout          = 10;
 
 - (void)trackSyncTimeout
 {
-    [WPAnalytics track:WPAnalyticsStatNotificationsMissingSyncWarning];
+    Simperium *simperium = [[WordPressAppDelegate sharedWordPressApplicationDelegate] simperium];
+    NSDictionary *properties = @{ NotificationsNetworkStatusKey : simperium.networkStatus };
+    
+    [WPAnalytics track:WPAnalyticsStatNotificationsMissingSyncWarning withProperties:properties];
 }
 
 


### PR DESCRIPTION
This PR adds extra debug information, to help us track a possible sync'ing glitch.

Steps to trigger this flow are as follows:
1. Fresh install WPiOS
2. Log into your account, and accept the Push Notifications badge
3. While the app is in background (or closed) receive a push notification, and tap on it

If the affected notification takes over 10 seconds to be received, the Timeout event will get triggered. This can be forced by means of the Network Link Conditioner tool.

/cc @diegoreymendez  (thanks in advance!)
