### PR TITLE
Prevents resetting the badge while the app is not active

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -223,6 +223,8 @@ static NSString const *NotificationsNetworkStatusKey    = @"network_status";
 
 - (void)bucket:(SPBucket *)bucket didChangeObjectForKey:(NSString *)key forChangeType:(SPBucketChangeType)changeType memberNames:(NSArray *)memberNames
 {
+    UIApplication *application = [UIApplication sharedApplication];
+    
     // Did the user tap on a push notification?
     if (changeType == SPBucketChangeInsert && [self.pushNotificationID isEqualToString:key]) {
 
@@ -239,8 +241,14 @@ static NSString const *NotificationsNetworkStatusKey    = @"network_status";
         self.pushNotificationDate   = nil;
     }
     
-    // Mark as read immediately (if we're onscreen!)
-    if (changeType == SPBucketChangeInsert && self.isViewOnScreen) {
+    // Mark as read immediately if:
+    //  -   We're onscreen
+    //  -   The app is in Foreground
+    //
+    // We need to make sure that the app is in FG, since this method might get called during a Background Fetch OS event,
+    // which would cause the badge to get reset on its own.
+    //
+    if (changeType == SPBucketChangeInsert && self.isViewOnScreen && application.applicationState == UIApplicationStateActive) {
         [self resetApplicationBadge];
         [self updateLastSeenTime];
     }


### PR DESCRIPTION
##### Scenario:
1. Fresh install WPiOS (on the device)
2. Launch the app, login and send it to background
3. Receive a Push Notification

As a result, the badge should **not** get reset. 

#### Notes:
We've discovered that, during the **background fetch** OS call, Simperium's *Object Inserted* callback might get called, and thus, the badge would be reset.

In this PR we just make sure that the app is in active state before resetting the badge. Plus: there is a notification listener waiting for the **appDidBecomeActive** note.

Closes #3638

@astralbodies may i bother you (yet again) with a review?

Thanks in advance!