### PR TITLE
Updates WPWalkthroughTextField Padding data type

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -67,7 +67,7 @@ static CGFloat const CreateAccountAndBlogTextFieldPhoneHeight = 38.0;
 static CGFloat const CreateAccountAndBlogiOS7StatusBarOffset = 20.0;
 static CGFloat const CreateAccountAndBlogButtonWidth = 290.0;
 static CGFloat const CreateAccountAndBlogButtonHeight = 40.0;
-static CGPoint const CreateAccountAndBlogOnePasswordPadding = {9.0, 0.0};
+static UIOffset const CreateAccountAndBlogOnePasswordPadding = {9.0, 0.0};
 
 - (id)init
 {

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -87,7 +87,7 @@ static NSTimeInterval const GeneralWalkthroughAnimationDuration = 0.3f;
 static CGFloat const GeneralWalkthroughAlphaHidden              = 0.0f;
 static CGFloat const GeneralWalkthroughAlphaEnabled             = 1.0f;
 
-static CGPoint const LoginOnePasswordPadding                    = {9.0, 0.0f};
+static UIOffset const LoginOnePasswordPadding                   = {9.0, 0.0f};
 static NSInteger const LoginVerificationCodeNumberOfLines       = 2;
 
 - (void)dealloc

--- a/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.h
+++ b/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.h
@@ -3,7 +3,7 @@
 @interface WPWalkthroughTextField : UITextField
 
 @property (nonatomic) UIEdgeInsets textInsets;
-@property (nonatomic) CGPoint rightViewPadding;
+@property (nonatomic) UIOffset rightViewPadding;
 @property (nonatomic) BOOL showTopLineSeparator;
 @property (nonatomic) BOOL showSecureTextEntryToggle;
 

--- a/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.m
+++ b/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.m
@@ -123,8 +123,8 @@
 - (CGRect)rightViewRectForBounds:(CGRect)bounds
 {
     CGRect textRect = [super rightViewRectForBounds:bounds];
-    textRect.origin.x -= _rightViewPadding.x;
-    textRect.origin.y -= _rightViewPadding.y;
+    textRect.origin.x -= _rightViewPadding.horizontal;
+    textRect.origin.y -= _rightViewPadding.vertical;
     
     return textRect;
 }


### PR DESCRIPTION
#### Details:
This PR switches rightPadding property's data type to *UIOffset*, which is way more appropiate (thanks for the tip Koke!).

#### Testing:
1. Fresh install WPiOS on a device that has 1Password
2. Launch the app
3. Verify if the 1Password button is properly aligned
4. Tap over the *Create Account* button
5. Same as (3), the 1P button should look fine.

/cc @koke (Thanks in advance Jorge!)
