### PR TITLE
Initializing WebViewController with Credentials

### DIFF
--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -331,8 +331,11 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
     DDLogInfo(@"%@ Should Start Loading [%@]", NSStringFromClass([self class]), request.URL.absoluteString);
     
     // WP Login: Send the credentials, if needed
-    NSRange loginRange = [request.URL.absoluteString rangeOfString:@"wp-login.php"];
-    if (loginRange.location != NSNotFound && !self.needsLogin && self.username && self.password) {
+    NSRange loginRange  = [request.URL.absoluteString rangeOfString:@"wp-login.php"];
+    BOOL isLoginURL     = loginRange.location != NSNotFound;
+    BOOL hasCredentials = (self.username && (self.password || self.authToken));
+    
+    if (isLoginURL && !self.needsLogin && hasCredentials) {
         DDLogInfo(@"WP is asking for credentials, let's login first");
         [self retryWithLogin];
         return NO;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -944,6 +944,15 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     }
     
     WPWebViewController *webViewController  = [WPWebViewController webViewControllerWithURL:url];
+    if (url.isWordPressDotComUrl) {
+        NSManagedObjectContext *context     = [[ContextManager sharedInstance] mainContext];
+        AccountService *accountService      = [[AccountService alloc] initWithManagedObjectContext:context];
+        WPAccount *account                  = accountService.defaultWordPressComAccount;
+        
+        webViewController.username          = account.username;
+        webViewController.authToken         = account.authToken;
+    }
+    
     UINavigationController *navController   = [[UINavigationController alloc] initWithRootViewController:webViewController];
     
     [self presentViewController:navController animated:YES completion:nil];


### PR DESCRIPTION
#### Steps:
1. Fresh install WPiOS
2. Tap over the Notifications tab
3. Find any achievement notification (ie. stats) and open it
4. Tap over the linked site

As a result, the site stats (web version) should be onscreen.

I've found, and patched, a logic error in the **WPWebViewController**'s `retryWithLogin` mechanism as well.

Closes #3755

Needs Review: @bummytime (Thanks in advance Matt!)
