### PR TITLE
Enables validatesDomainName on AFSecurityPolicy

### DIFF
--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -74,6 +74,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 		
         NSString *userAgent = [[WordPressAppDelegate sharedWordPressApplicationDelegate] applicationUserAgent];
 		[self.requestSerializer setValue:userAgent forHTTPHeaderField:@"User-Agent"];
+        self.securityPolicy.validatesDomainName = YES;
 	}
 	
 	return self;

--- a/WordPress/WordPressApi/WordPressComOAuthClient.m
+++ b/WordPress/WordPressApi/WordPressComOAuthClient.m
@@ -15,7 +15,9 @@ static NSString * const WordPressComOAuthRedirectUrl = @"https://wordpress.com/"
 
 	client.responseSerializer = [[AFJSONResponseSerializer alloc] init];
 	[client.requestSerializer setValue:@"application/json" forHTTPHeaderField:@"Accept"];
-	
+
+    client.securityPolicy.validatesDomainName = YES;
+
     return client;
 }
 


### PR DESCRIPTION
We should be able to revert this after AFNetworking 2.5.3 or higher is
released.