### PR TITLE
Fixes restoration issues in tab bar

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -55,6 +55,8 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
 {
     self = [super init];
     if (self) {
+        self.title = NSLocalizedString(@"Me", @"Me page title");
+
         // we want to observe for the account change notification even if the view is not visible
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(defaultAccountDidChange:)

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -31,11 +31,12 @@ const typedef enum {
     MeSectionWpCom
 } MeSectionContentType;
 
+static NSString *const WPMeRestorationID = @"WPMeRestorationID";
 static NSString *const MVCCellReuseIdentifier = @"MVCCellReuseIdentifier";
 
 static CGFloat const MVCTableViewRowHeight = 50.0;
 
-@interface MeViewController () <UITableViewDataSource, UITableViewDelegate, UIActionSheetDelegate>
+@interface MeViewController () <UIViewControllerRestoration, UITableViewDataSource, UITableViewDelegate, UIActionSheetDelegate>
 
 @property (nonatomic, strong) UITableView *tableView;
 @property (nonatomic, strong) MeHeaderView *headerView;
@@ -43,6 +44,11 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
 @end
 
 @implementation MeViewController
+
++ (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
+{
+    return [[self alloc] init];
+}
 
 #pragma mark - LifeCycle Methods
 
@@ -56,6 +62,8 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
     self = [super init];
     if (self) {
         self.title = NSLocalizedString(@"Me", @"Me page title");
+        self.restorationIdentifier = WPMeRestorationID;
+        self.restorationClass = [self class];
 
         // we want to observe for the account change notification even if the view is not visible
         [[NSNotificationCenter defaultCenter] addObserver:self

--- a/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
@@ -43,12 +43,14 @@ typedef enum {
     SettingsSectionCount
 } SettingsSection;
 
+static NSString * const WPSettingsRestorationID = @"WPSettingsRestorationID";
+
 static CGFloat const HorizontalMargin = 16.0;
 static CGFloat const MediaSizeControlHeight = 44.0;
 static CGFloat const MediaSizeControlOffset = 12.0;
 static CGFloat const SettingsRowHeight = 44.0;
 
-@interface SettingsViewController ()
+@interface SettingsViewController () <UIViewControllerRestoration>
 
 @property (nonatomic, assign) BOOL showInternalBetaSection;
 @property (nonatomic, strong) UISlider *mediaSizeSlider;
@@ -59,10 +61,27 @@ static CGFloat const SettingsRowHeight = 44.0;
 
 @implementation SettingsViewController
 
++ (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
+{
+    return [[self alloc] init];
+}
+
+- (instancetype)initWithStyle:(UITableViewStyle)style
+{
+    self = [super initWithStyle:style];
+    if (self) {
+        self.restorationIdentifier = WPSettingsRestorationID;
+        self.restorationClass = [self class];
+    }
+    return self;
+}
+
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
+
+#pragma mark - View lifecycle
 
 - (void)viewDidLoad
 {

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -21,8 +21,10 @@
 #import "HelpshiftUtils.h"
 #import "WPLogger.h"
 
+static NSString *const WPSupportRestorationID = @"WPSupportRestorationID";
+
 static NSString *const UserDefaultsFeedbackEnabled = @"wp_feedback_enabled";
-static NSString * const kExtraDebugDefaultsKey = @"extra_debug";
+static NSString *const kExtraDebugDefaultsKey = @"extra_debug";
 int const kActivitySpinnerTag = 101;
 int const kHelpshiftWindowTypeFAQs = 1;
 int const kHelpshiftWindowTypeConversation = 2;
@@ -31,7 +33,7 @@ static NSString *const FeedbackCheckUrl = @"https://api.wordpress.org/iphoneapp/
 
 static CGFloat const SupportRowHeight = 44.0f;
 
-@interface SupportViewController ()
+@interface SupportViewController () <UIViewControllerRestoration>
 
 @property (nonatomic, assign) BOOL feedbackEnabled;
 
@@ -45,6 +47,11 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
     SettingsSectionFeedback,
     SettingsSectionActivityLog,
 };
+
++ (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
+{
+    return [[self alloc] init];
+}
 
 + (void)checkIfFeedbackShouldBeEnabled
 {
@@ -101,6 +108,9 @@ typedef NS_ENUM(NSInteger, SettingsViewControllerSections)
     self = [super initWithStyle:UITableViewStyleGrouped];
     if (self) {
         self.title = NSLocalizedString(@"Support", @"");
+        self.restorationIdentifier = WPSupportRestorationID;
+        self.restorationClass = [self class];
+
         _feedbackEnabled = YES;
     }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -143,7 +143,6 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
 
 - (void)decodeRestorableStateWithCoder:(NSCoder *)coder
 {
-    // Set last selected tab bar item
     self.selectedIndex = [coder decodeIntegerForKey:WPTabBarSelectedIndexKey];
     [super decodeRestorableStateWithCoder:coder];
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -23,7 +23,7 @@
 
 static NSString * const WPTabBarRestorationID = @"WPTabBarID";
 static NSString * const WPBlogListNavigationRestorationID = @"WPBlogListNavigationID";
-static NSString * const WPReaderNavigationRestorationID= @"WPReaderNavigationID";
+static NSString * const WPReaderNavigationRestorationID = @"WPReaderNavigationID";
 static NSString * const WPNotificationsNavigationRestorationID  = @"WPNotificationsNavigationID";
 
 // used to restore the last selected tab bar item
@@ -162,6 +162,7 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
     _blogListNavigationController.tabBarItem.image = [mySitesTabBarImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
     _blogListNavigationController.tabBarItem.selectedImage = mySitesTabBarImage;
     _blogListNavigationController.restorationIdentifier = WPBlogListNavigationRestorationID;
+    _blogListNavigationController.restorationClass = [UINavigationController class];
     self.blogListViewController.title = NSLocalizedString(@"My Sites", @"");
     [_blogListNavigationController.tabBarItem setTitlePositionAdjustment:self.tabBarTitleOffset];
     _blogListNavigationController.tabBarItem.accessibilityIdentifier = NSLocalizedString(@"My Sites", @"");
@@ -191,6 +192,7 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
     _readerNavigationController.tabBarItem.image = [readerTabBarImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
     _readerNavigationController.tabBarItem.selectedImage = readerTabBarImage;
     _readerNavigationController.restorationIdentifier = WPReaderNavigationRestorationID;
+    _readerNavigationController.restorationClass = [UINavigationController class];
     [_readerNavigationController.tabBarItem setTitlePositionAdjustment:self.tabBarTitleOffset];
     _readerNavigationController.tabBarItem.title = NSLocalizedString(@"Reader", @"Description of the Reader tab");
 
@@ -253,6 +255,7 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
     _notificationsNavigationController.tabBarItem.image = [notificationsTabBarImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
     _notificationsNavigationController.tabBarItem.selectedImage = notificationsTabBarImage;
     _notificationsNavigationController.restorationIdentifier = WPNotificationsNavigationRestorationID;
+    _notificationsNavigationController.restorationClass = [UINavigationController class];
     self.notificationsViewController.title = NSLocalizedString(@"Notifications", @"");
     [_notificationsNavigationController.tabBarItem setTitlePositionAdjustment:self.tabBarTitleOffset];
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -26,6 +26,9 @@ static NSString * const WPBlogListNavigationRestorationID = @"WPBlogListNavigati
 static NSString * const WPReaderNavigationRestorationID= @"WPReaderNavigationID";
 static NSString * const WPNotificationsNavigationRestorationID  = @"WPNotificationsNavigationID";
 
+// used to restore the last selected tab bar item
+static NSString * const WPTabBarSelectedIndexKey = @"WPTabBarSelectedIndexKey";
+
 static NSString * const WPApplicationIconBadgeNumberKeyPath = @"applicationIconBadgeNumber";
 
 NSString * const WPNewPostURLParamTitleKey = @"title";
@@ -41,7 +44,7 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPadInPortrait 
 static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPadInLandscape = 236;
 static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLandscape = 93;
 
-@interface WPTabBarController () <UITabBarControllerDelegate>
+@interface WPTabBarController () <UITabBarControllerDelegate, UIViewControllerRestoration>
 
 @property (nonatomic, strong) BlogListViewController *blogListViewController;
 @property (nonatomic, strong) ReaderViewController *readerViewController;
@@ -60,6 +63,8 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
 
 @implementation WPTabBarController
 
+#pragma mark - Class methods
+
 + (instancetype)sharedInstance
 {
     static WPTabBarController *shared = nil;
@@ -70,6 +75,13 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
     return shared;
 }
 
++ (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
+{
+    return [[self class] sharedInstance];
+}
+
+#pragma mark - Instance methods
+
 - (instancetype)init
 {
     self = [super init];
@@ -77,6 +89,7 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
         [self setDelegate:self];
 
         [self setRestorationIdentifier:WPTabBarRestorationID];
+        [self setRestorationClass:[WPTabBarController class]];
         [[self tabBar] setTranslucent:NO];
         [[self tabBar] setAccessibilityIdentifier:NSLocalizedString(@"Main Navigation", @"")];
         // Create a background
@@ -117,6 +130,21 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [[UIApplication sharedApplication] removeObserver:self forKeyPath:WPApplicationIconBadgeNumberKeyPath];
+}
+
+#pragma mark - UIViewControllerRestoration methods
+
+- (void)encodeRestorableStateWithCoder:(NSCoder *)coder
+{
+    [coder encodeInteger:self.selectedIndex forKey:WPTabBarSelectedIndexKey];
+    [super encodeRestorableStateWithCoder:coder];
+}
+
+- (void)decodeRestorableStateWithCoder:(NSCoder *)coder
+{
+    // Set last selected tab bar item
+    self.selectedIndex = [coder decodeIntegerForKey:WPTabBarSelectedIndexKey];
+    [super decodeRestorableStateWithCoder:coder];
 }
 
 #pragma mark - Tab Bar Items

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -163,7 +163,6 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
     _blogListNavigationController.tabBarItem.image = [mySitesTabBarImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
     _blogListNavigationController.tabBarItem.selectedImage = mySitesTabBarImage;
     _blogListNavigationController.restorationIdentifier = WPBlogListNavigationRestorationID;
-    _blogListNavigationController.restorationClass = [UINavigationController class];
     self.blogListViewController.title = NSLocalizedString(@"My Sites", @"");
     [_blogListNavigationController.tabBarItem setTitlePositionAdjustment:self.tabBarTitleOffset];
     _blogListNavigationController.tabBarItem.accessibilityIdentifier = NSLocalizedString(@"My Sites", @"");
@@ -193,7 +192,6 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
     _readerNavigationController.tabBarItem.image = [readerTabBarImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
     _readerNavigationController.tabBarItem.selectedImage = readerTabBarImage;
     _readerNavigationController.restorationIdentifier = WPReaderNavigationRestorationID;
-    _readerNavigationController.restorationClass = [UINavigationController class];
     [_readerNavigationController.tabBarItem setTitlePositionAdjustment:self.tabBarTitleOffset];
     _readerNavigationController.tabBarItem.title = NSLocalizedString(@"Reader", @"Description of the Reader tab");
 
@@ -238,7 +236,6 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
     _meNavigationController.tabBarItem.selectedImage = meTabBarImage;
     _meNavigationController.tabBarItem.titlePositionAdjustment = self.tabBarTitleOffset;
     _meNavigationController.restorationIdentifier = WPMeNavigationRestorationID;
-    _meNavigationController.restorationClass = [UINavigationController class];
 
     return _meNavigationController;
 }
@@ -257,7 +254,6 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
     _notificationsNavigationController.tabBarItem.image = [notificationsTabBarImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
     _notificationsNavigationController.tabBarItem.selectedImage = notificationsTabBarImage;
     _notificationsNavigationController.restorationIdentifier = WPNotificationsNavigationRestorationID;
-    _notificationsNavigationController.restorationClass = [UINavigationController class];
     self.notificationsViewController.title = NSLocalizedString(@"Notifications", @"");
     [_notificationsNavigationController.tabBarItem setTitlePositionAdjustment:self.tabBarTitleOffset];
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -24,6 +24,7 @@
 static NSString * const WPTabBarRestorationID = @"WPTabBarID";
 static NSString * const WPBlogListNavigationRestorationID = @"WPBlogListNavigationID";
 static NSString * const WPReaderNavigationRestorationID = @"WPReaderNavigationID";
+static NSString * const WPMeNavigationRestorationID = @"WPMeNavigationID";
 static NSString * const WPNotificationsNavigationRestorationID  = @"WPNotificationsNavigationID";
 
 // used to restore the last selected tab bar item
@@ -231,12 +232,13 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetForIPhone6PlusInLa
     }
 
     self.meViewController = [MeViewController new];
-    UIImage *meTabBarImage = [UIImage imageNamed:@"icon-tab-me"];
-    self.meViewController.tabBarItem.image = [meTabBarImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
-    self.meViewController.tabBarItem.selectedImage = meTabBarImage;
-    self.meViewController.tabBarItem.titlePositionAdjustment = self.tabBarTitleOffset;
-    self.meViewController.title = NSLocalizedString(@"Me", @"Me page title");
     _meNavigationController = [[UINavigationController alloc] initWithRootViewController:self.meViewController];
+    UIImage *meTabBarImage = [UIImage imageNamed:@"icon-tab-me"];
+    _meNavigationController.tabBarItem.image = [meTabBarImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+    _meNavigationController.tabBarItem.selectedImage = meTabBarImage;
+    _meNavigationController.tabBarItem.titlePositionAdjustment = self.tabBarTitleOffset;
+    _meNavigationController.restorationIdentifier = WPMeNavigationRestorationID;
+    _meNavigationController.restorationClass = [UINavigationController class];
 
     return _meNavigationController;
 }


### PR DESCRIPTION
Fixes #3723. This PR adds the restoration to `WPTabBarController` and it now opens up with the last selected tab. I've also added restoration to `MeViewController`, `SettingsViewController` and `SupportViewController`. There are a lot of pages that currently doesn't support restoration, we probably should add them in the future.

I didn't know this before, so I am sharing here just in case it's not common knowledge: "Be aware that the system automatically deletes an app’s preserved state when the user force quits the app." http://stackoverflow.com/questions/12718341/ios-6-saving-restoring-app-state-feature

@sendhil Can I bother you with a review? Thanks!