### PR TITLE
Issues/3786 issues with local posts

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -1,10 +1,11 @@
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
 #import "BasePost.h"
+#import "WPPostContentViewProvider.h"
 
 @class Media;
 
-@interface AbstractPost : BasePost
+@interface AbstractPost : BasePost<WPPostContentViewProvider>
 
 // Relationships
 @property (nonatomic, strong) Blog *blog;

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -1,6 +1,7 @@
 #import "AbstractPost.h"
 #import "Media.h"
 #import "ContextManager.h"
+#import "NSDate+StringFormatting.h"
 
 @implementation AbstractPost
 
@@ -230,17 +231,73 @@
     return featuredMedia;
 }
 
-#pragma mark - WPContentViewProvider protocol
 
-- (NSString *)blogNameForDisplay
+#pragma mark - WPPostContentViewProvider protocol
+
+- (NSString *)authorNameForDisplay
 {
-    return self.blog.blogName;
+    return self.author;
 }
 
 - (NSURL *)avatarURLForDisplay
 {
     return [NSURL URLWithString:self.blog.blavatarUrl];
 }
+
+- (NSString *)blogNameForDisplay
+{
+    return self.blog.blogName;
+}
+
+- (NSURL *)blogURL
+{
+    return [NSURL URLWithString:self.blog.url];
+}
+
+- (NSString *)blogURLForDisplay
+{
+    return self.blog.displayURL;
+}
+
+- (NSString *)blavatarForDisplay
+{
+    return self.blog.blavatarUrl;
+}
+
+- (NSString *)contentPreviewForDisplay
+{
+    return self.mt_excerpt;
+}
+
+- (NSString *)dateStringForDisplay
+{
+    NSDate *date = [self dateCreated];
+    if (!date) {
+        return NSLocalizedString(@"Publish Immediately",@"A short phrase indicating a post is due to be immedately published.");
+    }
+    return [date shortString];
+}
+
+- (BOOL)supportsStats
+{
+    return [self.blog supports:BlogFeatureStats] && [self hasRemote];
+}
+
+- (BOOL)isPrivate
+{
+    return self.blog.isPrivate;
+}
+
+- (BOOL)isMultiAuthorBlog
+{
+    return self.blog.isMultiAuthor;
+}
+
+- (BOOL)isUploading
+{
+    return self.remoteStatus == AbstractPostRemoteStatusPushing;
+}
+
 
 #pragma mark - Post
 

--- a/WordPress/Classes/Models/Post.h
+++ b/WordPress/Classes/Models/Post.h
@@ -4,7 +4,7 @@
 
 @class Coordinate;
 
-@interface Post : AbstractPost <WPPostContentViewProvider>
+@interface Post : AbstractPost
 
 ///-------------------------------
 /// @name Specific Post properties

--- a/WordPress/Classes/Models/Post.m
+++ b/WordPress/Classes/Models/Post.m
@@ -185,37 +185,6 @@
 
 #pragma mark - WPPostContentViewProvider Methods
 
-- (NSString *)authorNameForDisplay
-{
-    return self.author;
-}
-
-- (NSURL *)blogURL
-{
-    return [NSURL URLWithString:self.blog.url];
-}
-
-- (NSString *)blogURLForDisplay
-{
-    return self.blog.displayURL;
-}
-
-- (NSInteger)numberOfComments
-{
-    if (self.commentCount) {
-        return [self.commentCount integerValue];
-    }
-    return 0;
-}
-
-- (NSInteger)numberOfLikes
-{
-    if (self.likeCount) {
-        return [self.likeCount integerValue];
-    }
-    return 0;
-}
-
 - (NSString *)titleForDisplay
 {
     NSString *title = [self.postTitle stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] ?: @"";
@@ -226,66 +195,12 @@
     return title;
 }
 
