### PR TITLE
Adds missing event to Automattic Tracks tracker

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -48,6 +48,11 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
 - (void)track:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties
 {
     TracksEventPair *eventPair = [self eventPairForStat:stat];
+    if (!eventPair) {
+        DDLogInfo(@"WPAnalyticsStat not supported by WPAnalyticsTrackerAutomatticTracks: %@", @(stat));
+        return;
+    }
+    
     NSMutableDictionary *mergedProperties = [NSMutableDictionary new];
 
     [mergedProperties addEntriesFromDictionary:eventPair.properties];
@@ -162,6 +167,9 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
             break;
         case WPAnalyticsStatAppInstalled:
             eventName = @"application_installed";
+            break;
+        case WPAnalyticsStatAppUpgraded:
+            eventName = @"application_upgraded";
             break;
         case WPAnalyticsStatApplicationOpened:
             eventName = @"application_opened";
@@ -320,7 +328,7 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
             eventName = @"login_failed_to_guess_xmlrpc";
             break;
         case WPAnalyticsStatLogout:
-            eventName = @"logout";
+            eventName = @"account_logout";
             break;
         case WPAnalyticsStatLowMemoryWarning:
             eventName = @"application_low_memory_warning";
@@ -594,7 +602,6 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
             eventName = @"two_factor_sent_sms";
             break;
             
-        case WPAnalyticsStatAppUpgraded:
         case WPAnalyticsStatDefaultAccountChanged:
         case WPAnalyticsStatNoStat:
         case WPAnalyticsStatPerformedCoreDataMigrationFixFor45:

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -322,6 +322,7 @@
 		93A379DB19FE6D3000415023 /* DDLogSwift.m in Sources */ = {isa = PBXBuildFile; fileRef = 93A379DA19FE6D3000415023 /* DDLogSwift.m */; };
 		93A379EC19FFBF7900415023 /* KeychainTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 93A379EB19FFBF7900415023 /* KeychainTest.m */; };
 		93A3F7DE1843F6F00082FEEA /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93A3F7DD1843F6F00082FEEA /* CoreTelephony.framework */; };
+		93B853231B4416A30064FE72 /* WPAnalyticsTrackerAutomatticTracksTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B853221B4416A30064FE72 /* WPAnalyticsTrackerAutomatticTracksTests.m */; };
 		93C1147F18EC5DD500DAC95C /* AccountService.m in Sources */ = {isa = PBXBuildFile; fileRef = 93C1147E18EC5DD500DAC95C /* AccountService.m */; };
 		93C1148518EDF6E100DAC95C /* BlogService.m in Sources */ = {isa = PBXBuildFile; fileRef = 93C1148418EDF6E100DAC95C /* BlogService.m */; };
 		93C4864F181043D700A24725 /* ActivityLogDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 93069F581762410B000C966D /* ActivityLogDetailViewController.m */; };
@@ -1160,6 +1161,7 @@
 		93A379DA19FE6D3000415023 /* DDLogSwift.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDLogSwift.m; sourceTree = "<group>"; };
 		93A379EB19FFBF7900415023 /* KeychainTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeychainTest.m; sourceTree = "<group>"; };
 		93A3F7DD1843F6F00082FEEA /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
+		93B853221B4416A30064FE72 /* WPAnalyticsTrackerAutomatticTracksTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAnalyticsTrackerAutomatticTracksTests.m; sourceTree = "<group>"; };
 		93C1147D18EC5DD500DAC95C /* AccountService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccountService.h; sourceTree = "<group>"; };
 		93C1147E18EC5DD500DAC95C /* AccountService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccountService.m; sourceTree = "<group>"; };
 		93C1148318EDF6E100DAC95C /* BlogService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogService.h; sourceTree = "<group>"; };
@@ -2428,6 +2430,7 @@
 		852416D01A12ED2D0030700C /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				93B853211B44165B0064FE72 /* Analytics */,
 				852416D11A12ED690030700C /* AppRatingUtilityTests.m */,
 				5DA988051AEEA594002AFB12 /* DisplayableImageHelperTest.m */,
 				93A379EB19FFBF7900415023 /* KeychainTest.m */,
