### PR TITLE
Fixes issue:  Reply comment button is unreadable in Spanish #3653

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -230,6 +230,7 @@ import Foundation
         replyButton.titleLabel?.font    = WPStyleGuide.Reply.buttonFont
         replyButton.setTitleColor(WPStyleGuide.Reply.disabledColor, forState: .Disabled)
         replyButton.setTitleColor(WPStyleGuide.Reply.enabledColor,  forState: .Normal)
+        replyButton.titleLabel?.adjustsFontSizeToFitWidth = true
         
         // Background
         layoutView.backgroundColor      = WPStyleGuide.Reply.backgroundColor


### PR DESCRIPTION
 by resizing font to fit width.

- https://github.com/wordpress-mobile/WordPress-iOS/issues/3653