### PR TITLE
Fixing NSObjectInaccessibleException Crash

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -501,7 +501,16 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
         CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
-        [commentService deleteComment:weakSelf.comment success:nil failure:nil];
+        
+        NSError *error = nil;
+        Comment *reloadedComment = [context existingObjectWithID:weakSelf.comment error:&error];
+        
+        if (error) {
+            DDLogError(@"Comment was deleted while awaiting for alertView confirmation");
+            return;
+        }
+        
+        [commentService deleteComment:reloadedComment success:nil failure:nil];
 
         // Note: the parent class of CommentsViewController will pop this as a result of NSFetchedResultsChangeDelete
     };
@@ -528,7 +537,16 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
         CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
-        [commentService spamComment:weakSelf.comment success:nil failure:nil];
+        
+        NSError *error = nil;
+        Comment *reloadedComment = [context existingObjectWithID:weakSelf.comment error:&error];
+        
+        if (error) {
+            DDLogError(@"Comment was deleted while awaiting for alertView confirmation");
+            return;
+        }
+        
+        [commentService spamComment:reloadedComment success:nil failure:nil];
     };
 
     NSString *message = NSLocalizedString(@"Are you sure you want to mark this comment as Spam?",

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -503,7 +503,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
         CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
         
         NSError *error = nil;
-        Comment *reloadedComment = [context existingObjectWithID:weakSelf.comment error:&error];
+        Comment *reloadedComment = (Comment *)[context existingObjectWithID:weakSelf.comment.objectID error:&error];
         
         if (error) {
             DDLogError(@"Comment was deleted while awaiting for alertView confirmation");
@@ -539,7 +539,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
         CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
         
         NSError *error = nil;
-        Comment *reloadedComment = [context existingObjectWithID:weakSelf.comment error:&error];
+        Comment *reloadedComment = (Comment *)[context existingObjectWithID:weakSelf.comment.objectID error:&error];
         
         if (error) {
             DDLogError(@"Comment was deleted while awaiting for alertView confirmation");

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -263,6 +263,11 @@ NSTimeInterval const CommentsRefreshTimeoutInSeconds    = 60 * 5; // 5 minutes
     [self refreshNoResultsView];
 }
 
+- (void)deletingSelectedRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    [self.navigationController popToViewController:self animated:YES];
+}
+
 
 #pragma mark - WPContentSyncHelper Methods
 


### PR DESCRIPTION
Although i've been unable to directly reproduce this issue, apparently, what's going on is:

- The user is about to spam a comment.
- In the meantime, the comment was already trashed/removed.
- The local CoreData entity for this comment has been already invalidated.

With this patch, we're simply making sure that **CommentViewController** gets dismissed whenever the comment is spammed / trashed.

--

#### Steps:
1. Receive a comment
2. Open `My Sites` > `Blog` > `Comments`
3. Open the new comment
4. Try trashing / marking as spam

As a result, CommentViewController should get dismissed. Note that (prior to this patch) the comment details view was being left onscreen.


Needs Review: @diegoreymendez (Thanks in advance Diego!)
Fixes #4084