### PR TITLE
First stab at making the OAuth2 token less susceptible to breaking

### DIFF
--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -56,6 +56,27 @@
 
 #pragma mark - Custom accessors
 
+- (void)setUsername:(NSString *)username
+{
+    NSString *previousUsername = self.username;
+    
+    BOOL usernameChanged = ![previousUsername isEqualToString:username];
+    NSString *authToken = nil;
+    
+    if (usernameChanged) {
+        authToken = self.authToken;
+        self.authToken = nil;
+    }
+    
+    [self willChangeValueForKey:@"username"];
+    [self setPrimitiveValue:username forKey:@"username"];
+    [self didChangeValueForKey:@"username"];
+    
+    if (usernameChanged) {
+        self.authToken = authToken;
+    }
+}
+
 - (NSString *)password
 {
     if (self.isWpcom) {


### PR DESCRIPTION
Fixes #3950 

This isn't the final solution but it's a minimally-impacting change to make the OAuth2 token not get lost when the username is changed. AccountService will possibly change the username from an email address (for example) to a WordPress.com username after a sync occurs. This makes sure that if a username is changed that the token is moved along as well.

I tried to write this so we continue to use existing accessor methods for authToken and a minimal impact on the setter for username. I'm open to suggestions for improvements but I wanted to touch the least amount of code for this hot fix.

I haven't written a unit test for this - which I can do. The keychain unit tests are notoriously unreliable though. Simulator seems to work fine when I log in with an email address and kill and restart.

I'm pulling everyone into this PR that was in the discussion today about the crashes/problems.

Needs Review: @aerych, @sendhil, @diegoreymendez, @oguzkocer 