### PR TITLE
Issues/3797 change author filter

### DIFF
--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -70,6 +70,43 @@ extern NSString * const PostServiceTypeAny;
 
  @param postType The type (post or page) of post to sync
  @param postStatus An array of post status strings.
+ @param blog The blog that has the posts.
+ @param success A success block
+ @param failure A failure block
+ */
+- (void)syncPostsOfType:(NSString *)postType
+           withStatuses:(NSArray *)postStatus
+                forBlog:(Blog *)blog
+                success:(void (^)(BOOL hasMore))success
+                failure:(void (^)(NSError *))failure;
+
+/**
+ Sync additional posts of the specific status types from the specified blog
+ Please note that success and/or failure are called in the context of the
+ NSManagedObjectContext supplied when the PostService was initialized, and may not
+ run on the main thread.
+
+ @param postType The type (post or page) of post to sync
+ @param postStatus An array of post status strings.
+ @param blog The blog that has the posts.
+ @param success A success block
+ @param failure A failure block
+ */
+
+- (void)loadMorePostsOfType:(NSString *)postType
+               withStatuses:(NSArray *)postStatus
+                    forBlog:(Blog *)blog
+                    success:(void (^)(BOOL hasMore))success
+                    failure:(void (^)(NSError *))failure;
+
+/**
+ Sync an initial batch of posts of the specific status types from the specified blog
+ Please note that success and/or failure are called in the context of the
+ NSManagedObjectContext supplied when the PostService was initialized, and may not
+ run on the main thread.
+
+ @param postType The type (post or page) of post to sync
+ @param postStatus An array of post status strings.
  @param authorID The user ID of a specific author, or nil if everyone's posts should be synced.
  @param blog The blog that has the posts.
  @param success A success block

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -70,12 +70,14 @@ extern NSString * const PostServiceTypeAny;
 
  @param postType The type (post or page) of post to sync
  @param postStatus An array of post status strings.
+ @param authorID The user ID of a specific author, or nil if everyone's posts should be synced.
  @param blog The blog that has the posts.
  @param success A success block
  @param failure A failure block
  */
 - (void)syncPostsOfType:(NSString *)postType
            withStatuses:(NSArray *)postStatus
+               byAuthor:(NSNumber *)authorID
                 forBlog:(Blog *)blog
                 success:(void (^)(BOOL hasMore))success
                 failure:(void (^)(NSError *))failure;
@@ -88,6 +90,7 @@ extern NSString * const PostServiceTypeAny;
  
  @param postType The type (post or page) of post to sync
  @param postStatus An array of post status strings.
+ @param authorID The user ID of a specific author, or nil if everyone's posts should be synced.
  @param blog The blog that has the posts.
  @param success A success block
  @param failure A failure block
@@ -95,6 +98,7 @@ extern NSString * const PostServiceTypeAny;
 
 - (void)loadMorePostsOfType:(NSString *)postType
                withStatuses:(NSArray *)postStatus
+                   byAuthor:(NSNumber *)authorID
                     forBlog:(Blog *)blog
                     success:(void (^)(BOOL hasMore))success
                     failure:(void (^)(NSError *))failure;

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -130,7 +130,8 @@ const NSInteger PostServiceNumberToFetch = 40;
                            if (blogInContext) {
                                [self mergePosts:posts
                                          ofType:postType
-                                   withStatuses:nil byAuthor:nil
+                                   withStatuses:nil
+                                       byAuthor:nil
                                         forBlog:blog
                                   purgeExisting:YES
                               completionHandler:success];
@@ -194,6 +195,24 @@ const NSInteger PostServiceNumberToFetch = 40;
             }];
         }
     }];
