### PR TITLE
Fixing PushAuthentication Unit Test

### DIFF
--- a/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
@@ -100,7 +100,7 @@ class PushAuthenticationManagerTests : XCTestCase {
         pushAuthenticationManager!.handlePushAuthenticationNotification(validPushAuthenticationDictionary())
         
         XCTAssertTrue(mockAlertViewProxy.showWithTitleCalled, "Should show the login verification")
-        XCTAssertEqual(mockAlertViewProxy.titlePassedIn!, NSLocalizedString("Verify Login", comment: ""), "")
+        XCTAssertEqual(mockAlertViewProxy.titlePassedIn!, NSLocalizedString("Verify Sign In", comment: ""), "")
     }
     
     func testHandlePushAuthenticationNotificationShouldAttemptToAuthorizeTheLoginIfTheUserIndicatesTheyWantTo() {


### PR DESCRIPTION
One of the Push Auth strings was recently updated, and i didn't notice i broke the unit test (Sorry!!)

Needs Review: @diegoreymendez 
