### PR TITLE
Marking new Notifications immediately as seen if the list is onscreen

### DIFF
--- a/WordPress/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIViewController+Helpers.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+
+extension UIViewController
+{
+    public func isViewOnScreen() -> Bool {
+        let visibleAsRoot       = view.window?.rootViewController == self
+        let visibleAsTopOnStack = navigationController?.topViewController == self && view.window != nil
+        let visibleAsPresented  = view.window?.rootViewController?.presentedViewController == self
+        
+        return visibleAsRoot || visibleAsTopOnStack || visibleAsPresented
+    }
+}

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -238,6 +238,12 @@ static NSString const *NotificationsNetworkStatusKey    = @"network_status";
         self.pushNotificationID     = nil;
         self.pushNotificationDate   = nil;
     }
+    
+    // Mark as read immediately (if we're onscreen!)
+    if (changeType == SPBucketChangeInsert && self.isViewOnScreen) {
+        [self resetApplicationBadge];
+        [self updateLastSeenTime];
+    }
 }
 
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -321,6 +321,7 @@
 		B558541419631A1000FAF6C3 /* Notifications.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B558541019631A1000FAF6C3 /* Notifications.storyboard */; };
 		B57B99D519A2C20200506504 /* NoteTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57B99D419A2C20200506504 /* NoteTableHeaderView.swift */; };
 		B57B99DE19A2DBF200506504 /* NSObject+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = B57B99DD19A2DBF200506504 /* NSObject+Helpers.m */; };
+		B580E4791AEA91000091A094 /* UIViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B580E4781AEA91000091A094 /* UIViewController+Helpers.swift */; };
 		B586593F197EE15900F67E57 /* Merriweather-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 462F4E0F183867AE0028D2F8 /* Merriweather-Bold.ttf */; };
 		B587797A19B799D800E57C5A /* NSDate+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B587796F19B799D800E57C5A /* NSDate+Helpers.swift */; };
 		B587797B19B799D800E57C5A /* NSIndexPath+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = B587797019B799D800E57C5A /* NSIndexPath+Swift.swift */; };
@@ -1110,6 +1111,7 @@
 		B57B99D419A2C20200506504 /* NoteTableHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoteTableHeaderView.swift; sourceTree = "<group>"; };
 		B57B99DC19A2DBF200506504 /* NSObject+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+Helpers.h"; sourceTree = "<group>"; };
 		B57B99DD19A2DBF200506504 /* NSObject+Helpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+Helpers.m"; sourceTree = "<group>"; };
+		B580E4781AEA91000091A094 /* UIViewController+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Helpers.swift"; sourceTree = "<group>"; };
 		B587796F19B799D800E57C5A /* NSDate+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+Helpers.swift"; sourceTree = "<group>"; };
 		B587797019B799D800E57C5A /* NSIndexPath+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSIndexPath+Swift.swift"; sourceTree = "<group>"; };
 		B587797119B799D800E57C5A /* NSParagraphStyle+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSParagraphStyle+Helpers.swift"; sourceTree = "<group>"; };
@@ -2511,6 +2513,7 @@
 				B587797519B799D800E57C5A /* UITableView+Helpers.swift */,
 				B587797619B799D800E57C5A /* UITableViewCell+Helpers.swift */,
 				B587797719B799D800E57C5A /* UIView+Helpers.swift */,
+				B580E4781AEA91000091A094 /* UIViewController+Helpers.swift */,
 				B53FDF6C19B8C336000723B6 /* UIScreen+Helpers.swift */,
 				B54866C91A0D7042004AC79D /* NSAttributedString+Helpers.swift */,
 			);
@@ -3715,6 +3718,7 @@
 				85D239BB1AE5A6620074768D /* LoginFields.m in Sources */,
 				5DAE40AD19EC70930011A0AE /* ReaderPostHeaderView.m in Sources */,
 				74BB6F1A19AE7B9400FB7829 /* WPLegacyEditPageViewController.m in Sources */,
+				B580E4791AEA91000091A094 /* UIViewController+Helpers.swift in Sources */,
 				85B6F7521742DAE800CE7F3A /* WPNUXBackButton.m in Sources */,
 				937F3E321AD6FDA7006BA498 /* WPAnalyticsTrackerAutomatticTracks.m in Sources */,
 				B54E1DF01A0A7BAA00807537 /* ReplyBezierView.swift in Sources */,


### PR DESCRIPTION
#### Testing Steps:
1. Launch WPiOS
2. Tap over the Notifications tab
3. Receive a new Notification

As a result, the new notification should be marked immediately as seen, and the badge should get reset.

#### Details:
As of now, the badge and "last seen" are both being reset in the viewWillAppear's method of NotificationsViewController.

There is a potential race condition between the Push Notification, and the actual Simperium Sync, in which the user first gets the Push Notification, opens the Notifications tab, and the Note arrives afterwards. This could cause the newly arrived note not to get marked as seen (and the badge could also remain intact).

In this PR we make sure that new notifications are marked as seen, as long as *NotificationsViewController* is onscreen.

Fixes #3559


@astralbodies may i bother you with a review?

Thanks!.
