### PR TITLE
More unit tests for our REST service classes.

### DIFF
--- a/WordPress/Classes/Networking/AccountServiceRemote.h
+++ b/WordPress/Classes/Networking/AccountServiceRemote.h
@@ -5,7 +5,24 @@
 
 @protocol AccountServiceRemote <NSObject>
 
-- (void)getBlogsWithSuccess:(void (^)(NSArray *blogs))success failure:(void (^)(NSError *error))failure;
-- (void)getDetailsForAccount:(WPAccount *)account success:(void (^)(RemoteUser *remoteUser))success failure:(void (^)(NSError *error))failure;
+/**
+ *  @brief      Gets an account's posts.
+ *
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)getBlogsWithSuccess:(void (^)(NSArray *blogs))success
+                    failure:(void (^)(NSError *error))failure;
+
+/**
+ *  @brief      Gets an account's details.
+ *
+ *  @param      account     The account to get the details of.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)getDetailsForAccount:(WPAccount *)account
+                     success:(void (^)(RemoteUser *remoteUser))success
+                     failure:(void (^)(NSError *error))failure;
 
 @end

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -27,7 +27,9 @@ static NSString * const UserDictionaryAvatarURLKey = @"avatar_URL";
           }];
 }
 
-- (void)getDetailsForAccount:(WPAccount *)account success:(void (^)(RemoteUser *remoteUser))success failure:(void (^)(NSError *error))failure
+- (void)getDetailsForAccount:(WPAccount *)account
+                     success:(void (^)(RemoteUser *remoteUser))success
+                     failure:(void (^)(NSError *error))failure
 {
     NSString *path = @"me";
     [self.api GET:path

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -2,6 +2,7 @@
 #import "WordPressComApi.h"
 #import "RemoteBlog.h"
 #import "Constants.h"
+#import "WPAccount.h"
 
 static NSString * const UserDictionaryIDKey = @"ID";
 static NSString * const UserDictionaryUsernameKey = @"username";
@@ -31,6 +32,12 @@ static NSString * const UserDictionaryAvatarURLKey = @"avatar_URL";
                      success:(void (^)(RemoteUser *remoteUser))success
                      failure:(void (^)(NSError *error))failure
 {
+    // IMPORTANT: We're adding this assertion even though the account is not used here to let the
+    // caller know this parameter needs to be set (following the documentation of the protocol).
+    // This parameter is used and required by the XMLRPC variant of this method.
+    //
+    NSParameterAssert([account isKindOfClass:[WPAccount class]]);
+    
     NSString *path = @"me";
     [self.api GET:path
        parameters:nil

--- a/WordPress/Classes/Networking/BlogServiceRemote.h
+++ b/WordPress/Classes/Networking/BlogServiceRemote.h
@@ -8,14 +8,35 @@ typedef void (^MultiAuthorCheckHandler)(BOOL isMultiAuthor);
 
 @protocol BlogServiceRemote <NSObject>
 
+/**
+ *  @brief      Checks if a blog has multiple authors.
+ *
+ *  @param      blog        The blog to check for multi-authors.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
 - (void)checkMultiAuthorForBlog:(Blog *)blog
                         success:(MultiAuthorCheckHandler)success
                         failure:(void (^)(NSError *error))failure;
 
+/**
+ *  @brief      Synchronizes a blog's options.
+ *
+ *  @param      blog        The blog to synchronize.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
 - (void)syncOptionsForBlog:(Blog *)blog
                    success:(OptionsHandler)success
                    failure:(void (^)(NSError *error))failure;
 
+/**
+ *  @brief      Synchronizes a blog's post formats.
+ *
+ *  @param      blog        The blog to synchronize.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
 - (void)syncPostFormatsForBlog:(Blog *)blog
                        success:(PostFormatsHandler)success
                        failure:(void (^)(NSError *error))failure;

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -8,8 +8,9 @@
                         success:(void(^)(BOOL isMultiAuthor))success
                         failure:(void (^)(NSError *error))failure
 {
-    NSParameterAssert(blog != nil);
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
     NSParameterAssert(blog.dotComID != nil);
+    
     NSDictionary *parameters = @{@"authors_only":@(YES)};
     NSString *path = [NSString stringWithFormat:@"sites/%@/users", blog.dotComID];
     [self.api GET:path
@@ -27,10 +28,13 @@
           }];
 }
 
-- (void)syncOptionsForBlog:(Blog *)blog success:(OptionsHandler)success failure:(void (^)(NSError *))failure
+- (void)syncOptionsForBlog:(Blog *)blog
+                   success:(OptionsHandler)success
+                   failure:(void (^)(NSError *))failure
 {
-    NSParameterAssert(blog != nil);
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
     NSParameterAssert(blog.dotComID != nil);
+    
     NSString *path = [self pathForOptionsWithBlog:blog];
     [self.api GET:path
        parameters:nil
@@ -49,8 +53,9 @@
 
 - (void)syncPostFormatsForBlog:(Blog *)blog success:(PostFormatsHandler)success failure:(void (^)(NSError *))failure
 {
-    NSParameterAssert(blog != nil);
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
     NSParameterAssert(blog.dotComID != nil);
+    
     NSString *path = [self pathForPostFormatsWithBlog:blog];
     [self.api GET:path
        parameters:nil

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -51,7 +51,9 @@
           }];
 }
 
-- (void)syncPostFormatsForBlog:(Blog *)blog success:(PostFormatsHandler)success failure:(void (^)(NSError *))failure
+- (void)syncPostFormatsForBlog:(Blog *)blog
+                       success:(PostFormatsHandler)success
+                       failure:(void (^)(NSError *))failure
 {
     NSParameterAssert([blog isKindOfClass:[Blog class]]);
     NSParameterAssert(blog.dotComID != nil);

--- a/WordPress/Classes/Networking/PostServiceRemote.h
+++ b/WordPress/Classes/Networking/PostServiceRemote.h
@@ -4,42 +4,107 @@
 
 @protocol PostServiceRemote <NSObject>
 
+/**
+ *  @brief      Requests the post with the specified ID.
+ *
+ *  @param      postID      The ID of the post to get.  Cannot be nil.
+ *  @param      blog        The blog to get the post from.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
 - (void)getPostWithID:(NSNumber *)postID
               forBlog:(Blog *)blog
               success:(void (^)(RemotePost *post))success
               failure:(void (^)(NSError *))failure;
 
+/**
+ *  @brief      Requests the posts of the specified type.
+ *
+ *  @param      postType    The type of the posts to get.  Cannot be nil.
+ *  @param      blog        The blog to get the posts from.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
 - (void)getPostsOfType:(NSString *)postType
                forBlog:(Blog *)blog
-                success:(void (^)(NSArray *posts))success
-                failure:(void (^)(NSError *error))failure;
+               success:(void (^)(NSArray *posts))success
+               failure:(void (^)(NSError *error))failure;
 
+/**
+ *  @brief      Requests the posts of the specified type using the specified options.
+ *
+ *  @param      postType    The type of the posts to get.  Cannot be nil.
+ *  @param      blog        The blog to get the posts from.  Cannot be nil.
+ *  @param      options     The options to use for the request.  Can be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
 - (void)getPostsOfType:(NSString *)postType
                forBlog:(Blog *)blog
                options:(NSDictionary *)options
                success:(void (^)(NSArray *posts))success
                failure:(void (^)(NSError *error))failure;
 
+/**
+ *  @brief      Creates a post remotely for the specified blog.
+ *
+ *  @param      post        The post to create remotely.  Cannot be nil.
+ *  @param      blog        The blog to create the post in.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
 - (void)createPost:(RemotePost *)post
            forBlog:(Blog *)blog
            success:(void (^)(RemotePost *post))success
            failure:(void (^)(NSError *error))failure;
 
+/**
+ *  @brief      Updates a blog's post.
+ *
+ *  @param      post        The post to update.  Cannot be nil.
+ *  @param      blog        The blog that owns the post to update.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
 - (void)updatePost:(RemotePost *)post
            forBlog:(Blog *)blog
            success:(void (^)(RemotePost *post))success
            failure:(void (^)(NSError *error))failure;
 
+/**
+ *  @brief      Deletes a post.
+ *
+ *  @param      post        The post to delete.  Cannot be nil.
+ *  @param      blog        The blog that owns the post to delete.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
 - (void)deletePost:(RemotePost *)post
            forBlog:(Blog *)blog
            success:(void (^)())success
            failure:(void (^)(NSError *error))failure;
 
+/**
+ *  @brief      Trashes a post.
+ *
+ *  @param      post        The post to trash.  Cannot be nil.
+ *  @param      blog        The blog that owns the post to trash.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
 - (void)trashPost:(RemotePost *)post
           forBlog:(Blog *)blog
           success:(void (^)(RemotePost *))success
           failure:(void (^)(NSError *))failure;
 
+/**
+ *  @brief      Restores a post.
+ *
+ *  @param      post        The post to restore.  Cannot be nil.
+ *  @param      blog        The blog that owns the post to restore.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
 - (void)restorePost:(RemotePost *)post
             forBlog:(Blog *)blog
             success:(void (^)(RemotePost *))success

--- a/WordPress/Classes/Networking/PostServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.m
@@ -45,6 +45,7 @@
                success:(void (^)(NSArray *))success
                failure:(void (^)(NSError *))failure
 {
+    NSParameterAssert([postType isKindOfClass:[NSString class]]);
     NSParameterAssert([blog isKindOfClass:[Blog class]]);
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts", blog.dotComID];
@@ -129,6 +130,7 @@
 {
     NSParameterAssert([post isKindOfClass:[RemotePost class]]);
     NSParameterAssert([blog isKindOfClass:[Blog class]]);
+    NSParameterAssert(blog.dotComID != nil);
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", blog.dotComID, post.postID];
     [self.api POST:path
@@ -145,9 +147,9 @@
 }
 
 - (void)trashPost:(RemotePost *)post
-           forBlog:(Blog *)blog
-           success:(void (^)(RemotePost *))success
-           failure:(void (^)(NSError *))failure
+          forBlog:(Blog *)blog
+          success:(void (^)(RemotePost *))success
+          failure:(void (^)(NSError *))failure
 {
     NSParameterAssert([post isKindOfClass:[RemotePost class]]);
     NSParameterAssert([blog isKindOfClass:[Blog class]]);
@@ -169,9 +171,9 @@
 }
 
 - (void)restorePost:(RemotePost *)post
-           forBlog:(Blog *)blog
-           success:(void (^)(RemotePost *))success
-           failure:(void (^)(NSError *))failure
+            forBlog:(Blog *)blog
+            success:(void (^)(RemotePost *))success
+            failure:(void (^)(NSError *))failure
 {
     NSParameterAssert([post isKindOfClass:[RemotePost class]]);
     NSParameterAssert([blog isKindOfClass:[Blog class]]);

--- a/WordPress/Classes/Networking/PostServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.m
@@ -127,6 +127,9 @@
            success:(void (^)())success
            failure:(void (^)(NSError *))failure
 {
+    NSParameterAssert([post isKindOfClass:[RemotePost class]]);
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
+    
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", blog.dotComID, post.postID];
     [self.api POST:path
         parameters:nil
@@ -146,9 +149,10 @@
            success:(void (^)(RemotePost *))success
            failure:(void (^)(NSError *))failure
 {
-    NSParameterAssert(post != nil);
-    NSParameterAssert(blog != nil);
+    NSParameterAssert([post isKindOfClass:[RemotePost class]]);
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
     NSParameterAssert(blog.dotComID != nil);
+    
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", blog.dotComID, post.postID];
     [self.api POST:path
         parameters:nil
@@ -169,9 +173,10 @@
            success:(void (^)(RemotePost *))success
            failure:(void (^)(NSError *))failure
 {
-    NSParameterAssert(post != nil);
-    NSParameterAssert(blog != nil);
+    NSParameterAssert([post isKindOfClass:[RemotePost class]]);
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
     NSParameterAssert(blog.dotComID != nil);
+    
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/restore", blog.dotComID, post.postID];
     [self.api POST:path
         parameters:nil

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		5903AE1B19B60A98009D5354 /* WPButtonForNavigationBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 5903AE1A19B60A98009D5354 /* WPButtonForNavigationBar.m */; };
 		591A428C1A6DC1B0003807A6 /* WPBackgroundDimmerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */; };
 		591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */; };
