### PR TITLE
Use local previews if we don't have credentials

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -218,14 +218,18 @@
                 token = self.apost.blog.authToken;
             }
 
-            NSURLRequest *request = [WPURLRequest requestForAuthenticationWithURL:loginURL
-                                                                      redirectURL:redirectURL
-                                                                         username:self.apost.blog.username
-                                                                         password:self.apost.blog.password
-                                                                      bearerToken:token
-                                                                        userAgent:nil];
-            [self.webView loadRequest:request];
-            DDLogInfo(@"Showing real preview (login) for %@", link);
+            if (self.apost.blog.password.length > 0 && token.length > 0) {
+                NSURLRequest *request = [WPURLRequest requestForAuthenticationWithURL:loginURL
+                                                                          redirectURL:redirectURL
+                                                                             username:self.apost.blog.username
+                                                                             password:self.apost.blog.password
+                                                                          bearerToken:token
+                                                                            userAgent:nil];
+                [self.webView loadRequest:request];
+                DDLogInfo(@"Showing real preview (login) for %@", link);
+            } else {
+                [self showSimplePreview];
+            }
         } else {
             [self.webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:link]]];
             DDLogInfo(@"Showing real preview for %@", link);


### PR DESCRIPTION
When Jetpack REST is enabled, we don't have the self hosted credentials, and the Jetpack site won't care for the OAuth2 token.

Let's fall back to a local preview until we have a better solution for authentication

See #3627 

Needs Review: @jleandroperez 