### PR TITLE
Fixed web view rendering

### DIFF
--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -536,7 +536,7 @@
 
     if (self.view.frame.size.width < self.view.window.bounds.size.width) {
         NSString *js = [NSString stringWithFormat:@"var meta = document.createElement('meta');meta.setAttribute( 'name', 'viewport' ); meta.setAttribute( 'content', 'width = available-width, initial-scale = 1.0, user-scalable = yes' );document.getElementsByTagName('head')[0].appendChild(meta)"];
-        [aWebView stringByEvaluatingJavaScriptFromString: js];
+        [aWebView stringByEvaluatingJavaScriptFromString:js];
     }
 
     if (!self.hasLoadedContent && ([aWebView.request.URL.absoluteString rangeOfString:WPMobileReaderDetailURL].location == NSNotFound || self.detailContent)) {

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -534,10 +534,11 @@
     DDLogMethod()
     [self setLoading:NO];
 
-    CGSize webviewSize = self.view.frame.size;
-    NSString *js = [NSString stringWithFormat:@"var meta = document.createElement('meta');meta.setAttribute( 'name', 'viewport' ); meta.setAttribute( 'content', 'width = %d, initial-scale = 1.0, user-scalable = yes' );document.getElementsByTagName('head')[0].appendChild(meta)", webviewSize.width];
-    [aWebView stringByEvaluatingJavaScriptFromString: js];
-    
+    if (self.view.frame.size.width < self.view.window.bounds.size.width) {
+        NSString *js = [NSString stringWithFormat:@"var meta = document.createElement('meta');meta.setAttribute( 'name', 'viewport' ); meta.setAttribute( 'content', 'width = available-width, initial-scale = 1.0, user-scalable = yes' );document.getElementsByTagName('head')[0].appendChild(meta)"];
+        [aWebView stringByEvaluatingJavaScriptFromString: js];
+    }
+
     if (!self.hasLoadedContent && ([aWebView.request.URL.absoluteString rangeOfString:WPMobileReaderDetailURL].location == NSNotFound || self.detailContent)) {
         [aWebView stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"Reader2.set_loaded_items(%@);", self.readerAllItems]];
         [aWebView stringByEvaluatingJavaScriptFromString:[NSString stringWithFormat:@"Reader2.show_article_details(%@);", self.detailContent]];


### PR DESCRIPTION
On #2679, a hack was introduced to set the viewport width to the actual
web view width.

The problem is some sites set the viewport width to `device-width`,
which is a problem if the web view is in a modal window instead of full
screen.

This change only applies the hack if the web view's width is less than
the window's width

Also helps with #1652 