### PR TITLE
Assign current date for existing post if date is nil.

### DIFF
--- a/WordPress/Classes/Networking/PostServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.m
@@ -268,6 +268,7 @@
 {
     NSParameterAssert(post.title != nil);
     NSParameterAssert(post.content != nil);
+    BOOL existingPost = ([post.postID longLongValue] > 0);
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     
     if (post.title) {
@@ -283,6 +284,8 @@
 
     if (post.date) {
         parameters[@"date"] = [post.date WordPressComJSONString];
+    } else if (existingPost) {
+        parameters[@"date"] = [[NSDate date] WordPressComJSONString];
     }
     if (post.excerpt) {
         parameters[@"excerpt"] = post.excerpt;


### PR DESCRIPTION
Fixes publish immediately for wpcom scheduled posts.

Closes #3732 

Needs Review: @bummytime 