### PR TITLE
Tailors no results message for searches.

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
@@ -103,27 +103,35 @@ static NSString * const CurrentPageListStatusFilterKey = @"CurrentPageListStatus
         return NSLocalizedString(@"Fetching pages...", @"A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new pages.");
     }
     PostListFilter *filter = [self currentPostListFilter];
-    NSString *title;
-    switch (filter.filterType) {
-        case PostListStatusFilterDraft:
-            title = NSLocalizedString(@"You don't have any drafts.", @"Displayed when the user views drafts in the pages list and there are no posts");
-            break;
-        case PostListStatusFilterScheduled:
-            title = NSLocalizedString(@"You don't have any scheduled pages.", @"Displayed when the user views scheduled pages in the pages list and there are no pages");
-            break;
-        case PostListStatusFilterTrashed:
-            title = NSLocalizedString(@"You don't have any pages in your trash folder.", @"Displayed when the user views trashed in the pages list and there are no pages");
-            break;
-        default:
-            title = NSLocalizedString(@"You haven't published any pages yet.", @"Displayed when the user views published pages in the pages list and there are no pages");
-            break;
-    }
+    NSDictionary *titles = [self noResultsTitles];
+    NSString *title = [titles stringForKey:@(filter.filterType)];
     return title;
+}
+
+- (NSDictionary *)noResultsTitles
+{
+    NSDictionary *titles;
+    if ([self isSearching]) {
+        titles = @{
+                   @(PostListStatusFilterDraft):[NSString stringWithFormat:NSLocalizedString(@"No drafts match your search for %@", @"The '%@' is a placeholder for the search term."), [self currentSearchTerm]],
+                   @(PostListStatusFilterScheduled):[NSString stringWithFormat:NSLocalizedString(@"No scheduled pages match your search for %@", @"The '%@' is a placeholder for the search term."), [self currentSearchTerm]],
+                   @(PostListStatusFilterTrashed):[NSString stringWithFormat:NSLocalizedString(@"No trashed pages match your search for %@", @"The '%@' is a placeholder for the search term."), [self currentSearchTerm]],
+                   @(PostListStatusFilterPublished):[NSString stringWithFormat:NSLocalizedString(@"No pages match your search for %@", @"The '%@' is a placeholder for the search term."), [self currentSearchTerm]],
+                   };
+    } else {
+        titles = @{
+                   @(PostListStatusFilterDraft):NSLocalizedString(@"You don't have any drafts.", @"Displayed when the user views drafts in the pages list and there are no pages"),
+                   @(PostListStatusFilterScheduled):NSLocalizedString(@"You don't have any scheduled pages.", @"Displayed when the user views scheduled pages in the pages list and there are no pages"),
+                   @(PostListStatusFilterTrashed):NSLocalizedString(@"You don't have any pages in your trash folder.", @"Displayed when the user views trashed in the pages list and there are no pages"),
+                   @(PostListStatusFilterPublished):NSLocalizedString(@"You haven't published any pages yet.", @"Displayed when the user views published pages in the pages list and there are no pages"),
+                   };
+    }
+    return titles;
 }
 
 - (NSString *)noResultsMessageText
 {
-    if (self.syncHelper.isSyncing) {
+    if (self.syncHelper.isSyncing || [self isSearching]) {
         return [NSString string];
     }
     NSString *message;
@@ -147,7 +155,7 @@ static NSString * const CurrentPageListStatusFilterKey = @"CurrentPageListStatus
 
 - (NSString *)noResultsButtonText
 {
-    if (self.syncHelper.isSyncing) {
+    if (self.syncHelper.isSyncing || [self isSearching]) {
         return nil;
     }
     NSString *title;

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -702,6 +702,16 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     return UIDeviceOrientationIsPortrait(self.interfaceOrientation) ? SearchWrapperViewPortraitHeight : SearchWrapperViewLandscapeHeight;
 }
 
+- (BOOL)isSearching
+{
+    return self.searchController.isActive && [[self currentSearchTerm] length]> 0;
+}
+
+- (NSString *)currentSearchTerm
+{
+    return self.searchController.searchBar.text;
+}
+
 
 #pragma mark - Filter related
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
@@ -72,5 +72,7 @@ extern const CGFloat SearchWrapperViewLandscapeHeight;
 - (void)deletePost:(AbstractPost *)apost;
 - (void)restorePost:(AbstractPost *)apost;
 - (void)updateAndPerformFetchRequestRefreshingCachedRowHeights;
+- (BOOL)isSearching;
+- (NSString *)currentSearchTerm;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -153,26 +153,34 @@ static const CGFloat PostListHeightForFooterView = 34.0;
         return NSLocalizedString(@"Fetching posts...", @"A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new posts.");
     }
     PostListFilter *filter = [self currentPostListFilter];
-    NSString *title;
-    switch (filter.filterType) {
-        case PostListStatusFilterDraft:
-            title = NSLocalizedString(@"You don't have any drafts.", @"Displayed when the user views drafts in the posts list and there are no posts");
-            break;
-        case PostListStatusFilterScheduled:
-            title = NSLocalizedString(@"You don't have any scheduled posts.", @"Displayed when the user views scheduled posts in the posts list and there are no posts");
-            break;
-        case PostListStatusFilterTrashed:
-            title = NSLocalizedString(@"You don't have any posts in your trash folder.", @"Displayed when the user views trashed in the posts list and there are no posts");
-            break;
-        default:
-            title = NSLocalizedString(@"You haven't published any posts yet.", @"Displayed when the user views published posts in the posts list and there are no posts");
-            break;
-    }
+    NSDictionary *titles = [self noResultsTitles];
+    NSString *title = [titles stringForKey:@(filter.filterType)];
     return title;
 }
 
+- (NSDictionary *)noResultsTitles
+{
+    NSDictionary *titles;
+    if ([self isSearching]) {
+        titles = @{
+                   @(PostListStatusFilterDraft):[NSString stringWithFormat:NSLocalizedString(@"No drafts match your search for %@", @"The '%@' is a placeholder for the search term."), [self currentSearchTerm]],
+                   @(PostListStatusFilterScheduled):[NSString stringWithFormat:NSLocalizedString(@"No scheduled posts match your search for %@", @"The '%@' is a placeholder for the search term."), [self currentSearchTerm]],
+                   @(PostListStatusFilterTrashed):[NSString stringWithFormat:NSLocalizedString(@"No trashed posts match your search for %@", @"The '%@' is a placeholder for the search term."), [self currentSearchTerm]],
+                   @(PostListStatusFilterPublished):[NSString stringWithFormat:NSLocalizedString(@"No posts match your search for %@", @"The '%@' is a placeholder for the search term."), [self currentSearchTerm]],
+                   };
+    } else {
+        titles = @{
+                   @(PostListStatusFilterDraft):NSLocalizedString(@"You don't have any drafts.", @"Displayed when the user views drafts in the posts list and there are no posts"),
+                   @(PostListStatusFilterScheduled):NSLocalizedString(@"You don't have any scheduled posts.", @"Displayed when the user views scheduled posts in the posts list and there are no posts"),
+                   @(PostListStatusFilterTrashed):NSLocalizedString(@"You don't have any posts in your trash folder.", @"Displayed when the user views trashed in the posts list and there are no posts"),
+                   @(PostListStatusFilterPublished):NSLocalizedString(@"You haven't published any posts yet.", @"Displayed when the user views published posts in the posts list and there are no posts"),
+                   };
+    }
+    return titles;
+}
+
 - (NSString *)noResultsMessageText {
-    if (self.syncHelper.isSyncing) {
+    if (self.syncHelper.isSyncing || [self isSearching]) {
         return [NSString string];
     }
     NSString *message;
@@ -196,7 +204,7 @@ static const CGFloat PostListHeightForFooterView = 34.0;
 
 - (NSString *)noResultsButtonText
 {
-    if (self.syncHelper.isSyncing) {
+    if (self.syncHelper.isSyncing || [self isSearching]) {
         return nil;
     }
     NSString *title;
@@ -271,7 +279,7 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     NSPredicate *basePredicate = [NSPredicate predicateWithFormat:@"blog = %@ && original = nil", self.blog];
     [predicates addObject:basePredicate];
 
-    NSString *searchText = self.searchController.searchBar.text;
+    NSString *searchText = [self currentSearchTerm];
     NSPredicate *filterPredicate = [self currentPostListFilter].predicateForFetchRequest;
 
     // If we have recently trashed posts, create an OR predicate to find posts matching the filter,


### PR DESCRIPTION
Closes #3832 

To test:
Go to the post list and search for any term that should have no results.
The no results view should indicate there are no posts (or drafts, scheduled posts, trashed posts) for the specific search term. 
Repeat for each filter. 
Repeat for the page list. 

Needs Review: @jleandroperez 
