### PR TITLE
Change login label for WordPress.com to fit in iPhone 5 screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -226,7 +226,7 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
                 cell.accessibilityIdentifier = signOutString;
             }
             else {
-                NSString *signInString = NSLocalizedString(@"Connect to WordPress.com Account",
+                NSString *signInString = NSLocalizedString(@"Connect to WordPress.com",
                                                            @"Label for connecting to WordPress.com account");
                 cell.textLabel.text = signInString;
                 cell.accessibilityIdentifier = signInString;


### PR DESCRIPTION
Fixes #3636. This PR changes the login label for WordPress.com in Me page to "Connect to WordPress.com" so that it fits in iPhone 5 screens. This also matches the Android counterpart with this change.

iPhone 5: https://cloudup.com/cIyLAmUWXwd
Android: https://cloudup.com/chuP-oxsaf0

@aerych Can I bother you with a really quick review? Thanks in advance!