### PR TITLE
Modularizes the lookback presenter code.

### DIFF
--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -20,7 +20,6 @@ extern NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey;
 extern NSString *const WPStatsTodayWidgetUserDefaultsViewCountKey;
 extern NSString *const WPStatsTodayWidgetUserDefaultsVisitorCountKey;
 
-extern NSString *const WPInternalBetaShakeToPullUpFeedbackKey;
 extern BOOL const WPJetpackRESTEnabled;
 
 extern NSString *const WPiTunesAppId;

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -26,8 +26,6 @@ NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey       = @"WordPres
 NSString *const WPStatsTodayWidgetUserDefaultsViewCountKey          = @"TodayViewCount";
 NSString *const WPStatsTodayWidgetUserDefaultsVisitorCountKey       = @"TodayVisitorCount";
 
-NSString *const WPInternalBetaShakeToPullUpFeedbackKey              = @"InternalBetaShakeToPullUpFeedback";
-
 #if defined(INTERNAL_BUILD) || defined(DEBUG)
 BOOL const WPJetpackRESTEnabled                                     = YES;
 #else

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -209,12 +209,15 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
             UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
 
             NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-            AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
-            WPAccount *account = [accountService defaultWordPressComAccount];
+            
+            [context performBlock:^{
+                AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+                WPAccount *account = [accountService defaultWordPressComAccount];
 
-            self.lookbackPresenter = [[WPLookbackPresenter alloc] initWithToken:lookbackToken
-                                                                         userId:account.username
-                                                                         window:keyWindow];
+                self.lookbackPresenter = [[WPLookbackPresenter alloc] initWithToken:lookbackToken
+                                                                             userId:account.username
+                                                                             window:keyWindow];
+            }];
         }
     });
 #endif

--- a/WordPress/Classes/Utility/WPLookbackPresenter.h
+++ b/WordPress/Classes/Utility/WPLookbackPresenter.h
@@ -1,0 +1,31 @@
+#import <Foundation/Foundation.h>
+
+/**
+ *  @brief      The user defaults key to store the shake-to-pull setting for Lookback.
+ */
+extern NSString* const WPLookbackPresenterShakeToPullUpFeedbackKey;
+
+/**
+ *  @class      WPLookbackPresenter
+ *  @brief      Presents lookback when the shake gesture is identified.
+ *  @details    
+ */
+@interface WPLookbackPresenter : NSObject
+
+/**
+ *  @brief      Initializes the object to use the specified key window for the shake gesture
+ *              recognizer.
+ *
+ *  @param      token       The token to use to initialize lookback.  Cannot be an empty string and
+ *                          cannot be nil.
+ *  @param      userId      The identifier that lookback will use for the user.  Cannot be an empty
+ *                          string and cannot be nil.
+ *  @param      window      The window to add the shake gesture recognizer to.  Cannot be nil.
+ *
+ *  @returns    The initialized object.
+ */
+- (instancetype)initWithToken:(NSString *)token
+                       userId:(NSString *)userId
+                       window:(UIWindow *)window;
+
+@end

--- a/WordPress/Classes/Utility/WPLookbackPresenter.h
+++ b/WordPress/Classes/Utility/WPLookbackPresenter.h
@@ -18,8 +18,8 @@ extern NSString* const WPLookbackPresenterShakeToPullUpFeedbackKey;
  *
  *  @param      token       The token to use to initialize lookback.  Cannot be an empty string and
  *                          cannot be nil.
- *  @param      userId      The identifier that lookback will use for the user.  Cannot be an empty
- *                          string and cannot be nil.
+ *  @param      userId      The identifier that lookback will use for the user.  Can be nil or empty
+ *                          since the user may not be logged in yet.
  *  @param      window      The window to add the shake gesture recognizer to.  Cannot be nil.
  *
  *  @returns    The initialized object.

