### PR TITLE
Update WPMediaPicker to version 0.3.6

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -36,7 +36,7 @@ pod 'WordPressCom-Stats-iOS', '0.3.4'
 pod 'WordPressCom-Analytics-iOS', '0.0.31'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '303b8068530389ea87afde38b77466d685fe3210'
-pod 'WPMediaPicker', '~>0.3.5'
+pod 'WPMediaPicker', '~>0.3.6'
 pod 'ReactiveCocoa', '~> 2.4.7'
 
 target 'WordPressTodayWidget', :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -132,7 +132,7 @@ PODS:
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.3)
     - WordPressCom-Analytics-iOS
-  - WPMediaPicker (0.3.5)
+  - WPMediaPicker (0.3.6)
   - wpxmlrpc (0.8)
 
 DEPENDENCIES:
@@ -177,7 +177,7 @@ DEPENDENCIES:
   - WordPressApi (~> 0.3.4)
   - WordPressCom-Analytics-iOS (= 0.0.31)
   - WordPressCom-Stats-iOS (= 0.3.4)
-  - WPMediaPicker (~> 0.3.5)
+  - WPMediaPicker (~> 0.3.6)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -262,7 +262,7 @@ SPEC CHECKSUMS:
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
   WordPressCom-Analytics-iOS: a35692b0bb5a1d5081da2481614a66663dfb091f
   WordPressCom-Stats-iOS: 63269dc52c52087184eaacbc1ad9d502fd189450
-  WPMediaPicker: 53eb0bc7b04111a99f7be64ce873c12ff9600e7d
+  WPMediaPicker: 2338901ebd4501e76103735ccc2e5e15ff1082ee
   wpxmlrpc: 053c9cbed13dcec08515a4ffeb51780f6e858cc7
 
 COCOAPODS: 0.37.1


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/654

This version of WPMediaPicker adds proper layout support for FullScreen Mode in the iPhone 6 Plus.

Needs Review: @diegoreymendez, @sendhil 