### PR TITLE
Fix some race conditions with Mixpanel tracking

### DIFF
--- a/WordPress/Classes/Utility/Analytics/MixpanelProxy.h
+++ b/WordPress/Classes/Utility/Analytics/MixpanelProxy.h
@@ -4,9 +4,9 @@
 
 - (void)registerInstanceWithToken:(NSString *)token;
 - (NSDictionary *)currentSuperProperties;
-- (void)incrementSuperProperty:(NSString *)property;
 - (void)flagSuperProperty:(NSString *)property;
 - (void)setSuperProperty:(NSString *)property toValue:(id)value;
+- (void)incrementSuperProperty:(NSString *)property;
 - (void)registerSuperProperties:(NSDictionary *)superProperties;
 - (void)identify:(NSString *)username;
 - (void)setPeopleProperties:(NSDictionary *)peopleProperties;

--- a/WordPress/Classes/Utility/Analytics/MixpanelProxy.h
+++ b/WordPress/Classes/Utility/Analytics/MixpanelProxy.h
@@ -1,17 +1,79 @@
 #import <Foundation/Foundation.h>
 
+/**
+ *  A class acting as an intermediary for Mixpanel.
+ */
 @interface MixpanelProxy : NSObject
 
+/**
+ *  Sets up Mixpanel
+ *
+ *  @param token the API token for the Mixpanel project.
+ */
 - (void)registerInstanceWithToken:(NSString *)token;
+
+/**
+ *  The current super properties stored by Mixpanel
+ */
 - (NSDictionary *)currentSuperProperties;
+
+/**
+ *  Sets a particular super property to true
+ *
+ *  @param property the name of the property
+ */
 - (void)flagSuperProperty:(NSString *)property;
+
+/**
+ *  Sets a particular super property to a specific value
+ *
+ *  @param property the name of the property
+ *  @param value    the value to store
+ */
 - (void)setSuperProperty:(NSString *)property toValue:(id)value;
+
+/**
+ *  Increments a partcular super property by value 1
+ *
+ *  @param property the name of the property
+ */
 - (void)incrementSuperProperty:(NSString *)property;
+
+/**
+ *  Combines a dictionary of passed in super properties with the ones currently stored.
+ */
 - (void)registerSuperProperties:(NSDictionary *)superProperties;
+
+/**
+ *  Identifies the particular user with the people analytics portion of Mixpanel.
+ */
 - (void)identify:(NSString *)username;
+
+/**
+ *  Combines a dictionary of passed in people properties with the ones currently stored.
+ */
 - (void)setPeopleProperties:(NSDictionary *)peopleProperties;
+
+/**
+ *  Increments a particular people property by value 1.
+ *
+ *  @param property the name of the property
+ */
 - (void)incrementPeopleProperty:(NSString *)property;
+
+/**
+ *  Aliases a new user to the anonymous id stored by Mixpanel. This method is called after a user logs in to make sure that the prior actions they took before they were logged in are propertly aggregated with their logged in account. Without this funnels tracking logins are useless.
+ *
+ *  @param username the WordPress.com username
+ */
 - (void)aliasNewUser:(NSString *)username;
+
+/**
+ *  Tracks an event with properties.
+ *
+ *  @param eventName  event name to be tracked
+ *  @param properties properties to associated with the event
+ */
 - (void)track:(NSString *)eventName properties:(NSDictionary *)properties;
 
 @end

--- a/WordPress/Classes/Utility/Analytics/MixpanelProxy.h
+++ b/WordPress/Classes/Utility/Analytics/MixpanelProxy.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+@interface MixpanelProxy : NSObject
+
+- (void)registerInstanceWithToken:(NSString *)token;
+- (NSDictionary *)currentSuperProperties;
+- (void)incrementSuperProperty:(NSString *)property;
+- (void)flagSuperProperty:(NSString *)property;
+- (void)setSuperProperty:(NSString *)property toValue:(id)value;
+- (void)registerSuperProperties:(NSDictionary *)superProperties;
+- (void)identify:(NSString *)username;
+- (void)setPeopleProperties:(NSDictionary *)peopleProperties;
+- (void)incrementPeopleProperty:(NSString *)property;
+- (void)aliasNewUser:(NSString *)username;
+- (void)track:(NSString *)eventName properties:(NSDictionary *)properties;
+
+@end

--- a/WordPress/Classes/Utility/Analytics/MixpanelProxy.m
+++ b/WordPress/Classes/Utility/Analytics/MixpanelProxy.m
@@ -1,0 +1,98 @@
+#import "MixpanelProxy.h"
+
+#import <Mixpanel/Mixpanel.h>
+
+
+@interface MixpanelProxy ()
+
+@property (nonatomic, strong) NSLock *lock;
+
+@end
+
+
+@implementation MixpanelProxy
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _lock = [NSLock new];
+    }
+    return self;
+}
+
+- (void)registerInstanceWithToken:(NSString *)token
+{
+    [Mixpanel sharedInstanceWithToken:token];
+}
+
+- (NSDictionary *)currentSuperProperties
+{
+    return [Mixpanel sharedInstance].currentSuperProperties;
+}
+
+- (void)incrementSuperProperty:(NSString *)property
+{
+    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:self.currentSuperProperties];
+    NSUInteger propertyValue = [superProperties[property] integerValue];
+    superProperties[property] = @(++propertyValue);
+    [self registerSuperProperties:superProperties];
+}
+
+- (void)flagSuperProperty:(NSString *)property
+{
+    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:self.currentSuperProperties];
+    superProperties[property] = @(YES);
+    [self registerSuperProperties:superProperties];
+}
+
+- (void)setSuperProperty:(NSString *)property toValue:(id)value
+{
+    NSParameterAssert(property.length > 0);
+    NSParameterAssert(value != nil);
+    
+    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:self.currentSuperProperties];
+    superProperties[property] = value;
+    [self registerSuperProperties:superProperties];
+}
+
+- (void)registerSuperProperties:(NSDictionary *)superProperties
+{
+    [[Mixpanel sharedInstance] registerSuperProperties:superProperties];
+}
+
+- (void)identify:(NSString *)username
+{
+    NSParameterAssert(username.length > 0);
+    
+    [[Mixpanel sharedInstance] identify:username];
+}
+
+- (void)setPeopleProperties:(NSDictionary *)peopleProperties
+{
+    [[Mixpanel sharedInstance].people set:peopleProperties];
+}
+
+- (void)incrementPeopleProperty:(NSString *)property
+{
+    NSParameterAssert(property.length > 0);
+    
+    [[Mixpanel sharedInstance].people increment:property by:@(1)];
+}
+
+- (void)aliasNewUser:(NSString *)username
+{
+    NSParameterAssert(username.length > 0);
+    
+    [[Mixpanel sharedInstance] createAlias:username forDistinctID:[Mixpanel sharedInstance].distinctId];
+    [[Mixpanel sharedInstance] identify:[Mixpanel sharedInstance].distinctId];
+}
+
+- (void)track:(NSString *)eventName properties:(NSDictionary *)properties
+{
+    NSParameterAssert(eventName.length > 0);
+    
+    [[Mixpanel sharedInstance] track:eventName properties:properties];
+}
+
+@end

