### PR TITLE
Turns LocalCoreDataService into a superclass.

### DIFF
--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -6,7 +6,7 @@
 extern NSString *const WPAccountDefaultWordPressComAccountChangedNotification;
 extern NSString *const WPAccountEmailAndDefaultBlogUpdatedNotification;
 
-@interface AccountService : NSObject <LocalCoreDataService>
+@interface AccountService : LocalCoreDataService
 
 ///------------------------------------
 /// @name Default WordPress.com account

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -14,27 +14,11 @@
 static NSString * const DefaultDotcomAccountUUIDDefaultsKey = @"AccountDefaultDotcomUUID";
 static NSString * const DefaultDotcomAccountPasswordRemovedKey = @"DefaultDotcomAccountPasswordRemovedKey";
 
-@interface AccountService ()
-
-@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
-
-@end
-
 static NSString * const WordPressDotcomXMLRPCKey = @"https://wordpress.com/xmlrpc.php";
 NSString * const WPAccountDefaultWordPressComAccountChangedNotification = @"WPAccountDefaultWordPressComAccountChangedNotification";
 NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEmailAndDefaultBlogUpdatedNotification";
 
 @implementation AccountService
-
-- (id)initWithManagedObjectContext:(NSManagedObjectContext *)context
-{
-    self = [super init];
-    if (self) {
-        _managedObjectContext = context;
-    }
-
-    return self;
-}
 
 ///------------------------------------
 /// @name Default WordPress.com account

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -4,7 +4,7 @@
 
 @class WPAccount;
 
-@interface BlogService : NSObject<LocalCoreDataService>
+@interface BlogService : LocalCoreDataService
 
 /**
  Returns the blog that matches with a given blogID

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -28,23 +28,7 @@ NSString *const MinimumVersion = @"3.6";
 NSString *const HttpsPrefix = @"https://";
 CGFloat const OneHourInSeconds = 60.0 * 60.0;
 
-@interface BlogService ()
-
-@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
-
-@end
-
 @implementation BlogService
-
-- (id)initWithManagedObjectContext:(NSManagedObjectContext *)context
-{
-    self = [super init];
-    if (self) {
-        _managedObjectContext = context;
-    }
-
-    return self;
-}
 
 - (Blog *)blogByBlogId:(NSNumber *)blogID
 {

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -8,7 +8,7 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 @class ReaderPost;
 @class BasePost;
 
-@interface CommentService : NSObject <LocalCoreDataService>
+@interface CommentService : LocalCoreDataService
 
 + (BOOL)isSyncingCommentsForBlog:(Blog *)blog;
 

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -15,12 +15,6 @@
 
 NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
 
-@interface CommentService ()
-
-@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
-
-@end
-
 @implementation CommentService
 
 + (NSMutableSet *)syncingCommentsLocks
@@ -61,16 +55,6 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
     @synchronized([self syncingCommentsLocks]) {
         [[self syncingCommentsLocks] removeObject:blogID];
     }
-}
-
-- (id)initWithManagedObjectContext:(NSManagedObjectContext *)context
-{
-    self = [super init];
-    if (self) {
-        _managedObjectContext = context;
-    }
-
-    return self;
 }
 
 - (NSSet *)findCommentsWithPostID:(NSNumber *)postID inBlog:(Blog *)blog

--- a/WordPress/Classes/Services/JetpackService.h
+++ b/WordPress/Classes/Services/JetpackService.h
@@ -3,7 +3,7 @@
 
 @class WPAccount;
 
-@interface JetpackService : NSObject<LocalCoreDataService>
+@interface JetpackService : LocalCoreDataService
 
 - (void)validateAndLoginWithUsername:(NSString *)username
                             password:(NSString *)password

--- a/WordPress/Classes/Services/JetpackService.m
+++ b/WordPress/Classes/Services/JetpackService.m
@@ -7,20 +7,7 @@
 #import "WPAccount.h"
 #import "Blog.h"
 
-@interface JetpackService ()
-@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
-@end
-
 @implementation JetpackService
-
-- (id)initWithManagedObjectContext:(NSManagedObjectContext *)context
-{
-    self = [super init];
-    if (self) {
-        _managedObjectContext = context;
-    }
-    return self;
-}
 
 - (void)validateAndLoginWithUsername:(NSString *)username
                             password:(NSString *)password

--- a/WordPress/Classes/Services/LocalCoreDataService.h
+++ b/WordPress/Classes/Services/LocalCoreDataService.h
@@ -1,9 +1,20 @@
 #import <Foundation/Foundation.h>
 
-@protocol LocalCoreDataService <NSObject>
+@interface LocalCoreDataService : NSObject
 
-@required
+/**
+ *  @brief      The context this object will use for interacting with CoreData.
+ */
+@property (nonatomic, strong, readonly) NSManagedObjectContext *managedObjectContext;
 
