### PR TITLE
Notifications: Like should auto approve comments

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.h
+++ b/WordPress/Classes/Models/Notifications/Notification.h
@@ -166,6 +166,13 @@ typedef NS_ENUM(NSInteger, NoteBlockGroupType)
  */
 - (NSArray *)imageUrls;
 
+/**
+ *	@brief      Returns YES if the associated comment (if any) is approved. NO otherwise.
+ *
+ *  @returns                A boolean value indicating whether the comment is approved, or not.
+ */
+- (BOOL)isCommentApproved;
+
 - (void)setActionOverrideValue:(NSNumber *)obj forKey:(NSString *)key;
 - (void)removeActionOverrideForKey:(NSString *)key;
 - (NSNumber *)actionForKey:(NSString *)key;

--- a/WordPress/Classes/Models/Notifications/Notification.m
+++ b/WordPress/Classes/Models/Notifications/Notification.m
@@ -303,6 +303,11 @@ NSString const *NoteReplyIdKey          = @"reply_comment";
     return urls;
 }
 
+- (BOOL)isCommentApproved
+{
+    return [self isActionOn:NoteActionApproveKey] || ![self isActionEnabled:NoteActionApproveKey];
+}
+
 - (void)setActionOverrideValue:(NSNumber *)value forKey:(NSString *)key
 {
     if (!_actionsOverride) {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -978,7 +978,13 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 - (void)likeCommentWithBlock:(NotificationBlock *)block
 {
     [WPAnalytics track:WPAnalyticsStatNotificationLiked];
-    
+
+    // If the associated comment is *not* approved, let's attempt to auto-approve it, automatically
+    if (!block.isCommentApproved) {
+        [self approveCommentWithBlock:block];
+    }
+
+    // Proceed toggling the Like field
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     CommentService *service         = [[CommentService alloc] initWithManagedObjectContext:context];
     __typeof(self) __weak weakSelf  = self;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -659,7 +659,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     cell.timestamp                  = [self.note.timestampAsDate shortString];
     cell.site                       = userBlock.metaTitlesHome ?: userBlock.metaLinksHome.hostname;
     cell.attributedCommentText      = [commentBlock.attributedRichText stringByEmbeddingImageAttachments:mediaRanges];
-    cell.isApproved                 = [commentBlock isActionOn:NoteActionApproveKey] || ![commentBlock isActionEnabled:NoteActionApproveKey];
+    cell.isApproved                 = [commentBlock isCommentApproved];
     cell.hasReply                   = self.note.hasReply;
     
     // Setup the Callbacks


### PR DESCRIPTION
#### Steps:
1. Receive a new Comment on any of your blogs
2. Disapprove the comment
3. Tap over *Like*.

As a result, the comment should get auto approved, right after tapping *Like*.

/cc @sendhil (Thanks in advance!)

Closes #3705