--- a/WordPress/Classes/Utility/Analytics/MixpanelProxy.m
+++ b/WordPress/Classes/Utility/Analytics/MixpanelProxy.m
@@ -5,7 +5,6 @@
 
 @interface MixpanelProxy ()
 
-@property (nonatomic, strong) NSLock *lock;
 @property (nonatomic, strong) dispatch_queue_t superPropertiesQueue;
 
 @end
@@ -16,7 +15,6 @@
 {
     self = [super init];
     if (self) {
-        _lock = [NSLock new];
         _superPropertiesQueue = dispatch_queue_create("org.wordpress.analytics.mixpanelproxy", DISPATCH_QUEUE_SERIAL);
     }
     return self;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.h
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.h
@@ -1,8 +1,12 @@
 #import <Foundation/Foundation.h>
 #import "WPAnalytics.h"
 
+@class MixpanelProxy;
 @interface WPAnalyticsTrackerMixpanel : NSObject <WPAnalyticsTracker> {
     NSMutableDictionary *_aggregatedStatProperties;
 }
+
+- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context;
+- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context mixpanelProxy:(MixpanelProxy *)mixpanelProxy;
 
 @end

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -245,7 +245,13 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatApplicationOpened:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Application Opened"];
             [instructions setPeoplePropertyToIncrement:@"Application Opened"];
-            [self incrementSessionCount];
+            
+            // As this event increments the session count stat on the Mixpanel super properties we are forced to set it by hand otherwise
+            // this property will always be one session count behind. The reason being is that by the time the updated super property is ready
+            // to be applied this event will have already been processed by Mixpanel.
+            NSUInteger sessionCount = [self incrementSessionCount];
+            [self saveProperty:SessionCount withValue:@(sessionCount) forStat:WPAnalyticsStatApplicationOpened];
+            
             break;
         case WPAnalyticsStatApplicationClosed:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Application Closed"];
@@ -764,7 +770,7 @@ NSString *const SessionCount = @"session_count";
     [self saveProperty:property withValue:@(newValue) forStat:stat];
 }
 
-- (void)incrementSessionCount
+- (NSUInteger)incrementSessionCount
 {
     NSInteger sessionCount = [self sessionCount];
     sessionCount++;
@@ -774,6 +780,8 @@ NSString *const SessionCount = @"session_count";
     }
 
     [self.mixpanelProxy registerSuperProperties:@{ SessionCount : @(sessionCount) }];
+    
+    return sessionCount;
 }
 
 - (NSInteger)sessionCount

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -1,5 +1,5 @@
 #import "WPAnalyticsTrackerMixpanel.h"
-#import <Mixpanel/Mixpanel.h>
+#import "MixpanelProxy.h"
 #import "WPAnalyticsTrackerMixpanelInstructionsForStat.h"
 #import "WordPressComApiCredentials.h"
 #import "AccountService.h"
@@ -11,6 +11,14 @@
 #import "AccountServiceRemoteREST.h"
 #import "WPPostViewController.h"
 
+
+@interface WPAnalyticsTrackerMixpanel ()
+
+@property (nonatomic, strong) MixpanelProxy *mixpanelProxy;
+
+@end
+
+
 @implementation WPAnalyticsTrackerMixpanel
 
 NSString *const CheckedIfUserHasSeenLegacyEditor = @"checked_if_user_has_seen_legacy_editor";
@@ -21,13 +29,14 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
     self = [super init];
     if (self) {
         _aggregatedStatProperties = [[NSMutableDictionary alloc] init];
+        _mixpanelProxy = [MixpanelProxy new];
     }
     return self;
 }
 
 - (void)beginSession
 {
-    [Mixpanel sharedInstanceWithToken:[WordPressComApiCredentials mixpanelAPIToken]];
+    [self.mixpanelProxy registerInstanceWithToken:[WordPressComApiCredentials mixpanelAPIToken]];
     [self refreshMetadata];
     [self flagIfUserHasSeenLegacyEditor];
 }
@@ -57,7 +66,7 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
 
 - (BOOL)didUserCreateAccountOnMobile
 {
-    return [[Mixpanel sharedInstance].currentSuperProperties[@"created_account_on_mobile"] boolValue];
+    return [self.mixpanelProxy.currentSuperProperties[@"created_account_on_mobile"] boolValue];
 }
 
 - (void)track:(WPAnalyticsStat)stat
@@ -112,19 +121,19 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
         }
     }
 