+		591CFB061B28A960009E61B3 /* AccountServiceRemoteRESTTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 591CFB051B28A960009E61B3 /* AccountServiceRemoteRESTTests.m */; };
+		591CFB091B28AC8C009E61B3 /* BlogServiceRemoteRESTTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 591CFB081B28AC8C009E61B3 /* BlogServiceRemoteRESTTests.m */; };
 		5926E1E31AC4468300964783 /* WPCrashlytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 5926E1E21AC4468300964783 /* WPCrashlytics.m */; };
 		5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */; };
 		5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */; };
@@ -707,6 +709,8 @@
 		591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPBackgroundDimmerView.m; sourceTree = "<group>"; };
 		591A428D1A6DC6F2003807A6 /* WPGUIConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPGUIConstants.h; sourceTree = "<group>"; };
 		591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPGUIConstants.m; sourceTree = "<group>"; };
+		591CFB051B28A960009E61B3 /* AccountServiceRemoteRESTTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccountServiceRemoteRESTTests.m; sourceTree = "<group>"; };
+		591CFB081B28AC8C009E61B3 /* BlogServiceRemoteRESTTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogServiceRemoteRESTTests.m; sourceTree = "<group>"; };
 		5926E1E11AC4468300964783 /* WPCrashlytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPCrashlytics.h; sourceTree = "<group>"; };
 		5926E1E21AC4468300964783 /* WPCrashlytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPCrashlytics.m; sourceTree = "<group>"; };
 		5948AD0C1AB734F2006E8882 /* WPAppAnalytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAppAnalytics.h; sourceTree = "<group>"; };
@@ -1981,6 +1985,8 @@
 		59E2AAE91B20E3FB0051DC06 /* Remote Services */ = {
 			isa = PBXGroup;
 			children = (
+				591CFB051B28A960009E61B3 /* AccountServiceRemoteRESTTests.m */,
+				591CFB081B28AC8C009E61B3 /* BlogServiceRemoteRESTTests.m */,
 				59E2AAEB1B20E5CE0051DC06 /* PostServiceRemoteRESTTests.m */,
 				59E2AAE71B20E3EA0051DC06 /* ServiceRemoteRESTTests.m */,
 			);
@@ -4245,6 +4251,7 @@
 				85D239C01AE5A7020074768D /* LoginFacadeTests.m in Sources */,
 				5DA988061AEEA594002AFB12 /* DisplayableImageHelperTest.m in Sources */,
 				9363113F19FA996700B0C739 /* AccountServiceTests.swift in Sources */,
+				591CFB061B28A960009E61B3 /* AccountServiceRemoteRESTTests.m in Sources */,
 				F1564E5B18946087009F8F97 /* NSStringHelpersTest.m in Sources */,
 				93EF094C19ED533500C89770 /* ContextManagerTests.swift in Sources */,
 				B5D689FD1A5EBC900063D9E5 /* NotificationsManager+TestHelper.m in Sources */,
@@ -4261,6 +4268,7 @@
 				9358D15919FFD4E10094BBF5 /* WPImageOptimizerTest.m in Sources */,
 				85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */,
 				E19A10CA1B010AA0006192B0 /* WPURLRequestTest.m in Sources */,
+				591CFB091B28AC8C009E61B3 /* BlogServiceRemoteRESTTests.m in Sources */,
 				931D26F819ED7F7800114F17 /* ReaderTopicServiceTest.m in Sources */,
 				E1E4CE0D177439D100430844 /* WPAvatarSourceTest.m in Sources */,
 			);

