### PR TITLE
Fix iPad sign out

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -966,8 +966,10 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
             [WPAnalytics track:WPAnalyticsStatLogout];
         }
         [self logoutSimperiumAndResetNotifications];
-        [self showWelcomeScreenIfNeededAnimated:NO];
         [self removeTodayWidgetConfiguration];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self showWelcomeScreenIfNeededAnimated:NO];
+        });
     }
     
     [self toggleExtraDebuggingIfNeeded];

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -967,9 +967,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
         }
         [self logoutSimperiumAndResetNotifications];
         [self removeTodayWidgetConfiguration];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self showWelcomeScreenIfNeededAnimated:NO];
-        });
+        [self showWelcomeScreenIfNeededAnimated:NO];
     }
     
     [self toggleExtraDebuggingIfNeeded];

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -356,14 +356,17 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
 - (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex
 {
     if (buttonIndex == 0) {
-        // Sign out
-        NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+        // Sign out asynchronously so the popover animation can finish on iPad #3667
+        dispatch_async(dispatch_get_main_queue(), ^{
+            // Sign out
+            NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+            AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
 
-        [accountService removeDefaultWordPressComAccount];
+            [accountService removeDefaultWordPressComAccount];
 
-        // reload all table view to update the header as well
-        [self.tableView reloadData];
+            // reload all table view to update the header as well
+            [self.tableView reloadData];
+        });
     }
 }
 


### PR DESCRIPTION
Since the iPad uses a popover to confirm the sign out, it seems it was
preventing the NUX from being presented.

After debugging, all the right things were being called and the app
delegate was presenting the welcome screen, yet nothing happened.

I added a `dispatch_async` to let the popover dismiss animation finish.

Fixes #3667