### PR TITLE
Review of remote theme services

### DIFF
--- a/WordPress/Classes/Networking/Remote Objects/RemoteTheme.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteTheme.h
@@ -1,0 +1,20 @@
+#import <Foundation/Foundation.h>
+
+@interface RemoteTheme : NSObject
+
+@property (nonatomic, copy, readwrite) NSString *costCurrency;
+@property (nonatomic, copy, readwrite) NSString *costDisplay;
+@property (nonatomic, copy, readwrite) NSNumber *costNumber;
+@property (nonatomic, copy, readwrite) NSString *desc;
+@property (nonatomic, copy, readwrite) NSString *downloadUrl;
+@property (nonatomic, copy, readwrite) NSDate *launchDate;
+@property (nonatomic, copy, readwrite) NSString *name;
+@property (nonatomic, copy, readwrite) NSNumber *popularityRank;
+@property (nonatomic, copy, readwrite) NSString *previewUrl;
+@property (nonatomic, copy, readwrite) NSString *screenshotUrl;
+@property (nonatomic, copy, readwrite) NSArray *tags;
+@property (nonatomic, copy, readwrite) NSString *themeId;
+@property (nonatomic, copy, readwrite) NSNumber *trendingRank;
+@property (nonatomic, copy, readwrite) NSString *version;
+
+@end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteTheme.m
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteTheme.m
@@ -1,0 +1,5 @@
+#import "RemoteTheme.h"
+
+@implementation RemoteTheme
+
+@end

--- a/WordPress/Classes/Networking/ThemeServiceRemote.h
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.h
@@ -1,11 +1,12 @@
 #import "ServiceRemoteREST.h"
 
-typedef void(^ThemeServiceSuccessBlock)();
-typedef void(^ThemeServiceThemeRequestSuccessBlock)(NSDictionary *theme);
-typedef void(^ThemeServiceThemesRequestSuccessBlock)(NSArray *themes);
-typedef void(^ThemeServiceFailureBlock)(NSError *error);
-
 @class Blog;
+@class RemoteTheme;
+
+typedef void(^ThemeServiceRemoteSuccessBlock)();
+typedef void(^ThemeServiceRemoteThemeRequestSuccessBlock)(RemoteTheme *theme);
+typedef void(^ThemeServiceRemoteThemesRequestSuccessBlock)(NSArray *themes);
+typedef void(^ThemeServiceRemoteFailureBlock)(NSError *error);
 
 @interface ThemeServiceRemote : ServiceRemoteREST
 
@@ -17,10 +18,12 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
  *  @param      blogId      The ID of the blog to get the active theme for.  Cannot be nil.
  *  @param      success     The success handler.  Can be nil.
  *  @param      failure     The failure handler.  Can be nil.
+ *
+ *  @returns    The asynch operation triggered by this call.
  */
-- (void)getActiveThemeForBlogId:(NSNumber *)blogId
-                        success:(ThemeServiceThemeRequestSuccessBlock)success
-                        failure:(ThemeServiceFailureBlock)failure;
+- (NSOperation *)getActiveThemeForBlogId:(NSNumber *)blogId
+                                 success:(ThemeServiceRemoteThemeRequestSuccessBlock)success
+                                 failure:(ThemeServiceRemoteFailureBlock)failure;
 
 /**
  *  @brief      Gets the list of purchased themes for a blog.
@@ -28,10 +31,12 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
  *  @param      blogId      The ID of the blog to get the themes for.  Cannot be nil.
  *  @param      success     The success handler.  Can be nil.
  *  @param      failure     The failure handler.  Can be nil.
+ *
+ *  @returns    The asynch operation triggered by this call.
  */