--- a/WordPress/WordPressTest/AccountServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/AccountServiceRemoteRESTTests.m
@@ -2,6 +2,7 @@
 #import <XCTest/XCTest.h>
 #import "AccountServiceRemoteREST.h"
 #import "WordPressComApi.h"
+#import "WPAccount.h"
 
 @interface AccountServiceRemoteRESTTests : XCTestCase
 @end
@@ -32,6 +33,8 @@
 
 - (void)testThatGetDetailsForAccountWorks
 {
+    WPAccount* account = OCMStrictClassMock([WPAccount class]);
+    
     WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
     AccountServiceRemoteREST *service = nil;
     
@@ -44,7 +47,7 @@
     
     XCTAssertNoThrow(service = [[AccountServiceRemoteREST alloc] initWithApi:api]);
     
-    [service getDetailsForAccount:nil
+    [service getDetailsForAccount:account
                           success:^(RemoteUser *remoteUser) {}
                           failure:^(NSError *error) {}];
 }

--- a/WordPress/WordPressTest/AccountServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/AccountServiceRemoteRESTTests.m
@@ -1,0 +1,52 @@
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+#import "AccountServiceRemoteREST.h"
+#import "WordPressComApi.h"
+
+@interface AccountServiceRemoteRESTTests : XCTestCase
+@end
+
+@implementation AccountServiceRemoteRESTTests
+
+#pragma mark - Getting blogs
+
+- (void)testThatGetBlogsWorks
+{    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    AccountServiceRemoteREST *service = nil;
+    
+    NSString* url = @"me/sites";
+    
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[AccountServiceRemoteREST alloc] initWithApi:api]);
+    
+    [service getBlogsWithSuccess:^(NSArray *blogs) {}
+                         failure:^(NSError *error) {}];
+}
+
+#pragma mark - Getting account details
+
+- (void)testThatGetDetailsForAccountWorks
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    AccountServiceRemoteREST *service = nil;
+    
+    NSString* url = @"me";
+    
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[AccountServiceRemoteREST alloc] initWithApi:api]);
+    
+    [service getDetailsForAccount:nil
+                          success:^(RemoteUser *remoteUser) {}
+                          failure:^(NSError *error) {}];
+}
+
+@end

