### PR TITLE
Updates for clean compile with Xcode 6.3/Swift 1.2

### DIFF
--- a/WordPress/Classes/Extensions/NSAttributedString+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSAttributedString+Helpers.swift
@@ -16,7 +16,7 @@ extension NSAttributedString
         
         // Proceed embedding!
         let unwrappedEmbeds = embeds!
-        let theString       = self.mutableCopy() as NSMutableAttributedString
+        let theString       = self.mutableCopy() as! NSMutableAttributedString
         var rangeDelta      = 0
         
         for (value, image) in unwrappedEmbeds {

--- a/WordPress/Classes/Extensions/NSIndexPath+Swift.swift
+++ b/WordPress/Classes/Extensions/NSIndexPath+Swift.swift
@@ -6,6 +6,6 @@ extension NSIndexPath
     public func toString() -> String {
         // Padding: Make sure that, when sorted, there are no inconsistencies!
         let padding = 20
-        return NSString(format: "%\(padding)d-%\(padding)d", section, row)
+        return NSString(format: "%\(padding)d-%\(padding)d", section, row) as String
     }
 }

--- a/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
@@ -123,7 +123,7 @@ extension NotificationBlock
         
         var ranges = [NSValue: UIImage]()
         
-        for theMedia in media as [NotificationMedia] {
+        for theMedia in media as! [NotificationMedia] {
             // Failsafe: if the mediaURL couldn't be parsed, don't proceed
             if theMedia.mediaURL == nil {
                 continue
@@ -197,7 +197,7 @@ extension NotificationBlock
         // Apply the Ranges
         var lengthShift = 0
         
-        for range in ranges as [NotificationRange] {
+        for range in ranges as! [NotificationRange] {
             var shiftedRange        = range.range
             shiftedRange.location   += lengthShift
 

--- a/WordPress/Classes/Extensions/UIView+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIView+Helpers.swift
@@ -31,8 +31,8 @@ extension UIView
     }
     
     public func constraintForAttribute(attribute: NSLayoutAttribute) -> CGFloat? {
-        for constraint in constraints() as [NSLayoutConstraint] {
-            if constraint.firstItem as NSObject == self {
+        for constraint in constraints() as! [NSLayoutConstraint] {
+            if constraint.firstItem as! NSObject == self {
                 if constraint.firstAttribute == attribute || constraint.secondAttribute == attribute {
                     return constraint.constant
                 }
@@ -46,8 +46,8 @@ extension UIView
     }
 
     public func updateConstraintWithFirstItem(firstItem: NSObject!, attribute: NSLayoutAttribute, constant: CGFloat) {
-        for constraint in constraints() as [NSLayoutConstraint] {
-            if constraint.firstItem as NSObject == firstItem {
+        for constraint in constraints() as! [NSLayoutConstraint] {
+            if constraint.firstItem as! NSObject == firstItem {
                 if constraint.firstAttribute == attribute || constraint.secondAttribute == attribute {
                     constraint.constant = constant
                 }
@@ -56,8 +56,8 @@ extension UIView
     }
     
     public func updateConstraintWithFirstItem(firstItem: NSObject!, secondItem: NSObject!, firstItemAttribute: NSLayoutAttribute, secondItemAttribute: NSLayoutAttribute, constant: CGFloat) {
-        for constraint in constraints() as [NSLayoutConstraint] {
-            if (constraint.firstItem as NSObject == firstItem) && (constraint.secondItem as? NSObject == secondItem) {
+        for constraint in constraints() as! [NSLayoutConstraint] {
+            if (constraint.firstItem as! NSObject == firstItem) && (constraint.secondItem as? NSObject == secondItem) {
                 if constraint.firstAttribute == firstItemAttribute && constraint.secondAttribute == secondItemAttribute {
                     constraint.constant = constant
                 }

--- a/WordPress/Classes/Utility/Migrations/20-21/AccountToAccount20to21.swift
+++ b/WordPress/Classes/Utility/Migrations/20-21/AccountToAccount20to21.swift
@@ -18,7 +18,7 @@ class AccountToAccount20to21: NSEntityMigrationPolicy {
         // Note: 
         // NSEntityMigrationPolicy instance might not be the same all over. Let's use NSUserDefaults
         if let unwrappedAccount = legacyDefaultWordPressAccount(manager.sourceContext) {
-            let username = unwrappedAccount.valueForKey("username") as String
+            let username = unwrappedAccount.valueForKey("username") as! String
             
             let userDefaults = NSUserDefaults.standardUserDefaults()
             userDefaults.setValue(username, forKey: defaultDotcomUsernameKey)
@@ -43,7 +43,7 @@ class AccountToAccount20to21: NSEntityMigrationPolicy {
         let predicate = NSPredicate(format: "username == %@ AND isWpcom == true", defaultUsername)
         request.predicate = predicate
         
-        let accounts = context.executeFetchRequest(request, error: nil) as [NSManagedObject]?
+        let accounts = context.executeFetchRequest(request, error: nil) as! [NSManagedObject]?
         
         if let defaultAccount = accounts?.first {
             setLegacyDefaultWordPressAccount(defaultAccount)

--- a/WordPress/Classes/Utility/Migrations/AccountToAccount22to23.swift
+++ b/WordPress/Classes/Utility/Migrations/AccountToAccount22to23.swift
@@ -51,7 +51,7 @@ class AccountToAccount22to23: NSEntityMigrationPolicy {
         let context = manager.destinationContext
         let request = NSFetchRequest(entityName: "Account")
         var error: NSError?
-        let accounts = context.executeFetchRequest(request, error: &error) as [NSManagedObject]?
+        let accounts = context.executeFetchRequest(request, error: &error) as! [NSManagedObject]?
         
         if accounts == nil {
             return true
@@ -84,7 +84,7 @@ class AccountToAccount22to23: NSEntityMigrationPolicy {
         let userDefaults = NSUserDefaults.standardUserDefaults()
         
         if defaultAccount != nil {
-            let uuid = defaultAccount!.valueForKey("uuid") as String
+            let uuid = defaultAccount!.valueForKey("uuid") as! String
             userDefaults.setObject(uuid, forKey: defaultDotcomUUIDKey)
         }
         

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -92,23 +92,23 @@ import Foundation
     
     
     // MARK: - UITextViewDelegate Methods
-    public func textViewShouldBeginEditing(textView: UITextView!) -> Bool {
+    public func textViewShouldBeginEditing(textView: UITextView) -> Bool {
         return delegate?.textViewShouldBeginEditing?(textView) ?? true
     }
     
-    public func textViewDidBeginEditing(textView: UITextView!) {
+    public func textViewDidBeginEditing(textView: UITextView) {
         delegate?.textViewDidBeginEditing?(textView)
     }
     
-    public func textViewShouldEndEditing(textView: UITextView!) -> Bool {
+    public func textViewShouldEndEditing(textView: UITextView) -> Bool {
         return delegate?.textViewShouldEndEditing?(textView) ?? true
     }
 
-    public func textViewDidEndEditing(textView: UITextView!) {
+    public func textViewDidEndEditing(textView: UITextView) {
         delegate?.textViewDidEndEditing?(textView)
     }
     
-    public func textView(textView: UITextView!, shouldChangeTextInRange range: NSRange, replacementText text: String!) -> Bool {
+    public func textView(textView: UITextView, shouldChangeTextInRange range: NSRange, replacementText text: String) -> Bool {
         let shouldChange = delegate?.textView?(textView, shouldChangeTextInRange: range, replacementText: text) ?? true
         let respondsToDidType = delegate?.respondsToSelector(Selector("textView:didTypeWord:")) ?? false
 
@@ -117,20 +117,20 @@ import Foundation
             let prerange = NSMakeRange(0, range.location)
             let pretext: NSString = textViewText.substringWithRange(prerange) + text
             let words = pretext.componentsSeparatedByCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
-            let lastWord: NSString = words.last as NSString
+            let lastWord: NSString = words.last as! NSString
             
-            delegate?.textView?(textView, didTypeWord: lastWord)
+            delegate?.textView?(textView, didTypeWord: lastWord as String)
         }
         
         return shouldChange
     }
 
-    public func textViewDidChange(textView: UITextView!) {
+    public func textViewDidChange(textView: UITextView) {
         refreshInterface()
         delegate?.textViewDidChange?(textView)
     }
     
-    public func textView(textView: UITextView!, shouldInteractWithURL URL: NSURL!, inRange characterRange: NSRange) -> Bool {
+    public func textView(textView: UITextView, shouldInteractWithURL URL: NSURL, inRange characterRange: NSRange) -> Bool {
         return delegate?.textView?(textView, shouldInteractWithURL: URL, inRange: characterRange) ?? true
     }
     

--- a/WordPress/Classes/ViewRelated/Notifications/RichTextView/RichTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/RichTextView/RichTextView.swift
@@ -19,9 +19,8 @@ import Foundation
     
     
     // MARK: - Initializers
-    public override init() {
-        super.init()
-        setupSubviews()
+    convenience init() {
+        self.init(frame: CGRectZero)
     }
     
     public override init(frame: CGRect) {

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -98,8 +98,8 @@ import Foundation
             return false
         }
         
-        for operation in downloadQueue.operations as [AFHTTPRequestOperation] {
-            if operation.request.URL.isEqual(url) {
+        for operation in downloadQueue.operations as! [AFHTTPRequestOperation] {
+            if operation.request.URL!.isEqual(url) {
                 return false
             }
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
@@ -109,7 +109,7 @@ import Foundation
     }
 
     public func downloadGravatarWithGravatarEmail(email: NSString?) {
-        gravatarImageView.setImageWithGravatarEmail(email)
+        gravatarImageView.setImageWithGravatarEmail(email as String?)
     }
 
     // MARK: - View Methods
@@ -270,7 +270,7 @@ import Foundation
             return nil
         }
 
-        let unwrappedMutableString  = attributedCommentText!.mutableCopy() as NSMutableAttributedString
+        let unwrappedMutableString  = attributedCommentText!.mutableCopy() as! NSMutableAttributedString
         let range                   = NSRange(location: 0, length: unwrappedMutableString.length)
         let textColor               = WPStyleGuide.Notifications.blockUnapprovedTextColor
         unwrappedMutableString.addAttribute(NSForegroundColorAttributeName, value: textColor, range: range)

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -47,7 +47,7 @@ import Foundation
     }
     public var noticon: NSString? {
         set {
-            noticonLabel.text = newValue
+            noticonLabel.text = newValue as String?
         }
         get {
             return noticonLabel.text

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostContentView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostContentView.m
@@ -15,6 +15,8 @@
 
 @implementation ReaderPostContentView
 
+@dynamic delegate;
+
 #pragma mark - LifeCycle Methods
 
 - (instancetype)initWithFrame:(CGRect)frame

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostRichContentView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostRichContentView.m
@@ -10,6 +10,8 @@
 
 @implementation ReaderPostRichContentView
 
+@dynamic delegate;
+
 #pragma mark - Life Cycle Methods
 
 - (void)dealloc

--- a/WordPress/Classes/ViewRelated/Views/CircularImageView.swift
+++ b/WordPress/Classes/ViewRelated/Views/CircularImageView.swift
@@ -22,10 +22,14 @@ class CircularImageView : UIImageView
         layer.masksToBounds = true
     }
 
-    override init() {
-        super.init()
-
+    override init(image: UIImage!) {
+        super.init(image: image)
+        
         layer.masksToBounds = true
+    }
+    
+    convenience init() {
+        self.init(frame: CGRectZero)
     }
 
     override var frame: CGRect {

--- a/WordPress/Classes/ViewRelated/Views/WPRichContentView.m
+++ b/WordPress/Classes/ViewRelated/Views/WPRichContentView.m
@@ -10,6 +10,8 @@
 
 @implementation WPRichContentView
 
+@dynamic delegate;
+
 #pragma mark - Lifecycle Methods
 
 - (void)dealloc

--- a/WordPress/Classes/ViewRelated/Views/WPRichTextEmbed.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichTextEmbed.swift
@@ -113,7 +113,7 @@ class WPRichTextEmbed : UIView, UIWebViewDelegate, WPRichTextMediaAttachment
 
     func loadHTMLString(html: NSString) {
         var htmlString = NSString(format: "<html><head><meta name=\"viewport\" content=\"width=available-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no\" /></head><body>%@</body></html>", html)
-        webView.loadHTMLString(htmlString, baseURL: nil)
+        webView.loadHTMLString(htmlString as String, baseURL: nil)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichTextImage.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichTextImage.swift
@@ -32,9 +32,9 @@ class WPRichTextImage : UIControl, WPRichTextMediaAttachment {
     }
 
     required init(coder aDecoder: NSCoder) {
-        imageView = aDecoder.decodeObjectForKey(UIImage.classNameWithoutNamespaces()) as UIImageView
-        contentURL = aDecoder.decodeObjectForKey("contentURL") as NSURL?
-        linkURL = aDecoder.decodeObjectForKey("linkURL") as NSURL?
+        imageView = aDecoder.decodeObjectForKey(UIImage.classNameWithoutNamespaces()) as! UIImageView
+        contentURL = aDecoder.decodeObjectForKey("contentURL") as! NSURL?
+        linkURL = aDecoder.decodeObjectForKey("linkURL") as! NSURL?
 
         super.init(coder: aDecoder)
     }

--- a/WordPress/SwiftPlayground.playground/contents.xcplayground
+++ b/WordPress/SwiftPlayground.playground/contents.xcplayground
@@ -3,5 +3,4 @@
     <sections>
         <code source-file-name='section-1.swift'/>
     </sections>
-    <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/WordPress/SwiftPlayground.playground/timeline.xctimeline
+++ b/WordPress/SwiftPlayground.playground/timeline.xctimeline
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Timeline
-   version = "3.0">
-   <TimelineItems>
-   </TimelineItems>
-</Timeline>

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -25,7 +25,7 @@ class ContextManagerTests: XCTestCase {
         let psc = contextManager.persistentStoreCoordinator
         
         // Insert a Theme Entity
-        let objectOriginal = NSEntityDescription.insertNewObjectForEntityForName("Theme", inManagedObjectContext: mocOriginal) as NSManagedObject
+        let objectOriginal = NSEntityDescription.insertNewObjectForEntityForName("Theme", inManagedObjectContext: mocOriginal) as! NSManagedObject
         mocOriginal.obtainPermanentIDsForObjects([objectOriginal], error: nil)
         var error: NSError?
         mocOriginal.save(&error)
@@ -220,11 +220,11 @@ class ContextManagerTests: XCTestCase {
 
         let authorAvatarURL = "http://lorempixum.com/"
 
-        let post = NSEntityDescription.insertNewObjectForEntityForName("Post", inManagedObjectContext: mainContext) as Post
+        let post = NSEntityDescription.insertNewObjectForEntityForName("Post", inManagedObjectContext: mainContext) as! Post
         post.blog = blog
         post.authorAvatarURL = authorAvatarURL
 
-        let readerPost = NSEntityDescription.insertNewObjectForEntityForName("ReaderPost", inManagedObjectContext: mainContext) as ReaderPost
+        let readerPost = NSEntityDescription.insertNewObjectForEntityForName("ReaderPost", inManagedObjectContext: mainContext) as! ReaderPost
         readerPost.authorAvatarURL = authorAvatarURL
 
         mainContext.save(nil)
@@ -239,7 +239,7 @@ class ContextManagerTests: XCTestCase {
         XCTAssertEqual(1, postsResults!.count, "We should get one Post")
 
         // Test authorAvatarURL integrity after migration
-        let existingPost = postsResults!.first! as Post
+        let existingPost = postsResults!.first! as! Post
         XCTAssertEqual(existingPost.authorAvatarURL, authorAvatarURL)
 
         // Test the existence of ReaderPost object after migration
@@ -248,13 +248,13 @@ class ContextManagerTests: XCTestCase {
         XCTAssertEqual(1, readerPostsResults!.count, "We should get one ReaderPost")
 
         // Test authorAvatarURL integrity after migration
-        let existingReaderPost = readerPostsResults!.first! as ReaderPost
+        let existingReaderPost = readerPostsResults!.first! as! ReaderPost
         XCTAssertEqual(existingReaderPost.authorAvatarURL, authorAvatarURL)
 
         // Test for existence of authorAvatarURL in the model
         let secondAccount = newAccountInContext(secondContext)
         let secondBlog = newBlogInAccount(secondAccount)
-        let page = NSEntityDescription.insertNewObjectForEntityForName("Page", inManagedObjectContext: secondContext) as Page
+        let page = NSEntityDescription.insertNewObjectForEntityForName("Page", inManagedObjectContext: secondContext) as! Page
         page.blog = secondBlog
         page.authorAvatarURL = authorAvatarURL
 
@@ -306,12 +306,12 @@ class ContextManagerTests: XCTestCase {
     
     private func urlForModelName(name: NSString!) -> NSURL? {
         var bundle = NSBundle.mainBundle()
-        var url = bundle.URLForResource(name, withExtension: "mom")
+        var url:NSURL? = bundle.URLForResource(name as String, withExtension: "mom")
         
         if url == nil {
             var momdPaths = bundle.pathsForResourcesOfType("momd", inDirectory: nil);
             for momdPath in momdPaths {
-                url = bundle.URLForResource(name, withExtension: "mom", subdirectory: momdPath.lastPathComponent)
+                url = bundle.URLForResource(name as String, withExtension: "mom", subdirectory: momdPath.lastPathComponent)
             }
         }
         
@@ -325,7 +325,7 @@ class ContextManagerTests: XCTestCase {
         
         let fileManager = NSFileManager.defaultManager()
         let directoryUrl = storeURL.URLByDeletingLastPathComponent
-        let files = fileManager.contentsOfDirectoryAtURL(directoryUrl!, includingPropertiesForKeys: nil, options: NSDirectoryEnumerationOptions.SkipsSubdirectoryDescendants, error: nil) as Array<NSURL>
+        let files = fileManager.contentsOfDirectoryAtURL(directoryUrl!, includingPropertiesForKeys: nil, options: NSDirectoryEnumerationOptions.SkipsSubdirectoryDescendants, error: nil) as! Array<NSURL>
         for file in files {
             let range = file.lastPathComponent?.rangeOfString(storeURL.lastPathComponent!, options: nil, range: nil, locale: nil)
             if range?.startIndex != range?.endIndex {
@@ -335,7 +335,7 @@ class ContextManagerTests: XCTestCase {
     }
     
     private func newAccountInContext(context: NSManagedObjectContext) -> WPAccount {
-        let account = NSEntityDescription.insertNewObjectForEntityForName("Account", inManagedObjectContext: context) as WPAccount
+        let account = NSEntityDescription.insertNewObjectForEntityForName("Account", inManagedObjectContext: context) as! WPAccount
         account.username = "username"
         account.isWpcom = true
         account.authToken = "authtoken"
@@ -344,7 +344,7 @@ class ContextManagerTests: XCTestCase {
     }
     
     private func newBlogInAccount(account: WPAccount) -> Blog {
-        let blog = NSEntityDescription.insertNewObjectForEntityForName("Blog", inManagedObjectContext: account.managedObjectContext!) as Blog
+        let blog = NSEntityDescription.insertNewObjectForEntityForName("Blog", inManagedObjectContext: account.managedObjectContext!) as! Blog
         blog.xmlrpc = "http://test.blog/xmlrpc.php";
         blog.url = "http://test.blog/";
         blog.account = account

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -16,7 +16,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     override func viewDidLoad() {
         super.viewDidLoad()
         let sharedDefaults = NSUserDefaults(suiteName: WPAppGroupName)!
-        self.siteId = sharedDefaults.objectForKey(WPStatsTodayWidgetUserDefaultsSiteIdKey) as NSNumber?
+        self.siteId = sharedDefaults.objectForKey(WPStatsTodayWidgetUserDefaultsSiteIdKey) as! NSNumber?
 
         visitorsLabel?.text = NSLocalizedString("Visitors", comment: "Stats Visitors Label")
         viewsLabel?.text = NSLocalizedString("Views", comment: "Stats Views Label")
@@ -60,7 +60,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         // If there's an update, use NCUpdateResult.NewData
         
         let sharedDefaults = NSUserDefaults(suiteName: WPAppGroupName)!
-        let siteId = sharedDefaults.objectForKey(WPStatsTodayWidgetUserDefaultsSiteIdKey) as NSNumber?
+        let siteId = sharedDefaults.objectForKey(WPStatsTodayWidgetUserDefaultsSiteIdKey) as! NSNumber?
         self.siteName = sharedDefaults.stringForKey(WPStatsTodayWidgetUserDefaultsSiteNameKey) ?? ""
         let timeZoneName = sharedDefaults.stringForKey(WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey)
         let oauth2Token = self.getOAuth2Token()
@@ -101,7 +101,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         
         var oauth2Token:NSString? = SFHFKeychainUtils.getPasswordForUsername(WPStatsTodayWidgetOAuth2TokenKeychainUsername, andServiceName: WPStatsTodayWidgetOAuth2TokenKeychainServiceName, accessGroup: WPStatsTodayWidgetOAuth2TokenKeychainAccessGroup, error: &error)
         
-        return oauth2Token
+        return oauth2Token as String?
     }
     
 }


### PR DESCRIPTION
Fixes #3514.

Problems mainly with changes to Swift downcasts and Objective-C interop with String v. NSString. Also, override declarations of properties to add protocol conformance, as found in ContentView classes, now will complain if lacking an @dynamic implementation.