-- (void)getPurchasedThemesForBlogId:(NSNumber *)blogId
-                            success:(ThemeServiceThemesRequestSuccessBlock)success
-                            failure:(ThemeServiceFailureBlock)failure;
+- (NSOperation *)getPurchasedThemesForBlogId:(NSNumber *)blogId
+                                     success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
+                                     failure:(ThemeServiceRemoteFailureBlock)failure;
 
 /**
  *  @brief      Gets information for a specific theme.
@@ -39,10 +44,12 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
  *  @param      themeId     The identifier of the theme to request info for.  Cannot be nil.
  *  @param      success     The success handler.  Can be nil.
  *  @param      failure     The failure handler.  Can be nil.
+ *
+ *  @returns    The asynch operation triggered by this call.
  */
-- (void)getThemeId:(NSString*)themeId
-           success:(ThemeServiceThemeRequestSuccessBlock)success
-           failure:(ThemeServiceFailureBlock)failure;
+- (NSOperation *)getThemeId:(NSString*)themeId
+                    success:(ThemeServiceRemoteThemeRequestSuccessBlock)success
+                    failure:(ThemeServiceRemoteFailureBlock)failure;
 
 /**
  *  @brief      Gets the list of WP.com available themes.
@@ -51,9 +58,11 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
  *
  *  @param      success     The success handler.  Can be nil.
  *  @param      failure     The failure handler.  Can be nil.
+ *
+ *  @returns    The asynch operation triggered by this call.
  */
-- (void)getThemes:(ThemeServiceThemesRequestSuccessBlock)success
-          failure:(ThemeServiceFailureBlock)failure;
+- (NSOperation *)getThemes:(ThemeServiceRemoteThemesRequestSuccessBlock)success
+                   failure:(ThemeServiceRemoteFailureBlock)failure;
 
 /**
  *  @brief      Gets the list of available themes for a blog.
@@ -66,10 +75,12 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
  *  @param      blogId      The ID of the blog to get the themes for.  Cannot be nil.
  *  @param      success     The success handler.  Can be nil.
  *  @param      failure     The failure handler.  Can be nil.
+ *
+ *  @returns    The asynch operation triggered by this call.
  */
-- (void)getThemesForBlogId:(NSNumber *)blogId
-                   success:(ThemeServiceThemesRequestSuccessBlock)success
-                   failure:(ThemeServiceFailureBlock)failure;
+- (NSOperation *)getThemesForBlogId:(NSNumber *)blogId
+                            success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
+                            failure:(ThemeServiceRemoteFailureBlock)failure;
 
 #pragma mark - Activating themes
 
@@ -80,10 +91,12 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
  *  @param      blogId      The ID of the target blog.  Cannot be nil.
  *  @param      success     The success handler.  Can be nil.
  *  @param      failure     The failure handler.  Can be nil.
+ *
+ *  @returns    The asynch operation triggered by this call.
  */
-- (void)activateThemeId:(NSString*)themeId
-              forBlogId:(NSNumber *)blogId
-                success:(ThemeServiceSuccessBlock)success
-                failure:(ThemeServiceFailureBlock)failure;
+- (NSOperation *)activateThemeId:(NSString*)themeId
+                       forBlogId:(NSNumber *)blogId
+                         success:(ThemeServiceRemoteSuccessBlock)success
+                         failure:(ThemeServiceRemoteFailureBlock)failure;
 
 @end

--- a/WordPress/Classes/Networking/ThemeServiceRemote.m
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.m
@@ -1,4 +1,6 @@
 #import "ThemeServiceRemote.h"
+
+#import <NSObject-SafeExpectations/NSDictionary+SafeExpectations.h>
 #import "RemoteTheme.h"
 #import "WordPressComApi.h"
 
@@ -188,16 +190,16 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
     [self loadCostForTheme:theme fromDictionary:dictionary];
     [self loadLaunchDateForTheme:theme fromDictionary:dictionary];
     