+}
+
+- (void)syncPostsOfType:(NSString *)postType
+           withStatuses:(NSArray *)postStatus
+                forBlog:(Blog *)blog
+                success:(void (^)(BOOL hasMore))success
+                failure:(void (^)(NSError *))failure
+{
+    [self syncPostsOfType:postType withStatuses:postStatus byAuthor:nil forBlog:blog success:success failure:failure];
+}
+
+- (void)loadMorePostsOfType:(NSString *)postType
+               withStatuses:(NSArray *)postStatus
+                    forBlog:(Blog *)blog
+                    success:(void (^)(BOOL hasMore))success
+                    failure:(void (^)(NSError *))failure
+{
+    [self loadMorePostsOfType:postType withStatuses:postStatus byAuthor:nil forBlog:blog success:success failure:failure];
 }
 
 - (void)syncPostsOfType:(NSString *)postType

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -701,7 +701,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 
 - (BOOL)canFilterByAuthor
 {
-    return [self.blog isMultiAuthor] && self.blog.account.userID && [self.blog supports:BlogFeatureWPComRESTAPI];
+    return [self.blog isMultiAuthor] && self.blog.account.userID && [self.blog isHostedAtWPcom];
 }
 
 - (BOOL)shouldShowOnlyMyPosts

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -390,9 +390,10 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 
     PostListFilter *filter = [self currentPostListFilter];
     NSArray *postStatus = filter.statuses;
