### PR TITLE
Fixing web view authentication

### DIFF
--- a/WordPress/Classes/Utility/WPURLRequest.m
+++ b/WordPress/Classes/Utility/WPURLRequest.m
@@ -21,15 +21,22 @@
     NSParameterAssert(username);
     NSParameterAssert(password != nil || bearerToken != nil);
     
-    NSString *hostname = loginUrl.host;
+    NSString *hostname          = loginUrl.host;
+    NSString *unsecuredProtocol = @"http";
+    NSString *securedProtocol   = @"https";
     
     // Let's make sure we don't send OAuth2 tokens outside of wordpress.com
     if (![hostname isEqualToString:@"wordpress.com"] && ![hostname hasSuffix:@".wordpress.com"]) {
         bearerToken = nil;
         
     // Enforce HTTPS for WordPress.com Sites
-    } else if ([loginUrl.scheme isEqual:@"http"]) {
-        loginUrl = [[NSURL alloc] initWithScheme:@"https" host:loginUrl.host path:loginUrl.path];
+    } else if ([loginUrl.scheme isEqual:unsecuredProtocol]) {
+        NSRange range = NSMakeRange(0, unsecuredProtocol.length);
+        NSString *secureURL = [loginUrl.absoluteString stringByReplacingOccurrencesOfString:unsecuredProtocol
+                                                                                 withString:securedProtocol
+                                                                                    options:NSDiacriticInsensitiveSearch
+                                                                                      range:range];
+        loginUrl = [NSURL URLWithString:secureURL];
     }
     
     NSMutableURLRequest *request = [self mutableRequestWithURL:loginUrl userAgent:userAgent];

--- a/WordPress/Classes/Utility/WPURLRequest.m
+++ b/WordPress/Classes/Utility/WPURLRequest.m
@@ -21,13 +21,18 @@
     NSParameterAssert(username);
     NSParameterAssert(password != nil || bearerToken != nil);
     
-    NSMutableURLRequest *request = [self mutableRequestWithURL:loginUrl userAgent:userAgent];
-
-    NSString *hostname = [loginUrl host];
+    NSString *hostname = loginUrl.host;
+    
+    // Let's make sure we don't send OAuth2 tokens outside of wordpress.com
     if (![hostname isEqualToString:@"wordpress.com"] && ![hostname hasSuffix:@".wordpress.com"]) {
-        // Let's make sure we don't send OAuth2 tokens outside of wordpress.com
         bearerToken = nil;
+        
+    // Enforce HTTPS for WordPress.com Sites
+    } else if ([loginUrl.scheme isEqual:@"http"]) {
+        loginUrl = [[NSURL alloc] initWithScheme:@"https" host:loginUrl.host path:loginUrl.path];
     }
+    
+    NSMutableURLRequest *request = [self mutableRequestWithURL:loginUrl userAgent:userAgent];
     
     // If we've got a token, let's make sure the password never gets sent
     NSString *encodedPassword = bearerToken.length == 0 ? [password stringByUrlEncoding] : nil;

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -262,7 +262,11 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
     }
     
     _url = theURL;
-    [self loadWebViewRequest];
+    
+    // Prevent double load in viewDidLoad Method
+    if (self.isViewLoaded) {
+        [self loadWebViewRequest];
+    }
 }
 
 

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -183,7 +183,7 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
         return;
     }
 
-    if (!self.needsLogin && self.username && self.password && ![WPCookie hasCookieForURL:self.url andUsername:self.username]) {
+    if (!self.needsLogin && self.hasCredentials && ![WPCookie hasCookieForURL:self.url andUsername:self.username]) {
         DDLogWarn(@"We have login credentials but no cookie, let's try login first");
         [self retryWithLogin];
         return;
@@ -337,9 +337,8 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
     // WP Login: Send the credentials, if needed
     NSRange loginRange  = [request.URL.absoluteString rangeOfString:@"wp-login.php"];
     BOOL isLoginURL     = loginRange.location != NSNotFound;
-    BOOL hasCredentials = (self.username && (self.password || self.authToken));
     
-    if (isLoginURL && !self.needsLogin && hasCredentials) {
+    if (isLoginURL && !self.needsLogin && self.hasCredentials) {
         DDLogInfo(@"WP is asking for credentials, let's login first");
         [self retryWithLogin];
         return NO;
@@ -427,6 +426,14 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
            self.progressView.alpha = WPWebViewAnimationAlphaHidden;
        }];
     }];
+}
+
+
+#pragma mark - Authentication Helpers
+
+- (BOOL)hasCredentials
+{
+    return self.username && (self.password || self.authToken);
 }
 
 


### PR DESCRIPTION
#### Steps:
1. Fresh install WPiOS
2. Launch the app, and log into your account
3. Tap over the Notifications tab
4. Find a Stats-Y notification for a *private* site and open it
5. Tap over the site name

As a result, WebViewController is expected to be onscreen, and the blog should be visible. No extra authentication should be required.

Needs Review: @diegoreymendez  ||  @sendhil (Thanks in advance!)
