### PR TITLE
Adds a missing call to super.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -390,6 +390,8 @@ EditImageDetailsViewControllerDelegate
 
 - (void)decodeRestorableStateWithCoder:(NSCoder *)coder
 {
+    [super decodeRestorableStateWithCoder:coder];
+    
     BOOL ownsPost = [[self class] decodeOwnsPostFromCoder:coder];
     
     self.ownsPost = ownsPost;


### PR DESCRIPTION
Just a small bug fix.  Can't be really tested because the app wasn't breaking because of this - but it's nevertheless correct to call `super` here.

**How to test restoration is working fine:**
1. Launch the app
2. Open the editor and create a new post
3. Send app to background
4. Stop the app from xcode
5. Run the app again

Make sure the post editor is restored.