### PR TITLE
Fixes Signup 1Password Glitch

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -543,6 +543,10 @@ static CGPoint const CreateAccountAndBlogOnePasswordPadding = {9.0, 0.0};
         _passwordField.text = loginDict[AppExtensionPasswordKey] ?: [NSString string];
                                                             
         [WPAnalytics track:WPAnalyticsStatOnePasswordSignup];
+                 
+        // Note: Since the Site field is right below the 1Password field, let's continue with the edition flow
+        // and make the SiteAddress Field the first responder.
+        [_siteAddressField becomeFirstResponder];
     }];
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -509,6 +509,10 @@ static CGPoint const CreateAccountAndBlogOnePasswordPadding = {9.0, 0.0};
 
 - (IBAction)saveLoginToOnePassword:(id)sender
 {
+    // Dismiss the keyboard right away
+    [self.view endEditing:YES];
+    
+    // Hit 1Password!
     NSDictionary *newLoginDetails = @{
         AppExtensionTitleKey        : WPOnePasswordWordPressTitle,
         AppExtensionUsernameKey     : _usernameField.text ?: [NSString string],


### PR DESCRIPTION
#### Steps:

1. Fresh install WPiOS.
2. Tap over the *Create Account* button
3. Tap over any of the TextFields
4. Tap over the 1Password field
5. The keyboard should get dismissed, and the Activity List should show up.
6. Tap over 1Password again.

#### Expected:
The keyboard, which got dismissed in (5), shouldn't reappear after tapping 1Password in (6).
**Additionally:** once 1Password flow is ready, the Site URL should become the first responder. Reason to do so is: it's the field below the 1P button.

@diegoreymendez i'm sorry i missed this screen last time (#3440). Mind taking a quick review?

Fixes #3488 

Thank you!
