### PR TITLE
Issues/api tweaks

### DIFF
--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -59,18 +59,11 @@
 - (void)migrateJetpackBlogsToXMLRPCWithCompletion:(void (^)())success;
 
 /**
- Syncs an entire blog in the background including posts, pages, comments, and blog meta such as
- post formats, blog options, and categories. Also checks if the blog is multi-author.
+ Syncs an blog "meta data" including post formats, blog options, and categories. 
+ Also checks if the blog is multi-author.
  Used for instances where the entire blog should be refreshed or initially downloaded.
  */
-- (void)backgroundSyncBlog:(Blog *)blog;
-
-/**
- Syncs blog meta in the background including post formats, blog options and categories.
- post formats, blog options, and categories.
- Used for instances where the blog meta needs to be refreshed, but not posts, comments, etc.
- */
-- (void)backgroundSyncMetaForBlog:(Blog *)blog;
+- (void)syncBlog:(Blog *)blog;
 
 - (BOOL)hasVisibleWPComAccounts;
 

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -58,15 +58,19 @@
 
 - (void)migrateJetpackBlogsToXMLRPCWithCompletion:(void (^)())success;
 
-/*! Syncs an entire blog include posts, pages, comments, options, post formats and categories.
- *  Used for instances where the entire blog should be refreshed or initially downloaded.
- *
- *  \param success Completion block called if the operation was a success
- *  \param failure Completion block called if the operation was a failure
+/**
+ Syncs an entire blog in the background including posts, pages, comments, and blog meta such as
+ post formats, blog options, and categories. Also checks if the blog is multi-author.
+ Used for instances where the entire blog should be refreshed or initially downloaded.
  */
-- (void)syncBlog:(Blog *)blog
-         success:(void (^)())success
-         failure:(void (^)(NSError *error))failure;
+- (void)backgroundSyncBlog:(Blog *)blog;
+
+/**
+ Syncs blog meta in the background including post formats, blog options and categories.
+ post formats, blog options, and categories.
+ Used for instances where the blog meta needs to be refreshed, but not posts, comments, etc.
+ */
+- (void)backgroundSyncMetaForBlog:(Blog *)blog;
 
 - (BOOL)hasVisibleWPComAccounts;
 

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -230,26 +230,6 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
                            failure:failure];
 }
 
