### PR TITLE
Update status bar management to use iOS 7+ features

### DIFF
--- a/WordPress/Classes/Categories/MFMailComposeViewController+StatusBarStyle.h
+++ b/WordPress/Classes/Categories/MFMailComposeViewController+StatusBarStyle.h
@@ -1,11 +1,3 @@
-//
-//  MFMailComposeViewController+StatusBarStyle.h
-//  WordPress
-//
-//  Created by Cyril Chandelier on 26/04/15.
-//  Copyright (c) 2015 WordPress. All rights reserved.
-//
-
 #import <MessageUI/MessageUI.h>
 
 @interface MFMailComposeViewController (StatusBarStyle)

--- a/WordPress/Classes/Categories/MFMailComposeViewController+StatusBarStyle.h
+++ b/WordPress/Classes/Categories/MFMailComposeViewController+StatusBarStyle.h
@@ -1,0 +1,13 @@
+//
+//  MFMailComposeViewController+StatusBarStyle.h
+//  WordPress
+//
+//  Created by Cyril Chandelier on 26/04/15.
+//  Copyright (c) 2015 WordPress. All rights reserved.
+//
+
+#import <MessageUI/MessageUI.h>
+
+@interface MFMailComposeViewController (StatusBarStyle)
+
+@end

--- a/WordPress/Classes/Categories/MFMailComposeViewController+StatusBarStyle.m
+++ b/WordPress/Classes/Categories/MFMailComposeViewController+StatusBarStyle.m
@@ -1,11 +1,3 @@
-//
-//  MFMailComposeViewController+StatusBarStyle.m
-//  WordPress
-//
-//  Created by Cyril Chandelier on 26/04/15.
-//  Copyright (c) 2015 WordPress. All rights reserved.
-//
-
 #import "MFMailComposeViewController+StatusBarStyle.h"
 
 @implementation MFMailComposeViewController (StatusBarStyle)

--- a/WordPress/Classes/Categories/MFMailComposeViewController+StatusBarStyle.m
+++ b/WordPress/Classes/Categories/MFMailComposeViewController+StatusBarStyle.m
@@ -1,0 +1,25 @@
+//
+//  MFMailComposeViewController+StatusBarStyle.m
+//  WordPress
+//
+//  Created by Cyril Chandelier on 26/04/15.
+//  Copyright (c) 2015 WordPress. All rights reserved.
+//
+
+#import "MFMailComposeViewController+StatusBarStyle.h"
+
+@implementation MFMailComposeViewController (StatusBarStyle)
+
+#pragma mark - Status bar management
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return UIStatusBarStyleLightContent;
+}
+
+- (UIViewController *)childViewControllerForStatusBarStyle
+{
+    return nil;
+}
+
+@end

--- a/WordPress/Classes/Categories/MFMessageComposeViewController+StatusBarStyle.h
+++ b/WordPress/Classes/Categories/MFMessageComposeViewController+StatusBarStyle.h
@@ -1,11 +1,3 @@
-//
-//  MFMessageComposeViewController+StatusBarStyle.h
-//  WordPress
-//
-//  Created by Cyril Chandelier on 03/05/15.
-//  Copyright (c) 2015 WordPress. All rights reserved.
-//
-
 #import <MessageUI/MessageUI.h>
 
 @interface MFMessageComposeViewController (StatusBarStyle)

--- a/WordPress/Classes/Categories/MFMessageComposeViewController+StatusBarStyle.h
+++ b/WordPress/Classes/Categories/MFMessageComposeViewController+StatusBarStyle.h
@@ -1,0 +1,13 @@
+//
+//  MFMessageComposeViewController+StatusBarStyle.h
+//  WordPress
+//
+//  Created by Cyril Chandelier on 03/05/15.
+//  Copyright (c) 2015 WordPress. All rights reserved.
+//
+
+#import <MessageUI/MessageUI.h>
+
+@interface MFMessageComposeViewController (StatusBarStyle)
+
+@end