-- (id)initWithManagedObjectContext:(NSManagedObjectContext *)context;
+/**
+ *  @brief      Initializes the instance.
+ *
+ *  @param      context     The context this instance will use for interacting with CoreData.
+ *                          Cannot be nil.
+ *
+ *  @returns    The initialized object.
+ */
+- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context;
 
 @end

--- a/WordPress/Classes/Services/LocalCoreDataService.m
+++ b/WordPress/Classes/Services/LocalCoreDataService.m
@@ -1,0 +1,21 @@
+#import "LocalCoreDataService.h"
+
+@interface LocalCoreDataService ()
+@property (nonatomic, strong, readwrite) NSManagedObjectContext *managedObjectContext;
+@end
+
+@implementation LocalCoreDataService
+
+- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context
+{
+    NSParameterAssert([context isKindOfClass:[NSManagedObjectContext class]]);
+    
+    self = [super init];
+    if (self) {
+        _managedObjectContext = context;
+    }
+    
+    return self;
+}
+
+@end

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -9,7 +9,7 @@ extern NSInteger const MediaMaxImageSizeDimension;
 @class Media;
 @class Blog;
 
-@interface MediaService : NSObject <LocalCoreDataService>
+@interface MediaService : LocalCoreDataService
 
 + (CGSize)maxImageSizeSetting;
 

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -18,12 +18,6 @@ CGSize const MediaMaxImageSize = {3000, 3000};
 NSInteger const MediaMinImageSizeDimension = 150;
 NSInteger const MediaMaxImageSizeDimension = 3000;
 
-@interface MediaService ()
-
-@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
-
-@end
-
 @implementation MediaService
 
 + (CGSize)maxImageSizeSetting
@@ -47,16 +41,6 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
     NSString *strSize = NSStringFromCGSize(CGSizeMake(width, height));
     [[NSUserDefaults standardUserDefaults] setObject:strSize forKey:SavedMaxImageSizeSetting];
     [NSUserDefaults resetStandardUserDefaults];
-}
-
-- (id)initWithManagedObjectContext:(NSManagedObjectContext *)context
-{
-    self = [super init];
-    if (self) {
-        _managedObjectContext = context;
-    }
-
-    return self;
 }
 
 - (void)createMediaWithAsset:(ALAsset *)asset

--- a/WordPress/Classes/Services/PostCategoryService.h
+++ b/WordPress/Classes/Services/PostCategoryService.h
@@ -3,7 +3,7 @@
 
 @class Blog, PostCategory;
 
-@interface PostCategoryService : NSObject <LocalCoreDataService>
+@interface PostCategoryService : LocalCoreDataService
 
 - (PostCategory *)newCategoryForBlogObjectID:(NSManagedObjectID *)blogObjectID;
 

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -7,23 +7,7 @@
 #import "PostCategoryServiceRemoteREST.h"
 #import "PostCategoryServiceRemoteXMLRPC.h"
 
