### PR TITLE
Fixes Invalid PushAuthenticationManager Alert Button

### DIFF
--- a/WordPress/Classes/Utility/PushAuthenticationManager.swift
+++ b/WordPress/Classes/Utility/PushAuthenticationManager.swift
@@ -128,7 +128,7 @@ import UIKit
         let title               = NSLocalizedString("Login Request Expired", comment: "Login Request Expired")
         let message             = NSLocalizedString("The login request has expired. Log in to WordPress.com to try again.",
                                                     comment: "WordPress.com Push Authentication Expired message")
-        let acceptButtonTitle   = NSLocalizedString("Approve", comment: "Approve action. Verb")
+        let acceptButtonTitle   = NSLocalizedString("Accept", comment: "Accept. Verb")
         
         self.alertViewProxy.showWithTitle(title,
             message:            message,


### PR DESCRIPTION
#### Steps:
1. Install WPiOS 5.3 on your phone
2. Log into WordPress.com, in your web browser, with an a8c account that has 2FA enabled
3. A Push Notification should arrive shortly
4. Wait ~20 minutes before tapping on it

#### Expected: 
An alertView should show up onscreen, indicating that the login request has expired. The button text should say **Accept**.

Props to @dmsnell for spotting this one.

Needs Review: @sendhil (thanks in advance Sendhil!)
