### PR TITLE
Hide username in Jetpack site settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/EditSiteViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/EditSiteViewController.m
@@ -36,7 +36,7 @@ static CGFloat const EditSiteRowHeight = 48.0;
 NSInteger const EditSiteURLMinimumLabelWidth = 30;
 NSInteger const EditSiteSectionCount = 2;
 
-NSInteger const EditSiteRowCountForSectionTitle = 2;
+NSInteger const EditSiteRowCountForSectionTitle = 1;
 NSInteger const EditSiteRowCountForSectionTitleSelfHosted = 3;
 NSInteger const EditSiteRowCountForSectionSettings = 2;
 NSInteger const EditSiteRowCountForSectionSettingsSelfHosted = 1;


### PR DESCRIPTION
Before:
![site-settings](https://cloud.githubusercontent.com/assets/8739/8180916/174ade5c-1422-11e5-9dd1-e073defe8fda.png)

After:
![site-settings](https://cloud.githubusercontent.com/assets/8739/8255794/c7d3432c-16a2-11e5-8a28-abfabe885b2a.png)

In #3719 we discussed better alternatives, but since @tonyr59h is going to update the settings screen soon I went for the simplest solution so at least it's not broken.

Since we don't have a way to get the username for Jetpack managed sites right now, let's just hide username for wp.com+Jetpack

Needs Review: @tonyr59h 