### PR TITLE
Adds theme services.

### DIFF
--- a/WordPress/Classes/Networking/ThemeServiceRemote.h
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.h
@@ -1,0 +1,91 @@
+#import "ServiceRemoteREST.h"
+
+typedef void(^ThemeServiceSuccessBlock)();
+typedef void(^ThemeServiceThemeRequestSuccessBlock)(NSDictionary *theme);
+typedef void(^ThemeServiceThemesRequestSuccessBlock)(NSArray *themes);
+typedef void(^ThemeServiceFailureBlock)(NSError *error);
+
+@class Blog;
+
+@interface ThemeServiceRemote : ServiceRemoteREST
+
+#pragma mark - Getting themes
+
+/**
+ *  @brief      Gets the active theme for a specific blog.
+ *
+ *  @param      blogId      The ID of the blog to get the active theme for.  Cannot be nil.
+ *  @param      success     The success handler.  Can be nil.
+ *  @param      failure     The failure handler.  Can be nil.
+ */
+- (void)getActiveThemeForBlogId:(NSNumber *)blogId
+                        success:(ThemeServiceThemeRequestSuccessBlock)success
+                        failure:(ThemeServiceFailureBlock)failure;
+
+/**
+ *  @brief      Gets information for a specific theme.
+ *
+ *  @param      themeId     The identifier of the theme to request info for.  Cannot be nil.
+ *  @param      success     The success handler.  Can be nil.
+ *  @param      failure     The failure handler.  Can be nil.
+ */
+- (void)getThemeId:(NSString*)themeId
+           success:(ThemeServiceThemeRequestSuccessBlock)success
+           failure:(ThemeServiceFailureBlock)failure;
+
+/**
+ *  @brief      Gets the list of WP.com available themes.
+ *  @details    Includes premium themes even if not purchased.  Don't call this method if the list
+ *              you want to retrieve is for a specific blog.  Use getThemesForBlogId instead.
+ *
+ *  @param      success     The success handler.  Can be nil.
+ *  @param      failure     The failure handler.  Can be nil.
+ */
+- (void)getThemes:(ThemeServiceThemesRequestSuccessBlock)success
+          failure:(ThemeServiceFailureBlock)failure;
+
+/**
+ *  @brief      Gets the list of available themes for a blog.
+ *  @details    Includes premium themes even if not purchased.  The only difference with the
+ *              regular getThemes method is that legacy themes that are no longer available to new
+ *              blogs, can be accessible for older blogs through this call.  This means that
+ *              whenever we need to show the list of themes a blog can use, we should be calling
+ *              this method and not getThemes.
+ *
+ *  @param      blogId      The ID of the blog to get the themes for.  Cannot be nil.
+ *  @param      success     The success handler.  Can be nil.
+ *  @param      failure     The failure handler.  Can be nil.
+ */
+- (void)getThemesForBlogId:(NSNumber *)blogId
+                   success:(ThemeServiceThemesRequestSuccessBlock)success
+                   failure:(ThemeServiceFailureBlock)failure;
+
+#pragma mark - Activating themes
+
+/**
+ *  @brief      Activates the specified theme for the specified blog.
+ *
+ *  @param      themeId     The ID of the theme to activate.  Cannot be nil.
+ *  @param      blogId      The ID of the target blog.  Cannot be nil.
+ *  @param      success     The success handler.  Can be nil.
+ *  @param      failure     The failure handler.  Can be nil.
+ */
+- (void)activateThemeId:(NSString*)themeId
+              forBlogId:(NSNumber *)blogId
+                success:(ThemeServiceSuccessBlock)success
+                failure:(ThemeServiceFailureBlock)failure;
+
+#pragma mark - Old services...
+
+/*
+- (void)fetchAndInsertThemesForBlog:(Blog *)blog
+                            success:(ThemeServiceSuccessBlock)success
+                            failure:(ThemeServiceFailureBlock)failure;
+- (void)fetchCurrentThemeForBlog:(Blog *)blog
+                         success:(ThemeServiceSuccessBlock)success
+                         failure:(ThemeServiceFailureBlock)failure;
+- (void)activateThemeWithSuccess:(ThemeServiceSuccessBlock)success
+                         failure:(ThemeServiceFailureBlock)failure;
+ */
+
+@end