-    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:[Mixpanel sharedInstance].currentSuperProperties];
+    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:self.mixpanelProxy.currentSuperProperties];
     superProperties[@"platform"] = @"iOS";
     superProperties[@"dotcom_user"] = @(dotcom_user);
     superProperties[@"jetpack_user"] = @(jetpack_user);
     superProperties[@"number_of_blogs"] = @(blogCount);
     superProperties[@"accessibility_voice_over_enabled"] = @(UIAccessibilityIsVoiceOverRunning());
-    [[Mixpanel sharedInstance] registerSuperProperties:superProperties];
+    [self.mixpanelProxy registerSuperProperties:superProperties];
 
     if (accountPresent && [username length] > 0) {
-        [[Mixpanel sharedInstance] identify:username];
-        [[Mixpanel sharedInstance].people set:@{ @"$username": username, @"$first_name" : username }];
+        [self.mixpanelProxy identify:username];
+        [self.mixpanelProxy setPeopleProperties:@{ @"$username": username, @"$first_name" : username }];
         if ([emailAddress length] > 0) {
-            [[Mixpanel sharedInstance].people set:@"$email" to:emailAddress];
+            [self.mixpanelProxy setPeopleProperties:@{ @"$email": emailAddress }];
         }
     }
 }
@@ -137,8 +146,7 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
         WPAccount *account = [accountService defaultWordPressComAccount];
         NSString *username = account.username;
         
-        [[Mixpanel sharedInstance] createAlias:username forDistinctID:[Mixpanel sharedInstance].distinctId];
-        [[Mixpanel sharedInstance] identify:[Mixpanel sharedInstance].distinctId];
+        [self.mixpanelProxy aliasNewUser:username];
     }];
 }
 
@@ -172,9 +180,9 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
             NSMutableDictionary *combinedProperties = [[NSMutableDictionary alloc] init];
             [combinedProperties addEntriesFromDictionary:aggregatedPropertiesForEvent];
             [combinedProperties addEntriesFromDictionary:properties];
-            [[Mixpanel sharedInstance] track:instructions.mixpanelEventName properties:combinedProperties];
+            [self.mixpanelProxy track:instructions.mixpanelEventName properties:combinedProperties];
         } else {
-            [[Mixpanel sharedInstance] track:instructions.mixpanelEventName properties:properties];
+            [self.mixpanelProxy track:instructions.mixpanelEventName properties:properties];
         }
     }
 
@@ -205,34 +213,27 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
 
 - (void)incrementPeopleProperty:(NSString *)property
 {
-    [[Mixpanel sharedInstance].people increment:property by:@(1)];
+    [self.mixpanelProxy incrementPeopleProperty:property];
 }
 
 - (void)incrementSuperProperty:(NSString *)property
 {
-    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:[Mixpanel sharedInstance].currentSuperProperties];
-    NSUInteger propertyValue = [superProperties[property] integerValue];
-    superProperties[property] = @(++propertyValue);
-    [[Mixpanel sharedInstance] registerSuperProperties:superProperties];
+    [self.mixpanelProxy incrementSuperProperty:property];
 }
 
 - (void)flagSuperProperty:(NSString *)property
 {
-    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:[Mixpanel sharedInstance].currentSuperProperties];
-    superProperties[property] = @(YES);
-    [[Mixpanel sharedInstance] registerSuperProperties:superProperties];
+    [self.mixpanelProxy flagSuperProperty:property];
 }
 
 - (void)setSuperProperty:(NSString *)property toValue:(id)value
 {
-    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:[Mixpanel sharedInstance].currentSuperProperties];
-    superProperties[property] = value;
-    [[Mixpanel sharedInstance] registerSuperProperties:superProperties];
+    [self.mixpanelProxy setSuperProperty:property toValue:value];
 }
 
 - (void)setValue:(id)value forPeopleProperty:(NSString *)property
 {
-    [[Mixpanel sharedInstance].people set:@{ property : value } ];
+    [self.mixpanelProxy setPeopleProperties:@{ property : value } ];
 }
 
 - (WPAnalyticsTrackerMixpanelInstructionsForStat *)instructionsForStat:(WPAnalyticsStat )stat
@@ -771,14 +772,14 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
         [WPAnalytics track:WPAnalyticsStatAppInstalled];
     }
 
-    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:[Mixpanel sharedInstance].currentSuperProperties];
+    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:self.mixpanelProxy.currentSuperProperties];
     superProperties[@"session_count"] = @(sessionCount);
-    [[Mixpanel sharedInstance] registerSuperProperties:superProperties];
+    [self.mixpanelProxy registerSuperProperties:superProperties];
 }
 
 - (NSInteger)sessionCount
 {
-    return [[[[Mixpanel sharedInstance] currentSuperProperties] numberForKey:@"session_count"] integerValue];
+    return [[[self.mixpanelProxy currentSuperProperties] numberForKey:@"session_count"] integerValue];
 }
 
 @end

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -23,6 +23,7 @@
 
 NSString *const CheckedIfUserHasSeenLegacyEditor = @"checked_if_user_has_seen_legacy_editor";
 NSString *const SeenLegacyEditor = @"seen_legacy_editor";
+NSString *const SessionCount = @"session_count";
 
 - (instancetype)init
 {
@@ -121,7 +122,7 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
         }
     }
 
-    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:self.mixpanelProxy.currentSuperProperties];
+    NSMutableDictionary *superProperties = [NSMutableDictionary new];
     superProperties[@"platform"] = @"iOS";
     superProperties[@"dotcom_user"] = @(dotcom_user);
     superProperties[@"jetpack_user"] = @(jetpack_user);
@@ -772,14 +773,12 @@ NSString *const SeenLegacyEditor = @"seen_legacy_editor";
         [WPAnalytics track:WPAnalyticsStatAppInstalled];
     }
 
