### PR TITLE
Support for Jetpack site icons

### DIFF
--- a/WordPress/Classes/Categories/UIImageView+Gravatar.h
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.h
@@ -11,7 +11,7 @@ extern NSString *const GravatarRatingX;
 - (void)setImageWithGravatarEmail:(NSString *)emailAddress gravatarRating:(NSString *)rating;
 - (void)setImageWithGravatarEmail:(NSString *)emailAddress fallbackImage:(UIImage *)fallbackImage;
 - (void)setImageWithGravatarEmail:(NSString *)emailAddress fallbackImage:(UIImage *)fallbackImage gravatarRating:(NSString *)rating;
-- (void)setImageWithBlavatarUrl:(NSString *)blavatarUrl;
-- (void)setImageWithBlavatarUrl:(NSString *)blavatarUrl placeholderImage:(UIImage *)placeholderImage;
+- (void)setImageWithSiteIcon:(NSString *)siteIcon;
+- (void)setImageWithSiteIcon:(NSString *)siteIcon placeholderImage:(UIImage *)placeholderImage;
 
 @end

--- a/WordPress/Classes/Categories/UIImageView+Gravatar.m
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.m
@@ -61,7 +61,7 @@ NSString *const GravatarRatingX = @"x";
 {
     if ([self isPhotonURL:siteIcon]) {
         [self setImageWithURL:[self siteIconURLForSiteIconUrl:siteIcon] placeholderImage:placeholderImage];
-    } else if ([siteIcon rangeOfString:@"gravatar.com/blavatar"].location != NSNotFound) {
+    } else if ([self isBlavatarURL:siteIcon]) {
         [self setImageWithURL:[self blavatarURLForBlavatarURL:siteIcon] placeholderImage:placeholderImage];
     } else {
         [self setImageWithURL:[self blavatarURLForHost:siteIcon] placeholderImage:placeholderImage];
@@ -136,6 +136,11 @@ NSString *const GravatarRatingX = @"x";
 - (BOOL)isPhotonURL:(NSString *)path
 {
     return [path rangeOfString:@".wp.com"].location != NSNotFound;
+}
+
+- (BOOL)isBlavatarURL:(NSString *)path
+{
+    return [path rangeOfString:@"gravatar.com/blavatar"].location != NSNotFound;
 }
 
 @end

--- a/WordPress/Classes/Categories/UIImageView+Gravatar.m
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.m
@@ -86,8 +86,9 @@ NSString *const GravatarRatingX = @"x";
 - (NSURL *)siteIconURLForSiteIconUrl:(NSString *)path
 {
     NSInteger size = [self sizeForBlavatarDownload];
-    NSString *siteIconUrl = [NSString stringWithFormat:@"%@?w=%d&h=%d", path, size, size];
-    return [NSURL URLWithString:siteIconUrl];
+    NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithString:path];
+    urlComponents.query = [NSString stringWithFormat:@"w=%d&h=%d", size, size];
+    return urlComponents.URL;
 }
 
 - (NSURL *)blavatarURLForHost:(NSString *)host
@@ -104,8 +105,9 @@ NSString *const GravatarRatingX = @"x";
 - (NSURL *)blavatarURLForBlavatarURL:(NSString *)path
 {
     NSInteger size = [self sizeForBlavatarDownload];
-    NSString *blavatarURL = [NSString stringWithFormat:@"%@?d=404&s=%d", path, size];
-    return [NSURL URLWithString:blavatarURL];
+    NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithString:path];
+    urlComponents.query = [NSString stringWithFormat:@"d=404&s=%d", path, size];
+    return urlComponents.URL;
 }
 
 - (NSInteger)sizeForGravatarDownload

--- a/WordPress/Classes/Categories/UIImageView+Gravatar.m
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.m
@@ -50,19 +50,22 @@ NSString *const GravatarRatingX = @"x";
     }];
 }
 
-- (void)setImageWithBlavatarUrl:(NSString *)blavatarUrl
+- (void)setImageWithSiteIcon:(NSString *)siteIcon
 {
     UIImage *blavatarDefaultImage = [UIImage imageNamed:BlavatarDefault];
 
-    [self setImageWithBlavatarUrl:blavatarUrl placeholderImage:blavatarDefaultImage];
+    [self setImageWithSiteIcon:siteIcon placeholderImage:blavatarDefaultImage];
 }
 
