### PR TITLE
Properly handle lifecycle changes in WPAnalytics with Tracks

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -25,7 +25,7 @@ pod 'CTAssetsPickerController', '~> 2.9.3'
 pod 'Lookback', '0.9.2', :configurations => ['Release-Internal']
 pod 'MRProgress', '~>0.7.0'
 
-pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.0.3', :configurations => ['Debug', 'Release-Internal']
+pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.0.4', :configurations => ['Debug', 'Release-Internal']
 pod 'EmailChecker', :podspec => 'https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec'
 pod 'MGImageUtilities', :git => 'git://github.com/wordpress-mobile/MGImageUtilities.git', :branch => 'gifsupport'
 pod 'NSObject-SafeExpectations', '0.0.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,8 @@ PODS:
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - AMPopTip (0.8)
-  - Automattic-Tracks-iOS (0.0.3):
+  - Automattic-Tracks-iOS (0.0.4):
+    - CocoaLumberjack (~> 2.0)
     - UIDeviceIdentifier (~> 0.4)
   - CocoaLumberjack (2.0.0):
     - CocoaLumberjack/Default (= 2.0.0)
@@ -140,7 +141,7 @@ DEPENDENCIES:
   - AFNetworking (~> 2.5.3)
   - AMPopTip (~> 0.7)
   - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`,
-    tag `0.0.3`)
+    tag `0.0.4`)
   - CocoaLumberjack (~> 2.0)
   - CrashlyticsLumberjack (= 2.0.1-beta)
   - CTAssetsPickerController (~> 2.9.3)
@@ -184,7 +185,7 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.0.3
+    :tag: 0.0.4
   EmailChecker:
     :podspec: https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec
   MGImageUtilities:
@@ -206,7 +207,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.0.3
+    :tag: 0.0.4
   MGImageUtilities:
     :commit: e946cf3d97eb95372f4fc4478bf2e0099e73f4b0
     :git: git://github.com/wordpress-mobile/MGImageUtilities.git
@@ -227,7 +228,7 @@ SPEC CHECKSUMS:
   1PasswordExtension: 66365c1e1264a83edec6c84c6eb2df41b50a70d3
   AFNetworking: e1d86c2a96bb5d2e7408da36149806706ee122fe
   AMPopTip: 2291c7a088e519a8d57794f63bc7507acde9c57b
-  Automattic-Tracks-iOS: d22bc1f15c7c898036649c0df7a9da0c4a253e3f
+  Automattic-Tracks-iOS: 41e28904cae548a5065887778e51e084888ab93e
   CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
   CrashlyticsLumberjack: 26034b4b6d8b0bf547ea9ba201ff53c6cd50f971
   CTAssetsPickerController: 56a4a228dcb48a9375ab8d4922e82ac74af74aa1


### PR DESCRIPTION
Closes #3688 

Fixes a crash when the anonymous ID might be blank. Added safety checks to prevent this but also am handling the creation of the anonymous aliasing events properly. 