-    NSMutableDictionary *superProperties = [[NSMutableDictionary alloc] initWithDictionary:self.mixpanelProxy.currentSuperProperties];
-    superProperties[@"session_count"] = @(sessionCount);
-    [self.mixpanelProxy registerSuperProperties:superProperties];
+    [self.mixpanelProxy registerSuperProperties:@{ SessionCount : @(sessionCount) }];
 }
 
 - (NSInteger)sessionCount
 {
-    return [[[self.mixpanelProxy currentSuperProperties] numberForKey:@"session_count"] integerValue];
+    return [[self.mixpanelProxy.currentSuperProperties numberForKey:SessionCount] integerValue];
 }
 
 @end

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -1,5 +1,6 @@
 #import "WPAppAnalytics.h"
 
+#import "ContextManager.h"
 #import "WPAnalyticsTrackerMixpanel.h"
 #import "WPAnalyticsTrackerWPCom.h"
 #import "WPAnalyticsTrackerAutomatticTracks.h"
@@ -67,7 +68,7 @@ static NSString* const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
     [self initializeUsageTrackingIfNecessary];
     
     if ([WordPressComApiCredentials mixpanelAPIToken].length > 0) {
-        [WPAnalytics registerTracker:[[WPAnalyticsTrackerMixpanel alloc] init]];
+        [WPAnalytics registerTracker:[[WPAnalyticsTrackerMixpanel alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]]];
     }
 
     [WPAnalytics registerTracker:[[WPAnalyticsTrackerWPCom alloc] init]];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		83F3E2D311276371004CD686 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E2D211276371004CD686 /* CoreLocation.framework */; };
 		83FEFC7611FF6C5A0078B462 /* EditSiteViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 83FEFC7411FF6C5A0078B462 /* EditSiteViewController.m */; };
 		85149741171E13DF00B87F3F /* WPAsyncBlockOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 85149740171E13DF00B87F3F /* WPAsyncBlockOperation.m */; };
+		8514B8D41AE85B19007E58BA /* WPAnalyticsTrackerMixpanelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8514B8D31AE85B19007E58BA /* WPAnalyticsTrackerMixpanelTests.m */; };
 		8516972C169D42F4006C5DED /* WPToast.m in Sources */ = {isa = PBXBuildFile; fileRef = 8516972B169D42F4006C5DED /* WPToast.m */; };
 		851734431798C64700A30E27 /* NSURL+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 851734421798C64700A30E27 /* NSURL+Util.m */; };
 		852416CF1A12EBDD0030700C /* AppRatingUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 852416CE1A12EBDD0030700C /* AppRatingUtility.m */; };
@@ -244,6 +245,8 @@
 		85D239BC1AE5A6620074768D /* LoginViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D239BA1AE5A6620074768D /* LoginViewModel.m */; };
 		85D239C01AE5A7020074768D /* LoginFacadeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D239BE1AE5A7020074768D /* LoginFacadeTests.m */; };
 		85D239C11AE5A7020074768D /* LoginViewModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D239BF1AE5A7020074768D /* LoginViewModelTests.m */; };
+		85D790AA1AE5C6790033AE83 /* MixpanelProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D790A81AE5BF1F0033AE83 /* MixpanelProxy.m */; };
+		85D790AC1AE5D95E0033AE83 /* MixpanelProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D790AB1AE5D95E0033AE83 /* MixpanelProxyTests.m */; };
 		85D80558171630B30075EEAC /* DotCom-Languages.plist in Resources */ = {isa = PBXBuildFile; fileRef = 85D80557171630B30075EEAC /* DotCom-Languages.plist */; };
 		85D8055D171631F10075EEAC /* SelectWPComLanguageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D8055C171631F10075EEAC /* SelectWPComLanguageViewController.m */; };
 		85DA8C4418F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m in Sources */ = {isa = PBXBuildFile; fileRef = 85DA8C4318F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m */; };
@@ -908,6 +911,7 @@
 		83FEFC7411FF6C5A0078B462 /* EditSiteViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EditSiteViewController.m; sourceTree = "<group>"; };
 		8514973F171E13DF00B87F3F /* WPAsyncBlockOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAsyncBlockOperation.h; sourceTree = "<group>"; };
 		85149740171E13DF00B87F3F /* WPAsyncBlockOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAsyncBlockOperation.m; sourceTree = "<group>"; };
+		8514B8D31AE85B19007E58BA /* WPAnalyticsTrackerMixpanelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAnalyticsTrackerMixpanelTests.m; sourceTree = "<group>"; };
 		8516972A169D42F4006C5DED /* WPToast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPToast.h; sourceTree = "<group>"; };
 		8516972B169D42F4006C5DED /* WPToast.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPToast.m; sourceTree = "<group>"; };
 		851734411798C64700A30E27 /* NSURL+Util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+Util.h"; sourceTree = "<group>"; };
@@ -967,6 +971,9 @@
 		85D239BA1AE5A6620074768D /* LoginViewModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoginViewModel.m; sourceTree = "<group>"; };
 		85D239BE1AE5A7020074768D /* LoginFacadeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoginFacadeTests.m; sourceTree = "<group>"; };
 		85D239BF1AE5A7020074768D /* LoginViewModelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoginViewModelTests.m; sourceTree = "<group>"; };
+		85D790A71AE5BF1F0033AE83 /* MixpanelProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MixpanelProxy.h; sourceTree = "<group>"; };
+		85D790A81AE5BF1F0033AE83 /* MixpanelProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MixpanelProxy.m; sourceTree = "<group>"; };
+		85D790AB1AE5D95E0033AE83 /* MixpanelProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MixpanelProxyTests.m; sourceTree = "<group>"; };
 		85D80557171630B30075EEAC /* DotCom-Languages.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "DotCom-Languages.plist"; sourceTree = "<group>"; };
 		85D8055B171631F10075EEAC /* SelectWPComLanguageViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SelectWPComLanguageViewController.h; sourceTree = "<group>"; };
 		85D8055C171631F10075EEAC /* SelectWPComLanguageViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SelectWPComLanguageViewController.m; sourceTree = "<group>"; };
@@ -2160,6 +2167,8 @@
 				5DA3EE191925111700294E0B /* WPImageOptimizerTest.m */,
 				5D2BEB4819758102005425F7 /* WPTableImageSourceTest.m */,
 				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
