### PR TITLE
Faster implementation of findPostWithID

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -516,8 +516,10 @@ const NSInteger PostServiceNumberToFetch = 40;
 }
 
 - (AbstractPost *)findPostWithID:(NSNumber *)postID inBlog:(Blog *)blog {
-    NSSet *posts = [blog.posts filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"original = NULL AND postID = %@", postID]];
-    return [posts anyObject];
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:NSStringFromClass([AbstractPost class])];
+    request.predicate = [NSPredicate predicateWithFormat:@"blog = %@ AND original = NULL AND postID = %@", blog, postID];
+    NSArray *posts = [self.managedObjectContext executeFetchRequest:request error:nil];
+    return [posts firstObject];
 }
 
 - (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost {


### PR DESCRIPTION
While running the profiler with Instruments I noticed this method was taking some time.

Previously we filtered `blog.posts`, which means every post is fetched then filtered. Since #3577, Post will build the content preview on each awakeFromFetch, which was being called for every post, and not just the matching one.

Switching to a fetch request doesn't call awakeFromFetch

Needs Review: @aerych 