### PR TITLE
Notifications: Resizing Media Embeds on Rotation

### DIFF
--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -1,7 +1,7 @@
 #import <AFNetworking/AFNetworking.h>
 #import <AFNetworking/UIKit+AFNetworking.h>
 
-#import <MGImageUtilities/UIImage+ProportionalFill.h>
+#import "UIImage+Resize.h"
 
 #import "Notification.h"
 #import "Notification+Internals.h"

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -526,7 +526,14 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     __weak __typeof(self) weakSelf  = self;
     
     void (^completion)(void)        = ^{
-        [weakSelf.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
+        
+        // Workaround:
+        // Performing the reload call, multiple times, without the UIViewAnimationOptionBeginFromCurrentState might lead
+        // to a state in which the cell remains not visible.
+        //
+        [UIView animateWithDuration:0.25 delay:0.0 options:UIViewAnimationOptionOverrideInheritedDuration | UIViewAnimationOptionBeginFromCurrentState animations:^{
+            [weakSelf.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationFade];
+        } completion:nil];
     };
 
     [self.mediaDownloader downloadMediaWithUrls:imageUrls maximumWidth:self.maxMediaEmbedWidth completion:completion];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -520,7 +520,11 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 - (void)downloadAndResizeMedia:(NSIndexPath *)indexPath blockGroup:(NotificationBlockGroup *)blockGroup
 {
-    // Download Media: Only embeds for Text and Comment notifications
+    //  Notes:
+    //  -   We'll *only* download Media for Text and Comment Blocks
+    //  -   Plus, we'll also resize the downloaded media cache *if needed*. This is meant to adjust images to
+    //      better fit onscreen, whenever the device orientation changes (and in turn, the maxMediaEmbedWidth changes too).
+    //
     NSSet *richBlockTypes           = [NSSet setWithObjects:@(NoteBlockTypeText), @(NoteBlockTypeComment), nil];
     NSSet *imageUrls                = [blockGroup imageUrlsForBlocksOfTypes:richBlockTypes];
     __weak __typeof(self) weakSelf  = self;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -548,7 +548,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 {
     UIEdgeInsets textPadding        = NoteBlockTextTableViewCell.defaultLabelPadding;
     CGFloat portraitWidth           = [UIDevice isPad] ? WPTableViewFixedWidth : CGRectGetWidth(self.view.bounds);
-    CGFloat maxWidth                = portraitWidth - textPadding.left - textPadding.right;
+    CGFloat maxWidth                = portraitWidth - (textPadding.left + textPadding.right);
     
     return maxWidth;
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -163,7 +163,7 @@ import Foundation
     *  @returns     A dictionary with URL as Key, and Image as Value.
     */
     private func shouldDownloadImage(#url: NSURL) -> Bool {
-        return originalImagesMap[url] == nil && checkRetryCount(url) < maximumRetryCount && !beingDownloaded.contains(url)
+        return originalImagesMap[url] == nil && getRetryCount(url) < maximumRetryCount && !beingDownloaded.contains(url)
     }
     
     /**
@@ -172,7 +172,7 @@ import Foundation
     *  @param       urls            The URL we're tracking
     */
     private func increaseRetryCount(url: NSURL) {
-        retryMap[url] = checkRetryCount(url) + 1
+        retryMap[url] = getRetryCount(url) + 1
     }
 
     /**
@@ -181,7 +181,7 @@ import Foundation
     *  @param       urls            The URL we're tracking
     *  @return      The current retry count
     */
-    private func checkRetryCount(url: NSURL) -> Int {
+    private func getRetryCount(url: NSURL) -> Int {
         return retryMap[url] ?? 0
     }
     

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -21,18 +21,11 @@ import Foundation
     public typealias SuccessBlock = (()->())
     
     public func downloadMediaWithUrls(urls: NSSet, completion: SuccessBlock) {
-        let allUrls = urls.allObjects as? [NSURL]
-        if allUrls == nil {
-            return
-        }
-        
-        let missingUrls = allUrls!.filter { self.shouldDownloadImageWithURL($0) }
-        if missingUrls.count == 0 {
-            return
-        }
-        
-        for url in missingUrls {
-            downloadImageWithURL(url) { (NSError error, UIImage downloadedImage) -> () in
+        let allUrls     = urls.allObjects as? [NSURL]
+        let missingUrls = allUrls?.filter { self.shouldDownloadImageWithURL($0) }
+
+        missingUrls?.map { (url) in
+            self.downloadImageWithURL(url) { (NSError error, UIImage downloadedImage) -> () in
                 if error != nil || downloadedImage == nil {
                     return
                 }
@@ -119,12 +112,12 @@ import Foundation
         targetSize.height   = round(maxImageWidth * targetSize.height / targetSize.width)
         targetSize.width    = maxImageWidth
         
-        dispatch_async(resizeQueue, { () -> Void in
+        dispatch_async(resizeQueue) {
             let resizedImage = image.imageCroppedToFitSize(targetSize, ignoreAlpha: false)
-            dispatch_async(dispatch_get_main_queue(), { () -> Void in
+            dispatch_async(dispatch_get_main_queue()) {
                 callback(resizedImage)
-            })
-        })
+            }
+        }
     }
     
     // MARK: - Constants

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -103,7 +103,7 @@ import Foundation
         }
         
         dispatch_async(resizeQueue) {
-            let resizedImage = image.imageScaledToFitSize(targetSize, ignoreAlpha: false)
+            let resizedImage = image.resizedImage(targetSize, interpolationQuality: kCGInterpolationHigh)
             dispatch_async(dispatch_get_main_queue()) {
                 callback(resizedImage)
             }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -7,24 +7,33 @@ import Foundation
         downloadQueue.cancelAllOperations()
     }
     
-    public init(maximumImageWidth: CGFloat) {
-        maxImageWidth = maximumImageWidth
-        super.init()
-    }
-    
     // MARK: - Public Helpers
-    public typealias SuccessBlock = (Void -> Void)
-    
-    public func downloadMediaWithUrls(urls: NSSet, completion: SuccessBlock) {
-        let allUrls     = urls.allObjects as? [NSURL]
-        let missingUrls = allUrls?.filter { self.shouldDownloadImage(url: $0) }
+    public func downloadMedia(#urls: Set<NSURL>, maximumWidth: CGFloat, completion: SuccessBlock) {
+        let missingUrls = filter(urls) { self.shouldDownloadImage(url: $0) }
 
-        missingUrls?.map { (url) in
-            self.downloadImage(url) {
-                self.resizeImageIfNeeded($0, maxImageWidth: self.maxImageWidth) {
-                    self.mediaMap[url] = $0
+        for url in missingUrls {
+            downloadImage(url) {
+                self.originalImagesMap[url] = $0
+                
+                self.resizeImageIfNeeded($0, maximumWidth: maximumWidth) {
+                    self.resizedImagesMap[url] = $0
                     completion()
                 }
+            }
+        }
+    }
+    
+    public func resizeMediaWithIncorrectSize(maximumWidth: CGFloat, completion: SuccessBlock) {
+        for (url, originalImage) in originalImagesMap {
+            let targetSize = cappedImageSize(originalImage.size, maximumWidth: maximumWidth)
+
+            if resizedImagesMap[url]?.size == targetSize {
+                continue
+            }
+println("Resizing \(url) original \(originalImage.size) target \(targetSize)")
+            resizeImageIfNeeded(originalImage, maximumWidth: maximumWidth) {
+                self.resizedImagesMap[url] = $0
+                completion()
             }
         }
     }
@@ -32,7 +41,7 @@ import Foundation
     public func imagesForUrls(urls: [NSURL]) -> [NSURL: UIImage] {
         var filtered = [NSURL: UIImage]()
         
-        for (url, image) in mediaMap {
+        for (url, image) in resizedImagesMap {
             if contains(urls, url) {
                 filtered[url] = image
             }
@@ -51,7 +60,6 @@ import Foundation
         let operation                   = AFHTTPRequestOperation(request: request)
         operation.responseSerializer    = responseSerializer
         operation.setCompletionBlockWithSuccess({
-            [weak self]
             (AFHTTPRequestOperation operation, AnyObject responseObject) -> Void in
             
             if let unwrappedImage = responseObject as? UIImage {
@@ -61,52 +69,70 @@ import Foundation
         }, failure: nil)
         
         downloadQueue.addOperation(operation)
-        retryMap[url] = retryCount(url) + 1
+        increaseRetryCount(url)
     }
     
-    private func shouldDownloadImage(url url: NSURL) -> Bool {
-        if mediaMap[url] != nil || retryCount(url) > maximumRetryCount {
-            return false
-        }
-
+    private func shouldDownloadImage(#url: NSURL) -> Bool {
         let operations  = downloadQueue.operations as? [AFHTTPRequestOperation]
-        let filtered    = operations?.filter { $0.request.URL!.isEqual(url) }
+        let filtered    = operations?.filter { $0.request.URL!.isEqual(url) } ?? [AFHTTPRequestOperation]()
         
-        return filtered?.count == 0
-    }    
+        return originalImagesMap[url] == nil && !exceededRetryCount(url) && filtered.isEmpty
+    }
     
-    private func retryCount(url: NSURL) -> Int {
+    
+    // MARK: - Retry Helpers
+    private func increaseRetryCount(url: NSURL) {
+        retryMap[url] = currentRetryCount(url) + 1
+    }
+    
+    private func currentRetryCount(url: NSURL) -> Int {
         return retryMap[url] ?? 0
+    }
+    
+    private func exceededRetryCount(url: NSURL) -> Bool {
+        return currentRetryCount(url) >= maximumRetryCount
     }
     
     
     // MARK: - Async Image Resizing Helpers
-    private func resizeImageIfNeeded(image: UIImage, maxImageWidth: CGFloat, callback: ((UIImage) -> ())) {
-        if image.size.width <= maxImageWidth {
+    private func resizeImageIfNeeded(image: UIImage, maximumWidth: CGFloat, callback: ((UIImage) -> ())) {
+        let targetSize = cappedImageSize(image.size, maximumWidth: maximumWidth)
+        if image.size == targetSize {
             callback(image)
             return
         }
-
-        var targetSize      = image.size
-        targetSize.height   = round(maxImageWidth * targetSize.height / targetSize.width)
-        targetSize.width    = maxImageWidth
         
         dispatch_async(resizeQueue) {
-            let resizedImage = image.imageCroppedToFitSize(targetSize, ignoreAlpha: false)
+            let resizedImage = image.imageScaledToFitSize(targetSize, ignoreAlpha: false)
             dispatch_async(dispatch_get_main_queue()) {
                 callback(resizedImage)
             }
         }
     }
+
+    private func cappedImageSize(originalSize: CGSize, maximumWidth: CGFloat) -> CGSize {
+        var targetSize = originalSize
+
+        if targetSize.width > maximumWidth {
+            targetSize.height   = round(maximumWidth * targetSize.height / targetSize.width)
+            targetSize.width    = maximumWidth
+        }
+        
+        return targetSize
+    }
     
-    // MARK: - Constants
+    
+    // MARK: - Public Aliases
+    public typealias SuccessBlock   = (Void -> Void)
+    
+    // MARK: - Private Constants
     private let maximumRetryCount   = 3
     
     // MARK: - Private Properties
     private let responseSerializer  = AFImageResponseSerializer()
     private let downloadQueue       = NSOperationQueue()
     private let resizeQueue         = dispatch_queue_create("notifications.media.resize", DISPATCH_QUEUE_CONCURRENT)
-    private var mediaMap            = [NSURL: UIImage]()
+    private var originalImagesMap   = [NSURL: UIImage]()
+    private var resizedImagesMap    = [NSURL: UIImage]()
     private var retryMap            = [NSURL: Int]()
-    private let maxImageWidth:      CGFloat
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -44,14 +44,17 @@ import Foundation
     }
     
     /**
-    *  @brief       Resizes the downloaded media to fit a "new" maximumWidth, if needed.
+    *  @brief       Resizes the downloaded media to fit a "new" maximumWidth ***if needed**.
     *  @details     This method will check the cache of "resized images", and will verify if the original image
     *               *could* be resized again, so that it better fits the *maximumWidth* received.
+    *               If an image *could* be resized, we proceed, and hit the completion block, once per asset.
+    *               Otherwise, we just don't do anything else.
+    *
     *               Useful to handle rotation events: the downloaded images may need to be resized, again, to 
     *               fit onscreen.
     *
     *  @param       maximumWidth    Represents the maximum width that a returned image should have
-    *  @param       completion      Is a closure that will get executed each time a new asset is available
+    *  @param       completion      Is a closure that will get executed each time a new asset is effectively resized
     */
     public func resizeMediaWithIncorrectSize(maximumWidth: CGFloat, completion: SuccessBlock) {
         for (url, originalImage) in originalImagesMap {

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -30,7 +30,7 @@ import Foundation
             if resizedImagesMap[url]?.size == targetSize {
                 continue
             }
-println("Resizing \(url) original \(originalImage.size) target \(targetSize)")
+
             resizeImageIfNeeded(originalImage, maximumWidth: maximumWidth) {
                 self.resizedImagesMap[url] = $0
                 completion()

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -17,7 +17,7 @@ import Foundation
     
     public func downloadMediaWithUrls(urls: NSSet, completion: SuccessBlock) {
         let allUrls     = urls.allObjects as? [NSURL]
-        let missingUrls = allUrls?.filter { self.shouldDownloadImageWithURL($0) }
+        let missingUrls = allUrls?.filter { self.shouldDownloadImage(url: $0) }
 
         missingUrls?.map { (url) in
             self.downloadImage(url) {
@@ -64,7 +64,7 @@ import Foundation
         retryMap[url] = retryCount(url) + 1
     }
     
-    private func shouldDownloadImageWithURL(url: NSURL) -> Bool {
+    private func shouldDownloadImage(url url: NSURL) -> Bool {
         if mediaMap[url] != nil || retryCount(url) > maximumRetryCount {
             return false
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -8,12 +8,7 @@ import Foundation
     }
     
     public init(maximumImageWidth: CGFloat) {
-        downloadQueue       = NSOperationQueue()
-        resizeQueue         = dispatch_queue_create("org.wordpress.notifications.media-downloader", DISPATCH_QUEUE_CONCURRENT)
-        mediaMap            = [NSURL: UIImage]()
-        retryMap            = [NSURL: Int]()
         maxImageWidth       = maximumImageWidth
-        responseSerializer  = AFImageResponseSerializer() as AFImageResponseSerializer
         super.init()
     }
     
@@ -121,13 +116,13 @@ import Foundation
     }
     
     // MARK: - Constants
-    private let maximumRetryCount:  Int = 3
+    private let maximumRetryCount   = 3
     
     // MARK: - Private Properties
-    private let responseSerializer: AFHTTPResponseSerializer
-    private let downloadQueue:      NSOperationQueue
-    private let resizeQueue:        dispatch_queue_t
-    private var mediaMap:           [NSURL: UIImage]
-    private var retryMap:           [NSURL: Int]
+    private let responseSerializer  = AFImageResponseSerializer()
+    private let downloadQueue       = NSOperationQueue()
+    private let resizeQueue         = dispatch_queue_create("notifications.media.resize", DISPATCH_QUEUE_CONCURRENT)
+    private var mediaMap            = [NSURL: UIImage]()
+    private var retryMap            = [NSURL: Int]()
     private let maxImageWidth:      CGFloat
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -151,6 +151,9 @@ import Foundation
             
             if let unwrappedImage = responseObject as? UIImage {
                 completion(nil, unwrappedImage)
+            } else {
+                let error = NSError(domain: self.downloaderDomain, code: self.emptyMediaErrorCode, userInfo: nil)
+                completion(error, nil)
             }
             
             self.urlsBeingDownloaded.remove(url)
@@ -234,6 +237,8 @@ import Foundation
     
     // MARK: - Private Constants
     private let maximumRetryCount   = 3
+    private let emptyMediaErrorCode = -1
+    private let downloaderDomain    = "notifications.media.downloader"
     
     // MARK: - Private Properties
     private let responseSerializer  = AFImageResponseSerializer()

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -1,13 +1,33 @@
 import Foundation
 
 
+/**
+*  @class           NotificationMediaDownloader
+*  @brief           The purpose of this class is to provide a simple API to download assets from the web.
+*  @details         Assets are downloaded, and resized to fit a maximumWidth, specified in the initial download call.
+*                   Internally, images get downloaded and resized: both copies of the image get cached.
+*                   Since the user may rotate the device, we also provide a second helper (resizeMediaWithIncorrectSize),
+*                   which will take care of resizing the original image, to fit the new orientation.
+*/
+
 @objc public class NotificationMediaDownloader : NSObject
 {
+    //
+    // MARK: - Public Methods
+    //
     deinit {
         downloadQueue.cancelAllOperations()
     }
     
-    // MARK: - Public Helpers
+    /**
+    *  @brief       Downloads a set of assets, resizes them (if needed), and hits a completion block.
+    *  @details     The completion block will get called multiple times (once every time a new asset is
+    *               ready for usage), so that the interface can get gradually populated.
+    *
+    *  @param       urls            Is the collection of unique Image URL's we'd need to download.
+    *  @param       maximumWidth    Represents the maximum width that a returned image should have
+    *  @param       completion      Is a closure that will get executed each time a new asset is available
+    */
     public func downloadMedia(#urls: Set<NSURL>, maximumWidth: CGFloat, completion: SuccessBlock) {
         let missingUrls = filter(urls) { self.shouldDownloadImage(url: $0) }
 
@@ -23,6 +43,16 @@ import Foundation
         }
     }
     
+    /**
+    *  @brief       Resizes the downloaded media to fit a "new" maximumWidth, if needed.
+    *  @details     This method will check the cache of "resized images", and will verify if the original image
+    *               *could* be resized again, so that it better fits the *maximumWidth* received.
+    *               Useful to handle rotation events: the downloaded images may need to be resized, again, to 
+    *               fit onscreen.
+    *
+    *  @param       maximumWidth    Represents the maximum width that a returned image should have
+    *  @param       completion      Is a closure that will get executed each time a new asset is available
+    */
     public func resizeMediaWithIncorrectSize(maximumWidth: CGFloat, completion: SuccessBlock) {
         for (url, originalImage) in originalImagesMap {
             let targetSize = cappedImageSize(originalImage.size, maximumWidth: maximumWidth)
@@ -37,7 +67,15 @@ import Foundation
             }
         }
     }
-    
+
+    /**
+    *  @brief       Returns a collection of images, ready to be displayed onscreen.
+    *  @details     For convenience, we return a map with URL as Key, and Image as Value, so that each asset can be
+    *               easily addressed.
+    *
+    *  @param       urls            The collection of URL's of the assets you'd need.
+    *  @returns     A dictionary with URL as Key, and Image as Value.
+    */
     public func imagesForUrls(urls: [NSURL]) -> [NSURL: UIImage] {
         var filtered = [NSURL: UIImage]()
         
@@ -51,7 +89,17 @@ import Foundation
     }
     
     
-    // MARK: - Networking Wrappers
+    //
+    // MARK: - Private Helpers
+    //
+    
+    
+    /**
+    *  @brief       Downloads an asset, given its URL
+    *
+    *  @param       url             The URL of the media we should download
+    *  @param       success         A closure to be executed, on success.
+    */
     private func downloadImage(url: NSURL, success: (UIImage -> ())) {
         let request                     = NSMutableURLRequest(URL: url)
         request.HTTPShouldHandleCookies = false
@@ -72,29 +120,51 @@ import Foundation
         increaseRetryCount(url)
     }
     
+    /**
+    *  @brief       Checks if an image should be downloaded, or not.
+    *  @details     An image should be downloaded if:
+    *
+    *               -   It's not already being downloaded
+    *               -   Isn't already in the cache!
+    *               -   Hasn't exceeded the retry count
+    *
+    *  @param       urls            The collection of URL's of the assets you'd need.
+    *  @returns     A dictionary with URL as Key, and Image as Value.
+    */
     private func shouldDownloadImage(#url: NSURL) -> Bool {
         let operations  = downloadQueue.operations as? [AFHTTPRequestOperation]
         let filtered    = operations?.filter { $0.request.URL!.isEqual(url) } ?? [AFHTTPRequestOperation]()
         
-        return originalImagesMap[url] == nil && !exceededRetryCount(url) && filtered.isEmpty
+        return originalImagesMap[url] == nil && checkRetryCount(url) < maximumRetryCount && filtered.isEmpty
     }
     
-    
-    // MARK: - Retry Helpers
+    /**
+    *  @brief       Increases the retry count for a given URL
+    *
+    *  @param       urls            The URL we're tracking
+    */
     private func increaseRetryCount(url: NSURL) {
-        retryMap[url] = currentRetryCount(url) + 1
+        retryMap[url] = checkRetryCount(url) + 1
     }
-    
-    private func currentRetryCount(url: NSURL) -> Int {
+
+    /**
+    *  @brief       Returns the current retry count for a given URL
+    *
+    *  @param       urls            The URL we're tracking
+    *  @return      The current retry count
+    */
+    private func checkRetryCount(url: NSURL) -> Int {
         return retryMap[url] ?? 0
     }
     
-    private func exceededRetryCount(url: NSURL) -> Bool {
-        return currentRetryCount(url) >= maximumRetryCount
-    }
     
-    
-    // MARK: - Async Image Resizing Helpers
+    /**
+    *  @brief       Resizes -in background- a given image, if needed, to fit a maximum width
+    *
+    *  @param       image           The image to resize
+    *  @param       maximumWidth    The maximum width in which the image should fit
+    *  @param       callback        A closure to be called, on the main thread, on completion
+    */
     private func resizeImageIfNeeded(image: UIImage, maximumWidth: CGFloat, callback: ((UIImage) -> ())) {
         let targetSize = cappedImageSize(image.size, maximumWidth: maximumWidth)
         if image.size == targetSize {
@@ -110,6 +180,13 @@ import Foundation
         }
     }
 
+    /**
+    *  @brief       Returns the scaled size, scaled down proportionally (if needed) to fit a maximumWidth
+    *
+    *  @param       originalSize    The original size of the image
+    *  @param       maximumWidth    The maximum width we've got available
+    *  @return      The size, scaled down proportionally (if needed) to fit a maximum width
+    */
     private func cappedImageSize(originalSize: CGSize, maximumWidth: CGFloat) -> CGSize {
         var targetSize = originalSize
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -40,7 +40,7 @@ import Foundation
     }
     
     public var labelPadding: UIEdgeInsets {
-        return privateLabelPadding
+        return self.dynamicType.defaultLabelPadding
     }
     
     public var isTextViewSelectable: Bool {
@@ -83,7 +83,7 @@ import Foundation
     
     public override func layoutSubviews() {
         // Calculate the TextView's width, before hitting layoutSubviews!
-        textView.preferredMaxLayoutWidth = min(bounds.width, maxWidth) - labelPadding.left - labelPadding.right
+        textView.preferredMaxLayoutWidth = min(bounds.width, self.dynamicType.maxWidth) - labelPadding.left - labelPadding.right
         super.layoutSubviews()
     }
         
@@ -103,8 +103,8 @@ import Foundation
     }
     
     // MARK: - Constants
-    private let maxWidth            = WPTableViewFixedWidth
-    private let privateLabelPadding = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
+    public static let maxWidth            = WPTableViewFixedWidth
+    public static let defaultLabelPadding = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
     
     // MARK: - IBOutlets
     @IBOutlet private weak var textView: RichTextView!

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -104,7 +104,7 @@ import Foundation
     
     // MARK: - Constants
     public static let maxWidth            = WPTableViewFixedWidth
-    public static let defaultLabelPadding = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
+    public static let defaultLabelPadding = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 12.0)
     
     // MARK: - IBOutlets
     @IBOutlet private weak var textView: RichTextView!


### PR DESCRIPTION
### Testing Steps:
1. Launch WPiOS
2. Receive a Comment Notification with embedded images
3. Tap over the Notifications tab
4. Open the new notification
5. Verify that the assets should show up shortly, once available
6. Rotate the device
7. Verify that the assets get properly resized to fit the new width

### Notes:
This can be tested with the following images:

```
We'll do an inline image here <img src="https://i.cloudup.com/RiNQdiWYLe.gif">.

Another one here:

<img src="https://i.cloudup.com/RiNQdiWYLe.gif">

Another here:

<img src="https://cldup.com/XD_ZVbGXD7.png">

And last one: <img src="https://cldup.com/VSVBixYg33.png">
```

Needs Review: @aerych (thanks in advance Eric!)

Closes #2765