+				85D790AB1AE5D95E0033AE83 /* MixpanelProxyTests.m */,
+				8514B8D31AE85B19007E58BA /* WPAnalyticsTrackerMixpanelTests.m */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -2308,6 +2317,8 @@
 				85DA8C4318F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m */,
 				5948AD0C1AB734F2006E8882 /* WPAppAnalytics.h */,
 				5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */,
+				85D790A71AE5BF1F0033AE83 /* MixpanelProxy.h */,
+				85D790A81AE5BF1F0033AE83 /* MixpanelProxy.m */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -3791,6 +3802,7 @@
 				85CE4C201A703CF200780DFE /* NSBundle+VersionNumberHelper.m in Sources */,
 				E1D95EB817A28F5E00A3E9F3 /* WPActivityDefaults.m in Sources */,
 				591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */,
+				85D790AA1AE5C6790033AE83 /* MixpanelProxy.m in Sources */,
 				857610D618C0377300EDF406 /* StatsWebViewController.m in Sources */,
 				5D08B90419648C3400D5B381 /* ReaderSubscriptionViewController.m in Sources */,
 				5DDC44671A72BB07007F538E /* ReaderViewController.m in Sources */,
@@ -3828,6 +3840,7 @@
 				5D12FE221988245B00378BD6 /* RemoteReaderSite.m in Sources */,
 				93A379EC19FFBF7900415023 /* KeychainTest.m in Sources */,
 				5D12FE1F1988243700378BD6 /* RemoteReaderTopic.m in Sources */,
+				8514B8D41AE85B19007E58BA /* WPAnalyticsTrackerMixpanelTests.m in Sources */,
 				931D26F719ED7F7500114F17 /* ReaderPostServiceTest.m in Sources */,
 				93E9050719E6F3D8005513C9 /* TestContextManager.m in Sources */,
 				5D2BEB4919758102005425F7 /* WPTableImageSourceTest.m in Sources */,
@@ -3839,6 +3852,7 @@
 				B5D689FD1A5EBC900063D9E5 /* NotificationsManager+TestHelper.m in Sources */,
 				931D270019EDAE8600114F17 /* CoreDataMigrationTests.m in Sources */,
 				85D239C11AE5A7020074768D /* LoginViewModelTests.m in Sources */,
+				85D790AC1AE5D95E0033AE83 /* MixpanelProxyTests.m in Sources */,
 				931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */,
 				852416D21A12ED690030700C /* AppRatingUtilityTests.m in Sources */,
 				E15618FD16DB8677006532C4 /* UIKitTestHelper.m in Sources */,

--- a/WordPress/WordPressTest/MixpanelProxyTests.m
+++ b/WordPress/WordPressTest/MixpanelProxyTests.m
@@ -43,14 +43,14 @@ describe(@"currentSuperProperties", ^{
         
         NSDictionary *currentSuperProperties = mixpanelProxy.currentSuperProperties;
         
-        expect(currentSuperProperties).to.equal(superProperties);
+        expect([currentSuperProperties[@"property"] boolValue]).to.beTruthy();
     });
 });
 
 // Create helper to intercept super property dictionary
 __block NSDictionary *superPropertiesRegistering;
 void (^interceptSuperPropertyDictionary)() = ^{
-    [OCMStub([mixpanelProxy registerSuperProperties:OCMOCK_ANY]) andDo:^(NSInvocation *invocation) {
+    [OCMStub([mixpanelMock registerSuperProperties:OCMOCK_ANY]) andDo:^(NSInvocation *invocation) {
         __unsafe_unretained NSDictionary *props;
         [invocation getArgument:&props atIndex:2];
         
@@ -67,6 +67,10 @@ describe(@"incrementSuperProperty:", ^{
         
         [mixpanelProxy incrementSuperProperty:property];
         
+        setAsyncSpecTimeout(1.0);
+        
+        // Sleeping briefly to give the MixpanelProxy time to kick off the async tasks that eventually register the super properties
+        [NSThread sleepForTimeInterval:0.1];
         expect(superPropertiesRegistering[property]).to.equal(@11);
     });
 });
@@ -78,6 +82,8 @@ describe(@"flagSuperProperty:", ^{
         
         [mixpanelProxy flagSuperProperty:property];
         
+        // Sleeping briefly to give the MixpanelProxy time to kick off the async tasks that eventually register the super properties
+        [NSThread sleepForTimeInterval:0.1];
         expect(superPropertiesRegistering[property]).to.equal(@YES);
     });
 });
@@ -91,6 +97,8 @@ describe(@"setSuperProperty:toValue:", ^{
         NSString *value = @"value";
         [mixpanelProxy setSuperProperty:property toValue:value];
         
+        // Sleeping briefly to give the MixpanelProxy time to kick off the async tasks that eventually register the super properties
+        [NSThread sleepForTimeInterval:0.1];
         expect(superPropertiesRegistering[property]).to.equal(value);
     });
 });
@@ -103,6 +111,8 @@ describe(@"registerSuperProperties:", ^{
         
         [mixpanelProxy registerSuperProperties:properties];
         
+        // Sleeping briefly to give the MixpanelProxy time to kick off the async tasks that eventually register the super properties
+        [NSThread sleepForTimeInterval:0.1];
         [mixpanelMock verify];
     });
 });

