### PR TITLE
Update the cursor position when toggling secure mode

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.m
+++ b/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.m
@@ -140,9 +140,12 @@
 
 - (void)secureTextEntryToggleAction:(id)sender
 {
-    [self setSecureTextEntry:!self.isSecureTextEntry];
-    self.text = self.text; // Fixes cursor position after toggling
-    [self setNeedsDisplay];
+    self.secureTextEntry = !self.secureTextEntry;
+    
+    // Save and re-apply the current selection range to save the cursor position
+    UITextRange *currentTextRange = self.selectedTextRange;
+    [self becomeFirstResponder];
+    [self setSelectedTextRange:currentTextRange];
 }
 
 - (void)updateSecureTextEntryToggleImage


### PR DESCRIPTION
When switching between secure and readable mode, it's necessary to resign focus before applying the selected range again to prevent the caret to be at the wrong position

Fixes #2498