### PR TITLE
Fixes Notifications Unit Tests

### DIFF
--- a/WordPress/WordPressTest/NotificationTests.m
+++ b/WordPress/WordPressTest/NotificationTests.m
@@ -116,22 +116,22 @@
     XCTAssertNotNil(note.metaSiteID, @"Missing siteID");
 }
 
-- (void)testFollowerNotificationContainsUserBlocksInTheBody
+- (void)testFollowerNotificationContainsUserAndFooterBlocksInTheBody
 {
     Notification *note = [self loadFollowerNotification];
     
     // Note: Account for 'View All Followers'
     for (NotificationBlockGroup *group in note.bodyBlockGroups) {
-        XCTAssertTrue(group.type == NoteBlockGroupTypeUser || group.type == NoteBlockGroupTypeText);
+        XCTAssertTrue(group.type == NoteBlockGroupTypeUser || group.type == NoteBlockGroupTypeFooter);
     }
 }
 
-- (void)testFollowerNotificationContainsTextBlockWithFollowRangeAtTheEnd
+- (void)testFollowerNotificationContainsFooterBlockWithFollowRangeAtTheEnd
 {
     Notification *note = [self loadFollowerNotification];
     
     NotificationBlockGroup *lastGroup = note.bodyBlockGroups.lastObject;
-    XCTAssertTrue(lastGroup.type == NoteBlockGroupTypeText);
+    XCTAssertTrue(lastGroup.type == NoteBlockGroupTypeFooter);
     
     NotificationBlock *block = [lastGroup.blocks firstObject];
     XCTAssertNotNil(block.text, @"Missing block text");


### PR DESCRIPTION
As a side effect of #3699, Notifications Unit Tests broke.

@SergioEstevao may i bother you with a quick review?

Thank you!

-- 

Needs Review: @SergioEstevao 