--- a/WordPress/WordPressTest/MixpanelProxyTests.m
+++ b/WordPress/WordPressTest/MixpanelProxyTests.m
@@ -1,0 +1,183 @@
+#import <Specta/Specta.h>
+#define EXP_SHORTHAND
+#import <Expecta/Expecta.h>
+#import <OCMock/OCMock.h>
+#import <Mixpanel/Mixpanel.h>
+#import "MixpanelProxy.h"
+
+SpecBegin(MixpanelProxy)
+
+__block id mixpanelMock;
+__block id mixpanelPeopleMock;
+__block MixpanelProxy *mixpanelProxy;
+__block NSMutableDictionary *superProperties;
+
+beforeEach(^{
+    mixpanelMock = OCMClassMock([Mixpanel class]);
+    mixpanelPeopleMock = OCMClassMock([MixpanelPeople class]);
+    [OCMStub(ClassMethod([mixpanelMock sharedInstance])) andReturn:mixpanelMock];
+    [OCMStub([mixpanelMock people]) andReturn:mixpanelPeopleMock];
+    
+    superProperties = [NSMutableDictionary new];
+    [OCMStub([mixpanelMock currentSuperProperties]) andReturn:superProperties];
+    
+    mixpanelProxy = [MixpanelProxy new];
+});
+
+describe(@"registerInstanceWithToken:", ^{
+    
+    it(@"should register the token with Mixpanel", ^{
+        NSString *token = @"mixpanel-token";
+        OCMExpect(ClassMethod([mixpanelMock sharedInstanceWithToken:token]));
+        
+        [mixpanelProxy registerInstanceWithToken:token];
+        
+        OCMVerifyAll(mixpanelMock);
+    });
+});
+
+describe(@"currentSuperProperties", ^{
+    
+    it(@"returns the currentSuperProperties", ^{
+        superProperties[@"property"] = @YES;
+        
+        NSDictionary *currentSuperProperties = mixpanelProxy.currentSuperProperties;
+        
+        expect(currentSuperProperties).to.equal(superProperties);
+    });
+});
+
+// Create helper to intercept super property dictionary
+__block NSDictionary *superPropertiesRegistering;
+void (^interceptSuperPropertyDictionary)() = ^{
+    [OCMStub([mixpanelProxy registerSuperProperties:OCMOCK_ANY]) andDo:^(NSInvocation *invocation) {
+        __unsafe_unretained NSDictionary *props;
+        [invocation getArgument:&props atIndex:2];
+        
+        superPropertiesRegistering = props;
+    }];
+};
+
+describe(@"incrementSuperProperty:", ^{
+    
+    NSString *property = @"property";
+    it(@"should increment the super property", ^{
+        superProperties[property] = @10;
+        interceptSuperPropertyDictionary();
+        
+        [mixpanelProxy incrementSuperProperty:property];
+        
+        expect(superPropertiesRegistering[property]).to.equal(@11);
+    });
+});
+
+describe(@"flagSuperProperty:", ^{
+    NSString *property = @"property";
+    it(@"should flag the super property", ^{
+        interceptSuperPropertyDictionary();
+        
+        [mixpanelProxy flagSuperProperty:property];
+        
+        expect(superPropertiesRegistering[property]).to.equal(@YES);
+    });
+});
+
+describe(@"setSuperProperty:toValue:", ^{
+    
+    NSString *property = @"property";
+    it(@"should set the super property", ^{
+        interceptSuperPropertyDictionary();
+        
+        NSString *value = @"value";
+        [mixpanelProxy setSuperProperty:property toValue:value];
+        
+        expect(superPropertiesRegistering[property]).to.equal(value);
+    });
+});
+
+describe(@"registerSuperProperties:", ^{
+    
+    it(@"register's the super properties passed in", ^{
+        NSDictionary *properties = @{ @"hello" : @"world"};
+        [[mixpanelMock expect] registerSuperProperties:properties];
+        
+        [mixpanelProxy registerSuperProperties:properties];
+        
+        [mixpanelMock verify];
+    });
+});
+
+describe(@"identify:", ^{
+    
+    it(@"identifies the user", ^{
+        NSString *username = @"username";
+        [[mixpanelMock expect] identify:username];
+        
+        [mixpanelProxy identify:username];
+        
+        [mixpanelMock verify];
+    });
+});
+
+describe(@"setPeopleProperties:", ^{
+    
+    it(@"should set the people properties", ^{
+        NSDictionary *properties = @{ @"hello" : @"world"};
+        [[mixpanelPeopleMock expect] set:properties];
+        
+        [mixpanelProxy setPeopleProperties:properties];
+        
+        [mixpanelPeopleMock verify];
+    });
+});
+
+describe(@"incrementPeopleProperty:", ^{
+    
+    it(@"should increment a people property", ^{
+        NSString *property = @"random-property";
+        [[mixpanelPeopleMock expect] increment:property by:@(1)];
+        
+        [mixpanelProxy incrementPeopleProperty:property];
+        
+        [mixpanelPeopleMock verify];
+    });
+});
+
+describe(@"aliasNewUser:", ^{
+    
+    it(@"should correctly alias the new user", ^{
+        NSString *username = @"username";
+        NSString *distinctId = @"distinctId";
+        [OCMStub([mixpanelMock distinctId]) andReturn:distinctId];
+        [[mixpanelMock expect] createAlias:username forDistinctID:distinctId];
+        [[mixpanelMock expect] identify:distinctId];
+        
+        [mixpanelProxy aliasNewUser:username];
+        
+        [mixpanelMock verify];
+    });
+});
+
+describe(@"track:properties:", ^{
+    
+    NSString *eventName = @"eventName";
+    NSDictionary *properties = @{ @"hello" : @"world" };
+    
+    it(@"should track an event with no properties", ^{
+        [[mixpanelMock expect] track:eventName properties:nil];
+        
+        [mixpanelProxy track:eventName properties:nil];
+        
+        [mixpanelMock verify];
+    });
+    
+    it(@"should track an event with properties", ^{
+        [[mixpanelMock expect] track:eventName properties:properties];
+        
+        [mixpanelProxy track:eventName properties:properties];
+        
+        [mixpanelMock verify];
+    });
+});
+
+SpecEnd

