### PR TITLE
Bump stats to 0.4.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -32,8 +32,8 @@ pod 'Simperium', '0.7.9'
 pod 'WordPressApi', '~> 0.3.4'
 pod 'WordPress-iOS-Shared', '0.3.3'
 pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => '78d59da8eaf49042b88f7141beac614379149d6f'
-pod 'WordPressCom-Stats-iOS', '0.4.0'
-pod 'WordPressCom-Analytics-iOS', '0.0.33'
+pod 'WordPressCom-Stats-iOS', :git => 'git@github.com:wordpress-mobile/WordPressCom-Stats-iOS.git', :tag => '0.4.1'
+pod 'WordPressCom-Analytics-iOS', '0.0.34'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '303b8068530389ea87afde38b77466d685fe3210'
 pod 'WPMediaPicker', '~>0.4.4'
@@ -41,7 +41,7 @@ pod 'ReactiveCocoa', '~> 2.4.7'
 pod 'FormatterKit', '~> 1.8.0'
 
 target 'WordPressTodayWidget', :exclusive => true do
-  pod 'WordPressCom-Stats-iOS', '0.4.0'
+  pod 'WordPressCom-Stats-iOS', :git => 'git@github.com:wordpress-mobile/WordPressCom-Stats-iOS.git', :tag => '0.4.1'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile
+++ b/Podfile
@@ -32,7 +32,7 @@ pod 'Simperium', '0.7.9'
 pod 'WordPressApi', '~> 0.3.4'
 pod 'WordPress-iOS-Shared', '0.3.3'
 pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => '78d59da8eaf49042b88f7141beac614379149d6f'
-pod 'WordPressCom-Stats-iOS', :git => 'git@github.com:wordpress-mobile/WordPressCom-Stats-iOS.git', :tag => '0.4.1'
+pod 'WordPressCom-Stats-iOS', '0.4.1'
 pod 'WordPressCom-Analytics-iOS', '0.0.34'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '303b8068530389ea87afde38b77466d685fe3210'
@@ -41,7 +41,7 @@ pod 'ReactiveCocoa', '~> 2.4.7'
 pod 'FormatterKit', '~> 1.8.0'
 
 target 'WordPressTodayWidget', :exclusive => true do
-  pod 'WordPressCom-Stats-iOS', :git => 'git@github.com:wordpress-mobile/WordPressCom-Stats-iOS.git', :tag => '0.4.1'
+  pod 'WordPressCom-Stats-iOS', '0.4.1'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -147,7 +147,7 @@ PODS:
   - WordPressCom-Analytics-iOS (0.0.34)
   - WordPressCom-Stats-iOS (0.4.1):
     - AFNetworking (~> 2.5)
-    - CocoaLumberjack (~> 2.0)
+    - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.3)
     - WordPressCom-Analytics-iOS (~> 0.0.34)
@@ -196,8 +196,7 @@ DEPENDENCIES:
   - WordPress-iOS-Shared (= 0.3.3)
   - WordPressApi (~> 0.3.4)
   - WordPressCom-Analytics-iOS (= 0.0.34)
-  - WordPressCom-Stats-iOS (from `git@github.com:wordpress-mobile/WordPressCom-Stats-iOS.git`,
-    tag `0.4.1`)
+  - WordPressCom-Stats-iOS (= 0.4.1)
   - WPMediaPicker (~> 0.4.4)
   - wpxmlrpc (~> 0.8)
 
@@ -222,9 +221,6 @@ EXTERNAL SOURCES:
   WordPress-iOS-Editor:
     :commit: 78d59da8eaf49042b88f7141beac614379149d6f
     :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
-  WordPressCom-Stats-iOS:
-    :git: git@github.com:wordpress-mobile/WordPressCom-Stats-iOS.git
-    :tag: 0.4.1
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -245,9 +241,6 @@ CHECKOUT OPTIONS:
   WordPress-iOS-Editor:
     :commit: 78d59da8eaf49042b88f7141beac614379149d6f
     :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
-  WordPressCom-Stats-iOS:
-    :git: git@github.com:wordpress-mobile/WordPressCom-Stats-iOS.git
-    :tag: 0.4.1
 
 SPEC CHECKSUMS:
   1PasswordExtension: 66365c1e1264a83edec6c84c6eb2df41b50a70d3
@@ -289,7 +282,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Shared: f0a1c534dbe0a4047dac42fb59d1ed4beab6e22d
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
   WordPressCom-Analytics-iOS: 85c1609bbcdc2cec25dddc633568c8970811b9d2
-  WordPressCom-Stats-iOS: abe53bb887f39507479d2b5e91cac84159e30f05
+  WordPressCom-Stats-iOS: c7ec665c037a2bae50cf5971c4ee6dba27859269
   WPMediaPicker: 7bb4147fda5306e20be0958334da0071eebf0616
   wpxmlrpc: 053c9cbed13dcec08515a4ffeb51780f6e858cc7
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -144,13 +144,13 @@ PODS:
   - WordPressApi (0.3.4):
     - AFNetworking (~> 2.5.1)
     - wpxmlrpc (~> 0.7)
