### PR TITLE
Fixes statusBar Appearance

### DIFF
--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -85,6 +85,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
I'm matching the `UIViewControllerBasedStatusBarAppearance` we already've got in `Info.plist`, so that a given UIViewController can tweak the statusBar appearance.

This affects only the Internal build. This can be tested by means of the new WebViewController:

1. Log into WPiOS
2. Tap over the My Sites tab
3. Pick a random blog
4. Tap over `View Site`

As a result, a modal viewController should be onscreen, with the statusBar text set to black. In the latest internal beta, the text is set to white instead.


Needs Review: @diegoreymendez  (Tanks Diego!)