--- a/WordPress/WordPressTest/WPAnalyticsTrackerMixpanelTests.m
+++ b/WordPress/WordPressTest/WPAnalyticsTrackerMixpanelTests.m
@@ -1,0 +1,237 @@
+#import <Specta/Specta.h>
+#define EXP_SHORTHAND
+#import <Expecta/Expecta.h>
+#import <OCMock/OCMock.h>
+#import <Mixpanel/Mixpanel.h>
+#import "MixpanelProxy.h"
+#import "WPAnalyticsTrackerMixpanel.h"
+#import "TestContextManager.h"
+#import "AccountService.h"
+#import "BlogService.h"
+#import "WPAccount.h"
+#import "Blog.h"
+#import "Blog+Jetpack.h"
+
+SpecBegin(WPAnalyticsTrackerMixpanel)
+
+__block WPAnalyticsTrackerMixpanel *mixpanelTracker;
+__block id mixpanelProxyMock;
+__block TestContextManager *testContextManager;
+__block AccountService *accountService;
+__block BlogService *blogService;
+__block WPAccount *account;
+
+// Helper Methods
+NSString *username = @"username";
+void (^createDotComAccount)() = ^{
+    account = [accountService createOrUpdateWordPressComAccountWithUsername:username authToken:@"authtoken"];
+};
+
+typedef void (^BlockWithDict)(NSDictionary *);
+void (^interceptSuperProperties)(BlockWithDict) = ^(BlockWithDict callback){
+    [OCMStub([mixpanelProxyMock registerSuperProperties:OCMOCK_ANY]) andDo:^(NSInvocation *invocation) {
+        __unsafe_unretained NSDictionary *superProperties;
+        [invocation getArgument:&superProperties atIndex:2];
+        
+        callback(superProperties);
+    }];
+};
+
+void (^interceptPeopleProperties)(BlockWithDict) = ^(BlockWithDict callback){
+    [OCMStub([mixpanelProxyMock setPeopleProperties:OCMOCK_ANY]) andDo:^(NSInvocation *invocation) {
+        __unsafe_unretained NSDictionary *peopleProperties;
+        [invocation getArgument:&peopleProperties atIndex:2];
+        
+        callback(peopleProperties);
+        expect(peopleProperties[@"$username"]).to.equal(username);
+        expect(peopleProperties[@"$first_name"]).to.equal(username);
+    }];
+};
+
+__block Blog *blog;
+void (^createBlog)() = ^{
+    blog = (Blog *)[NSEntityDescription insertNewObjectForEntityForName:@"Blog" inManagedObjectContext:testContextManager.mainContext];
+    blog.xmlrpc = @"http://test.blog/xmlrpc.php";
+    blog.url = @"http://test.blog/";
+    blog.options = @{@"jetpack_version": @{
+                             @"value": @"1.8.2",
+                             @"desc": @"stub",
+                             @"readonly": @YES,
+                             },
+                     @"jetpack_client_id": @{
+                             @"value": @"1",
+                             @"desc": @"stub",
+                             @"readonly": @YES,
+                             },
+                     };
+    blog.account = account;
+    [testContextManager.mainContext save:nil];
+};
+
+beforeEach(^{
+    testContextManager = [TestContextManager new];
+    accountService = [[AccountService alloc] initWithManagedObjectContext:testContextManager.mainContext];
+    blogService = [[BlogService alloc] initWithManagedObjectContext:testContextManager.mainContext];
+    
+    mixpanelProxyMock = [OCMockObject niceMockForClass:[MixpanelProxy class]];
+    mixpanelTracker = [[WPAnalyticsTrackerMixpanel alloc] initWithManagedObjectContext:testContextManager.mainContext mixpanelProxy:mixpanelProxyMock];
+});
+
+describe(@"beginSession", ^{
+    
+    it(@"should register the instance token with Mixpanel", ^{
+        [[mixpanelProxyMock expect] registerInstanceWithToken:OCMOCK_ANY];
+        
+        [mixpanelTracker beginSession];
+        
+        [mixpanelProxyMock verify];
+    });
+});
+
+describe(@"refreshMetadata", ^{
+    
+    context(@"registering of superproperties", ^{
+        
+        context(@"dotcom_user", ^{
+            
+            it(@"should be YES when the user is a .com user", ^{
+                interceptSuperProperties(^(NSDictionary *superProperties){
+                    expect(superProperties[@"dotcom_user"]).to.equal(YES);
+                });
+                createDotComAccount();
+                
+                [mixpanelTracker refreshMetadata];
+            });
+            
+            it(@"should be NO when the user is self hosted", ^{
+                interceptSuperProperties(^(NSDictionary *superProperties){
+                    expect(superProperties[@"dotcom_user"]).to.equal(NO);
+                });
+                account = [accountService createOrUpdateSelfHostedAccountWithXmlrpc:@"xmlrpc" username:username andPassword:@"password"];
+                
+                [mixpanelTracker refreshMetadata];
+            });
+            
+            it(@"should be NO if there is no account", ^{
+                interceptSuperProperties(^(NSDictionary *superProperties){
+                    expect(superProperties[@"dotcom_user"]).to.equal(NO);
+                });
+                
+                [mixpanelTracker refreshMetadata];
+            });
+        });
+        
+        context(@"number_of_blogs", ^{
+            
+            it(@"should be zero when there are no blogs", ^{
+                interceptSuperProperties(^(NSDictionary *superProperties){
+                    expect(superProperties[@"number_of_blogs"]).to.equal(0);
+                });
+                
+                [mixpanelTracker refreshMetadata];
+            });
+            
+            it(@"should be 1 when there is a blog", ^{
+                createDotComAccount();
+                interceptSuperProperties(^(NSDictionary *superProperties){
+                    expect(superProperties[@"number_of_blogs"]).to.equal(1);
+                });
+                createBlog();
+                
+                [mixpanelTracker refreshMetadata];
+            });
+        });
+        
+        context(@"jetpack_user", ^{
+            
+            beforeEach(^{
+                createDotComAccount();
+                createBlog();
+            });
+            
+            it(@"should be NO when the user isn't connected to Jetpack", ^{
+                interceptSuperProperties(^(NSDictionary *superProperties){
+                    expect(superProperties[@"jetpack_user"]).to.beFalsy();
+                });
+                
+                [mixpanelTracker refreshMetadata];
+            });
+            
+            it(@"should be YES when the user is connected to Jetpack", ^{
+                blog.jetpackAccount = account;
+                [account addJetpackBlogsObject:blog];
+                [testContextManager.mainContext save:nil];
+                
+                interceptSuperProperties(^(NSDictionary *superProperties){
+                    expect(superProperties[@"jetpack_user"]).to.beTruthy();
+                });
+                
+                [mixpanelTracker refreshMetadata];
+            });
+        });
+    });
+    
+    context(@"when an account with a username is available", ^{
+        
+        beforeEach(^{
+            createDotComAccount();
+        });
+        
+        it(@"should identify the username to Mixpanel", ^{
+            [[mixpanelProxyMock expect] identify:@"username"];
+            
+            [mixpanelTracker refreshMetadata];
+            
+            [mixpanelProxyMock verify];
+        });
+        
+        it(@"should track the username via the people properties", ^{
+            interceptPeopleProperties(^(NSDictionary *peopleProperties){
+                expect(peopleProperties[@"$username"]).to.equal(username);
+                expect(peopleProperties[@"$first_name"]).to.equal(username);
+            });
+            
+            [mixpanelTracker refreshMetadata];
+        });
+        
+        it(@"should not track the email address if it's not available", ^{
+            interceptPeopleProperties(^(NSDictionary *peopleProperties){
+                expect(peopleProperties[@"$email"]).to.beNil();
+            });
+            
+            [mixpanelTracker refreshMetadata];
+        });
+        
+        it(@"should track the email address if it's available", ^{
+            NSString *email = @"test@example.com";
+            account.email = email;
+            [[testContextManager mainContext] save:nil];
+            
+            interceptPeopleProperties(^(NSDictionary *peopleProperties){
+                expect(peopleProperties[@"$email"]).to.equal(email);
+            });
+            
+            [mixpanelTracker refreshMetadata];
+        });
+    });
+});
+
+it(@"should alias new users when the account is created", ^{
+    createDotComAccount();
+    [[mixpanelProxyMock expect] aliasNewUser:username];
+    
+    [mixpanelTracker track:WPAnalyticsStatCreatedAccount];
+    
+    [mixpanelProxyMock verify];
+});
+
+it(@"should increment the session_count when the application is opened", ^{
+    [[[mixpanelProxyMock stub] andReturn:@{ @"session_count" : @(3) }] currentSuperProperties];
+    interceptSuperProperties(^(NSDictionary *superProperties){
+        expect([superProperties[@"session_count"] integerValue]).to.equal(4);
+    });
+    
+    [mixpanelTracker track:WPAnalyticsStatApplicationOpened];
+});
+
+SpecEnd