--- a/WordPress/Classes/Categories/MFMessageComposeViewController+StatusBarStyle.m
+++ b/WordPress/Classes/Categories/MFMessageComposeViewController+StatusBarStyle.m
@@ -1,0 +1,25 @@
+//
+//  MFMessageComposeViewController+StatusBarStyle.m
+//  WordPress
+//
+//  Created by Cyril Chandelier on 03/05/15.
+//  Copyright (c) 2015 WordPress. All rights reserved.
+//
+
+#import "MFMessageComposeViewController+StatusBarStyle.h"
+
+@implementation MFMessageComposeViewController (StatusBarStyle)
+
+#pragma mark - Status bar management
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return UIStatusBarStyleLightContent;
+}
+
+- (UIViewController *)childViewControllerForStatusBarStyle
+{
+    return nil;
+}
+
+@end

--- a/WordPress/Classes/Categories/MFMessageComposeViewController+StatusBarStyle.m
+++ b/WordPress/Classes/Categories/MFMessageComposeViewController+StatusBarStyle.m
@@ -1,11 +1,3 @@
-//
-//  MFMessageComposeViewController+StatusBarStyle.m
-//  WordPress
-//
-//  Created by Cyril Chandelier on 03/05/15.
-//  Copyright (c) 2015 WordPress. All rights reserved.
-//
-
 #import "MFMessageComposeViewController+StatusBarStyle.h"
 
 @implementation MFMessageComposeViewController (StatusBarStyle)

--- a/WordPress/Classes/Categories/WPMediaPickerViewController+StatusBarStyle.h
+++ b/WordPress/Classes/Categories/WPMediaPickerViewController+StatusBarStyle.h
@@ -1,0 +1,5 @@
+#import "WPMediaPickerViewController.h"
+
+@interface WPMediaPickerViewController (StatusBarStyle)
+
+@end

--- a/WordPress/Classes/Categories/WPMediaPickerViewController+StatusBarStyle.m
+++ b/WordPress/Classes/Categories/WPMediaPickerViewController+StatusBarStyle.m
@@ -1,0 +1,17 @@
+#import "WPMediaPickerViewController+StatusBarStyle.h"
+
+@implementation WPMediaPickerViewController (StatusBarStyle)
+
+#pragma mark - Status bar management
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return UIStatusBarStyleLightContent;
+}
+
+- (UIViewController *)childViewControllerForStatusBarStyle
+{
+    return nil;
+}
+
+@end

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -581,6 +581,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 
     [[UINavigationBar appearance] setBackgroundImage:[UIImage imageWithColor:[WPStyleGuide wordPressBlue]] forBarMetrics:UIBarMetricsDefault];
     [[UINavigationBar appearance] setShadowImage:[UIImage imageWithColor:[UIColor UIColorFromHex:0x007eb1]]];
+    [[UINavigationBar appearance] setBarStyle:UIBarStyleBlack];
 
     [[UIBarButtonItem appearance] setTintColor:[UIColor whiteColor]];
     [[UIBarButtonItem appearance] setTitleTextAttributes:@{NSFontAttributeName: [WPStyleGuide regularTextFont], NSForegroundColorAttributeName: [UIColor whiteColor]} forState:UIControlStateNormal];
@@ -589,7 +590,6 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     [[UISegmentedControl appearance] setTitleTextAttributes:@{NSFontAttributeName: [WPStyleGuide regularTextFont]} forState:UIControlStateNormal];
     [[UIToolbar appearance] setBarTintColor:[WPStyleGuide wordPressBlue]];
     [[UISwitch appearance] setOnTintColor:[WPStyleGuide wordPressBlue]];
