### PR TITLE
Post card title font should be bold.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -127,7 +127,7 @@
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager merriweatherRegularFontOfSize:fontSize]};
+    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager merriweatherBoldFontOfSize:fontSize]};
 }
 
 + (NSDictionary *)postCardSnippetAttributes


### PR DESCRIPTION
Missed making the post card title bold with the reset of the font changes. 

Previously:
![regular](https://cloud.githubusercontent.com/assets/1435271/8319586/04636eda-19d6-11e5-8ef4-4198be0f1bc7.png)


After:
![bold](https://cloud.githubusercontent.com/assets/1435271/8319587/07ca9954-19d6-11e5-90e9-9085572a4966.png)


Needs review: @jleandroperez 