### PR TITLE
Updates analytics for reader detail view.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -46,9 +46,6 @@ NSString * const BlockedCellIdentifier = @"BlockedCellIdentifier";
 NSString * const FeaturedImageCellIdentifier = @"FeaturedImageCellIdentifier";
 NSString * const NoFeaturedImageCellIdentifier = @"NoFeaturedImageCellIdentifier";
 NSString * const RPVCDisplayedNativeFriendFinder = @"DisplayedNativeFriendFinder";
-NSString * const ReaderDetailTypeKey = @"post-detail-type";
-NSString * const ReaderDetailTypeNormal = @"normal";
-NSString * const ReaderDetailTypePreviewSite = @"preview-site";
 
 @interface ReaderPostsViewController ()<UIActionSheetDelegate,
                                         WPContentSyncHelperDelegate,
@@ -1099,9 +1096,6 @@ NSString * const ReaderDetailTypePreviewSite = @"preview-site";
 
     detailController.readerViewStyle = self.readerViewStyle;
     [self.navigationController pushViewController:detailController animated:YES];
-
-    NSString *detailType = (self.readerViewStyle == ReaderViewStyleNormal) ? ReaderDetailTypeNormal : ReaderDetailTypePreviewSite;
-    [WPAnalytics track:WPAnalyticsStatReaderOpenedArticle withProperties:@{ReaderDetailTypeKey:detailType}];
 }
 
 


### PR DESCRIPTION
Closes #4038 
This PR: 
Moves "Opened Article" stat from post list to post detail. It will now track posts opened from notifications.
Updates to proper naming convention.
Adds property to track offline views.
Bumps a post's "page view" state via the tracking pixel when its viewed in the reader.

To test:
- Follow one of your test blogs and add a new post to the blog. 
- Open the reader and view the Blogs I Follow feed. 
- Find your newly created post in the list and tap to view it.  (Do this a few times if you want more page views.)
- Wait a couple of minutes til the server side process has run.
- Go to your stats page either in the app or on the web and confirm that your reader views are registering as page views for your test post. 

Needs Review: @astralbodies 