-@interface PostCategoryService ()
-
-@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
-
-@end
-
 @implementation PostCategoryService
-
-- (id)initWithManagedObjectContext:(NSManagedObjectContext *)context
-{
-    self = [super init];
-    if (self) {
-        _managedObjectContext = context;
-    }
-
-    return self;
-}
 
 - (PostCategory *)newCategoryForBlog:(Blog *)blog
 {

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -7,7 +7,7 @@ extern NSString * const PostServiceTypePost;
 extern NSString * const PostServiceTypePage;
 extern NSString * const PostServiceTypeAny;
 
-@interface PostService : NSObject <LocalCoreDataService>
+@interface PostService : LocalCoreDataService
 
 - (Post *)createDraftPostForBlog:(Blog *)blog;
 - (Page *)createDraftPageForBlog:(Blog *)blog;

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -19,22 +19,7 @@ NSString * const PostServiceTypeAny = @"any";
 NSString * const PostServiceErrorDomain = @"PostServiceErrorDomain";
 const NSInteger PostServiceNumberToFetch = 40;
 
-@interface PostService ()
-
-@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
-
-@end
-
 @implementation PostService
-
-- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context {
-    self = [super init];
-    if (self) {
-        _managedObjectContext = context;
-    }
-
-    return self;
-}
 
 + (instancetype)serviceWithMainContext {
     return [[PostService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];

--- a/WordPress/Classes/Services/PushAuthenticationService.swift
+++ b/WordPress/Classes/Services/PushAuthenticationService.swift
@@ -7,7 +7,7 @@ import Foundation
 *                   Code Verification.
 */
 
-@objc public class PushAuthenticationService : NSObject, LocalCoreDataService
+@objc public class PushAuthenticationService : LocalCoreDataService
 {
     var authenticationServiceRemote:PushAuthenticationServiceRemote?
     
@@ -16,9 +16,8 @@ import Foundation
     *  @param       managedObjectContext    A Reference to the MOC that should be used to interact with
     *                                       the Core Data Persistent Store.
     */
-    public required init(managedObjectContext: NSManagedObjectContext) {
-        super.init()
-        self.managedObjectContext = managedObjectContext
+    public required override init(managedObjectContext: NSManagedObjectContext) {
+        super.init(managedObjectContext: managedObjectContext)
         self.authenticationServiceRemote = PushAuthenticationServiceRemote(remoteApi: apiForRequest())
     }
 
@@ -56,8 +55,4 @@ import Foundation
         
         return nil
     }
-
-    
-    // MARK: - Private Internal Properties
-    private var managedObjectContext : NSManagedObjectContext!
 }

--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -6,7 +6,7 @@
 
 extern NSString * const ReaderPostServiceErrorDomain;
 
-@interface ReaderPostService : NSObject<LocalCoreDataService>
+@interface ReaderPostService : LocalCoreDataService
 
 /**
  Fetches the posts for the specified topic

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -33,23 +33,7 @@ NSString * const ReaderPostServiceErrorDomain = @"ReaderPostServiceErrorDomain";
 @implementation ReaderPostServiceBackfillState
 @end
 
-@interface ReaderPostService()
-
-@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
-
-@end
-
 @implementation ReaderPostService
-
-- (id)initWithManagedObjectContext:(NSManagedObjectContext *)context
-{
-    self = [super init];
-    if (self) {
-        _managedObjectContext = context;
-    }
-
-    return self;
-}
 
 #pragma mark - Fetch Methods
 

--- a/WordPress/Classes/Services/ReaderSiteService.h
+++ b/WordPress/Classes/Services/ReaderSiteService.h
@@ -10,7 +10,7 @@ extern NSString * const ReaderSiteServiceErrorDomain;
 
 @class ReaderSite;
 
-@interface ReaderSiteService : NSObject<LocalCoreDataService>
+@interface ReaderSiteService : LocalCoreDataService
 
 /**
  Get a list of the sites the user follows.

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -12,23 +12,7 @@
 
 NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
 
-@interface ReaderSiteService()
-
-@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
-
-@end
-
 @implementation ReaderSiteService
-
-- (id)initWithManagedObjectContext:(NSManagedObjectContext *)context
-{
-    self = [super init];
-    if (self) {
-        _managedObjectContext = context;
-    }
-
-    return self;
-}
 
 - (void)fetchFollowedSitesWithSuccess:(void(^)())success failure:(void(^)(NSError *error))failure
 {

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -9,7 +9,7 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 @class ReaderSite;
 @class ReaderPost;
 
-@interface ReaderTopicService : NSObject <LocalCoreDataService>
+@interface ReaderTopicService : LocalCoreDataService
 
 /**
  Sets the currentTopic and dispatches the `ReaderTopicDidChangeNotification` notification.

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -16,23 +16,7 @@ NSString * const ReaderTopicFreshlyPressedPathCommponent = @"freshly-pressed";
 static NSString * const ReaderTopicCurrentTopicURIKey = @"ReaderTopicCurrentTopicURIKey"; // Deprecated
 static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTopicPathKey";
 
-@interface ReaderTopicService ()
-
-@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
-
-@end
-
 @implementation ReaderTopicService
-
-- (id)initWithManagedObjectContext:(NSManagedObjectContext *)context
-{
-    self = [super init];
-    if (self) {
-        _managedObjectContext = context;
-    }
-
-    return self;
-}
 
 - (void)fetchReaderMenuWithSuccess:(void (^)())success failure:(void (^)(NSError *error))failure
 {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */; };
 		598351AE1A704E7A00B6DD4F /* WPWhatsNew.m in Sources */ = {isa = PBXBuildFile; fileRef = 598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */; };
 		5987857D1B39A3D5000E4F51 /* WPThemeSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 5987857C1B39A3D5000E4F51 /* WPThemeSettings.m */; };
+		59A9AB371B4C378800A433DC /* LocalCoreDataService.m in Sources */ = {isa = PBXBuildFile; fileRef = 59A9AB361B4C378800A433DC /* LocalCoreDataService.m */; };
+		59A9AB3A1B4C3ECD00A433DC /* LocalCoreDataServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 59A9AB391B4C3ECD00A433DC /* LocalCoreDataServiceTests.m */; };
 		59D328FD1ACC2D0700356827 /* WPLookbackPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 59D328FC1ACC2D0700356827 /* WPLookbackPresenter.m */; };
 		59DD94341AC479ED0032DD6B /* WPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 59DD94331AC479ED0032DD6B /* WPLogger.m */; };
 		59E2AAE31B2096BF0051DC06 /* ServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = 59E2AAE21B2096BF0051DC06 /* ServiceRemoteREST.m */; };