--- a/WordPress/Classes/Networking/ThemeServiceRemote.h
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.h
@@ -23,6 +23,17 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
                         failure:(ThemeServiceFailureBlock)failure;
 
 /**
+ *  @brief      Gets the list of purchased themes for a blog.
+ *
+ *  @param      blogId      The ID of the blog to get the themes for.  Cannot be nil.
+ *  @param      success     The success handler.  Can be nil.
+ *  @param      failure     The failure handler.  Can be nil.
+ */
+- (void)getPurchasedThemesForBlogId:(NSNumber *)blogId
+                            success:(ThemeServiceThemesRequestSuccessBlock)success
+                            failure:(ThemeServiceFailureBlock)failure;
+
+/**
  *  @brief      Gets information for a specific theme.
  *
  *  @param      themeId     The identifier of the theme to request info for.  Cannot be nil.

--- a/WordPress/Classes/Networking/ThemeServiceRemote.h
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.h
@@ -75,17 +75,4 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
                 success:(ThemeServiceSuccessBlock)success
                 failure:(ThemeServiceFailureBlock)failure;
 
-#pragma mark - Old services...
-
-/*
-- (void)fetchAndInsertThemesForBlog:(Blog *)blog
-                            success:(ThemeServiceSuccessBlock)success
-                            failure:(ThemeServiceFailureBlock)failure;
-- (void)fetchCurrentThemeForBlog:(Blog *)blog
-                         success:(ThemeServiceSuccessBlock)success
-                         failure:(ThemeServiceFailureBlock)failure;
-- (void)activateThemeWithSuccess:(ThemeServiceSuccessBlock)success
-                         failure:(ThemeServiceFailureBlock)failure;
- */
-
 @end

--- a/WordPress/Classes/Networking/ThemeServiceRemote.m
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.m
@@ -5,7 +5,6 @@
 static NSString* const ThemeServiceRemoteThemesKey = @"themes";
 
 @interface ThemeServiceRemote ()
-@property (nonatomic, strong, readwrite) NSManagedObjectContext *context;
 @end
 
 @implementation ThemeServiceRemote
@@ -124,93 +123,5 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
                }
            }];
 }
-
-#pragma mark - Old services...
-
-/*
-- (void)fetchAndInsertThemesForBlogId:(NSNumber *)blogId
-                            success:(ThemeServiceSuccessBlock)success
-                            failure:(ThemeServiceFailureBlock)failure
-{
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-    
-    [[defaultAccount restApi] fetchThemesForBlogId:blogId.stringValue success:^(AFHTTPRequestOperation *operation, id responseObject) {
-        NSManagedObjectContext *backgroundMOC = [[ContextManager sharedInstance] newDerivedContext];
-        [backgroundMOC performBlock:^{
-            NSMutableArray *themesToKeep = [NSMutableArray array];
-            for (NSDictionary *t in responseObject[@"themes"]) {
-                Theme *theme = [Theme createOrUpdateThemeFromDictionary:t withBlog:blog withContext:backgroundMOC];
-                [themesToKeep addObject:theme];
-            }
-            
-            NSSet *existingThemes = ((Blog *)[backgroundMOC objectWithID:blog.objectID]).themes;
-            for (Theme *theme in existingThemes) {
-                if (![themesToKeep containsObject:theme]) {
-                    [backgroundMOC deleteObject:theme];
-                }
-            }
-            
-            [[ContextManager sharedInstance] saveDerivedContext:backgroundMOC];
-            
-            dateFormatter = nil;
-            
-            if (success) {
-                dispatch_async(dispatch_get_main_queue(), success);
-            }
-            
-        }];
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-        if (failure) {
-            failure(error);
-        }
-    }];
-}
-
-- (void)fetchCurrentThemeForBlog:(Blog *)blog
-                         success:(ThemeServiceSuccessBlock)success
-                         failure:(ThemeServiceFailureBlock)failure
-{
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-    
-    [[defaultAccount restApi] fetchCurrentThemeForBlogId:blog.blogID.stringValue success:^(AFHTTPRequestOperation *operation, id responseObject) {
-        [blog.managedObjectContext performBlock:^{
-            blog.currentThemeId = responseObject[@"id"];
-            [[ContextManager sharedInstance] saveContext:blog.managedObjectContext];
-            if (success) {
-                dispatch_async(dispatch_get_main_queue(), success);
-            }
-        }];
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-        if (failure) {
-            failure(error);
-        }
-    }];
-}
-
-- (void)activateThemeWithSuccess:(ThemeServiceSuccessBlock)success
-                         failure:(ThemeServiceFailureBlock)failure
-{
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-    
-    [[defaultAccount restApi] activateThemeForBlogId:self.blog.blogID.stringValue themeId:self.themeId success:^(AFHTTPRequestOperation *operation, id responseObject) {
-        [self.blog.managedObjectContext performBlock:^{
-            self.blog.currentThemeId = self.themeId;
-            [[ContextManager sharedInstance] saveContext:self.blog.managedObjectContext];
-            if (success) {
-                dispatch_async(dispatch_get_main_queue(), success);
-            }
-        }];
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-        if (failure) {
-            failure(error);
-        }
-    }];
-}
- */
 
 @end

