### PR TITLE
Added push notification type to the WPAnalytics call

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -469,7 +469,7 @@ static NSString const *NotificationsNetworkStatusKey    = @"network_status";
 
 - (void)showDetailsForNotification:(Notification *)note
 {
-    [WPAnalytics track:WPAnalyticsStatNotificationsOpenedNotificationDetails];
+    [WPAnalytics track:WPAnalyticsStatNotificationsOpenedNotificationDetails withProperties:@{ @"notification_type" : note.type ?: @"unknown"}];
     
     // Mark as Read, if needed
     if(!note.read.boolValue) {


### PR DESCRIPTION
Closes #3706 

Adds a push type to the WPAnalytics tracker so we have an idea of what type of note is involved. 

Needs Review: @jleandroperez @sendhil 