### PR TITLE
Bump stats pod to 0.4.2 to include state restoration fix from 0.3.6

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -32,7 +32,7 @@ pod 'Simperium', '0.7.9'
 pod 'WordPressApi', '~> 0.3.4'
 pod 'WordPress-iOS-Shared', '0.3.3'
 pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => '78d59da8eaf49042b88f7141beac614379149d6f'
-pod 'WordPressCom-Stats-iOS', '0.4.1'
+pod 'WordPressCom-Stats-iOS', '0.4.2'
 pod 'WordPressCom-Analytics-iOS', '0.0.34'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '303b8068530389ea87afde38b77466d685fe3210'
@@ -41,7 +41,7 @@ pod 'ReactiveCocoa', '~> 2.4.7'
 pod 'FormatterKit', '~> 1.8.0'
 
 target 'WordPressTodayWidget', :exclusive => true do
-  pod 'WordPressCom-Stats-iOS', '0.4.1'
+  pod 'WordPressCom-Stats-iOS', '0.4.2'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -145,7 +145,7 @@ PODS:
     - AFNetworking (~> 2.5.1)
     - wpxmlrpc (~> 0.7)
   - WordPressCom-Analytics-iOS (0.0.34)
-  - WordPressCom-Stats-iOS (0.4.1):
+  - WordPressCom-Stats-iOS (0.4.2):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (= 0.0.2)
@@ -196,7 +196,7 @@ DEPENDENCIES:
   - WordPress-iOS-Shared (= 0.3.3)
   - WordPressApi (~> 0.3.4)
   - WordPressCom-Analytics-iOS (= 0.0.34)
-  - WordPressCom-Stats-iOS (= 0.4.1)
+  - WordPressCom-Stats-iOS (= 0.4.2)
   - WPMediaPicker (~> 0.4.6)
   - wpxmlrpc (~> 0.8)
 
@@ -282,7 +282,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Shared: f0a1c534dbe0a4047dac42fb59d1ed4beab6e22d
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
   WordPressCom-Analytics-iOS: 85c1609bbcdc2cec25dddc633568c8970811b9d2
-  WordPressCom-Stats-iOS: c7ec665c037a2bae50cf5971c4ee6dba27859269
+  WordPressCom-Stats-iOS: 53a6d3573f5e443458a6dca4ddb9bb09fd423920
   WPMediaPicker: 481fb7201ba8fd410527d5d953a944d6ba644184
   wpxmlrpc: 053c9cbed13dcec08515a4ffeb51780f6e858cc7
 


### PR DESCRIPTION
Fixes #4010 

Bump the stats pod to 0.4.2 which includes the changes from 0.3.6 which was aimed at release/5.3.1 to prevent crashes during state restoration.

Changes: https://github.com/wordpress-mobile/WordPressCom-Stats-iOS/commit/eebff1229141214ff75671fe22632bf317bde696

Needs Review: @sendhil, @diegoreymendez