--- a/WordPress/Classes/Utility/WPLookbackPresenter.m
+++ b/WordPress/Classes/Utility/WPLookbackPresenter.m
@@ -33,8 +33,6 @@ NSString* const WPLookbackPresenterShakeToPullUpFeedbackKey = @"InternalBetaShak
 {
     NSParameterAssert([token isKindOfClass:[NSString class]]);
     NSParameterAssert([token length] > 0);
-    NSParameterAssert([userId isKindOfClass:[NSString class]]);
-    NSParameterAssert([userId length] > 0);
     NSParameterAssert([window isKindOfClass:[UIWindow class]]);
     
     self = [super init];
@@ -58,8 +56,6 @@ NSString* const WPLookbackPresenterShakeToPullUpFeedbackKey = @"InternalBetaShak
 {
     NSParameterAssert([token isKindOfClass:[NSString class]]);
     NSParameterAssert([token length] > 0);
-    NSParameterAssert([userId isKindOfClass:[NSString class]]);
-    NSParameterAssert([userId length] > 0);
     NSParameterAssert([window isKindOfClass:[UIWindow class]]);
     
 #ifndef LOOKBACK_ENABLED

--- a/WordPress/Classes/Utility/WPLookbackPresenter.m
+++ b/WordPress/Classes/Utility/WPLookbackPresenter.m
@@ -1,0 +1,109 @@
+#import "WPLookbackPresenter.h"
+
+#import <Lookback/Lookback.h>
+
+NSString* const WPLookbackPresenterShakeToPullUpFeedbackKey = @"InternalBetaShakeToPullUpFeedback";
+
+@interface WPLookbackPresenter ()
+@property (nonatomic, strong, readwrite) UILongPressGestureRecognizer *gestureRecognizer;
+@property (nonatomic, strong, readwrite) UIWindow *window;
+@end
+
+@implementation WPLookbackPresenter
+
+#pragma mark - Dealloc
+
+- (void)dealloc
+{
+    [self.window removeGestureRecognizer:self.gestureRecognizer];
+}
+
+#pragma mark - Initialization
+
+- (instancetype)init
+{
+    [self doesNotRecognizeSelector:_cmd];
+    self = nil;
+    return nil;
+}
+
+- (instancetype)initWithToken:(NSString*)token
+                       userId:(NSString*)userId
+                       window:(UIWindow*)window
+{
+    NSParameterAssert([token isKindOfClass:[NSString class]]);
+    NSParameterAssert([token length] > 0);
+    NSParameterAssert([userId isKindOfClass:[NSString class]]);
+    NSParameterAssert([userId length] > 0);
+    NSParameterAssert([window isKindOfClass:[UIWindow class]]);
+    
+    self = [super init];
+    
+    if (self) {
+        _window = window;
+        
+        [self setupLookbackWithToken:token
+                              userId:userId
+                              window:window];
+    }
+    
+    return self;
+}
+
+#pragma mark - One time setup
+
+- (void)setupLookbackWithToken:(NSString*)token
+                        userId:(NSString*)userId
+                        window:(UIWindow*)window
+{
+    NSParameterAssert([token isKindOfClass:[NSString class]]);
+    NSParameterAssert([token length] > 0);
+    NSParameterAssert([userId isKindOfClass:[NSString class]]);
+    NSParameterAssert([userId length] > 0);
+    NSParameterAssert([window isKindOfClass:[UIWindow class]]);
+    
+#ifndef LOOKBACK_ENABLED
+    NSAssert(NO,
+             @"This method should not be called when lookback is disabled");
+#else
+    [Lookback setupWithAppToken:token];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{WPLookbackPresenterShakeToPullUpFeedbackKey: @YES}];
+    [[NSUserDefaults standardUserDefaults] setObject:@(NO) forKey:LookbackCameraEnabledSettingsKey];
+    [Lookback lookback].shakeToRecord = [[NSUserDefaults standardUserDefaults] boolForKey:WPLookbackPresenterShakeToPullUpFeedbackKey];
+    
+    // Setup Lookback to fire when the user holds down with three fingers for around 3 seconds
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UILongPressGestureRecognizer *recognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(lookbackGestureRecognized:)];
+        recognizer.minimumPressDuration = 3;
+            recognizer.cancelsTouchesInView = NO;
+#if TARGET_IPHONE_SIMULATOR
+        recognizer.numberOfTouchesRequired = 2;
+#else
+        recognizer.numberOfTouchesRequired = 3;
+#endif
+        self.gestureRecognizer = recognizer;
+        
+        [window addGestureRecognizer:recognizer];
+    });
+    
+    [Lookback lookback].userIdentifier = userId;
+#endif
+}
+
+#pragma mark - Gestures recognition
+
+- (void)lookbackGestureRecognized:(UILongPressGestureRecognizer *)sender
+{
+#ifndef LOOKBACK_ENABLED
+    NSAssert(NO,
+             @"This method should not be called when lookback is disabled");
+#else
+    if (sender.state == UIGestureRecognizerStateBegan) {
+        [LookbackRecordingViewController presentOntoScreenAnimated:YES];
+    }
+#endif
+}
+
+@end
+
+

--- a/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
@@ -30,6 +30,7 @@
 #import "WPImageOptimizer.h"
 #import "Constants.h"
 #import "Mediaservice.h"
+#import "WPLookbackPresenter.h"
 #import <WordPress-iOS-Shared/WPTableViewCell.h>
 
 #ifdef LOOKBACK_ENABLED
@@ -187,7 +188,7 @@ static CGFloat const SettingsRowHeight = 44.0;
 #ifdef LOOKBACK_ENABLED
     UISwitch *aSwitch = (UISwitch *)sender;
     BOOL shakeForFeedback = aSwitch.on;
-    [[NSUserDefaults standardUserDefaults] setBool:shakeForFeedback forKey:WPInternalBetaShakeToPullUpFeedbackKey];
+    [[NSUserDefaults standardUserDefaults] setBool:shakeForFeedback forKey:WPLookbackPresenterShakeToPullUpFeedbackKey];
     [Lookback lookback].shakeToRecord = shakeForFeedback;
 #endif
 }
