### PR TITLE
Remove Jetpack settings from Edit Site

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/EditSiteViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/EditSiteViewController.m
@@ -4,7 +4,6 @@
 #import "WordPressComApi.h"
 #import "SupportViewController.h"
 #import "WPWebViewController.h"
-#import "JetpackSettingsViewController.h"
 #import "ReachabilityUtils.h"
 #import "WPAccount.h"
 #import "WPTableViewSectionHeaderView.h"

--- a/WordPress/Classes/ViewRelated/Blog/EditSiteViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/EditSiteViewController.m
@@ -19,7 +19,6 @@
 static NSString *const TextFieldCellIdentifier = @"TextFieldCellIdentifier";
 static NSString *const GeotaggingCellIdentifier = @"GeotaggingCellIdentifier";
 static NSString *const PushNotificationsCellIdentifier = @"PushNotificationsCellIdentifier";
-static NSString *const JetpackConnectedCellIdentifier = @"JetpackConnectedCellIdentifier";
 static CGFloat const EditSiteRowHeight = 48.0;
 
 @interface EditSiteViewController () <UITableViewDelegate, UITextFieldDelegate, UIAlertViewDelegate>
@@ -126,7 +125,6 @@ static CGFloat const EditSiteRowHeight = 48.0;
     [self.tableView registerClass:[UITableViewTextFieldCell class] forCellReuseIdentifier:TextFieldCellIdentifier];
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:GeotaggingCellIdentifier];
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:PushNotificationsCellIdentifier];
-    [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:JetpackConnectedCellIdentifier];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -140,9 +138,6 @@ static CGFloat const EditSiteRowHeight = 48.0;
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tv
 {
-    if (self.blog && ![self.blog isWPcom]) {
-        return 3;
-    }
     return 2;
 }
 
@@ -162,8 +157,6 @@ static CGFloat const EditSiteRowHeight = 48.0;
                 return 2;
             }
 
-            return 1;
-        case 2:
             return 1;
         default:
             break;
@@ -200,8 +193,6 @@ static CGFloat const EditSiteRowHeight = 48.0;
             return self.blog.blogName;
         case 1:
             return NSLocalizedString(@"Settings", @"");
-        case 2:
-            return NSLocalizedString(@"Jetpack Stats", @"");
         default:
             break;
     }
@@ -297,21 +288,6 @@ static CGFloat const EditSiteRowHeight = 48.0;
             [WPStyleGuide configureTableViewCell:pushCell];
             return pushCell;
         }
-    } else if (indexPath.section == 2) {
-        UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:JetpackConnectedCellIdentifier];
-
-        cell.textLabel.text = NSLocalizedString(@"Configure", @"");
-        if (self.blog.jetpackUsername) {
-            cell.detailTextLabel.text = [NSString stringWithFormat:NSLocalizedString(@"Connected as %@", @"Connected to jetpack as the specified usernaem"), self.blog.jetpackUsername];
-        } else {
-            cell.detailTextLabel.text = NSLocalizedString(@"Not connected", @"Jetpack is not connected yet.");
-        }
-        cell.selectionStyle = UITableViewCellSelectionStyleNone;
-        cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-        cell.selectionStyle = UITableViewCellSelectionStyleBlue;
-        [WPStyleGuide configureTableViewCell:cell];
-
-        return cell;
     }
 
     // We shouldn't reach this point, but return an empty cell just in case
@@ -332,15 +308,6 @@ static CGFloat const EditSiteRowHeight = 48.0;
         }
     }
     [tv deselectRowAtIndexPath:indexPath animated:YES];
-
-    if (indexPath.section == 2) {
-        JetpackSettingsViewController *controller = [[JetpackSettingsViewController alloc] initWithBlog:self.blog];
-        controller.showFullScreen = NO;
-        [controller setCompletionBlock:^(BOOL didAuthenticate) {
-            [self.navigationController popViewControllerAnimated:YES];
-        }];
-        [self.navigationController pushViewController:controller animated:YES];
-    }
 }
 
 #pragma mark - UITextField methods


### PR DESCRIPTION
You can set up Jetpack when you actually need it, from Stats and soon
from notifications.

Also, when Jetpack is already setup, settings would still show the same
login form as when it's not setup.

Related to #3628 