-- (void)setImageWithBlavatarUrl:(NSString *)blavatarUrl placeholderImage:(UIImage *)placeholderImage
+- (void)setImageWithSiteIcon:(NSString *)siteIcon placeholderImage:(UIImage *)placeholderImage
 {
-    if ([blavatarUrl rangeOfString:@"gravatar.com/blavatar"].location == NSNotFound) {
-        [self setImageWithURL:[self blavatarURLForHost:blavatarUrl] placeholderImage:placeholderImage];
+    // Check if the site icon is a photon url: https://developer.wordpress.com/docs/photon/
+    if ([siteIcon rangeOfString:@".wp.com"].location != NSNotFound) {
+        [self setImageWithURL:[self siteIconURLForSiteIconUrl:siteIcon] placeholderImage:placeholderImage];
+    } else if ([siteIcon rangeOfString:@"gravatar.com/blavatar"].location != NSNotFound) {
+        [self setImageWithURL:[self blavatarURLForBlavatarURL:siteIcon] placeholderImage:placeholderImage];
     } else {
-        [self setImageWithURL:[self blavatarURLForBlavatarURL:blavatarUrl] placeholderImage:placeholderImage];
+        [self setImageWithURL:[self blavatarURLForHost:siteIcon] placeholderImage:placeholderImage];
     }
 }
 
@@ -81,6 +84,13 @@ NSString *const GravatarRatingX = @"x";
     return [NSURL URLWithString:gravatarUrl];
 }
 