--- a/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
@@ -1,0 +1,118 @@
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+#import "Blog.h"
+#import "BlogServiceRemoteREST.h"
+#import "WordPressComApi.h"
+
+@interface BlogServiceRemoteRESTTests : XCTestCase
+@end
+
+@implementation BlogServiceRemoteRESTTests
+
+#pragma mark - Checking multi author for a blog
+
+- (void)testThatCheckMultiAuthorForBlogWorks
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    BlogServiceRemoteREST *service = nil;
+    
+    NSString* url = [NSString stringWithFormat:@"sites/%@/users", blog.dotComID];
+    
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isKindOfClass:[NSDictionary class]]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
+    
+    [service checkMultiAuthorForBlog:blog
+                             success:^(BOOL isMultiAuthor) {}
+                             failure:^(NSError *error) {}];
+}
+
+
+- (void)testThatCheckMultiAuthorForBlogThrowsExceptionWithoutBlog
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    BlogServiceRemoteREST *service = nil;
+    
+    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertThrows([service checkMultiAuthorForBlog:nil
+                                             success:^(BOOL isMultiAuthor) {}
+                                             failure:^(NSError *error) {}]);
+}
+
+#pragma mark - Synchronizing options for a blog
+
+- (void)testThatSyncOptionForBlogWorks
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    BlogServiceRemoteREST *service = nil;
+    
+    NSString* url = [NSString stringWithFormat:@"sites/%@", blog.dotComID];
+    
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
+    
+    [service syncOptionsForBlog:blog
+                        success:^(NSDictionary *options) {}
+                        failure:^(NSError *error) {}];
+}
+
+- (void)testThatSyncOptionForBlogThrowsExceptionWithoutBlog
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    BlogServiceRemoteREST *service = nil;
+    
+    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertThrows([service syncOptionsForBlog:nil
+                                        success:^(NSDictionary *options) {}
+                                        failure:^(NSError *error) {}]);
+}
+
+#pragma mark - Synchronizing post formats for a blog
+
+- (void)testThatSyncPostFormatsForBlogWorks
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    BlogServiceRemoteREST *service = nil;
+    
+    NSString* url = [NSString stringWithFormat:@"sites/%@/post-formats", blog.dotComID];
+    
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
+    
+    [service syncPostFormatsForBlog:blog
+                            success:^(NSDictionary *options) {}
+                            failure:^(NSError *error) {}];
+}
+
+- (void)testThatSyncPostFormatsForBlogThrowsExceptionWithoutBlog
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    BlogServiceRemoteREST *service = nil;
+    
+    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertThrows([service syncPostFormatsForBlog:nil
+                                            success:^(NSDictionary *options) {}
+                                            failure:^(NSError *error) {}]);
+}
+
+@end

