### PR TITLE
Issue/3708 clean up temporary video files

### DIFF
--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -233,6 +233,7 @@ CGFloat const MediaDefaultJPEGCompressionQuality = 0.9;
 {
     NSError *error = nil;
     [[NSFileManager defaultManager] removeItemAtPath:self.localURL error:&error];
+    [[NSFileManager defaultManager] removeItemAtPath:self.thumbnailLocalURL error:&error];
 
     [self.managedObjectContext performBlockAndWait:^{
         [self.managedObjectContext deleteObject:self];

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -389,7 +389,7 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
         NSString *documentsDirectory    = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
         NSArray *contentsOfDir          = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:documentsDirectory error:nil];
         
-        NSSet *mediaExtensions          = [NSSet setWithObjects:@"jpg", @"jpeg", @"png", @"gif", @"mov", nil];
+        NSSet *mediaExtensions          = [NSSet setWithObjects:@"jpg", @"jpeg", @"png", @"gif", @"mov", @"avi", @"mp4", nil];
         
         for (NSString *currentPath in contentsOfDir) {
             NSString *extension = currentPath.pathExtension.lowercaseString;

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -389,7 +389,7 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
         NSString *documentsDirectory    = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
         NSArray *contentsOfDir          = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:documentsDirectory error:nil];
         
-        NSSet *mediaExtensions          = [NSSet setWithObjects:@"jpg", @"jpeg", @"png", @"gif", nil];
+        NSSet *mediaExtensions          = [NSSet setWithObjects:@"jpg", @"jpeg", @"png", @"gif", @"mov", nil];
         
         for (NSString *currentPath in contentsOfDir) {
             NSString *extension = currentPath.pathExtension.lowercaseString;


### PR DESCRIPTION
Closes #3708 

How To Test:

 * Using the simulator (iOS 8 or above)
 * Create a new post
 * Add a video to the post
 * Kill the app while the upload is happening
 * Check the simulator folder for the app, for a video file with extension .mov that represents the video you where uploading
 * Restart the app and after a while check to see if the video was deleted.

In case you don't have a video in your simulator just drag and drop a video file to the simulator screen. It will open safari to preview the video. Stop/Pause the video and then click the share button and select Save Video to save it to the Camera Roll of the simulator.

Nees Review: @diegoreymendez 