@@ -729,6 +731,8 @@
 		598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNew.m; path = WhatsNew/WPWhatsNew.m; sourceTree = "<group>"; };
 		5987857B1B39A3D5000E4F51 /* WPThemeSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPThemeSettings.h; sourceTree = "<group>"; };
 		5987857C1B39A3D5000E4F51 /* WPThemeSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPThemeSettings.m; sourceTree = "<group>"; };
+		59A9AB361B4C378800A433DC /* LocalCoreDataService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LocalCoreDataService.m; sourceTree = "<group>"; };
+		59A9AB391B4C3ECD00A433DC /* LocalCoreDataServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LocalCoreDataServiceTests.m; sourceTree = "<group>"; };
 		59D328FB1ACC2D0700356827 /* WPLookbackPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPLookbackPresenter.h; sourceTree = "<group>"; };
 		59D328FC1ACC2D0700356827 /* WPLookbackPresenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPLookbackPresenter.m; sourceTree = "<group>"; };
 		59DD94321AC479ED0032DD6B /* WPLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPLogger.h; sourceTree = "<group>"; };
@@ -2683,6 +2687,7 @@
 				E1556CF0193F6FE900FC52EA /* CommentService.h */,
 				E1556CF1193F6FE900FC52EA /* CommentService.m */,
 				930284B618EAF7B600CB0BF4 /* LocalCoreDataService.h */,