-    [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
     [[UITabBarItem appearance] setTitleTextAttributes:@{NSFontAttributeName: [WPFontManager openSansRegularFontOfSize:10.0], NSForegroundColorAttributeName: [WPStyleGuide allTAllShadeGrey]} forState:UIControlStateNormal];
     [[UITabBarItem appearance] setTitleTextAttributes:@{NSForegroundColorAttributeName: [WPStyleGuide wordPressBlue]} forState:UIControlStateSelected];
 

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -870,4 +870,11 @@ static UIOffset const CreateAccountAndBlogOnePasswordPadding = {9.0, 0.0};
     [_operationQueue addOperation:blogCreation];
 }
 
+#pragma mark - Status bar management
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return UIStatusBarStyleLightContent;
+}
+
 @end

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -1048,4 +1048,11 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 2;
     [self.view endEditing:NO];
 }
 
+#pragma mark - Status bar management
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return UIStatusBarStyleLightContent;
+}
+
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -57,9 +57,6 @@
 {
     [super viewWillAppear:animated];
     [[WordPressAppDelegate sharedInstance].userAgent useDefaultUserAgent];
-    if (self.shouldHideStatusBar && !IS_IPAD) {
-        [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:nil];
-    }
     [self refreshWebView];
 }
 
@@ -305,6 +302,14 @@
 {
     NSArray *comps = [surString componentsSeparatedByString:@"\n"];
     return [comps componentsJoinedByString:@"<br>"];
+}
+
+#pragma mark - Status bar management
+
+- (BOOL)prefersStatusBarHidden
+{
+    // Do not hide status bar on iPad
+    return (self.shouldHideStatusBar && !IS_IPAD);
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -125,12 +125,6 @@ UIImagePickerControllerDelegate, UINavigationControllerDelegate, UIPopoverContro
     [self.navigationController setNavigationBarHidden:NO animated:NO];
     [self.navigationController setToolbarHidden:YES];
     
-    // Do not hide the status bar on iPads
-    if (self.shouldHideStatusBar && !IS_IPAD) {
-        [[UIApplication sharedApplication] setStatusBarHidden:YES
-                                                withAnimation:nil];
-    }
-    
     [self reloadData];
 }
 
@@ -1128,6 +1122,14 @@ UIImagePickerControllerDelegate, UINavigationControllerDelegate, UIPopoverContro
     // Reset delegate and nil popover property
     self.popover.delegate = nil;
     self.popover = nil;
