### PR TITLE
Update to MediaPicker version 0.4.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -36,7 +36,7 @@ pod 'WordPressCom-Stats-iOS', '0.3.4'
 pod 'WordPressCom-Analytics-iOS', '0.0.31'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '303b8068530389ea87afde38b77466d685fe3210'
-pod 'WPMediaPicker', '~>0.3.6'
+pod 'WPMediaPicker', '~>0.4.1'
 pod 'ReactiveCocoa', '~> 2.4.7'
 
 target 'WordPressTodayWidget', :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -132,7 +132,7 @@ PODS:
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.3)
     - WordPressCom-Analytics-iOS
-  - WPMediaPicker (0.3.6)
+  - WPMediaPicker (0.4.1)
   - wpxmlrpc (0.8)
 
 DEPENDENCIES:
@@ -177,7 +177,7 @@ DEPENDENCIES:
   - WordPressApi (~> 0.3.4)
   - WordPressCom-Analytics-iOS (= 0.0.31)
   - WordPressCom-Stats-iOS (= 0.3.4)
-  - WPMediaPicker (~> 0.3.6)
+  - WPMediaPicker (~> 0.4.1)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -262,7 +262,7 @@ SPEC CHECKSUMS:
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
   WordPressCom-Analytics-iOS: a35692b0bb5a1d5081da2481614a66663dfb091f
   WordPressCom-Stats-iOS: 63269dc52c52087184eaacbc1ad9d502fd189450
-  WPMediaPicker: 2338901ebd4501e76103735ccc2e5e15ff1082ee
+  WPMediaPicker: 010e0ecab215bf837ab4cc42e3223d5abd738a4d
   wpxmlrpc: 053c9cbed13dcec08515a4ffeb51780f6e858cc7
 
 COCOAPODS: 0.37.1

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -889,7 +889,7 @@ UIImagePickerControllerDelegate, UINavigationControllerDelegate, UIPopoverContro
 - (void)showPhotoPicker
 {
     WPMediaPickerViewController *picker = [[WPMediaPickerViewController alloc] init];
-    picker.assetsFilter = [ALAssetsFilter allPhotos];
+    picker.filter = WPMediaTypeImage;
     picker.delegate = self;
     picker.allowMultipleSelection = NO;
 
@@ -1082,10 +1082,10 @@ UIImagePickerControllerDelegate, UINavigationControllerDelegate, UIPopoverContro
 
 - (void)mediaPickerController:(WPMediaPickerViewController *)picker didFinishPickingAssets:(NSArray *)assets
 {
-    if (assets.count == 0){
+    if (assets.count == 0 || ![[assets firstObject] isKindOfClass:[ALAsset class]]){
         return;
     }
-    ALAsset *asset = assets[0];
+    ALAsset *asset = [assets firstObject];
     if (!asset.defaultRepresentation) {
         [WPError showAlertWithTitle:NSLocalizedString(@"Image unavailable", @"The title for an alert that says the image the user selected isn't available.")
                             message:NSLocalizedString(@"This Photo Stream image cannot be added to your WordPress. Try saving it to your Camera Roll before uploading.", @"User information explaining that the image is not available locally. This is normally related to share photo stream images.")  withSupportButton:NO];

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -362,7 +362,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     WPMediaPickerViewController *picker = [[WPMediaPickerViewController alloc] init];
     picker.delegate = self;
 
-    picker.assetsFilter = [ALAssetsFilter allPhotos];
+    picker.filter = WPMediaTypeImage;
 
     [self presentViewController:picker animated:YES completion:nil];
 }


### PR DESCRIPTION
Updates the media picker to the latest version.

Changes on media picker here:
 * https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.4.0
 * https://github.com/wordpress-mobile/MediaPicker-iOS/releases/tag/0.4.1

To test it try to add images and videos to a post using the picker. And also add a featured image to a post.

Needs Review: @bummytime 