### PR TITLE
NotificationDetailsViewController: Adds missing removeObserver call

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -86,6 +86,8 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 - (void)dealloc
 {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    
     // Failsafe: Manually nuke the tableView dataSource and delegate. Make sure not to force a loadView event!
     if (!self.isViewLoaded) {
         return;


### PR DESCRIPTION
@diegoreymendez may i bother you with a very quick review?.

Found a missing *removeObserver* call!.

Thanks!
