### PR TITLE
Fix issues in opening of the post view controller directly in edit mode

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -102,6 +102,7 @@ EditImageDetailsViewControllerDelegate
 @property (nonatomic, strong) UIPopoverController *blogSelectorPopover;
 @property (nonatomic) BOOL dismissingBlogPicker;
 @property (nonatomic) CGPoint scrollOffsetRestorePoint;
+@property (nonatomic) BOOL isOpenedDirectlyForEditing;
 
 #pragma mark - Media related properties
 @property (nonatomic, strong) NSProgress * mediaGlobalProgress;
@@ -222,6 +223,7 @@ EditImageDetailsViewControllerDelegate
         
         _changedToEditModeDueToUnsavedChanges = changeToEditModeDueToUnsavedChanges;
         _post = post;
+        _isOpenedDirectlyForEditing = (mode == kWPEditorViewControllerModeEdit);
         
         if (post.blog.isHostedAtWPcom) {
             [PrivateSiteURLProtocol registerPrivateSiteURLProtocol];
@@ -1372,7 +1374,7 @@ EditImageDetailsViewControllerDelegate
 {
     [self discardChanges];
     
-    if (!self.post) {
+    if (!self.post || self.isOpenedDirectlyForEditing) {
         [self dismissEditView];
     } else {
         [self refreshUIForCurrentPost];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -288,7 +288,9 @@ EditImageDetailsViewControllerDelegate
     self.delegate = self;
     self.failedMediaAlertView = nil;
     [self configureMediaUpload];
-    [self refreshNavigationBarButtons:NO];
+    if (!self.isOpenedDirectlyForEditing) {
+        [self refreshNavigationBarButtons:NO];
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated


### PR DESCRIPTION
This fixes two of the three problems listed in #3910 :

>  1. The user taps once on a post to bring up the editor, however when they want to return to the post list screen they need to tap twice. (once to exit edit mode and once to return to the post list screen from preview mode).
>
>  3. Even though we are editing an existing post, the navbar command in the upper right corner starts as "Post" and then changes to "Update" after the screen transitions (admittedly, this could be a separate issue in github).

Per the current 'develop' branch code, when the user taps on a post in the list of posts, it opens the post view controller in preview mode (not edit mode). However, when the user taps on an 'Edit' button at the bottom of a post in the list of posts, it opens the post view controller in edit mode.

This PR fixes the above described problems when the user opens the post view controller in edit mode using the 'Edit' button at the bottom of a post in the list of posts.
