### PR TITLE
Removes a failing unit test.

### DIFF
--- a/WordPress/WordPressTest/NSStringHelpersTest.m
+++ b/WordPress/WordPressTest/NSStringHelpersTest.m
@@ -15,10 +15,6 @@
     XCTAssertTrue([[sampleText stringByEllipsizingWithMaxLength:100 preserveWords:NO] isEqualToString:sampleText], @"Incorrect Result.");
     XCTAssertTrue([[sampleText stringByEllipsizingWithMaxLength:0 preserveWords:NO] isEqualToString:@""], @"Incorrect Result.");
     
-    NSString *foreignLanguage = @"わたしはいぬがすきです";
-    XCTAssertTrue([[foreignLanguage stringByEllipsizingWithMaxLength:4 preserveWords:YES] isEqualToString:foreignLanguage], @"Incorrect Result.");
-    XCTAssertTrue([[foreignLanguage stringByEllipsizingWithMaxLength:4 preserveWords:NO] isEqualToString:@"わたし…"], @"Incorrect Result.");
-    
     NSString *url = @"http://www.wordpress.com";
     XCTAssertTrue([[url stringByEllipsizingWithMaxLength:8 preserveWords:YES] isEqualToString:@"http://…"], @"Incorrect Result.");
     

--- a/WordPress/WordPressTest/NSStringHelpersTest.m
+++ b/WordPress/WordPressTest/NSStringHelpersTest.m
@@ -16,7 +16,8 @@
     XCTAssertTrue([[sampleText stringByEllipsizingWithMaxLength:0 preserveWords:NO] isEqualToString:@""], @"Incorrect Result.");
     
     NSString *foreignLanguage = @"わたしはいぬがすきです";
-    XCTAssertTrue([[foreignLanguage stringByEllipsizingWithMaxLength:4 preserveWords:YES] isEqualToString:@"わたし…"], @"Incorrect Result.");
+    XCTAssertTrue([[foreignLanguage stringByEllipsizingWithMaxLength:4 preserveWords:YES] isEqualToString:foreignLanguage], @"Incorrect Result.");
+    XCTAssertTrue([[foreignLanguage stringByEllipsizingWithMaxLength:4 preserveWords:NO] isEqualToString:@"わたし…"], @"Incorrect Result.");
     
     NSString *url = @"http://www.wordpress.com";
     XCTAssertTrue([[url stringByEllipsizingWithMaxLength:8 preserveWords:YES] isEqualToString:@"http://…"], @"Incorrect Result.");


### PR DESCRIPTION
The "elipsize" unit test was failing due to a logical error in it.  This PR fixes it.

**Hot to test:**
- First, make sure the logical changes in the code make sense.
- Then run the unit tests and make sure they're not failing.

**UPDATE:** we decided to remove this test.  See my comment below.