### PR TITLE
PushAuthenticationManager: Dismiss AlertView should say OK

### DIFF
--- a/WordPress/Classes/Utility/PushAuthenticationManager.swift
+++ b/WordPress/Classes/Utility/PushAuthenticationManager.swift
@@ -128,7 +128,7 @@ import UIKit
         let title               = NSLocalizedString("Login Request Expired", comment: "Login Request Expired")
         let message             = NSLocalizedString("The login request has expired. Log in to WordPress.com to try again.",
                                                     comment: "WordPress.com Push Authentication Expired message")
-        let acceptButtonTitle   = NSLocalizedString("Accept", comment: "Accept. Verb")
+        let acceptButtonTitle   = NSLocalizedString("OK", comment: "OK")
         
         self.alertViewProxy.showWithTitle(title,
             message:            message,


### PR DESCRIPTION
Whenever a Push Authentication Notification is received, if the app is open after (5) minutes, it'll have expired.

In that scenario, we'll display an AlertView indicating what happened. Let's update the `Accept` button, so that it reads `OK`, since there's nothing to actually accept.

Thanks @dmsnell for the suggestion!

Needs Review: @astralbodies 

