### PR TITLE
Add video tracking events

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -34,7 +34,7 @@ pod 'WordPressApi', '~> 0.3.4'
 pod 'WordPress-iOS-Shared', '0.3'
 pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => '410a94de9b71ef4cb300f5215d3ef09bfdd7abfb'
 pod 'WordPressCom-Stats-iOS', '0.3.0'
-pod 'WordPressCom-Analytics-iOS', '0.0.30'
+pod 'WordPressCom-Analytics-iOS', '0.0.31'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '303b8068530389ea87afde38b77466d685fe3210'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -112,7 +112,7 @@ PODS:
   - WordPressApi (0.3.4):
     - AFNetworking (~> 2.5.1)
     - wpxmlrpc (~> 0.7)
-  - WordPressCom-Analytics-iOS (0.0.30)
+  - WordPressCom-Analytics-iOS (0.0.31)
   - WordPressCom-Stats-iOS (0.3.0):
     - AFNetworking (~> 2.5.1)
     - CocoaLumberjack (~> 1.9)
@@ -153,7 +153,7 @@ DEPENDENCIES:
   - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`, commit `410a94de9b71ef4cb300f5215d3ef09bfdd7abfb`)
   - WordPress-iOS-Shared (= 0.3)
   - WordPressApi (~> 0.3.4)
-  - WordPressCom-Analytics-iOS (= 0.0.30)
+  - WordPressCom-Analytics-iOS (= 0.0.31)
   - WordPressCom-Stats-iOS (= 0.3.0)
   - wpxmlrpc (~> 0.8)
 
@@ -229,7 +229,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Editor: 8bd67af1e0391fb6a118cee583ba6163e04ab5b2
   WordPress-iOS-Shared: 0f5281492166bb89ea09d8ab5011e871ba4f6709
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
-  WordPressCom-Analytics-iOS: c1338756ca3f889e5a115fb73343b6bd2e7bfa0f
+  WordPressCom-Analytics-iOS: a35692b0bb5a1d5081da2481614a66663dfb091f
   WordPressCom-Stats-iOS: b0b767b8aab64b4446e547d6bbd23060ec78e1ab
   wpxmlrpc: 053c9cbed13dcec08515a4ffeb51780f6e858cc7
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -185,6 +185,12 @@
         case WPAnalyticsStatEditorAddedPhotoViaWPMediaLibrary:
             eventName = @"editor_added_photo_via_wp_media_library";
             break;
+        case WPAnalyticsStatEditorAddedVideoViaLocalLibrary:
+            eventName = @"editor_added_video_via_local_library";
+            break;
+        case WPAnalyticsStatEditorAddedVideoViaWPMediaLibrary:
+            eventName = @"editor_added_video_via_wp_media_library";
+            break;
         case WPAnalyticsStatEditorClosed:
             eventName = @"editor_closed";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -374,6 +374,16 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_added_photo_via_wp_media_library"];
             [instructions setCurrentDateForPeopleProperty:@"last_time_added_photo_via_wp_media_library_to_post"];
             break;
+        case WPAnalyticsStatEditorAddedVideoViaLocalLibrary:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Added Video via Local Library"];
+            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_added_video_via_local_library"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_added_video_via_local_library_to_post"];
+            break;
+        case WPAnalyticsStatEditorAddedVideoViaWPMediaLibrary:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Added Video via WP Media Library"];
+            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_added_video_via_wp_media_library"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_added_video_via_wp_media_library_to_post"];
+            break;
         case WPAnalyticsStatEditorPublishedPost:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Published Post"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_editor_published_post"];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1694,6 +1694,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
             [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary];
             [self.editorView replaceLocalImageWithRemoteImage:media.remoteURL uniqueId:mediaUniqueId];
         } else if (media.mediaType == MediaTypeVideo) {
+            [WPAnalytics track:WPAnalyticsStatEditorAddedVideoViaLocalLibrary];
             [self.editorView replaceLocalVideoWithID:mediaUniqueId
                                       forRemoteVideo:media.remoteURL
                                         remotePoster:media.thumbnailLocalURL
@@ -1709,6 +1710,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
             }
             [media remove];
         } else {
+            [WPAnalytics track:WPAnalyticsStatEditorUploadMediaFailed];
             [self dismissAssociatedActionSheetIfVisible:mediaUniqueId];
             self.mediaGlobalProgress.completedUnitCount++;
             if (media.mediaType == MediaTypeImage) {


### PR DESCRIPTION
Fix #3537 

How to test:

 * Open the app, create a new post and insert a video.
 * Wait for the video to be uploaded 
 * When the video is finished check in mix panel to see if the video event was reported: Editor - Added  Video via Local Library

cc @sendhil can you please review