-- (NSString *)authorForDisplay
-{
-    return self.author;
-}
-
-- (NSString *)blogNameForDisplay
-{
-    return self.blog.blogName;
-}
-
-- (NSString *)contentForDisplay
-{
-    return self.content;
-}
-
 - (NSString *)contentPreviewForDisplay
 {
     if (self.storedContentPreviewForDisplay == nil) {
         [self buildContentPreview];
     }
     return self.storedContentPreviewForDisplay;
-}
-
-- (NSString *)gravatarEmailForDisplay
-{
-    return nil;
-}
-
-- (NSString *)blavatarForDisplay
-{
-    return self.blog.blavatarUrl;
-}
-
-- (NSURL *)avatarURLForDisplay
-{
-    return nil;
-}
-
-- (NSString *)dateStringForDisplay
-{
-    NSDate *date = [self dateCreated];
-    if (!date) {
-        return NSLocalizedString(@"Publish Immediately",@"A short phrase indicating a post is due to be immedately published.");
-    }
-    return [date shortString];
-}
-
-- (BOOL)supportsStats
-{
-    return [self.blog supports:BlogFeatureStats] && [self hasRemote];
-}
-
-- (BOOL)isPrivate
-{
-    return self.blog.isPrivate;
-}
-
-- (BOOL)isMultiAuthorBlog
-{
-    return self.blog.isMultiAuthor;
 }
 
 - (NSString *)statusForDisplay
@@ -305,15 +220,27 @@
     return statusString;
 }
 
-- (BOOL)isUploading
-{
-    return self.remoteStatus == AbstractPostRemoteStatusPushing;
-}
-
 - (NSURL *)featuredImageURLForDisplay
 {
     NSURL *url = [NSURL URLWithString:self.pathForDisplayImage];
     return url;
 }
+
+- (NSInteger)numberOfComments
+{
+    if (self.commentCount) {
+        return [self.commentCount integerValue];
+    }
+    return 0;
+}
+
+- (NSInteger)numberOfLikes
+{
+    if (self.likeCount) {
+        return [self.likeCount integerValue];
+    }
+    return 0;
+}
+
 
 @end

--- a/WordPress/Classes/Models/Post.m
+++ b/WordPress/Classes/Models/Post.m
@@ -261,7 +261,7 @@
 
 - (BOOL)supportsStats
 {
-    return [self.blog supports:BlogFeatureStats];
+    return [self.blog supports:BlogFeatureStats] && [self hasRemote];
 }
 
 - (BOOL)isPrivate

--- a/WordPress/Classes/Models/WPPostContentViewProvider.h
+++ b/WordPress/Classes/Models/WPPostContentViewProvider.h
@@ -20,6 +20,7 @@
 
 // Meta accessors
 - (NSDate *)dateForDisplay;
+- (NSString *)dateStringForDisplay;
 - (NSString *)status;
 - (NSString *)statusForDisplay;
 - (BOOL)unreadStatusForDisplay;

--- a/WordPress/Classes/Models/WPPostContentViewProvider.h
+++ b/WordPress/Classes/Models/WPPostContentViewProvider.h
@@ -16,7 +16,6 @@
 - (NSString *)titleForDisplay;
 - (NSString *)contentForDisplay;
 - (NSString *)contentPreviewForDisplay;
-- (NSURL *)featuredImageURLForDisplay;
 
 // Meta accessors
 - (NSDate *)dateForDisplay;
@@ -24,11 +23,16 @@
 - (NSString *)status;
 - (NSString *)statusForDisplay;
 - (BOOL)unreadStatusForDisplay;
-- (NSInteger)numberOfComments;
-- (NSInteger)numberOfLikes;
 - (BOOL)supportsStats;
 - (BOOL)isPrivate;
 - (BOOL)isMultiAuthorBlog;
 - (BOOL)isUploading;
