### PR TITLE
Fixes web stats for Jetpack sites

### DIFF
--- a/WordPress/Classes/Models/Blog+Jetpack.m
+++ b/WordPress/Classes/Models/Blog+Jetpack.m
@@ -225,6 +225,15 @@ NSString * const BlogJetpackApiPath = @"get-user-blogs/1.0";
     return [self jetpackBlogID];
 }
 
+- (NSString *)jetpackAuthToken
+{
+    if ([self isWPcom]) {
+        return [self jetpackAuthToken];
+    } else {
+        return self.jetpackAccount.authToken;
+    }
+}
+
 + (void)load
 {
     Method originalRemove = class_getInstanceMethod(self, @selector(remove));
@@ -233,6 +242,9 @@ NSString * const BlogJetpackApiPath = @"get-user-blogs/1.0";
     Method originalDotcomId = class_getInstanceMethod(self, @selector(dotComID));
     Method customDotcomId = class_getInstanceMethod(self, @selector(jetpackDotComID));
     method_exchangeImplementations(originalDotcomId, customDotcomId);
+    Method originalAuthToken = class_getInstanceMethod(self, @selector(authToken));
+    Method customAuthToken = class_getInstanceMethod(self, @selector(jetpackAuthToken));
+    method_exchangeImplementations(originalAuthToken, customAuthToken);
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Stats/StatsWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsWebViewController.m
@@ -225,7 +225,7 @@ NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
 
     } else {
         // Check for credentials.
-        if (![blog.jetpackUsername length] || ![blog.jetpackPassword length]) {
+        if (![blog.jetpackUsername length] || ![blog.authToken length]) {
             prompt = YES;
         }
     }
@@ -270,7 +270,6 @@ NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
     }
 
     NSString *username = blog.isWPcom ? blog.username : blog.jetpackUsername;
-    NSString *password = blog.isWPcom ? blog.password : blog.jetpackPassword;
     
     // Skip the auth call to reduce loadtime if its the same username as before.
     if ([WPCookie hasCookieForURL:[NSURL URLWithString:@"https://wordpress.com/"] andUsername:username]) {
@@ -285,7 +284,7 @@ NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
     NSURLRequest *request = [WPURLRequest requestForAuthenticationWithURL:loginURL
                                                               redirectURL:redirectURL
                                                                  username:username
-                                                                 password:password
+                                                                 password:[NSString string]
                                                               bearerToken:blog.authToken
                                                                 userAgent:nil];
     


### PR DESCRIPTION
Since we don't store wp.com passwords anymore, this makes
`blog.authToken` return the Jetpack account's token for Jetpack blogs.

Fixes #3508 

*Testing note:* make sure to set `WPJetpackRESTEnabled` to NO (normally enabled on Debug builds). Otherwise, Jetpack sites turn into wp.com sites and the original issue doesn't appear.