-- (void)backgroundSyncMetaForBlog:(Blog *)blog
-{
-    NSManagedObjectID *blogObjectID = blog.objectID;
-    id<BlogServiceRemote> remote = [self remoteForBlog:blog];
-    [remote syncOptionsForBlog:blog success:[self optionsHandlerWithBlogObjectID:blogObjectID
-                                                               completionHandler:nil]
-                       failure:^(NSError *error) { DDLogError(@"Failed syncing options for blog %@: %@", blog.url, error); }];
-
-    [remote syncPostFormatsForBlog:blog
-                           success:[self postFormatsHandlerWithBlogObjectID:blogObjectID
-                                                          completionHandler:nil]
-                           failure:^(NSError *error) { DDLogError(@"Failed syncing post formats for blog %@: %@", blog.url, error); }];
-
-    PostCategoryService *categoryService = [[PostCategoryService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    [categoryService syncCategoriesForBlog:blog
-                                   success:nil
-                                   failure:^(NSError *error) { DDLogError(@"Failed syncing categories for blog %@: %@", blog.url, error); }];
-
-}
-
 - (void)syncBlog:(Blog *)blog
 {
     NSManagedObjectID *blogObjectID = blog.objectID;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -230,24 +230,32 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
                            failure:failure];
 }
 
-- (void)syncBlog:(Blog *)blog
-         success:(void (^)())success
-         failure:(void (^)(NSError *error))failure
+- (void)backgroundSyncMetaForBlog:(Blog *)blog
 {
-    if ([self shouldStaggerRequestsForBlog:blog]) {
-        [self syncBlogStaggeringRequests:blog];
-        return;
-    }
     NSManagedObjectID *blogObjectID = blog.objectID;
     id<BlogServiceRemote> remote = [self remoteForBlog:blog];
     [remote syncOptionsForBlog:blog success:[self optionsHandlerWithBlogObjectID:blogObjectID
                                                                completionHandler:nil]
                        failure:^(NSError *error) { DDLogError(@"Failed syncing options for blog %@: %@", blog.url, error); }];
-    
+
     [remote syncPostFormatsForBlog:blog
                            success:[self postFormatsHandlerWithBlogObjectID:blogObjectID
                                                           completionHandler:nil]
                            failure:^(NSError *error) { DDLogError(@"Failed syncing post formats for blog %@: %@", blog.url, error); }];
+
+    PostCategoryService *categoryService = [[PostCategoryService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    [categoryService syncCategoriesForBlog:blog
+                                   success:nil
+                                   failure:^(NSError *error) { DDLogError(@"Failed syncing categories for blog %@: %@", blog.url, error); }];
+
+}
+
+- (void)backgroundSyncBlog:(Blog *)blog
+{
+    [self backgroundSyncMetaForBlog:blog];
+
+    NSManagedObjectID *blogObjectID = blog.objectID;
+    id<BlogServiceRemote> remote = [self remoteForBlog:blog];
 
     [remote checkMultiAuthorForBlog:blog
                             success:^(BOOL isMultiAuthor) {
@@ -261,111 +269,20 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     // We're ignoring the callbacks here but this needs refactoring
     [commentService syncCommentsForBlog:blog
                                 success:nil
-                                failure:nil];
-
-    PostCategoryService *categoryService = [[PostCategoryService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    [categoryService syncCategoriesForBlog:blog
-                                   success:nil
-                                   failure:nil];
+                                failure:^(NSError *error) { DDLogError(@"Failed syncing comments for blog %@: %@", blog.url, error); }];
 
     PostService *postService = [[PostService alloc] initWithManagedObjectContext:self.managedObjectContext];
     // FIXME: this is hacky, ideally we'd do a multicall and fetch both posts/pages, but it's out of scope for this commit
     [postService syncPostsOfType:PostServiceTypePost
                          forBlog:blog
                          success:nil
-                         failure:nil];
+                         failure:^(NSError *error) { DDLogError(@"Failed syncing posts for blog %@: %@", blog.url, error); }];
+
     [postService syncPostsOfType:PostServiceTypePage
                          forBlog:blog
                          success:nil
-                         failure:nil];
+                         failure:^(NSError *error) { DDLogError(@"Failed syncing pages for blog %@: %@", blog.url, error); }];
 
-}
-
-- (void)syncBlogStaggeringRequests:(Blog *)blog
-{
-    [self staggerSyncPostsForBlog:blog];
-}
-
-- (void)staggerSyncPostsForBlog:(Blog *)blog
-{
-    PostService *postService = [[PostService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    [postService syncPostsOfType:PostServiceTypePost forBlog:blog success:^{
-        [self staggerSyncPagesForBlog:blog];
-    } failure:^(NSError *error) {
-        [self staggerSyncPagesForBlog:blog];
-    }];
-}
-
-- (void)staggerSyncPagesForBlog:(Blog *)blog
-{
-    PostService *postService = [[PostService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    [postService syncPostsOfType:PostServiceTypePage forBlog:blog success:^{
-        [self staggerSyncCommentsForBlog:blog];
-    } failure:^(NSError *error) {
-        [self staggerSyncCommentsForBlog:blog];
-    }];
-}
-
-- (void)staggerSyncCommentsForBlog:(Blog *)blog
-{
-    CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    [commentService syncCommentsForBlog:blog success:^{
-        [self staggerSyncCategoriesForBlog:blog];
-    } failure:^(NSError *error) {
-        [self staggerSyncCategoriesForBlog:blog];
-    }];
-}
-
-- (void)staggerSyncCategoriesForBlog:(Blog *)blog
-{
-    PostCategoryService *categoryService = [[PostCategoryService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    [categoryService syncCategoriesForBlog:blog success:^{
-        [self staggerSyncBlogMetaForBlog:blog];
-    } failure:^(NSError *error) {
-        [self staggerSyncBlogMetaForBlog:blog];
-    }];
-}
-
-- (void)staggerSyncBlogMetaForBlog:(Blog *)blog
-{
-    id<BlogServiceRemote> remote = [self remoteForBlog:blog];
-    NSManagedObjectID *blogObjectID = blog.objectID;
-    NSString *url = blog.url;
-    [remote syncOptionsForBlog:blog success:[self optionsHandlerWithBlogObjectID:blogObjectID completionHandler:nil] failure:^(NSError *error) {
-        DDLogError(@"Failed syncing options for blog %@: %@", url, error);
-    }];
-
-    [remote syncPostFormatsForBlog:blog success:[self postFormatsHandlerWithBlogObjectID:blogObjectID completionHandler:nil] failure:^(NSError *error) {
-        DDLogError(@"Failed syncing post formats for blog %@: %@", url, error);
-    }];
-
-    [remote checkMultiAuthorForBlog:blog
-                            success:^(BOOL isMultiAuthor) {
-                                [self updateMutliAuthor:isMultiAuthor forBlog:blogObjectID];
-                            } failure:^(NSError *error) {
-                                DDLogError(@"Failed checking muti-author status for blog %@: %@", url, error);
-                            }];
-}
-
-// Batch requests to sites using basic http auth to avoid auth failures in certain cases.
-// See: https://github.com/wordpress-mobile/WordPress-iOS/issues/3016
-- (BOOL)shouldStaggerRequestsForBlog:(Blog *)blog
-{
-    if (blog.account || blog.jetpackAccount) {
-        return NO;
-    }
-
-    __block BOOL stagger = NO;
-    NSURL *url = [NSURL URLWithString:blog.url];
-    [[[NSURLCredentialStorage sharedCredentialStorage] allCredentials] enumerateKeysAndObjectsUsingBlock:^(NSURLProtectionSpace *ps, NSDictionary *dict, BOOL *stop) {
-        [dict enumerateKeysAndObjectsUsingBlock:^(id key, NSURLCredential *credential, BOOL *stop) {
-            if ([[ps host] isEqualToString:[url host]]) {
-                stagger = YES;
-                *stop = YES;
-            }
-        }];
-    }];
-    return stagger;
 }
 
 - (BOOL)hasVisibleWPComAccounts

--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -49,7 +49,7 @@
     blog.password = password;
     blog.options = options;
     [[ContextManager sharedInstance] saveContext:context];
-    [blogService syncBlog:blog success:nil failure:nil];
+    [blogService backgroundSyncBlog:blog];
 
     if (blog.jetpack.isInstalled) {
         if (blog.jetpack.isConnected) {

--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -19,7 +19,8 @@
 
 - (void)syncBlogWithUsername:(NSString *)username
                     password:(NSString *)password
-                      xmlrpc:(NSString *)xmlrpc options:(NSDictionary *)options
+                      xmlrpc:(NSString *)xmlrpc
+                     options:(NSDictionary *)options
                 finishedSync:(void(^)())finishedSync
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
@@ -49,7 +50,6 @@
     blog.password = password;
     blog.options = options;
     [[ContextManager sharedInstance] saveContext:context];
-    [blogService syncBlog:blog];
 
     if (blog.jetpack.isInstalled) {
         if (blog.jetpack.isConnected) {

--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -49,7 +49,7 @@
     blog.password = password;
     blog.options = options;
     [[ContextManager sharedInstance] saveContext:context];
-    [blogService backgroundSyncBlog:blog];
+    [blogService syncBlog:blog];
 
     if (blog.jetpack.isInstalled) {
         if (blog.jetpack.isConnected) {

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -977,8 +977,7 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
     if (blog.restApi) {
         remote = [[CommentServiceRemoteREST alloc] initWithApi:blog.restApi];
     } else {
-        WPXMLRPCClient *client = [WPXMLRPCClient clientWithXMLRPCEndpoint:[NSURL URLWithString:blog.xmlrpc]];
-        remote = [[CommentServiceRemoteXMLRPC alloc] initWithApi:client];
+        remote = [[CommentServiceRemoteXMLRPC alloc] initWithApi:blog.api];
     }
     return remote;
 }

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -766,8 +766,7 @@ const NSInteger PostServiceNumberToFetch = 40;
     if (blog.restApi) {
         remote = [[PostServiceRemoteREST alloc] initWithApi:blog.restApi];
     } else {
-        WPXMLRPCClient *client = [WPXMLRPCClient clientWithXMLRPCEndpoint:[NSURL URLWithString:blog.xmlrpc]];
-        remote = [[PostServiceRemoteXMLRPC alloc] initWithApi:client];
+        remote = [[PostServiceRemoteXMLRPC alloc] initWithApi:blog.api];
     }
     return remote;
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -148,8 +148,7 @@ NSInteger const BlogDetailsRowCountForSectionRemove = 1;
 
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-    [blogService syncBlog:_blog success:nil failure:nil];
-
+    [blogService backgroundSyncBlog:_blog];
     if (self.blog.account && !self.blog.account.userID) {
         // User's who upgrade may not have a userID recorded.
         AccountService *acctService = [[AccountService alloc] initWithManagedObjectContext:context];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -148,7 +148,7 @@ NSInteger const BlogDetailsRowCountForSectionRemove = 1;
 
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-    [blogService backgroundSyncBlog:_blog];
+    [blogService syncBlog:_blog];
     if (self.blog.account && !self.blog.account.userID) {
         // User's who upgrade may not have a userID recorded.
         AccountService *acctService = [[AccountService alloc] initWithManagedObjectContext:context];

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -840,7 +840,7 @@ static UIOffset const CreateAccountAndBlogOnePasswordPadding = {9.0, 0.0};
             [[ContextManager sharedInstance] saveContext:context];
 
             [accountService updateUserDetailsForAccount:defaultAccount success:nil failure:nil];
-            [blogService syncBlog:blog success:nil failure:nil];
+            [blogService backgroundSyncBlog:blog];
             [WPAnalytics refreshMetadata];
             [self setAuthenticating:NO];
             [self dismissViewControllerAnimated:YES completion:nil];

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -840,7 +840,7 @@ static UIOffset const CreateAccountAndBlogOnePasswordPadding = {9.0, 0.0};
             [[ContextManager sharedInstance] saveContext:context];
 
             [accountService updateUserDetailsForAccount:defaultAccount success:nil failure:nil];
-            [blogService backgroundSyncBlog:blog];
+            [blogService syncBlog:blog];
             [WPAnalytics refreshMetadata];
             [self setAuthenticating:NO];
             [self dismissViewControllerAnimated:YES completion:nil];

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -467,13 +467,8 @@ NS_ENUM(NSInteger, WPLegacyEditPostViewControllerActionSheet)
 {
     if (blogChanged) {
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        __block BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-
-        [blogService syncBlog:blog success:^{
-            blogService = nil;
-        } failure:^(NSError *error) {
-            blogService = nil;
-        }];
+        BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+        [blogService backgroundSyncBlog:blog];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -468,7 +468,7 @@ NS_ENUM(NSInteger, WPLegacyEditPostViewControllerActionSheet)
     if (blogChanged) {
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
         BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-        [blogService backgroundSyncBlog:blog];
+        [blogService syncBlog:blog];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -970,7 +970,7 @@ EditImageDetailsViewControllerDelegate
     if (blogChanged) {
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
         BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-        [blogService backgroundSyncMetaForBlog:blog];
+        [blogService syncBlog:blog];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -969,13 +969,8 @@ EditImageDetailsViewControllerDelegate
 {
     if (blogChanged) {
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        __block BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-
-        [blogService syncBlog:blog success:^{
-            blogService = nil;
-        } failure:^(NSError *error) {
-            blogService = nil;
-        }];
+        BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+        [blogService backgroundSyncMetaForBlog:blog];
     }
 }
 


### PR DESCRIPTION
This is a housekeeping patch addressing a few annoyances with our XMLRPC API calls about which I have an axe to grind. 

This patch:
- Reduces the number of WordPressXMLRPCApi instances created from sign up to viewing the post list from 10 to 3, and only a single instance is created during subsequent launches. The two extra instances during signup are used for blog detection and validation.
- Removes the staggered sync request methods we were using to avoid issues with basic http auth with some hosts. We should no longer need this work around if we're reusing a single api instance. The max concurrent request setting should be enough, but we needs through testing. @maxme, @jleandroperez can you help me with some test servers again to verify this works? 
- Separates syncing blog meta data (options, post formats, and categories) into its own method that runs in the background. 
- Updates the editor to sync post meta only (and not all post content) when being launched from the tab bar. This reduces the network calls made from 7 to 3 avoiding some waste, potentially addresses an edge case where local edits to a post/page were being erased(!), and helps reduce the risk of running afoul of some host's overly aggressive request throttling. (cc @bummytime) 
- Removes the callback blocks from the blog sync method since they were never used to begin with. 
- Adds some logging for failed requests. 

Needs review: @koke 