### PR TITLE
Open post in edit mode if edit is tapped.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -431,7 +431,7 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     [WPAnalytics track:WPAnalyticsStatPostListEditAction withProperties:[self propertiesForAnalytics]];
     if ([WPPostViewController isNewEditorEnabled]) {
         WPPostViewController *postViewController = [[WPPostViewController alloc] initWithPost:apost
-                                                                                         mode:kWPPostViewControllerModePreview];
+                                                                                         mode:kWPPostViewControllerModeEdit];
         postViewController.hidesBottomBarWhenPushed = YES;
         [self.navigationController pushViewController:postViewController animated:YES];
     } else {


### PR DESCRIPTION
Closes #3864 

To Test:
Open the post list.
Tap the edit button at the bottom of a post card view in the list. 
Confirm the editor opens in edit mode. 

Needs Review: @diegoreymendez 