+- (NSURL *)siteIconURLForSiteIconUrl:(NSString *)path
+{
+    NSInteger size = [self sizeForBlavatarDownload];
+    NSString *siteIconUrl = [NSString stringWithFormat:@"%@?w=%d&h=%d", path, size, size];
+    return [NSURL URLWithString:siteIconUrl];
+}
+
 - (NSURL *)blavatarURLForHost:(NSString *)host
 {
     return [self blavatarURLForHost:host withSize:[self sizeForBlavatarDownload]];
@@ -94,7 +104,7 @@ NSString *const GravatarRatingX = @"x";
 
 - (NSURL *)blavatarURLForBlavatarURL:(NSString *)path
 {
-    CGFloat size = [self sizeForBlavatarDownload];
+    NSInteger size = [self sizeForBlavatarDownload];
     NSString *blavatarURL = [NSString stringWithFormat:@"%@?d=404&s=%d", path, size];
     return [NSURL URLWithString:blavatarURL];
 }

--- a/WordPress/Classes/Categories/UIImageView+Gravatar.m
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.m
@@ -59,8 +59,7 @@ NSString *const GravatarRatingX = @"x";
 
 - (void)setImageWithSiteIcon:(NSString *)siteIcon placeholderImage:(UIImage *)placeholderImage
 {
-    // Check if the site icon is a photon url: https://developer.wordpress.com/docs/photon/
-    if ([siteIcon rangeOfString:@".wp.com"].location != NSNotFound) {
+    if ([self isPhotonURL:siteIcon]) {
         [self setImageWithURL:[self siteIconURLForSiteIconUrl:siteIcon] placeholderImage:placeholderImage];
     } else if ([siteIcon rangeOfString:@"gravatar.com/blavatar"].location != NSNotFound) {
         [self setImageWithURL:[self blavatarURLForBlavatarURL:siteIcon] placeholderImage:placeholderImage];
@@ -131,6 +130,12 @@ NSString *const GravatarRatingX = @"x";
     size *= [[UIScreen mainScreen] scale];
 
     return size;
+}
+
+// Possible matches are "i0.wp.com", "i1.wp.com" & "i2.wp.com" -> https://developer.wordpress.com/docs/photon/
+- (BOOL)isPhotonURL:(NSString *)path
+{
+    return [path rangeOfString:@".wp.com"].location != NSNotFound;
 }
 
 @end

--- a/WordPress/Classes/Categories/UIImageView+Gravatar.m
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.m
@@ -106,7 +106,7 @@ NSString *const GravatarRatingX = @"x";
 {
     NSInteger size = [self sizeForBlavatarDownload];
     NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithString:path];
-    urlComponents.query = [NSString stringWithFormat:@"d=404&s=%d", path, size];
+    urlComponents.query = [NSString stringWithFormat:@"d=404&s=%d", size];
     return urlComponents.URL;
 }
 

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -239,7 +239,7 @@
 
 - (NSURL *)avatarURLForDisplay
 {
-    return [NSURL URLWithString:self.blog.blavatarUrl];
+    return [NSURL URLWithString:self.blog.icon];
 }
 
 #pragma mark - Post

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -61,9 +61,9 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
 @property (nonatomic, assign, readwrite) BOOL           videoPressEnabled;
 @property (nonatomic, assign, readwrite) BOOL           isMultiAuthor;
 @property (nonatomic, assign, readwrite) BOOL           isJetpack;
+@property (nonatomic, strong, readwrite) NSString       *blavatarUrl;
 
 // Readonly Properties
-@property (nonatomic,   weak,  readonly) NSString       *blavatarUrl;
 @property (nonatomic,   weak,  readonly) NSArray        *sortedPostFormatNames;
 @property (nonatomic, strong,  readonly) WPXMLRPCClient *api;
 @property (nonatomic,   weak,  readonly) NSString       *version;

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -61,7 +61,7 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
 @property (nonatomic, assign, readwrite) BOOL           videoPressEnabled;
 @property (nonatomic, assign, readwrite) BOOL           isMultiAuthor;
 @property (nonatomic, assign, readwrite) BOOL           isJetpack;
-@property (nonatomic, strong, readwrite) NSString       *blavatarUrl;
+@property (nonatomic, strong, readwrite) NSString       *icon;
 
 // Readonly Properties
 @property (nonatomic,   weak,  readonly) NSArray        *sortedPostFormatNames;

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -48,7 +48,7 @@ static NSInteger const ImageSizeLargeHeight = 480;
 @dynamic jetpackAccount;
 @dynamic isMultiAuthor;
 @dynamic isJetpack;
-@dynamic blavatarUrl;
+@dynamic icon;
 @synthesize api = _api;
 @synthesize isSyncingPosts;
 @synthesize isSyncingPages;
@@ -99,17 +99,17 @@ static NSInteger const ImageSizeLargeHeight = 480;
 #pragma mark -
 #pragma mark Custom methods
 
-- (NSString *)blavatarUrl
+- (NSString *)icon
 {
-    [self willAccessValueForKey:@"blavatarUrl"];
-    NSString *blavatarUrl = [self primitiveValueForKey:@"blavatarUrl"];
-    [self didAccessValueForKey:@"blavatarUrl"];
+    [self willAccessValueForKey:@"icon"];
+    NSString *icon = [self primitiveValueForKey:@"icon"];
+    [self didAccessValueForKey:@"icon"];
 
-    if (blavatarUrl) {
-        return blavatarUrl;
+    if (icon) {
+        return icon;
     }
 
-    // if the blavatarUrl is not set we can use the host url to construct it
+    // if the icon is not set we can use the host url to construct it
     NSString *hostUrl = [[NSURL URLWithString:self.xmlrpc] host];
     if (hostUrl == nil) {
         hostUrl = self.xmlrpc;

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -16,7 +16,6 @@ static NSInteger const ImageSizeLargeHeight = 480;
 
 @interface Blog ()
 @property (nonatomic, strong, readwrite) WPXMLRPCClient *api;
-@property (nonatomic, weak, readwrite) NSString *blavatarUrl;
 @property (nonatomic, strong, readwrite) JetpackState *jetpack;
 @end
 
@@ -49,8 +48,8 @@ static NSInteger const ImageSizeLargeHeight = 480;
 @dynamic jetpackAccount;
 @dynamic isMultiAuthor;
 @dynamic isJetpack;
+@dynamic blavatarUrl;
 @synthesize api = _api;
-@synthesize blavatarUrl = _blavatarUrl;
 @synthesize isSyncingPosts;
 @synthesize isSyncingPages;
 @synthesize videoPressEnabled;
@@ -72,7 +71,6 @@ static NSInteger const ImageSizeLargeHeight = 480;
     [super didTurnIntoFault];
 
     // Clean up instance variables
-    self.blavatarUrl = nil;
     self.api = nil;
 
     [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -103,16 +101,20 @@ static NSInteger const ImageSizeLargeHeight = 480;
 
 - (NSString *)blavatarUrl
 {
-    if (_blavatarUrl == nil) {
-        NSString *hostUrl = [[NSURL URLWithString:self.xmlrpc] host];
-        if (hostUrl == nil) {
-            hostUrl = self.xmlrpc;
-        }
+    [self willAccessValueForKey:@"blavatarUrl"];
+    NSString *blavatarUrl = [self primitiveValueForKey:@"blavatarUrl"];
+    [self didAccessValueForKey:@"blavatarUrl"];
 
-        _blavatarUrl = hostUrl;
+    if (blavatarUrl) {
+        return blavatarUrl;
     }
 
-    return _blavatarUrl;
+    // if the blavatarUrl is not set we can use the host url to construct it
+    NSString *hostUrl = [[NSURL URLWithString:self.xmlrpc] host];
+    if (hostUrl == nil) {
+        hostUrl = self.xmlrpc;
+    }
+    return hostUrl;
 }
 
 // Used as a key to store passwords, if you change the algorithm, logins will break
@@ -276,8 +278,6 @@ static NSInteger const ImageSizeLargeHeight = 480;
     [self willChangeValueForKey:@"xmlrpc"];
     [self setPrimitiveValue:xmlrpc forKey:@"xmlrpc"];
     [self didChangeValueForKey:@"xmlrpc"];
-    
-    self.blavatarUrl = nil;
 
     // Reset the api client so next time we use the new XML-RPC URL
     self.api = nil;

--- a/WordPress/Classes/Models/Post.m
+++ b/WordPress/Classes/Models/Post.m
@@ -251,7 +251,7 @@
 
 - (NSString *)blavatarForDisplay
 {
-    return self.blog.blavatarUrl;
+    return self.blog.icon;
 }
 
 - (NSURL *)avatarURLForDisplay

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -95,7 +95,7 @@ static NSString * const UserDictionaryAvatarURLKey = @"avatar_URL";
     blog.url = [jsonBlog stringForKey:@"URL"];
     blog.xmlrpc = [jsonBlog stringForKeyPath:@"meta.links.xmlrpc"];
     blog.jetpack = [[jsonBlog numberForKey:@"jetpack"] boolValue];
-    blog.blavatarUrl = [jsonBlog stringForKeyPath:@"icon.img"];
+    blog.icon = [jsonBlog stringForKeyPath:@"icon.img"];
     return blog;
 }
 

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -95,6 +95,7 @@ static NSString * const UserDictionaryAvatarURLKey = @"avatar_URL";
     blog.url = [jsonBlog stringForKey:@"URL"];
     blog.xmlrpc = [jsonBlog stringForKeyPath:@"meta.links.xmlrpc"];
     blog.jetpack = [[jsonBlog numberForKey:@"jetpack"] boolValue];
+    blog.blavatarUrl = [jsonBlog stringForKeyPath:@"icon.img"];
     return blog;
 }
 

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
@@ -4,4 +4,5 @@
 @property (copy) NSString *url;
 @property (copy) NSString *xmlrpc;
 @property (assign) BOOL jetpack;
+@property (copy) NSString *blavatarUrl;
 @end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
@@ -4,5 +4,5 @@
 @property (copy) NSString *url;
 @property (copy) NSString *xmlrpc;
 @property (assign) BOOL jetpack;
-@property (copy) NSString *blavatarUrl;
+@property (copy) NSString *icon;
 @end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlog.m
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlog.m
@@ -9,7 +9,7 @@
                                  @"url": self.url,
                                  @"xmlrpc": self.xmlrpc,
                                  @"jetpack": self.jetpack ? @"YES" : @"NO",
-                                 @"icon": self.icon
+                                 @"icon": self.icon ? self.icon : @""
                                  };
     return [NSString stringWithFormat:@"<%@: %p> (%@)", NSStringFromClass([self class]), self, properties];
 }

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlog.m
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlog.m
@@ -9,6 +9,7 @@
                                  @"url": self.url,
                                  @"xmlrpc": self.xmlrpc,
                                  @"jetpack": self.jetpack ? @"YES" : @"NO",
+                                 @"icon": self.icon
                                  };
     return [NSString stringWithFormat:@"<%@: %p> (%@)", NSStringFromClass([self class]), self, properties];
 }

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -495,7 +495,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
         blog.blogName = [remoteBlog.title stringByDecodingXMLCharacters];
         blog.blogID = remoteBlog.ID;
         blog.isJetpack = remoteBlog.jetpack;
-        blog.blavatarUrl = remoteBlog.blavatarUrl;
+        blog.icon = remoteBlog.icon;
         
         // If non-WPcom then always default or if first from remote (assuming .com)
         if (!account.isWpcom || [blogs indexOfObject:remoteBlog] == 0) {

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -495,6 +495,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
         blog.blogName = [remoteBlog.title stringByDecodingXMLCharacters];
         blog.blogID = remoteBlog.ID;
         blog.isJetpack = remoteBlog.jetpack;
+        blog.blavatarUrl = remoteBlog.blavatarUrl;
         
         // If non-WPcom then always default or if first from remote (assuming .com)
         if (!account.isWpcom || [blogs indexOfObject:remoteBlog] == 0) {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -39,7 +39,7 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 
 - (void)setBlog:(Blog *)blog
 {
-    [self.blavatarImageView setImageWithBlavatarUrl:blog.blavatarUrl];
+    [self.blavatarImageView setImageWithBlavatarUrl:blog.icon];
 
     // if the blog name is missing, we want to show the blog displayURL instead
     [self.titleLabel setText:((blog.blogName && !blog.blogName.isEmpty) ? blog.blogName : blog.displayURL)];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -39,7 +39,7 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 
 - (void)setBlog:(Blog *)blog
 {
-    [self.blavatarImageView setImageWithBlavatarUrl:blog.icon];
+    [self.blavatarImageView setImageWithSiteIcon:blog.icon];
 
     // if the blog name is missing, we want to show the blog displayURL instead
     [self.titleLabel setText:((blog.blogName && !blog.blogName.isEmpty) ? blog.blogName : blog.displayURL)];

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -332,7 +332,7 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
             cell.detailTextLabel.text = @"";
         }
 
-        [cell.imageView setImageWithBlavatarUrl:blog.blavatarUrl];
+        [cell.imageView setImageWithBlavatarUrl:blog.icon];
         if ([self.tableView isEditing] && [blog supports:BlogFeatureVisibility]) {
             UISwitch *visibilitySwitch = [UISwitch new];
             visibilitySwitch.on = blog.visible;

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -332,7 +332,7 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
             cell.detailTextLabel.text = @"";
         }
 
-        [cell.imageView setImageWithBlavatarUrl:blog.icon];
+        [cell.imageView setImageWithSiteIcon:blog.icon];
         if ([self.tableView isEditing] && [blog supports:BlogFeatureVisibility]) {
             UISwitch *visibilitySwitch = [UISwitch new];
             visibilitySwitch.on = blog.visible;

--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
@@ -161,7 +161,7 @@ static NSString *const BlogCellIdentifier = @"BlogCell";
         cell.textLabel.text = blog.url;
     }
 
-    [cell.imageView setImageWithBlavatarUrl:blog.icon];
+    [cell.imageView setImageWithSiteIcon:blog.icon];
 
     cell.accessoryType = blog.objectID == self.selectedObjectID ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;

--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
@@ -161,7 +161,7 @@ static NSString *const BlogCellIdentifier = @"BlogCell";
         cell.textLabel.text = blog.url;
     }
 
-    [cell.imageView setImageWithBlavatarUrl:blog.blavatarUrl];
+    [cell.imageView setImageWithBlavatarUrl:blog.icon];
 
     cell.accessoryType = blog.objectID == self.selectedObjectID ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;

--- a/WordPress/Classes/ViewRelated/NUX/AddUsersBlogCell.m
+++ b/WordPress/Classes/ViewRelated/NUX/AddUsersBlogCell.m
@@ -78,7 +78,7 @@ CGFloat const cellStandardOffset = 16.0;
     y = (rowHeight - cellBlavatarSide)/2.0;
     _blavatarImage.frame = CGRectIntegral(CGRectMake(x, y, cellBlavatarSide, cellBlavatarSide));
     NSURL *blogURL = [NSURL URLWithString:_blavatarUrl];
-    [_blavatarImage setImageWithBlavatarUrl:[blogURL host]];
+    [_blavatarImage setImageWithSiteIcon:[blogURL host]];
 
     // Setup Checkbox
     x = cellWidth - cellStandardOffset - CGRectGetWidth(_checkboxImage.frame);

--- a/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
@@ -154,7 +154,7 @@ static CGFloat const FollowSitesRowHeight = 54.0;
     cell.detailTextLabel.text = [site pathForDisplay];;
     if (site.icon) {
         cell.imageView.backgroundColor = nil;
-        [cell.imageView setImageWithBlavatarUrl:site.icon placeholderImage:defaultImage];
+        [cell.imageView setImageWithSiteIcon:site.icon placeholderImage:defaultImage];
     }
 
     [WPStyleGuide configureTableViewSmallSubtitleCell:cell];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderBrowseSiteViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBrowseSiteViewController.m
@@ -98,9 +98,9 @@
 
     NSURL *blogURL = [NSURL URLWithString:self.post.blogURL];
     if (self.post.isWPCom) {
-        [attributionView.avatarImageView setImageWithBlavatarUrl:[blogURL host] placeholderImage:[UIImage imageNamed:@"blavatar-wpcom"]];
+        [attributionView.avatarImageView setImageWithSiteIcon:[blogURL host] placeholderImage:[UIImage imageNamed:@"blavatar-wpcom"]];
     } else {
-        [attributionView.avatarImageView setImageWithBlavatarUrl:[blogURL host] placeholderImage:[UIImage imageNamed:@"icon-feed"]];
+        [attributionView.avatarImageView setImageWithSiteIcon:[blogURL host] placeholderImage:[UIImage imageNamed:@"icon-feed"]];
     }
 
     [self.view addSubview:self.siteHeaderView];

--- a/WordPress/Classes/WordPress.xcdatamodeld/.xccurrentversion
+++ b/WordPress/Classes/WordPress.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>WordPress 31.xcdatamodel</string>
+	<string>WordPress 32.xcdatamodel</string>
 </dict>
 </plist>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 32.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 32.xcdatamodel/contents
@@ -69,7 +69,6 @@
         <attribute name="apiKey" optional="YES" attributeType="String">
             <userInfo/>
         </attribute>
-        <attribute name="blavatarUrl" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="blogID" attributeType="Integer 32" defaultValueString="0">
             <userInfo/>
         </attribute>
@@ -86,6 +85,7 @@
         <attribute name="hasOlderPosts" transient="YES" attributeType="Boolean" defaultValueString="YES">
             <userInfo/>
         </attribute>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="isActivated" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="isAdmin" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="isJetpack" optional="YES" attributeType="Boolean" syncable="YES"/>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 32.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 32.xcdatamodel/contents
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7549" systemVersion="14D136" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+    <entity name="AbstractPost" representedClassName="AbstractPost" isAbstract="YES" parentEntity="BasePost">
+        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="posts" inverseEntity="Blog" indexed="YES" syncable="YES"/>
+        <relationship name="media" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Media" inverseName="posts" inverseEntity="Media" indexed="YES" syncable="YES"/>
+        <relationship name="original" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPost" inverseName="revision" inverseEntity="AbstractPost" indexed="YES" syncable="YES"/>
+        <relationship name="revision" optional="YES" minCount="1" maxCount="1" deletionRule="Cascade" destinationEntity="AbstractPost" inverseName="original" inverseEntity="AbstractPost" indexed="YES" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Account" representedClassName="WPAccount" syncable="YES">
+        <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isWpcom" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
+        <attribute name="userID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="xmlrpc" attributeType="String" indexed="YES" syncable="YES"/>
+        <relationship name="blogs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Blog" inverseName="account" inverseEntity="Blog" indexed="YES" syncable="YES"/>
+        <relationship name="defaultBlog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="accountForDefaultBlog" inverseEntity="Blog" syncable="YES"/>
+        <relationship name="jetpackBlogs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Blog" inverseName="jetpackAccount" inverseEntity="Blog" indexed="YES" syncable="YES"/>
+        <relationship name="readerSites" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ReaderSite" inverseName="account" inverseEntity="ReaderSite" syncable="YES"/>
+        <relationship name="readerTopics" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ReaderTopic" inverseName="account" inverseEntity="ReaderTopic" syncable="YES"/>
+    </entity>
+    <entity name="BasePost" representedClassName="BasePost" isAbstract="YES">
+        <attribute name="author" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="authorAvatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorID" optional="YES" attributeType="Integer 64" defaultValueString="0" indexed="YES" syncable="YES"/>
+        <attribute name="content" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="date_created_gmt" optional="YES" attributeType="Date">
+            <userInfo/>
+        </attribute>
+        <attribute name="mt_excerpt" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="mt_text_more" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="password" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="pathForDisplayImage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="permaLink" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="post_thumbnail" optional="YES" attributeType="Integer 32" syncable="YES"/>
+        <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="-1">
+            <userInfo/>
+        </attribute>
+        <attribute name="postTitle" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="remoteStatusNumber" optional="YES" attributeType="Integer 16" defaultValueString="0">
+            <userInfo/>
+        </attribute>
+        <attribute name="status" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="wp_slug" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="comments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Comment" inverseName="post" inverseEntity="Comment" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Blog" representedClassName="Blog">
+        <attribute name="apiKey" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="blavatarUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogID" attributeType="Integer 32" defaultValueString="0">
+            <userInfo/>
+        </attribute>
+        <attribute name="blogName" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="currentThemeId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="geolocationEnabled" attributeType="Boolean" defaultValueString="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="hasOlderPages" transient="YES" attributeType="Boolean" defaultValueString="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="hasOlderPosts" transient="YES" attributeType="Boolean" defaultValueString="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="isActivated" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isAdmin" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isJetpack" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isMultiAuthor" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="lastCommentsSync" optional="YES" attributeType="Date">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastPagesSync" optional="YES" attributeType="Date">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastPostsSync" optional="YES" attributeType="Date">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastStatsSync" optional="YES" attributeType="Date">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastUpdateWarning" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="options" optional="YES" attributeType="Transformable">
+            <userInfo/>
+        </attribute>
+        <attribute name="postFormats" optional="YES" attributeType="Transformable">
+            <userInfo/>
+        </attribute>
+        <attribute name="url" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="username" optional="YES" transient="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="visible" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>
+        <attribute name="xmlrpc" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="account" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="blogs" inverseEntity="Account" indexed="YES" syncable="YES"/>
+        <relationship name="accountForDefaultBlog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="defaultBlog" inverseEntity="Account" syncable="YES"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Category" inverseName="blog" inverseEntity="Category" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="comments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Comment" inverseName="blog" inverseEntity="Comment" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="jetpackAccount" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="jetpackBlogs" inverseEntity="Account" indexed="YES" syncable="YES"/>
+        <relationship name="media" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Media" inverseName="blog" inverseEntity="Media" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="AbstractPost" inverseName="blog" inverseEntity="AbstractPost" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="themes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Theme" inverseName="blog" inverseEntity="Theme" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Category" representedClassName="PostCategory">
+        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="-1">
+            <userInfo/>
+        </attribute>
+        <attribute name="categoryName" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="parentID" attributeType="Integer 32" defaultValueString="0">
+            <userInfo/>
+        </attribute>
+        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="categories" inverseEntity="Blog" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Post" inverseName="categories" inverseEntity="Post" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
+    </entity>
+    <entity name="Comment" representedClassName="Comment">
+        <attribute name="author" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="author_email" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="author_ip" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="author_url" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="authorAvatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="commentID" optional="YES" attributeType="Integer 32">
+            <userInfo/>
+        </attribute>
+        <attribute name="content" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="dateCreated" optional="YES" attributeType="Date">
+            <userInfo/>
+        </attribute>
+        <attribute name="depth" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="hierarchy" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isLiked" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="likeCount" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="link" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="parentID" optional="YES" attributeType="Integer 32">
+            <userInfo/>
+        </attribute>
+        <attribute name="postID" optional="YES" attributeType="Integer 32">
+            <userInfo/>
+        </attribute>
+        <attribute name="postTitle" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="status" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="type" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="comments" inverseEntity="Blog" syncable="YES"/>
+        <relationship name="post" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BasePost" inverseName="comments" inverseEntity="BasePost" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Media" representedClassName="Media">
+        <attribute name="caption" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="creationDate" optional="YES" attributeType="Date">
+            <userInfo/>
+        </attribute>
+        <attribute name="desc" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="filename" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="filesize" optional="YES" attributeType="Integer 32" defaultValueString="0">
+            <userInfo/>
+        </attribute>
+        <attribute name="height" optional="YES" attributeType="Integer 32" defaultValueString="0">
+            <userInfo/>
+        </attribute>
+        <attribute name="length" optional="YES" attributeType="Integer 32" defaultValueString="0">
+            <userInfo/>
+        </attribute>
+        <attribute name="localURL" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="mediaID" optional="YES" attributeType="Integer 32">
+            <userInfo/>
+        </attribute>
+        <attribute name="mediaTypeString" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="orientation" optional="YES" attributeType="String" defaultValueString="portrait">
+            <userInfo/>
+        </attribute>
+        <attribute name="progress" optional="YES" transient="YES" attributeType="Float" defaultValueString="0">
+            <userInfo/>
+        </attribute>
+        <attribute name="remoteStatusNumber" optional="YES" attributeType="Integer 16" defaultValueString="0">
+            <userInfo/>
+        </attribute>
+        <attribute name="remoteURL" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="shortcode" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="title" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="width" optional="YES" attributeType="Integer 32" defaultValueString="0">
+            <userInfo/>
+        </attribute>
+        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="media" inverseEntity="Blog" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AbstractPost" inverseName="media" inverseEntity="AbstractPost" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
+    </entity>
+    <entity name="Meta" representedClassName="Meta" syncable="YES">
+        <attribute name="ghostData" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="last_seen" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="latest_note_time" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="simperiumKey" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Notification" representedClassName="Notification" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="ghostData" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="header" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="id" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="meta" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="noticon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="read" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="simperiumKey" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subject" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="timestamp" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Page" representedClassName="Page" parentEntity="AbstractPost">
+        <attribute name="parentID" optional="YES" attributeType="Integer 32" defaultValueString="0">
+            <userInfo/>
+        </attribute>
+        <userInfo/>
+    </entity>
+    <entity name="Post" representedClassName="Post" parentEntity="AbstractPost">
+        <attribute name="commentCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="geolocation" optional="YES" attributeType="Transformable">
+            <userInfo/>
+        </attribute>
+        <attribute name="latitudeID" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="likeCount" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="longitudeID" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="postFormat" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="publicID" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="tags" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Category" inverseName="posts" inverseEntity="Category" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
+    </entity>
+    <entity name="ReaderPost" representedClassName="ReaderPost" parentEntity="BasePost" syncable="YES">
+        <attribute name="authorDisplayName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="commentCount" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="commentsOpen" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="dateCommentsSynced" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="dateSynced" optional="YES" attributeType="Date" indexed="YES" syncable="YES"/>
+        <attribute name="featuredImage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="globalID" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="isBlogPrivate" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isFollowing" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isLiked" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isLikesEnabled" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isReblogged" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isSharingEnabled" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="isSiteBlocked" attributeType="Boolean" defaultValueString="NO" indexed="YES" syncable="YES"/>
+        <attribute name="isWPCom" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="likeCount" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
+        <attribute name="postAvatar" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" indexed="YES" syncable="YES"/>
+        <attribute name="sortDate" optional="YES" attributeType="Date" indexed="YES" syncable="YES"/>
+        <attribute name="storedComment" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="summary" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tags" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="topic" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ReaderTopic" inverseName="posts" inverseEntity="ReaderTopic" syncable="YES"/>
+    </entity>
+    <entity name="ReaderSite" representedClassName="ReaderSite" syncable="YES">
+        <attribute name="feedID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isSubscribed" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
+        <attribute name="name" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="path" attributeType="String" syncable="YES"/>
+        <attribute name="recordID" attributeType="Integer 32" defaultValueString="0" indexed="YES" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="readerSites" inverseEntity="Account" syncable="YES"/>
+    </entity>
+    <entity name="ReaderTopic" representedClassName="ReaderTopic" syncable="YES">
+        <attribute name="isMenuItem" optional="YES" attributeType="Boolean" defaultValueString="NO" indexed="YES" syncable="YES"/>
+        <attribute name="isRecommended" optional="YES" attributeType="Boolean" defaultValueString="NO" indexed="YES" syncable="YES"/>
+        <attribute name="isSubscribed" optional="YES" attributeType="Boolean" defaultValueString="NO" indexed="YES" syncable="YES"/>
+        <attribute name="lastSynced" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="path" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="title" attributeType="String" syncable="YES"/>
+        <attribute name="topicDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="topicID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="type" attributeType="String" indexed="YES" syncable="YES"/>
+        <relationship name="account" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="readerTopics" inverseEntity="Account" syncable="YES"/>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ReaderPost" inverseName="topic" inverseEntity="ReaderPost" syncable="YES"/>
+    </entity>
+    <entity name="Theme" representedClassName="Theme" syncable="YES">
+        <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="launchDate" optional="YES" attributeType="Date" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="popularityRank" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="premium" optional="YES" attributeType="Boolean" syncable="YES"/>
+        <attribute name="previewUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="screenshotUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="themeId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="trendingRank" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="version" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="themes" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <fetchRequest name="UnreadNotes" entity="Notification" predicateString="unread == 1"/>
+    <elements>
+        <element name="AbstractPost" positionX="0" positionY="0" width="128" height="105"/>
+        <element name="Account" positionX="0" positionY="0" width="128" height="223"/>
+        <element name="BasePost" positionX="0" positionY="0" width="128" height="300"/>
+        <element name="Blog" positionX="0" positionY="0" width="128" height="510"/>
+        <element name="Category" positionX="0" positionY="0" width="128" height="120"/>
+        <element name="Comment" positionX="0" positionY="0" width="128" height="343"/>
+        <element name="Media" positionX="0" positionY="0" width="128" height="330"/>
+        <element name="Meta" positionX="9" positionY="153" width="128" height="105"/>
+        <element name="Notification" positionX="18" positionY="162" width="128" height="255"/>
+        <element name="Page" positionX="0" positionY="0" width="128" height="60"/>
+        <element name="Post" positionX="0" positionY="0" width="128" height="180"/>
+        <element name="ReaderPost" positionX="0" positionY="0" width="128" height="465"/>
+        <element name="ReaderSite" positionX="9" positionY="153" width="128" height="163"/>
+        <element name="ReaderTopic" positionX="18" positionY="162" width="128" height="225"/>
+        <element name="Theme" positionX="9" positionY="153" width="128" height="225"/>
+    </elements>
+</model>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -659,6 +659,7 @@
 		313AE49C19E3F20400AAFABE /* CommentViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommentViewController.m; sourceTree = "<group>"; };
 		315FC2C31A2CB29300E7CDA2 /* MeHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MeHeaderView.h; path = Me/MeHeaderView.h; sourceTree = "<group>"; };
 		315FC2C41A2CB29300E7CDA2 /* MeHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MeHeaderView.m; path = Me/MeHeaderView.m; sourceTree = "<group>"; };
+		316B99031B205AFB007963EF /* WordPress 32.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 32.xcdatamodel"; sourceTree = "<group>"; };
 		319D6E7919E447500013871C /* Suggestion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Suggestion.h; sourceTree = "<group>"; };
 		319D6E7A19E447500013871C /* Suggestion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Suggestion.m; sourceTree = "<group>"; };
 		319D6E7C19E447C80013871C /* SuggestionService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SuggestionService.h; sourceTree = "<group>"; };
@@ -1540,7 +1541,6 @@
 		FFAC890F1A96A85800CC06AC /* NSProcessInfo+Util.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSProcessInfo+Util.m"; sourceTree = "<group>"; };
 		FFB7B81C1A0012E80032E723 /* WordPressTestCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressTestCredentials.m; sourceTree = "<group>"; };
 		FFB7B81D1A0012E80032E723 /* WordPressComApiCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressComApiCredentials.m; sourceTree = "<group>"; };
-		FFE69A2D1B1DF8D60073C2EB /* WordPress 31.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 31.xcdatamodel"; sourceTree = "<group>"; };
 		FFE69A1E1B1BD4F10073C2EB /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		FFE69A1F1B1BD6D60073C2EB /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		FFE69A201B1BD79F0073C2EB /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -1555,6 +1555,7 @@
 		FFE69A291B1BFE050073C2EB /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		FFE69A2A1B1BFE200073C2EB /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		FFE69A2B1B1BFE620073C2EB /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		FFE69A2D1B1DF8D60073C2EB /* WordPress 31.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 31.xcdatamodel"; sourceTree = "<group>"; };
 		FFF96F8219EBE7FB00DFC821 /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FFF96F8519EBE7FB00DFC821 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FFF96F8F19EBE81F00DFC821 /* CommentsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommentsTests.m; sourceTree = "<group>"; };
@@ -5314,6 +5315,7 @@
 		E125443B12BF5A7200D87A0A /* WordPress.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				316B99031B205AFB007963EF /* WordPress 32.xcdatamodel */,
 				FFE69A2D1B1DF8D60073C2EB /* WordPress 31.xcdatamodel */,
 				E1939C671B15B4D2001AFEF7 /* WordPress 30.xcdatamodel */,
 				5D91D9021AE1AD12000BF163 /* WordPress 29.xcdatamodel */,
@@ -5346,7 +5348,7 @@
 				8350E15911D28B4A00A7B073 /* WordPress.xcdatamodel */,
 				E125443D12BF5A7200D87A0A /* WordPress 2.xcdatamodel */,
 			);
-			currentVersion = FFE69A2D1B1DF8D60073C2EB /* WordPress 31.xcdatamodel */;
+			currentVersion = 316B99031B205AFB007963EF /* WordPress 32.xcdatamodel */;
 			name = WordPress.xcdatamodeld;
 			path = Classes/WordPress.xcdatamodeld;
 			sourceTree = "<group>";


### PR DESCRIPTION
Closes #3720. The issue we wanted to fix was the Jetpack site icons were not showing up in the app. Up until now, we used the host url to construct a gravatar.com url for the blavatar. However, we do not support this for Jetpack sites. In order to solve the issue, we need to start saving the icon url for the `Blog`. As discussed on Slack with @koke, we have opted to use the term "icon" instead of "blavatarUrl" since the url returned might not be a blavatar url. Also, we originally wanted to move the URL construction away from `UIImageView+Gravatar` since it's a UIKit category, but we need the size information, so it's probably best to keep it there.

Needs Review: @koke (Thank you!)