### PR TITLE
Only show blogs hosted at WordPress.com when reblogging.

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -76,7 +76,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
 {
     Blog *blog = [self lastUsedOrPrimaryBlog];
 
-    if (!blog) {
+    if (![blog supports:feature]) {
         blog = [self firstBlogThatSupports:feature];
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/WPComBlogSelectorViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/WPComBlogSelectorViewController.h
@@ -1,5 +1,8 @@
 #import "BlogSelectorViewController.h"
 
+/**
+ A version of the blog selector that shows only blogs hosted on WordPress.com.
+ */
 @interface WPComBlogSelectorViewController : BlogSelectorViewController
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/WPComBlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/WPComBlogSelectorViewController.m
@@ -4,11 +4,12 @@
 
 - (NSPredicate *)fetchRequestPredicate
 {
+    NSString *predicateString = @"account.isWpcom = YES AND isJetpack = NO";
     if ([self.tableView isEditing]) {
-        return [NSPredicate predicateWithFormat:@"account.isWpcom = YES"];
+        predicateString = [NSString stringWithFormat:@"%@ AND visible = YES", predicateString];
     }
 
-    return [NSPredicate predicateWithFormat:@"account.isWpcom = YES AND visible = YES"];
+    return [NSPredicate predicateWithFormat:predicateString];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Reader/RebloggingViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/RebloggingViewController.m
@@ -4,7 +4,7 @@
 #import "ReaderPost.h"
 #import "ReaderPostSimpleContentView.h"
 #import "ReaderPostService.h"
-#import "BlogSelectorViewController.h"
+#import "WPComBlogSelectorViewController.h"
 #import "WPBlogSelectorButton.h"
 #import "BlogService.h"
 #import "ContextManager.h"
@@ -391,9 +391,9 @@ CGFloat const ReblogViewTextBottomInset = 30;
         dismissHandler();
     };
 
-    BlogSelectorViewController *vc = [[BlogSelectorViewController alloc] initWithSelectedBlogObjectID:self.blog.objectID
-                                                                                   selectedCompletion:selectedCompletion
-                                                                                     cancelCompletion:dismissHandler];
+    WPComBlogSelectorViewController *vc = [[WPComBlogSelectorViewController alloc] initWithSelectedBlogObjectID:self.blog.objectID
+                                                                                             selectedCompletion:selectedCompletion
+                                                                                               cancelCompletion:dismissHandler];
     vc.title = NSLocalizedString(@"Select Site", @"");
 
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];


### PR DESCRIPTION
Closes #3724 

To test:
1) Be signed in with a WordPress.com account and have a Jetpack connected blog.
2) Open the Reader and view Freshly Pressed
3) Tap the reblog button on a cell. 
4) Tap the blog selector to choose the target for the reblog. 
The Jetpack connected blog should not appear in the list. 

Needs Review: @koke 