### PR TITLE
Fix Jetpack preview authentication

### DIFF
--- a/WordPress/Classes/Utility/WPURLRequest.m
+++ b/WordPress/Classes/Utility/WPURLRequest.m
@@ -22,6 +22,12 @@
     NSParameterAssert(password != nil || bearerToken != nil);
     
     NSMutableURLRequest *request = [self mutableRequestWithURL:loginUrl userAgent:userAgent];
+
+    NSString *hostname = [loginUrl host];
+    if (![hostname isEqualToString:@"wordpress.com"] && ![hostname hasSuffix:@".wordpress.com"]) {
+        // Let's make sure we don't send OAuth2 tokens outside of wordpress.com
+        bearerToken = nil;
+    }
     
     // If we've got a token, let's make sure the password never gets sent
     NSString *encodedPassword = bearerToken.length == 0 ? [password stringByUrlEncoding] : nil;

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -218,12 +218,16 @@
         if (needsLogin) {
             NSURL *loginURL = [NSURL URLWithString:self.apost.blog.loginUrl];
             NSURL *redirectURL = [NSURL URLWithString:link];
-            
+            NSString *token;
+            if ([self.apost.blog isWPcom]) {
+                token = self.apost.blog.authToken;
+            }
+
             NSURLRequest *request = [WPURLRequest requestForAuthenticationWithURL:loginURL
                                                                       redirectURL:redirectURL
                                                                          username:self.apost.blog.username
                                                                          password:self.apost.blog.password
-                                                                      bearerToken:self.apost.blog.authToken
+                                                                      bearerToken:token
                                                                         userAgent:nil];
             [self.webView loadRequest:request];
             DDLogInfo(@"Showing real preview (login) for %@", link);

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -426,6 +426,7 @@
 		E183ECB216B2179B00C2EB11 /* Twitter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC24E5F21577DFF400A6D5B5 /* Twitter.framework */; };
 		E18EE94E19349EBA00B0A40C /* BlogServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = E18EE94D19349EBA00B0A40C /* BlogServiceRemote.m */; };
 		E18EE95119349EC300B0A40C /* ReaderTopicServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = E18EE95019349EC300B0A40C /* ReaderTopicServiceRemote.m */; };
+		E19A10CA1B010AA0006192B0 /* WPURLRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E19A10C91B010AA0006192B0 /* WPURLRequestTest.m */; };
 		E19DF741141F7BDD000002F3 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E19DF740141F7BDD000002F3 /* libz.dylib */; };
 		E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A03EE117422DCE0085D192 /* BlogToAccount.m */; };
 		E1A03F48174283E10085D192 /* BlogToJetpackAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A03F47174283E00085D192 /* BlogToJetpackAccount.m */; };
@@ -1286,6 +1287,7 @@
 		E18EE95019349EC300B0A40C /* ReaderTopicServiceRemote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReaderTopicServiceRemote.m; sourceTree = "<group>"; };
 		E19853331755E461001CC6D5 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E19853341755E4B3001CC6D5 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		E19A10C91B010AA0006192B0 /* WPURLRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPURLRequestTest.m; sourceTree = "<group>"; };
 		E19BF8F913CC69E7004753FE /* WordPress 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 3.xcdatamodel"; sourceTree = "<group>"; };
 		E19DF740141F7BDD000002F3 /* libz.dylib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		E1A03EE017422DCD0085D192 /* BlogToAccount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogToAccount.h; sourceTree = "<group>"; };
@@ -2163,6 +2165,7 @@
 				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
 				85D790AB1AE5D95E0033AE83 /* MixpanelProxyTests.m */,
 				8514B8D31AE85B19007E58BA /* WPAnalyticsTrackerMixpanelTests.m */,
+				E19A10C91B010AA0006192B0 /* WPURLRequestTest.m */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -3864,6 +3867,7 @@
 				E15618FD16DB8677006532C4 /* UIKitTestHelper.m in Sources */,
 				B5AEEC721ACACF2F008BF2A4 /* NotificationTests.m in Sources */,
 				9358D15919FFD4E10094BBF5 /* WPImageOptimizerTest.m in Sources */,
+				E19A10CA1B010AA0006192B0 /* WPURLRequestTest.m in Sources */,
 				931D26F819ED7F7800114F17 /* ReaderTopicServiceTest.m in Sources */,
 				E1E4CE0D177439D100430844 /* WPAvatarSourceTest.m in Sources */,
 			);

--- a/WordPress/WordPressTest/WPURLRequestTest.m
+++ b/WordPress/WordPressTest/WPURLRequestTest.m
@@ -1,0 +1,52 @@
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "WPURLRequest.h"
+
+@interface WPURLRequestTest : XCTestCase
+@end
+
+@implementation WPURLRequestTest
+
+
+- (void)testWordPressComURLShouldNotIncludePassword
+{
+    NSURL *redirectURL = [NSURL URLWithString:@"http://example.com"];
+    NSURL *loginURL = [NSURL URLWithString:@"https://wordpress.com/"];
+    NSString *password = @"Iab5aK9myf3oR9I";
+    NSString *token = @"Pog4Byiv6viG9Wy";
+    NSURLRequest *request = [WPURLRequest requestForAuthenticationWithURL:loginURL
+                                                              redirectURL:redirectURL
+                                                                 username:@"username"
+                                                                 password:password
+                                                              bearerToken:token
+                                                                userAgent:@"agent"];
+    XCTAssertEqualObjects(request.URL, loginURL);
+    XCTAssertNotNil(request.HTTPBody);
+    NSString *body = [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding];
+    XCTAssertEqual([body rangeOfString:password].location, NSNotFound, @"password shouldn't be in the request body");
+    NSString *authorization = [request valueForHTTPHeaderField:@"Authorization"];
+    XCTAssertNotNil(authorization);
+    XCTAssertNotEqual([authorization rangeOfString:token].location, NSNotFound, @"token should be in the request body");
+}
+
+- (void)testTokenShouldNotBeSentOutsideDotCom
+{
+    NSURL *redirectURL = [NSURL URLWithString:@"http://example.com"];
+    NSURL *loginURL = [NSURL URLWithString:@"http://example.com/"];
+    NSString *password = @"Iab5aK9myf3oR9I";
+    NSString *token = @"Pog4Byiv6viG9Wy";
+    NSURLRequest *request = [WPURLRequest requestForAuthenticationWithURL:loginURL
+                                                              redirectURL:redirectURL
+                                                                 username:@"username"
+                                                                 password:password
+                                                              bearerToken:token
+                                                                userAgent:@"agent"];
+    XCTAssertEqualObjects(request.URL, loginURL);
+    XCTAssertNotNil(request.HTTPBody);
+    NSString *body = [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding];
+    XCTAssertNotEqual([body rangeOfString:password].location, NSNotFound, @"password should in the request body");
+    NSString *authorization = [request valueForHTTPHeaderField:@"Authorization"];
+    XCTAssertNil(authorization);
+}
+
+@end


### PR DESCRIPTION
As a side effect of #3597, `blog.authToken` was not `nil` for Jetpack
sites. When there's an auth token, WPURLRequest will drop the password
from the request. Since the login was posted to the self hosted and not
WordPress.com, the authentication failed.

This sets the token only if the blog is a WordPress.com one, and adds a
safeguard to prevent tokens from being sent to non-wp.com URLs.

fixes #3637 

/cc @jleandroperez since I think you wrote WPURLRequest
/cc @sendhil since I mentioned it in private