### PR TITLE
BlogService: Prevents NSObjectInaccessibleException

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -175,7 +175,8 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
             [self mergeBlogs:blogs withAccount:accountInContext completion:success];
             
             // Update the Widget Configuration
-            Blog *defaultBlog = accountInContext.defaultBlog;
+            Blog *defaultBlog = (Blog *)[self.managedObjectContext existingObjectWithID:accountInContext.defaultBlog.objectID
+                                                                                  error:nil];
             TodayExtensionService *service = [TodayExtensionService new];
             BOOL widgetIsConfigured = [service widgetIsConfigured];
             


### PR DESCRIPTION
@astralbodies i'm afraid that the previous NSObjectInaccessibleException has proven to be ineffective.

Just got the crash again in the simulator (screenshot below). The spot in which it crashed had the *Account* entity effectively load, but the *defaultBlog* was faulted.

This fix should fix it, for real, this time!.

<img width="1217" alt="screen shot 2015-07-16 at 3 39 54 pm" src="https://cloud.githubusercontent.com/assets/1195260/8732550/9db67b9e-2bd4-11e5-88a7-c9e8ed6dd430.png">

