### PR TITLE
Auth token issues solver. [DO NOT MERGE]

### DIFF
--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -56,6 +56,27 @@
 
 #pragma mark - Custom accessors
 
+- (void)setUsername:(NSString *)username
+{
+    NSString *previousUsername = self.username;
+    
+    BOOL usernameChanged = ![previousUsername isEqualToString:username];
+    NSString *authToken = nil;
+    
+    if (usernameChanged) {
+        authToken = self.authToken;
+        self.authToken = nil;
+    }
+    
+    [self willChangeValueForKey:@"username"];
+    [self setPrimitiveValue:username forKey:@"username"];
+    [self didChangeValueForKey:@"username"];
+    
+    if (usernameChanged) {
+        self.authToken = authToken;
+    }
+}
+
 - (NSString *)password
 {
     if (self.isWpcom) {

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -88,6 +88,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 @property (nonatomic, assign, readwrite) UIBackgroundTaskIdentifier     bgTask;
 @property (nonatomic, assign, readwrite) BOOL                           connectionAvailable;
 @property (nonatomic, strong, readwrite) WPUserAgent                    *userAgent;
+@property (nonatomic, assign, readwrite) BOOL                           shouldRestoreApplicationState;
 
 /**
  *  @brief      Flag that signals wether Whats New is on screen or not.
@@ -119,6 +120,12 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     // Basic networking setup
     [self setupReachability];
     
+    // Set the main window up
+    CGRect bounds = [[UIScreen mainScreen] bounds];
+    [self.window setFrame:bounds];
+    [self.window setBounds:bounds];
+    [self.window makeKeyAndVisible];
+    
     // Simperium: Wire CoreData Stack
     [self configureSimperiumWithLaunchOptions:launchOptions];
 
@@ -126,9 +133,11 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     
     __weak __typeof(self) weakSelf = self;
     
-    [authTokenIssueSolver fixAuthTokenIssueAndDo:^{
+    BOOL isFixingAuthTokenIssue = [authTokenIssueSolver fixAuthTokenIssueAndDo:^{
         [weakSelf runStartupSequenceWithLaunchOptions:launchOptions];
     }];
+    
+    self.shouldRestoreApplicationState = !isFixingAuthTokenIssue;
 
     return YES;
 }
@@ -344,7 +353,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 
 - (BOOL)application:(UIApplication *)application shouldRestoreApplicationState:(NSCoder *)coder
 {
-    return YES;
+    return self.shouldRestoreApplicationState;
 }
 
 #pragma mark - Application startup
@@ -406,9 +415,6 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
         [self setMustShowWhatsNewPopup:YES];
     }
     
-    CGRect bounds = [[UIScreen mainScreen] bounds];
-    [self.window setFrame:bounds];
-    [self.window setBounds:bounds]; // for good measure.
     self.window.rootViewController = [WPTabBarController sharedInstance];
 }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -1029,6 +1029,12 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 
 #pragma mark - Simperium helpers
 
+/**
+ *  @brief      This code exists for the sole purpose of fixing the missing-auth-token issue in
+ *              WPiOS 5.3.
+ *  @details    Read this: https://github.com/wordpress-mobile/WordPress-iOS/issues/3964
+ *  @todo       Remove this once enough version numbers have passed :)
+ */
 - (void)resetSimperiumOnAuthTokenIssue
 {
     SPBucket *notesBucket = [self.simperium bucketForName:NSStringFromClass([Notification class])];

--- a/WordPress/Classes/Utility/NotificationsManager.m
+++ b/WordPress/Classes/Utility/NotificationsManager.m
@@ -141,7 +141,23 @@ static NSString *const NotificationActionCommentApprove             = @"COMMENT_
         DDLogError(@"Couldn't unregister push token: %@", [error localizedDescription]);
     };
     
-    [defaultAccount.restApi unregisterForPushNotificationsWithDeviceId:deviceId success:successBlock failure:failureBlock];
+    // This method may have been called as a result of an issue that's setting authTokens to nil
+    // in WordPress v5.3, if the user decides to log out of his WP.com account.  This is part of a
+    // hotfix for WordPress v5.3.1.
+    //
+    // The following conditional check is only performed in case the authToken is nil, since we
+    // can't really use the restApi to unregister the token in this case.
+    //
+    // For more info on the issue check this URL:
+    // https://github.com/wordpress-mobile/WordPress-iOS/pull/3956
+    //
+    // Feel free to remove the following code once we're in a galaxy far, far away (from WPiOS 5.3).
+    //
+    if (defaultAccount.authToken) {
+        [defaultAccount.restApi unregisterForPushNotificationsWithDeviceId:deviceId
+                                                                   success:successBlock
+                                                                   failure:failureBlock];
+    }
 }
 
 + (BOOL)deviceRegisteredForPushNotifications

--- a/WordPress/Classes/Utility/WPAuthTokenIssueSolver.h
+++ b/WordPress/Classes/Utility/WPAuthTokenIssueSolver.h
@@ -15,7 +15,10 @@ typedef void(^WPAuthTokenissueSolverCompletionBlock)();
  *
  *  @param      onComplete      The block to execute once the issues are solved.  Will be executed
  *                              also if there's no issue to solve at all.
+ *
+ *  @returns    YES if the authToken issue is being fixed.  NO otherwise.  Useful to inhibit the
+ *              app's state restoration.
  */
-- (void)fixAuthTokenIssueAndDo:(WPAuthTokenissueSolverCompletionBlock)onComplete;
+- (BOOL)fixAuthTokenIssueAndDo:(WPAuthTokenissueSolverCompletionBlock)onComplete;
 
 @end

--- a/WordPress/Classes/Utility/WPAuthTokenIssueSolver.h
+++ b/WordPress/Classes/Utility/WPAuthTokenIssueSolver.h
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+
+typedef void(^WPAuthTokenissueSolverCompletionBlock)();
+
+/**
+ *  @class      WPAuthTokenIssueSolver
+ *  @brief      This class exists for the sole purpose of fixing the missing-auth-token issue in
+ *              WPiOS 5.3.
+ *  @details    Read this: https://github.com/wordpress-mobile/WordPress-iOS/issues/3964
+ */
+@interface WPAuthTokenIssueSolver : NSObject
+
+/**
+ *  @brief      Fixes the authToken issue.
+ *
+ *  @param      onComplete      The block to execute once the issues are solved.  Will be executed
+ *                              also if there's no issue to solve at all.
+ */
+- (void)fixAuthTokenIssueAndDo:(WPAuthTokenissueSolverCompletionBlock)onComplete;
+
+@end

--- a/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
+++ b/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
@@ -1,0 +1,130 @@
+#import "WPAuthTokenIssueSolver.h"
+#import "AccountService.h"
+#import "BlogService.h"
+#import "ContextManager.h"
+#import "LoginViewController.h"
+#import "UIAlertView+Blocks.h"
+#import "WordPressAppDelegate.h"
+#import "WPAccount.h"
+
+@implementation WPAuthTokenIssueSolver
+
+#pragma mark - Fixing the authToken issue.
+
+- (void)fixAuthTokenIssueAndDo:(WPAuthTokenissueSolverCompletionBlock)onComplete
+{
+    NSParameterAssert(onComplete);
+    
+    if ([self hasAuthTokenIssues]) {
+        LoginViewController *loginViewController = [[LoginViewController alloc] init];
+        
+        loginViewController.onlyDotComAllowed = YES;
+        loginViewController.shouldReauthenticateDefaultAccount = YES;
+        loginViewController.cancellable = ![self noSelfHostedBlogs];
+        loginViewController.dismissBlock = ^(BOOL cancelled) {
+            if (cancelled) {
+                [self showCancelReAuthenticationAlertAndOnOK:^{
+                    NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
+                    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:mainContext];
+                    
+                    [accountService removeDefaultWordPressComAccount];
+                    onComplete();
+                }];
+            } else {
+                onComplete();
+            }
+        };
+        
+        WordPressAppDelegate *appDelegate = (WordPressAppDelegate *)[UIApplication sharedApplication].delegate;
+        appDelegate.window.rootViewController = loginViewController;
+        
+        [self showExplanationAlertForReAuthenticationDueToMissingAuthToken];
+    } else {
+        onComplete();
+    }
+}
+
+#pragma mark - Misc
+
+/**
+ *  @brief      Call this method to know if there are hosted blogs.
+ *
+ *  @returns    YES if there are hosted blogs, NO otherwise.
+ */
+- (BOOL)noSelfHostedBlogs
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+    
+    NSInteger blogCount = [blogService blogCountSelfHosted];
+    return blogCount == 0;
+}
+
+/**
+ *  @brief      Call this method to know if the local installation of WPiOS has the authToken issue
+ *              this class was designed to solve.
+ *
+ *  @returns    YES if the local WPiOS installation needs to be fixed by this class.
+ */
+- (BOOL)hasAuthTokenIssues
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+    WPAccount *account = [accountService defaultWordPressComAccount];
+    
+    BOOL hasAuthTokenIssues = account && ![account authToken];
+    
+    return hasAuthTokenIssues;
+}
+
+#pragma mark - Alerts
+
+/**
+ *  @brief      Shows the alert when the re-authentication is cancelled by the user.
+ *
+ *  @param      okBlock     The block that will be executed if the user confirms the operation.
+ */
+- (void)showCancelReAuthenticationAlertAndOnOK:(WPAuthTokenissueSolverCompletionBlock)okBlock
+{
+    NSParameterAssert(okBlock);
+    
+    NSString *alertTitle = NSLocalizedString(@"Careful!",
+                                             @"Title for the warning shown to the user when he refuses to re-login when the authToken is missing.");
+    NSString *alertMessage = NSLocalizedString(@"If you proceed, all your WP.com account data will be removed from this device.  This means any unsaved data such as locally stored posts will be deleted.  This will not affect data that has already been uploaded to your WP.com account.",
+                                               @"Message for the warning shown to the user when he refuses to re-login when the authToken is missing.");
+    NSString *cancelButtonTitle = NSLocalizedString(@"Cancel",
+                                                    @"Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.");
+    NSString *deleteButtonTitle = NSLocalizedString(@"Delete",
+                                                    @"Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.");
+    
+    [UIAlertView showWithTitle:alertTitle
+                       message:alertMessage
+             cancelButtonTitle:cancelButtonTitle
+             otherButtonTitles:@[deleteButtonTitle]
+                      tapBlock:^(UIAlertView *alertView, NSInteger buttonIndex) {
+                          if (buttonIndex == alertView.firstOtherButtonIndex) {
+                              okBlock();
+                          }
+                      }];
+}
+
+/**
+ *  @brief      Shows the alert explaining the authToken issue to the user.
+ */
+- (void)showExplanationAlertForReAuthenticationDueToMissingAuthToken
+{
+    NSString *alertTitle = NSLocalizedString(@"Oops!",
+                                             @"Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.");
+    NSString *alertMessage = NSLocalizedString(@"We have detected a synchronization problem with your locally stored WP.com credentials. You're going to be prompted to re-authenticate.",
+                                               @"Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one.");
+    NSString *okButtonTitle = NSLocalizedString(@"OK",
+                                                @"OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.");
+    
+    [UIAlertView showWithTitle:alertTitle
+                       message:alertMessage
+             cancelButtonTitle:nil
+             otherButtonTitles:@[okButtonTitle]
+                      tapBlock:nil];
+}
+
+@end

