### PR TITLE
Improve logging for Jetpack REST migrations

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -85,6 +85,13 @@
 - (NSUInteger)numberOfPendingComments;
 - (NSDictionary *) getImageResizeDimensions;
 - (BOOL)supportsFeaturedImages;
+/**
+ Returns a human readable description for logging
+ 
+ Instead of inspecting the core data object, this returns select information, more
+ useful for support.
+ */
+- (NSString *)logDescription;
 
 /**
  Returns a REST API client if available

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -379,7 +379,7 @@ static NSInteger const ImageSizeLargeHeight = 480;
     } else {
         extra = [NSString stringWithFormat:@" jetpack: %@", [self.jetpack description]];
     }
-    return [NSString stringWithFormat:@"<Blog Name: %@ URL: %@ XML-RPC: %@%@", self.blogName, self.url, self.xmlrpc, extra];
+    return [NSString stringWithFormat:@"<Blog Name: %@ URL: %@ XML-RPC: %@%@>", self.blogName, self.url, self.xmlrpc, extra];
 }
 
 #pragma mark - api accessor

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -369,6 +369,19 @@ static NSInteger const ImageSizeLargeHeight = 480;
     return [NSSet setWithObject:@"options"];
 }
 
+- (NSString *)logDescription
+{
+    NSString *extra = @"";
+    if (self.account.isWpcom) {
+        extra = [NSString stringWithFormat:@" wp.com account: %@ blogId: %@", self.account.isWpcom ? self.account.username : @"NO", self.blogID];
+    } else if (self.jetpackAccount) {
+        extra = [NSString stringWithFormat:@" jetpack: 🚀🚀 Jetpack %@ fully connected as %@ with site ID %@", self.jetpack.version, self.jetpackAccount.username, self.jetpack.siteID];
+    } else {
+        extra = [NSString stringWithFormat:@" jetpack: %@", [self.jetpack description]];
+    }
+    return [NSString stringWithFormat:@"<Blog Name: %@ URL: %@ XML-RPC: %@%@", self.blogName, self.url, self.xmlrpc, extra];
+}
+
 #pragma mark - api accessor
 
 - (WPXMLRPCClient *)api

--- a/WordPress/Classes/Models/JetpackState.m
+++ b/WordPress/Classes/Models/JetpackState.m
@@ -4,6 +4,24 @@ NSString * const JetpackVersionMinimumRequired = @"3.4.3";
 
 @implementation JetpackState
 
+- (NSString *)description
+{
+    if ([self isConnected]) {
+        NSString *connectedAs = self.connectedUsername;
+        if (connectedAs.length == 0) {
+            connectedAs = self.connectedEmail;
+        }
+        if (connectedAs.length == 0) {
+            connectedAs = @"UNKNOWN";
+        }
+        return [NSString stringWithFormat:@"🚀✅ Jetpack %@ connected as %@ with site ID %@", self.version, self.connectedUsername, self.siteID];
+    } else if ([self isInstalled]) {
+        return [NSString stringWithFormat:@"🚀❌ Jetpack %@ not connected", self.version];
+    } else {
+        return @"🚀❔Jetpack not installed";
+    }
+}
+
 - (BOOL)isInstalled
 {
     return self.version != nil;

--- a/WordPress/Classes/Models/JetpackState.m
+++ b/WordPress/Classes/Models/JetpackState.m
@@ -14,7 +14,7 @@ NSString * const JetpackVersionMinimumRequired = @"3.4.3";
         if (connectedAs.length == 0) {
             connectedAs = @"UNKNOWN";
         }
-        return [NSString stringWithFormat:@"🚀✅ Jetpack %@ connected as %@ with site ID %@", self.version, self.connectedUsername, self.siteID];
+        return [NSString stringWithFormat:@"🚀✅ Jetpack %@ connected as %@ with site ID %@", self.version, connectedAs, self.siteID];
     } else if ([self isInstalled]) {
         return [NSString stringWithFormat:@"🚀❌ Jetpack %@ not connected", self.version];
     } else {

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlog.m
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlog.m
@@ -1,7 +1,7 @@
 #import "RemoteBlog.h"
 
 @implementation RemoteBlog
-- (NSString *)debugDescription
+- (NSString *)description
 {
     NSDictionary *properties = @{
                                  @"ID": self.ID,

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -563,6 +563,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
                                        forAccount:account];
         }
         if (!blog) {
+            DDLogInfo(@"New blog from account %@: %@", account.username, remoteBlog);
             blog = [self createBlogWithAccount:account];
             blog.xmlrpc = remoteBlog.xmlrpc;
         }
@@ -606,6 +607,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     }]] anyObject];
 
     if (jetpackBlog) {
+        DDLogInfo(@"Migrating %@ to wp.com account %@", [jetpackBlog hostURL], account.username);
         WPAccount *oldAccount = jetpackBlog.account;
         jetpackBlog.account = account;
         jetpackBlog.jetpackAccount = nil;

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -872,7 +872,13 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     if (blogs.count > 0) {
         DDLogInfo(@"All blogs on device:");
         for (Blog *blog in blogs) {
-            DDLogInfo(@"Name: %@ URL: %@ XML-RPC: %@ isWpCom: %@ blogId: %@ jetpackAccount: %@", blog.blogName, blog.url, blog.xmlrpc, blog.account.isWpcom ? @"YES" : @"NO", blog.blogID, !!blog.jetpackAccount ? @"PRESENT" : @"NONE");
+            if (blog.account.isWpcom) {
+                DDLogInfo(@"Name: %@ URL: %@ XML-RPC: %@ wp.com account: %@ blogId: %@", blog.blogName, blog.url, blog.xmlrpc, blog.account.isWpcom ? blog.account.username : @"NO", blog.blogID);
+            } else if (blog.jetpackAccount) {
+                DDLogInfo(@"Name: %@ URL: %@ XML-RPC: %@ jetpack: 🚀🚀 Jetpack %@ fully connected as %@ with site ID %@", blog.blogName, blog.url, blog.xmlrpc, blog.jetpack.version, blog.jetpackAccount.username, blog.jetpack.siteID);
+            } else {
+                DDLogInfo(@"Name: %@ URL: %@ XML-RPC: %@ jetpack: %@", blog.blogName, blog.url, blog.xmlrpc, [blog.jetpack description]);
+            }
         }
     } else {
         DDLogInfo(@"No blogs configured on device.");

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -872,13 +872,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     if (blogs.count > 0) {
         DDLogInfo(@"All blogs on device:");
         for (Blog *blog in blogs) {
-            if (blog.account.isWpcom) {
-                DDLogInfo(@"Name: %@ URL: %@ XML-RPC: %@ wp.com account: %@ blogId: %@", blog.blogName, blog.url, blog.xmlrpc, blog.account.isWpcom ? blog.account.username : @"NO", blog.blogID);
-            } else if (blog.jetpackAccount) {
-                DDLogInfo(@"Name: %@ URL: %@ XML-RPC: %@ jetpack: 🚀🚀 Jetpack %@ fully connected as %@ with site ID %@", blog.blogName, blog.url, blog.xmlrpc, blog.jetpack.version, blog.jetpackAccount.username, blog.jetpack.siteID);
-            } else {
-                DDLogInfo(@"Name: %@ URL: %@ XML-RPC: %@ jetpack: %@", blog.blogName, blog.url, blog.xmlrpc, [blog.jetpack description]);
-            }
+            DDLogInfo(@"%@", [blog logDescription]);
         }
     } else {
         DDLogInfo(@"No blogs configured on device.");

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -182,9 +182,7 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
     for (int i = 0; i < allBlogs.count; i++) {
         Blog *blog = allBlogs[i];
 
-        NSDictionary *blogData = @{[NSString stringWithFormat:@"blog-%i-Name", i+1]: blog.blogName,
-                                   [NSString stringWithFormat:@"blog-%i-ID", i+1]: blog.blogID,
-                                   [NSString stringWithFormat:@"blog-%i-URL", i+1]: blog.url};
+        NSDictionary *blogData = @{[NSString stringWithFormat:@"blog-%i", i+1]: [blog logDescription]};
 
         [metaData addEntriesFromDictionary:blogData];
     }


### PR DESCRIPTION
As part of #3627 this improves logging so we can support Jetpack sites better:

- It will log when a new site is added automatically via `syncBlogs`
- It will log when a Jetpack site is migrated to use REST
- Improves the blog list logged on launch

Some sample blogs and their logged description on launch

**Before**

>Name: Edge test site URL: http://edge.wpmt.co XML-RPC: http://edge.wpmt.co/xmlrpc.php isWpCom: NO blogId: 0 jetpackAccount: PRESENT
Name: Jetpack Test #2 URL: http://jp2.koke.co XML-RPC: http://jp2.koke.co/xmlrpc.php isWpCom: NO blogId: 0 jetpackAccount: NONE
Name: Jorge Bernal URL: http://jorgebernal.es XML-RPC: https://jorgebernales.wordpress.com/xmlrpc.php isWpCom: YES blogId: 17691640 jetpackAccount: NONE
Name: Jorge Bernal URL: http://jorgebernal.info XML-RPC: https://jorgebernalen.wordpress.com/xmlrpc.php isWpCom: YES blogId: 17758711 jetpackAccount: NONE
Name: Koke's Journal URL: http://koke.me XML-RPC: https://kokejournal.wordpress.com/xmlrpc.php isWpCom: YES blogId: 16764956 jetpackAccount: NONE
Name: Test site URL: http://test.koke.co XML-RPC: http://test.koke.co/xmlrpc.php isWpCom: YES blogId: 63902892 jetpackAccount: NONE
Name: WordPress Latest URL: http://wp.koke.me XML-RPC: http://wp.koke.me/xmlrpc.php isWpCom: NO blogId: 0 jetpackAccount: NONE
Name: WordPress Secure URL: http://wps.koke.me XML-RPC: https://wps.koke.me/xmlrpc.php isWpCom: YES blogId: 91395574 jetpackAccount: NONE
Name: WordPress Trunk URL: http://wpt.koke.me XML-RPC: http://wpt.koke.me/xmlrpc.php isWpCom: NO blogId: 0 jetpackAccount: NONE

**After**

><Blog Name: Edge test site URL: http://edge.wpmt.co XML-RPC: http://edge.wpmt.co/xmlrpc.php jetpack: 🚀🚀 Jetpack 3.5.3 fully connected as wpmtestjp with site ID 59803729
<Blog Name: Jetpack Test #2 URL: http://jp2.koke.co XML-RPC: http://jp2.koke.co/xmlrpc.php jetpack: 🚀❌ Jetpack 3.5.3 not connected
<Blog Name: Jorge Bernal URL: http://jorgebernal.es XML-RPC: https://jorgebernales.wordpress.com/xmlrpc.php wp.com account: kokeme blogId: 17691640
<Blog Name: Jorge Bernal URL: http://jorgebernal.info XML-RPC: https://jorgebernalen.wordpress.com/xmlrpc.php wp.com account: kokeme blogId: 17758711
<Blog Name: Koke's Journal URL: http://koke.me XML-RPC: https://kokejournal.wordpress.com/xmlrpc.php wp.com account: kokeme blogId: 16764956
<Blog Name: Test site URL: http://test.koke.co XML-RPC: http://test.koke.co/xmlrpc.php wp.com account: kokeme blogId: 63902892
<Blog Name: WordPress Latest URL: http://wp.koke.me XML-RPC: http://wp.koke.me/xmlrpc.php jetpack: 🚀❔Jetpack not installed
<Blog Name: WordPress Secure URL: http://wps.koke.me XML-RPC: https://wps.koke.me/xmlrpc.php wp.com account: kokeme blogId: 91395574
<Blog Name: WordPress Trunk URL: http://wpt.koke.me XML-RPC: http://wpt.koke.me/xmlrpc.php jetpack: 🚀✅ Jetpack 3.5.3 connected as UNKNOWN with site ID 22793269

Needs Review: @sendhil 