@@ -301,10 +302,14 @@ static CGFloat const SettingsRowHeight = 44.0;
         aSwitch.on = [WPPostViewController isNewEditorEnabled];
         
     } else if (indexPath.section == SettingsSectionInternalBeta) {
+#ifndef LOOKBACK_ENABLED
+        NSAssert(NO, @"Should never execute this when Lookback is disabled.");
+#else
         cell.textLabel.text = NSLocalizedString(@"Shake for Feedback", @"Option to allow the user to shake the device to pull up the feedback mechanism");
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         UISwitch *aSwitch = (UISwitch *)cell.accessoryView;
-        aSwitch.on = [[NSUserDefaults standardUserDefaults] boolForKey:WPInternalBetaShakeToPullUpFeedbackKey];
+        aSwitch.on = [[NSUserDefaults standardUserDefaults] boolForKey:WPLookbackPresenterShakeToPullUpFeedbackKey];
+#endif
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */; };
 		598351AE1A704E7A00B6DD4F /* WPWhatsNew.m in Sources */ = {isa = PBXBuildFile; fileRef = 598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */; };
 		5993E7291AC5D65600D31D2B /* WPAppFilesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 5993E7281AC5D65600D31D2B /* WPAppFilesManager.m */; };
+		59D328FD1ACC2D0700356827 /* WPLookbackPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 59D328FC1ACC2D0700356827 /* WPLookbackPresenter.m */; };
 		59DD94341AC479ED0032DD6B /* WPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 59DD94331AC479ED0032DD6B /* WPLogger.m */; };
 		5D0431AE1A7C31AB0025BDFD /* ReaderBrowseSiteViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D0431AD1A7C31AB0025BDFD /* ReaderBrowseSiteViewController.m */; };
 		5D08B90419648C3400D5B381 /* ReaderSubscriptionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D08B90319648C3400D5B381 /* ReaderSubscriptionViewController.m */; };
@@ -643,6 +644,8 @@
 		598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNew.m; path = WhatsNew/WPWhatsNew.m; sourceTree = "<group>"; };
 		5993E7271AC5D65600D31D2B /* WPAppFilesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAppFilesManager.h; sourceTree = "<group>"; };
 		5993E7281AC5D65600D31D2B /* WPAppFilesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAppFilesManager.m; sourceTree = "<group>"; };
+		59D328FB1ACC2D0700356827 /* WPLookbackPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPLookbackPresenter.h; sourceTree = "<group>"; };
+		59D328FC1ACC2D0700356827 /* WPLookbackPresenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPLookbackPresenter.m; sourceTree = "<group>"; };
 		59DD94321AC479ED0032DD6B /* WPLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPLogger.h; sourceTree = "<group>"; };
 		59DD94331AC479ED0032DD6B /* WPLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPLogger.m; sourceTree = "<group>"; };
 		5D0431AC1A7C31AB0025BDFD /* ReaderBrowseSiteViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReaderBrowseSiteViewController.h; sourceTree = "<group>"; };
@@ -2202,6 +2205,8 @@
 				5926E1E21AC4468300964783 /* WPCrashlytics.m */,
 				E114D798153D85A800984182 /* WPError.h */,
 				E114D799153D85A800984182 /* WPError.m */,
+				59D328FB1ACC2D0700356827 /* WPLookbackPresenter.h */,
+				59D328FC1ACC2D0700356827 /* WPLookbackPresenter.m */,
 				5DA3EE0E192508F700294E0B /* WPImageOptimizer.h */,
 				5DA3EE0F192508F700294E0B /* WPImageOptimizer.m */,
 				5DA3EE10192508F700294E0B /* WPImageOptimizer+Private.h */,
@@ -3702,6 +3707,7 @@
 				319D6E8519E44F7F0013871C /* SuggestionsTableViewCell.m in Sources */,
 				E1AC282D18282423004D394C /* SFHFKeychainUtils.m in Sources */,
 				740BD8351A0D4C3600F04D18 /* WPUploadStatusButton.m in Sources */,
+				59D328FD1ACC2D0700356827 /* WPLookbackPresenter.m in Sources */,
 				319D6E7E19E447C80013871C /* SuggestionService.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Modularizes the lookback presenter code.

**Test 1:**
- Build in debug mode.
- Run the app.
- Make sure Lookback doesn't launch when shaking the device.

**Test 2:**
- Build in release-internal mode, or make sure LOOKBACK_ENABLED is defined and that the lookback pod is installed for the debug configuration.
- Run the app.
- Make sure Lookback is launched when shaking the device.

**Test 3:**
- Build in release-internal mode, or make sure LOOKBACK_ENABLED is defined and that the lookback pod is installed for the debug configuration.
- Remove the Lookback credential from the credentials .m file.
- Run the app.
- Make sure Lookback is not launched when shaking the device.