### PR TITLE
Send SMS Feedback

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -35,6 +35,8 @@
 #import "WordPress-Swift.h"
 
 #import "LoginViewModel.h"
+#import "SVProgressHUD.h"
+
 
 #pragma mark ====================================================================================
 #pragma mark Private
@@ -851,6 +853,12 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 2;
 - (void)showActivityIndicator:(BOOL)show
 {
     [self.signInButton showActivityIndicator:show];
+}
+
+- (void)showAlertWithMessage:(NSString *)message
+{
+    NSParameterAssert(message);
+    [SVProgressHUD showSuccessWithStatus:message];
 }
 
 - (void)setUsernameAlpha:(CGFloat)alpha

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
@@ -189,6 +189,7 @@ typedef void (^OverlayViewCallback)(WPWalkthroughOverlayView *);
 @protocol LoginViewModelPresenter
 
 - (void)showActivityIndicator:(BOOL)show;
+- (void)showAlertWithMessage:(NSString *)message;
 
 - (void)setUsernameAlpha:(CGFloat)alpha;
 - (void)setUsernameEnabled:(BOOL)enabled;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -187,6 +187,8 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
 
 - (void)requestOneTimeCode
 {
+    NSString *message = NSLocalizedString(@"Sending SMS!", @"The app will request One Time Code to be sent via SMS");
+    [self.presenter showAlertWithMessage:message];
     [self.loginFacade requestOneTimeCodeWithLoginFields:[self loginFields]];
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -187,7 +187,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
 
 - (void)requestOneTimeCode
 {
-    NSString *message = NSLocalizedString(@"SMS Sent!", @"One Time Code has been sent via SMS");
+    NSString *message = NSLocalizedString(@"SMS Sent", @"One Time Code has been sent via SMS");
     [self.presenter showAlertWithMessage:message];
     [self.loginFacade requestOneTimeCodeWithLoginFields:[self loginFields]];
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -187,7 +187,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
 
 - (void)requestOneTimeCode
 {
-    NSString *message = NSLocalizedString(@"Sending SMS!", @"The app will request One Time Code to be sent via SMS");
+    NSString *message = NSLocalizedString(@"SMS Sent!", @"One Time Code has been sent via SMS");
     [self.presenter showAlertWithMessage:message];
     [self.loginFacade requestOneTimeCodeWithLoginFields:[self loginFields]];
 }

--- a/WordPress/WordPressTest/LoginViewModelTests.m
+++ b/WordPress/WordPressTest/LoginViewModelTests.m
@@ -1784,6 +1784,7 @@ describe(@"requestOneTimeCode", ^{
     
     it(@"should pass on the request to the oauth client facade", ^{
         [[mockLoginFacade expect] requestOneTimeCodeWithLoginFields:OCMOCK_ANY];
+        [[mockViewModelPresenter expect] showAlertWithMessage:OCMOCK_ANY];
         
         [viewModel requestOneTimeCode];
         


### PR DESCRIPTION
#### Steps:
1. Fresh Install
2. Log into a WordPress.com with 2FA enabled
3. When the app requests the One Time Code, tap over the 'Send SMS' label

#### Expected:
As a result, a SVProgressHUD instance should be briefly displayed, with the legend 'Sending SMS!'.

Fixes #3643

Needs Review: @astralbodies 