+- (BOOL)hasRevision;
+- (id<WPPostContentViewProvider>)revision;
+
+@optional
+- (NSURL *)featuredImageURLForDisplay;
+- (NSInteger)numberOfComments;
+- (NSInteger)numberOfLikes;
 
 @end

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -346,7 +346,7 @@ const NSInteger PostServiceNumberToFetch = 40;
           failure:(void (^)(NSError *error))failure
 {
     NSNumber *postID = post.postID;
-    if ([postID longLongValue] == 0 || [post.status isEqualToString:PostStatusTrash]) {
+    if ([postID longLongValue] <= 0 || [post.status isEqualToString:PostStatusTrash]) {
         // Local draft, or a trashed post. Hand off to the delete method.
         [self deletePost:post success:success failure:failure];
         return;

--- a/WordPress/Classes/ViewRelated/Pages/PageListCell.h
+++ b/WordPress/Classes/ViewRelated/Pages/PageListCell.h
@@ -1,10 +1,10 @@
-#import "WPContentViewProvider.h"
+#import "WPPostContentViewProvider.h"
 #import "PageListTableViewCellDelegate.h"
 
 @protocol PageListCell <NSObject>
 
 @property (nonatomic, weak) id<PageListTableViewCellDelegate>delegate;
 
-- (void)configureCell:(id<WPContentViewProvider>)contentProvider;
+- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider;
 
 @end

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -7,7 +7,7 @@
 @property (nonatomic, strong) IBOutlet UIView *pageContentView;
 @property (nonatomic, strong) IBOutlet UILabel *titleLabel;
 @property (nonatomic, strong) IBOutlet UIButton *menuButton;
-@property (nonatomic, strong) id<WPContentViewProvider> contentProvider;
+@property (nonatomic, strong) id<WPPostContentViewProvider> contentProvider;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *maxIPadWidthConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *titleLabelTopMarginConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *titleLabelBottomMarginConstraint;
@@ -71,7 +71,7 @@
     return width;
 }
 
-- (void)setContentProvider:(id<WPContentViewProvider>)contentProvider
+- (void)setContentProvider:(id<WPPostContentViewProvider>)contentProvider
 {
     _contentProvider = contentProvider;
 
@@ -87,14 +87,15 @@
     [WPStyleGuide applyPageTitleStyle:self.titleLabel];
 }
 
-- (void)configureCell:(id<WPContentViewProvider>)contentProvider
+- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider
 {
     self.contentProvider = contentProvider;
 }
 
 - (void)configureTitle
 {
-    NSString *str = [self.contentProvider titleForDisplay] ?: [NSString string];
+    id<WPPostContentViewProvider>provider = [self.contentProvider hasRevision] ? [self.contentProvider revision] : self.contentProvider;
+    NSString *str = [provider titleForDisplay] ?: [NSString string];
     self.titleLabel.attributedText = [[NSAttributedString alloc] initWithString:str attributes:[WPStyleGuide pageCellTitleAttributes]];
     self.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCellDelegate.h
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCellDelegate.h
@@ -1,6 +1,6 @@
-#import "WPContentViewProvider.h"
+#import "WPPostContentViewProvider.h"
 @protocol PageListTableViewCellDelegate <NSObject>
 @optional
-- (void)cell:(UITableViewCell *)cell receivedMenuActionFromButton:(UIButton *)button forProvider:(id<WPContentViewProvider>)contentProvider;
-- (void)cell:(UITableViewCell *)cell receivedRestoreActionForProvider:(id<WPContentViewProvider>)contentProvider;
+- (void)cell:(UITableViewCell *)cell receivedMenuActionFromButton:(UIButton *)button forProvider:(id<WPPostContentViewProvider>)contentProvider;
+- (void)cell:(UITableViewCell *)cell receivedRestoreActionForProvider:(id<WPPostContentViewProvider>)contentProvider;
 @end

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.m
@@ -6,7 +6,7 @@
 @property (nonatomic, strong) IBOutlet UIView *pageContentView;
 @property (nonatomic, strong) IBOutlet UILabel *restoreLabel;
 @property (nonatomic, strong) IBOutlet UIButton *restoreButton;
-@property (nonatomic, strong) id<WPContentViewProvider>contentProvider;
+@property (nonatomic, strong) id<WPPostContentViewProvider>contentProvider;
 
 @end
 
@@ -49,7 +49,7 @@
     [self.restoreButton setTitle:buttonTitle forState:UIControlStateNormal];
 }
 
-- (void)configureCell:(id<WPContentViewProvider>)contentProvider
+- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider
 {
     self.contentProvider = contentProvider;
 }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -592,6 +592,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 
 - (void)viewPost:(AbstractPost *)apost
 {
+    apost = ([apost hasRevision]) ? apost.revision : apost;
     PostPreviewViewController *controller = [[PostPreviewViewController alloc] initWithPost:apost shouldHideStatusBar:NO];
     controller.hidesBottomBarWhenPushed = YES;
     [self.navigationController pushViewController:controller animated:YES];

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -1,6 +1,5 @@
 #import "PostCardTableViewCell.h"
 #import "BasePost.h"
-#import "NSDate+StringFormatting.h"
 #import "PhotonImageURLHelper.h"
 #import "PostCardActionBar.h"
 #import "PostCardActionBarItem.h"
@@ -303,7 +302,7 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 - (void)configureDate
 {
-    self.dateLabel.text = [[self.contentProvider dateForDisplay] shortString];
+    self.dateLabel.text = [self.contentProvider dateStringForDisplay];
 }
 
 - (void)configureStatusView
@@ -318,19 +317,20 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
         self.statusHeightConstraint.constant = self.statusViewHeight;
     }
 
+    self.statusLabel.text = str;
     // Set the correct icon and text color
     if ([[self.contentProvider status] isEqualToString:PostStatusPending]) {
-        self.statusLabel.text = str;
         self.statusImageView.image = [UIImage imageNamed:@"icon-post-status-pending"];
         self.statusLabel.textColor = [WPStyleGuide jazzyOrange];
     } else if ([[self.contentProvider status] isEqualToString:PostStatusScheduled]) {
-        self.statusLabel.text = str;
         self.statusImageView.image = [UIImage imageNamed:@"icon-post-status-scheduled"];
         self.statusLabel.textColor = [WPStyleGuide wordPressBlue];
     } else if ([[self.contentProvider status] isEqualToString:PostStatusTrash]) {
-        self.statusLabel.text = str;
         self.statusImageView.image = [UIImage imageNamed:@"icon-post-status-trashed"];
         self.statusLabel.textColor = [WPStyleGuide errorRed];
+    } else if (!self.statusView.hidden) {
+        self.statusImageView.image = [UIImage imageNamed:@"icon-post-status-pending"];
+        self.statusLabel.textColor = [WPStyleGuide jazzyOrange];
     } else {
         self.statusLabel.text = nil;
         self.statusImageView.image = nil;

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -164,6 +164,11 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
     [self setNeedsUpdateConstraints];
 }
 
+- (id<WPPostContentViewProvider>)providerOrRevision
+{
+    return [self.contentProvider hasRevision] ? [self.contentProvider revision] : self.contentProvider;
+}
+
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated
 {
     BOOL previouslyHighlighted = self.highlighted;
@@ -269,13 +274,14 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
         return;
     }
 
-    if (![self.contentProvider featuredImageURLForDisplay]) {
+    id<WPPostContentViewProvider>provider = [self providerOrRevision];
+    if (![provider featuredImageURLForDisplay]) {
         self.postCardImageView.image = nil;
     }
 
-    NSURL *url = [self.contentProvider featuredImageURLForDisplay];
+    NSURL *url = [provider featuredImageURLForDisplay];
     // if not private create photon url
-    if (![self.contentProvider isPrivate]) {
+    if (![provider isPrivate]) {
         CGSize imageSize = self.postCardImageView.frame.size;
         url = [PhotonImageURLHelper photonURLWithSize:imageSize forImageURL:url];
     }
@@ -286,7 +292,8 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 - (void)configureTitle
 {
-    NSString *str = [self.contentProvider titleForDisplay] ?: [NSString string];
+    id<WPPostContentViewProvider>provider = [self providerOrRevision];
+    NSString *str = [provider titleForDisplay] ?: [NSString string];
     self.titleLabel.attributedText = [[NSAttributedString alloc] initWithString:str attributes:[WPStyleGuide postCardTitleAttributes]];
     self.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     self.titleLowerConstraint.constant = ([str length] > 0) ? self.titleViewLowerMargin : 0.0;
@@ -294,7 +301,8 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 - (void)configureSnippet
 {
-    NSString *str = [self.contentProvider contentPreviewForDisplay];
+    id<WPPostContentViewProvider>provider = [self providerOrRevision];
+    NSString *str = [provider contentPreviewForDisplay] ?: [NSString string];
     self.snippetLabel.attributedText = [[NSAttributedString alloc] initWithString:str attributes:[WPStyleGuide postCardSnippetAttributes]];
     self.snippetLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     self.snippetLowerConstraint.constant = ([str length] > 0) ? self.snippetViewLowerMargin : 0.0;
@@ -302,7 +310,8 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 - (void)configureDate
 {
-    self.dateLabel.text = [self.contentProvider dateStringForDisplay];
+    id<WPPostContentViewProvider>provider = [self providerOrRevision];
+    self.dateLabel.text = [provider dateStringForDisplay];
 }
 
 - (void)configureStatusView


### PR DESCRIPTION
Refs #3786 

Addresses some behavior and appearance issues with local-only posts.
- With this patch it should again be possible to delete a local-only post or page. 
- Features that require a remote version of a post should be disabled. I think stats is the only feature currently affected
- A "local" status flag is displayed after any other normal status flag.
- A nil date is shown as publish immediately. 
- A local-only post with no title or description will have a placeholder title for the sake of appearance. 

To test: 
Test with a blog that has very few posts because local-only posts are currently sorted to the bottom of the list (follow up patch coming).
Follow the steps outlined in this video to create a local-only post https://cloudup.com/iOZ-BQXHqyx 

Needs Review: @koke 