### PR TITLE
Ability to filter gravatars with rating

### DIFF
--- a/WordPress/Classes/Categories/UIImageView+Gravatar.h
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.h
@@ -1,8 +1,15 @@
+extern NSString *const GravatarRatingG;
+extern NSString *const GravatarRatingPG;
+extern NSString *const GravatarRatingR;
+extern NSString *const GravatarRatingX;
+
 @interface UIImageView (Gravatar)
 
 - (NSURL *)blavatarURLForHost:(NSString *)host;
 - (void)setImageWithGravatarEmail:(NSString *)emailAddress;
+- (void)setImageWithGravatarEmail:(NSString *)emailAddress gravatarRating:(NSString *)rating;
 - (void)setImageWithGravatarEmail:(NSString *)emailAddress fallbackImage:(UIImage *)fallbackImage;
+- (void)setImageWithGravatarEmail:(NSString *)emailAddress fallbackImage:(UIImage *)fallbackImage gravatarRating:(NSString *)rating;
 - (void)setImageWithBlavatarUrl:(NSString *)blavatarUrl;
 - (void)setImageWithBlavatarUrl:(NSString *)blavatarUrl isWPcom:(BOOL)wpcom;
 - (void)setImageWithBlavatarUrl:(NSString *)blavatarUrl placeholderImage:(UIImage *)placeholderImage;

--- a/WordPress/Classes/Categories/UIImageView+Gravatar.m
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.m
@@ -12,21 +12,37 @@ NSString *const BlavatarDefaultWporg = @"blavatar-wporg.png";
 NSString *const BlavatarDefaultWpcom = @"blavatar-wpcom.png";
 NSString *const GravatarDefault = @"gravatar.png";
 
+// More information on gravatar ratings: https://en.gravatar.com/site/implement/images/
+NSString *const GravatarRatingG = @"g"; // default
+NSString *const GravatarRatingPG = @"pg";
+NSString *const GravatarRatingR = @"r";
+NSString *const GravatarRatingX = @"x";
+
 @implementation UIImageView (Gravatar)
 
 - (void)setImageWithGravatarEmail:(NSString *)emailAddress
+{
+    [self setImageWithGravatarEmail:emailAddress gravatarRating:GravatarRatingG];
+}
+
+- (void)setImageWithGravatarEmail:(NSString *)emailAddress gravatarRating:(NSString *)rating
 {
     static UIImage *gravatarDefaultImage;
     if (gravatarDefaultImage == nil) {
         gravatarDefaultImage = [UIImage imageNamed:GravatarDefault];
     }
 
-    [self setImageWithURL:[self gravatarURLForEmail:emailAddress] placeholderImage:gravatarDefaultImage];
+    [self setImageWithURL:[self gravatarURLForEmail:emailAddress gravatarRating:rating] placeholderImage:gravatarDefaultImage];
 }
 
 - (void)setImageWithGravatarEmail:(NSString *)emailAddress fallbackImage:(UIImage *)fallbackImage
 {
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[self gravatarURLForEmail:emailAddress]];
+    [self setImageWithGravatarEmail:emailAddress fallbackImage:fallbackImage gravatarRating:GravatarRatingG];
+}
+
+- (void)setImageWithGravatarEmail:(NSString *)emailAddress fallbackImage:(UIImage *)fallbackImage gravatarRating:(NSString *)rating
+{
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[self gravatarURLForEmail:emailAddress gravatarRating:rating]];
     [request addValue:@"image/*" forHTTPHeaderField:@"Accept"];
 
     __weak UIImageView *weakSelf = self;
@@ -71,14 +87,18 @@ NSString *const GravatarDefault = @"gravatar.png";
     }
 }
 
-- (NSURL *)gravatarURLForEmail:(NSString *)email
+- (NSURL *)gravatarURLForEmail:(NSString *)email gravatarRating:(NSString *)rating
 {
-    return [self gravatarURLForEmail:email withSize:[self sizeForGravatarDownload]];
+    return [self gravatarURLForEmail:email withSize:[self sizeForGravatarDownload] gravatarRating:rating];
 }
 
-- (NSURL *)gravatarURLForEmail:(NSString *)email withSize:(NSInteger)size
+- (NSURL *)gravatarURLForEmail:(NSString *)email withSize:(NSInteger)size gravatarRating:(NSString *)rating
 {
-    NSString *gravatarUrl = [NSString stringWithFormat:@"%@/%@?d=404&s=%d", GravatarBaseUrl, [email md5], size];
+    // fallback to "G" rating
+    if (!rating) {
+        rating = GravatarRatingG;
+    }
+    NSString *gravatarUrl = [NSString stringWithFormat:@"%@/%@?d=404&s=%d&r=%@", GravatarBaseUrl, [email md5], size, rating];
     return [NSURL URLWithString:gravatarUrl];
 }
 

--- a/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
@@ -47,7 +47,8 @@ const CGFloat MeHeaderViewVerticalMargin = 10.0;
 
 - (void)setGravatarEmail:(NSString *)gravatarEmail
 {
-    [self.gravatarImageView setImageWithGravatarEmail:gravatarEmail];
+    // Since this view is only visible to the current user, we should show all ratings
+    [self.gravatarImageView setImageWithGravatarEmail:gravatarEmail gravatarRating:GravatarRatingX];
 }
 
 #pragma mark - Private Methods


### PR DESCRIPTION
Fixes #3109. This PR introduces a way to pass a gravatar rating parameter. Currently, if the gravatar doesn't have a "G" rating, the app will not show it, which in most cases what we would like to do. However, in pages such as the new "Me", it'd be a good idea to show the avatar no matter what it's rating is since that page will only be visible for the current user. So, I've added a way to pass the gravatar rating parameter if you want to, otherwise it'll fallback to G rating by default.

@aerych Can I bother you with a quick review?

Note: If you close the simulator before running the app, it will not use the cached version of the image, so it's easy to reproduce the issue in #3109.