### PR TITLE
Alters pageview tracking for site admins of viewed post.

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -64,6 +64,14 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
 @property (nonatomic, assign, readwrite) BOOL isHostedAtWPcom;
 @property (nonatomic, strong, readwrite) NSString *icon;
 /**
+ Flags whether the current user is an admin on the blog.
+ 
+ @warn `isAdmin` is only being set for wpcom sites and checked when bumping page
+ views in the reader detail.
+ */
+@property (nonatomic, assign, readwrite) BOOL isAdmin;
+
+/**
  Stores the username for self hosted sites
  
  @warn For WordPress.com or Jetpack Managed sites this will be nil. Use usernameForSite instead

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -50,6 +50,7 @@ static NSInteger const ImageSizeLargeHeight = 480;
 @dynamic visible;
 @dynamic account;
 @dynamic jetpackAccount;
+@dynamic isAdmin;
 @dynamic isMultiAuthor;
 @dynamic isHostedAtWPcom;
 @dynamic icon;

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -93,6 +93,7 @@ static NSString * const UserDictionaryAvatarURLKey = @"avatar_URL";
     blog.xmlrpc = [jsonBlog stringForKeyPath:@"meta.links.xmlrpc"];
     blog.jetpack = [[jsonBlog numberForKey:@"jetpack"] boolValue];
     blog.icon = [jsonBlog stringForKeyPath:@"icon.img"];
+    blog.isAdmin = [[jsonBlog numberForKeyPath:@"capabilities.manage_options"] boolValue];
     return blog;
 }
 

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
@@ -6,4 +6,5 @@
 @property (copy) NSString *xmlrpc;
 @property (assign) BOOL jetpack;
 @property (copy) NSString *icon;
+@property (assign) BOOL isAdmin;
 @end

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -462,6 +462,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
         blog.blogID = remoteBlog.ID;
         blog.isHostedAtWPcom = !remoteBlog.jetpack;
         blog.icon = remoteBlog.icon;
+        blog.isAdmin = remoteBlog.isAdmin;
     }
 
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
@@ -401,6 +401,12 @@ NSString * const ReaderPixelStatReferrer = @"https://wordpress.com/";
     }
     self.didBumpPageViews = YES;
 
+    // If the user is an admin on the post's site do not bump the page view unless
+    // the the post is private.
+    if (!self.post.isPrivate && [self isUserAdminOnSiteWithID:self.post.siteID]) {
+        return;
+    }
+
     NSURL *site = [NSURL URLWithString:siteURL];
     if (![site host]) {
         return;
@@ -426,6 +432,13 @@ NSString * const ReaderPixelStatReferrer = @"https://wordpress.com/";
     NSURLSession *session = [NSURLSession sharedSession];
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request];
     [task resume];
+}
+
+- (BOOL)isUserAdminOnSiteWithID:(NSNumber *)siteID
+{
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
+    Blog *blog = [blogService blogByBlogId:siteID];
+    return blog.isAdmin;
 }
 
 


### PR DESCRIPTION
Closes #4062 

Viewing a post detail in the reader should not bump the page view if the current user is an admin on the post's site, (unless the site is private). 
In this PR I'm leveraging an existing (but unused) `isAdmin` attribute on the `Blog` model.

To Test: 

Prep:
Be signed into WordPress.com since this is a wpcom only feature. 
Visit the blog list in the My Sites tab. This syncs blog info and updates the isAdmin attribute which wasn't previously set.

Scenario 1:
View a post in the reader from a private site you admin.
You should see the page view reflected in your stats after a few minutes (processing time) 

Scenario 2:
View a post from the reader in a public site you admin. 
You should not see a page view reflected in your stats. 

You can also set breakpoints to confirm the proper execution path. 

Needs Review: @astralbodies 
