### PR TITLE
Adding unit tests to #3615

### DIFF
--- a/WordPress/Classes/Services/PushAuthenticationService.swift
+++ b/WordPress/Classes/Services/PushAuthenticationService.swift
@@ -9,15 +9,18 @@ import Foundation
 
 @objc public class PushAuthenticationService : NSObject, LocalCoreDataService
 {
+    var authenticationServiceRemote:PushAuthenticationServiceRemote?
+    
     /**
     *  @details     Designated Initializer
     *  @param       managedObjectContext    A Reference to the MOC that should be used to interact with
     *                                       the Core Data Persistent Store.
     */
     public required init(managedObjectContext: NSManagedObjectContext) {
+        super.init()
         self.managedObjectContext = managedObjectContext
+        self.authenticationServiceRemote = PushAuthenticationServiceRemote(remoteApi: apiForRequest())
     }
-    
 
     /**
     *  @details     Authorizes a WordPress.com Login Attempt (2FA Protected Accounts)
@@ -25,12 +28,11 @@ import Foundation
     *  @param       completion  The completion block to be executed when the remote call finishes.
     */
     public func authorizeLogin(token: String, completion: ((Bool) -> ())) {
-        let remoteService = PushAuthenticationServiceRemote(remoteApi: apiForRequest())
-        if remoteService == nil {
+        if self.authenticationServiceRemote == nil {
             return
         }
         
-        remoteService!.authorizeLogin(token,
+        self.authenticationServiceRemote!.authorizeLogin(token,
             success:    {
                             completion(true)
                         },

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -12,6 +12,7 @@
 #import "NSDate+StringFormatting.h"
 #import "NSURL+Util.h"
 #import "UIAlertView+Blocks.h"
+#import "UIAlertViewProxy.h"
 
 #import "ContextManager.h"
 

--- a/WordPress/Classes/Utility/NotificationsManager.m
+++ b/WordPress/Classes/Utility/NotificationsManager.m
@@ -190,7 +190,7 @@ static NSString *const NotificationActionCommentApprove             = @"COMMENT_
     // while the app is in BG, and when it's about to become active. In order to prevent UI glitches, let's skip
     // notifications when in BG mode.
     //
-    PushAuthenticationManager *authenticationManager = [PushAuthenticationManager sharedInstance];
+    PushAuthenticationManager *authenticationManager = [PushAuthenticationManager new];
     if ([authenticationManager isPushAuthenticationNotification:userInfo] && state != UIApplicationStateBackground) {
         [authenticationManager handlePushAuthenticationNotification:userInfo];
         return;

--- a/WordPress/Classes/Utility/PushAuthenticationManager.swift
+++ b/WordPress/Classes/Utility/PushAuthenticationManager.swift
@@ -11,22 +11,22 @@ import UIKit
 *                   by this specific class.
 */
 
-@objc public class PushAuthenticationManager
+@objc public class PushAuthenticationManager : NSObject
 {
-    //
-    // MARK: - Public Properties
-    //
-    
-    /**
-    *  @brief      Returns the PushAuthenticator Singleton Instance
-    */
-    static let sharedInstance = PushAuthenticationManager()
-    
-
-    
     //
     // MARK: - Public Methods
     //
+    var alertViewProxy = UIAlertViewProxy()
+    let pushAuthenticationService:PushAuthenticationService
+    
+    override convenience init() {
+        self.init(pushAuthenticationService: PushAuthenticationService(managedObjectContext: ContextManager.sharedInstance().mainContext))
+    }
+    
+    public init(pushAuthenticationService: PushAuthenticationService) {
+        self.pushAuthenticationService = pushAuthenticationService
+        super.init()
+    }
     
     /**
     *  @brief       Checks if a given Push Notification is a Push Authentication.
@@ -94,11 +94,8 @@ import UIKit
             WPAnalytics.track(.PushAuthenticationFailed)
             return
         }
-        
-        let mainContext = ContextManager.sharedInstance().mainContext
-        let service     = PushAuthenticationService(managedObjectContext: mainContext)
 
-        service.authorizeLogin(token) { (success) -> () in
+        self.pushAuthenticationService.authorizeLogin(token) { (success) -> () in
             if !success {
                 self.authorizeLogin(token, retryCount: (retryCount + 1))
             }
@@ -131,7 +128,7 @@ import UIKit
                                                     comment: "WordPress.com Push Authentication Expired message")
         let acceptButtonTitle   = NSLocalizedString("Approve", comment: "Approve action. Verb")
         
-        UIAlertView.showWithTitle(title,
+        self.alertViewProxy.showWithTitle(title,
             message:            message,
             cancelButtonTitle:  acceptButtonTitle,
             otherButtonTitles:  nil,
@@ -150,7 +147,7 @@ import UIKit
         let cancelButtonTitle   = NSLocalizedString("Ignore",       comment: "Ignore action. Verb")
         let acceptButtonTitle   = NSLocalizedString("Approve",      comment: "Approve action. Verb")
         
-        UIAlertView.showWithTitle(title,
+        self.alertViewProxy.showWithTitle(title,
             message:            message,
             cancelButtonTitle: cancelButtonTitle,
             otherButtonTitles: [acceptButtonTitle as AnyObject])

--- a/WordPress/Classes/Utility/UIAlertViewProxy.h
+++ b/WordPress/Classes/Utility/UIAlertViewProxy.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+#import "UIAlertView+Blocks.h"
+
+/**
+ *  This class acts as proxy for UIAlertView to make testing easier
+ */
+@interface UIAlertViewProxy : NSObject
+
+- (UIAlertView *)showWithTitle:(NSString *)title
+                      message:(NSString *)message
+            cancelButtonTitle:(NSString *)cancelButtonTitle
+            otherButtonTitles:(NSArray *)otherButtonTitles
+                     tapBlock:(UIAlertViewCompletionBlock)tapBlock;
+
+@end

--- a/WordPress/Classes/Utility/UIAlertViewProxy.m
+++ b/WordPress/Classes/Utility/UIAlertViewProxy.m
@@ -1,0 +1,14 @@
+#import "UIAlertViewProxy.h"
+
+@implementation UIAlertViewProxy
+
+- (UIAlertView *)showWithTitle:(NSString *)title
+                      message:(NSString *)message
+            cancelButtonTitle:(NSString *)cancelButtonTitle
+            otherButtonTitles:(NSArray *)otherButtonTitles
+                     tapBlock:(UIAlertViewCompletionBlock)tapBlock
+{
+    return [UIAlertView showWithTitle:title message:message cancelButtonTitle:cancelButtonTitle otherButtonTitles:otherButtonTitles tapBlock:tapBlock];
+}
+
+@end

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -225,6 +225,9 @@
 		85AD6AEC173CCF9E002CB896 /* WPNUXPrimaryButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 85AD6AEB173CCF9E002CB896 /* WPNUXPrimaryButton.m */; };
 		85AD6AEF173CCFDC002CB896 /* WPNUXSecondaryButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 85AD6AEE173CCFDC002CB896 /* WPNUXSecondaryButton.m */; };
 		85B1253F1B02849B008A3D95 /* PushAuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B535209C1AF7EB9F00B33BA8 /* PushAuthenticationService.swift */; };
+		85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B125401B028E34008A3D95 /* PushAuthenticationManagerTests.swift */; };
+		85B125421B028F62008A3D95 /* PushAuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B535209A1AF7BBB800B33BA8 /* PushAuthenticationManager.swift */; };
+		85B125461B0294F6008A3D95 /* UIAlertViewProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 85B125441B02937E008A3D95 /* UIAlertViewProxy.m */; };
 		85B6F74F1742DA1E00CE7F3A /* WPNUXMainButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 85B6F74E1742DA1D00CE7F3A /* WPNUXMainButton.m */; };
 		85B6F7521742DAE800CE7F3A /* WPNUXBackButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 85B6F7511742DAE800CE7F3A /* WPNUXBackButton.m */; };
 		85C720B11730CEFA00460645 /* WPWalkthroughTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 85C720B01730CEFA00460645 /* WPWalkthroughTextField.m */; };
