### PR TITLE
Login: Stuck with an invalid Multifactor Code

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -63,7 +63,9 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
 
 - (LoginFields *)loginFields
 {
-    return [LoginFields loginFieldsWithUsername:self.username password:self.password siteUrl:self.siteUrl multifactorCode:self.multifactorCode userIsDotCom:self.userIsDotCom shouldDisplayMultiFactor:self.shouldDisplayMultifactor];
+    // Do not return the Multifactor Code, unless the field is actually onscreen!
+    NSString *multifactorCode = self.isMultifactorEnabled ? self.multifactorCode : nil;
+    return [LoginFields loginFieldsWithUsername:self.username password:self.password siteUrl:self.siteUrl multifactorCode:multifactorCode userIsDotCom:self.userIsDotCom shouldDisplayMultiFactor:self.shouldDisplayMultifactor];
 }
 
 - (void)signInButtonAction


### PR DESCRIPTION
#### Steps:

1. Fresh install WPiOS
2. Enter the credentials for an account with 2FA enabled
3. Whenever requested, enter an invalid One Time Code
4. Tap over the background to dismiss the keyboard
5. Tap login again.

As a result, the app is expected to submit the credentials again, and request the Multifactor Code.

Fixes #3983

Needs Review: @sendhil || @diegoreymendez 

Thanks in advance!
