### PR TITLE
WP media library repaints while loading.

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -80,8 +80,21 @@
 - (id<NSObject>)registerChangeObserverBlock:(WPMediaChangesBlock)callback
 {
     NSUUID *blockKey = [NSUUID UUID];
-    id<NSObject> oneKey = [self.deviceLibraryDataSource registerChangeObserverBlock:callback];
-    id<NSObject> secondKey = [self.mediaLibraryDataSource registerChangeObserverBlock:callback];
+    __weak __typeof__(self) weakSelf = self;
+    id<NSObject> oneKey = [self.deviceLibraryDataSource registerChangeObserverBlock:^{
+        if (weakSelf.currentDataSource == weakSelf.deviceLibraryDataSource) {
+            if (callback) {
+                callback();
+            }
+        }
+    }];
+    id<NSObject> secondKey = [self.mediaLibraryDataSource registerChangeObserverBlock:^{
+        if (weakSelf.currentDataSource == weakSelf.mediaLibraryDataSource) {
+            if (callback) {
+                callback();
+            }
+        }
+    }];
     
     self.observers[blockKey] = @[oneKey, secondKey];
     return blockKey;


### PR DESCRIPTION
Closes #3925

See the ticket above for more details about the bug.

I found that updates to the device library where getting propagate to the WP media library and making the screen get repainted. 
This is specially bad when you have iCloud Photos enabled, because iCloud can make changes to the device library and then these where getting in the app and making the screen refresh. 

How to test: 
 * Open the app
 * Go to a blog and create a post
 * Select Insert a Media 
 * Select the Media Library
 * After the media library loads, exit the app
 * Go to the Photos app and start changing things there, for example delete some photos you don't need
 * Go back to the app, and check if you don't see the Media Library refresh
 * After while switch to the Camera Roll and check if your changes happen.


Needs Review: @bummytime 