### PR TITLE
Adjusted spacing on editor navbar

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -37,6 +37,7 @@
 #import "WPTooltip.h"
 #import "MediaLibraryPickerDataSource.h"
 #import "WPAndDeviceMediaLibraryDataSource.h"
+#import "WPDeviceIdentification.h"
 
 typedef NS_ENUM(NSInteger, EditPostViewControllerAlertTag) {
     EditPostViewControllerAlertTagNone,
@@ -79,7 +80,7 @@ NS_ENUM(NSUInteger, WPPostViewControllerActionSheet) {
     WPPostViewControllerActionSheetRetryVideoUpload = 205,
 };
 
-static CGFloat const SpacingBetweeenNavbarButtons = 20.0f;
+static CGFloat const SpacingBetweeenNavbarButtons = 40.0f;
 static CGFloat const RightSpacingOnExitNavbarButton = 5.0f;
 static NSDictionary *DisabledButtonBarStyle;
 static NSDictionary *EnabledButtonBarStyle;
@@ -1282,7 +1283,14 @@ EditImageDetailsViewControllerDelegate
 - (UIButton *)blogPickerButton
 {
     if (!_blogPickerButton) {
-        CGFloat titleButtonWidth = (IS_IPAD) ? 300.0f : 170.0f;
+        CGFloat titleButtonWidth = 140.0f;
+        
+        if ([WPDeviceIdentification isiPhoneSixPlus] || [WPDeviceIdentification isiPhoneSix]) {
+            titleButtonWidth = 190.0f;
+        } else if (IS_IPAD) {
+            titleButtonWidth = 300.0f;
+        }
+        
         UIButton *button = [WPBlogSelectorButton buttonWithFrame:CGRectMake(0.0f, 0.0f, titleButtonWidth , 30.0f) buttonStyle:WPBlogSelectorButtonTypeSingleLine];
         [button addTarget:self action:@selector(showBlogSelectorPrompt:) forControlEvents:UIControlEventTouchUpInside];
         _blogPickerButton = button;

--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
@@ -67,7 +67,10 @@
 {
     _buttonMode = value;
     if (self.buttonMode == WPBlogSelectorButtonSingleSite) {
-        [self setImage:nil forState:UIControlStateNormal];
+        UIGraphicsBeginImageContextWithOptions(CGSizeMake(15, 15), NO, 0.0);
+        UIImage *blankFillerImage = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+        [self setImage:blankFillerImage forState:UIControlStateNormal];
     } else {
         [self setImage:[UIImage imageNamed:@"icon-navbar-dropdown.png"] forState:UIControlStateNormal];
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/653

This PR adds a little more space between the navbar buttons (preview, options, etc) as well as fixes an overlap issue with the blog picker button on smaller devices.

How to test:
* Test the code on a wide variety of devices, make sure the editor navbar looks ok.
* Make sure the blog picker button does not overlap the preview button when in a new post AND editing an existing post (e.g. on a iPhone 4s)

/cc @diegoreymendez 