### PR TITLE
Notifications tab accessibility label updated to reflect unread state

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -463,13 +463,16 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
 - (void)updateNotificationBadgeVisibility
 {
     NSInteger count = [[UIApplication sharedApplication] applicationIconBadgeNumber];
+    UITabBarItem *tabBarItem = self.notificationsNavigationController.tabBarItem;
     if (count == 0) {
         self.notificationBadgeIconView.hidden = YES;
+        tabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications", @"Notifications tab bar item accessibility label");
         return;
     }
 
     BOOL wasNotificationBadgeHidden = self.notificationBadgeIconView.hidden;
     self.notificationBadgeIconView.hidden = NO;
+    tabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications Unread", @"Notifications tab bar item accessibility label, unread notifications state");
     if (wasNotificationBadgeHidden) {
         [self animateNotificationBadgeIcon];
     }


### PR DESCRIPTION
This PR adds "Notifications Unread" accessibility label in case there are unread notifications. Before the change it used to say "X items", which was not very descriptive. Also, we decided to keep "Notifications" part in the beginning so users can easily determine which tab they are on using Voice Over, in case they are switching tabs quickly.

/cc @astralbodies 