-    theme.desc = dictionary[ThemeDescriptionKey];
-    theme.downloadUrl = dictionary[ThemeDownloadURLKey];
-    theme.name = dictionary[ThemeNameKey];
-    theme.popularityRank = dictionary[ThemePopularityRankKey];
-    theme.previewUrl = dictionary[ThemePreviewURLKey];
-    theme.screenshotUrl = dictionary[ThemeScreenshotKey];
-    theme.tags = dictionary[ThemeTagsKey];
-    theme.themeId = dictionary[ThemeIdKey];
-    theme.trendingRank = dictionary[ThemeTrendingRankKey];
-    theme.version = dictionary[ThemeVersionKey];
+    theme.desc = [dictionary stringForKey:ThemeDescriptionKey];
+    theme.downloadUrl = [dictionary stringForKey:ThemeDownloadURLKey];
+    theme.name = [dictionary stringForKey:ThemeNameKey];
+    theme.popularityRank = [dictionary numberForKey:ThemePopularityRankKey];
+    theme.previewUrl = [dictionary stringForKey:ThemePreviewURLKey];
+    theme.screenshotUrl = [dictionary stringForKey:ThemeScreenshotKey];
+    theme.tags = [dictionary arrayForKey:ThemeTagsKey];
+    theme.themeId = [dictionary stringForKey:ThemeIdKey];
+    theme.trendingRank = [dictionary numberForKey:ThemeTrendingRankKey];
+    theme.version = [dictionary stringForKey:ThemeVersionKey];
     
     return theme;
 }
@@ -249,9 +251,9 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
     
     NSDictionary *costDictionary = dictionary[ThemeCostKey];
     
-    theme.costCurrency = costDictionary[ThemeCostCurrencyKey];
-    theme.costDisplay = costDictionary[ThemeCostDisplayKey];
-    theme.costNumber = costDictionary[ThemeCostNumberKey];
+    theme.costCurrency = [costDictionary stringForKey:ThemeCostCurrencyKey];
+    theme.costDisplay = [costDictionary stringForKey:ThemeCostDisplayKey];
+    theme.costNumber = [costDictionary numberForKey:ThemeCostNumberKey];
 }
 
 /**

--- a/WordPress/Classes/Networking/ThemeServiceRemote.m
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.m
@@ -271,7 +271,7 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
     
     static NSString* const ThemeLaunchDateKey = @"launch_date";
     
-    NSString *launchDateString = dictionary[ThemeLaunchDateKey];
+    NSString *launchDateString = [dictionary stringForKey:ThemeLaunchDateKey];
     
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     [formatter setDateFormat:@"yyyy-mm-dd"];

--- a/WordPress/Classes/Networking/ThemeServiceRemote.m
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.m
@@ -161,6 +161,13 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
 
 #pragma mark - Parsing the dictionary replies
 
+/**
+ *  @brief      Creates a remote theme object from the specified dictionary.
+ *
+ *  @param      dictionary      The dictionary containing the theme information.  Cannot be nil.
+ *
+ *  @returns    A remote theme object.
+ */
 - (RemoteTheme *)themeFromDictionary:(NSDictionary *)dictionary
 {
     NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
@@ -195,6 +202,14 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
     return theme;
 }
 