@@ -943,6 +946,9 @@
 		85AD6AEB173CCF9E002CB896 /* WPNUXPrimaryButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPNUXPrimaryButton.m; sourceTree = "<group>"; };
 		85AD6AED173CCFDC002CB896 /* WPNUXSecondaryButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPNUXSecondaryButton.h; sourceTree = "<group>"; };
 		85AD6AEE173CCFDC002CB896 /* WPNUXSecondaryButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPNUXSecondaryButton.m; sourceTree = "<group>"; };
+		85B125401B028E34008A3D95 /* PushAuthenticationManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationManagerTests.swift; sourceTree = "<group>"; };
+		85B125431B02937E008A3D95 /* UIAlertViewProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIAlertViewProxy.h; sourceTree = "<group>"; };
+		85B125441B02937E008A3D95 /* UIAlertViewProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIAlertViewProxy.m; sourceTree = "<group>"; };
 		85B6F74D1742DA1D00CE7F3A /* WPNUXMainButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPNUXMainButton.h; sourceTree = "<group>"; };
 		85B6F74E1742DA1D00CE7F3A /* WPNUXMainButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPNUXMainButton.m; sourceTree = "<group>"; };
 		85B6F7501742DAE800CE7F3A /* WPNUXBackButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPNUXBackButton.h; sourceTree = "<group>"; };
@@ -2274,6 +2280,8 @@
 				594DB2941AB891A200E2E456 /* WPUserAgent.m */,
 				FF28B3EF1AEB251200E11AAE /* InfoPListTranslator.h */,
 				FF28B3F01AEB251200E11AAE /* InfoPListTranslator.m */,
+				85B125431B02937E008A3D95 /* UIAlertViewProxy.h */,
+				85B125441B02937E008A3D95 /* UIAlertViewProxy.m */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -2348,6 +2356,7 @@
 				85F8E19A1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift */,
 				85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */,
 				85F8E19E1B0186D0000859BB /* MockWordPressComApi.swift */,
+				85B125401B028E34008A3D95 /* PushAuthenticationManagerTests.swift */,
 			);
 			name = Networking;
 			sourceTree = "<group>";
@@ -3754,6 +3763,7 @@
 				5DE88FAA1A859DD9000E2CA6 /* ReaderPostUnattributedTableViewCell.m in Sources */,
 				3101866B1A373B01008F7DF6 /* WPTabBarController.m in Sources */,
 				85E105861731A597001071A3 /* WPWalkthroughOverlayView.m in Sources */,
+				85B125461B0294F6008A3D95 /* UIAlertViewProxy.m in Sources */,
 				B587797B19B799D800E57C5A /* NSIndexPath+Swift.swift in Sources */,
 				85D08A7117342ECE00E2BBCA /* AddUsersBlogCell.m in Sources */,
 				85EC44D41739826A00686604 /* CreateAccountAndBlogViewController.m in Sources */,
@@ -3889,6 +3899,7 @@
 				5D12FE1F1988243700378BD6 /* RemoteReaderTopic.m in Sources */,
 				8514B8D41AE85B19007E58BA /* WPAnalyticsTrackerMixpanelTests.m in Sources */,
 				931D26F719ED7F7500114F17 /* ReaderPostServiceTest.m in Sources */,
+				85B125421B028F62008A3D95 /* PushAuthenticationManager.swift in Sources */,
 				93E9050719E6F3D8005513C9 /* TestContextManager.m in Sources */,
 				5D2BEB4919758102005425F7 /* WPTableImageSourceTest.m in Sources */,
 				5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */,
