### PR TITLE
Makes buttons extend PostMetaButton

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -152,7 +152,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U6E-MB-03K">
                                         <rect key="frame" x="217" y="332" width="77" height="18"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U4X-fn-9uf">
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U4X-fn-9uf" customClass="PostMetaButton">
                                                 <rect key="frame" x="47" y="0.0" width="30" height="18"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="18" id="YVF-bx-Qxo"/>
@@ -164,7 +164,7 @@
                                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                                 </state>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f2K-8g-nnA">
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f2K-8g-nnA" customClass="PostMetaButton">
                                                 <rect key="frame" x="4" y="0.0" width="30" height="18"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="18" id="GFc-LE-9Ao"/>


### PR DESCRIPTION
Fixes #3961 

The buttons for the image post card were not subclassing `PostMetaButton` as they should.  This patch adds the missing inheritance to `PostCardImageCell.xib`. 

To test:
Replace `PostCardTableViewCell configureMetaButtons` with [this snippet](https://gist.github.com/aerych/091fd1eaaa7e8469c8ac) to randomly populate the title values of the like and comment buttons and confirm the titles never overlap the image, and the titles are never truncated. 

@kwonye would you be game for a review?

Needs Review: @kwonye 

