### PR TITLE
Prevents Unregister Token OP's cancellation

### DIFF
--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -32,7 +32,7 @@
     }
 
     // Beware: Lazy getters below. Let's hit directly the ivar
-    [_restApi cancelPendingOperations];
+    [_restApi.operationQueue cancelAllOperations];
     [_restApi reset];
 
     [_xmlrpcApi.operationQueue cancelAllOperations];

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -32,7 +32,7 @@
     }
 
     // Beware: Lazy getters below. Let's hit directly the ivar
-    [_restApi.operationQueue cancelAllOperations];
+    [_restApi cancelPendingOperations];
     [_restApi reset];
 
     [_xmlrpcApi.operationQueue cancelAllOperations];

--- a/WordPress/WordPressApi/WordPressComApi.h
+++ b/WordPress/WordPressApi/WordPressComApi.h
@@ -43,6 +43,15 @@ extern NSString *const WordPressComApiPushAppId;
  */
 - (void)reset;
 
+
+/**
+ Cancels pending HTTP Request Operations
+ 
+ @discussion This method will skip any pending OP marked as Non Cancellable.
+ */
+- (void)cancelPendingOperations;
+
+
 ///-------------------------
 /// @name Account management
 ///-------------------------

--- a/WordPress/WordPressApi/WordPressComApi.h
+++ b/WordPress/WordPressApi/WordPressComApi.h
@@ -44,14 +44,6 @@ extern NSString *const WordPressComApiPushAppId;
 - (void)reset;
 
 
-/**
- Cancels pending HTTP Request Operations
- 
- @discussion This method will skip any pending OP marked as Non Cancellable.
- */
-- (void)cancelPendingOperations;
-
-
 ///-------------------------
 /// @name Account management
 ///-------------------------

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -47,6 +47,15 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 	return self;
 }
 
+- (void)cancel
+{
+    if (self.disallowsCancellation) {
+        return;
+    }
+    
+    [super cancel];
+}
+
 @end
 
 

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -171,17 +171,6 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
     [self clearAuthorizationHeader];
 }
 
-- (void)cancelPendingOperations
-{
-    for (WPJSONRequestOperation *operation in self.operationQueue.operations) {
-        if ([operation isKindOfClass:[WPJSONRequestOperation class]] && operation.disallowsCancellation) {
-            continue;
-        }
-        
-        [operation cancel];
-    }
-}
-
 - (BOOL)hasCredentials {
     return self.authToken.length > 0;
 }

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -31,15 +31,16 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 // This will match all public-api.wordpress.com/rest/v1/ URI's and parse them as JSON
 
 @interface WPJSONRequestOperation : AFHTTPRequestOperation
+@property (nonatomic, assign) BOOL disallowsCancellation;
 @end
+
 @implementation WPJSONRequestOperation
 
--(id)initWithRequest:(NSURLRequest *)urlRequest
+- (instancetype)initWithRequest:(NSURLRequest *)urlRequest
 {
 	self = [super initWithRequest:urlRequest];
 	
-	if (self)
-	{
+	if (self) {
 		self.responseSerializer = [[AFJSONResponseSerializer alloc] init];
 	}
 	
@@ -47,6 +48,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 }
 
 @end
+
 
 @interface WordPressComApi ()
 @property (readwrite, nonatomic, strong) NSString *username;

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -162,6 +162,17 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
     [self clearAuthorizationHeader];
 }
 
+- (void)cancelPendingOperations
+{
+    for (WPJSONRequestOperation *operation in self.operationQueue.operations) {
+        if ([operation isKindOfClass:[WPJSONRequestOperation class]] && operation.disallowsCancellation) {
+            continue;
+        }
+        
+        [operation cancel];
+    }
+}
+
 - (BOOL)hasCredentials {
     return self.authToken.length > 0;
 }


### PR DESCRIPTION
#### Steps:

1. Install WPiOS on your device
2. Allow the app to receive Push Notifications
3. Log into your account
4. Tap over the Me tab, and hit the Disconnect row

As a result, the Push Notifications token should be removed from the backend, and the following legend should show up in the console:

```
2015-06-09 14:57:20:509 WordPress[10095:807] Successfully unregistered device ID [Device's ID]
```

Needs Review: @SergioEstevao + @diegoreymendez 

Any improvements / suggestions will be very welcome, thank you!
