### PR TITLE
Let post card action buttons have exclusive touch.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
@@ -177,6 +177,7 @@ static const UIEdgeInsets MoreButtonImageInsets = {3.0, 0.0, 0.0, 4.0};
 {
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     button.translatesAutoresizingMaskIntoConstraints = NO;
+    button.exclusiveTouch = YES;
     button.backgroundColor = [WPStyleGuide lightGrey];
     button.titleLabel.font = [WPStyleGuide subtitleFont];
     [button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];


### PR DESCRIPTION
Closes #3894 

To test:
- The most reliable way is probably to use the iPad simulator. 
- Hold down the option button to display the touch indicators. 
- Position them above the preview and stats buttons on a card, and then click your mouse. 
Set a break point in `PostCardActionBar handleButtonTap:` to ensure only a single tap is registered.

@diegoreymendez since you're familiar with this one would you be up for the review? 

Needs Review: @diegoreymendez 