### PR TITLE
Skip jetpack login on setup

### DIFF
--- a/WordPress/Classes/Services/BlogSyncFacade.h
+++ b/WordPress/Classes/Services/BlogSyncFacade.h
@@ -27,13 +27,13 @@
  *  @param password     password for the self hosted blog.
  *  @param xmlrpc       xmlrpc url for the self hosted blog.
  *  @param options      options dictionary for the self hosted blog.
- *  @param needsJetpack a block that's called when the site needs to connect to Jetpack.
  *  @param finishedSync a block that's called when this is done.
  */
 - (void)syncBlogForAccount:(WPAccount *)account
                   username:(NSString *)username
                   password:(NSString *)password
-                    xmlrpc:(NSString *)xmlrpc options:(NSDictionary *)options needsJetpack:(void(^)(NSNumber *))needsJetpack finishedSync:(void(^)())finishedSync;
+                    xmlrpc:(NSString *)xmlrpc options:(NSDictionary *)options
+              finishedSync:(void(^)())finishedSync;
 
 @end
 

--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -1,6 +1,7 @@
 #import "BlogSyncFacade.h"
 #import "ContextManager.h"
 #import "BlogService.h"
+#import "AccountService.h"
 #import "Blog.h"
 #import "Blog+Jetpack.h"
 
@@ -20,7 +21,9 @@
 - (void)syncBlogForAccount:(WPAccount *)account
                   username:(NSString *)username
                   password:(NSString *)password
-                    xmlrpc:(NSString *)xmlrpc options:(NSDictionary *)options needsJetpack:(void(^)(NSNumber *))needsJetpack finishedSync:(void(^)())finishedSync
+                    xmlrpc:(NSString *)xmlrpc
+                   options:(NSDictionary *)options
+              finishedSync:(void(^)())finishedSync
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
@@ -47,19 +50,23 @@
 
     if ([blog hasJetpack]) {
         if ([blog hasJetpackAndIsConnectedToWPCom]) {
-            if (needsJetpack != nil) {
-                needsJetpack(blog.blogID);
+            NSString *dotcomUsername = [blog getOptionValue:@"jetpack_user_login"];
+            if (dotcomUsername) {
+                // Search for a matching .com account
+                AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+                account = [accountService findWordPressComAccountWithUsername:dotcomUsername];
+                if (account) {
+                    blog.jetpackAccount = account;
+                    [WPAnalytics track:WPAnalyticsStatSignedInToJetpack];
+                }
             }
         } else {
             [WPAnalytics track:WPAnalyticsStatAddedSelfHostedSiteButJetpackNotConnectedToWPCom];
-            if (finishedSync != nil) {
-                finishedSync();
-            }
         }
-    } else {
-        if (finishedSync != nil) {
-            finishedSync();
-        }
+    }
+
+    if (finishedSync != nil) {
+        finishedSync();
     }
 
     [WPAnalytics track:WPAnalyticsStatAddedSelfHostedSite];

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -632,27 +632,6 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 2;
     [self.navigationController pushViewController:createAccountViewController animated:YES];
 }
 
