### PR TITLE
Remove thumbnail field from database.

### DIFF
--- a/WordPress/Classes/Models/Media.h
+++ b/WordPress/Classes/Models/Media.h
@@ -41,7 +41,6 @@ typedef NS_ENUM(NSUInteger, MediaOrientation) {
 @property (nonatomic, strong) NSString * shortcode;
 @property (nonatomic, strong) NSNumber * length;
 @property (nonatomic, strong) NSString * title;
-@property (nonatomic, strong) NSData * thumbnail;
 @property (nonatomic, strong) NSString * filename;
 @property (nonatomic, strong) NSNumber * filesize;
 @property (nonatomic, strong) NSNumber * width;

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -25,7 +25,6 @@
 @dynamic width;
 @dynamic length;
 @dynamic title;
-@dynamic thumbnail;
 @dynamic height;
 @dynamic filename;
 @dynamic filesize;

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -104,7 +104,6 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
             Media *media = [self newMediaForPost:post];
             media.filename = [mediaPath lastPathComponent];
             media.localURL = mediaPath;
-            media.thumbnail = thumbnailData;
             [thumbnailData writeToFile:media.thumbnailLocalURL atomically:NO];
             NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:mediaPath error:nil];
             // This is kind of lame, but we've been storing file size as KB so far

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1003,7 +1003,7 @@ UIImagePickerControllerDelegate, UINavigationControllerDelegate, UIPopoverContro
                               [WPError showAlertWithTitle:NSLocalizedString(@"Couldn't upload featured image", @"The title for an alert that says to the user that the featured image he selected couldn't be uploaded.") message:error.localizedDescription];
                               DDLogError(@"Couldn't upload featured image: %@", [error localizedDescription]);
                           }];
-        [progress setUserInfoObject:[UIImage imageWithData:media.thumbnail] forKey:WPProgressImageThumbnailKey];
+        [progress setUserInfoObject:[UIImage imageWithContentsOfFile:media.thumbnailLocalURL] forKey:WPProgressImageThumbnailKey];
         progress.localizedDescription = NSLocalizedString(@"Uploading...",@"Label to show while uploading media to server");
         progress.kind = NSProgressKindFile;
         [progress setUserInfoObject:NSProgressFileOperationKindCopying forKey:NSProgressFileOperationKindKey];

--- a/WordPress/Classes/WordPress.xcdatamodeld/.xccurrentversion
+++ b/WordPress/Classes/WordPress.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>WordPress 30.xcdatamodel</string>
+	<string>WordPress 31.xcdatamodel</string>
 </dict>
 </plist>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 31.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 31.xcdatamodel/contents
@@ -245,6 +245,9 @@
         <attribute name="shortcode" optional="YES" attributeType="String">
             <userInfo/>
         </attribute>
+        <attribute name="thumbnail" optional="YES" attributeType="Binary">
+            <userInfo/>
+        </attribute>
         <attribute name="title" optional="YES" attributeType="String">
             <userInfo/>
         </attribute>
@@ -389,7 +392,7 @@
         <element name="Blog" positionX="0" positionY="0" width="128" height="495"/>
         <element name="Category" positionX="0" positionY="0" width="128" height="120"/>
         <element name="Comment" positionX="0" positionY="0" width="128" height="343"/>
-        <element name="Media" positionX="0" positionY="0" width="128" height="330"/>
+        <element name="Media" positionX="0" positionY="0" width="128" height="343"/>
         <element name="Meta" positionX="9" positionY="153" width="128" height="105"/>
         <element name="Notification" positionX="18" positionY="162" width="128" height="255"/>
         <element name="Page" positionX="0" positionY="0" width="128" height="60"/>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1520,6 +1520,7 @@
 		FFAC890F1A96A85800CC06AC /* NSProcessInfo+Util.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSProcessInfo+Util.m"; sourceTree = "<group>"; };
 		FFB7B81C1A0012E80032E723 /* WordPressTestCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressTestCredentials.m; sourceTree = "<group>"; };
 		FFB7B81D1A0012E80032E723 /* WordPressComApiCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressComApiCredentials.m; sourceTree = "<group>"; };
+		FFE69A2C1B1D5AB40073C2EB /* WordPress 31.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 31.xcdatamodel"; sourceTree = "<group>"; };
 		FFF96F8219EBE7FB00DFC821 /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FFF96F8519EBE7FB00DFC821 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FFF96F8F19EBE81F00DFC821 /* CommentsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommentsTests.m; sourceTree = "<group>"; };
@@ -5229,6 +5230,7 @@
 		E125443B12BF5A7200D87A0A /* WordPress.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				FFE69A2C1B1D5AB40073C2EB /* WordPress 31.xcdatamodel */,
 				E1939C671B15B4D2001AFEF7 /* WordPress 30.xcdatamodel */,
 				5D91D9021AE1AD12000BF163 /* WordPress 29.xcdatamodel */,
 				B54810F61AA656B40081B54D /* WordPress 28.xcdatamodel */,
@@ -5260,7 +5262,7 @@
 				8350E15911D28B4A00A7B073 /* WordPress.xcdatamodel */,
 				E125443D12BF5A7200D87A0A /* WordPress 2.xcdatamodel */,
 			);
-			currentVersion = E1939C671B15B4D2001AFEF7 /* WordPress 30.xcdatamodel */;
+			currentVersion = FFE69A2C1B1D5AB40073C2EB /* WordPress 31.xcdatamodel */;
 			name = WordPress.xcdatamodeld;
 			path = Classes/WordPress.xcdatamodeld;
 			sourceTree = "<group>";


### PR DESCRIPTION
Removing this field from database. In the future thumbnails will be stored in a file inside local folder instead of the database.

Needs Review: @diegoreymendez 