### PR TITLE
NotificationDetails: Fallback to Root on Delete

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -1257,12 +1257,18 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 - (void)handleNotificationChange:(NSNotification *)notification
 {
-    NSSet *updated = notification.userInfo[NSUpdatedObjectsKey];
-    NSSet *refreshed = notification.userInfo[NSRefreshedObjectsKey];
+    NSSet *updated      = notification.userInfo[NSUpdatedObjectsKey];
+    NSSet *refreshed    = notification.userInfo[NSRefreshedObjectsKey];
+    NSSet *deleted      = notification.userInfo[NSDeletedObjectsKey];
     
     // Reload the table, if *our* notification got updated
     if ([updated containsObject:self.note] || [refreshed containsObject:self.note]) {
         [self reloadData];
+    }
+    
+    // Dismiss this ViewController if *our* notification... just got deleted
+    if ([deleted containsObject:self.note]) {
+        [self.navigationController popToRootViewControllerAnimated:YES];
     }
 }
 


### PR DESCRIPTION
#### Testing Steps:
1. Launch WPiOS
2. Receive a new Like Notification
3. Tap over the new notification
4. Remove the like added in (2)

As a result, the view should get dismissed, and the user should be left in NotificationsViewController.

Ref. Issue #3692

/cc @astralbodies (Thank you!)
