### PR TITLE
Set a background color for blavatars

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -107,6 +107,7 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 {
     CGRect blavatarFrame = CGRectMake(0.0f, 0.0f, BlogDetailHeaderViewBlavatarSize, BlogDetailHeaderViewBlavatarSize);
     UIImageView *imageView = [[UIImageView alloc] initWithFrame:blavatarFrame];
+    imageView.backgroundColor = [UIColor whiteColor];
     imageView.translatesAutoresizingMaskIntoConstraints = NO;
     imageView.layer.borderColor = [[UIColor whiteColor] CGColor];
     imageView.layer.borderWidth = 1.0;


### PR DESCRIPTION
Sets a default background for blavatars on the blog details screen.

Before:
![screen shot 2015-05-28 at 13 01 11](https://cloud.githubusercontent.com/assets/8739/7858597/bd8cad06-0539-11e5-8f14-11f0ae4c6776.png)

After:
![ios simulator screen shot 28 jun 2015 15 49 59](https://cloud.githubusercontent.com/assets/8739/8396633/cea43e8c-1dae-11e5-8607-69d566c47b78.png)

Fixes #3738 

Needs Review: @oguzkocer 