@@ -2634,6 +2637,14 @@
 				937D9A1019F838C2007B9D5F /* AccountToAccount22to23.swift */,
 			);
 			name = "22-23";
+			sourceTree = "<group>";
+		};
+		93B853211B44165B0064FE72 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				93B853221B4416A30064FE72 /* WPAnalyticsTrackerAutomatticTracksTests.m */,
+			);
+			name = Analytics;
 			sourceTree = "<group>";
 		};
 		93E5283D19A7741A003A1A9C /* WordPressTodayWidget */ = {
@@ -4239,6 +4250,7 @@
 				931D26F519ED7E6D00114F17 /* BlogJetpackTest.m in Sources */,
 				5D12FE1E1988243700378BD6 /* RemoteReaderPost.m in Sources */,
 				5D12FE221988245B00378BD6 /* RemoteReaderSite.m in Sources */,
+				93B853231B4416A30064FE72 /* WPAnalyticsTrackerAutomatticTracksTests.m in Sources */,
 				5DFA7EBC1AF7B8D30072023B /* NSDateStringFormattingTest.m in Sources */,
 				93A379EC19FFBF7900415023 /* KeychainTest.m in Sources */,
 				85F8E1981B017A86000859BB /* PushAuthenticationServiceRemote.swift in Sources */,

--- a/WordPress/WordPressTest/WPAnalyticsTrackerAutomatticTracksTests.m
+++ b/WordPress/WordPressTest/WPAnalyticsTrackerAutomatticTracksTests.m
@@ -1,0 +1,61 @@
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import "WPAnalyticsTrackerAutomatticTracks.h"
+#import <Automattic-Tracks-iOS/TracksService.h>
+#import <OCMock/OCMock.h>
+
+@interface WPAnalyticsTrackerAutomatticTracksTests : XCTestCase
+
+@property (nonatomic, strong) WPAnalyticsTrackerAutomatticTracks *subject;
+@property (nonatomic, strong) id serviceMock;
+
+@end
+
+@interface WPAnalyticsTrackerAutomatticTracks (Testing)
+
+@property (nonatomic, strong) TracksService *tracksService;
+@property (nonatomic, strong) TracksContextManager *contextManager;
+
+@end
+
+@implementation WPAnalyticsTrackerAutomatticTracksTests
+
+- (void)setUp {
+    [super setUp];
+
+    self.subject = [[WPAnalyticsTrackerAutomatticTracks alloc] init];
+    self.serviceMock = OCMStrictClassMock([TracksService class]);
+    self.subject.tracksService = self.serviceMock;
+    self.subject.contextManager = nil;
+}
+
+- (void)tearDown {
+    [super tearDown];
+    
+    self.subject = nil;
+    self.serviceMock = nil;
+}
+
+- (void)testVerifyTracksNamesMappings {
+    for (NSUInteger x = 0; x <= WPAnalyticsStatTwoFactorSentSMS; ++x) {
+        OCMExpect(([self.serviceMock trackEventName:[OCMArg checkWithBlock:^BOOL(id obj) {
+            TracksEvent *tracksEvent = [TracksEvent new];
+            tracksEvent.uuid = [NSUUID UUID];
+            tracksEvent.eventName = [NSString stringWithFormat:@"wpios_%@", obj];
+            
+            NSError *error;
+            BOOL isValid = [tracksEvent validateObject:&error];
+            
+            if (!isValid) {
+                NSLog(@"Error when validating TracksEvent: %@", error);
+            }
+            
+            return isValid;
+        }] withCustomProperties:[OCMArg any]]));
+        
+
+        [self.subject track:(WPAnalyticsStat)x];
+    }
+}
+
+@end


### PR DESCRIPTION
Closes #3959 

Adds the missing implementation for the app upgraded event to Tracks. Also fixes an event name mapping that doesn't pass validation. Created a unit test to scan all of the event enum to make sure the mappings are valid.

This isn't the best solution for doing all enum values as there isn't any way to count the enums. The unit test will have to be maintained or we add an enum in for the last placeholder.

cc: @daniloercoli 
Needs Review: @aerych, @sendhil 