### PR TITLE
Reference trashed post/page by NSManagedObjectID not postID

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
@@ -209,8 +209,8 @@ static NSString * const CurrentPageListStatusFilterKey = @"CurrentPageListStatus
 
     // If we have recently trashed posts, create an OR predicate to find posts matching the filter,
     // or posts that were recently deleted.
-    if ([searchText length] == 0 && [self.recentlyTrashedPostIDs count] > 0) {
-        NSPredicate *trashedPredicate = [NSPredicate predicateWithFormat:@"postID IN %@", self.recentlyTrashedPostIDs];
+    if ([searchText length] == 0 && [self.recentlyTrashedPostObjectIDs count] > 0) {
+        NSPredicate *trashedPredicate = [NSPredicate predicateWithFormat:@"SELF IN %@", self.recentlyTrashedPostObjectIDs];
         filterPredicate = [NSCompoundPredicate orPredicateWithSubpredicates:@[filterPredicate, trashedPredicate]];
     }
     [predicates addObject:filterPredicate];
@@ -323,7 +323,7 @@ static NSString * const CurrentPageListStatusFilterKey = @"CurrentPageListStatus
 - (NSString *)cellIdentifierForPage:(Page *)page
 {
     NSString *identifier;
-    if ([self.recentlyTrashedPostIDs containsObject:page.postID] && [self currentPostListFilter].filterType != PostListStatusFilterTrashed) {
+    if ([self.recentlyTrashedPostObjectIDs containsObject:page.objectID] && [self currentPostListFilter].filterType != PostListStatusFilterTrashed) {
         identifier = RestorePageCellIdentifier;
     } else {
         identifier = PageCellIdentifier;

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
@@ -53,7 +53,7 @@ extern const CGSize PreferredFiltersPopoverContentSize;
 @property (nonatomic, strong) WPSearchController *searchController; // Stand-in for UISearchController
 @property (nonatomic, strong) UIPopoverController *postFilterPopoverController;
 @property (nonatomic, strong) NSArray *postListFilters;
-@property (nonatomic, strong) NSMutableArray *recentlyTrashedPostIDs; // IDs of trashed posts. Cleared on refresh or when filter changes.
+@property (nonatomic, strong) NSMutableArray *recentlyTrashedPostObjectIDs; // IDs of trashed posts. Cleared on refresh or when filter changes.
 
 - (NSString *)postTypeToSync;
 - (NSDate *)lastSyncDate;

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -289,8 +289,8 @@ static const CGFloat PostListHeightForFooterView = 34.0;
 
     // If we have recently trashed posts, create an OR predicate to find posts matching the filter,
     // or posts that were recently deleted.
-    if ([searchText length] == 0 && [self.recentlyTrashedPostIDs count] > 0) {
-        NSPredicate *trashedPredicate = [NSPredicate predicateWithFormat:@"postID IN %@", self.recentlyTrashedPostIDs];
+    if ([searchText length] == 0 && [self.recentlyTrashedPostObjectIDs count] > 0) {
+        NSPredicate *trashedPredicate = [NSPredicate predicateWithFormat:@"SELF IN %@", self.recentlyTrashedPostObjectIDs];
         filterPredicate = [NSCompoundPredicate orPredicateWithSubpredicates:@[filterPredicate, trashedPredicate]];
     }
     [predicates addObject:filterPredicate];
@@ -391,7 +391,7 @@ static const CGFloat PostListHeightForFooterView = 34.0;
 - (NSString *)cellIdentifierForPost:(Post *)post
 {
     NSString *identifier;
-    if ([self.recentlyTrashedPostIDs containsObject:post.postID] && [self currentPostListFilter].filterType != PostListStatusFilterTrashed) {
+    if ([self.recentlyTrashedPostObjectIDs containsObject:post.objectID] && [self currentPostListFilter].filterType != PostListStatusFilterTrashed) {
         identifier = PostCardRestoreCellIdentifier;
     } else if (![post.pathForDisplayImage length]) {
         identifier = PostCardTextCellIdentifier;
@@ -541,7 +541,7 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     [[NSUserDefaults standardUserDefaults] setObject:@(filter) forKey:CurrentPostAuthorFilterKey];
     [NSUserDefaults resetStandardUserDefaults];
 
-    [self.recentlyTrashedPostIDs removeAllObjects];
+    [self.recentlyTrashedPostObjectIDs removeAllObjects];
     [self updateAndPerformFetchRequestRefreshingCachedRowHeights];
     [self syncItemsWithUserInteraction:NO];
 }


### PR DESCRIPTION
Fixes #3966 
All local-only `AbstractPosts` have a `postID` of `-1`.  This led to an inconsistent row count when trashing a local post when the app had more than one local post saved. 
Rather instead using the postID to reference a trashed post in an `NSPredicate`, we'll use the post object's `NSManagedObjectID` which should always be unique.

Steps to reproduce the error are included in the issue.

@bummytime since this is tangentially related to the editor would you mind taking a peek?
@astralbodies Would you mind vetting the Core Data voodoo at play?

Needs Review: @bummytime @astralbodies 