+}
+
+#pragma mark - Status bar management
+
+- (BOOL)prefersStatusBarHidden
+{
+    // Do not hide the status bar on iPad
+    return self.shouldHideStatusBar && !IS_IPAD;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -293,10 +293,7 @@ EditImageDetailsViewControllerDelegate
         [self refreshNavigationBarButtons:NO];
         [self.navigationController.navigationBar addSubview:self.mediaProgressView];
         if (self.isEditing) {
-            if ([self shouldHideStatusBarWhileTyping]) {
-                [[UIApplication sharedApplication] setStatusBarHidden:YES
-                                                        withAnimation:UIStatusBarAnimationSlide];
-            }
+            [self setNeedsStatusBarAppearanceUpdate];
         } else {
             // Preview mode...show the onboarding hint the first time through only
             if (!self.wasOnboardingShown) {
@@ -1078,24 +1075,6 @@ EditImageDetailsViewControllerDelegate
     }
     
     [self refreshNavigationBarButtons:YES];
-}
-
-/**
- *	@brief		Returns a BOOL specifying if the status bar should be hidden while typing.
- *	@details	The status bar should never hide on the iPad.
- *
- *	@returns	YES if the keyboard should be hidden, NO otherwise.
- */
-- (BOOL)shouldHideStatusBarWhileTyping
-{
-    /*
-     Never hide for the iPad.
-     Always hide on the iPhone except for portrait + external keyboard
-     */
-    if (IS_IPAD) {
-        return NO;
-    }
-    return YES;
 }
 
 #pragma mark - Custom UI elements
@@ -1953,19 +1932,13 @@ EditImageDetailsViewControllerDelegate
 
 - (void)editorDidBeginEditing:(WPEditorViewController *)editorController
 {
-	if ([self shouldHideStatusBarWhileTyping])
-	{
-		[[UIApplication sharedApplication] setStatusBarHidden:YES
-												withAnimation:UIStatusBarAnimationSlide];
-	}
-    
+    [self setNeedsStatusBarAppearanceUpdate];
     [self refreshNavigationBarButtons:YES];
 }
 
 - (void)editorDidEndEditing:(WPEditorViewController *)editorController
 {
-	[[UIApplication sharedApplication] setStatusBarHidden:NO
-											withAnimation:UIStatusBarAnimationSlide];
+    [self setNeedsStatusBarAppearanceUpdate];
 }
 
 - (void)editorTitleDidChange:(WPEditorViewController *)editorController
@@ -2214,6 +2187,27 @@ EditImageDetailsViewControllerDelegate
 - (void)editImageDetailsViewController:(EditImageDetailsViewController *)controller didFinishEditingImageDetails:(WPImageMeta *)imageMeta
 {
     [self.editorView updateCurrentImageMeta:imageMeta];
+}
+
+
+
+#pragma mark - Status bar management
+
+- (BOOL)prefersStatusBarHidden
+{
+    /**
+     Never hide for the iPad. 
+     Always hide on the iPhone except when user is not editing
+     */
+    if (IS_IPAD || !self.isEditing) {
+        return NO;
+    }
+    return YES;
+}
+
+- (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
+{
+    return UIStatusBarAnimationSlide;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -8,6 +8,8 @@
 - (void)handleImageTapped:(UITapGestureRecognizer *)tgr;
 - (void)handleImageDoubleTapped:(UITapGestureRecognizer *)tgr;
 
+@property (nonatomic, assign) BOOL shouldHideStatusBar;
+
 @end
 
 @implementation WPImageViewController
@@ -138,9 +140,17 @@
 
 - (void)hideBars:(BOOL)hide animated:(BOOL)animated
 {
-
-    [[UIApplication sharedApplication] setStatusBarHidden:hide withAnimation:(animated ? UIStatusBarAnimationFade : UIStatusBarAnimationNone)];
-
+    self.shouldHideStatusBar = hide;
+    
+    // Force an update of the status bar appearance and visiblity
+    if (animated) {
+        [UIView animateWithDuration:0.3
+                         animations:^{
+                             [self setNeedsStatusBarAppearanceUpdate];
+                         }];
+    } else {
+        [self setNeedsStatusBarAppearanceUpdate];
+    }
 }
 
 - (void)centerImage
@@ -203,6 +213,23 @@
     }
 
     _imageView.frame = frame;
+}
+
+#pragma mark - Status bar management
+
+- (BOOL)prefersStatusBarHidden
+{
+    return self.shouldHideStatusBar;
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return UIStatusBarStyleLightContent;
+}
+
+- (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
+{
+    return UIStatusBarAnimationFade;
 }
 
 @end

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -77,6 +77,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -495,6 +495,7 @@
 		E2E7EB46185FB140004F5E72 /* WPBlogSelectorButton.m in Sources */ = {isa = PBXBuildFile; fileRef = E2E7EB45185FB140004F5E72 /* WPBlogSelectorButton.m */; };
 		EC4696FF0EA75D460040EE8E /* PagesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EC4696FE0EA75D460040EE8E /* PagesViewController.m */; };
 		ECFA8F2B890D45298F324B8B /* libPods-WordPressTodayWidget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 872A78E046E04A05B17EB1A1 /* libPods-WordPressTodayWidget.a */; };
+		F128C31C1AFCC95B008C2404 /* WPMediaPickerViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F128C31B1AFCC95B008C2404 /* WPMediaPickerViewController+StatusBarStyle.m */; };
 		F1564E5B18946087009F8F97 /* NSStringHelpersTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F1564E5A18946087009F8F97 /* NSStringHelpersTest.m */; };
 		F1A0C49C1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F1A0C49B1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m */; };
 		F1FA2C4E1AED07FC00255FCD /* MFMailComposeViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F1FA2C491AECEE1900255FCD /* MFMailComposeViewController+StatusBarStyle.m */; };