-- (void)showJetpackAuthenticationForBlog:(NSNumber *)blogId
-{
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-    Blog *blog = [blogService blogByBlogId:blogId];
-    NSAssert(blog != nil, @"blog should not be nil here");
-    JetpackSettingsViewController *jetpackSettingsViewController = [[JetpackSettingsViewController alloc] initWithBlog:blog];
-    jetpackSettingsViewController.canBeSkipped = YES;
-    [jetpackSettingsViewController setCompletionBlock:^(BOOL didAuthenticate) {
-        if (didAuthenticate) {
-            [WPAnalytics track:WPAnalyticsStatSignedInToJetpack];
-            [WPAnalytics refreshMetadata];
-        } else {
-            [WPAnalytics track:WPAnalyticsStatSkippedConnectingToJetpack];
-        }
-
-        [self dismiss];
-    }];
-    [self.navigationController pushViewController:jetpackSettingsViewController animated:YES];
-}
-
 - (void)showHelpViewController:(BOOL)animated
 {
     SupportViewController *supportViewController = [[SupportViewController alloc] init];

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
@@ -225,7 +225,6 @@ typedef void (^OverlayViewCallback)(WPWalkthroughOverlayView *);
 - (void)displayLoginMessage:(NSString *)message;
 - (void)dismissLoginMessage;
 - (void)dismissLoginView;
-- (void)showJetpackAuthenticationForBlog:(NSNumber *)blogId;
 - (void)displayOverlayViewWithMessage:(NSString *)message firstButtonText:(NSString *)firstButtonText firstButtonCallback:(OverlayViewCallback)firstButtonCallback secondButtonText:(NSString *)secondButtonText secondButtonCallback:(OverlayViewCallback)secondButtonCallback accessibilityIdentifier:(NSString *)accessibilityIdentifier;
 - (void)displayHelpViewControllerWithAnimation:(BOOL)animated;
 - (void)displayHelpshiftConversationView;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -512,10 +512,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
                                            options:(NSDictionary *)options
 {
     WPAccount *account = [self.accountServiceFacade createOrUpdateSelfHostedAccountWithXmlrpc:xmlrpc username:username andPassword:password];
-    [self.blogSyncFacade syncBlogForAccount:account username:username password:password xmlrpc:xmlrpc options:options needsJetpack:^(NSNumber *blogId){
-        [self.presenter dismissLoginMessage];
-        [self.presenter showJetpackAuthenticationForBlog:blogId];
-    } finishedSync:^{
+    [self.blogSyncFacade syncBlogForAccount:account username:username password:password xmlrpc:xmlrpc options:options finishedSync:^{
         // once blogs for the accounts are synced, we want to update account details for it
         [self.accountServiceFacade updateUserDetailsForAccount:account success:nil failure:nil];
         [self finishedLogin];

--- a/WordPress/WordPressTest/LoginViewModelTests.m
+++ b/WordPress/WordPressTest/LoginViewModelTests.m
@@ -861,7 +861,7 @@ describe(@"displayRemoteError", ^{
     NSString *sharedExamplesForAButtonThatOpensUpTheFAQ = @"a button that opens up the FAQ";
     sharedExamplesFor(sharedExamplesForAButtonThatOpensUpTheFAQ, ^(NSDictionary *data) {
         it(@"should open the FAQ on the website", ^{
-            [[mockViewModelPresenter expect] displayWebViewForURL:[NSURL URLWithString:@"http://ios.wordpress.org/faq/#faq_3"] username:nil password:nil];
+            [[mockViewModelPresenter expect] displayWebViewForURL:[NSURL URLWithString:@"https://apps.wordpress.org/support/#faq-ios-3"] username:nil password:nil];
             
             [viewModel displayRemoteError:error];
             
@@ -1103,8 +1103,11 @@ describe(@"displayRemoteError", ^{
         
         context(@"when the url is bad", ^{
             
-            it(@"should display an overlay with the default button text", ^{
+            beforeEach(^{
                 error = [NSError errorWithDomain:WPXMLRPCFaultErrorDomain code:NSURLErrorBadURL userInfo:@{NSLocalizedDescriptionKey : errorMessage}];
+            });
+            
+            it(@"should display an overlay with the default button text", ^{
                 [[mockViewModelPresenter expect] displayOverlayViewWithMessage:OCMOCK_ANY firstButtonText:defaultFirstButtonText firstButtonCallback:OCMOCK_ANY secondButtonText:defaultSecondButtonText secondButtonCallback:OCMOCK_ANY accessibilityIdentifier:OCMOCK_ANY];
                 
                 [viewModel displayRemoteError:error];
@@ -1703,7 +1706,7 @@ describe(@"LoginFacadeDelegate methods", ^{
             // Retrieve finishedSync block and execute it when appropriate
             [OCMStub([mockBlogSyncFacade syncBlogForAccount:OCMOCK_ANY username:username password:password xmlrpc:xmlrpc options:options finishedSync:OCMOCK_ANY]) andDo:^(NSInvocation *invocation) {
                 void (^ __unsafe_unretained finishedSyncStub)(void);
-                [invocation getArgument:&finishedSyncStub atIndex:8];
+                [invocation getArgument:&finishedSyncStub atIndex:7];
                 
                 finishedSyncStub();
             }];

--- a/WordPress/WordPressTest/LoginViewModelTests.m
+++ b/WordPress/WordPressTest/LoginViewModelTests.m
@@ -1690,34 +1690,18 @@ describe(@"LoginFacadeDelegate methods", ^{
         });
         
         it(@"should sync the newly added site", ^{
-            [[mockBlogSyncFacade expect] syncBlogForAccount:OCMOCK_ANY username:username password:password xmlrpc:xmlrpc options:options needsJetpack:OCMOCK_ANY finishedSync:OCMOCK_ANY];
+            [[mockBlogSyncFacade expect] syncBlogForAccount:OCMOCK_ANY username:username password:password xmlrpc:xmlrpc options:options finishedSync:OCMOCK_ANY];
             
             [viewModel finishedLoginWithUsername:username password:password xmlrpc:xmlrpc options:options];
             
             [mockBlogSyncFacade verify];
         });
-        
-        it(@"should show jetpack authentication when the blog syncing facade tells it to", ^{
-            [[mockViewModelPresenter expect] showJetpackAuthenticationForBlog:OCMOCK_ANY];
-            
-            // Retrieve jetpack block and execute it when appropriate
-            [OCMStub([mockBlogSyncFacade syncBlogForAccount:OCMOCK_ANY username:username password:password xmlrpc:xmlrpc options:options needsJetpack:OCMOCK_ANY finishedSync:OCMOCK_ANY]) andDo:^(NSInvocation *invocation) {
-                void (^ __unsafe_unretained jetpackStub)(NSNumber *);
-                [invocation getArgument:&jetpackStub atIndex:7];
                 
-                jetpackStub(@1);
-            }];
-            
-            [viewModel finishedLoginWithUsername:username password:password xmlrpc:xmlrpc options:options];
-            
-            [mockViewModelPresenter verify];
-        });
-        
         it(@"should dismiss the login view", ^{
             [[mockViewModelPresenter expect] dismissLoginView];
             
             // Retrieve finishedSync block and execute it when appropriate
-            [OCMStub([mockBlogSyncFacade syncBlogForAccount:OCMOCK_ANY username:username password:password xmlrpc:xmlrpc options:options needsJetpack:OCMOCK_ANY finishedSync:OCMOCK_ANY]) andDo:^(NSInvocation *invocation) {
+            [OCMStub([mockBlogSyncFacade syncBlogForAccount:OCMOCK_ANY username:username password:password xmlrpc:xmlrpc options:options finishedSync:OCMOCK_ANY]) andDo:^(NSInvocation *invocation) {
                 void (^ __unsafe_unretained finishedSyncStub)(void);
                 [invocation getArgument:&finishedSyncStub atIndex:8];
                 


### PR DESCRIPTION
If the added site has Jetpack, it's connected, we know the wp.com
username, and we have a matching account, setup Jetpack automatically.
Otherwise, delay Jetpack setup until the user tries to access stats

A first step towards #3628 

@sendhil I'm having trouble with those Specta tests. There are three of them failing, but since it doesn't integrate well with Xcode I can't really figure out what's failing and why