### PR TITLE
Fixes breaking constraint on iPad 2, iOS 8.1

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -226,7 +226,7 @@
                                     </constraint>
                                     <constraint firstItem="U6E-MB-03K" firstAttribute="centerY" secondItem="zle-VU-ygo" secondAttribute="centerY" id="NCb-6E-SND"/>
                                     <constraint firstItem="Y9d-Yk-F4X" firstAttribute="top" secondItem="rIp-IY-Ng4" secondAttribute="bottom" constant="16" id="QbH-qP-NR7"/>
-                                    <constraint firstAttribute="width" constant="600" id="Qi6-dA-tg8"/>
+                                    <constraint firstAttribute="width" priority="750" constant="600" id="Qi6-dA-tg8"/>
                                     <constraint firstItem="rIp-IY-Ng4" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="14" id="SmN-xb-mWD">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="sqZ-hd-ibO" customClass="PostCardTableViewCell">
-            <rect key="frame" x="0.0" y="0.0" width="612" height="238"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="238"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="sqZ-hd-ibO" id="MWK-lj-FaS">
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P6C-o2-FTR">
-                        <rect key="frame" x="0.0" y="0.0" width="612" height="237"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="237"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nUV-EO-Wtj">
-                                <rect key="frame" x="5" y="9" width="602" height="218"/>
+                                <rect key="frame" x="5" y="9" width="310" height="218"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                             </view>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lk7-nZ-b0t">
-                                <rect key="frame" x="6" y="10" width="600" height="216"/>
+                                <rect key="frame" x="6" y="10" width="308" height="216"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OuO-i7-2Ds">
-                                        <rect key="frame" x="14" y="15" width="572" height="34"/>
+                                        <rect key="frame" x="14" y="15" width="280" height="34"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="tB9-qp-pdv">
                                                 <rect key="frame" x="0.0" y="1" width="32" height="32"/>
@@ -34,14 +34,14 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Glg-dS-0y2">
-                                                <rect key="frame" x="48" y="0.0" width="524" height="17"/>
+                                                <rect key="frame" x="48" y="0.0" width="232" height="17"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l4E-Qn-Vgl">
-                                                <rect key="frame" x="48" y="18" width="524" height="15"/>
+                                                <rect key="frame" x="48" y="18" width="232" height="15"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -62,21 +62,21 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="xIT-FJ-g43">
-                                        <rect key="frame" x="14" y="65" width="572" height="24"/>
+                                        <rect key="frame" x="14" y="65" width="280" height="24"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="POV-pe-wu8">
-                                        <rect key="frame" x="14" y="95" width="572" height="17"/>
+                                        <rect key="frame" x="14" y="95" width="280" height="17"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z3W-ou-g2J">
-                                        <rect key="frame" x="14" y="120" width="495" height="18"/>
+                                        <rect key="frame" x="14" y="120" width="203" height="18"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="38V-Vw-GfJ">
                                                 <rect key="frame" x="0.0" y="1" width="16" height="16"/>
@@ -86,7 +86,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q5D-nc-yvr">
-                                                <rect key="frame" x="19" y="2" width="476" height="15"/>
+                                                <rect key="frame" x="19" y="2" width="184" height="15"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -106,7 +106,7 @@
                                         </constraints>
                                     </view>
                                     <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="O28-fP-tpX">
-                                        <rect key="frame" x="14" y="146" width="572" height="18"/>
+                                        <rect key="frame" x="14" y="146" width="280" height="18"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="8Cs-fq-wSe">
                                                 <rect key="frame" x="0.0" y="1" width="16" height="16"/>
@@ -116,7 +116,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbu-l3-L8G">
-                                                <rect key="frame" x="19" y="2" width="553" height="15"/>
+                                                <rect key="frame" x="19" y="2" width="261" height="15"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -136,7 +136,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YwV-AJ-Nvl">
-                                        <rect key="frame" x="509" y="120" width="77" height="18"/>
+                                        <rect key="frame" x="217" y="120" width="77" height="18"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ovg-ci-Pfb" customClass="PostMetaButton">
                                                 <rect key="frame" x="47" y="0.0" width="30" height="18"/>
@@ -176,7 +176,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BlB-Gp-P6A" customClass="PostCardActionBar">
-                                        <rect key="frame" x="0.0" y="179" width="600" height="37"/>
+                                        <rect key="frame" x="0.0" y="179" width="308" height="37"/>
                                         <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="37" id="tqV-2T-l9Q"/>
@@ -210,7 +210,7 @@
                                     <constraint firstAttribute="trailing" secondItem="POV-pe-wu8" secondAttribute="trailing" constant="14" id="SjY-e4-XWL">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstAttribute="width" constant="600" id="UEv-b1-gAx"/>
+                                    <constraint firstAttribute="width" priority="750" constant="600" id="UEv-b1-gAx"/>
                                     <constraint firstItem="Z3W-ou-g2J" firstAttribute="top" secondItem="POV-pe-wu8" secondAttribute="bottom" constant="8" id="cgz-3E-MrQ">
                                         <variation key="heightClass=regular-widthClass=regular" constant="12"/>
                                     </constraint>


### PR DESCRIPTION
Closes #3815 
Adjusts constraint priority so there is no warning about a broken constraint on some iPad and OS versions.  

Test by launching the iPad 2, iOS 8.1 simulator and navigating to the post list. You should not see any warnings about constraints when viewing the post list. 

Needs Review: @SergioEstevao 