+				59A9AB361B4C378800A433DC /* LocalCoreDataService.m */,
 				5DA3EE141925090A00294E0B /* MediaService.h */,
 				5DA3EE151925090A00294E0B /* MediaService.m */,
 				5D3D559518F88C3500782892 /* ReaderPostService.h */,
@@ -2860,6 +2865,7 @@
 				9363113E19FA996700B0C739 /* AccountServiceTests.swift */,
 				E150520B16CAC5C400D3DDDC /* BlogJetpackTest.m */,
 				930FD0A519882742000CC81D /* BlogServiceTest.m */,
+				59A9AB391B4C3ECD00A433DC /* LocalCoreDataServiceTests.m */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -4193,6 +4199,7 @@
 				E1556CF2193F6FE900FC52EA /* CommentService.m in Sources */,
 				5D42A3FD175E75EE005CFF05 /* ReaderPostTableViewCell.m in Sources */,
 				5DB3BA0518D0E7B600F3F3E9 /* WPPickerView.m in Sources */,
+				59A9AB371B4C378800A433DC /* LocalCoreDataService.m in Sources */,
 				5D42A405175E76A7005CFF05 /* WPImageViewController.m in Sources */,
 				931D26FE19EDA10D00114F17 /* ALIterativeMigrator.m in Sources */,
 				E1F8E1231B0B411E0073E628 /* JetpackService.m in Sources */,
@@ -4298,6 +4305,7 @@
 				931D270019EDAE8600114F17 /* CoreDataMigrationTests.m in Sources */,
 				85D239C11AE5A7020074768D /* LoginViewModelTests.m in Sources */,
 				85D790AC1AE5D95E0033AE83 /* MixpanelProxyTests.m in Sources */,
+				59A9AB3A1B4C3ECD00A433DC /* LocalCoreDataServiceTests.m in Sources */,
 				85F8E19F1B0186D0000859BB /* MockWordPressComApi.swift in Sources */,
 				931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */,
 				852416D21A12ED690030700C /* AppRatingUtilityTests.m in Sources */,

--- a/WordPress/WordPressTest/LocalCoreDataServiceTests.m
+++ b/WordPress/WordPressTest/LocalCoreDataServiceTests.m
@@ -1,0 +1,30 @@
+#import <CoreData/CoreData.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+#import "LocalCoreDataService.h"
+
+@interface LocalCoreDataServiceTests : XCTestCase
+@end
+
+@implementation LocalCoreDataServiceTests
+
+- (void)testThatInitWorks
+{
+    NSManagedObjectContext *context = OCMClassMock([NSManagedObjectContext class]);
+    
+    LocalCoreDataService *service = nil;
+    
+    XCTAssertNoThrow(service = [[LocalCoreDataService alloc] initWithManagedObjectContext:context]);
+    XCTAssertNotNil(service);
+    XCTAssert(context == service.managedObjectContext);
+}
+
+- (void)testThatInitThrowsExceptionWithoutContext
+{
+    NSManagedObjectContext *context = nil;
+    LocalCoreDataService *service = nil;
+    
+    XCTAssertThrows(service = [[LocalCoreDataService alloc] initWithManagedObjectContext:context]);
+}
+
+@end


### PR DESCRIPTION
Turns LocalCoreDataService into a superclass, thus reducing code redundancy since all classes implementing the old protocol shared the initialization code and the `manageObjectContext` property.

**Test 1:**
- Run the unit tests

**Test 2:** (this is pretty broad, but I tried to make the change as atomic as possible to make the review easier)
- Launch the app and move around the different sections, thus triggering service calls.
- Make sure no service call fails because of this.

/cc @kwonye, @jleandroperez