### PR TITLE
Implement Comments infinite scroll

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -23,7 +23,6 @@
 @property (nonatomic, strong, readwrite) NSString       *currentThemeId;
 @property (nonatomic, assign, readwrite) BOOL           isSyncingPosts;
 @property (nonatomic, assign, readwrite) BOOL           isSyncingPages;
-@property (nonatomic, assign, readwrite) BOOL           isSyncingComments;
 @property (nonatomic, assign, readwrite) BOOL           isSyncingMedia;
 @property (nonatomic, strong, readwrite) NSDate         *lastPostsSync;
 @property (nonatomic, strong, readwrite) NSDate         *lastPagesSync;

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -49,7 +49,6 @@ static NSInteger const ImageSizeLargeHeight = 480;
 @synthesize blavatarUrl = _blavatarUrl;
 @synthesize isSyncingPosts;
 @synthesize isSyncingPages;
-@synthesize isSyncingComments;
 @synthesize videoPressEnabled;
 @synthesize isSyncingMedia;
 

--- a/WordPress/Classes/Networking/CommentServiceRemote.h
+++ b/WordPress/Classes/Networking/CommentServiceRemote.h
@@ -19,7 +19,8 @@
  Loads all of the comments associated with a blog
  */
 - (void)getCommentsForBlog:(Blog *)blog
