### PR TITLE
Sets search keyboard return key to 'Done'.

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Search/WPSearchControllerConfigurator.m
+++ b/WordPress/Classes/ViewRelated/System/Search/WPSearchControllerConfigurator.m
@@ -54,6 +54,7 @@ const NSTimeInterval SearchBarAnimationDuration = 0.2; // seconds
     self.searchBar.barStyle = UIBarStyleBlack;
     self.searchBar.barTintColor = [WPStyleGuide wordPressBlue];
     self.searchBar.showsCancelButton = YES;
+    self.searchBar.returnKeyType = UIReturnKeyDone;
     [self.searchBar setImage:[UIImage imageNamed:@"icon-clear-textfield"] forSearchBarIcon:UISearchBarIconClear state:UIControlStateNormal];
     [self.searchBar setImage:[UIImage imageNamed:@"icon-post-list-search"] forSearchBarIcon:UISearchBarIconSearch state:UIControlStateNormal];
     


### PR DESCRIPTION
Closes #3893 

To test:
Open the post or page list
Tap to search
Ensure the keyboard return key has the label "Done" 

Needs to be tested on iOS 7.1 to ensure backward compat. 

Needs Review: @diegoreymendez 
