### PR TITLE
Fixes warning when using Ruby 2.2

### DIFF
--- a/WordPress/WordPressApi/gencredentials.rb
+++ b/WordPress/WordPressApi/gencredentials.rb
@@ -181,7 +181,7 @@ if rawpath.nil?
 end
 
 path = File.expand_path(rawpath)
-unless File.exists?(path)
+unless File.exist?(path)
   $stderr.puts "error: file #{path} not found"
   exit 1
 end


### PR DESCRIPTION
I recently upgraded to Ruby 2.2 and I get this warning when building

> File.exists? is a deprecated name, use File.exist? instead

According to [the docs](http://ruby-doc.org/core-1.8.6/File.html#method-c-exist-3F), `File.exist?` already existed in 1.8 and `File.exists?` was already obsolete, so this should be safe