### PR TITLE
Include error code in error message

### DIFF
--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -102,6 +102,9 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
                 } else if ([errorString isEqualToString:@"authorization_required"]) {
                     errorCode = WordPressComApiErrorAuthorizationRequired;
                 }
+                if (errorString) {
+                    errorMessage = [errorMessage stringByAppendingFormat:@" [%@]", errorString];
+                }
                 newError = [NSError errorWithDomain:WordPressComApiErrorDomain code:errorCode userInfo:@{NSLocalizedDescriptionKey: errorMessage, WordPressComApiErrorCodeKey: errorString}];
             }
         }


### PR DESCRIPTION
Sometimes the error code is a clearer indicator of what's wrong when debugging an issue, e.g. `json_syntax` vs `Invalid response from the Jetpack site`.

Let's include that in the log.

As a side effect, this might show in some user facing errors

![ios simulator screen shot 10 jun 2015 17 38 02](https://cloud.githubusercontent.com/assets/8739/8086793/82909cae-0f97-11e5-863f-7655a2c3792b.png)

I think that's probably OK as long as we show the friendly error message first

References #3627 

Needs Review: @aerych 