@@ -3908,6 +3919,7 @@
 				E15618FD16DB8677006532C4 /* UIKitTestHelper.m in Sources */,
 				B5AEEC721ACACF2F008BF2A4 /* NotificationTests.m in Sources */,
 				9358D15919FFD4E10094BBF5 /* WPImageOptimizerTest.m in Sources */,
+				85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */,
 				931D26F819ED7F7800114F17 /* ReaderTopicServiceTest.m in Sources */,
 				E1E4CE0D177439D100430844 /* WPAvatarSourceTest.m in Sources */,
 			);

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 		859F761D18F2159800EF8D5D /* WPAnalyticsTrackerMixpanelInstructionsForStat.m in Sources */ = {isa = PBXBuildFile; fileRef = 859F761C18F2159800EF8D5D /* WPAnalyticsTrackerMixpanelInstructionsForStat.m */; };
 		85AD6AEC173CCF9E002CB896 /* WPNUXPrimaryButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 85AD6AEB173CCF9E002CB896 /* WPNUXPrimaryButton.m */; };
 		85AD6AEF173CCFDC002CB896 /* WPNUXSecondaryButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 85AD6AEE173CCFDC002CB896 /* WPNUXSecondaryButton.m */; };
+		85B1253F1B02849B008A3D95 /* PushAuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B535209C1AF7EB9F00B33BA8 /* PushAuthenticationService.swift */; };
 		85B6F74F1742DA1E00CE7F3A /* WPNUXMainButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 85B6F74E1742DA1D00CE7F3A /* WPNUXMainButton.m */; };
 		85B6F7521742DAE800CE7F3A /* WPNUXBackButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 85B6F7511742DAE800CE7F3A /* WPNUXBackButton.m */; };
 		85C720B11730CEFA00460645 /* WPWalkthroughTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 85C720B01730CEFA00460645 /* WPWalkthroughTextField.m */; };
@@ -3879,6 +3880,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */,
+				85B1253F1B02849B008A3D95 /* PushAuthenticationService.swift in Sources */,
 				931D26F519ED7E6D00114F17 /* BlogJetpackTest.m in Sources */,
 				5D12FE1E1988243700378BD6 /* RemoteReaderPost.m in Sources */,
 				5D12FE221988245B00378BD6 /* RemoteReaderSite.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -252,6 +252,8 @@
 		85ED988817DFA00000090D0B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85ED988717DFA00000090D0B /* Images.xcassets */; };
 		85F8E1981B017A86000859BB /* PushAuthenticationServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B535209E1AF7EFEC00B33BA8 /* PushAuthenticationServiceRemote.swift */; };
 		85F8E19B1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8E19A1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift */; };
+		85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */; };
+		85F8E19F1B0186D0000859BB /* MockWordPressComApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8E19E1B0186D0000859BB /* MockWordPressComApi.swift */; };
 		931D26F519ED7E6D00114F17 /* BlogJetpackTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E150520B16CAC5C400D3DDDC /* BlogJetpackTest.m */; };
 		931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 930FD0A519882742000CC81D /* BlogServiceTest.m */; };
 		931D26F719ED7F7500114F17 /* ReaderPostServiceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DE8A0401912D95B00B2FF59 /* ReaderPostServiceTest.m */; };
@@ -989,6 +991,8 @@
 		85ED988717DFA00000090D0B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		85ED98AA17DFB17200090D0B /* iTunesArtwork@2x */ = {isa = PBXFileReference; lastKnownFileType = file; path = "iTunesArtwork@2x"; sourceTree = "<group>"; };
 		85F8E19A1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationServiceRemoteTests.swift; sourceTree = "<group>"; };
+		85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationServiceTests.swift; sourceTree = "<group>"; };
+		85F8E19E1B0186D0000859BB /* MockWordPressComApi.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockWordPressComApi.swift; sourceTree = "<group>"; };
 		872A78E046E04A05B17EB1A1 /* libPods-WordPressTodayWidget.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-WordPressTodayWidget.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9198544476D3B385673B18E9 /* Pods-WordPressTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release.xcconfig"; sourceTree = "<group>"; };
@@ -2341,6 +2345,8 @@
 			isa = PBXGroup;
 			children = (
 				85F8E19A1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift */,
+				85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */,
+				85F8E19E1B0186D0000859BB /* MockWordPressComApi.swift */,
 			);
 			name = Networking;
 			sourceTree = "<group>";
@@ -3890,9 +3896,11 @@
 				93EF094C19ED533500C89770 /* ContextManagerTests.swift in Sources */,
 				B5D689FD1A5EBC900063D9E5 /* NotificationsManager+TestHelper.m in Sources */,
 				85F8E19B1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift in Sources */,
+				85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */,
 				931D270019EDAE8600114F17 /* CoreDataMigrationTests.m in Sources */,
 				85D239C11AE5A7020074768D /* LoginViewModelTests.m in Sources */,
 				85D790AC1AE5D95E0033AE83 /* MixpanelProxyTests.m in Sources */,
+				85F8E19F1B0186D0000859BB /* MockWordPressComApi.swift in Sources */,
 				931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */,
 				852416D21A12ED690030700C /* AppRatingUtilityTests.m in Sources */,
 				E15618FD16DB8677006532C4 /* UIKitTestHelper.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -250,6 +250,8 @@
 		85E105861731A597001071A3 /* WPWalkthroughOverlayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 85E105851731A597001071A3 /* WPWalkthroughOverlayView.m */; };
 		85EC44D41739826A00686604 /* CreateAccountAndBlogViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 85EC44D31739826A00686604 /* CreateAccountAndBlogViewController.m */; };
 		85ED988817DFA00000090D0B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85ED988717DFA00000090D0B /* Images.xcassets */; };
