### PR TITLE
Issue/3954 improve loading speed of media library

### DIFF
--- a/WordPress/Classes/Models/Media.h
+++ b/WordPress/Classes/Models/Media.h
@@ -57,9 +57,10 @@ typedef NS_ENUM(NSUInteger, MediaOrientation) {
 @property (nonatomic, strong) NSMutableSet * posts;
 @property (nonatomic, assign, readonly) BOOL unattached;
 @property (nonatomic, assign) BOOL featured;
-@property (nonatomic, strong, readonly) NSString *thumbnailLocalURL;
 @property (nonatomic, strong) NSString *absoluteLocalURL;
 @property (nonatomic, strong) NSString *remoteThumbnailURL;
+@property (nonatomic, strong) NSString *localThumbnailURL;
+@property (nonatomic, strong) NSString *absoluteThumbnailLocalURL;
 
 + (Media *)newMediaForPost:(AbstractPost *)post;
 + (Media *)newMediaForBlog:(Blog *)blog;

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -21,6 +21,7 @@
 @dynamic desc;
 @dynamic mediaTypeString;
 @dynamic videopressGUID;
+@dynamic localThumbnailURL;
 @dynamic remoteThumbnailURL;
 
 @synthesize unattached;
@@ -167,7 +168,7 @@
     if (![[NSFileManager defaultManager] removeItemAtPath:self.absoluteLocalURL error:&error]) {
         DDLogError(@"Error removing media files:%@", error);
     }
-    if (![[NSFileManager defaultManager] removeItemAtPath:self.thumbnailLocalURL error:&error]) {
+    if (![[NSFileManager defaultManager] removeItemAtPath:self.absoluteThumbnailLocalURL error:&error]) {
         DDLogError(@"Error removing media files:%@", error);
     }
     [super prepareForDeletion];
@@ -269,13 +270,25 @@
     return result;
 }
 
-- (NSString *)thumbnailLocalURL;
+- (NSString *)absoluteThumbnailLocalURL;
 {
-    if ( self.absoluteLocalURL ) {
-        return [NSString stringWithFormat:@"%@-thumbnail",self.absoluteLocalURL];
+    if ( self.localThumbnailURL ) {
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+        NSString *documentsDirectory = [paths firstObject];
+        NSString *absolutePath = [NSString pathWithComponents:@[documentsDirectory, self.localThumbnailURL]];
+        return absolutePath;
     } else {
         return nil;
     }
+}
+
+- (void)setAbsoluteThumbnailLocalURL:(NSString *)absoluteLocalURL
+{
+    NSParameterAssert([absoluteLocalURL isAbsolutePath]);
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentsDirectory = [paths firstObject];
+    NSString *localPath =  [absoluteLocalURL stringByReplacingOccurrencesOfString:documentsDirectory withString:@""];
+    self.localThumbnailURL = localPath;
 }
 
 - (NSString *)absoluteLocalURL

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -87,16 +87,16 @@ extern NSInteger const MediaMaxImageSizeDimension;
                         failure:(void (^)(NSError *error))failure;
 
 /**
- + Get a image for a Media by downloading its image or using the local cache
+ + Get a thumbnail image for a Media by downloading its image or using the local cache
  +
  + @param media
  + @success a block that will be invoked when the media is retrieved
  + @failure a block that will be invoked if an error happens returnin the associated error object with the details.
  + */
-- (void)imageForMedia:(Media *)media
-                 size:(CGSize)size
-              success:(void (^)(UIImage *image))success
-              failure:(void (^)(NSError *error))failure;
+- (void)thumbnailForMedia:(Media *)media
+                     size:(CGSize)size
+                  success:(void (^)(UIImage *image))success
+                  failure:(void (^)(NSError *error))failure;
 /**
  *  Get number of items in media library
  *

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -223,8 +223,12 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
     NSError *error = nil;
     Media *media = [[self.managedObjectContext executeFetchRequest:request error:&error] firstObject];
     if (media) {
+        NSString  *posterURL = media.absoluteThumbnailLocalURL;
+        if (!posterURL) {
+            posterURL = media.remoteThumbnailURL;
+        }
         if (success) {
-            success(media.remoteURL, media.remoteThumbnailURL);
+            success(media.remoteURL, posterURL);
         }
     } else {
         if (failure) {

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -293,7 +293,11 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
         if (media.mediaType == MediaTypeVideo) {
             remoteURL = [NSURL URLWithString:media.remoteThumbnailURL];
         } else if (media.mediaType == MediaTypeImage) {
-            remoteURL = [NSURL URLWithString:media.remoteURL];
+            NSString *remote = media.remoteURL;
+            if ([media.blog isHostedAtWPcom]) {
+                remote = [NSString stringWithFormat:@"%@?w=%ld",remote, (long)size.width];
+            }
+            remoteURL = [NSURL URLWithString:remote];
         }
         if (!remoteURL) {
             if (failure) {
@@ -310,11 +314,11 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
                 [[[self class] queueForResizeMediaOperations] addOperationWithBlock:^{                    
                     NSData *data = UIImagePNGRepresentation(image);
                     [data writeToFile:filePath atomically:YES];
-                    UIImage *thumbnail = [image thumbnailImage:size.width transparentBorder:0 cornerRadius:0 interpolationQuality:kCGInterpolationHigh];
-                    NSData *thumbnailData = UIImagePNGRepresentation(thumbnail);
-                    [thumbnailData writeToFile:thumbnailPath atomically:YES];
+                    //UIImage *thumbnail = [image thumbnailImage:size.width transparentBorder:0 cornerRadius:0 interpolationQuality:kCGInterpolationHigh];
+                    //NSData *thumbnailData = UIImagePNGRepresentation(thumbnail);
+                    [data writeToFile:thumbnailPath atomically:YES];
                     if (success) {
-                        success(thumbnail);
+                        success(image);
                     }
                 }];
             }];

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -343,7 +343,7 @@
 
     NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
     MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:mainContext];
-    [mediaService imageForMedia:self size:realSize success:^(UIImage *image) {
+    [mediaService thumbnailForMedia:self size:realSize success:^(UIImage *image) {
         if (completionHandler) {
             completionHandler(image, nil);
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1017,7 +1017,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate>
                           [WPError showAlertWithTitle:NSLocalizedString(@"Couldn't upload featured image", @"The title for an alert that says to the user that the featured image he selected couldn't be uploaded.") message:error.localizedDescription];
                           DDLogError(@"Couldn't upload featured image: %@", [error localizedDescription]);
                       }];
-    [progress setUserInfoObject:[UIImage imageWithData:[NSData dataWithContentsOfFile:media.thumbnailLocalURL]] forKey:WPProgressImageThumbnailKey];
+    [progress setUserInfoObject:[UIImage imageWithData:[NSData dataWithContentsOfFile:media.absoluteThumbnailLocalURL]] forKey:WPProgressImageThumbnailKey];
     progress.localizedDescription = NSLocalizedString(@"Uploading...",@"Label to show while uploading media to server");
     progress.kind = NSProgressKindFile;
     [progress setUserInfoObject:NSProgressFileOperationKindCopying forKey:NSProgressFileOperationKindKey];

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -997,7 +997,7 @@ NS_ENUM(NSInteger, WPLegacyEditPostViewControllerActionSheet)
         }
         [WPError showAlertWithTitle:NSLocalizedString(@"Media upload failed", @"The title for an alert that says to the user the media (image or video) failed to be uploaded to the server.") message:error.localizedDescription];
     }];
-    UIImage * image = [UIImage imageWithContentsOfFile:media.thumbnailLocalURL];
+    UIImage * image = [UIImage imageWithContentsOfFile:media.absoluteThumbnailLocalURL];
     [uploadProgress setUserInfoObject:image forKey:WPProgressImageThumbnailKey];
     uploadProgress.kind = NSProgressKindFile;
     [uploadProgress setUserInfoObject:NSProgressFileOperationKindCopying forKey:NSProgressFileOperationKindKey];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1705,7 +1705,7 @@ EditImageDetailsViewControllerDelegate
             [WPAnalytics track:WPAnalyticsStatEditorAddedVideoViaLocalLibrary];
             [self.editorView replaceLocalVideoWithID:mediaUniqueId
                                       forRemoteVideo:media.remoteURL
-                                        remotePoster:media.thumbnailLocalURL
+                                        remotePoster:media.remoteThumbnailURL
                                           videoPress:media.videopressGUID];
         }
     } failure:^(NSError *error) {
@@ -1817,7 +1817,7 @@ EditImageDetailsViewControllerDelegate
         if ([media mediaType] == MediaTypeImage) {
             [self.editorView insertImage:media.remoteURL alt:media.title];
         } else if ([media mediaType] == MediaTypeVideo) {
-            [self.editorView insertInProgressVideoWithID:[media.mediaID stringValue] usingPosterImage:[media thumbnailLocalURL]];
+            [self.editorView insertInProgressVideoWithID:[media.mediaID stringValue] usingPosterImage:[media absoluteThumbnailLocalURL]];
             [self.editorView replaceLocalVideoWithID:[media.mediaID stringValue] forRemoteVideo:media.remoteURL remotePoster:media.remoteThumbnailURL videoPress:media.videopressGUID];
         }
         [self stopTrackingProgressOfMediaWithId:mediaUniqueID];
@@ -1825,7 +1825,7 @@ EditImageDetailsViewControllerDelegate
         if ([media mediaType] == MediaTypeImage) {
             [self.editorView insertLocalImage:media.absoluteLocalURL uniqueId:mediaUniqueID];
         } else if ([media mediaType] == MediaTypeVideo) {
-            [self.editorView insertInProgressVideoWithID:mediaUniqueID usingPosterImage:[media thumbnailLocalURL]];
+            [self.editorView insertInProgressVideoWithID:mediaUniqueID usingPosterImage:[media absoluteThumbnailLocalURL]];
         }
         [self uploadMedia:media trackingId:mediaUniqueID];
     }

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 34.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 34.xcdatamodel/contents
@@ -222,6 +222,7 @@
         <attribute name="length" optional="YES" attributeType="Integer 32" defaultValueString="0">
             <userInfo/>
         </attribute>
+        <attribute name="localThumbnailURL" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="localURL" optional="YES" attributeType="String">
             <userInfo/>
         </attribute>
@@ -392,7 +393,7 @@
         <element name="Blog" positionX="0" positionY="0" width="128" height="510"/>
         <element name="Category" positionX="0" positionY="0" width="128" height="120"/>
         <element name="Comment" positionX="0" positionY="0" width="128" height="343"/>
-        <element name="Media" positionX="0" positionY="0" width="128" height="360"/>
+        <element name="Media" positionX="0" positionY="0" width="128" height="375"/>
         <element name="Meta" positionX="9" positionY="153" width="128" height="105"/>
         <element name="Notification" positionX="18" positionY="162" width="128" height="255"/>
         <element name="Page" positionX="0" positionY="0" width="128" height="60"/>


### PR DESCRIPTION
Closes #3954 

This PR uses photon to load thumbnail and saves the thumbnails locally. This avoid to load the full sized image and also to the rescales of the image on the fly.

To test it: 

 * Open a blog with a lot of media: for example Meetomatic
 * Create a new post
 * Insert media and select the Media Library
 * Check the speed of loading the thumbnails. ( remember the spinner is referring to the time of loading all the media objects son not the images itself)

Needs Review: @bummytime 