### PR TITLE
Nukes dead Notifications Styles

### DIFF
--- a/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
@@ -260,9 +260,6 @@ extension NotificationBlock
         ]
         
         static let richRangeStylesMap = [
-            NoteRangeTypeUser               : Styles.blockBoldStyle,
-            NoteRangeTypePost               : Styles.blockItalicsStyle,
-            NoteRangeTypeComment            : Styles.blockItalicsStyle,
             NoteRangeTypeBlockquote         : Styles.blockQuotedStyle,
             NoteRangeTypeNoticon            : Styles.blockNoticonStyle,
             NoteRangeTypeMatch              : Styles.blockMatchStyle


### PR DESCRIPTION
We spotted several Notification Styles that are not being used anymore. Comment blocks and Text blocks may not contain the following ranges:

- User
- Post
- Comment

I'm removing those references from the proper styles map, just to clean things up.
This is probably a leftover from the `Badges` style implementation, which *may* contain those ranges, but since it requires different alignment settings, we ended up adding another styles collection, down the road.

Props to @dmsnell for checking the backend side, and @aerych for spotting this!

Needs Review: @aerych (Thanks in advance!)