--- a/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
+++ b/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
@@ -93,7 +93,7 @@
     
     NSString *alertTitle = NSLocalizedString(@"Careful!",
                                              @"Title for the warning shown to the user when he refuses to re-login when the authToken is missing.");
-    NSString *alertMessage = NSLocalizedString(@"If you proceed, all your WP.com account data will be removed from this device.  This means any unsaved data such as locally stored posts will be deleted.  This will not affect data that has already been uploaded to your WP.com account.",
+    NSString *alertMessage = NSLocalizedString(@"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not loose anything already saved to your WordPress.com blog(s).",
                                                @"Message for the warning shown to the user when he refuses to re-login when the authToken is missing.");
     NSString *cancelButtonTitle = NSLocalizedString(@"Cancel",
                                                     @"Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.");
@@ -118,7 +118,7 @@
 {
     NSString *alertTitle = NSLocalizedString(@"Oops!",
                                              @"Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.");
-    NSString *alertMessage = NSLocalizedString(@"We have detected a synchronization problem with your locally stored WP.com credentials. You're going to be prompted to re-authenticate.",
+    NSString *alertMessage = NSLocalizedString(@"There was a problem connecting to WordPress.com. Please sign in again.",
                                                @"Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one.");
     NSString *okButtonTitle = NSLocalizedString(@"OK",
                                                 @"OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.");

--- a/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
+++ b/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
@@ -4,16 +4,17 @@
 #import "ContextManager.h"
 #import "LoginViewController.h"
 #import "UIAlertView+Blocks.h"
-#import "WordPressAppDelegate.h"
 #import "WPAccount.h"
 
 @implementation WPAuthTokenIssueSolver
 
 #pragma mark - Fixing the authToken issue.
 
-- (void)fixAuthTokenIssueAndDo:(WPAuthTokenissueSolverCompletionBlock)onComplete
+- (BOOL)fixAuthTokenIssueAndDo:(WPAuthTokenissueSolverCompletionBlock)onComplete
 {
     NSParameterAssert(onComplete);
+    
+    BOOL isFixingAuthTokenIssue = NO;
     
     if ([self hasAuthTokenIssues]) {
         LoginViewController *loginViewController = [[LoginViewController alloc] init];
@@ -35,13 +36,15 @@
             }
         };
         
-        WordPressAppDelegate *appDelegate = (WordPressAppDelegate *)[UIApplication sharedApplication].delegate;
-        appDelegate.window.rootViewController = loginViewController;
+        [UIApplication sharedApplication].keyWindow.rootViewController = loginViewController;
         
         [self showExplanationAlertForReAuthenticationDueToMissingAuthToken];
+        isFixingAuthTokenIssue = YES;
     } else {
         onComplete();
     }
+    
+    return isFixingAuthTokenIssue;
 }
 
 #pragma mark - Misc

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -396,7 +396,7 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
         if (!defaultAccount) {
             loginViewController.prefersSelfHosted = YES;
         }
-        loginViewController.dismissBlock = ^{
+        loginViewController.dismissBlock = ^(BOOL cancelled){
             [self dismissViewControllerAnimated:YES completion:nil];
         };
         UINavigationController *loginNavigationController = [[UINavigationController alloc] initWithRootViewController:loginViewController];

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -316,7 +316,7 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
                 LoginViewController *loginViewController = [[LoginViewController alloc] init];
                 loginViewController.onlyDotComAllowed = YES;
                 loginViewController.cancellable = YES;
-                loginViewController.dismissBlock = ^{
+                loginViewController.dismissBlock = ^(BOOL cancelled){
                     [self dismissViewControllerAnimated:YES completion:nil];
                 };
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.h
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.h
@@ -7,7 +7,7 @@
 @property (nonatomic, assign) BOOL shouldReauthenticateDefaultAccount;
 @property (nonatomic, assign) BOOL showEditorAfterAddingSites;
 @property (nonatomic, assign) BOOL cancellable;
-@property (nonatomic,   copy) void (^dismissBlock)();
+@property (nonatomic,   copy) void (^dismissBlock)(BOOL cancelled);
 
 + (void)presentModalReauthScreen;
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -285,7 +285,7 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
 - (IBAction)cancelButtonAction:(id)sender
 {
     if (self.dismissBlock) {
-        self.dismissBlock();
+        self.dismissBlock(YES);
     }
 }
 
@@ -623,7 +623,7 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
     }
 
     if (self.dismissBlock) {
-        self.dismissBlock();
+        self.dismissBlock(NO);
     }
 }
 
@@ -815,7 +815,7 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
     loginViewController.onlyDotComAllowed = YES;
     loginViewController.shouldReauthenticateDefaultAccount = YES;
     loginViewController.cancellable = YES;
-    loginViewController.dismissBlock = ^{
+    loginViewController.dismissBlock = ^(BOOL cancelled){
         [rootViewController dismissViewControllerAnimated:YES completion:nil];
     };
     

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		591A428C1A6DC1B0003807A6 /* WPBackgroundDimmerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */; };
 		591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */ = {isa = PBXBuildFile; fileRef = 591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */; };
 		5926E1E31AC4468300964783 /* WPCrashlytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 5926E1E21AC4468300964783 /* WPCrashlytics.m */; };