-  - WordPressCom-Analytics-iOS (0.0.33)
-  - WordPressCom-Stats-iOS (0.4.0):
+  - WordPressCom-Analytics-iOS (0.0.34)
+  - WordPressCom-Stats-iOS (0.4.1):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (~> 2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.3)
-    - WordPressCom-Analytics-iOS
+    - WordPressCom-Analytics-iOS (~> 0.0.34)
   - WPMediaPicker (0.4.4)
   - wpxmlrpc (0.8)
 
@@ -195,8 +195,9 @@ DEPENDENCIES:
     commit `78d59da8eaf49042b88f7141beac614379149d6f`)
   - WordPress-iOS-Shared (= 0.3.3)
   - WordPressApi (~> 0.3.4)
-  - WordPressCom-Analytics-iOS (= 0.0.33)
-  - WordPressCom-Stats-iOS (= 0.4.0)
+  - WordPressCom-Analytics-iOS (= 0.0.34)
+  - WordPressCom-Stats-iOS (from `git@github.com:wordpress-mobile/WordPressCom-Stats-iOS.git`,
+    tag `0.4.1`)
   - WPMediaPicker (~> 0.4.4)
   - wpxmlrpc (~> 0.8)
 
@@ -221,6 +222,9 @@ EXTERNAL SOURCES:
   WordPress-iOS-Editor:
     :commit: 78d59da8eaf49042b88f7141beac614379149d6f
     :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
+  WordPressCom-Stats-iOS:
+    :git: git@github.com:wordpress-mobile/WordPressCom-Stats-iOS.git
+    :tag: 0.4.1
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -241,6 +245,9 @@ CHECKOUT OPTIONS:
   WordPress-iOS-Editor:
     :commit: 78d59da8eaf49042b88f7141beac614379149d6f
     :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
+  WordPressCom-Stats-iOS:
+    :git: git@github.com:wordpress-mobile/WordPressCom-Stats-iOS.git
+    :tag: 0.4.1
 
 SPEC CHECKSUMS:
   1PasswordExtension: 66365c1e1264a83edec6c84c6eb2df41b50a70d3
@@ -281,8 +288,8 @@ SPEC CHECKSUMS:
   WordPress-iOS-Editor: 28eb6e7763e2f277fbdfda6a78cad42d43b25791
   WordPress-iOS-Shared: f0a1c534dbe0a4047dac42fb59d1ed4beab6e22d
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
-  WordPressCom-Analytics-iOS: 69b875d5bc1b053be13c6a33c7233bf6f50949b1
-  WordPressCom-Stats-iOS: e08916b72f626c9600b5cd85e8a12aa3532a3190
+  WordPressCom-Analytics-iOS: 85c1609bbcdc2cec25dddc633568c8970811b9d2
+  WordPressCom-Stats-iOS: abe53bb887f39507479d2b5e91cac84159e30f05
   WPMediaPicker: 7bb4147fda5306e20be0958334da0071eebf0616
   wpxmlrpc: 053c9cbed13dcec08515a4ffeb51780f6e858cc7
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -313,6 +313,9 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         case WPAnalyticsStatEditorUploadMediaRetried:
             eventName = @"editor_upload_media_retried";
             break;
+        case WPAnalyticsStatLogSpecialCondition:
+            eventName = @"log_special_condition";
+            break;
         case WPAnalyticsStatLoginFailed:
             eventName = @"login_failed_to_login";
             break;
@@ -547,6 +550,25 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
             break;
         case WPAnalyticsStatStatsAccessed:
             eventName = @"stats_accessed";