--- a/WordPress/Classes/Networking/ThemeServiceRemote.m
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.m
@@ -32,6 +32,29 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
           }];
 }
 
+- (void)getPurchasedThemesForBlogId:(NSNumber *)blogId
+                            success:(ThemeServiceThemesRequestSuccessBlock)success
+                            failure:(ThemeServiceFailureBlock)failure
+{
+    NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
+    
+    NSString *path = [NSString stringWithFormat:@"sites/%@/themes/purchased", blogId];
+    
+    [self.api GET:path
+       parameters:nil
+          success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
+              if (success) {
+                  NSArray *themes = [response arrayForKey:ThemeServiceRemoteThemesKey];
+                  
+                  success(themes);
+              }
+          } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+              if (failure) {
+                  failure(error);
+              }
+          }];
+}
+
 - (void)getThemeId:(NSString*)themeId
            success:(ThemeServiceThemeRequestSuccessBlock)success
            failure:(ThemeServiceFailureBlock)failure
@@ -79,7 +102,7 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
 {
     NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
     
-    static NSString* const path = @"themes";
+    NSString *path = [NSString stringWithFormat:@"sites/%@/themes", blogId];
     
     [self.api GET:path
        parameters:nil

--- a/WordPress/Classes/Networking/ThemeServiceRemote.m
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.m
@@ -1,0 +1,216 @@
+#import "ThemeServiceRemote.h"
+#import "WordPressComApi.h"
+
+// Service dictionary keys
+static NSString* const ThemeServiceRemoteThemesKey = @"themes";
+
+@interface ThemeServiceRemote ()
+@property (nonatomic, strong, readwrite) NSManagedObjectContext *context;
+@end
+
+@implementation ThemeServiceRemote
+
+#pragma mark - Getting themes
+
+- (void)getActiveThemeForBlogId:(NSNumber *)blogId
+                        success:(ThemeServiceThemeRequestSuccessBlock)success
+                        failure:(ThemeServiceFailureBlock)failure
+{
+    NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
+    
+    NSString *path = [NSString stringWithFormat:@"sites/%@/themes/mine", blogId];
+    
+    [self.api GET:path
+       parameters:nil
+          success:^(AFHTTPRequestOperation *operation, NSDictionary *themeDictionary) {
+              if (success) {
+                  success(themeDictionary);
+              }
+          } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+              if (failure) {
+                  failure(error);
+              }
+          }];
+}
+
+- (void)getThemeId:(NSString*)themeId
+           success:(ThemeServiceThemeRequestSuccessBlock)success
+           failure:(ThemeServiceFailureBlock)failure
+{
+    NSParameterAssert([themeId isKindOfClass:[NSString class]]);
+    
+    NSString *path = [NSString stringWithFormat:@"themes/%@", themeId];
+    
+    [self.api GET:path
+       parameters:nil
+          success:^(AFHTTPRequestOperation *operation, NSDictionary *themeDictionary) {
+              if (success) {
+                  success(themeDictionary);
+              }
+          } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+              if (failure) {
+                  failure(error);
+              }
+          }];
+}
+
+- (void)getThemes:(ThemeServiceThemesRequestSuccessBlock)success
+          failure:(ThemeServiceFailureBlock)failure
+{
+    static NSString* const path = @"themes";
+    
+    [self.api GET:path
+       parameters:nil
+          success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
+              if (success) {
+                  NSArray *themes = [response arrayForKey:ThemeServiceRemoteThemesKey];
+                  
+                  success(themes);
+              }
+          } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+              if (failure) {
+                  failure(error);
+              }
+          }];
+}
+
+- (void)getThemesForBlogId:(NSNumber *)blogId
+                   success:(ThemeServiceThemesRequestSuccessBlock)success
+                   failure:(ThemeServiceFailureBlock)failure
+{
+    NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
+    
+    static NSString* const path = @"themes";
+    
+    [self.api GET:path
+       parameters:nil
+          success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
+              if (success) {
+                  NSArray *themes = [response arrayForKey:ThemeServiceRemoteThemesKey];
+                  
+                  success(themes);
+              }
+          } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+              if (failure) {
+                  failure(error);
+              }
+          }];
+}
+
+#pragma mark - Activating themes
+
+- (void)activateThemeId:(NSString*)themeId
+              forBlogId:(NSNumber *)blogId
+                success:(ThemeServiceSuccessBlock)success
+                failure:(ThemeServiceFailureBlock)failure
+{
+    NSParameterAssert([themeId isKindOfClass:[NSString class]]);
+    NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
+    
+    NSString* const path = [NSString stringWithFormat:@"sites/%@/themes/mine", blogId];
+    NSDictionary* parameters = @{@"theme": themeId};
+    
+    [self.api POST:path
+        parameters:parameters
+           success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
+               if (success) {
+                   NSArray *themes = [response arrayForKey:ThemeServiceRemoteThemesKey];
+                   
+                   success(themes);
+               }
+           } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+               if (failure) {
+                   failure(error);
+               }
+           }];
+}
+
+#pragma mark - Old services...
+
+/*
+- (void)fetchAndInsertThemesForBlogId:(NSNumber *)blogId
+                            success:(ThemeServiceSuccessBlock)success
+                            failure:(ThemeServiceFailureBlock)failure
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
+    
+    [[defaultAccount restApi] fetchThemesForBlogId:blogId.stringValue success:^(AFHTTPRequestOperation *operation, id responseObject) {
+        NSManagedObjectContext *backgroundMOC = [[ContextManager sharedInstance] newDerivedContext];
+        [backgroundMOC performBlock:^{
+            NSMutableArray *themesToKeep = [NSMutableArray array];
+            for (NSDictionary *t in responseObject[@"themes"]) {
+                Theme *theme = [Theme createOrUpdateThemeFromDictionary:t withBlog:blog withContext:backgroundMOC];
+                [themesToKeep addObject:theme];
+            }
+            
+            NSSet *existingThemes = ((Blog *)[backgroundMOC objectWithID:blog.objectID]).themes;
+            for (Theme *theme in existingThemes) {
+                if (![themesToKeep containsObject:theme]) {
+                    [backgroundMOC deleteObject:theme];
+                }
+            }
+            
+            [[ContextManager sharedInstance] saveDerivedContext:backgroundMOC];
+            
+            dateFormatter = nil;
+            
+            if (success) {
+                dispatch_async(dispatch_get_main_queue(), success);
+            }
+            
+        }];
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+}
+
+- (void)fetchCurrentThemeForBlog:(Blog *)blog
+                         success:(ThemeServiceSuccessBlock)success
+                         failure:(ThemeServiceFailureBlock)failure
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
+    
+    [[defaultAccount restApi] fetchCurrentThemeForBlogId:blog.blogID.stringValue success:^(AFHTTPRequestOperation *operation, id responseObject) {
+        [blog.managedObjectContext performBlock:^{
+            blog.currentThemeId = responseObject[@"id"];
+            [[ContextManager sharedInstance] saveContext:blog.managedObjectContext];
+            if (success) {
+                dispatch_async(dispatch_get_main_queue(), success);
+            }
+        }];
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+}
+
+- (void)activateThemeWithSuccess:(ThemeServiceSuccessBlock)success
+                         failure:(ThemeServiceFailureBlock)failure
+{
+    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
+    
+    [[defaultAccount restApi] activateThemeForBlogId:self.blog.blogID.stringValue themeId:self.themeId success:^(AFHTTPRequestOperation *operation, id responseObject) {
+        [self.blog.managedObjectContext performBlock:^{
+            self.blog.currentThemeId = self.themeId;
+            [[ContextManager sharedInstance] saveContext:self.blog.managedObjectContext];
+            if (success) {
+                dispatch_async(dispatch_get_main_queue(), success);
+            }
+        }];
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+}
+ */
+
+@end

