### PR TITLE
Removes checks for WPAccount when syncing posts for the reader.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostsViewController.m
@@ -709,13 +709,6 @@ NSString * const ReaderDetailTypePreviewSite = @"preview-site";
         return;
     }
 
-    // Weird we should ever have a topic without an account but check for it just in case
-    NSManagedObjectContext *context = [self managedObjectContext];
-    AccountService *service = [[AccountService alloc] initWithManagedObjectContext:context];
-    if ([service numberOfAccounts] == 0) {
-        return;
-    }
-
     // The synchelper only supports a single sync operation at a time. Since contextForSync is assigned
     // in the delegate callbacks, and cleared when the sync operation is cleared up (or after scrolling
     // finishes) there *should't* be an existing instance of the context when the synchelper's delegate

--- a/WordPress/Classes/ViewRelated/Reader/ReaderViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderViewController.m
@@ -121,13 +121,6 @@
 
 - (void)syncTopics
 {
-    // TODO: Should we check for an account?
-    NSManagedObjectContext *context = [self managedObjectContext];
-    AccountService *service = [[AccountService alloc] initWithManagedObjectContext:context];
-    if ([service numberOfAccounts] == 0) {
-        return;
-    }
-
     __weak __typeof(self) weakSelf = self;
     ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:[self managedObjectContext]];
     [topicService fetchReaderMenuWithSuccess:^{


### PR DESCRIPTION
Fixes #4059 

In #3860 (d860c744b342b0a9544f8e37aed5ae54345f244d) the app was altered so that a WPAccount would only ever exist for WordPress.com blogs and there would no longer be one for a self-hosted blog. This broke the Reader for users who only had a self-hosted account in the app as no posts would sync due to checks added in #2023 to prevent unnecessary syncing while signed out. 

This PR removes the checks for the number of accounts that are gate-keeping the post sync. Since it should be very rare that the app is ever on the sign in screen, the checks probably weren't doing much for optimization anyway. 

To test, follow the steps below in each of the scenarios described to confirm posts are loading correctly:

#### Steps
- Switch to the reader tap. 
- Confirm Freshly Pressed is loaded
- Confirm pull to refresh works.
- Tap the tag icon to open the topics menu. 
- Confirm that there are no duplicate topics
- Choose one of the default topics
- Confirm posts from the topic are loaded.

#### Scenario 1
From a fresh install, sign into a self-hosted blog

#### Scenario 2
From a fresh install, sign into a wpcom account

#### Scenario 3
With a wpcom account existing in the app, add a self-hosted blog. 
Sign out from WordPress.com

#### Scenario 4
With a self-hosted blog in the app, sign into a WordPress.com account. 

#### Scenario 5
From a fresh install, add self-hosted blog with Jetpack installed. 
Check the reader loads freshly pressed and the default topics. 
Tap on notifications and sign into wpcom to enable Jetpack supported features. 

Needs Review: @sendhil 