+            break;
+        case WPAnalyticsStatStatsInsightsAccessed:
+            eventName = @"stats_insights_accessed";
+            break;
+        case WPAnalyticsStatStatsPeriodDaysAccessed:
+            eventName = @"stats_period_accessed";
+            eventProperties = @{ @"period" : @"days" };
+            break;
+        case WPAnalyticsStatStatsPeriodMonthsAccessed:
+            eventName = @"stats_period_accessed";
+            eventProperties = @{ @"period" : @"months" };
+            break;
+        case WPAnalyticsStatStatsPeriodWeeksAccessed:
+            eventName = @"stats_period_accessed";
+            eventProperties = @{ @"period" : @"weeks" };
+            break;
+        case WPAnalyticsStatStatsPeriodYearsAccessed:
+            eventName = @"stats_period_accessed";
+            eventProperties = @{ @"period" : @"years" };
             break;
         case WPAnalyticsStatStatsOpenedWebVersion:
             eventName = @"stats_opened_web_version_accessed";

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -343,10 +343,35 @@ NSString *const SessionCount = @"session_count";
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_stats"];
             [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_stats"];
             break;
+        case WPAnalyticsStatStatsInsightsAccessed:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Stats - Insights Accessed"];
+            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_insights_screen_stats"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_insights_screen_stats"];
+            break;
         case WPAnalyticsStatStatsOpenedWebVersion:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Stats - Opened Web Version"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_web_version_of_stats"];
             [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_web_version_of_stats"];
+            break;
+        case WPAnalyticsStatStatsPeriodDaysAccessed:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Stats - Period Days Accessed"];
+            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_days_screen_stats"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_days_screen_stats"];
+            break;
+        case WPAnalyticsStatStatsPeriodMonthsAccessed:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Stats - Period Months Accessed"];
+            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_months_screen_stats"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_months_screen_stats"];
+            break;
+        case WPAnalyticsStatStatsPeriodWeeksAccessed:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Stats - Period Weeks Accessed"];
+            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_weeks_screen_stats"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_weeks_screen_stats"];
+            break;
+        case WPAnalyticsStatStatsPeriodYearsAccessed:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Stats - Period Years Accessed"];
+            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_years_screen_stats"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_years_screen_stats"];
             break;
         case WPAnalyticsStatStatsScrolledToBottom:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Stats - Scrolled to Bottom"];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -692,8 +692,6 @@
 		45C73C24113C36F70024D0D2 /* MainWindow-iPad.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = "MainWindow-iPad.xib"; path = "Resources-iPad/MainWindow-iPad.xib"; sourceTree = "<group>"; };
 		462F4E0618369F0B0028D2F8 /* BlogDetailsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogDetailsViewController.h; sourceTree = "<group>"; };
 		462F4E0718369F0B0028D2F8 /* BlogDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BlogDetailsViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		462F4E0818369F0B0028D2F8 /* BlogListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogListViewController.h; sourceTree = "<group>"; };
-		462F4E0918369F0B0028D2F8 /* BlogListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogListViewController.m; sourceTree = "<group>"; };
 		4645AFC41961E1FB005F7509 /* AppImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = AppImages.xcassets; path = Resources/AppImages.xcassets; sourceTree = "<group>"; };
 		46F84612185A8B7E009D0DA5 /* WPContentViewProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPContentViewProvider.h; sourceTree = "<group>"; };
 		46F8714D1838C41600BC149B /* NSDate+StringFormatting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+StringFormatting.h"; sourceTree = "<group>"; };

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4429,7 +4429,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = WordPress.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4469,7 +4469,7 @@
 					"-l\"z\"",
 				);
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "2c67955d-6e0d-474f-89c0-f2ed02e3292a";
+				PROVISIONING_PROFILE = "ff005e41-8db5-4302-8115-f040d6318e8f";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -4490,7 +4490,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = WordPress.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc. (PZYM8XX95Q)";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4527,7 +4527,7 @@
 					"-l\"z\"",
 				);
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "99275e9d-ad23-4674-aa89-8a5d9ffcccef";
+				PROVISIONING_PROFILE = "6846ba54-fdc2-4d75-a7ab-708a173c8c45";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4568,7 +4568,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = WordPress.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc. (PZYM8XX95Q)";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4606,7 +4606,7 @@
 					"-l\"z\"",
 				);
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "99275e9d-ad23-4674-aa89-8a5d9ffcccef";
+				PROVISIONING_PROFILE = "6846ba54-fdc2-4d75-a7ab-708a173c8c45";
 				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
@@ -4647,7 +4647,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = "WordPress-Internal.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4764,7 +4764,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "fed7d2ed-7100-4fde-a859-61a2eae697ac";
+				PROVISIONING_PROFILE = "4ff57c1e-0ae3-47c7-b285-bba23be276e1";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressTodayWidget/WordPressTodayWidget-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -4813,7 +4813,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "19ab21e5-f92b-4f14-8bf2-89cf344b0a45";
+				PROVISIONING_PROFILE = "5c90251a-c3f7-4731-8cda-15d81f3e6b05";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressTodayWidget/WordPressTodayWidget-Bridging-Header.h";
 				WPCOM_SCHEME = wordpress;
@@ -4910,7 +4910,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "19ab21e5-f92b-4f14-8bf2-89cf344b0a45";
+				PROVISIONING_PROFILE = "5c90251a-c3f7-4731-8cda-15d81f3e6b05";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressTodayWidget/WordPressTodayWidget-Bridging-Header.h";
 				WPCOM_SCHEME = wordpress;


### PR DESCRIPTION
Closes #3923 

# What's Included in Stats 0.4.1

1. Fixes refresh state weirdness with insights and regular stats.
2. More button now works properly when switching between days and insights.
3. Today stats (individual stats for views/visitors/etc) in Insights now switches to related view on graph in Days view.
4. Fixes a rare crash on /stats/visits mainly on iOS 7 and logs the data to Tracks for further analysis.

# Testing

The individual pieces of the stats update have been tested in StatsDemo in the source project/pod. Simply load stats and make sure the screens work and there are no demons.

Needs Review: @sendhil, @jleandroperez 