--- a/WordPress/Classes/Networking/ThemeServiceRemote.m
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.m
@@ -4,9 +4,6 @@
 // Service dictionary keys
 static NSString* const ThemeServiceRemoteThemesKey = @"themes";
 
-@interface ThemeServiceRemote ()
-@end
-
 @implementation ThemeServiceRemote
 
 #pragma mark - Getting themes

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		595B02221A6C4ECD00415A30 /* WPWhatsNewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */; };
 		595B02271A6C504400415A30 /* WPWhatsNewView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 595B02261A6C504400415A30 /* WPWhatsNewView.xib */; };
 		5971178D1B4204C7005E4EFD /* ThemeServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = 5971178C1B4204C7005E4EFD /* ThemeServiceRemote.m */; };
+		597117901B421B54005E4EFD /* ThemeServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5971178F1B421B54005E4EFD /* ThemeServiceRemoteTests.m */; };
 		5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */; };
 		598351AE1A704E7A00B6DD4F /* WPWhatsNew.m in Sources */ = {isa = PBXBuildFile; fileRef = 598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */; };
 		5987857D1B39A3D5000E4F51 /* WPThemeSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 5987857C1B39A3D5000E4F51 /* WPThemeSettings.m */; };
@@ -721,6 +722,7 @@
 		595B02261A6C504400415A30 /* WPWhatsNewView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = WPWhatsNewView.xib; path = Resources/WhatsNew/WPWhatsNewView.xib; sourceTree = "<group>"; };
 		5971178B1B4204C7005E4EFD /* ThemeServiceRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThemeServiceRemote.h; sourceTree = "<group>"; };
 		5971178C1B4204C7005E4EFD /* ThemeServiceRemote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemote.m; sourceTree = "<group>"; };
+		5971178F1B421B54005E4EFD /* ThemeServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemoteTests.m; sourceTree = "<group>"; };
 		5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUserAgentTests.m; sourceTree = "<group>"; };
 		598351AC1A704E7A00B6DD4F /* WPWhatsNew.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPWhatsNew.h; path = WhatsNew/WPWhatsNew.h; sourceTree = "<group>"; };
 		598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNew.m; path = WhatsNew/WPWhatsNew.m; sourceTree = "<group>"; };
@@ -1985,6 +1987,7 @@
 				591CFB081B28AC8C009E61B3 /* BlogServiceRemoteRESTTests.m */,
 				59E2AAEB1B20E5CE0051DC06 /* PostServiceRemoteRESTTests.m */,
 				59E2AAE71B20E3EA0051DC06 /* ServiceRemoteRESTTests.m */,
