### PR TITLE
Show edit button only if there are hideable blogs

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -633,7 +633,7 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
     AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
     WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
 
-    return [NSPredicate predicateWithFormat:@"account = %@", defaultAccount];
+    return [NSPredicate predicateWithFormat:@"account != NULL AND account = %@", defaultAccount];
 }
 
 - (void)updateFetchRequest


### PR DESCRIPTION
Fixes the predicate for hideable blogs so it doesn't falsely return all blogs when there's no default account

Fixes #3932 

Needs Review: @astralbodies 