### PR TITLE
Fixes Login Layout Inconsistency

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -14,6 +14,7 @@
 #import "WPNUXUtility.h"
 #import "WPWebViewController.h"
 #import "WPStyleGuide.h"
+#import "WPFontManager.h"
 #import "UILabel+SuggestSize.h"
 #import "WPAccount.h"
 #import "Blog.h"
@@ -23,6 +24,8 @@
 #import "ContextManager.h"
 #import "NSString+XMLExtensions.h"
 #import "Constants.h"
+
+#import "WordPress-Swift.h"
 
 #import <1PasswordExtension/OnePasswordExtension.h>
 
@@ -59,15 +62,21 @@
 
 @implementation CreateAccountAndBlogViewController
 
-static CGFloat const CreateAccountAndBlogStandardOffset = 15.0;
-static CGFloat const CreateAccountAndBlogMaxTextWidth = 260.0;
-static CGFloat const CreateAccountAndBlogTextFieldWidth = 320.0;
-static CGFloat const CreateAccountAndBlogTextFieldHeight = 44.0;
-static CGFloat const CreateAccountAndBlogTextFieldPhoneHeight = 38.0;
-static CGFloat const CreateAccountAndBlogiOS7StatusBarOffset = 20.0;
-static CGFloat const CreateAccountAndBlogButtonWidth = 290.0;
-static CGFloat const CreateAccountAndBlogButtonHeight = 40.0;
-static UIOffset const CreateAccountAndBlogOnePasswordPadding = {9.0, 0.0};
+static CGFloat const CreateAccountAndBlogStandardOffset             = 15.0;
+static CGFloat const CreateAccountAndBlogMaxTextWidth               = 260.0;
+static CGFloat const CreateAccountAndBlogTextFieldWidth             = 320.0;
+static CGFloat const CreateAccountAndBlogTextFieldHeight            = 44.0;
+static CGFloat const CreateAccountAndBlogTextFieldPhoneHeight       = 38.0;
+static CGFloat const CreateAccountAndBlogiOS7StatusBarOffset        = 20.0;
+static CGFloat const CreateAccountAndBlogButtonWidth                = 290.0;
+static CGFloat const CreateAccountAndBlogButtonHeight               = 41.0;
+static UIOffset const CreateAccountAndBlogOnePasswordPadding        = {9.0, 0.0};
+
+static UIEdgeInsets const CreateAccountAndBlogBackButtonPadding     = {1.0, 0.0, 0.0, 0.0};
+static UIEdgeInsets const CreateAccountAndBlogBackButtonPaddingPad  = {1.0, 13.0, 0.0, 0.0};
+
+static UIEdgeInsets const CreateAccountAndBlogHelpButtonPadding     = {1.0, 0.0, 0.0, 13.0};
+static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0, 0.0, 20.0};
 
 - (instancetype)init
 {
@@ -406,16 +415,19 @@ static UIOffset const CreateAccountAndBlogOnePasswordPadding = {9.0, 0.0};
 
     CGFloat viewWidth = CGRectGetWidth(self.view.bounds);
     CGFloat viewHeight = CGRectGetHeight([UIScreen mainScreen].bounds);
-
+    
+    UIEdgeInsets helpButtonPadding = [UIDevice isPad] ? CreateAccountAndBlogHelpButtonPaddingPad : CreateAccountAndBlogHelpButtonPadding;
+    UIEdgeInsets backButtonPadding = [UIDevice isPad] ? CreateAccountAndBlogBackButtonPaddingPad : CreateAccountAndBlogBackButtonPadding;
+    
     // Layout Help Button
     UIImage *helpButtonImage = [UIImage imageNamed:@"btn-help"];
-    x = viewWidth - helpButtonImage.size.width - CreateAccountAndBlogStandardOffset;
-    y = 0.5 * CreateAccountAndBlogStandardOffset + CreateAccountAndBlogiOS7StatusBarOffset;
+    x = viewWidth - helpButtonImage.size.width - helpButtonPadding.right;
+    y = CreateAccountAndBlogiOS7StatusBarOffset + helpButtonPadding.top;
     _helpButton.frame = CGRectMake(x, y, helpButtonImage.size.width, CreateAccountAndBlogButtonHeight);
 
     // Layout Cancel Button
-    x = 0;
-    y = 0.5 * CreateAccountAndBlogStandardOffset + CreateAccountAndBlogiOS7StatusBarOffset;
+    x = backButtonPadding.left;
+    y = CreateAccountAndBlogiOS7StatusBarOffset + backButtonPadding.top;
     _backButton.frame = CGRectMake(x, y, CGRectGetWidth(_backButton.frame), CreateAccountAndBlogButtonHeight);
 
     // Layout the controls starting out from y of 0, then offset them once the height of the controls

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -69,7 +69,7 @@ static CGFloat const CreateAccountAndBlogButtonWidth = 290.0;
 static CGFloat const CreateAccountAndBlogButtonHeight = 40.0;
 static UIOffset const CreateAccountAndBlogOnePasswordPadding = {9.0, 0.0};
 
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     if (self) {

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -555,7 +555,7 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
     self.helpButton.frame = CGRectIntegral(CGRectMake(helpButtonX, helpButtonY, CGRectGetWidth(self.helpButton.frame), GeneralWalkthroughButtonSize.height));
 
     // layout help badge
-    CGFloat helpBadgeX = viewWidth - CGRectGetWidth(self.helpBadge.frame) - GeneralWalkthroughStandardOffset + 5;
+    CGFloat helpBadgeX = viewWidth - CGRectGetWidth(self.helpBadge.frame) - helpButtonPadding.right + 5;
     CGFloat helpBadgeY = GeneralWalkthroughStatusBarOffset + CGRectGetHeight(self.helpBadge.frame) - 5;
     self.helpBadge.frame = CGRectIntegral(CGRectMake(helpBadgeX, helpBadgeY, CGRectGetWidth(self.helpBadge.frame), CGRectGetHeight(self.helpBadge.frame)));
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -88,6 +88,13 @@ static NSTimeInterval const GeneralWalkthroughAnimationDuration = 0.3f;
 static CGFloat const GeneralWalkthroughAlphaHidden              = 0.0f;
 static CGFloat const GeneralWalkthroughAlphaEnabled             = 1.0f;
 
+static UIEdgeInsets const LoginBackButtonTitleInsets            = {0.0, 7.0, 0.0, 15.0};
+static UIEdgeInsets const LoginBackButtonPadding                = {1.0, 0.0, 0.0, 0.0};
+static UIEdgeInsets const LoginBackButtonPaddingPad             = {1.0, 13.0, 0.0, 0.0};
+
+static UIEdgeInsets const LoginHelpButtonPadding                = {1.0, 0.0, 0.0, 13.0};
+static UIEdgeInsets const LoginHelpButtonPaddingPad             = {1.0, 0.0, 0.0, 20.0};
+
 static UIOffset const LoginOnePasswordPadding                   = {9.0, 0.0f};
 static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
 
@@ -457,8 +464,10 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
     [cancelButton setTitle:NSLocalizedString(@"Cancel", nil) forState:UIControlStateNormal];
     [cancelButton addTarget:self action:@selector(cancelButtonAction:) forControlEvents:UIControlEventTouchUpInside];
     [cancelButton setExclusiveTouch:YES];
+    [cancelButton setTitleEdgeInsets:LoginBackButtonTitleInsets];
+    [cancelButton.titleLabel setFont:[WPFontManager openSansRegularFontOfSize:15.0]];
     [cancelButton sizeToFit];
-
+    
     // Add status label
     UILabel *statusLabel = [[UILabel alloc] init];
     statusLabel.font = [WPNUXUtility confirmationLabelFont];
@@ -537,19 +546,22 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
     CGFloat textLabelX = (viewWidth - GeneralWalkthroughMaxTextWidth) * 0.5f;
     CGFloat buttonX = (viewWidth - GeneralWalkthroughButtonSize.width) * 0.5f;
     
+    UIEdgeInsets helpButtonPadding = [UIDevice isPad] ? LoginHelpButtonPaddingPad : LoginHelpButtonPadding;
+    UIEdgeInsets backButtonPadding = [UIDevice isPad] ? LoginBackButtonPaddingPad : LoginBackButtonPadding;
+    
     // Layout Help Button
-    CGFloat helpButtonX = viewWidth - CGRectGetWidth(self.helpButton.frame) - GeneralWalkthroughStandardOffset;
-    CGFloat helpButtonY = 0.5 * GeneralWalkthroughStandardOffset + GeneralWalkthroughStatusBarOffset;
+    CGFloat helpButtonX = viewWidth - CGRectGetWidth(self.helpButton.frame) - helpButtonPadding.right;
+    CGFloat helpButtonY = GeneralWalkthroughStatusBarOffset + helpButtonPadding.top;
     self.helpButton.frame = CGRectIntegral(CGRectMake(helpButtonX, helpButtonY, CGRectGetWidth(self.helpButton.frame), GeneralWalkthroughButtonSize.height));
 
     // layout help badge
     CGFloat helpBadgeX = viewWidth - CGRectGetWidth(self.helpBadge.frame) - GeneralWalkthroughStandardOffset + 5;
-    CGFloat helpBadgeY = 0.5 * GeneralWalkthroughStandardOffset + GeneralWalkthroughStatusBarOffset + CGRectGetHeight(self.helpBadge.frame) - 5;
+    CGFloat helpBadgeY = GeneralWalkthroughStatusBarOffset + CGRectGetHeight(self.helpBadge.frame) - 5;
     self.helpBadge.frame = CGRectIntegral(CGRectMake(helpBadgeX, helpBadgeY, CGRectGetWidth(self.helpBadge.frame), CGRectGetHeight(self.helpBadge.frame)));
 
     // Layout Cancel Button
-    CGFloat cancelButtonX = 0;
-    CGFloat cancelButtonY = 0.5 * GeneralWalkthroughStandardOffset + GeneralWalkthroughStatusBarOffset;
+    CGFloat cancelButtonX = backButtonPadding.left;
+    CGFloat cancelButtonY = GeneralWalkthroughStatusBarOffset + backButtonPadding.top;
     self.cancelButton.frame = CGRectIntegral(CGRectMake(cancelButtonX, cancelButtonY, CGRectGetWidth(self.cancelButton.frame), GeneralWalkthroughButtonSize.height));
 
     // Calculate total height and starting Y origin of controls

--- a/WordPress/Classes/ViewRelated/NUX/WPNUXBackButton.m
+++ b/WordPress/Classes/ViewRelated/NUX/WPNUXBackButton.m
@@ -8,7 +8,7 @@
 // this extra space into account.
 CGFloat const WPNUXBackButtonExtraHorizontalWidthForSpace = 30;
 
-- (id)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self) {
@@ -17,7 +17,7 @@ CGFloat const WPNUXBackButtonExtraHorizontalWidthForSpace = 30;
     return self;
 }
 
-- (id)initWithCoder:(NSCoder *)aDecoder
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     self = [super initWithCoder:aDecoder];
     if (self) {

--- a/WordPress/Classes/ViewRelated/NUX/WPNUXBackButton.m
+++ b/WordPress/Classes/ViewRelated/NUX/WPNUXBackButton.m
@@ -6,7 +6,9 @@
 // There's some extra space in the btn-back and btn-back-tap images to improve the
 // tap area of this image and in order for sizeToFit to work correctly we have to take
 // this extra space into account.
-CGFloat const WPNUXBackButtonExtraHorizontalWidthForSpace = 30;
+static CGFloat const WPNUXBackButtonExtraHorizontalWidthForSpace    = 30;
+static UIEdgeInsets const WPNUXBackButtonTitleEdgeInsets            = {0.0, 0.0, 0, 10.0};
+static UIEdgeInsets const WPNUXBackButtonImageEdgeInsets            = {0, -22, 0, 0};
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -45,11 +47,11 @@ CGFloat const WPNUXBackButtonExtraHorizontalWidthForSpace = 30;
 
 - (void)configureButton
 {
-    self.titleLabel.font = [WPFontManager openSansRegularFontOfSize:16.0];
-    [self setTitleEdgeInsets:UIEdgeInsetsMake(0.0, 6.0, 0, 10.0)];
-    [self setTitleColor:[UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:0.8] forState:UIControlStateNormal];
-    [self setTitleColor:[UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:0.5] forState:UIControlStateHighlighted];
-    [self setImageEdgeInsets:UIEdgeInsetsMake(0, -18, 0, 0)];
+    self.titleLabel.font = [WPFontManager openSansRegularFontOfSize:15.0];
+    [self setTitleEdgeInsets:WPNUXBackButtonTitleEdgeInsets];
+    [self setTitleColor:[UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:1.0] forState:UIControlStateNormal];
+    [self setTitleColor:[UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:0.4] forState:UIControlStateHighlighted];
+    [self setImageEdgeInsets:WPNUXBackButtonImageEdgeInsets];
     [self setImage:[UIImage imageNamed:@"btn-back-chevron"] forState:UIControlStateNormal];
     [self setImage:[UIImage imageNamed:@"btn-back-chevron-tapped"] forState:UIControlStateHighlighted];
     [self setTitle:NSLocalizedString(@"Back", nil) forState:UIControlStateNormal];

--- a/WordPress/Classes/ViewRelated/NUX/WPNUXSecondaryButton.m
+++ b/WordPress/Classes/ViewRelated/NUX/WPNUXSecondaryButton.m
@@ -3,7 +3,7 @@
 
 @implementation WPNUXSecondaryButton
 
-- (id)initWithFrame:(CGRect)frame
+- (instancetype)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self) {
@@ -12,7 +12,7 @@
     return self;
 }
 
-- (id)initWithCoder:(NSCoder *)aDecoder
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     self = [super initWithCoder:aDecoder];
     if (self) {

--- a/WordPress/Classes/ViewRelated/NUX/WPNUXSecondaryButton.m
+++ b/WordPress/Classes/ViewRelated/NUX/WPNUXSecondaryButton.m
@@ -1,6 +1,10 @@
 #import "WPNUXSecondaryButton.h"
 #import <WordPress-iOS-Shared/WPFontManager.h>
 
+
+static UIEdgeInsets const WPNUXSecondaryButtonTitleEdgeInsets = {0, 15.0, 0, 15.0};
+
+
 @implementation WPNUXSecondaryButton
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -45,7 +49,7 @@
     self.titleLabel.font = [WPFontManager openSansRegularFontOfSize:15.0];
     self.titleLabel.minimumScaleFactor = 10.0/15.0;
     self.titleLabel.adjustsFontSizeToFitWidth = YES;
-    [self setTitleEdgeInsets:UIEdgeInsetsMake(0, 15.0, 0, 15.0)];
+    [self setTitleEdgeInsets:WPNUXSecondaryButtonTitleEdgeInsets];
     [self setTitleColor:[UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:1.0] forState:UIControlStateNormal];
     [self setTitleColor:[UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:0.4] forState:UIControlStateHighlighted];
 }


### PR DESCRIPTION
#### Scenario 1: Logged Off
1. Fresh Install WPiOS
2. Press the `Create Account` button
3. Tap over the top right button

Note that the `Close` button of the modal screen should be placed at the exact same position as the `Back` that shows up in the `Create Account` view.

#### Scenario 2: Logged In
1. Log into WPiOS
2. Tap over `My Site` > `Add Site`
3. Notice the position of the cancel button in the sign in modal.
4. Tap the (?) button in the top right to open the support screen.

The Navigation Buttons are expected to be displayed at the exact same position, so that it looks consistent.

I'm afraid that the NavigationBar Metrics are different for iPad / iPhone. Please, verify this PR in both devices.

Needs Review: @aerych  (I believe these changes look / feel okay Eric, thanks in advance!)

Fixes #4013