+				5971178F1B421B54005E4EFD /* ThemeServiceRemoteTests.m */,
 			);
 			name = "Remote Services";
 			sourceTree = "<group>";
@@ -4248,6 +4251,7 @@
 				85F8E19F1B0186D0000859BB /* MockWordPressComApi.swift in Sources */,
 				931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */,
 				852416D21A12ED690030700C /* AppRatingUtilityTests.m in Sources */,
+				597117901B421B54005E4EFD /* ThemeServiceRemoteTests.m in Sources */,
 				E15618FD16DB8677006532C4 /* UIKitTestHelper.m in Sources */,
 				B5AEEC721ACACF2F008BF2A4 /* NotificationTests.m in Sources */,
 				9358D15919FFD4E10094BBF5 /* WPImageOptimizerTest.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = 594DB2941AB891A200E2E456 /* WPUserAgent.m */; };
 		595B02221A6C4ECD00415A30 /* WPWhatsNewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */; };
 		595B02271A6C504400415A30 /* WPWhatsNewView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 595B02261A6C504400415A30 /* WPWhatsNewView.xib */; };
+		5971178D1B4204C7005E4EFD /* ThemeServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = 5971178C1B4204C7005E4EFD /* ThemeServiceRemote.m */; };
 		5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */; };
 		598351AE1A704E7A00B6DD4F /* WPWhatsNew.m in Sources */ = {isa = PBXBuildFile; fileRef = 598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */; };
 		5987857D1B39A3D5000E4F51 /* WPThemeSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 5987857C1B39A3D5000E4F51 /* WPThemeSettings.m */; };
