### PR TITLE
CommentsViewController: Updating Blog's lastCommentsSync property

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -145,10 +145,15 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
                            [self.managedObjectContext performBlock:^{
                                Blog *blogInContext = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:nil];
                                if (blogInContext) {
-                                   [self mergeComments:comments forBlog:blog
+                                   [self mergeComments:comments
+                                               forBlog:blog
                                          purgeExisting:YES
                                      completionHandler:^{
                                          [[self class] stopSyncingCommentsForBlog:blogID];
+                                         
+                                         blogInContext.lastCommentsSync = [NSDate date];
+                                         [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+                                         
                                          if (success) {
                                              success();
                                          }

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -240,11 +240,34 @@ const NSInteger PostServiceNumberToFetch = 40;
                    success:^(NSArray *posts) {
                        BOOL hasMore = ([posts count] < PostServiceNumberToFetch) ? NO : YES;
                        [self.managedObjectContext performBlock:^{
-                           [self mergePosts:posts ofType:postType withStatuses:postStatus byAuthor:authorID forBlog:blog purgeExisting:YES completionHandler:^{
-                               if (success) {
-                                   success(hasMore);
-                               }
-                           }];
+                           [self mergePosts:posts
+                                     ofType:postType
+                               withStatuses:postStatus
+                                   byAuthor:authorID
+                                    forBlog:blog
+                              purgeExisting:YES
+                          completionHandler:^{
+                              // Update the Last Sync Date, accordingly
+                              Blog *blogInContext = (Blog *)[self.managedObjectContext existingObjectWithID:blog.objectID error:nil];
+                              
+                              BOOL syncedAll = [postType isEqual:PostServiceTypeAny];
+                              BOOL syncedPosts = [postType isEqual:PostServiceTypePost] || syncedAll;
+                              BOOL syncedPages = [postType isEqual:PostServiceTypePage] || syncedAll;
+                              
+                              if (syncedPages) {
+                                  blogInContext.lastPagesSync = [NSDate date];
+                              }
+                              
+                              if (syncedPosts) {
+                                  blogInContext.lastPostsSync = [NSDate date];
+                              }
+                              
+                              [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+                               
+                              if (success) {
+                                  success(hasMore);
+                              }
+                          }];
                        }];
                    } failure:^(NSError *error) {
                        if (failure) {

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -278,7 +278,7 @@ NSTimeInterval const CommentsRefreshTimeoutInSeconds    = 60 * 5; // 5 minutes
         }
         
         [commentService syncCommentsForBlog:blogInContext
-                                    success:^{                                        
+                                    success:^{
                                                 if (success) {
                                                     dispatch_async(dispatch_get_main_queue(), ^{
                                                         success(true);

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -279,6 +279,9 @@ NSTimeInterval const CommentsRefreshTimeoutInSeconds    = 60 * 5; // 5 minutes
         
         [commentService syncCommentsForBlog:blogInContext
                                     success:^{
+                                                blogInContext.lastCommentsSync = [NSDate date];
+                                                [[ContextManager sharedInstance] saveContext:context];
+                                        
                                                 if (success) {
                                                     dispatch_async(dispatch_get_main_queue(), ^{
                                                         success(true);

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -278,10 +278,7 @@ NSTimeInterval const CommentsRefreshTimeoutInSeconds    = 60 * 5; // 5 minutes
         }
         
         [commentService syncCommentsForBlog:blogInContext
-                                    success:^{
-                                                blogInContext.lastCommentsSync = [NSDate date];
-                                                [[ContextManager sharedInstance] saveContext:context];
-                                        
+                                    success:^{                                        
                                                 if (success) {
                                                     dispatch_async(dispatch_get_main_queue(), ^{
                                                         success(true);

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
@@ -184,6 +184,11 @@ static NSString * const CurrentPageListStatusFilterKey = @"CurrentPageListStatus
     return PostServiceTypePage;
 }
 
+- (NSDate *)lastSyncDate
+{
+    return self.blog.lastPagesSync;
+}
+
 
 #pragma mark - TableView Handler Delegate Methods
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -358,7 +358,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
         return;
     }
 
-    NSDate *lastSynced = self.blog.lastPostsSync;
+    NSDate *lastSynced = self.lastSyncDate;
     if (lastSynced == nil || ABS([lastSynced timeIntervalSinceNow]) > PostsControllerRefreshInterval) {
         // Update in the background
         [self syncItemsWithUserInteraction:NO];
@@ -385,6 +385,11 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 {
     // Subclasses should override.
     return PostServiceTypeAny;
+}
+
+- (NSDate *)lastSyncDate
+{
+    return self.blog.lastPostsSync;
 }
 
 - (void)syncHelper:(WPContentSyncHelper *)syncHelper syncContentWithUserInteraction:(BOOL)userInteraction success:(void (^)(BOOL))success failure:(void (^)(NSError *))failure

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -445,8 +445,6 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     [self.refreshControl endRefreshing];
     [self.postListFooterView showSpinner:NO];
 
-    self.blog.lastPostsSync = [NSDate date];
-
     [self.noResultsView removeFromSuperview];
     if ([[self.tableViewHandler.resultsController fetchedObjects] count] == 0) {
         // This is a special case.  Core data can be a bit slow about notifying

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
@@ -60,6 +60,7 @@ extern const CGFloat SearchWrapperViewLandscapeHeight;
 @property (nonatomic, strong) NSMutableArray *recentlyTrashedPostIDs; // IDs of trashed posts. Cleared on refresh or when filter changes.
 
 - (NSString *)postTypeToSync;
+- (NSDate *)lastSyncDate;
 - (void)syncItemsWithUserInteraction:(BOOL)userInteraction;
 - (BOOL)canFilterByAuthor;
 - (BOOL)shouldShowOnlyMyPosts;

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -252,6 +252,11 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     return PostServiceTypePost;
 }
 
+- (NSDate *)lastSyncDate
+{
+    return self.blog.lastPostsSync;
+}
+
 
 #pragma mark - Actions
 


### PR DESCRIPTION
@aerych i initially thought that `CommentService` should be the one updating the `lastCommentsSync` property.

However, after a brief check, i've found out that `AbstractPostListViewController` is the one that's actually updating `lastPostsSync`, so... thought it'd be a good idea to keep things consistent.

Mind taking a quick look?

Thank you!!

Closes #3867