### PR TITLE
Don't pop any site navigation on sign out

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -92,6 +92,11 @@ NSInteger const BlogDetailsRowCountForSectionAdmin = 1;
     return viewController;
 }
 
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 - (id)initWithStyle:(UITableViewStyle)style
 {
     self = [super initWithStyle:UITableViewStyleGrouped];
@@ -119,6 +124,11 @@ NSInteger const BlogDetailsRowCountForSectionAdmin = 1;
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
 
     [blogService syncBlog:_blog success:nil failure:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleDataModelChange:)
+                                                 name:NSManagedObjectContextObjectsDidChangeNotification
+                                               object:context];
 
     [self configureBlogDetailHeader];
     [self.headerView setBlog:_blog];
@@ -412,6 +422,16 @@ NSInteger const BlogDetailsRowCountForSectionAdmin = 1;
 
     NSString *dashboardUrl = [blog.xmlrpc stringByReplacingOccurrencesOfString:@"xmlrpc.php" withString:@"wp-admin/"];
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:dashboardUrl]];
+}
+
+#pragma mark - Notification handlers
+
+- (void)handleDataModelChange:(NSNotification *)note
+{
+    NSSet *deletedObjects = [[note userInfo] objectForKey:NSDeletedObjectsKey];
+    if ([deletedObjects containsObject:self.blog]) {
+        [self.navigationController popToRootViewControllerAnimated:NO];
+    }
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -452,10 +452,11 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
 
 - (void)defaultAccountDidChange:(NSNotification *)notification
 {
-    [self.blogListNavigationController popToRootViewControllerAnimated:NO];
-    [self.readerNavigationController popToRootViewControllerAnimated:NO];
-    [self.meNavigationController popToRootViewControllerAnimated:NO];
-    [self.notificationsNavigationController popToRootViewControllerAnimated:NO];
+    if (notification.object == nil) {
+        [self.readerNavigationController popToRootViewControllerAnimated:NO];
+        [self.meNavigationController popToRootViewControllerAnimated:NO];
+        [self.notificationsNavigationController popToRootViewControllerAnimated:NO];
+    }
 }
 
 #pragma mark - Handling Badges


### PR DESCRIPTION
In #3203, a fix for #3130 was introduced that popped all the main
navigation controllers when the account was changed.

This was causing #3594, as signing into a wordpress.com account from the
Stats view would change the account, resetting the navigation.

This change does two things:

- Only pop controllers on sign out (account == nil)
- Only pop the sites navigation if it was showing a site that was
  removed

Fixes #3594 

/cc @oguzkocer 