### PR TITLE
Adjusts iPad width constraint priority.

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -30,7 +30,7 @@
                     </subviews>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="600" id="FtB-JF-glz"/>
+                        <constraint firstAttribute="width" priority="750" constant="600" id="FtB-JF-glz"/>
                         <constraint firstItem="T0w-kY-8uW" firstAttribute="leading" secondItem="Ai0-Ac-pOc" secondAttribute="trailing" constant="6" id="Wsa-tE-gWT"/>
                         <constraint firstAttribute="trailing" secondItem="T0w-kY-8uW" secondAttribute="trailing" constant="8" id="Xsw-Up-pnb"/>
                         <constraint firstItem="Ai0-Ac-pOc" firstAttribute="leading" secondItem="efX-hG-Sds" secondAttribute="leading" constant="10" id="dri-xh-fhD"/>

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -50,7 +50,7 @@
                             </constraint>
                             <constraint firstItem="VPZ-yr-cJj" firstAttribute="leading" secondItem="rQF-5A-jGg" secondAttribute="trailing" id="g8I-1V-waz"/>
                             <constraint firstItem="rQF-5A-jGg" firstAttribute="top" secondItem="XtG-U3-A3y" secondAttribute="top" constant="10" id="kYH-1D-hI7"/>
-                            <constraint firstAttribute="width" constant="600" id="nXd-Nr-ibg"/>
+                            <constraint firstAttribute="width" priority="750" constant="600" id="nXd-Nr-ibg"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">

--- a/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
@@ -43,7 +43,7 @@
                     <constraints>
                         <constraint firstAttribute="centerX" secondItem="2lx-TZ-H9w" secondAttribute="centerX" id="BXl-cW-Ywt"/>
                         <constraint firstAttribute="centerY" secondItem="MBZ-lN-HGt" secondAttribute="centerY" constant="-0.5" id="SM7-09-i4J"/>
-                        <constraint firstAttribute="width" constant="612" id="URY-Vf-eVc"/>
+                        <constraint firstAttribute="width" priority="750" constant="612" id="URY-Vf-eVc"/>
                         <constraint firstAttribute="centerY" secondItem="wKm-Mr-TCA" secondAttribute="centerY" constant="-0.5" id="X37-jz-nrb"/>
                         <constraint firstItem="2lx-TZ-H9w" firstAttribute="leading" secondItem="MBZ-lN-HGt" secondAttribute="trailing" constant="8" id="Y0M-I9-BOr"/>
                         <constraint firstAttribute="trailing" secondItem="wKm-Mr-TCA" secondAttribute="trailing" constant="6" id="b0b-rA-YhB"/>


### PR DESCRIPTION
Closes #3823 

To test:
Launch the iOS 8.1 iPad 2 simulator
View the post list
Ensure constraints do not break on the table footer view. 
View the page list
Ensure constraints do not break on the section header views.
Ensure the page cells do not break constraints. 

Needs Review: @jleandroperez 