+		594399931B45091000539E21 /* WPAuthTokenIssueSolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 594399921B45091000539E21 /* WPAuthTokenIssueSolver.m */; };
 		5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */; };
 		5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */; };
 		594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = 594DB2941AB891A200E2E456 /* WPUserAgent.m */; };
@@ -710,6 +711,8 @@
 		591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPGUIConstants.m; sourceTree = "<group>"; };
 		5926E1E11AC4468300964783 /* WPCrashlytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPCrashlytics.h; sourceTree = "<group>"; };
 		5926E1E21AC4468300964783 /* WPCrashlytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPCrashlytics.m; sourceTree = "<group>"; };
+		594399911B45091000539E21 /* WPAuthTokenIssueSolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAuthTokenIssueSolver.h; sourceTree = "<group>"; };
+		594399921B45091000539E21 /* WPAuthTokenIssueSolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAuthTokenIssueSolver.m; sourceTree = "<group>"; };
 		5948AD0C1AB734F2006E8882 /* WPAppAnalytics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAppAnalytics.h; sourceTree = "<group>"; };
 		5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAppAnalytics.m; sourceTree = "<group>"; };
 		5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAppAnalyticsTests.m; sourceTree = "<group>"; };
@@ -2501,6 +2504,8 @@
 				292CECFF1027259000BD407D /* SFHFKeychainUtils.m */,
 				8514973F171E13DF00B87F3F /* WPAsyncBlockOperation.h */,
 				85149740171E13DF00B87F3F /* WPAsyncBlockOperation.m */,
