### PR TITLE
Updates the style of links in Unapproved Comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -109,6 +109,7 @@ extension WPStyleGuide
         public static let blockUnapprovedSideColor  = UIColor(red: 0xFF/255.0, green: 0xBA/255.0, blue: 0x00/255.0, alpha: 0xFF/255.0)
         public static let blockUnapprovedBgColor    = UIColor(red: 0xFF/255.0, green: 0xBA/255.0, blue: 0x00/255.0, alpha: 0x19/255.0)
         public static let blockUnapprovedTextColor  = UIColor(red: 0xF0/255.0, green: 0x82/255.0, blue: 0x1E/255.0, alpha: 0xFF/255.0)
+        public static let blockUnapprovedLinkColor  = WPStyleGuide.mediumBlue()
         
         public static let contentBlockRegularStyle  = [ NSParagraphStyleAttributeName:  contentBlockParagraph,
                                                         NSFontAttributeName:            contentBlockRegularFont,
@@ -181,7 +182,7 @@ extension WPStyleGuide
         }
         
         public static func blockLinkColorForComment(isApproved approved: Bool) -> UIColor {
-            return approved ? blockLinkColor : blockUnapprovedTextColor
+            return approved ? blockLinkColor : blockUnapprovedLinkColor
         }
 
         


### PR DESCRIPTION
#### Steps:
1. Receive a Comment Y notification, with a link in it
2. Launch WPiOS and open the Notification
3. Tap over the `Approve` button to disapprove the comment

As a result, the comment's view style is expected to change. However, the link should still be visible.

Fixes #4037

Needs Review: @aerych (thanks in advance Eric!).