### PR TITLE
Work around to correctly set the metaPublishImmediately flag.

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -492,6 +492,10 @@ const NSInteger PostServiceNumberToFetch = 40;
 - (void)initializeDraft:(AbstractPost *)post {
     post.remoteStatus = AbstractPostRemoteStatusLocal;
     post.status = PostStatusPublish;
+
+    // Hack: The date_create_gmt should arleady be nil for a draft but
+    // triggering the setter correctly sets the metaPublishImmediately flag.
+    post.date_created_gmt = nil;
 }
 
 - (NSPredicate *)predicateForPostsWithStatuses:(NSArray *)postStatus

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -493,7 +493,8 @@ const NSInteger PostServiceNumberToFetch = 40;
     post.remoteStatus = AbstractPostRemoteStatusLocal;
     post.status = PostStatusPublish;
 
-    // Hack: The date_create_gmt should arleady be nil for a draft but
+    // HACK: aerych - 2015-06-18
+    // The date_create_gmt should arleady be nil for a draft but
     // triggering the setter correctly sets the metaPublishImmediately flag.
     post.date_created_gmt = nil;
 }


### PR DESCRIPTION
Fixes an issue sorting pages.

Fixes #3886 

This is a rather hacky patch but takes advantage of an existing initialization feature. A better fix would probably be to set all of these properties as the default values in the model.   Let's follow up up with a PR doing that in the develop branch. 

To test:
- Open your page list. 
- If you have any pages already created today, move them into drafts or the trash. 
- Tap to create a new page. 
- Add a title and content and save. 
- The page should show up with the correct title under the "today" section and the UI should still be responsive. 

cc @koke, @sendhil 

Needs Review: @sendhil 