### PR TITLE
Includes newly created posts under the only me filter.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -291,7 +291,8 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     [predicates addObject:filterPredicate];
 
     if ([self shouldShowOnlyMyPosts]) {
-        NSPredicate *authorPredicate = [NSPredicate predicateWithFormat:@"authorID = %@", self.blog.account.userID];
+        // Brand new local drafts have an authorID of 0.
+        NSPredicate *authorPredicate = [NSPredicate predicateWithFormat:@"authorID = %@ || authorID = 0", self.blog.account.userID];
         [predicates addObject:authorPredicate];
     }
 


### PR DESCRIPTION
Closes #3835 

To test:
Start with a multi-author blog
Start a new post.
Double tap the home button and force quit WordPress. 
Relaunch the app. 
Make sure the newly started local-only post appears under both "only me" and "everyone" author filters. 

@koke since you discovered this one would you mind taking a look?

Needs Review: @koke 