### PR TITLE
Adjusts featured image selection logic.

### DIFF
--- a/WordPress/Classes/Utility/DisplayableImageHelper.m
+++ b/WordPress/Classes/Utility/DisplayableImageHelper.m
@@ -1,6 +1,6 @@
 #import "DisplayableImageHelper.h"
 
-static const NSInteger FeaturedImageMinimumWidth = 640;
+static const NSInteger FeaturedImageMinimumWidth = 150;
 
 static NSString * const AttachmentsDictionaryKeyWidth = @"width";
 static NSString * const AttachmentsDictionaryKeyURL = @"URL";
@@ -74,6 +74,7 @@ static NSString * const AttachmentsDictionaryKeyMimeType = @"mime_type";
     // Find all the image tags in the content passed.
     NSArray *matches = [regex matchesInString:content options:NSRegularExpressionCaseInsensitive range:NSMakeRange(0, [content length])];
 
+    NSString *firstImageWithNoSize;
     NSInteger currentMaxWidth = FeaturedImageMinimumWidth;
     for (NSTextCheckingResult *match in matches) {
         NSString *tag = [content substringWithRange:match.range];
@@ -84,7 +85,13 @@ static NSString * const AttachmentsDictionaryKeyMimeType = @"mime_type";
         if (width > currentMaxWidth) {
             imageSrc = src;
             currentMaxWidth = width;
+        } else if (!firstImageWithNoSize && width == 0) {
+            firstImageWithNoSize = src;
         }
+    }
+
+    if ([imageSrc length] == 0 && firstImageWithNoSize) {
+        imageSrc = firstImageWithNoSize;
     }
 
     return imageSrc;


### PR DESCRIPTION
Lowers the threshold size to match the web.
If no other image is found, chooses the first image without size information.
The assumption is this will be a feature worth image, and size info was omitted to allow it to naturally scale in the browser.

Closes #3853 

To test:
Try viewing the post list with posts that have images in the content, but no width defined on the image. Confirm the first image is now selected to show in the post card in the list. 

Its expected that some images will be up-scaled but this should happen infrequently, and a slightly grainy image is preferred to no image at all. 

Needs Review: @diegoreymendez 