+/**
+ *  @brief      Creates remote theme objects from the specified array of dictionaries.
+ *
+ *  @param      dictionaries    The array of dictionaries containing the themes information.  Cannot
+ *                              be nil.
+ *
+ *  @returns    An array of remote theme objects.
+ */
 - (NSArray *)themesFromDictionaries:(NSArray *)dictionaries
 {
     NSParameterAssert([dictionaries isKindOfClass:[NSArray class]]);

--- a/WordPress/Classes/Networking/ThemeServiceRemote.m
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.m
@@ -1,4 +1,5 @@
 #import "ThemeServiceRemote.h"
+#import "RemoteTheme.h"
 #import "WordPressComApi.h"
 
 // Service dictionary keys
@@ -8,120 +9,132 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
 
 #pragma mark - Getting themes
 
-- (void)getActiveThemeForBlogId:(NSNumber *)blogId
-                        success:(ThemeServiceThemeRequestSuccessBlock)success
-                        failure:(ThemeServiceFailureBlock)failure
+- (NSOperation *)getActiveThemeForBlogId:(NSNumber *)blogId
+                                 success:(ThemeServiceRemoteThemeRequestSuccessBlock)success
+                                 failure:(ThemeServiceRemoteFailureBlock)failure
 {
     NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/themes/mine", blogId];
     
-    [self.api GET:path
-       parameters:nil
-          success:^(AFHTTPRequestOperation *operation, NSDictionary *themeDictionary) {
-              if (success) {
-                  success(themeDictionary);
-              }
-          } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-              if (failure) {
-                  failure(error);
-              }
-          }];
+    NSOperation *operation = [self.api GET:path
+                                parameters:nil
+                                   success:^(AFHTTPRequestOperation *operation, NSDictionary *themeDictionary) {
+                                       if (success) {
+                                           RemoteTheme *theme = [self themeFromDictionary:themeDictionary];
+                                           success(theme);
+                                       }
+                                   } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                                       if (failure) {
+                                           failure(error);
+                                       }
+                                   }];
+    
+    return operation;
 }
 
-- (void)getPurchasedThemesForBlogId:(NSNumber *)blogId
-                            success:(ThemeServiceThemesRequestSuccessBlock)success
-                            failure:(ThemeServiceFailureBlock)failure
+- (NSOperation *)getPurchasedThemesForBlogId:(NSNumber *)blogId
+                                     success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
+                                     failure:(ThemeServiceRemoteFailureBlock)failure
 {
     NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/themes/purchased", blogId];
     
-    [self.api GET:path
-       parameters:nil
-          success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
-              if (success) {
-                  NSArray *themes = [response arrayForKey:ThemeServiceRemoteThemesKey];
-                  
-                  success(themes);
-              }
-          } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-              if (failure) {
-                  failure(error);
-              }
-          }];
+    NSOperation *operation = [self.api GET:path
+                                parameters:nil
+                                   success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
+                                       if (success) {
+                                           NSArray *themeDictionaries = [response arrayForKey:ThemeServiceRemoteThemesKey];
+                                           NSArray *themes = [self themesFromDictionaries:themeDictionaries];
+                                           success(themes);
+                                       }
+                                   } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                                       if (failure) {
+                                           failure(error);
+                                       }
+                                   }];
+    
+    return operation;
 }
 
-- (void)getThemeId:(NSString*)themeId
-           success:(ThemeServiceThemeRequestSuccessBlock)success
-           failure:(ThemeServiceFailureBlock)failure
+- (NSOperation *)getThemeId:(NSString*)themeId
+                    success:(ThemeServiceRemoteThemeRequestSuccessBlock)success
+                    failure:(ThemeServiceRemoteFailureBlock)failure
 {
     NSParameterAssert([themeId isKindOfClass:[NSString class]]);
     
     NSString *path = [NSString stringWithFormat:@"themes/%@", themeId];
     
-    [self.api GET:path
-       parameters:nil
-          success:^(AFHTTPRequestOperation *operation, NSDictionary *themeDictionary) {
-              if (success) {
-                  success(themeDictionary);
-              }
-          } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-              if (failure) {
-                  failure(error);
-              }
-          }];
+    NSOperation *operation = [self.api GET:path
+                                parameters:nil
+                                   success:^(AFHTTPRequestOperation *operation, NSDictionary *themeDictionary) {
+                                       if (success) {
+                                           RemoteTheme *theme = [self themeFromDictionary:themeDictionary];
+                                           success(theme);
+                                       }
+                                   } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                                       if (failure) {
+                                           failure(error);
+                                       }
+                                   }];
+    
+    return operation;
 }
 