@@ -718,6 +719,8 @@
 		595B02201A6C4ECD00415A30 /* WPWhatsNewView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPWhatsNewView.h; path = WhatsNew/WPWhatsNewView.h; sourceTree = "<group>"; };
 		595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNewView.m; path = WhatsNew/WPWhatsNewView.m; sourceTree = "<group>"; };
 		595B02261A6C504400415A30 /* WPWhatsNewView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = WPWhatsNewView.xib; path = Resources/WhatsNew/WPWhatsNewView.xib; sourceTree = "<group>"; };
+		5971178B1B4204C7005E4EFD /* ThemeServiceRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThemeServiceRemote.h; sourceTree = "<group>"; };
+		5971178C1B4204C7005E4EFD /* ThemeServiceRemote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemote.m; sourceTree = "<group>"; };
 		5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUserAgentTests.m; sourceTree = "<group>"; };
 		598351AC1A704E7A00B6DD4F /* WPWhatsNew.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPWhatsNew.h; path = WhatsNew/WPWhatsNew.h; sourceTree = "<group>"; };
 		598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNew.m; path = WhatsNew/WPWhatsNew.m; sourceTree = "<group>"; };
@@ -2355,6 +2358,8 @@
 				E1249B481940AE610035E895 /* ServiceRemoteREST.h */,
 				59E2AAE21B2096BF0051DC06 /* ServiceRemoteREST.m */,
 				E1249B471940AE550035E895 /* ServiceRemoteXMLRPC.h */,
+				5971178B1B4204C7005E4EFD /* ThemeServiceRemote.h */,
+				5971178C1B4204C7005E4EFD /* ThemeServiceRemote.m */,
 				E1F8E1241B0B422C0073E628 /* JetpackServiceRemote.h */,
 				E1F8E1251B0B422C0073E628 /* JetpackServiceRemote.m */,
 			);
@@ -3963,6 +3968,7 @@
 				E1B4A9E112FC8B1000EB3F67 /* EGORefreshTableHeaderView.m in Sources */,
 				5DA3EE12192508F700294E0B /* WPImageOptimizer.m in Sources */,
 				B5D7F2DE1A04180A006D3047 /* UITextView+RichTextView.swift in Sources */,
+				5971178D1B4204C7005E4EFD /* ThemeServiceRemote.m in Sources */,
 				E1D458691309589C00BF0235 /* Coordinate.m in Sources */,
 				375D090D133B94C3000CC9CD /* BlogsTableViewCell.m in Sources */,
 				5DA5BF4618E32DCF005F11F9 /* ThemeBrowserViewController.m in Sources */,

