### PR TITLE
Prompt to update Jetpack on connection

### DIFF
--- a/WordPress/Classes/Models/Blog+Jetpack.h
+++ b/WordPress/Classes/Models/Blog+Jetpack.h
@@ -25,56 +25,6 @@ typedef NS_ENUM(NSInteger, BlogJetpackErrorCode) {
  */
 @interface Blog (Jetpack)
 
-///--------------------------------------
-///@name Information about Jetpack support
-///---------------------------------------
-
-/**
- Returns a Boolean value indicating whether the blog has Jetpack installed
- 
- @return YES if the receiver blog has Jetpack installed or NO if it does not.
-*/
-- (BOOL)hasJetpack;
-
-/**
- Returns a Boolean value indicating whether the blog has Jetpack installed AND is connected to WordPress.com. An account is defined as connected to WordPress.com if the site has jetpack installed, enabled and has linked their Jetpack plugin with a WordPress.com account.
- 
- @return YES if the receiver blog has Jetpack installed and is connected to WordPress.com
-*/
-- (BOOL)hasJetpackAndIsConnectedToWPCom;
-
-/**
- Returns the jetpack version installed in the blog
- 
- @return the jetpack version installed in the blog
- */
-- (NSString *)jetpackVersion;
-
-/**
- Returns the WordPress.com blog ID assigned to the blog
- 
- @returns the WordPress.com blog ID assigned to the blog
- */
-- (NSNumber *)jetpackBlogID;
-
-///----------------------------------
-///@name Managing Jetpack credentials
-///----------------------------------
-
-/**
- Returns the WordPress.com username associated with the blog
- 
- @returns the WordPress.com username associated with the blog
- */
-- (NSString *)jetpackUsername;
-
-/**
- Returns the WordPress.com password associated with the blog
-
- @returns the WordPress.com password associated with the blog
- */
-- (NSString *)jetpackPassword;
-
 /**
  Checks if the provided WordPress.com username and password are valid and associated to the blog
  

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -3,10 +3,10 @@
 #import <CoreData/CoreData.h>
 #import <WordPressApi/WordPressApi.h>
 
+#import "JetpackState.h"
 
 @class WPAccount;
 @class WordPressComApi;
-@class JetpackState;
 
 @interface Blog : NSManagedObject
 

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -6,6 +6,7 @@
 
 @class WPAccount;
 @class WordPressComApi;
+@class JetpackState;
 
 @interface Blog : NSManagedObject
 
@@ -48,6 +49,10 @@
 @property (nonatomic, strong,  readonly) NSString       *password;
 @property (nonatomic, strong,  readonly) NSString       *authToken;
 @property (nonatomic, strong,  readonly) NSSet *allowedFileTypes;
+/**
+ Contains the Jetpack state. Returns nil if the blog options haven't been downloaded yet
+ */
+@property (nonatomic, strong,  readonly) JetpackState *jetpack;
 
 
 /**

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -5,7 +5,6 @@
 #import "NSURL+IDN.h"
 #import "ContextManager.h"
 #import "Constants.h"
-#import "JetpackState.h"
 
 static NSInteger const ImageSizeSmallWidth = 240;
 static NSInteger const ImageSizeSmallHeight = 180;
@@ -375,7 +374,7 @@ static NSInteger const ImageSizeLargeHeight = 480;
 
 - (NSString *)authToken
 {
-    return self.account.authToken;
+    return [self isWPcom] ? self.account.authToken : self.jetpackAccount.authToken;
 }
 
 - (BOOL)supportsFeaturedImages
@@ -390,7 +389,7 @@ static NSInteger const ImageSizeLargeHeight = 480;
 
 - (NSNumber *)dotComID
 {
-    return self.blogID;
+    return [self isWPcom] ? self.blogID : self.jetpack.siteID;
 }
 
 - (NSSet *)allowedFileTypes
@@ -441,7 +440,11 @@ static NSInteger const ImageSizeLargeHeight = 480;
     _jetpack = [JetpackState new];
     _jetpack.siteID = [[self getOptionValue:@"jetpack_client_id"] numericValue];
     _jetpack.version = [self getOptionValue:@"jetpack_version"];
-    _jetpack.connectedUsername = [self getOptionValue:@"jetpack_user_login"];
+    if (self.jetpackAccount.username) {
+        _jetpack.connectedUsername = self.jetpackAccount.username;
+    } else {
+        _jetpack.connectedUsername = [self getOptionValue:@"jetpack_user_login"];
+    }
     _jetpack.connectedEmail = [self getOptionValue:@"jetpack_user_email"];
     return _jetpack;
 }

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -402,6 +402,19 @@ static NSInteger const ImageSizeLargeHeight = 480;
     return [NSSet setWithArray:allowedFileTypes];
 }
 
+- (void)setOptions:(NSDictionary *)options
+{
+    [self willChangeValueForKey:@"options"];
+    [self setPrimitiveValue:options forKey:@"options"];
+    self.jetpack = nil;
+    [self didChangeValueForKey:@"options"];
+}
+
++ (NSSet *)keyPathsForValuesAffectingJetpack
+{
+    return [NSSet setWithObject:@"options"];
+}
+
 #pragma mark - api accessor
 
 - (WPXMLRPCClient *)api

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -5,6 +5,7 @@
 #import "NSURL+IDN.h"
 #import "ContextManager.h"
 #import "Constants.h"
+#import "JetpackState.h"
 
 static NSInteger const ImageSizeSmallWidth = 240;
 static NSInteger const ImageSizeSmallHeight = 180;
@@ -16,6 +17,7 @@ static NSInteger const ImageSizeLargeHeight = 480;
 @interface Blog ()
 @property (nonatomic, strong, readwrite) WPXMLRPCClient *api;
 @property (nonatomic, weak, readwrite) NSString *blavatarUrl;
+@property (nonatomic, strong, readwrite) JetpackState *jetpack;
 @end
 
 @implementation Blog
@@ -52,6 +54,7 @@ static NSInteger const ImageSizeLargeHeight = 480;
 @synthesize isSyncingPages;
 @synthesize videoPressEnabled;
 @synthesize isSyncingMedia;
+@synthesize jetpack = _jetpack;
 
 #pragma mark - NSManagedObject subclass methods
 
@@ -423,6 +426,24 @@ static NSInteger const ImageSizeLargeHeight = 480;
         return self.jetpackAccount.restApi;
     }
     return nil;
+}
+
+#pragma mark - Jetpack
+
+- (JetpackState *)jetpack
+{
+    if (_jetpack) {
+        return _jetpack;
+    }
+    if ([self.options count] == 0) {
+        return nil;
+    }
+    _jetpack = [JetpackState new];
+    _jetpack.siteID = [[self getOptionValue:@"jetpack_client_id"] numericValue];
+    _jetpack.version = [self getOptionValue:@"jetpack_version"];
+    _jetpack.connectedUsername = [self getOptionValue:@"jetpack_user_login"];
+    _jetpack.connectedEmail = [self getOptionValue:@"jetpack_user_email"];
+    return _jetpack;
 }
 
 - (BOOL)jetpackRESTSupported

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -406,6 +406,7 @@ static NSInteger const ImageSizeLargeHeight = 480;
 {
     [self willChangeValueForKey:@"options"];
     [self setPrimitiveValue:options forKey:@"options"];
+    // Invalidate the Jetpack state since it's constructed from options
     self.jetpack = nil;
     [self didChangeValueForKey:@"options"];
 }

--- a/WordPress/Classes/Models/JetpackState.h
+++ b/WordPress/Classes/Models/JetpackState.h
@@ -1,0 +1,41 @@
+#import <Foundation/Foundation.h>
+
+/**
+ The minimum Jetpack version required for the app to work.
+ */
+extern NSString * const JetpackVersionMinimumRequired;
+
+/**
+ 🚀 Encapsulates the Jetpack-related options for a blog.
+ */
+@interface JetpackState : NSObject
+
+#pragma mark Primitives
+
+@property (nonatomic, strong) NSNumber *siteID;
+@property (nonatomic, strong) NSString *version;
+@property (nonatomic, strong) NSString *connectedUsername;
+@property (nonatomic, strong) NSString *connectedEmail;
+
+#pragma mark Helpers
+
+/**
+ Returns YES if Jetpack is installed and activated on the site.
+ */
+- (BOOL)isInstalled;
+
+/**
+ Returns YES if Jetpack is connected to WordPress.com.
+ 
+ @warn Before Jetpack 3.6, a site might appear connected if it was connected and then disconnected. See https://github.com/Automattic/jetpack/issues/2137
+ */
+- (BOOL)isConnected;
+
+/**
+ Returns YES if the detected version meets the app requirements.
+ 
+ @see JetpackVersionMinimumRequired
+ */
+- (BOOL)isUpdatedToRequiredVersion;
+
+@end

--- a/WordPress/Classes/Models/JetpackState.m
+++ b/WordPress/Classes/Models/JetpackState.m
@@ -1,0 +1,22 @@
+#import "JetpackState.h"
+
+NSString * const JetpackVersionMinimumRequired = @"3.4.3";
+
+@implementation JetpackState
+
+- (BOOL)isInstalled
+{
+    return self.version != nil;
+}
+
+- (BOOL)isConnected
+{
+    return [self isInstalled] && [self.siteID floatValue] > 0;
+}
+
+- (BOOL)isUpdatedToRequiredVersion
+{
+    return [self.version compare:JetpackVersionMinimumRequired options:NSNumericSearch] != NSOrderedAscending;
+}
+
+@end

--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -45,8 +45,8 @@
     [blog dataSave];
     [blogService syncBlog:blog success:nil failure:nil];
 
-    if ([blog hasJetpack]) {
-        if ([blog hasJetpackAndIsConnectedToWPCom]) {
+    if (blog.jetpack.isInstalled) {
+        if (blog.jetpack.isConnected) {
             if (needsJetpack != nil) {
                 needsJetpack(blog.blogID);
             }

--- a/WordPress/Classes/Utility/WPURLRequest.m
+++ b/WordPress/Classes/Utility/WPURLRequest.m
@@ -57,8 +57,7 @@
     NSParameterAssert(url);
     
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
-    request.cachePolicy = NSURLRequestReturnCacheDataElseLoad;
-    
+
     if (userAgent) {
         [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];
     }

--- a/WordPress/Classes/ViewRelated/Blog/EditSiteViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/EditSiteViewController.m
@@ -445,7 +445,7 @@ static CGFloat const EditSiteRowHeight = 48.0;
         NSMutableArray *mutedBlogsArray = [[mutedBlogsDictionary objectForKey:@"value"] mutableCopy];
         NSMutableDictionary *updatedPreference;
 
-        NSNumber *blogID = [self.blog isWPcom] ? self.blog.blogID : self.blog.jetpack.siteID;
+        NSNumber *blogID = [self.blog dotComID];
         for (NSUInteger i = 0; i < [mutedBlogsArray count]; i++) {
             updatedPreference = [mutedBlogsArray[i] mutableCopy];
             NSString *currentblogID = [updatedPreference objectForKey:@"blog_id"];
@@ -708,7 +708,7 @@ static CGFloat const EditSiteRowHeight = 48.0;
     if (self.notificationPreferences) {
         NSDictionary *mutedBlogsDictionary = [self.notificationPreferences objectForKey:@"muted_blogs"];
         NSArray *mutedBlogsArray = [mutedBlogsDictionary objectForKey:@"value"];
-        NSNumber *blogID = [self.blog isWPcom] ? self.blog.blogID : self.blog.jetpack.siteID;
+        NSNumber *blogID = [self.blog dotComID];
         for (NSDictionary *currentBlog in mutedBlogsArray ){
             NSString *currentBlogID = [currentBlog objectForKey:@"blog_id"];
             if ([blogID intValue] == [currentBlogID intValue]) {

--- a/WordPress/Classes/ViewRelated/Blog/EditSiteViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/EditSiteViewController.m
@@ -301,8 +301,8 @@ static CGFloat const EditSiteRowHeight = 48.0;
         UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:JetpackConnectedCellIdentifier];
 
         cell.textLabel.text = NSLocalizedString(@"Configure", @"");
-        if (self.blog.jetpackUsername) {
-            cell.detailTextLabel.text = [NSString stringWithFormat:NSLocalizedString(@"Connected as %@", @"Connected to jetpack as the specified usernaem"), self.blog.jetpackUsername];
+        if (self.blog.jetpack.connectedUsername) {
+            cell.detailTextLabel.text = [NSString stringWithFormat:NSLocalizedString(@"Connected as %@", @"Connected to jetpack as the specified usernaem"), self.blog.jetpack.connectedUsername];
         } else {
             cell.detailTextLabel.text = NSLocalizedString(@"Not connected", @"Jetpack is not connected yet.");
         }
@@ -421,7 +421,7 @@ static CGFloat const EditSiteRowHeight = 48.0;
     WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
 
     return self.blog &&
-        ([self.blog isWPcom] || [self.blog hasJetpack]) &&
+        ([self.blog isWPcom] || [self.blog.jetpack isConnected]) &&
         [[defaultAccount restApi] hasCredentials] &&
         [NotificationsManager deviceRegisteredForPushNotifications];
 }
@@ -445,7 +445,7 @@ static CGFloat const EditSiteRowHeight = 48.0;
         NSMutableArray *mutedBlogsArray = [[mutedBlogsDictionary objectForKey:@"value"] mutableCopy];
         NSMutableDictionary *updatedPreference;
 
-        NSNumber *blogID = [self.blog isWPcom] ? self.blog.blogID : [self.blog jetpackBlogID];
+        NSNumber *blogID = [self.blog isWPcom] ? self.blog.blogID : self.blog.jetpack.siteID;
         for (NSUInteger i = 0; i < [mutedBlogsArray count]; i++) {
             updatedPreference = [mutedBlogsArray[i] mutableCopy];
             NSString *currentblogID = [updatedPreference objectForKey:@"blog_id"];
@@ -708,7 +708,7 @@ static CGFloat const EditSiteRowHeight = 48.0;
     if (self.notificationPreferences) {
         NSDictionary *mutedBlogsDictionary = [self.notificationPreferences objectForKey:@"muted_blogs"];
         NSArray *mutedBlogsArray = [mutedBlogsDictionary objectForKey:@"value"];
-        NSNumber *blogID = [self.blog isWPcom] ? self.blog.blogID : [self.blog jetpackBlogID];
+        NSNumber *blogID = [self.blog isWPcom] ? self.blog.blogID : self.blog.jetpack.siteID;
         for (NSDictionary *currentBlog in mutedBlogsArray ){
             NSString *currentBlogID = [currentBlog objectForKey:@"blog_id"];
             if ([blogID intValue] == [currentBlogID intValue]) {

--- a/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
@@ -319,7 +319,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 
 - (void)updateControls
 {
-    BOOL hasJetpack                         = self.blog.jetpack.isInstalled && self.blog.jetpack.isUpdatedToRequiredVersion;
+    BOOL hasJetpack                         = [self canSetupJetpack];
     
     self.usernameTextField.alpha            = self.shouldDisplayMultifactor ? JetpackTextFieldAlphaDisabled : JetpackTextFieldAlphaEnabled;
     self.passwordTextField.alpha            = self.shouldDisplayMultifactor ? JetpackTextFieldAlphaDisabled : JetpackTextFieldAlphaEnabled;
@@ -402,7 +402,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     _skipButton.frame = CGRectMake(skipButtonX, skipButtonY, CGRectGetWidth(_skipButton.frame), CGRectGetHeight(_skipButton.frame));
 
     NSArray *viewsToCenter;
-    if (self.blog.jetpack.isInstalled) {
+    if ([self canSetupJetpack]) {
         viewsToCenter = @[_icon, _descriptionLabel, _usernameTextField, _passwordTextField, _multifactorTextField, _sendVerificationCodeButton, _signInButton];
     } else {
         viewsToCenter = @[_icon, _descriptionLabel, _installJetpackButton, _moreInformationButton];
@@ -427,6 +427,10 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     return CGRectGetMaxY(bottomView.frame);
 }
 
+- (BOOL)canSetupJetpack
+{
+    return self.blog.jetpack.isInstalled && self.blog.jetpack.isUpdatedToRequiredVersion;
+}
 
 #pragma mark - Button Helpers
 

--- a/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
@@ -53,7 +53,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 @property (nonatomic, strong) WPWalkthroughTextField    *multifactorTextField;
 @property (nonatomic, strong) WPNUXMainButton           *signInButton;
 @property (nonatomic, strong) WPNUXSecondaryButton      *sendVerificationCodeButton;
-@property (nonatomic, strong) WPNUXMainButton           *installJetbackButton;
+@property (nonatomic, strong) WPNUXMainButton           *installJetpackButton;
 @property (nonatomic, strong) UIButton                  *moreInformationButton;
 @property (nonatomic, strong) WPNUXSecondaryButton      *skipButton;
 
@@ -229,10 +229,10 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     [sendVerificationCodeButton addTarget:self action:@selector(sendVerificationCode:) forControlEvents:UIControlEventTouchUpInside];
 
     // Add Download Button
-    WPNUXMainButton *installJetbackButton = [[WPNUXMainButton alloc] init];
-    [installJetbackButton setTitle:NSLocalizedString(@"Install Jetpack", @"") forState:UIControlStateNormal];
-    [installJetbackButton addTarget:self action:@selector(openInstallJetpackURL) forControlEvents:UIControlEventTouchUpInside];
-    installJetbackButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
+    WPNUXMainButton *installJetpackButton = [[WPNUXMainButton alloc] init];
+    [installJetpackButton setTitle:NSLocalizedString(@"Install Jetpack", @"") forState:UIControlStateNormal];
+    [installJetpackButton addTarget:self action:@selector(openInstallJetpackURL) forControlEvents:UIControlEventTouchUpInside];
+    installJetpackButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     
     // Add More Information Button
     UIButton *moreInformationButton = [UIButton buttonWithType:UIButtonTypeCustom];
@@ -250,7 +250,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     [self.view addSubview:multifactorText];
     [self.view addSubview:signInButton];
     [self.view addSubview:sendVerificationCodeButton];
-    [self.view addSubview:installJetbackButton];
+    [self.view addSubview:installJetpackButton];
     [self.view addSubview:moreInformationButton];
     
     // Keep the Reference!
@@ -261,7 +261,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     self.multifactorTextField = multifactorText;
     self.signInButton = signInButton;
     self.sendVerificationCodeButton = sendVerificationCodeButton;
-    self.installJetbackButton = installJetbackButton;
+    self.installJetpackButton = installJetpackButton;
     self.moreInformationButton = moreInformationButton;
 }
 
@@ -337,7 +337,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     self.multifactorTextField.hidden        = !hasJetpack;
     self.signInButton.hidden                = !hasJetpack;
     self.sendVerificationCodeButton.hidden  = !self.shouldDisplayMultifactor || self.authenticating;;
-    self.installJetbackButton.hidden        = hasJetpack;
+    self.installJetpackButton.hidden        = hasJetpack;
     self.moreInformationButton.hidden       = hasJetpack;
     
     
@@ -393,10 +393,10 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     
     // Layout Download Button
     CGFloat installJetpackButtonY = CGRectGetMaxY(_descriptionLabel.frame) + JetpackStandardOffset;
-    _installJetbackButton.frame = CGRectIntegral(CGRectMake(buttonX, installJetpackButtonY, JetpackSignInButtonWidth, JetpackSignInButtonHeight));
+    _installJetpackButton.frame = CGRectIntegral(CGRectMake(buttonX, installJetpackButtonY, JetpackSignInButtonWidth, JetpackSignInButtonHeight));
 
     // Layout More Information Button
-    CGFloat moreInformationButtonY = CGRectGetMaxY(_installJetbackButton.frame);
+    CGFloat moreInformationButtonY = CGRectGetMaxY(_installJetpackButton.frame);
     _moreInformationButton.frame = CGRectIntegral(CGRectMake(buttonX, moreInformationButtonY, JetpackSignInButtonWidth, JetpackSignInButtonHeight));
 
     // Layout Skip Button
@@ -408,7 +408,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     if (self.blog.jetpack.isInstalled) {
         viewsToCenter = @[_icon, _descriptionLabel, _usernameTextField, _passwordTextField, _multifactorTextField, _sendVerificationCodeButton, _signInButton];
     } else {
-        viewsToCenter = @[_icon, _descriptionLabel, _installJetbackButton, _moreInformationButton];
+        viewsToCenter = @[_icon, _descriptionLabel, _installJetpackButton, _moreInformationButton];
     }
     
     UIView *endingView = [viewsToCenter lastObject];

--- a/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
@@ -166,7 +166,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     usernameTextField.delegate = self;
     usernameTextField.autocorrectionType = UITextAutocorrectionTypeNo;
     usernameTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
-    usernameTextField.text = self.blog.jetpackUsername;
+    usernameTextField.text = self.blog.jetpack.connectedUsername;
     usernameTextField.clearButtonMode = UITextFieldViewModeWhileEditing;
     usernameTextField.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     
@@ -178,7 +178,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     passwordTextField.delegate = self;
     passwordTextField.secureTextEntry = YES;
     passwordTextField.showSecureTextEntryToggle = YES;
-    passwordTextField.text = self.blog.jetpackPassword;
+    passwordTextField.text = @"";
     passwordTextField.clearsOnBeginEditing = YES;
     passwordTextField.showTopLineSeparator = YES;
     passwordTextField.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
@@ -322,7 +322,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 
 - (void)updateControls
 {
-    BOOL hasJetpack                         = self.blog.hasJetpack;
+    BOOL hasJetpack                         = self.blog.jetpack.isInstalled;
     
     self.usernameTextField.alpha            = self.shouldDisplayMultifactor ? JetpackTextFieldAlphaDisabled : JetpackTextFieldAlphaEnabled;
     self.passwordTextField.alpha            = self.shouldDisplayMultifactor ? JetpackTextFieldAlphaDisabled : JetpackTextFieldAlphaEnabled;
@@ -405,7 +405,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     _skipButton.frame = CGRectMake(skipButtonX, skipButtonY, CGRectGetWidth(_skipButton.frame), CGRectGetHeight(_skipButton.frame));
 
     NSArray *viewsToCenter;
-    if (self.blog.hasJetpack) {
+    if (self.blog.jetpack.isInstalled) {
         viewsToCenter = @[_icon, _descriptionLabel, _usernameTextField, _passwordTextField, _multifactorTextField, _sendVerificationCodeButton, _signInButton];
     } else {
         viewsToCenter = @[_icon, _descriptionLabel, _installJetbackButton, _moreInformationButton];
@@ -670,7 +670,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 
 - (void)updateMessage
 {
-    if (self.blog.hasJetpack) {
+    if (self.blog.jetpack.isInstalled) {
         self.descriptionLabel.text = NSLocalizedString(@"Looks like you have Jetpack set up on your site. Congrats!\nSign in with your WordPress.com credentials below to enable Stats and Notifications.", @"");
     } else {
         self.descriptionLabel.text = NSLocalizedString(@"Jetpack 1.8.2 or later is required for stats. Do you want to install Jetpack?", @"");
@@ -682,8 +682,8 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 
 - (void)checkForJetpack
 {
-    if (self.blog.hasJetpack) {
-        if (!self.blog.jetpackUsername || !self.blog.jetpackPassword) {
+    if (self.blog.jetpack.isInstalled) {
+        if (!self.blog.jetpack.connectedUsername) {
             NSString *jetpackUsernameFromBlogOptions = [self.blog getOptionValue:@"jetpack_user_login"];
             if (jetpackUsernameFromBlogOptions) {
                 self.usernameTextField.text = jetpackUsernameFromBlogOptions;
@@ -703,7 +703,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     [blogService syncOptionsForBlog:self.blog success:^{
-        if (self.blog.hasJetpack) {
+        if (self.blog.jetpack.isInstalled) {
             [self updateMessage];
         }
     } failure:^(NSError *error) {

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -98,8 +98,8 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
     // Jetpack
     BOOL needsJetpackLogin = ![self.blog.jetpackAccount.restApi hasCredentials];
-    if (!needsJetpackLogin && self.blog.jetpackBlogID && self.blog.jetpackAccount) {
-        self.statsVC.siteID = self.blog.jetpackBlogID;
+    if (!needsJetpackLogin && self.blog.jetpack.siteID && self.blog.jetpackAccount) {
+        self.statsVC.siteID = self.blog.jetpack.siteID;
         self.statsVC.oauth2Token = self.blog.jetpackAccount.restApi.authToken;
         [self addStatsViewControllerToView];
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsWebViewController.m
@@ -219,13 +219,13 @@ NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
     // Looking for a self-hosted blog with a jetpackClientId and good crednetials.
     BOOL prompt = NO;
 
-    if (![blog jetpackBlogID]) {
+    if (!blog.jetpack.siteID) {
         // needs latest jetpack
         prompt = YES;
 
     } else {
         // Check for credentials.
-        if (![blog.jetpackUsername length] || ![blog.authToken length]) {
+        if (![blog.authToken length]) {
             prompt = YES;
         }
     }
@@ -269,7 +269,7 @@ NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
         return;
     }
 
-    NSString *username = blog.isWPcom ? blog.username : blog.jetpackUsername;
+    NSString *username = blog.isWPcom ? blog.username : blog.jetpack.connectedUsername;
     
     // Skip the auth call to reduce loadtime if its the same username as before.
     if ([WPCookie hasCookieForURL:[NSURL URLWithString:@"https://wordpress.com/"] andUsername:username]) {
@@ -351,7 +351,7 @@ NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
 
     NSNumber *blogID = [blog blogID];
     if (![blog isWPcom]) {
-        blogID = [blog jetpackBlogID];
+        blogID = blog.jetpack.siteID;
     }
 
     NSString *pathStr = [NSString stringWithFormat:@"https://wordpress.com/stats/%@", blogID];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 		E10DB0081771926D00B7A0A3 /* GooglePlusActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E10DB0071771926D00B7A0A3 /* GooglePlusActivity.m */; };
 		E11330511A13BAA300D36D84 /* me-sites-with-jetpack.json in Resources */ = {isa = PBXBuildFile; fileRef = E11330501A13BAA300D36D84 /* me-sites-with-jetpack.json */; };
 		E114D79A153D85A800984182 /* WPError.m in Sources */ = {isa = PBXBuildFile; fileRef = E114D799153D85A800984182 /* WPError.m */; };
+		E120D90E1B09D8C300FB9A6E /* JetpackState.m in Sources */ = {isa = PBXBuildFile; fileRef = E120D90D1B09D8C300FB9A6E /* JetpackState.m */; };
 		E1249B4319408C910035E895 /* RemoteComment.m in Sources */ = {isa = PBXBuildFile; fileRef = E1249B4219408C910035E895 /* RemoteComment.m */; };
 		E1249B4619408D0F0035E895 /* CommentServiceRemoteXMLRPC.m in Sources */ = {isa = PBXBuildFile; fileRef = E1249B4519408D0F0035E895 /* CommentServiceRemoteXMLRPC.m */; };
 		E1249B4B1940AECC0035E895 /* CommentServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = E1249B4A1940AECC0035E895 /* CommentServiceRemoteREST.m */; };
@@ -1268,6 +1269,8 @@
 		E114D798153D85A800984182 /* WPError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPError.h; sourceTree = "<group>"; };
 		E114D799153D85A800984182 /* WPError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPError.m; sourceTree = "<group>"; };
 		E115F2D116776A2900CCF00D /* WordPress 8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 8.xcdatamodel"; sourceTree = "<group>"; };
+		E120D90C1B09D8C300FB9A6E /* JetpackState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JetpackState.h; sourceTree = "<group>"; };
+		E120D90D1B09D8C300FB9A6E /* JetpackState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JetpackState.m; sourceTree = "<group>"; };
 		E1225A4C147E6D2400B4F3A0 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E1225A4D147E6D2C00B4F3A0 /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E1249B3D19408C230035E895 /* CommentServiceRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommentServiceRemote.h; sourceTree = "<group>"; };
@@ -1795,6 +1798,8 @@
 				46F84612185A8B7E009D0DA5 /* WPContentViewProvider.h */,
 				5D35F7581A042255004E7B0D /* WPCommentContentViewProvider.h */,
 				5D333A561AA7A9E200DA295F /* WPPostContentViewProvider.h */,
+				E120D90C1B09D8C300FB9A6E /* JetpackState.h */,
+				E120D90D1B09D8C300FB9A6E /* JetpackState.m */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3989,6 +3994,7 @@
 				E1D95EB817A28F5E00A3E9F3 /* WPActivityDefaults.m in Sources */,
 				591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */,
 				85D790AA1AE5C6790033AE83 /* MixpanelProxy.m in Sources */,
+				E120D90E1B09D8C300FB9A6E /* JetpackState.m in Sources */,
 				857610D618C0377300EDF406 /* StatsWebViewController.m in Sources */,
 				5DBFC8A71A9BC34F00E00DE4 /* PostListViewController.m in Sources */,
 				5D08B90419648C3400D5B381 /* ReaderSubscriptionViewController.m in Sources */,

--- a/WordPress/WordPressTest/BlogJetpackTest.m
+++ b/WordPress/WordPressTest/BlogJetpackTest.m
@@ -53,50 +53,22 @@
     self.testContextManager = nil;
 }
 
-- (void)testAssertionsOnWPcom {
-    XCTestExpectation *saveExpectation = [self expectationWithDescription:@"Context save expectation"];
-    self.testContextManager.testExpectation = saveExpectation;
-
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:self.testContextManager.mainContext];
-    WPAccount *wpComAccount = [accountService createOrUpdateWordPressComAccountWithUsername:@"user" authToken:@"token"];
-
-    // Wait on the merge to be completed
-    [self waitForExpectationsWithTimeout:2.0 handler:nil];
-
-    _blog = (Blog *)[NSEntityDescription insertNewObjectForEntityForName:@"Blog" inManagedObjectContext:self.testContextManager.mainContext];
-    _blog.xmlrpc = @"http://test.wordpress.com/xmlrpc.php";
-    _blog.url = @"http://test.wordpress.com/";
-    _blog.account = wpComAccount;
-    
-    XCTAssertThrows([_blog hasJetpack], @"WordPress.com blogs don't support Jetpack methods");
-    XCTAssertThrows([_blog jetpackVersion], @"WordPress.com blogs don't support Jetpack methods");
-    XCTAssertThrows([_blog jetpackUsername], @"WordPress.com blogs don't support Jetpack methods");
-    XCTAssertThrows([_blog jetpackPassword], @"WordPress.com blogs don't support Jetpack methods");
-    XCTAssertThrows([_blog jetpackBlogID], @"WordPress.com blogs don't support Jetpack methods");
-    XCTAssertThrows([_blog removeJetpackCredentials], @"WordPress.com blogs don't support Jetpack methods");
-    XCTAssertThrows([_blog validateJetpackUsername:@"test" password:@"test" multifactorCode:nil success:nil failure:nil], @"WordPress.com blogs don't support Jetpack methods");
-}
-
-- (void)testHasJetpack {
-    XCTAssertTrue([_blog hasJetpack]);
+- (void)testJetpackInstalled {
+    XCTAssertTrue(_blog.jetpack.isInstalled);
     _blog.options = nil;
-    XCTAssertFalse([_blog hasJetpack]);
+    XCTAssertFalse(_blog.jetpack.isInstalled);
 }
 
 - (void)testJetpackVersion {
-    XCTAssertEqualObjects([_blog jetpackVersion], @"1.8.2");
+    XCTAssertEqualObjects(_blog.jetpack.version, @"1.8.2");
 }
 
-- (void)testJetpackBlogId {
-    XCTAssertEqualObjects([_blog jetpackBlogID], @1);
+- (void)testJetpackSiteId {
+    XCTAssertEqualObjects(_blog.jetpack.siteID, @1);
 }
 
 - (void)testJetpackUsername {
-    XCTAssertNil([_blog jetpackUsername]);
-}
-
-- (void)testJetpackPassword {
-    XCTAssertNil([_blog jetpackPassword]);
+    XCTAssertNil(_blog.jetpack.connectedUsername);
 }
 
 - (void)testValidateCredentials {


### PR DESCRIPTION
While I just wanted to bump the required version (#2287) and update the Jetpack screen to ask users to update old installs, I used the opportunity to refactor a bit.

- Most of `Blog+Jetpack` is moved to a new `JetpackState` object
- I plan to move the rest of `Blog+Jetpack` to either `Blog` or a new `JetpackService`, but that's for the next PR
- In 20728ca I fixed an issue where the "Install Jetpack" web view would show the wrong plugin status, because we were caching too aggresively
- Also, no more _Jetback_ :v: 

Fixes #2278
References #3627 