-- (void)getThemes:(ThemeServiceThemesRequestSuccessBlock)success
-          failure:(ThemeServiceFailureBlock)failure
+- (NSOperation *)getThemes:(ThemeServiceRemoteThemesRequestSuccessBlock)success
+                   failure:(ThemeServiceRemoteFailureBlock)failure
 {
     static NSString* const path = @"themes";
     
-    [self.api GET:path
-       parameters:nil
-          success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
-              if (success) {
-                  NSArray *themes = [response arrayForKey:ThemeServiceRemoteThemesKey];
-                  
-                  success(themes);
-              }
-          } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-              if (failure) {
-                  failure(error);
-              }
-          }];
+    NSOperation *operation = [self.api GET:path
+                                parameters:nil
+                                   success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
+                                       if (success) {
+                                           NSArray *themeDictionaries = [response arrayForKey:ThemeServiceRemoteThemesKey];
+                                           NSArray *themes = [self themesFromDictionaries:themeDictionaries];
+                                           success(themes);
+                                       }
+                                   } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                                       if (failure) {
+                                           failure(error);
+                                       }
+                                   }];
+    
+    return operation;
 }
 
-- (void)getThemesForBlogId:(NSNumber *)blogId
-                   success:(ThemeServiceThemesRequestSuccessBlock)success
-                   failure:(ThemeServiceFailureBlock)failure
+- (NSOperation *)getThemesForBlogId:(NSNumber *)blogId
+                            success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
+                            failure:(ThemeServiceRemoteFailureBlock)failure
 {
     NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/themes", blogId];
     
-    [self.api GET:path
-       parameters:nil
-          success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
-              if (success) {
-                  NSArray *themes = [response arrayForKey:ThemeServiceRemoteThemesKey];
-                  
-                  success(themes);
-              }
-          } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-              if (failure) {
-                  failure(error);
-              }
-          }];
+    NSOperation *operation = [self.api GET:path
+                                parameters:nil
+                                   success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
+                                       if (success) {
+                                           NSArray *themeDictionaries = [response arrayForKey:ThemeServiceRemoteThemesKey];
+                                           NSArray *themes = [self themesFromDictionaries:themeDictionaries];
+                                           success(themes);
+                                       }
+                                   } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                                       if (failure) {
+                                           failure(error);
+                                       }
+                                   }];
+    
+    return operation;
 }
 
 #pragma mark - Activating themes
 
