### PR TITLE
Disable search button when in edit mode

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -558,7 +558,8 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
 {
     [super setEditing:editing animated:animated];
     [self.tableView setEditing:editing animated:animated];
-
+    self.navigationItem.rightBarButtonItem.enabled = !editing;
+    
     if (editing) {
         [self updateHeaderSize];
         self.tableView.tableHeaderView = self.headerView;

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -559,7 +559,7 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
     [super setEditing:editing animated:animated];
     [self.tableView setEditing:editing animated:animated];
     self.navigationItem.rightBarButtonItem.enabled = !editing;
-    
+
     if (editing) {
         [self updateHeaderSize];
         self.tableView.tableHeaderView = self.headerView;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -416,6 +416,7 @@
 		BE20F5E71B2F76660020694C /* WPSearchControllerConfiguratorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BE20F5E61B2F76660020694C /* WPSearchControllerConfiguratorTests.m */; };
 		BEBFE86F1B2F50C5002C04EF /* WPSearchController.m in Sources */ = {isa = PBXBuildFile; fileRef = BEBFE86E1B2F50C5002C04EF /* WPSearchController.m */; };
 		BEBFE8721B2F50E0002C04EF /* WPSearchControllerConfigurator.m in Sources */ = {isa = PBXBuildFile; fileRef = BEBFE8711B2F50E0002C04EF /* WPSearchControllerConfigurator.m */; };
+		BEC8A3FF1B4BAA2C001CB8C3 /* BlogListViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BEC8A3FE1B4BAA2C001CB8C3 /* BlogListViewControllerTests.m */; };
 		C533CF350E6D3ADA000C3DE8 /* CommentsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C533CF340E6D3ADA000C3DE8 /* CommentsViewController.m */; };
 		C545E0A21811B9880020844C /* ContextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C545E0A11811B9880020844C /* ContextManager.m */; };
 		C56636E91868D0CE00226AAB /* StatsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C56636E71868D0CE00226AAB /* StatsViewController.m */; };
@@ -1297,6 +1298,7 @@
 		BEBFE86E1B2F50C5002C04EF /* WPSearchController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPSearchController.m; path = Search/WPSearchController.m; sourceTree = "<group>"; };
 		BEBFE8701B2F50E0002C04EF /* WPSearchControllerConfigurator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPSearchControllerConfigurator.h; path = Search/WPSearchControllerConfigurator.h; sourceTree = "<group>"; };
 		BEBFE8711B2F50E0002C04EF /* WPSearchControllerConfigurator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPSearchControllerConfigurator.m; path = Search/WPSearchControllerConfigurator.m; sourceTree = "<group>"; };
+		BEC8A3FE1B4BAA2C001CB8C3 /* BlogListViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BlogListViewControllerTests.m; path = ViewRelated/Blog/BlogListViewControllerTests.m; sourceTree = "<group>"; };
 		C52812131832E071008931FD /* WordPress 13.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 13.xcdatamodel"; sourceTree = "<group>"; };
 		C533CF330E6D3ADA000C3DE8 /* CommentsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommentsViewController.h; sourceTree = "<group>"; };
 		C533CF340E6D3ADA000C3DE8 /* CommentsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommentsViewController.m; sourceTree = "<group>"; };
@@ -2927,6 +2929,7 @@
 			isa = PBXGroup;
 			children = (
 				BE20F5E21B2F739F0020694C /* System */,
+				BEC8A3FD1B4BAA08001CB8C3 /* Blog */,
 			);
 			name = ViewRelated;
 			sourceTree = "<group>";
@@ -2956,6 +2959,14 @@
 				BEBFE8711B2F50E0002C04EF /* WPSearchControllerConfigurator.m */,
 			);
 			name = Search;
+			sourceTree = "<group>";
+		};
+		BEC8A3FD1B4BAA08001CB8C3 /* Blog */ = {
+			isa = PBXGroup;
+			children = (
+				BEC8A3FE1B4BAA2C001CB8C3 /* BlogListViewControllerTests.m */,
+			);
+			name = Blog;
 			sourceTree = "<group>";
 		};
 		C430074CAC011A24F4A74E17 /* Pods */ = {
@@ -4247,6 +4258,7 @@
 				5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */,
 				59E2AAE81B20E3EA0051DC06 /* ServiceRemoteRESTTests.m in Sources */,
 				85B1253F1B02849B008A3D95 /* PushAuthenticationService.swift in Sources */,
+				BEC8A3FF1B4BAA2C001CB8C3 /* BlogListViewControllerTests.m in Sources */,
 				931D26F519ED7E6D00114F17 /* BlogJetpackTest.m in Sources */,
 				5D12FE1E1988243700378BD6 /* RemoteReaderPost.m in Sources */,
 				5D12FE221988245B00378BD6 /* RemoteReaderSite.m in Sources */,

--- a/WordPress/WordPressTest/ViewRelated/Blog/BlogListViewControllerTests.m
+++ b/WordPress/WordPressTest/ViewRelated/Blog/BlogListViewControllerTests.m
@@ -1,40 +1,40 @@
-//
-//  BlogListViewControllerTests.m
-//  WordPress
-//
-//  Created by Will Kwon on 7/6/15.
-//  Copyright (c) 2015 WordPress. All rights reserved.
-//
+@protocol NSFetchedResultsControllerDelegate <NSObject>
+
+@end
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import "BlogListViewController.h"
 
 @interface BlogListViewControllerTests : XCTestCase
+
+@property (nonatomic, strong) BlogListViewController *blogListViewController;
 
 @end
 
 @implementation BlogListViewControllerTests
 
-- (void)setUp {
+- (void)setUp
+{
     [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+    self.blogListViewController = [[BlogListViewController alloc] init];
 }
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
+- (void)tearDown
+{
+    self.blogListViewController = nil;
     [super tearDown];
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    XCTAssert(YES, @"Pass");
+- (void)testSetEditingTrueDisablesSearchButton
+{
+    [self.blogListViewController setEditing:YES];
+    XCTAssertFalse(self.blogListViewController.navigationItem.rightBarButtonItem.enabled);
 }
 
-- (void)testPerformanceExample {
-    // This is an example of a performance test case.
-    [self measureBlock:^{
-        // Put the code you want to measure the time of here.
-    }];
+- (void)testSetEditingFalseEnablesSearchButton
+{
+    [self.blogListViewController setEditing:NO];
+    XCTAssertTrue(self.blogListViewController.navigationItem.rightBarButtonItem.enabled);
 }
-
 @end

--- a/WordPress/WordPressTest/ViewRelated/Blog/BlogListViewControllerTests.m
+++ b/WordPress/WordPressTest/ViewRelated/Blog/BlogListViewControllerTests.m
@@ -1,0 +1,40 @@
+//
+//  BlogListViewControllerTests.m
+//  WordPress
+//
+//  Created by Will Kwon on 7/6/15.
+//  Copyright (c) 2015 WordPress. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface BlogListViewControllerTests : XCTestCase
+
+@end
+
+@implementation BlogListViewControllerTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    XCTAssert(YES, @"Pass");
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end


### PR DESCRIPTION
Addresses #3975

Testing instructions:
On the site picker, click 'edit'. Search button should be disabled. Clicking 'done' will re-enable the search button.