@@ -1435,6 +1436,8 @@
 		E2E7EB45185FB140004F5E72 /* WPBlogSelectorButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPBlogSelectorButton.m; sourceTree = "<group>"; };
 		EC4696FD0EA75D460040EE8E /* PagesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PagesViewController.h; sourceTree = "<group>"; };
 		EC4696FE0EA75D460040EE8E /* PagesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PagesViewController.m; sourceTree = "<group>"; };
+		F128C31A1AFCC95B008C2404 /* WPMediaPickerViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPMediaPickerViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
+		F128C31B1AFCC95B008C2404 /* WPMediaPickerViewController+StatusBarStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WPMediaPickerViewController+StatusBarStyle.m"; sourceTree = "<group>"; };
 		F1564E5A18946087009F8F97 /* NSStringHelpersTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringHelpersTest.m; sourceTree = "<group>"; };
 		F1A0C49A1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MFMessageComposeViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
 		F1A0C49B1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MFMessageComposeViewController+StatusBarStyle.m"; sourceTree = "<group>"; };
@@ -2878,6 +2881,8 @@
 				F1FA2C491AECEE1900255FCD /* MFMailComposeViewController+StatusBarStyle.m */,
 				F1A0C49A1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.h */,
 				F1A0C49B1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m */,
+				F128C31A1AFCC95B008C2404 /* WPMediaPickerViewController+StatusBarStyle.h */,
+				F128C31B1AFCC95B008C2404 /* WPMediaPickerViewController+StatusBarStyle.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -3703,6 +3708,7 @@
 				C58349C51806F95100B64089 /* IOS7CorrectedTextView.m in Sources */,
 				594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */,
 				C56636E91868D0CE00226AAB /* StatsViewController.m in Sources */,
+				F128C31C1AFCC95B008C2404 /* WPMediaPickerViewController+StatusBarStyle.m in Sources */,
 				313AE4A019E3F20400AAFABE /* CommentViewController.m in Sources */,
 				93A379DB19FE6D3000415023 /* DDLogSwift.m in Sources */,
 				A0E293F10E21027E00C6919C /* WPAddPostCategoryViewController.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -496,6 +496,8 @@
 		EC4696FF0EA75D460040EE8E /* PagesViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EC4696FE0EA75D460040EE8E /* PagesViewController.m */; };
 		ECFA8F2B890D45298F324B8B /* libPods-WordPressTodayWidget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 872A78E046E04A05B17EB1A1 /* libPods-WordPressTodayWidget.a */; };
 		F1564E5B18946087009F8F97 /* NSStringHelpersTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F1564E5A18946087009F8F97 /* NSStringHelpersTest.m */; };
+		F1A0C49C1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F1A0C49B1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m */; };
+		F1FA2C4E1AED07FC00255FCD /* MFMailComposeViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F1FA2C491AECEE1900255FCD /* MFMailComposeViewController+StatusBarStyle.m */; };
 		FD21397F13128C5300099582 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FD21397E13128C5300099582 /* libiconv.dylib */; };
 		FD3D6D2C1349F5D30061136A /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD3D6D2B1349F5D30061136A /* ImageIO.framework */; };
 		FD75DDAD15B021C80043F12C /* UIViewController+Rotation.m in Sources */ = {isa = PBXBuildFile; fileRef = FD75DDAC15B021C80043F12C /* UIViewController+Rotation.m */; };