-- (void)activateThemeId:(NSString*)themeId
-              forBlogId:(NSNumber *)blogId
-                success:(ThemeServiceSuccessBlock)success
-                failure:(ThemeServiceFailureBlock)failure
+- (NSOperation *)activateThemeId:(NSString*)themeId
+                       forBlogId:(NSNumber *)blogId
+                         success:(ThemeServiceRemoteSuccessBlock)success
+                         failure:(ThemeServiceRemoteFailureBlock)failure
 {
     NSParameterAssert([themeId isKindOfClass:[NSString class]]);
     NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
@@ -129,19 +142,111 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
     NSString* const path = [NSString stringWithFormat:@"sites/%@/themes/mine", blogId];
     NSDictionary* parameters = @{@"theme": themeId};
     
-    [self.api POST:path
-        parameters:parameters
-           success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
-               if (success) {
-                   NSArray *themes = [response arrayForKey:ThemeServiceRemoteThemesKey];
-                   
-                   success(themes);
-               }
-           } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-               if (failure) {
-                   failure(error);
-               }
-           }];
+    NSOperation *operation = [self.api POST:path
+                                 parameters:parameters
+                                    success:^(AFHTTPRequestOperation *operation, NSDictionary *response) {
+                                        if (success) {
+                                            NSArray *themeDictionaries = [response arrayForKey:ThemeServiceRemoteThemesKey];
+                                            NSArray *themes = [self themesFromDictionaries:themeDictionaries];
+                                            success(themes);
+                                        }
+                                    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                                        if (failure) {
+                                            failure(error);
+                                        }
+                                    }];
+    
+    return operation;
+}
+
+#pragma mark - Parsing the dictionary replies
+
+- (RemoteTheme *)themeFromDictionary:(NSDictionary *)dictionary
+{
+    NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
+    
+    static NSString* const ThemeIdKey = @"id";
+    static NSString* const ThemeScreenshotKey = @"screenshot";
+    static NSString* const ThemeVersionKey = @"version";
+    static NSString* const ThemeDownloadURLKey = @"download_url";
+    static NSString* const ThemeTrendingRankKey = @"trending_rank";
+    static NSString* const ThemePopularityRankKey = @"popularity_rank";
+    static NSString* const ThemeNameKey = @"name";
+    static NSString* const ThemeDescriptionKey = @"description";
+    static NSString* const ThemeTagsKey = @"tags";
+    static NSString* const ThemePreviewURLKey = @"preview_url";
+    
+    RemoteTheme *theme = [RemoteTheme new];
+    
+    [self loadCostForTheme:theme fromDictionary:dictionary];
+    [self loadLaunchDateForTheme:theme fromDictionary:dictionary];
+    
+    theme.desc = dictionary[ThemeDescriptionKey];
+    theme.downloadUrl = dictionary[ThemeDownloadURLKey];
+    theme.name = dictionary[ThemeNameKey];
+    theme.popularityRank = dictionary[ThemePopularityRankKey];
+    theme.previewUrl = dictionary[ThemePreviewURLKey];
+    theme.screenshotUrl = dictionary[ThemeScreenshotKey];
+    theme.tags = dictionary[ThemeTagsKey];
+    theme.themeId = dictionary[ThemeIdKey];
+    theme.trendingRank = dictionary[ThemeTrendingRankKey];
+    theme.version = dictionary[ThemeVersionKey];
+    
+    return theme;
+}
+
+- (NSArray *)themesFromDictionaries:(NSArray *)dictionaries
+{
+    NSParameterAssert([dictionaries isKindOfClass:[NSArray class]]);
+    
+    NSMutableArray *themes = [[NSMutableArray alloc] initWithCapacity:dictionaries.count];
+    
+    for (NSDictionary *dictionary in dictionaries) {
+        NSAssert([dictionary isKindOfClass:[NSDictionary class]],
+                 @"Expected a dictionary.");
+        
+        RemoteTheme *theme = [self themeFromDictionary:dictionary];
+        
+        [themes addObject:theme];
+    }
+    
+    return [NSArray arrayWithArray:themes];
+}
+
+#pragma mark - Field parsing
+
+- (void)loadCostForTheme:(RemoteTheme *)theme
+          fromDictionary:(NSDictionary *)dictionary
+{
+    NSParameterAssert([theme isKindOfClass:[RemoteTheme class]]);
+    NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
+    
+    static NSString* const ThemeCostKey = @"cost";
+    static NSString* const ThemeCostCurrencyKey = @"currency";
+    static NSString* const ThemeCostDisplayKey = @"display";
+    static NSString* const ThemeCostNumberKey = @"number";
+    
+    NSDictionary *costDictionary = dictionary[ThemeCostKey];
+    
+    theme.costCurrency = costDictionary[ThemeCostCurrencyKey];
+    theme.costDisplay = costDictionary[ThemeCostDisplayKey];
+    theme.costNumber = costDictionary[ThemeCostNumberKey];
+}
+
+- (void)loadLaunchDateForTheme:(RemoteTheme *)theme
+                fromDictionary:(NSDictionary *)dictionary
+{
+    NSParameterAssert([theme isKindOfClass:[RemoteTheme class]]);
+    NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
+    
+    static NSString* const ThemeLaunchDateKey = @"launch_date";
+    
+    NSString *launchDateString = dictionary[ThemeLaunchDateKey];
+    
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    [formatter setDateFormat:@"yyyy-mm-dd"];
+    
+    theme.launchDate = [formatter dateFromString:launchDateString];
 }
 
 @end

