### PR TITLE
Fixes 1Password Crash on iPad Devices

### DIFF
--- a/WordPress/Classes/Services/OnePasswordFacade.h
+++ b/WordPress/Classes/Services/OnePasswordFacade.h
@@ -12,9 +12,10 @@ typedef void (^OnePasswordFacadeCallback)(NSString *username, NSString *password
  *
  *  @param loginUrl       the URL of the site in question.
  *  @param viewController the view controller of the class that needs the 1Password extension to appear. Note this can't be nil.
+ *  @param sender         the control that triggered the action
  *  @param completion     block that is called when 1Password is done retrieving the password.
  */
-- (void)findLoginForURLString:(NSString *)loginUrl viewController:(UIViewController *)viewController completion:(OnePasswordFacadeCallback)completion;
+- (void)findLoginForURLString:(NSString *)loginUrl viewController:(UIViewController *)viewController sender:(id)sender completion:(OnePasswordFacadeCallback)completion;
 
 /**
  *  A method to check if the 1Password extension is enabled

--- a/WordPress/Classes/Services/OnePasswordFacade.m
+++ b/WordPress/Classes/Services/OnePasswordFacade.m
@@ -3,12 +3,13 @@
 
 @implementation OnePasswordFacade
 
-- (void)findLoginForURLString:(NSString *)loginUrl viewController:(UIViewController *)viewController completion:(OnePasswordFacadeCallback)completion;
+- (void)findLoginForURLString:(NSString *)loginUrl viewController:(UIViewController *)viewController sender:(id)sender completion:(OnePasswordFacadeCallback)completion
 {
     NSParameterAssert(viewController != nil);
+    NSParameterAssert(sender != nil);
     NSParameterAssert(completion != nil);
     
-    [[OnePasswordExtension sharedExtension] findLoginForURLString:loginUrl forViewController:viewController sender:nil completion:^(NSDictionary *loginDict, NSError *error) {
+    [[OnePasswordExtension sharedExtension] findLoginForURLString:loginUrl forViewController:viewController sender:sender completion:^(NSDictionary *loginDict, NSError *error) {
         if (error != nil && error.code != AppExtensionErrorCodeCancelledByUser) {
             completion(nil, nil, error);
         } else {

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -295,7 +295,7 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 2;
 
 - (IBAction)findLoginFromOnePassword:(id)sender
 {
-    [self.viewModel onePasswordButtonActionForViewController:self];
+    [self.viewModel onePasswordButtonActionForViewController:self sender:sender];
 }
 
 - (IBAction)sendVerificationCode:(id)sender

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
@@ -143,8 +143,9 @@
  *  This method will bring up the 1Password extension
  *
  *  @param viewController the view controller that will display the 1Password extension
+ *  @param sender the control that triggered this action
  */
-- (void)onePasswordButtonActionForViewController:(UIViewController *)viewController;
+- (void)onePasswordButtonActionForViewController:(UIViewController *)viewController sender:(id)sender;
 
 /**
  *  The method returns the base site url

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -89,7 +89,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     [self.loginFacade signInWithLoginFields:loginFields];
 }
 
-- (void)onePasswordButtonActionForViewController:(UIViewController *)viewController
+- (void)onePasswordButtonActionForViewController:(UIViewController *)viewController sender:(id)sender
 {
     [self.presenter endViewEditing];
     
@@ -100,7 +100,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
  
     NSString *loginURL = self.userIsDotCom ? WPOnePasswordWordPressComURL : self.siteUrl;
     
-    [self.onePasswordFacade findLoginForURLString:loginURL viewController:viewController completion:^(NSString *username, NSString *password, NSError *error) {
+    [self.onePasswordFacade findLoginForURLString:loginURL viewController:viewController sender:sender completion:^(NSString *username, NSString *password, NSError *error) {
         BOOL blankUsernameOrPassword = (username.length == 0) || (password.length == 0);
         if (blankUsernameOrPassword || (error != nil)) {
             if (error != nil) {

--- a/WordPress/WordPressTest/LoginViewModelTests.m
+++ b/WordPress/WordPressTest/LoginViewModelTests.m
@@ -624,8 +624,10 @@ describe(@"signInButton", ^{
 describe(@"onePasswordButtonActionForViewController", ^{
     
     __block id mockViewController;
+    __block id mockSender;
     before(^{
         mockViewController = [OCMockObject niceMockForClass:[UIViewController class]];
+        mockSender = [OCMockObject niceMockForClass:[UIButton class]];
     });
     
     __block NSError *error;
@@ -633,9 +635,9 @@ describe(@"onePasswordButtonActionForViewController", ^{
     __block NSString *password;
     
     void (^forceOnePasswordExtensionCallbackToExecute)() = ^{
-        [OCMStub([mockOnePasswordFacade findLoginForURLString:OCMOCK_ANY viewController:OCMOCK_ANY completion:OCMOCK_ANY]) andDo:^(NSInvocation *invocation) {
+        [OCMStub([mockOnePasswordFacade findLoginForURLString:OCMOCK_ANY viewController:OCMOCK_ANY sender:OCMOCK_ANY completion:OCMOCK_ANY]) andDo:^(NSInvocation *invocation) {
             void (^ __unsafe_unretained callback)(NSString *, NSString *, NSError *);
-            [invocation getArgument:&callback atIndex:4];
+            [invocation getArgument:&callback atIndex:5];
             
             callback(username, password, error);
         }];
@@ -659,7 +661,7 @@ describe(@"onePasswordButtonActionForViewController", ^{
                 [[mockViewModelPresenter reject] setUsernameTextValue:OCMOCK_ANY];
                 [[mockViewModelPresenter reject] setPasswordTextValue:OCMOCK_ANY];
                 
-                [viewModel onePasswordButtonActionForViewController:mockViewController];
+                [viewModel onePasswordButtonActionForViewController:mockViewController sender:mockSender];
                 
                 [mockViewModelPresenter verify];
             });
@@ -669,7 +671,7 @@ describe(@"onePasswordButtonActionForViewController", ^{
                     XCTFail(@"Shouldn't get here");
                 }];
                 
-                [viewModel onePasswordButtonActionForViewController:mockViewController];
+                [viewModel onePasswordButtonActionForViewController:mockViewController sender:mockSender];
             });
         });
         
@@ -684,7 +686,7 @@ describe(@"onePasswordButtonActionForViewController", ^{
                 [[mockViewModelPresenter reject] setUsernameTextValue:OCMOCK_ANY];
                 [[mockViewModelPresenter reject] setPasswordTextValue:OCMOCK_ANY];
                 
-                [viewModel onePasswordButtonActionForViewController:mockViewController];
+                [viewModel onePasswordButtonActionForViewController:mockViewController sender:mockSender];
                 
                 [mockViewModelPresenter verify];
             });
@@ -694,7 +696,7 @@ describe(@"onePasswordButtonActionForViewController", ^{
                     XCTFail(@"Shouldn't get here");
                 }];
                 
-                [viewModel onePasswordButtonActionForViewController:mockViewController];
+                [viewModel onePasswordButtonActionForViewController:mockViewController sender:mockSender];
             });
         });
     });
@@ -713,7 +715,7 @@ describe(@"onePasswordButtonActionForViewController", ^{
             [[mockViewModelPresenter expect] setUsernameTextValue:viewModel.username];
             [[mockViewModelPresenter expect] setPasswordTextValue:viewModel.password];
             
-            [viewModel onePasswordButtonActionForViewController:mockViewController];
+            [viewModel onePasswordButtonActionForViewController:mockViewController sender:mockSender];
             
             [mockViewModelPresenter verify];
         });
@@ -724,7 +726,7 @@ describe(@"onePasswordButtonActionForViewController", ^{
                 signInAttempted = YES;
             }];
             
-            [viewModel onePasswordButtonActionForViewController:mockViewController];
+            [viewModel onePasswordButtonActionForViewController:mockViewController sender:mockSender];
             
             expect(signInAttempted).to.beTruthy();
         });
@@ -737,7 +739,7 @@ describe(@"onePasswordButtonActionForViewController", ^{
         it(@"should occur", ^{
             [[mockViewModelPresenter expect] endViewEditing];
             
-            [viewModel onePasswordButtonActionForViewController:mockViewController];
+            [viewModel onePasswordButtonActionForViewController:mockViewController sender:mockSender];
             
             [mockViewModelPresenter verify];
         });
@@ -757,7 +759,7 @@ describe(@"onePasswordButtonActionForViewController", ^{
             viewModel.siteUrl = @"";
             [[mockViewModelPresenter expect] displayOnePasswordEmptySiteAlert];
             
-            [viewModel onePasswordButtonActionForViewController:mockViewController];
+            [viewModel onePasswordButtonActionForViewController:mockViewController sender:mockSender];
             
             [mockViewModelPresenter verify];
         });
@@ -765,15 +767,15 @@ describe(@"onePasswordButtonActionForViewController", ^{
         it(@"if the user has a site url it should not display an error", ^{
             [[mockViewModelPresenter reject] displayOnePasswordEmptySiteAlert];
             
-            [viewModel onePasswordButtonActionForViewController:mockViewController];
+            [viewModel onePasswordButtonActionForViewController:mockViewController sender:mockSender];
             
             [mockViewModelPresenter verify];
         });
         
         it(@"should use OnePassword to find the users credentials", ^{
-            [[mockOnePasswordFacade expect] findLoginForURLString:viewModel.siteUrl viewController:mockViewController completion:OCMOCK_ANY];
+            [[mockOnePasswordFacade expect] findLoginForURLString:viewModel.siteUrl viewController:mockViewController sender:OCMOCK_ANY completion:OCMOCK_ANY];
             
-            [viewModel onePasswordButtonActionForViewController:mockViewController];
+            [viewModel onePasswordButtonActionForViewController:mockViewController sender:mockSender];
             
             [mockOnePasswordFacade verify];
         });
@@ -790,9 +792,9 @@ describe(@"onePasswordButtonActionForViewController", ^{
         });
         
         it(@"should use OnePassword to find the users credentials", ^{
-            [[mockOnePasswordFacade expect] findLoginForURLString:@"wordpress.com" viewController:mockViewController completion:OCMOCK_ANY];
+            [[mockOnePasswordFacade expect] findLoginForURLString:@"wordpress.com" viewController:mockViewController sender:OCMOCK_ANY completion:OCMOCK_ANY];
             
-            [viewModel onePasswordButtonActionForViewController:mockViewController];
+            [viewModel onePasswordButtonActionForViewController:mockViewController sender:mockSender];
             
             [mockOnePasswordFacade verify];
         });


### PR DESCRIPTION
#### Steps:

1. Fresh install WPiOS (develop) on an iPad Device
2. Tap over the 1Password button

#### Expected Results:
The app should not crash, and 1Password Popover should appear onscreen.

Fixes #3567

/cc @sendhil (Thanks in advance!)
