### PR TITLE
Update to latest stats 0.3.5

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -32,7 +32,7 @@ pod 'Simperium', '0.7.9'
 pod 'WordPressApi', '~> 0.3.4'
 pod 'WordPress-iOS-Shared', '0.3.2'
 pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => '9812b6c9a699cd654ef5c0cffe9bed9f91c06782'
-pod 'WordPressCom-Stats-iOS', '0.3.4'
+pod 'WordPressCom-Stats-iOS', '0.3.5'
 pod 'WordPressCom-Analytics-iOS', '0.0.31'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '303b8068530389ea87afde38b77466d685fe3210'
@@ -41,7 +41,7 @@ pod 'ReactiveCocoa', '~> 2.4.7'
 pod 'FormatterKit', '~> 1.8.0'
 
 target 'WordPressTodayWidget', :exclusive => true do
-  pod 'WordPressCom-Stats-iOS', '0.3.4'
+  pod 'WordPressCom-Stats-iOS', '0.3.5'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -145,7 +145,7 @@ PODS:
     - AFNetworking (~> 2.5.1)
     - wpxmlrpc (~> 0.7)
   - WordPressCom-Analytics-iOS (0.0.31)
-  - WordPressCom-Stats-iOS (0.3.4):
+  - WordPressCom-Stats-iOS (0.3.5):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (~> 2.0)
     - NSObject-SafeExpectations (= 0.0.2)
@@ -196,7 +196,7 @@ DEPENDENCIES:
   - WordPress-iOS-Shared (= 0.3.2)
   - WordPressApi (~> 0.3.4)
   - WordPressCom-Analytics-iOS (= 0.0.31)
-  - WordPressCom-Stats-iOS (= 0.3.4)
+  - WordPressCom-Stats-iOS (= 0.3.5)
   - WPMediaPicker (~> 0.4.1)
   - wpxmlrpc (~> 0.8)
 
@@ -282,7 +282,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Shared: bd0506db9b824611246f35e774832ecbc18fc45e
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
   WordPressCom-Analytics-iOS: a35692b0bb5a1d5081da2481614a66663dfb091f
-  WordPressCom-Stats-iOS: 63269dc52c52087184eaacbc1ad9d502fd189450
+  WordPressCom-Stats-iOS: 41767306edc05ee41c8b9438481c32884569530f
   WPMediaPicker: 010e0ecab215bf837ab4cc42e3223d5abd738a4d
   wpxmlrpc: 053c9cbed13dcec08515a4ffeb51780f6e858cc7
 


### PR DESCRIPTION
Closes #3775 

Updates to the latest stats release. Included with this release:
* Removes Storyboard warning (cartwheel @koke)
* Improves user interface - aligned colors with rest of the app
* Added more bars to iPhone and iPad views
* New progress loading indicator

Needs Review: @sendhil