--- a/WordPress/WordPressTest/ThemeServiceRemoteTests.m
+++ b/WordPress/WordPressTest/ThemeServiceRemoteTests.m
@@ -1,0 +1,220 @@
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+#import "Theme.h"
+#import "ThemeServiceRemote.h"
+#import "WordPressComApi.h"
+
+@interface ThemeServiceRemoteTests : XCTestCase
+@end
+
+@implementation ThemeServiceRemoteTests
+
+#pragma mark - Getting the themes
+
+- (void)testThatGetActiveThemeForBlogIdWorks
+{
+    NSNumber *blogId = @124;
+
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+
+    NSString *url = [NSString stringWithFormat:@"sites/%@/themes/mine", blogId];
+
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow([service getActiveThemeForBlogId:blogId
+                                              success:nil
+                                              failure:nil]);
+}
+
+- (void)testThatGetActiveThemeForBlogThrowsExceptionWithoutBlogId
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+    
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertThrows([service getActiveThemeForBlogId:nil
+                                             success:nil
+                                             failure:nil]);
+}
+
+- (void)testThatGetPurchasedThemesForBlogIdWorks
+{
+    NSNumber *blogId = @124;
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+    
+    NSString *url = [NSString stringWithFormat:@"sites/%@/themes/purchased", blogId];
+    
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow([service getPurchasedThemesForBlogId:blogId
+                                                  success:nil
+                                                  failure:nil]);
+}
+
+- (void)testThatGetPurchasedThemesForBlogIdThrowsExceptionWithoutBlogId
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+    
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertThrows([service getPurchasedThemesForBlogId:nil
+                                                 success:nil
+                                                 failure:nil]);
+}
+
+- (void)testThatGetThemeIdWorks
+{
+    NSString *themeId = @"obsidian";
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+    
+    NSString *url = [NSString stringWithFormat:@"themes/%@", themeId];
+    
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow([service getThemeId:themeId
+                                 success:nil
+                                 failure:nil]);
+}
+
+- (void)testThatGetThemeIdThrowsExceptionWithoutThemeId
+{
+    NSString *themeId = @"obsidian";
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+    
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertThrows([service getThemeId:themeId
+                                success:nil
+                                failure:nil]);
+}
+
+- (void)testThatGetThemesWorks
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+    
+    static NSString* const url = @"themes";
+    
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow([service getThemes:nil
+                                failure:nil]);
+}
+
+- (void)testThatGetThemesForBlogIdWorks
+{
+    NSNumber *blogId = @124;
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+    
+    NSString *url = [NSString stringWithFormat:@"sites/%@/themes", blogId];
+    
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow([service getThemesForBlogId:blogId
+                                         success:nil
+                                         failure:nil]);
+}
+
+- (void)testThatGetThemesForBlogIdThrowsExceptionWithoutBlogId
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+    
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertThrows([service getThemesForBlogId:nil
+                                        success:nil
+                                        failure:nil]);
+}
+
+#pragma mark - Activating themes
+
+- (void)testThatActivateThemeIdWorks
+{
+    NSNumber *blogId = @124;
+    NSString *themeId = @"obsidian";
+    NSString *themeParameterKey = @"theme";
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+    
+    NSString *url = [NSString stringWithFormat:@"sites/%@/themes/mine", blogId];
+    
+    BOOL(^checkBlock)(id obj) = ^BOOL(NSDictionary *parameters) {
+        NSCAssert([parameters isKindOfClass:[NSDictionary class]],
+                  @"Type mistmatch for the 'parameters' param.");
+        
+        NSString* themeIdParameter = [parameters objectForKey:themeParameterKey];
+        
+        return [themeIdParameter isEqualToString:themeId];
+    };
+    
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg checkWithBlock:checkBlock]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow([service activateThemeId:themeId
+                                    forBlogId:blogId
+                                      success:nil
+                                      failure:nil]);
+}
+
+- (void)testThatActivateThemeIdThrowsExceptionWithoutThemeId
+{
+    NSNumber *blogId = @124;
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+    
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertThrows([service activateThemeId:nil
+                                   forBlogId:blogId
+                                     success:nil
+                                     failure:nil]);
+}
+
+- (void)testThatActivateThemeIdThrowsExceptionWithoutBlogId
+{
+    NSString *themeId = @"obsidian";
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    ThemeServiceRemote *service = nil;
+    
+    XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithApi:api]);
+    XCTAssertThrows([service activateThemeId:themeId
+                                   forBlogId:nil
+                                     success:nil
+                                     failure:nil]);
+}
+
+
+@end


### PR DESCRIPTION
Adds the services we're going to use for themes in our app.  Also adds unit tests for those services.  I specifically separated this from a larger set of changes since it was becoming too large (1k+ changes).  I'll soon be adding a VC to test these services from within the app.

**Test:**
- Run the unit tests, make sure they don't fail.

**Additional testing:**
Since the services are not currently wired, they will be tested in the upcoming themes view controller.

**Additional Code Checks:**
- When reviewing the code take a momento to make sure the services URLs match the URLs available for the themes services [here](https://developer.wordpress.com/docs/api/console/).

/cc @jleandroperez, @aerych 