### PR TITLE
SupportViewController: Dismiss button goes on the left

### DIFF
--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -162,7 +162,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionFeedbackRows)
     [self.navigationController setNavigationBarHidden:NO animated:YES];
 
     if ([self.navigationController.viewControllers count] == 1) {
-        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Close", @"") style:[WPStyleGuide barButtonStyleForBordered] target:self action:@selector(dismiss)];
+        self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Close", @"") style:[WPStyleGuide barButtonStyleForBordered] target:self action:@selector(dismiss)];
     }
 }
 


### PR DESCRIPTION
Fixes #4008

#### Steps:
1. Fresh install WPiOS on an iPad device
2. Tap over the top right icon (Help!)

As a result, the Support view should be onscreen. The dismiss button should be *on the right* side of the navBar.

Needs Review: @aerych (Thanks Eric!)
