### PR TITLE
The notification badge now hides with the tab bar.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -100,7 +100,7 @@ PODS:
   - UIAlertView+Blocks (0.8.1)
   - UIDeviceIdentifier (0.4.4)
   - WordPress-AppbotX (1.0.6)
-  - WordPress-iOS-Editor (0.6):
+  - WordPress-iOS-Editor (0.7):
     - CocoaLumberjack (~> 1.9)
     - NSObject-SafeExpectations (~> 0.0.2)
     - UIAlertView+Blocks (~> 0.8.1)
@@ -150,7 +150,7 @@ DEPENDENCIES:
   - SVProgressHUD (~> 1.1.3)
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `303b8068530389ea87afde38b77466d685fe3210`)
-  - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`, commit `72df4d5defefcf2a76b314a10fd01927a82a9f56`)
+  - WordPress-iOS-Editor (= 0.7)
   - WordPress-iOS-Shared (= 0.3)
   - WordPressApi (~> 0.3.4)
   - WordPressCom-Analytics-iOS (= 0.0.31)
@@ -172,9 +172,6 @@ EXTERNAL SOURCES:
   WordPress-AppbotX:
     :commit: 303b8068530389ea87afde38b77466d685fe3210
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPress-iOS-Editor:
-    :commit: 72df4d5defefcf2a76b314a10fd01927a82a9f56
-    :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -189,9 +186,6 @@ CHECKOUT OPTIONS:
   WordPress-AppbotX:
     :commit: 303b8068530389ea87afde38b77466d685fe3210
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPress-iOS-Editor:
-    :commit: 72df4d5defefcf2a76b314a10fd01927a82a9f56
-    :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 66365c1e1264a83edec6c84c6eb2df41b50a70d3
@@ -226,7 +220,7 @@ SPEC CHECKSUMS:
   UIAlertView+Blocks: 45c3d3b7194906702d3e9a14c7ece5581505646d
   UIDeviceIdentifier: 2eb1070f189a069184611e21b5e8832443e6f8ec
   WordPress-AppbotX: 8bb0ad23af141e85db282ce09b58e5b3604cf54c
-  WordPress-iOS-Editor: 8bd67af1e0391fb6a118cee583ba6163e04ab5b2
+  WordPress-iOS-Editor: 5fba0792b2ca492e075815f4480105ec3fc49045
   WordPress-iOS-Shared: 0f5281492166bb89ea09d8ab5011e871ba4f6709
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
   WordPressCom-Analytics-iOS: a35692b0bb5a1d5081da2481614a66663dfb091f

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -203,7 +203,7 @@ SPEC CHECKSUMS:
   CTAssetsPickerController: 56a4a228dcb48a9375ab8d4922e82ac74af74aa1
   DTCoreText: d90a4dca8e4f7b0eb18f12a967563b77a75694f0
   DTFoundation: 1d28080c20c3da041706545363f8238ab53a6204
-  EmailChecker: 406cf1f1b5cd2efb8401803b580abf4a43b0665c
+  EmailChecker: e909e6d113fac7ad5e3c304fabce30fc4a79c80e
   Google-Diff-Match-Patch: d8d1a2cc3ca2382f4855f0bf05821b91250927ee
   google-plus-ios-sdk: 47adbe03ea904bdb7aa1c0eca282a23c4686e1bc
   Helpshift: 9c84a5e4ffd881c7e7eb395c2afc8d6a46eb2187
@@ -221,11 +221,11 @@ SPEC CHECKSUMS:
   OHHTTPStubs: ad00ed452d4e3805ffb95977163879bd5bb121ea
   Reachability: dd9aa4fb6667b9f787690a74f53cb7634ce99893
   Simperium: 7d0a207d7f0ce918b36ba9e690cdb0d0d730cc28
-  SocketRocket: 77c536491ce78315d4f26a06057ed49aa36cef5e
+  SocketRocket: b809068861cb66d871eb93a428696b1eb5451318
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
   UIAlertView+Blocks: 45c3d3b7194906702d3e9a14c7ece5581505646d
   UIDeviceIdentifier: 2eb1070f189a069184611e21b5e8832443e6f8ec
-  WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
+  WordPress-AppbotX: 8bb0ad23af141e85db282ce09b58e5b3604cf54c
   WordPress-iOS-Editor: 8bd67af1e0391fb6a118cee583ba6163e04ab5b2
   WordPress-iOS-Shared: 0f5281492166bb89ea09d8ab5011e871ba4f6709
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -499,7 +499,7 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
     self.notificationBadgeIconView.layer.borderColor = [[UIColor whiteColor] CGColor];
     self.notificationBadgeIconView.layer.borderWidth = 1.0;
     self.notificationBadgeIconView.hidden = YES;
-    [self.view addSubview:self.notificationBadgeIconView];
+    [self.tabBar addSubview:self.notificationBadgeIconView];
 
     [self updateNotificationBadgeIconPosition];
     [self updateNotificationBadgeVisibility];
@@ -518,7 +518,7 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
     else if (isLandscape && WPDeviceIdentification.isiPhoneSixPlus) {
         horizontalOffset = WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLandscape;
     }
-    CGFloat verticalPosition = CGRectGetHeight(self.view.bounds) - (self.tabBar.frame.size.height - WPNotificationBadgeIconVerticalOffsetFromTop);
+    CGFloat verticalPosition = WPNotificationBadgeIconVerticalOffsetFromTop;
     // Subtract the space before & after the tabbar
     CGFloat tabBarContentWidth = self.tabBar.frame.size.width - (horizontalOffset * 2);
     CGFloat tabItemWidth = tabBarContentWidth / self.tabBar.items.count;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3886,7 +3886,7 @@
 					"-l\"z\"",
 				);
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "094101ad-44b6-4b37-806f-849562fb8425";
+				PROVISIONING_PROFILE = "2c67955d-6e0d-474f-89c0-f2ed02e3292a";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -4173,7 +4173,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "ddfaaebf-2573-4a5a-b455-f6ba1aabd978";
+				PROVISIONING_PROFILE = "5c9361df-f446-4a48-a4e1-01a3bceb96e8";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressTodayWidget/WordPressTodayWidget-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";


### PR DESCRIPTION
Alternative to [this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/3614).

Pros:
- The visibility of the badge is now inherently tied to the visibility of the tab bar.
- Less code to make sure the badge is hidden / shown when needed.