+				594399911B45091000539E21 /* WPAuthTokenIssueSolver.h */,
+				594399921B45091000539E21 /* WPAuthTokenIssueSolver.m */,
 				E1E4CE091773C59B00430844 /* WPAvatarSource.h */,
 				E1E4CE0A1773C59B00430844 /* WPAvatarSource.m */,
 				5DEB61B6156FCD5200242C35 /* WPChromelessWebViewController.h */,
@@ -3888,6 +3893,7 @@
 				5D7DEA2919D488DD0032EE77 /* WPStyleGuide+Comments.swift in Sources */,
 				5DB3BA0818D11D8D00F3F3E9 /* PublishDatePickerView.m in Sources */,
 				319D6E7B19E447500013871C /* Suggestion.m in Sources */,
+				594399931B45091000539E21 /* WPAuthTokenIssueSolver.m in Sources */,
 				B5B56D3219AFB68800B4E29B /* WPStyleGuide+Reply.swift in Sources */,
 				B535209F1AF7EFEC00B33BA8 /* PushAuthenticationServiceRemote.swift in Sources */,
 				30EABE0918A5903400B73A9C /* WPBlogTableViewCell.m in Sources */,


### PR DESCRIPTION
Takes care points 3, 4 and 5 from [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/3964) reported by @astralbodies.

