### PR TITLE
Tweak the 19-31 revision migration test.

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -46,10 +46,7 @@
 {
     NSString *key = @"remoteStatusNumber";
     [self willChangeValueForKey:key];
-    if ([self respondsToSelector:@selector(setMetaIsLocal:)]) {
-        // For migrations, ensure the property is supported on the current version of the entity.
-        self.metaIsLocal = ([remoteStatusNumber integerValue] == AbstractPostRemoteStatusLocal);
-    }
+    self.metaIsLocal = ([remoteStatusNumber integerValue] == AbstractPostRemoteStatusLocal);
     [self setPrimitiveValue:remoteStatusNumber forKey:key];
     [self didChangeValueForKey:key];
 }
@@ -58,10 +55,7 @@
 {
     NSString *key = @"date_created_gmt";
     [self willChangeValueForKey:key];
-    if ([self respondsToSelector:@selector(setMetaPublishImmediately:)]) {
-        // For migrations, ensure the property is supported on the current version of the entity.
-        self.metaPublishImmediately = (date_created_gmt == nil);
-    }
+    self.metaPublishImmediately = (date_created_gmt == nil);
     [self setPrimitiveValue:date_created_gmt forKey:key];
     [self didChangeValueForKey:key];
 }

--- a/WordPress/WordPressTest/CoreDataMigrationTests.m
+++ b/WordPress/WordPressTest/CoreDataMigrationTests.m
@@ -158,8 +158,8 @@
     XCTAssertNotNil(post, @"Couldn't insert a post");
 
     [post setValue:blog forKey:@"blog"];
-    [post setValue:@1 forKey:@"postID"];
-    [post setValue:@2 forKey:@"remoteStatusNumber"];
+    [post setPrimitiveValue:@1 forKey:@"postID"];
+    [post setPrimitiveValue:@2 forKey:@"remoteStatusNumber"];
 
     [context save:&error];
 


### PR DESCRIPTION
Avoids needing to check for an attribute's existence in the model.

cc @astralbodies :) 