### PR TITLE
Notifications: Disabling interaction on Nuked Notes

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.h
@@ -3,7 +3,24 @@
 
 
 @class Notification;
+typedef void (^NotificationDetailsCallbackBlock)();
+
 
 @interface NotificationDetailsViewController : UIViewController <UIViewControllerRestoration>
+
+/**
+ *	@brief		This block will be called whenever a destructive action is performed over a Notification object.
+ */
+
+@property (nonatomic, copy) NotificationDetailsCallbackBlock onDestructionCallback;
+
+/**
+ *	@brief		This method renders the details view, for any given notification/
+ *  @details    You should only call this method once. It will take care of attaching any required subviews,
+ *              in order to properly render the Notification's details.
+ *
+ *	@param		notification    The Notification to display.
+ */
 - (void)setupWithNotification:(Notification *)notification;
+
 @end

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -1061,6 +1061,11 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
         
         [service spamCommentWithID:block.metaCommentID siteID:block.metaSiteID success:nil failure:nil];
         
+        // Hi the destruction callback, if any, and pop to the root!
+        if (self.onDestructionCallback) {
+            self.onDestructionCallback();
+        }
+        
         [self.navigationController popToRootViewControllerAnimated:YES];
     };
     
@@ -1088,6 +1093,11 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
         CommentService *service         = [[CommentService alloc] initWithManagedObjectContext:context];
         
         [service deleteCommentWithID:block.metaCommentID siteID:block.metaSiteID success:nil failure:nil];
+        
+        // Hi the destruction callback, if any, and pop to the root!
+        if (self.onDestructionCallback) {
+            self.onDestructionCallback();
+        }
         
         [self.navigationController popToRootViewControllerAnimated:YES];
     };

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -464,6 +464,17 @@ static NSString const *NotificationsNetworkStatusKey    = @"network_status";
     self.trackedViewDisplay = YES;
 }
 
+- (void)disableInteractionsForNotification:(Notification *)note
+{
+    NSIndexPath *indexPath      = [self.tableViewHandler.resultsController indexPathForObject:note];
+    if (!indexPath) {
+        return;
+    }
+    
+    UITableViewCell *cell       = [self.tableView cellForRowAtIndexPath:indexPath];
+    cell.userInteractionEnabled = false;
+}
+
 
 #pragma mark - Segue Helpers
 
@@ -579,14 +590,18 @@ static NSString const *NotificationsNetworkStatusKey    = @"network_status";
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
 {
-    NSString *detailsSegueID    = NSStringFromClass([NotificationDetailsViewController class]);
-    NSString *readerSegueID     = NSStringFromClass([ReaderPostDetailViewController class]);
-    Notification *note          = sender;
+    NSString *detailsSegueID        = NSStringFromClass([NotificationDetailsViewController class]);
+    NSString *readerSegueID         = NSStringFromClass([ReaderPostDetailViewController class]);
+    Notification *note              = sender;
+    __weak __typeof(self) weakSelf  = self;
     
     if([segue.identifier isEqualToString:detailsSegueID]) {
         NotificationDetailsViewController *detailsViewController = segue.destinationViewController;
         [detailsViewController setupWithNotification:note];
-    
+        detailsViewController.onDestructionCallback = ^{
+            [weakSelf disableInteractionsForNotification:note];
+        };
+        
     } else if([segue.identifier isEqualToString:readerSegueID]) {
         ReaderPostDetailViewController *readerViewController = segue.destinationViewController;
         [readerViewController setupWithPostID:note.metaPostID siteID:note.metaSiteID];
@@ -624,7 +639,8 @@ static NSString const *NotificationsNetworkStatusKey    = @"network_status";
     cell.noticon                            = note.noticon;
     cell.unapproved                         = note.isUnapprovedComment;
     cell.showsSeparator                     = ![self isRowLastRowForSection:indexPath];
-    
+    cell.userInteractionEnabled             = YES;
+
     [cell downloadGravatarWithURL:note.iconURL];
 }
 


### PR DESCRIPTION
#### Steps:
1. Launch WPiOS and open the Notifications Tab.
2. Receive a comment on a testing blog.
3. Tap over the Notification, once it arrives.
4. Tap over the Trash action.

As a result, the Details ViewController should get dismissed, and the affected Notification cell should not be tappable anymore.

Closes #3692

/cc @diegoreymendez (Thanks in advance Diego!).