+    NSNumber *author = [self shouldShowOnlyMyPosts] ? self.blog.account.userID : nil;
     __weak __typeof(self) weakSelf = self;
     PostService *postService = [[PostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
-    [postService syncPostsOfType:PostServiceTypePost withStatuses:postStatus forBlog:self.blog success:^(BOOL hasMore){
+    [postService syncPostsOfType:PostServiceTypePost withStatuses:postStatus byAuthor:author forBlog:self.blog success:^(BOOL hasMore){
         if  (success) {
             [weakSelf setHasMore:hasMore forFilter:filter];
             success(hasMore);
@@ -412,9 +413,10 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     [self.postListFooterView showSpinner:YES];
     PostListFilter *filter = [self currentPostListFilter];
     NSArray *postStatus = filter.statuses;
+    NSNumber *author = [self shouldShowOnlyMyPosts] ? self.blog.account.userID : nil;
     __weak __typeof(self) weakSelf = self;
     PostService *postService = [[PostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
-    [postService loadMorePostsOfType:PostServiceTypePost withStatuses:postStatus forBlog:self.blog success:^(BOOL hasMore){
+    [postService loadMorePostsOfType:PostServiceTypePost withStatuses:postStatus byAuthor:author forBlog:self.blog success:^(BOOL hasMore){
         if (success) {
             [weakSelf setHasMore:hasMore forFilter:filter];
             success(hasMore);
@@ -696,6 +698,28 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 
 
 #pragma mark - Filter related
+
+- (BOOL)canFilterByAuthor
+{
+    return [self.blog isMultiAuthor] && self.blog.account.userID && [self.blog supports:BlogFeatureWPComRESTAPI];
+}
+
+- (BOOL)shouldShowOnlyMyPosts
+{
+    PostAuthorFilter filter = [self currentPostAuthorFilter];
+    return filter == PostAuthorFilterMine;
+}
+
+- (PostAuthorFilter)currentPostAuthorFilter
+{
+    return PostAuthorFilterEveryone;
+}
+
+- (void)setCurrentPostAuthorFilter:(PostAuthorFilter)filter
+{
+    // Noop. The default implementation is read only.
+    // Subclasses may override the getter and setter for their own filter storage.
+}
 
 - (PostListFilter *)currentPostListFilter
 {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
@@ -15,6 +15,11 @@
 #import <WordPress-iOS-Shared/WPStyleGuide.h>
 #import "WordPress-swift.h"
 
+typedef NS_ENUM(NSUInteger, PostAuthorFilter) {
+    PostAuthorFilterMine,
+    PostAuthorFilterEveryone,
+};
+
 extern const NSTimeInterval PostsControllerRefreshInterval;
 extern const NSTimeInterval PostSearchBarAnimationDuration;
 extern const NSInteger HTTPErrorCodeForbidden;
@@ -54,6 +59,10 @@ extern const CGFloat SearchWrapperViewLandscapeHeight;
 @property (nonatomic, strong) NSArray *postListFilters;
 @property (nonatomic, strong) NSMutableArray *recentlyTrashedPostIDs; // IDs of trashed posts. Cleared on refresh or when filter changes.
 
+- (BOOL)canFilterByAuthor;
+- (BOOL)shouldShowOnlyMyPosts;
+- (PostAuthorFilter)currentPostAuthorFilter;
+- (void)setCurrentPostAuthorFilter:(PostAuthorFilter)filter;
 - (PostListFilter *)currentPostListFilter;
 - (CGFloat)heightForFooterView;
 - (void)publishPost:(AbstractPost *)apost;

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
@@ -59,6 +59,7 @@ extern const CGFloat SearchWrapperViewLandscapeHeight;
 @property (nonatomic, strong) NSArray *postListFilters;
 @property (nonatomic, strong) NSMutableArray *recentlyTrashedPostIDs; // IDs of trashed posts. Cleared on refresh or when filter changes.
 
+- (void)syncItemsWithUserInteraction:(BOOL)userInteraction;
 - (BOOL)canFilterByAuthor;
 - (BOOL)shouldShowOnlyMyPosts;
 - (PostAuthorFilter)currentPostAuthorFilter;

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -517,8 +517,10 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     }
     [[NSUserDefaults standardUserDefaults] setObject:@(filter) forKey:CurrentPostAuthorFilterKey];
     [NSUserDefaults resetStandardUserDefaults];
+
     [self.recentlyTrashedPostIDs removeAllObjects];
     [self updateAndPerformFetchRequestRefreshingCachedRowHeights];
+    [self syncItemsWithUserInteraction:NO];
 }
 
 - (NSString *)keyForCurrentListStatusFilter

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -13,11 +13,6 @@
 #import "WPToast.h"
 #import <WordPress-iOS-Shared/UIImage+Util.h>
 
-typedef NS_ENUM(NSUInteger, PostAuthorFilter) {
-    PostAuthorFilterMine,
-    PostAuthorFilterEveryone,
-};
-
 static NSString * const PostCardTextCellIdentifier = @"PostCardTextCellIdentifier";
 static NSString * const PostCardImageCellIdentifier = @"PostCardImageCellIdentifier";
 static NSString * const PostCardThumbCellIdentifier = @"PostCardThumbCellIdentifier";
@@ -250,11 +245,6 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     }
 }
 
-- (BOOL)canFilterByAuthor
-{
-    return [self.blog isMultiAuthor] && self.blog.account.userID && [self.blog supports:BlogFeatureWPComRESTAPI];
-}
-
 
 #pragma mark - Actions
 
@@ -293,7 +283,7 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     }
     [predicates addObject:filterPredicate];
 
-    if (self.blog.isMultiAuthor && ![self shouldShowPostsForEveryone] && [self.blog.account.userID integerValue] > 0) {
+    if ([self shouldShowOnlyMyPosts]) {
         NSPredicate *authorPredicate = [NSPredicate predicateWithFormat:@"authorID = %@", self.blog.account.userID];
         [predicates addObject:authorPredicate];
     }
@@ -502,12 +492,6 @@ static const CGFloat PostListHeightForFooterView = 34.0;
 
 
 #pragma mark - Filter related
-
-- (BOOL)shouldShowPostsForEveryone
-{
-    PostAuthorFilter filter = [self currentPostAuthorFilter];
-    return filter == PostAuthorFilterEveryone;
-}
 
 - (PostAuthorFilter)currentPostAuthorFilter
 {


### PR DESCRIPTION
This PR fixes a few issues around filtering posts by author.  Previously we were just doing a local filter with core data. With this patch we'll apply the author filter to API requests as well. 

Test 1:
Sign into your wpcom account and view a multi-author blog like Mobile Manger.
Toggle the author filter.
Posts should automatically be synced for that filter.
Confirm that Pages always show all pages regardless of author.

Test 2:
View a multi-author Jetpack connected blog 
Confirm that the author filter does not appear
Confirm that everyone's posts are present.
Confirm that Pages always show all pages regardless of author.

Test 3:
View a self-hosted blog (no Jetpack)
Confirm that the author filter does not appear
Confirm that everyone's posts are present.
Confirm that Pages always show all pages regardless of author.

Closes #3726, #3797

Needs Review: @koke 