### PR TITLE
Updated to latest stats pod

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -32,7 +32,7 @@ pod 'Simperium', '0.7.9'
 pod 'WordPressApi', '~> 0.3.4'
 pod 'WordPress-iOS-Shared', '0.3.2'
 pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => 'b56ea686b980719c0d737ecf5f658da20befff8e'
-pod 'WordPressCom-Stats-iOS', '0.3.5'
+pod 'WordPressCom-Stats-iOS', '0.4.0'
 pod 'WordPressCom-Analytics-iOS', '0.0.33'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '303b8068530389ea87afde38b77466d685fe3210'
@@ -41,7 +41,7 @@ pod 'ReactiveCocoa', '~> 2.4.7'
 pod 'FormatterKit', '~> 1.8.0'
 
 target 'WordPressTodayWidget', :exclusive => true do
-  pod 'WordPressCom-Stats-iOS', '0.3.5'
+  pod 'WordPressCom-Stats-iOS', '0.4.0'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -145,7 +145,7 @@ PODS:
     - AFNetworking (~> 2.5.1)
     - wpxmlrpc (~> 0.7)
   - WordPressCom-Analytics-iOS (0.0.33)
-  - WordPressCom-Stats-iOS (0.3.5):
+  - WordPressCom-Stats-iOS (0.4.0):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (~> 2.0)
     - NSObject-SafeExpectations (= 0.0.2)
@@ -196,7 +196,7 @@ DEPENDENCIES:
   - WordPress-iOS-Shared (= 0.3.2)
   - WordPressApi (~> 0.3.4)
   - WordPressCom-Analytics-iOS (= 0.0.33)
-  - WordPressCom-Stats-iOS (= 0.3.5)
+  - WordPressCom-Stats-iOS (= 0.4.0)
   - WPMediaPicker (~> 0.4.4)
   - wpxmlrpc (~> 0.8)
 
@@ -282,7 +282,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Shared: bd0506db9b824611246f35e774832ecbc18fc45e
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
   WordPressCom-Analytics-iOS: 69b875d5bc1b053be13c6a33c7233bf6f50949b1
-  WordPressCom-Stats-iOS: 41767306edc05ee41c8b9438481c32884569530f
+  WordPressCom-Stats-iOS: e08916b72f626c9600b5cd85e8a12aa3532a3190
   WPMediaPicker: 7bb4147fda5306e20be0958334da0071eebf0616
   wpxmlrpc: 053c9cbed13dcec08515a4ffeb51780f6e858cc7
 

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -77,7 +77,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         
         let timeZone = NSTimeZone(name: timeZoneName!)
         var statsService: WPStatsService = WPStatsService(siteId: siteId, siteTimeZone: timeZone, oauth2Token: oauth2Token, andCacheExpirationInterval:0)
-        statsService.retrieveTodayStatsWithCompletionHandler({ (wpStatsSummary: StatsSummary!) -> Void in
+        statsService.retrieveTodayStatsWithCompletionHandler({ (wpStatsSummary: StatsSummary!, error: NSError!) -> Void in
             WPDDLogWrapper.logInfo("Downloaded data in the Today widget")
             
             self.visitorCount = wpStatsSummary.visitors


### PR DESCRIPTION
Closes #3881 

## What's New

Updates to latest stats pod which includes Insights stats for a site. 

There will be another version bump of this pod before WPiOS 5.4 is released to include a few open bug fixes.

## Testing

1. Load the app.
2. Visits stats for any site.
3. Notice a new tab labeled Insights.
4. Experience extreme joy.

Needs Review: @sendhil 