--- a/WordPress/WordPressTest/PostServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/PostServiceRemoteRESTTests.m
@@ -290,4 +290,169 @@
                                 failure:^(NSError *error) {}]);
 }
 
+#pragma mark - Deleting posts
+
+- (void)testThatDeletePostWorks
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    PostServiceRemoteREST *service = nil;
+    
+    RemotePost *post = OCMClassMock([RemotePost class]);
+    OCMStub([post postID]).andReturn(@1);
+    
+    NSString* url = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", blog.dotComID, post.postID];
+    
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg isNil]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api]);
+    
+    [service deletePost:post
+                forBlog:blog
+                success:^(RemotePost *posts) {}
+                failure:^(NSError *error) {}];
+}
+
+- (void)testThatDeletePostThrowsExceptionWithoutPost
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    PostServiceRemoteREST *service = nil;
+    
+    XCTAssertNoThrow(service = [self service]);
+    XCTAssertThrows([service deletePost:nil
+                                forBlog:blog
+                                success:^(RemotePost *posts) {}
+                                failure:^(NSError *error) {}]);
+}
+
+- (void)testThatDeletePostThrowsExceptionWithoutBlog
+{
+    RemotePost *post = OCMClassMock([RemotePost class]);
+    
+    PostServiceRemoteREST *service = nil;
+    
+    XCTAssertNoThrow(service = [self service]);
+    XCTAssertThrows([service deletePost:post
+                                forBlog:nil
+                                success:^(RemotePost *posts) {}
+                                failure:^(NSError *error) {}]);
+}
+
+#pragma mark - Trashing posts
+
+- (void)testThatTrashPostWorks
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    PostServiceRemoteREST *service = nil;
+    
+    RemotePost *post = OCMClassMock([RemotePost class]);
+    OCMStub([post postID]).andReturn(@1);
+    
+    NSString* url = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", blog.dotComID, post.postID];
+    
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg isNil]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api]);
+    
+    [service trashPost:post
+               forBlog:blog
+               success:^(RemotePost *posts) {}
+               failure:^(NSError *error) {}];
+}
+
+- (void)testThatTashPostThrowsExceptionWithoutPost
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    PostServiceRemoteREST *service = nil;
+    
+    XCTAssertNoThrow(service = [self service]);
+    XCTAssertThrows([service trashPost:nil
+                               forBlog:blog
+                               success:^(RemotePost *posts) {}
+                               failure:^(NSError *error) {}]);
+}
+
+- (void)testThatTrashPostThrowsExceptionWithoutBlog
+{
+    RemotePost *post = OCMClassMock([RemotePost class]);
+    
+    PostServiceRemoteREST *service = nil;
+    
+    XCTAssertNoThrow(service = [self service]);
+    XCTAssertThrows([service trashPost:post
+                               forBlog:nil
+                               success:^(RemotePost *posts) {}
+                               failure:^(NSError *error) {}]);
+}
+
+#pragma mark - Trashing posts
+
+- (void)testThatRestorePostWorks
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    PostServiceRemoteREST *service = nil;
+    
+    RemotePost *post = OCMClassMock([RemotePost class]);
+    OCMStub([post postID]).andReturn(@1);
+    
+    NSString* url = [NSString stringWithFormat:@"sites/%@/posts/%@/restore", blog.dotComID, post.postID];
+    
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg isNil]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api]);
+    
+    [service restorePost:post
+                 forBlog:blog
+                 success:^(RemotePost *posts) {}
+                 failure:^(NSError *error) {}];
+}
+
+- (void)testThatRestorePostThrowsExceptionWithoutPost
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    PostServiceRemoteREST *service = nil;
+    
+    XCTAssertNoThrow(service = [self service]);
+    XCTAssertThrows([service restorePost:nil
+                                 forBlog:blog
+                                 success:^(RemotePost *posts) {}
+                                 failure:^(NSError *error) {}]);
+}
+
+- (void)testThatRestorePostThrowsExceptionWithoutBlog
+{
+    RemotePost *post = OCMClassMock([RemotePost class]);
+    
+    PostServiceRemoteREST *service = nil;
+    
+    XCTAssertNoThrow(service = [self service]);
+    XCTAssertThrows([service restorePost:post
+                                 forBlog:nil
+                                 success:^(RemotePost *posts) {}
+                                 failure:^(NSError *error) {}]);
+}
+
 @end


### PR DESCRIPTION
Follow up to [this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/3808).

This PR adds several tests for:
- AccountServiceRemoteREST.
- BlogServiceRemoteREST.
- PostServiceRemoteREST.

**How to test:**
- Run the unit tests and make sure the newly added tests all succeed (at the time of this writing there are a few unrelated broken tests coming from `develop` which are outside of the scope of this PR).