### PR TITLE
Notifications Comment Embeds: Fullscreen Support

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -14,6 +14,8 @@
 #import "ReaderSiteService.h"
 
 #import "WPWebViewController.h"
+#import "WPImageViewController.h"
+
 #import "ReaderPostDetailViewController.h"
 #import "ReaderCommentsViewController.h"
 #import "StatsViewController.h"
@@ -670,17 +672,21 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     // Setup the Callbacks
     __weak __typeof(self) weakSelf  = self;
     
-    cell.onDetailsClick             = ^(UIButton * sender){
+    cell.onDetailsClick             = ^(UIButton * sender) {
         NSURL *url = [NSURL URLWithString:userBlock.metaLinksHome];
         if (url) {
             [weakSelf openURL:url];
         }
     };
     
-    cell.onUrlClick                 = ^(NSURL *url){
+    cell.onUrlClick                 = ^(NSURL *url) {
         [weakSelf openURL:url];
     };
 
+    cell.onAttachmentClick          = ^(NSTextAttachment *attachment) {
+        [weakSelf displayFullscreenImage:attachment.image];
+    };
+    
     // Download the Gravatar (If Needed!)
     if (cell.isLayoutCell) {
         return;
@@ -949,6 +955,20 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     [self presentViewController:navController animated:YES completion:nil];
     
     return success;
+}
+
+- (BOOL)displayFullscreenImage:(UIImage *)image
+{
+    if (!image) {
+        return NO;
+    }
+    
+    WPImageViewController *imageViewController = [[WPImageViewController alloc] initWithImage:image];
+    imageViewController.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
+    imageViewController.modalPresentationStyle = UIModalPresentationFullScreen;
+    [self presentViewController:imageViewController animated:YES completion:nil];
+    
+    return YES;
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -5,6 +5,7 @@ import Foundation
 {
     // MARK: - Public Properties
     public var onUrlClick: ((NSURL) -> Void)?
+    public var onAttachmentClick: ((NSTextAttachment) -> Void)?
     public var attributedText: NSAttributedString? {
         set {
             textView.attributedText = newValue
@@ -94,6 +95,11 @@ import Foundation
     
     public func textView(textView: UITextView, didPressLink link: NSURL) {
         onUrlClick?(link)
+    }
+    
+    public func textView(textView: UITextView, shouldInteractWithTextAttachment textAttachment: NSTextAttachment, inRange characterRange: NSRange) -> Bool {
+        onAttachmentClick?(textAttachment)
+        return false
     }
     
     // MARK: - Constants


### PR DESCRIPTION
#### Steps:
1. Receive a Comment Notification that contains an image embed. This can be used to test the feature:
  `<img src="https://i.cloudup.com/RiNQdiWYLe.gif">`
2. Launch WPiOS and open the Notifications tab
3. Open the new notification's details
4. Tap over the embedded image

Expected: the image should be displayed in a modal viewController.

Needs Review: @aerych (Thanks in advance Eric!)

Closes #2764
