### PR TITLE
Update CTAssetsPickerController pod version.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -21,7 +21,7 @@ pod 'google-plus-ios-sdk', '~>1.5'
 pod 'CrashlyticsLumberjack', '~>1.0.0'
 pod 'HockeySDK', '~>3.6.0'
 pod 'Helpshift', '~>4.10.0'
-pod 'CTAssetsPickerController', '~> 2.7.0'
+pod 'CTAssetsPickerController', '~> 2.9.3'
 pod 'Lookback', '0.9.2', :configurations => ['Release-Internal']
 pod 'MRProgress', '~>0.7.0'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -29,7 +29,7 @@ PODS:
     - CocoaLumberjack/Core
   - CrashlyticsLumberjack (1.0.2):
     - CocoaLumberjack/Core (~> 1.9)
-  - CTAssetsPickerController (2.7.0)
+  - CTAssetsPickerController (2.9.3)
   - DTCoreText (1.6.13):
     - DTFoundation/Core (~> 1.7.1)
     - DTFoundation/DTAnimatedGIF (~> 1.7.1)
@@ -125,7 +125,7 @@ DEPENDENCIES:
   - AMPopTip (~> 0.7)
   - CocoaLumberjack (~> 1.9)
   - CrashlyticsLumberjack (~> 1.0.0)
-  - CTAssetsPickerController (~> 2.7.0)
+  - CTAssetsPickerController (~> 2.9.3)
   - DTCoreText (= 1.6.13)
   - EmailChecker (from `https://raw.github.com/wordpress-mobile/EmailChecker/master/ios/EmailChecker.podspec`)
   - google-plus-ios-sdk (~> 1.5)
@@ -190,7 +190,7 @@ SPEC CHECKSUMS:
   AMPopTip: 5a78abc067fe3e2fb5d3980072ffae51c8c4f6c5
   CocoaLumberjack: 628fca2e88ef06f7cf6817309aa405f325d9a6fa
   CrashlyticsLumberjack: 36f8440f1f8a2e472816ecd51e9142f60b13fdce
-  CTAssetsPickerController: 085e7d4010bf51a7bd49d1ef75e534ca3090eb09
+  CTAssetsPickerController: 56a4a228dcb48a9375ab8d4922e82ac74af74aa1
   DTCoreText: d90a4dca8e4f7b0eb18f12a967563b77a75694f0
   DTFoundation: 1d28080c20c3da041706545363f8238ab53a6204
   EmailChecker: e909e6d113fac7ad5e3c304fabce30fc4a79c80e


### PR DESCRIPTION
This updates CTAssetsPickerController to the latest version.
Has it can be seen from the [release notes](https://github.com/chiunam/CTAssetsPickerController/blob/master/RELEASE-NOTES.md) it's mainly bug fixes and extra localisations.

cc @sendhil can you please review.