### PR TITLE
Standardizes the possible post status.

### DIFF
--- a/WordPress/Classes/Models/BasePost.h
+++ b/WordPress/Classes/Models/BasePost.h
@@ -36,11 +36,6 @@ typedef enum {
 
 - (NSArray *)availableStatuses;
 
-/**
- Returns YES if the post is scheduled to be published on a specific date in the future.
- */
-- (BOOL)isScheduled;
-
 // Does the post exist on the blog?
 - (BOOL)hasRemote;
 // Deletes post locally
@@ -58,5 +53,57 @@ typedef enum {
 // Subclass methods
 - (NSString *)remoteStatusText;
 + (NSString *)titleForRemoteStatus:(NSNumber *)remoteStatus;
+
+#pragma mark - Status
+
+/**
+ *  @brief      Call this method to know if the post is a draft.
+ *
+ *  @returns    YES if the post is a draft.  NO otherwise.
+ */
+- (BOOL)isDraft;
+
+/**
+ *  @brief      Call this method to know if the post is pending review.
+ *
+ *  @returns    YES if the post is pending review.  NO otherwise.
+ */
+- (BOOL)isPending;
+
+/**
+ *  @brief      Call this method to know if the post is published.
+ *
+ *  @returns    YES if the post is published.  NO otherwise.
+ */
+- (BOOL)isPublished;
+
+/**
+ *  @brief      Call this method to know if the post is private.
+ *
+ *  @returns    YES if the post is private.  NO otherwise.
+ */
+- (BOOL)isPrivate;
+
+/**
+ *  @brief      Call this method to know if the post is scheduled for publishing.
+ *  @details    This returns YES whether the scheduled publishing date is immediate or future.
+ *
+ *  @returns    YES if the post is scheduled for publishing.  NO otherwise.
+ */
+- (BOOL)isScheduled;
+
+/**
+ *  @brief      Call this method to know if the post is scheduled for immediate publishing.
+ *
+ *  @returns    YES if the post is scheduled for immediate publishing.  NO otherwise.
+ */
+- (BOOL)isScheduledForImmediatePublishing;
+
+/**
+ *  @brief      Call this method to know if the post is scheduled for future publishing.
+ *
+ *  @returns    YES if the post is scheduled for future publishing.  NO otherwise.
+ */
+- (BOOL)isScheduledForFuturePublishing;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1427,7 +1427,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
     [self.view endEditing:YES];
     
-    if (!self.post.isScheduled && [self.post.original.status isEqualToString:@"draft"]  && [self.post.status isEqualToString:@"publish"]) {
+    if (![self.post isScheduledForFuturePublishing]
+        && [self.post.original.status isEqualToString:@"draft"]
+        && [self.post.status isEqualToString:@"publish"]) {
         self.post.dateCreated = [NSDate date];
     }
     self.post = self.post.original;
@@ -1436,7 +1438,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     
 	__block NSString *postTitle = self.post.postTitle;
     __block NSString *postStatus = self.post.status;
-    __block BOOL postIsScheduled = self.post.isScheduled;
+    __block BOOL postIsScheduled = [self.post isScheduledForFuturePublishing];
     
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     PostService *postService = [[PostService alloc] initWithManagedObjectContext:context];


### PR DESCRIPTION
This is the initial commit to fix [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/3473).

This only creates the base set of methods we'll be using to centralize the post status checks.  This PR intentionally avoids changing the rest of the code to use these methods, to make this implementation atomic and easier to review.

/cc @aerych, @bummytime