-                   success:(void (^)(NSArray *comments))success
+                   options:(NSDictionary *)options
+                   success:(void (^)(NSArray *posts))success
                    failure:(void (^)(NSError *error))failure;
 
 /**

--- a/WordPress/Classes/Networking/CommentServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteREST.m
@@ -26,17 +26,28 @@
 
 #pragma mark Public methods
 
-#pragma mark Blog-centric methods
+#pragma mark - Blog-centric methods
 
 - (void)getCommentsForBlog:(Blog *)blog
                    success:(void (^)(NSArray *))success
                    failure:(void (^)(NSError *))failure
 {
+    [self getCommentsForBlog:blog options:nil success:success failure:failure];
+}
+
+- (void)getCommentsForBlog:(Blog *)blog
+                   options:(NSDictionary *)options
+                   success:(void (^)(NSArray *posts))success
+                   failure:(void (^)(NSError *error))failure
+{
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments", blog.dotComID];
-    NSDictionary *parameters = @{
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
                                  @"status": @"all",
                                  @"context": @"edit",
-                                 };
+                                 }];
+    if (options) {
+        [parameters addEntriesFromDictionary:options];
+    }
     [self.api GET:path
        parameters:parameters
           success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -48,7 +59,10 @@
                   failure(error);
               }
           }];
+
 }
+
+
 
 - (void)createComment:(RemoteComment *)comment
               forBlog:(Blog *)blog

--- a/WordPress/Classes/Networking/CommentServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteREST.m
@@ -5,6 +5,8 @@
 #import "NSDate+WordPressJSON.h"
 #import <NSObject+SafeExpectations.h>
 
+static const NSInteger NumberOfCommentsToSync = 100;
+
 @interface CommentServiceRemoteREST ()
 
 @property (nonatomic, strong) WordPressComApi *api;
@@ -44,7 +46,7 @@
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
                                  @"status": @"all",
                                  @"context": @"edit",
-                                 @"number": @(100)
+                                 @"number": @(NumberOfCommentsToSync)
                                  }];
     if (options) {
         [parameters addEntriesFromDictionary:options];

--- a/WordPress/Classes/Networking/CommentServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteREST.m
@@ -44,6 +44,7 @@
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
                                  @"status": @"all",
                                  @"context": @"edit",
+                                 @"number": @(100)
                                  }];
     if (options) {
         [parameters addEntriesFromDictionary:options];

--- a/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
@@ -3,6 +3,8 @@
 #import "RemoteComment.h"
 #import <WordPressApi.h>
 
+static const NSInteger NumberOfCommentsToSync = 100;
+
 @interface CommentServiceRemoteXMLRPC ()
 @property (nonatomic, strong) WPXMLRPCClient *api;
 @end
@@ -32,7 +34,7 @@
                    failure:(void (^)(NSError *))failure
 {
     NSMutableDictionary *extraParameters = [NSMutableDictionary dictionaryWithDictionary:@{
-                                      @"number": @100
+                                      @"number": @(NumberOfCommentsToSync)
                                       }];
     if (options) {
         [extraParameters addEntriesFromDictionary:options];

--- a/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
@@ -23,9 +23,20 @@
                    success:(void (^)(NSArray *))success
                    failure:(void (^)(NSError *))failure
 {
-    NSDictionary *extraParameters = @{
-                                     @"number": @100
-                                     };
+    [self getCommentsForBlog:blog options:nil success:success failure:failure];
+}
+
+- (void)getCommentsForBlog:(Blog *)blog
+                   options:(NSDictionary *)options
+                   success:(void (^)(NSArray *))success
+                   failure:(void (^)(NSError *))failure
+{
+    NSMutableDictionary *extraParameters = [NSMutableDictionary dictionaryWithDictionary:@{
+                                      @"number": @100
+                                      }];
+    if (options) {
+        [extraParameters addEntriesFromDictionary:options];
+    }
     NSArray *parameters = [blog getXMLRPCArgsWithExtra:extraParameters];
     [self.api callMethod:@"wp.getComments"
               parameters:parameters

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -26,6 +26,11 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
                     success:(void (^)())success
                     failure:(void (^)(NSError *error))failure;
 
+// Load extra comments
+- (void)loadMoreCommentsForBlog:(Blog *)blog
+                        success:(void (^)(BOOL hasMore))success
+                        failure:(void (^)(NSError *))failure;
+
 // Upload comment
 - (void)uploadComment:(Comment *)comment
               success:(void (^)())success

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -10,6 +10,8 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 
 @interface CommentService : NSObject <LocalCoreDataService>
 
++ (BOOL)isSyncingCommentsForBlogID:(NSNumber *)blogID;
+
 // Create comment
 - (Comment *)createCommentForBlog:(Blog *)blog;
 

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -10,7 +10,7 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 
 @interface CommentService : NSObject <LocalCoreDataService>
 
-+ (BOOL)isSyncingCommentsForBlogID:(NSNumber *)blogID;
++ (BOOL)isSyncingCommentsForBlog:(Blog *)blog;
 
 // Create comment
 - (Comment *)createCommentForBlog:(Blog *)blog;

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -126,8 +126,7 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
         }
     } else if ([remote isKindOfClass:[CommentServiceRemoteXMLRPC class]]) {
         NSUInteger postCount = [blog.posts count];
-        postCount += 40;
-        options[@"number"] = @(postCount);
+        options[@"offset"] = @(postCount);
     }
     [remote getCommentsForBlog:blog
         options:options

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -140,6 +140,9 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
                                      purgeExisting:YES
                                  completionHandler:^{
                                      [[self class] stopSyncingCommentsForBlog:blogID];
+                                     if (success) {
+                                         success();
+                                     }
                                  }];
                            }];
                        } failure:^(NSError *error) {

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -125,8 +125,8 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
             options[@"order"] = @"desc";
         }
     } else if ([remote isKindOfClass:[CommentServiceRemoteXMLRPC class]]) {
-        NSUInteger postCount = [blog.posts count];
-        options[@"offset"] = @(postCount);
+        NSUInteger commentCount = [blog.comments count];
+        options[@"offset"] = @(commentCount);
     }
     [remote getCommentsForBlog:blog
         options:options

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -116,7 +116,7 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
     if ([remote isKindOfClass:[CommentServiceRemoteREST class]]) {
         NSString *entityName = NSStringFromClass([Comment class]);
         NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
-        request.predicate = [NSPredicate predicateWithFormat:@"dateCreated != NULL"];
+        request.predicate = [NSPredicate predicateWithFormat:@"dateCreated != NULL && blog=%@", blog];
         NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"dateCreated" ascending:YES];
         request.sortDescriptors = @[sortDescriptor];
         Comment *oldestComment = [[self.managedObjectContext executeFetchRequest:request error:nil] firstObject];

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -33,20 +33,27 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
     return syncingCommentsLocks;
 }
 
-+ (BOOL)isSyncingCommentsForBlogID:(NSNumber *)blogID
++ (BOOL)isSyncingCommentsForBlog:(Blog *)blog {
+    return [self isSyncingCommentsForBlogID:blog.objectID.URIRepresentation];
+}
+
++ (BOOL)isSyncingCommentsForBlogID:(NSURL *)blogID
 {
+    NSParameterAssert(blogID);
     return [[self syncingCommentsLocks] containsObject:blogID];
 }
 
-+ (void)startSyncingCommentsForBlog:(NSNumber *)blogID
++ (void)startSyncingCommentsForBlog:(NSURL *)blogID
 {
+    NSParameterAssert(blogID);
     @synchronized([self syncingCommentsLocks]) {
         [[self syncingCommentsLocks] addObject:blogID];
     }
 }
 
-+ (void)stopSyncingCommentsForBlog:(NSNumber *)blogID
++ (void)stopSyncingCommentsForBlog:(NSURL *)blogID
 {
+    NSParameterAssert(blogID);
     @synchronized([self syncingCommentsLocks]) {
         [[self syncingCommentsLocks] removeObject:blogID];
     }
@@ -119,7 +126,7 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
                     success:(void (^)())success
                     failure:(void (^)(NSError *error))failure
 {
-    NSNumber *blogID = blog.blogID;
+    NSURL * blogID= blog.objectID.URIRepresentation;
     if ([[self class] isSyncingCommentsForBlogID:blogID]){
         return;
     }
@@ -159,7 +166,7 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
                         success:(void (^)(BOOL hasMore))success
                         failure:(void (^)(NSError *))failure
 {
-    NSNumber *blogID = blog.blogID;
+    NSURL * blogID= blog.objectID.URIRepresentation;
     if ([[self class] isSyncingCommentsForBlogID:blogID]){
         return;
     }

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -43,11 +43,15 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
     return [[self syncingCommentsLocks] containsObject:blogID];
 }
 
-+ (void)startSyncingCommentsForBlog:(NSURL *)blogID
++ (BOOL)startSyncingCommentsForBlog:(NSURL *)blogID
 {
     NSParameterAssert(blogID);
     @synchronized([self syncingCommentsLocks]) {
+        if ([self isSyncingCommentsForBlogID:blogID]){
+            return NO;
+        }
         [[self syncingCommentsLocks] addObject:blogID];
+         return YES;
     }
 }
 
@@ -127,10 +131,9 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
                     failure:(void (^)(NSError *error))failure
 {
     NSURL * blogID= blog.objectID.URIRepresentation;
-    if ([[self class] isSyncingCommentsForBlogID:blogID]){
+    if (![[self class] startSyncingCommentsForBlog:blogID]){
         return;
     }
-    [[self class] startSyncingCommentsForBlog:blogID];
     
     id<CommentServiceRemote> remote = [self remoteForBlog:blog];
     [remote getCommentsForBlog:blog
@@ -170,10 +173,9 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
                         failure:(void (^)(NSError *))failure
 {
     NSURL * blogID= blog.objectID.URIRepresentation;
-    if ([[self class] isSyncingCommentsForBlogID:blogID]){
+    if (![[self class] startSyncingCommentsForBlog:blogID]){
         return;
     }
-    [[self class] startSyncingCommentsForBlog:blogID];
 
     id<CommentServiceRemote> remote = [self remoteForBlog:blog];
     NSMutableDictionary *options = [NSMutableDictionary dictionary];

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -132,6 +132,10 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
 {
     NSManagedObjectID *blogID= blog.objectID;
     if (![[self class] startSyncingCommentsForBlog:blogID]){
+        // We assume success because a sync is already running and it will change the comments
+        if (success) {
+            success();
+        }
         return;
     }
     
@@ -174,7 +178,10 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
 {
     NSManagedObjectID *blogID= blog.objectID;
     if (![[self class] startSyncingCommentsForBlog:blogID]){
-        return;
+        // We assume success because a sync is already running and it will change the comments
+        if (success) {
+            success(YES);
+        }
     }
 
     id<CommentServiceRemote> remote = [self remoteForBlog:blog];

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -34,16 +34,16 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
 }
 
 + (BOOL)isSyncingCommentsForBlog:(Blog *)blog {
-    return [self isSyncingCommentsForBlogID:blog.objectID.URIRepresentation];
+    return [self isSyncingCommentsForBlogID:blog.objectID];
 }
 
-+ (BOOL)isSyncingCommentsForBlogID:(NSURL *)blogID
++ (BOOL)isSyncingCommentsForBlogID:(NSManagedObjectID *)blogID
 {
     NSParameterAssert(blogID);
     return [[self syncingCommentsLocks] containsObject:blogID];
 }
 
-+ (BOOL)startSyncingCommentsForBlog:(NSURL *)blogID
++ (BOOL)startSyncingCommentsForBlog:(NSManagedObjectID *)blogID
 {
     NSParameterAssert(blogID);
     @synchronized([self syncingCommentsLocks]) {
@@ -55,7 +55,7 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
     }
 }
 
-+ (void)stopSyncingCommentsForBlog:(NSURL *)blogID
++ (void)stopSyncingCommentsForBlog:(NSManagedObjectID *)blogID
 {
     NSParameterAssert(blogID);
     @synchronized([self syncingCommentsLocks]) {
@@ -130,7 +130,7 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
                     success:(void (^)())success
                     failure:(void (^)(NSError *error))failure
 {
-    NSURL * blogID= blog.objectID.URIRepresentation;
+    NSManagedObjectID *blogID= blog.objectID;
     if (![[self class] startSyncingCommentsForBlog:blogID]){
         return;
     }
@@ -172,7 +172,7 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
                         success:(void (^)(BOOL hasMore))success
                         failure:(void (^)(NSError *))failure
 {
-    NSURL * blogID= blog.objectID.URIRepresentation;
+    NSManagedObjectID *blogID= blog.objectID;
     if (![[self class] startSyncingCommentsForBlog:blogID]){
         return;
     }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -242,7 +242,7 @@ CGFloat const CommentsSectionHeaderHeight = 24.0;
 
 - (BOOL)isSyncing
 {
-    return [CommentService isSyncingCommentsForBlogID:self.blog.blogID];
+    return [CommentService isSyncingCommentsForBlog:self.blog];
 }
 
 - (NSDate *)lastSyncDate

--- a/WordPress/Classes/ViewRelated/System/WPTableViewController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTableViewController.m
@@ -617,6 +617,9 @@ NSString *const DefaultCellIdentifier = @"DefaultCellIdentifier";
 - (void)syncItemsViaUserInteraction:(BOOL)userInteraction
 {
     if ([self isSyncing]) {
+        if (self.didTriggerRefresh) {
+            [self hideRefreshHeader];
+        }
         return;
     }
 


### PR DESCRIPTION
Closes #2925 

cc @aerych and @koke can you please review

I implemented this feature based on the behaviour implements on Posts. While doing this I struggle with some things:

 * Do the blog properties isSyncingPosts, isSyncingPages, isSyncingComments, isSyncingMedia ever being accessed somewhere in the code? I searched but couldn't find a place where they are being changed.Was this something that was used before and didn't got deleted? Or something that was added but not used yet?
 * The same for hasOlderPosts, hasOlderPages

The PR don't need this properties but I wanted to now if this is something that needs to be fixed/implemented.