--- a/WordPress/Classes/Networking/ThemeServiceRemote.m
+++ b/WordPress/Classes/Networking/ThemeServiceRemote.m
@@ -215,6 +215,12 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
 
 #pragma mark - Field parsing
 
+/**
+ *  @brief      Loads the cost structure from a dictionary into the specified remote theme object.
+ *
+ *  @param      theme       The theme to load the info into.  Cannot be nil.
+ *  @param      dictionary  The dictionary to load the info from.  Cannot be nil.
+ */
 - (void)loadCostForTheme:(RemoteTheme *)theme
           fromDictionary:(NSDictionary *)dictionary
 {
@@ -233,6 +239,13 @@ static NSString* const ThemeServiceRemoteThemesKey = @"themes";
     theme.costNumber = costDictionary[ThemeCostNumberKey];
 }
 
+/**
+ *  @brief      Loads a theme's launch date from a dictionary into the specified remote theme
+ *              object.
+ *
+ *  @param      theme       The theme to load the info into.  Cannot be nil.
+ *  @param      dictionary  The dictionary to load the info from.  Cannot be nil.
+ */
 - (void)loadLaunchDateForTheme:(RemoteTheme *)theme
                 fromDictionary:(NSDictionary *)dictionary
 {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */; };
 		598351AE1A704E7A00B6DD4F /* WPWhatsNew.m in Sources */ = {isa = PBXBuildFile; fileRef = 598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */; };
 		598F86A71B67B7A000550C9C /* RemoteTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 598F86A61B67B7A000550C9C /* RemoteTheme.m */; };
+		598F86AB1B67BD7600550C9C /* ThemeServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 598F86AA1B67BD7600550C9C /* ThemeServiceRemoteTests.m */; };
 		59D328FD1ACC2D0700356827 /* WPLookbackPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 59D328FC1ACC2D0700356827 /* WPLookbackPresenter.m */; };
 		59DD94341AC479ED0032DD6B /* WPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 59DD94331AC479ED0032DD6B /* WPLogger.m */; };
 		59E2AAE31B2096BF0051DC06 /* ServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = 59E2AAE21B2096BF0051DC06 /* ServiceRemoteREST.m */; };
@@ -726,6 +727,7 @@
 		598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNew.m; path = WhatsNew/WPWhatsNew.m; sourceTree = "<group>"; };
 		598F86A51B67B7A000550C9C /* RemoteTheme.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteTheme.h; path = "Remote Objects/RemoteTheme.h"; sourceTree = "<group>"; };
 		598F86A61B67B7A000550C9C /* RemoteTheme.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteTheme.m; path = "Remote Objects/RemoteTheme.m"; sourceTree = "<group>"; };
+		598F86AA1B67BD7600550C9C /* ThemeServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemoteTests.m; sourceTree = "<group>"; };
 		59D328FB1ACC2D0700356827 /* WPLookbackPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPLookbackPresenter.h; sourceTree = "<group>"; };
 		59D328FC1ACC2D0700356827 /* WPLookbackPresenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPLookbackPresenter.m; sourceTree = "<group>"; };
 		59DD94321AC479ED0032DD6B /* WPLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPLogger.h; sourceTree = "<group>"; };
@@ -1996,6 +1998,7 @@
 				591CFB081B28AC8C009E61B3 /* BlogServiceRemoteRESTTests.m */,
 				59E2AAEB1B20E5CE0051DC06 /* PostServiceRemoteRESTTests.m */,
 				59E2AAE71B20E3EA0051DC06 /* ServiceRemoteRESTTests.m */,
+				598F86AA1B67BD7600550C9C /* ThemeServiceRemoteTests.m */,
 			);
 			name = "Remote Services";
 			sourceTree = "<group>";
@@ -4299,6 +4302,7 @@
 				85F8E19F1B0186D0000859BB /* MockWordPressComApi.swift in Sources */,
 				931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */,
 				852416D21A12ED690030700C /* AppRatingUtilityTests.m in Sources */,
