### PR TITLE
Fixes crash when logging in with self-hosted site

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -125,7 +125,7 @@ NSString *const TracksEventPropertyMenuItemKey = @"menu_item";
     
     [self.tracksService switchToAnonymousUserWithAnonymousID:self.anonymousID];
     
-    if (accountPresent && [username length] > 0) {
+    if (dotcom_user == YES && [username length] > 0) {
         [self.tracksService switchToAuthenticatedUserWithUsername:username userID:@"" skipAliasEventCreation:NO];
     }
 #endif


### PR DESCRIPTION
Fixes #3569 

Prevents a crash when logging in with a self-hosted site. Used the wrong variable to determine if a user is ready to be aliased or not with Tracks.