This should NOT be merged until [this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/3956) by @astralbodies is merged.  The reason is that this PR is a branch from that PR.

Please keep in mind this is a hotfix, so even though some code has been moved, as little as possible of the existing logic has been really modified.  This means there's some code duplication.

**Test 1:**
- Comment out method `setUsername:` in `WPAccount`
- Login with a mixed case WP.com username name or a WP.com email address
- Create post, quit app without hitting the save button
- Reopen the app, it should ask you to re-authenticate (if you disabled the method above)
- Re-authenticate
- Make sure your post is still there

**Test 2:**
- Comment out method `setUsername:` in `WPAccount`
- Login with a mixed case WP.com username name or a WP.com email address
- Go to the site picker and add self-hosted blog
- Quit the app normally
- Reopen the app, it should ask you to re-authenticate (if you disabled the method above)
- Hit cancel instead of re-authing
- A warning will ask if you want to delete your local wp.com data
- Delete it
- Make sure the self hosted blog is still there, but that the wp.com related data has been removed (such as all wp.com blogs from the site picker).

**Test 3:**
- Re-enable method `setUsername:` in `WPAccount`
- Login with either email or mixed cap username
- Quit app, reopen
- Should log in normally, without issues

**Test 4:** 
- Comment out method `setUsername:` in `WPAccount`
- Login with a mixed case WP.com username name or a WP.com email address
- Quit the app normally
- Reopen the app, it should ask you to re-authenticate (if you disabled the method above)
- Try logging-in with a bad password.
- Make sure you can interact with the overlay that comes up, and dismiss it by pressing "OK".

**Test 5:**
- Make sure to repeat all previous tests for different iOS versions.

**Discussion:** (please take a moment to read and provide feedback)
- We don't currently have any procedure to make sure the user re-authenticates with the same user he was using previously, which seems a bit dangerous to me not to have.  This feels like something doable, but completely outside of the scope of a simple hot-fix (especially a nightly hot-fix like this one).  We could enhance `LoginViewController` with code to check that `account.userId` matches the remote info returned by the new authentication attempt.
- I believe we could improve this PR **drastically* by adding an automatic recovery attempt.  I've reviewed the keychain code we have and it supports case insensitive searches and returning multiple results.  If the auth token is `nil` we could try to (case-insensitively) search the keychain for all `account.username` and `account.email` matches, then try logging in with the returned authTokens and, on success, confirming that our locally stored `account.userId` matches the account data returned by the services (in order to make sure we're logging into the right account).  If the automatic attempt fails we can fall back into this code.