### PR TITLE
Enable Jetpack REST for everyone

### DIFF
--- a/WordPress/Classes/Utility/JetpackREST.m
+++ b/WordPress/Classes/Utility/JetpackREST.m
@@ -9,11 +9,7 @@ static NSString * const JetpackRESTEnabledKey = @"JetpackRESTEnabled";
 
 + (void)initialize
 {
-#if defined(INTERNAL_BUILD) || defined(DEBUG)
     BOOL enabledByDefault = YES;
-#else
-    BOOL enabledByDefault = NO;
-#endif
     [[NSUserDefaults standardUserDefaults] registerDefaults:@{JetpackRESTEnabledKey: @(enabledByDefault)}];
 }
 


### PR DESCRIPTION
This enables Jetpack REST by default for app store builds.

@beaulebens any concerns before we flip the switch?
@oguzkocer this is pretty straightforward, but I ask for a review just to be safe :)

Fixes #3627 

Needs Review: @beaulebens @oguzkocer 