+		85F8E1981B017A86000859BB /* PushAuthenticationServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B535209E1AF7EFEC00B33BA8 /* PushAuthenticationServiceRemote.swift */; };
+		85F8E19B1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8E19A1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift */; };
 		931D26F519ED7E6D00114F17 /* BlogJetpackTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E150520B16CAC5C400D3DDDC /* BlogJetpackTest.m */; };
 		931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 930FD0A519882742000CC81D /* BlogServiceTest.m */; };
 		931D26F719ED7F7500114F17 /* ReaderPostServiceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DE8A0401912D95B00B2FF59 /* ReaderPostServiceTest.m */; };
@@ -986,6 +988,7 @@
 		85EC44D31739826A00686604 /* CreateAccountAndBlogViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CreateAccountAndBlogViewController.m; sourceTree = "<group>"; };
 		85ED988717DFA00000090D0B /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		85ED98AA17DFB17200090D0B /* iTunesArtwork@2x */ = {isa = PBXFileReference; lastKnownFileType = file; path = "iTunesArtwork@2x"; sourceTree = "<group>"; };
+		85F8E19A1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationServiceRemoteTests.swift; sourceTree = "<group>"; };
 		872A78E046E04A05B17EB1A1 /* libPods-WordPressTodayWidget.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-WordPressTodayWidget.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9198544476D3B385673B18E9 /* Pods-WordPressTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release.xcconfig"; sourceTree = "<group>"; };
@@ -2334,6 +2337,14 @@
 			name = NUX;
 			sourceTree = "<group>";
 		};
+		85F8E1991B017A8E000859BB /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				85F8E19A1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift */,
+			);
+			name = Networking;
+			sourceTree = "<group>";
+		};
 		931D26FB19EDA0D000114F17 /* ALIterativeMigrator */ = {
 			isa = PBXGroup;
 			children = (
@@ -2805,6 +2816,7 @@
 		E1239B7B176A2E0F00D37220 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				85F8E1991B017A8E000859BB /* Networking */,
 				85D239BD1AE5A6EE0074768D /* NUX */,
 				B5AEEC7F1ACAD099008BF2A4 /* Categories */,
 				B5AEEC731ACACF3B008BF2A4 /* Core Data */,
@@ -3865,6 +3877,7 @@
 				5D12FE1E1988243700378BD6 /* RemoteReaderPost.m in Sources */,
 				5D12FE221988245B00378BD6 /* RemoteReaderSite.m in Sources */,
 				93A379EC19FFBF7900415023 /* KeychainTest.m in Sources */,
+				85F8E1981B017A86000859BB /* PushAuthenticationServiceRemote.swift in Sources */,
 				5D12FE1F1988243700378BD6 /* RemoteReaderTopic.m in Sources */,
 				8514B8D41AE85B19007E58BA /* WPAnalyticsTrackerMixpanelTests.m in Sources */,
 				931D26F719ED7F7500114F17 /* ReaderPostServiceTest.m in Sources */,
@@ -3876,6 +3889,7 @@
 				F1564E5B18946087009F8F97 /* NSStringHelpersTest.m in Sources */,
 				93EF094C19ED533500C89770 /* ContextManagerTests.swift in Sources */,
 				B5D689FD1A5EBC900063D9E5 /* NotificationsManager+TestHelper.m in Sources */,
+				85F8E19B1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift in Sources */,
 				931D270019EDAE8600114F17 /* CoreDataMigrationTests.m in Sources */,
 				85D239C11AE5A7020074768D /* LoginViewModelTests.m in Sources */,
 				85D790AC1AE5D95E0033AE83 /* MixpanelProxyTests.m in Sources */,

--- a/WordPress/WordPressTest/MockWordPressComApi.swift
+++ b/WordPress/WordPressTest/MockWordPressComApi.swift
@@ -4,27 +4,15 @@ class MockWordPressComApi : WordPressComApi {
     var postMethodCalled = false
     var URLStringPassedIn:String?
     var parametersPassedIn:AnyObject?
-    
-    var shouldCallSuccessCallback = false
-    func callSuccessCallback() {
-        shouldCallSuccessCallback = true
-    }
-    
-    var shouldCallFailureCallback = false
-    func callFailureCallback() {
-        shouldCallFailureCallback = true
-    }
+    var successBlockPassedIn:((AFHTTPRequestOperation!, AnyObject!) -> Void)?
+    var failureBlockPassedIn:((AFHTTPRequestOperation!, NSError!) -> Void)?
     
     override func POST(URLString: String!, parameters: AnyObject!, success: ((AFHTTPRequestOperation!, AnyObject!) -> Void)!, failure: ((AFHTTPRequestOperation!, NSError!) -> Void)!) -> AFHTTPRequestOperation! {
         postMethodCalled = true
         URLStringPassedIn = URLString
         parametersPassedIn = parameters
-        
-        if (shouldCallSuccessCallback) {
-            success?(AFHTTPRequestOperation(), [])
-        } else if (shouldCallFailureCallback) {
-            failure?(AFHTTPRequestOperation(), NSError())
-        }
+        successBlockPassedIn = success
+        failureBlockPassedIn = failure
         
         return AFHTTPRequestOperation()
     }

--- a/WordPress/WordPressTest/MockWordPressComApi.swift
+++ b/WordPress/WordPressTest/MockWordPressComApi.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+class MockWordPressComApi : WordPressComApi {
+    var postMethodCalled = false
+    var URLStringPassedIn:String?
+    var parametersPassedIn:AnyObject?
+    
+    var shouldCallSuccessCallback = false
+    func callSuccessCallback() {
+        shouldCallSuccessCallback = true
+    }
+    
+    var shouldCallFailureCallback = false
+    func callFailureCallback() {
+        shouldCallFailureCallback = true
+    }
+    
+    override func POST(URLString: String!, parameters: AnyObject!, success: ((AFHTTPRequestOperation!, AnyObject!) -> Void)!, failure: ((AFHTTPRequestOperation!, NSError!) -> Void)!) -> AFHTTPRequestOperation! {
+        postMethodCalled = true
+        URLStringPassedIn = URLString
+        parametersPassedIn = parameters
+        
+        if (shouldCallSuccessCallback) {
+            success?(AFHTTPRequestOperation(), [])
+        } else if (shouldCallFailureCallback) {
+            failure?(AFHTTPRequestOperation(), NSError())
+        }
+        
+        return AFHTTPRequestOperation()
+    }
+}

--- a/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import XCTest
+
+class PushAuthenticationManagerTests : XCTestCase {
+    
+    class MockUIAlertViewProxy : UIAlertViewProxy {
+       
+        var titlePassedIn:String?
+        var messagePassedIn:String?
+        var cancelButtonTitlePassedIn:String?
+        var otherButtonTitlesPassedIn:[AnyObject]?
+        var shouldCallTapBlock = false
+        var tapBlockPassedIn:UIAlertViewCompletionBlock?
+        var showWithTitleCalled = false
+        
+        override func showWithTitle(title: String!, message: String!, cancelButtonTitle: String!, otherButtonTitles: [AnyObject]!, tapBlock: UIAlertViewCompletionBlock!) -> UIAlertView! {
+            showWithTitleCalled = true
+            titlePassedIn = title
+            messagePassedIn = message
+            cancelButtonTitlePassedIn = cancelButtonTitle
+            otherButtonTitlesPassedIn = otherButtonTitles
+            tapBlockPassedIn = tapBlock
+            return  UIAlertView()
+        }
+    }
+    
+    class MockPushAuthenticationService : PushAuthenticationService {
+       
+        var tokenPassedIn:String?
+        var completionBlockPassedIn:((Bool) -> ())?
+        var authorizedLoginCalled = false
+        var numberOfTimesAuthorizedLoginCalled = 0
+        
+        override func authorizeLogin(token: String, completion: ((Bool) -> ())) {
+            authorizedLoginCalled = true
+            numberOfTimesAuthorizedLoginCalled++
+            tokenPassedIn = token
+            completionBlockPassedIn = completion
+        }
+    }
+    
+    var mockPushAuthenticationService = MockPushAuthenticationService(managedObjectContext: TestContextManager().mainContext)
+    var mockAlertViewProxy = MockUIAlertViewProxy()
+    var pushAuthenticationManager:PushAuthenticationManager?
+    
+    override func setUp() {
+        super.setUp()
+        pushAuthenticationManager = PushAuthenticationManager(pushAuthenticationService: mockPushAuthenticationService)
+        pushAuthenticationManager?.alertViewProxy = mockAlertViewProxy;
+    }
+    
+    func testIsPushAuthenticationNotificationReturnsTrueWhenPassedTheCorrectPushAuthenticationNoteType() {
+        let result = pushAuthenticationManager!.isPushAuthenticationNotification(["type": "push_auth"])
+        
+        XCTAssertTrue(result, "Should be true when the type is 'push_auth'")
+    }
+    
+    func testIsPushAuthenticationNotificationReturnsFalseWhenPassedIncorrectPushAuthenticationNoteType() {
+        let result = pushAuthenticationManager!.isPushAuthenticationNotification(["type": "not_push"])
+        
+        XCTAssertFalse(result, "Should be false when the type is not 'push_auth'")
+    }
+    
+    func expiredPushNotificationDictionary() -> NSDictionary {
+       return ["expires": NSTimeInterval(3)]
+    }
+    
+    func validPushAuthenticationDictionary() -> NSMutableDictionary {
+        return ["push_auth_token" : "token", "aps" : [ "alert" : "an alert"]]
+    }
+    
+    func testHandlePushAuthenticationNotificationShowsTheLoginExpiredAlertIfNotificationHasExpired(){
+        pushAuthenticationManager!.handlePushAuthenticationNotification(expiredPushNotificationDictionary())
+        
+        XCTAssertTrue(mockAlertViewProxy.showWithTitleCalled, "Should show the login expired alert if the notification has expired")
+        XCTAssertEqual(mockAlertViewProxy.titlePassedIn!, NSLocalizedString("Login Request Expired", comment:""), "")
+    }
+    
+    func testHandlePushAuthenticationNotificationDoesNotShowTheLoginExpiredAlertIfNotificationHasNotExpired(){
+        pushAuthenticationManager!.handlePushAuthenticationNotification([:])
+        
+        XCTAssertFalse(mockAlertViewProxy.showWithTitleCalled, "Should not show the login expired alert if the notification hasn't expired")
+    }
+    
+    func testHandlePushAuthenticationNotificationWithBlankTokenDoesNotShowLoginVerificationAlert(){
+        var pushNotificationDictionary = validPushAuthenticationDictionary()
+        pushNotificationDictionary.removeObjectForKey("push_auth_token")
+        
+        pushAuthenticationManager!.handlePushAuthenticationNotification(pushNotificationDictionary)
+        
+        XCTAssertFalse(mockAlertViewProxy.showWithTitleCalled, "Should not show the login verification")
+    }
+    
+    func testHandlePushAuthenticationNotificationWithBlankMessageDoesNotShowLoginVerificationAlert(){
+        pushAuthenticationManager!.handlePushAuthenticationNotification(["push_auth_token" : "token"])
+        
+        XCTAssertFalse(mockAlertViewProxy.showWithTitleCalled, "Should not show the login verification")
+    }
+    
+    func testHandlePushAuthenticationNotificationWithValidDataShouldShowLoginVerification() {
+        pushAuthenticationManager!.handlePushAuthenticationNotification(validPushAuthenticationDictionary())
+        
+        XCTAssertTrue(mockAlertViewProxy.showWithTitleCalled, "Should show the login verification")
+        XCTAssertEqual(mockAlertViewProxy.titlePassedIn!, NSLocalizedString("Verify Login", comment: ""), "")
+    }
+    
+    func testHandlePushAuthenticationNotificationShouldAttemptToAuthorizeTheLoginIfTheUserIndicatesTheyWantTo() {
+        pushAuthenticationManager!.handlePushAuthenticationNotification(validPushAuthenticationDictionary())
+        let alertView = UIAlertView()
+        mockAlertViewProxy.tapBlockPassedIn?(alertView, 1)
+        
+        XCTAssertTrue(mockPushAuthenticationService.authorizedLoginCalled, "Should have attempted to authorize the login")
+    }
+    
+    func testHandlePushAuthenticationNotificationWhenAttemptingToLoginShouldAttemptToRetryTheLoginIfItFailed() {
+        pushAuthenticationManager!.handlePushAuthenticationNotification(validPushAuthenticationDictionary())
+        let alertView = UIAlertView()
+        mockAlertViewProxy.tapBlockPassedIn?(alertView, 1)
+        mockPushAuthenticationService.completionBlockPassedIn?(false)
+        
+        XCTAssertEqual(mockPushAuthenticationService.numberOfTimesAuthorizedLoginCalled, 2, "Should have attempted to retry a failed login")
+    }
+    
+    func testHandlePushAuthenticationNotificationShouldNotAttemptToAuthorizeTheLoginIfTheUserIndicatesTheyDontWantTo() {
+        pushAuthenticationManager!.handlePushAuthenticationNotification(validPushAuthenticationDictionary())
+        
+        let alertView = UIAlertView()
+        mockAlertViewProxy.tapBlockPassedIn?(alertView, alertView.cancelButtonIndex)
+        
+        XCTAssertFalse(mockPushAuthenticationService.authorizedLoginCalled, "Should not have attempted to authorize the login")
+    }
+}

--- a/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
@@ -9,7 +9,6 @@ class PushAuthenticationManagerTests : XCTestCase {
         var messagePassedIn:String?
         var cancelButtonTitlePassedIn:String?
         var otherButtonTitlesPassedIn:[AnyObject]?
-        var shouldCallTapBlock = false
         var tapBlockPassedIn:UIAlertViewCompletionBlock?
         var showWithTitleCalled = false
         

--- a/WordPress/WordPressTest/PushAuthenticationServiceRemoteTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationServiceRemoteTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import XCTest
+
+class PushAuthenticationServiceRemoteTests : XCTestCase {
+    
+    class MockWordPressComApi : WordPressComApi {
+        var postMethodCalled = false
+        var URLStringPassedIn:String?
+        var parametersPassedIn:AnyObject?
+        
+        var shouldCallSuccessCallback = false
+        func callSuccessCallback() {
+           shouldCallSuccessCallback = true
+        }
+        
+        var shouldCallFailureCallback = false
+        func callFailureCallback() {
+           shouldCallFailureCallback = true
+        }
+    
+        override func POST(URLString: String!, parameters: AnyObject!, success: ((AFHTTPRequestOperation!, AnyObject!) -> Void)!, failure: ((AFHTTPRequestOperation!, NSError!) -> Void)!) -> AFHTTPRequestOperation! {
+            postMethodCalled = true
+            URLStringPassedIn = URLString
+            parametersPassedIn = parameters
+            
+            if (shouldCallSuccessCallback) {
+                success?(AFHTTPRequestOperation(), [])
+            } else if (shouldCallFailureCallback) {
+                failure?(AFHTTPRequestOperation(), NSError())
+            }
+            
+            return AFHTTPRequestOperation()
+        }
+    }
+    
+    var pushAuthenticationServiceRemote:PushAuthenticationServiceRemote?
+    var mockRemoteApi:MockWordPressComApi?
+    let token = "token"
+    override func setUp() {
+        super.setUp()
+        mockRemoteApi = MockWordPressComApi()
+        pushAuthenticationServiceRemote = PushAuthenticationServiceRemote(remoteApi: mockRemoteApi)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testAuthorizeLoginUsesTheCorrectPath() {
+        pushAuthenticationServiceRemote?.authorizeLogin(token, success: nil, failure: nil)
+        
+        XCTAssertTrue(mockRemoteApi!.postMethodCalled, "Method was not called")
+        XCTAssertEqual(mockRemoteApi!.URLStringPassedIn!, "me/two-step/push-authentication", "Incorrect URL passed in")
+    }
+    
+    func testAuthorizeLoginUsesTheCorrectParameters() {
+        pushAuthenticationServiceRemote?.authorizeLogin(token, success: nil, failure: nil)
+        
+        var parameters:NSDictionary = mockRemoteApi!.parametersPassedIn as! NSDictionary
+        
+        XCTAssertTrue(mockRemoteApi!.postMethodCalled, "Method was not called")
+        XCTAssertEqual(parameters["action"] as! String, "authorize_login", "incorrect action parameter")
+        XCTAssertEqual(parameters["push_token"] as! String, token, "incorrect token parameter")
+    }
+    
+    func testAuthorizeLoginCallsSuccessBlock() {
+        var successBlockCalled = false
+        mockRemoteApi?.callSuccessCallback()
+        pushAuthenticationServiceRemote!.authorizeLogin(token, success: { () -> () in
+           successBlockCalled = true
+        }, failure: nil)
+        
+        XCTAssertTrue(mockRemoteApi!.postMethodCalled, "Method was not called")
+        XCTAssertTrue(successBlockCalled, "Success block not called")
+    }
+    
+    func testAuthorizeLoginCallsFailureBlock() {
+        var failureBlockCalled = false
+        mockRemoteApi?.callFailureCallback()
+        pushAuthenticationServiceRemote!.authorizeLogin(token, success: nil, failure: { () -> () in
+            failureBlockCalled = true
+        })
+        
+        pushAuthenticationServiceRemote?.authorizeLogin(token, success: nil, failure: nil)
+        
+        XCTAssertTrue(mockRemoteApi!.postMethodCalled, "Method was not called")
+        XCTAssertTrue(failureBlockCalled, "Failure block not called")
+    }
+    
+}

--- a/WordPress/WordPressTest/PushAuthenticationServiceRemoteTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationServiceRemoteTests.swift
@@ -31,10 +31,10 @@ class PushAuthenticationServiceRemoteTests : XCTestCase {
     
     func testAuthorizeLoginCallsSuccessBlock() {
         var successBlockCalled = false
-        mockRemoteApi?.callSuccessCallback()
         pushAuthenticationServiceRemote!.authorizeLogin(token, success: { () -> () in
            successBlockCalled = true
         }, failure: nil)
+        mockRemoteApi?.successBlockPassedIn?(AFHTTPRequestOperation(), [])
         
         XCTAssertTrue(mockRemoteApi!.postMethodCalled, "Method was not called")
         XCTAssertTrue(successBlockCalled, "Success block not called")
@@ -42,12 +42,10 @@ class PushAuthenticationServiceRemoteTests : XCTestCase {
     
     func testAuthorizeLoginCallsFailureBlock() {
         var failureBlockCalled = false
-        mockRemoteApi?.callFailureCallback()
         pushAuthenticationServiceRemote!.authorizeLogin(token, success: nil, failure: { () -> () in
             failureBlockCalled = true
         })
-        
-        pushAuthenticationServiceRemote?.authorizeLogin(token, success: nil, failure: nil)
+        mockRemoteApi?.failureBlockPassedIn?(AFHTTPRequestOperation(), NSError())
         
         XCTAssertTrue(mockRemoteApi!.postMethodCalled, "Method was not called")
         XCTAssertTrue(failureBlockCalled, "Failure block not called")

--- a/WordPress/WordPressTest/PushAuthenticationServiceRemoteTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationServiceRemoteTests.swift
@@ -2,37 +2,7 @@ import Foundation
 import XCTest
 
 class PushAuthenticationServiceRemoteTests : XCTestCase {
-    
-    class MockWordPressComApi : WordPressComApi {
-        var postMethodCalled = false
-        var URLStringPassedIn:String?
-        var parametersPassedIn:AnyObject?
-        
-        var shouldCallSuccessCallback = false
-        func callSuccessCallback() {
-           shouldCallSuccessCallback = true
-        }
-        
-        var shouldCallFailureCallback = false
-        func callFailureCallback() {
-           shouldCallFailureCallback = true
-        }
-    
-        override func POST(URLString: String!, parameters: AnyObject!, success: ((AFHTTPRequestOperation!, AnyObject!) -> Void)!, failure: ((AFHTTPRequestOperation!, NSError!) -> Void)!) -> AFHTTPRequestOperation! {
-            postMethodCalled = true
-            URLStringPassedIn = URLString
-            parametersPassedIn = parameters
-            
-            if (shouldCallSuccessCallback) {
-                success?(AFHTTPRequestOperation(), [])
-            } else if (shouldCallFailureCallback) {
-                failure?(AFHTTPRequestOperation(), NSError())
-            }
-            
-            return AFHTTPRequestOperation()
-        }
-    }
-    
+
     var pushAuthenticationServiceRemote:PushAuthenticationServiceRemote?
     var mockRemoteApi:MockWordPressComApi?
     let token = "token"
@@ -40,10 +10,6 @@ class PushAuthenticationServiceRemoteTests : XCTestCase {
         super.setUp()
         mockRemoteApi = MockWordPressComApi()
         pushAuthenticationServiceRemote = PushAuthenticationServiceRemote(remoteApi: mockRemoteApi)
-    }
-    
-    override func tearDown() {
-        super.tearDown()
     }
     
     func testAuthorizeLoginUsesTheCorrectPath() {

--- a/WordPress/WordPressTest/PushAuthenticationServiceTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationServiceTests.swift
@@ -11,26 +11,13 @@ class PushAuthenticationServiceTests : XCTestCase {
     class MockPushAuthenticationServiceRemote : PushAuthenticationServiceRemote {
         
         var authorizeLoginCalled = false
+        var successBlockPassedIn:(() -> ())?
+        var failureBlockPassedIn:(() -> ())?
+        
         override func authorizeLogin(token: String, success: (() -> ())?, failure: (() -> ())?) {
             authorizeLoginCalled = true
-            
-            if (shouldCallSuccessBlock) {
-               success?()
-            }
-            
-            if (shouldCallFailureBlock) {
-                failure?()
-            }
-        }
-        
-        var shouldCallSuccessBlock = false
-        func callSuccessBlock() {
-           shouldCallSuccessBlock = true
-        }
-        
-        var shouldCallFailureBlock = false
-        func callFailureBlock() {
-           shouldCallFailureBlock = true
+            successBlockPassedIn = success
+            failureBlockPassedIn = failure
         }
     }
     
@@ -57,21 +44,23 @@ class PushAuthenticationServiceTests : XCTestCase {
     
     func testAuthorizeLoginCallsCompletionCallbackWithTrueIfSuccessful() {
         var methodCalled = false
-        mockPushAuthenticationServiceRemote?.callSuccessBlock()
         pushAuthenticationService?.authorizeLogin(token, completion: { (completed:Bool) -> () in
             methodCalled = true
             XCTAssertTrue(completed, "Success callback should have been called with a value of true")
         })
+        mockPushAuthenticationServiceRemote?.successBlockPassedIn?()
+        
         XCTAssertTrue(methodCalled, "Success callback was not called")
     }
     
     func testAuthorizeLoginCallsCompletionCallbackWithFalseIfSuccessful() {
         var methodCalled = false
-        mockPushAuthenticationServiceRemote?.callFailureBlock()
         pushAuthenticationService?.authorizeLogin(token, completion: { (completed:Bool) -> () in
             methodCalled = true
             XCTAssertFalse(completed, "Failure callback should have been called with a value of false")
         })
+        mockPushAuthenticationServiceRemote?.failureBlockPassedIn?()
+        
         XCTAssertTrue(methodCalled, "Failure callback was not called")
     }
     

--- a/WordPress/WordPressTest/PushAuthenticationServiceTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationServiceTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import XCTest
+
+class PushAuthenticationServiceTests : XCTestCase {
+    
+    var pushAuthenticationService:PushAuthenticationService?
+    var mockPushAuthenticationServiceRemote:MockPushAuthenticationServiceRemote?
+    var mockRemoteApi:MockWordPressComApi?
+    let token = "token"
+    
+    class MockPushAuthenticationServiceRemote : PushAuthenticationServiceRemote {
+        
+        var authorizeLoginCalled = false
+        override func authorizeLogin(token: String, success: (() -> ())?, failure: (() -> ())?) {
+            authorizeLoginCalled = true
+            
+            if (shouldCallSuccessBlock) {
+               success?()
+            }
+            
+            if (shouldCallFailureBlock) {
+                failure?()
+            }
+        }
+        
+        var shouldCallSuccessBlock = false
+        func callSuccessBlock() {
+           shouldCallSuccessBlock = true
+        }
+        
+        var shouldCallFailureBlock = false
+        func callFailureBlock() {
+           shouldCallFailureBlock = true
+        }
+    }
+    
+    override func setUp() {
+        super.setUp()
+        mockRemoteApi = MockWordPressComApi()
+        mockPushAuthenticationServiceRemote = MockPushAuthenticationServiceRemote(remoteApi: mockRemoteApi)
+        pushAuthenticationService = PushAuthenticationService(managedObjectContext: TestContextManager().mainContext)
+        pushAuthenticationService?.authenticationServiceRemote = mockPushAuthenticationServiceRemote
+    }
+    
+    func testAuthorizeLoginDoesntCallServiceRemoteIfItsNull() {
+        pushAuthenticationService?.authenticationServiceRemote = nil
+        pushAuthenticationService?.authorizeLogin(token, completion: { (completed:Bool) -> () in
+        })
+        XCTAssertFalse(mockPushAuthenticationServiceRemote!.authorizeLoginCalled, "Authorize login should not have been called")
+    }
+    
+    func testAuthorizeLoginCallsServiceRemoteAuthorizeLoginWhenItsNotNull() {
+        pushAuthenticationService?.authorizeLogin(token, completion: { (completed:Bool) -> () in
+        })
+        XCTAssertTrue(mockPushAuthenticationServiceRemote!.authorizeLoginCalled, "Authorize login should have been called")
+    }
+    
+    func testAuthorizeLoginCallsCompletionCallbackWithTrueIfSuccessful() {
+        var methodCalled = false
+        mockPushAuthenticationServiceRemote?.callSuccessBlock()
+        pushAuthenticationService?.authorizeLogin(token, completion: { (completed:Bool) -> () in
+            methodCalled = true
+            XCTAssertTrue(completed, "Success callback should have been called with a value of true")
+        })
+        XCTAssertTrue(methodCalled, "Success callback was not called")
+    }
+    
+    func testAuthorizeLoginCallsCompletionCallbackWithFalseIfSuccessful() {
+        var methodCalled = false
+        mockPushAuthenticationServiceRemote?.callFailureBlock()
+        pushAuthenticationService?.authorizeLogin(token, completion: { (completed:Bool) -> () in
+            methodCalled = true
+            XCTAssertFalse(completed, "Failure callback should have been called with a value of false")
+        })
+        XCTAssertTrue(methodCalled, "Failure callback was not called")
+    }
+    
+}

--- a/WordPress/WordPressTest/WordPressTest-Bridging-Header.h
+++ b/WordPress/WordPressTest/WordPressTest-Bridging-Header.h
@@ -10,3 +10,6 @@
 #import "Post.h"
 #import "Page.h"
 #import "ReaderPost.h"
+#import "UIAlertView+Blocks.h"
+#import "UIAlertViewProxy.h"
+#import <WordPressCom-Analytics-iOS/WPAnalytics.h>


### PR DESCRIPTION
This PR adds in unit tests to @jleandroperez's pending PR(https://github.com/wordpress-mobile/WordPress-iOS/pull/3626). I had to adjust some of the classes just a little bit to be able to properly test the classes added to the original pull request. The changes I made were:

### PushAuthenticationService

* Pulled out the direct instantiation of `PushAuthenticationServiceRemote` in the `authorizeLogin` method so I could swap in a mock during testing.

### PushAuthenticationManager

* Dropped the singleton as singletons are a pain to test.
* Added a convenience initializer so the rest of the codebase wouldn't have to care about any internal dependencies.
* Pulled out the direct instantiation of `PushAuthenticationService` from `authorizeLogin`
* Created a `UIAlertViewProxy` class to control access to UIAlertView so we can more thoroughly test this class.

My prior unit tests have generally utilized BDD(<a href="https://github.com/specta/specta">Specta</a>) but unfortunately it doesn't work for Swift just yet. There are libraries out there(e.g. <a href="https://github.com/Quick/Quick">Quick</a>) that could work but to pull them in with Cocoapods would require us to bump the project to iOS8+ and I was reluctant to add them in via Submodules at the moment and create two methods for package management. As such I decided to use XCTest.test even though I think BDD style tests are much more readable. 