### PR TITLE
LoginViewController: Prevents setting full alpha on disabled fields

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -761,7 +761,10 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
 
     [UIView animateWithDuration:animationDuration animations:^{
         for (UIControl *control in [self controlsToHideWithKeyboardOffset:currentKeyboardOffset]) {
-            control.alpha = GeneralWalkthroughAlphaEnabled;
+            // Fix: Revert to Enabled only those fields that were, effectively, hidden!
+            if (control.alpha == GeneralWalkthroughAlphaHidden) {
+                control.alpha = GeneralWalkthroughAlphaEnabled;
+            }
         }
         
         for (UIControl *control in [self controlsToMoveForTextEntry]) {


### PR DESCRIPTION
#### Steps:
1. Fresh install WPiOS
2. Enter the credentials for a 2FA-Enabled account
3. Enter an invalid code

#### Expected:
The keyboard should get dismissed, and an error should appear onscreen (Invalid OTP). However, the Username Field should remain disabled.

Fixes #3985 

Needs Review: @aerych (Thanks in advance Eric!)
