### PR TITLE
WPError: Stripping HTML from the Message String

### DIFF
--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -89,7 +89,7 @@ NSInteger const SupportButtonIndex = 0;
     }
 
     if (message == nil) {
-        message = [[error localizedDescription] stringByStrippingHTML];
+        message = [error localizedDescription];
         message = [NSString decodeXMLCharactersIn:message];
     }
 
@@ -146,7 +146,7 @@ NSInteger const SupportButtonIndex = 0;
     DDLogInfo(@"Showing alert with title: %@ and message %@", title, message);
     NSString *supportText = showSupport ? NSLocalizedString(@"Need Help?", @"'Need help?' button label, links off to the WP for iOS FAQ.") : nil;
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title
-                                                    message:message
+                                                    message:[message stringByStrippingHTML]
                                                    delegate:[WPError internalInstance]
                                           cancelButtonTitle:supportText
                                           otherButtonTitles:NSLocalizedString(@"OK", nil), nil];

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -4,6 +4,7 @@
 #import "LoginViewController.h"
 #import "WPAccount.h"
 #import "NSString+XMLExtensions.h"
+#import "NSString+Helpers.h"
 #import "SupportViewController.h"
 
 NSInteger const SupportButtonIndex = 0;
@@ -88,7 +89,7 @@ NSInteger const SupportButtonIndex = 0;
     }
 
     if (message == nil) {
-        message = [error localizedDescription];
+        message = [[error localizedDescription] stringByStrippingHTML];
         message = [NSString decodeXMLCharactersIn:message];
     }
 


### PR DESCRIPTION
Fixes #4028

Needs Review: @aerych  (Thanks Eric!)
