### PR TITLE
Updates Push Auth AlertView's Title

### DIFF
--- a/WordPress/Classes/Utility/PushAuthenticationManager.swift
+++ b/WordPress/Classes/Utility/PushAuthenticationManager.swift
@@ -145,9 +145,9 @@ import UIKit
     *                           confirmed or not.
     */
     private func showLoginVerificationAlert(message: String, completion: ((approved: Bool) -> ())) {
-        let title               = NSLocalizedString("Verify Login", comment: "Push Authentication Alert Title")
-        let cancelButtonTitle   = NSLocalizedString("Ignore",       comment: "Ignore action. Verb")
-        let acceptButtonTitle   = NSLocalizedString("Approve",      comment: "Approve action. Verb")
+        let title               = NSLocalizedString("Verify Sign In", comment: "Push Authentication Alert Title")
+        let cancelButtonTitle   = NSLocalizedString("Ignore", comment: "Ignore action. Verb")
+        let acceptButtonTitle   = NSLocalizedString("Approve", comment: "Approve action. Verb")
         
         self.alertViewProxy.showWithTitle(title,
             message:            message,


### PR DESCRIPTION
We recently received feedback on the Push Authentication mechanism. In order to match Calypso's style, let's update the Push Auth's alertView to `Verify Sign In`.

#### Steps to verify:
1. Log into WordPress.com, in your browser, using your a8c account
2. WPiOS should receive a push notification
3. Tap over the push notification

Expected: The app will launch, and the Push Authentication alertView should be onscreen.
The title should read `Verify Sign In`

Needs Review: @SergioEstevao  (Thanks in advance Sergio!)