@@ -1434,6 +1436,10 @@
 		EC4696FD0EA75D460040EE8E /* PagesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PagesViewController.h; sourceTree = "<group>"; };
 		EC4696FE0EA75D460040EE8E /* PagesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PagesViewController.m; sourceTree = "<group>"; };
 		F1564E5A18946087009F8F97 /* NSStringHelpersTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringHelpersTest.m; sourceTree = "<group>"; };
+		F1A0C49A1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MFMessageComposeViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
+		F1A0C49B1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MFMessageComposeViewController+StatusBarStyle.m"; sourceTree = "<group>"; };
+		F1FA2C481AECEE1900255FCD /* MFMailComposeViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MFMailComposeViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
+		F1FA2C491AECEE1900255FCD /* MFMailComposeViewController+StatusBarStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MFMailComposeViewController+StatusBarStyle.m"; sourceTree = "<group>"; };
 		FD0D42C11499F31700F5E115 /* WordPress 4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 4.xcdatamodel"; sourceTree = "<group>"; };
 		FD21397E13128C5300099582 /* libiconv.dylib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
 		FD374343156CF4B800BAB5B5 /* WordPress 6.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 6.xcdatamodel"; sourceTree = "<group>"; };
@@ -2868,6 +2874,10 @@
 				85CE4C1F1A703CF200780DFE /* NSBundle+VersionNumberHelper.m */,
 				FFAC890E1A96A85800CC06AC /* NSProcessInfo+Util.h */,
 				FFAC890F1A96A85800CC06AC /* NSProcessInfo+Util.m */,
+				F1FA2C481AECEE1900255FCD /* MFMailComposeViewController+StatusBarStyle.h */,
+				F1FA2C491AECEE1900255FCD /* MFMailComposeViewController+StatusBarStyle.m */,
+				F1A0C49A1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.h */,
+				F1A0C49B1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -3686,6 +3696,7 @@
 				B55853F719630D5400FAF6C3 /* NSAttributedString+Util.m in Sources */,
 				ACBAB5FE0E121C7300F38795 /* PostSettingsViewController.m in Sources */,
 				319D6E8119E44C680013871C /* SuggestionsTableView.m in Sources */,
+				F1A0C49C1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m in Sources */,
 				ACBAB6860E1247F700F38795 /* PostPreviewViewController.m in Sources */,
 				5D2FB2861AE98C6600F1D4ED /* RestorePostTableViewCell.m in Sources */,
 				E1A6DBE519DC7D230071AC1E /* PostService.m in Sources */,
@@ -3745,6 +3756,7 @@
 				834CAE7C122D528A003DDF49 /* UIImage+Resize.m in Sources */,
 				5D9B17C519998A430047A4A2 /* ReaderBlockedTableViewCell.m in Sources */,
 				5D000DDE1AC076C000A7BAF9 /* PostCardActionBar.m in Sources */,
+				F1FA2C4E1AED07FC00255FCD /* MFMailComposeViewController+StatusBarStyle.m in Sources */,
 				834CAE9F122D56B1003DDF49 /* UIImage+Alpha.m in Sources */,
 				B54866CA1A0D7042004AC79D /* NSAttributedString+Helpers.swift in Sources */,
 				834CAEA0122D56B1003DDF49 /* UIImage+RoundedCorner.m in Sources */,


### PR DESCRIPTION
This is a refactor of the status bar management throughout the app in order to use the iOS 7+ way.

Refs #2507, it solves the problem of the status bar reseted to the default black color in ```MFMailComposeViewController``` and ```MFMessageComposeViewController```.

Basically, I turned the ```UIViewControllerBasedStatusBarAppearance``` key in Info.plist to YES. I then update everywhere I could the status bar management rules (color, animation and hidden settings) using the following overridden methods:
```
- (BOOL)prefersStatusBarHidden;
- (UIStatusBarStyle)preferredStatusBarStyle;
- (UIStatusBarAnimation)preferredStatusBarUpdateAnimation;
```
The ```setNeedsStatusBarAppearanceUpdate``` method is used whenever the previous methods values change at runtime.

Regarding the mail and message composers, I have created categories to apply the status bar settings globally (even from UIActivityViewController).

I hope this can help.