### PR DESCRIPTION
### The Problem

@meremagee noticed sometime back that some of the data coming into Mixpanel looked a little off when it came to super properties. In particular the `editor_enabled_new_version` wasn't being set about 70% of the time(yikes). After looking at `WPAnalyticsTrackerMixpanel` and the Mixpanel source I realized we were running into a race condition because of how we were storing super properties. 

The way we were storing super properties was basically:
1) Grab a copy of the super properties dictionary from Mixpanel.
2) Add in/modify the properties we care about
3) Tell Mixpanel to register the new dictionary of super properties.

The race condition occurred because of step 1 and step 3.  The race condition occurs for step 1 because if two methods call into the super property registration method on our tracker at the same time they will end up overriding their respective changes. The race condition can also occur because of step 3 because Mixpanel saves the super properties asynchronously which means if some code accessed the super properties before Mixpanel had a chance to save them they would be looking at an incorrect version of the super properties. 

I believe most of the errors due to race conditions we were seeing were a result of 1 and not 3. I can't think of any instance in the app where we rapidly update the same super property over and over. We are also unable to deal with 3) without modifying the source code to Mixpanel itself or without engaging in magic via method swizzling and that sort of thing. As such this PR only deals with the issues around step 1.

### Solution

I created a `MixpanelProxy` class that handles direct access to Mixpanel. I swapped this class into `WPAnalyticsTrackerMixpanel` so as to better control how we access super properties and also so we could more easily test this class. There are two key ways I address the race condition. The first is to stop grabbing a copy of the entire super property dictionary and modifying it before sending it back off to Mixpanel. Instead I just send the changes to Mixpanel a partial change. The reason we sent the whole dictionary previously was because I believe a long time ago when you passed up the super properties up to Mixpanel it required the whole dictionary instead of incremental changes. I could be wrong on this though and this could have just been an oversight on my part but I do recall some quirks with super properties way back in the day. Either way, my bad for not realizing the problem sooner :\. The second change I did was to make sure all code that writes to super properties in `MixpanelProxy` goes through a serial queue to prevent multiple things from writing to the super properties at the same time. 

cc @astralbodies

