### PR TITLE
Fixes accessibility on the Posts/Pages table so that VO users can use it

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostsViewController.m
@@ -57,7 +57,6 @@
     
     self.title = NSLocalizedString(@"Posts", @"");
     self.tableView.accessibilityIdentifier = @"PostsTable";
-    self.tableView.isAccessibilityElement = YES;
     UIImage *image = [UIImage imageNamed:@"icon-posts-add"];
     UIButton *button = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, image.size.width, image.size.height)];
     [button setImage:image forState:UIControlStateNormal];


### PR DESCRIPTION
Fixes #3467

Removes the flag set on the Posts/Pages VC that set the table view controller as an accessibility element. When in VoiceOver it makes the entire table a single element and not scrollable with a single finger left and right.

I left the accessibility label on it for the UI Automation tests that we may be using it for.

Video of broken VoiceOver: https://cloudup.com/cEB9_-6aGZ6
Video of fixed VoiceOver: https://cloudup.com/cCgpx7QjswR

cc: @sendhil @SergioEstevao