+				598F86AB1B67BD7600550C9C /* ThemeServiceRemoteTests.m in Sources */,
 				E15618FD16DB8677006532C4 /* UIKitTestHelper.m in Sources */,
 				B5AEEC721ACACF2F008BF2A4 /* NotificationTests.m in Sources */,
 				9358D15919FFD4E10094BBF5 /* WPImageOptimizerTest.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		595B02221A6C4ECD00415A30 /* WPWhatsNewView.m in Sources */ = {isa = PBXBuildFile; fileRef = 595B02211A6C4ECD00415A30 /* WPWhatsNewView.m */; };
 		5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */; };
 		598351AE1A704E7A00B6DD4F /* WPWhatsNew.m in Sources */ = {isa = PBXBuildFile; fileRef = 598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */; };
+		598F86A71B67B7A000550C9C /* RemoteTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = 598F86A61B67B7A000550C9C /* RemoteTheme.m */; };
 		59D328FD1ACC2D0700356827 /* WPLookbackPresenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 59D328FC1ACC2D0700356827 /* WPLookbackPresenter.m */; };
 		59DD94341AC479ED0032DD6B /* WPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 59DD94331AC479ED0032DD6B /* WPLogger.m */; };
 		59E2AAE31B2096BF0051DC06 /* ServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = 59E2AAE21B2096BF0051DC06 /* ServiceRemoteREST.m */; };
@@ -723,6 +724,8 @@
 		5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUserAgentTests.m; sourceTree = "<group>"; };
 		598351AC1A704E7A00B6DD4F /* WPWhatsNew.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPWhatsNew.h; path = WhatsNew/WPWhatsNew.h; sourceTree = "<group>"; };
 		598351AD1A704E7A00B6DD4F /* WPWhatsNew.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPWhatsNew.m; path = WhatsNew/WPWhatsNew.m; sourceTree = "<group>"; };
+		598F86A51B67B7A000550C9C /* RemoteTheme.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteTheme.h; path = "Remote Objects/RemoteTheme.h"; sourceTree = "<group>"; };
+		598F86A61B67B7A000550C9C /* RemoteTheme.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteTheme.m; path = "Remote Objects/RemoteTheme.m"; sourceTree = "<group>"; };
 		59D328FB1ACC2D0700356827 /* WPLookbackPresenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPLookbackPresenter.h; sourceTree = "<group>"; };
 		59D328FC1ACC2D0700356827 /* WPLookbackPresenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPLookbackPresenter.m; sourceTree = "<group>"; };
 		59DD94321AC479ED0032DD6B /* WPLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPLogger.h; sourceTree = "<group>"; };
@@ -3179,6 +3182,8 @@
 				5DED0E131B42E3E400431FCD /* RemoteSourcePostAttribution.m */,
 				5D9282F71B54697C00066CED /* RemoteReaderSiteInfo.h */,
 				5D9282F81B54697C00066CED /* RemoteReaderSiteInfo.m */,
+				598F86A51B67B7A000550C9C /* RemoteTheme.h */,
+				598F86A61B67B7A000550C9C /* RemoteTheme.m */,
 			);
 			name = "Remote Objects";
 			sourceTree = "<group>";
@@ -4239,6 +4244,7 @@
 				59D328FD1ACC2D0700356827 /* WPLookbackPresenter.m in Sources */,
 				FF3674151AD32CE100F24857 /* WPVideoOptimizer.m in Sources */,
 				319D6E7E19E447C80013871C /* SuggestionService.m in Sources */,
+				598F86A71B67B7A000550C9C /* RemoteTheme.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Follow up to [this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/3947).

Improves the services by renaming the result blocks.  Also adds the `RemoteTheme.h` object for a more standardized approach.

This is part of [a much larger incoming PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/4070) that will integrate these services into the app.

**To test:**
1. Run the unit tests.  For now this should suffice until the services are integrated.

/cc @jleandroperez 