### PR TITLE
Issue/3676 fix crash on add media asset

### DIFF
--- a/WordPress/Classes/Utility/WPAssetExporter.m
+++ b/WordPress/Classes/Utility/WPAssetExporter.m
@@ -81,7 +81,10 @@ const NSInteger WPAssetExportErrorCodeMissingAsset = 1;
     if ([filePath pathExtension]) {
         // Get the UTI from the file's extension:
         CFStringRef pathExtension = (__bridge_retained CFStringRef)[filePath pathExtension];
-        type = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension, NULL);
+        NSString * extensionType = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, pathExtension, NULL);
+        if (extensionType.length > 0) {
+            type = extensionType;
+        }
         CFRelease(pathExtension);
     }
     

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1777,7 +1777,7 @@ EditImageDetailsViewControllerDelegate
                 return;
             }
             createMediaProgress.completedUnitCount++;
-            if (error) {
+            if (error || !media || !media.localURL) {
                 [WPError showAlertWithTitle:NSLocalizedString(@"Failed to export media",
                                                               @"The title for an alert that says to the user the media (image or video) he selected couldn't be used on the post.")
                                     message:error.localizedDescription];


### PR DESCRIPTION
Close #3676 

Sometimes the creation of media was returning nil but no error is provided. So I added extra checks around that. I also add an extra check when trying to find the correct file format of a asset.

cc @sendhil, can you please review.