### PR TITLE
Updating Shared Pod

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,7 +30,7 @@ pod 'MGImageUtilities', :git => 'git://github.com/wordpress-mobile/MGImageUtilit
 pod 'NSObject-SafeExpectations', '0.0.2'
 pod 'Simperium', '0.7.9'
 pod 'WordPressApi', '~> 0.3.4'
-pod 'WordPress-iOS-Shared', '0.4.1'
+pod 'WordPress-iOS-Shared', '0.4.2'
 pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => 'a983547b5724d5fc3b79865da83e81db2b0b9de4'
 pod 'WordPressCom-Stats-iOS', '0.4.3'
 pod 'WordPressCom-Analytics-iOS', '0.0.35'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,11 +41,11 @@ PODS:
     - DTFoundation/DTAnimatedGIF (~> 1.7.1)
     - DTFoundation/DTHTMLParser (~> 1.7.1)
     - DTFoundation/UIKit (~> 1.7.1)
-  - DTFoundation/Core (1.7.6)
-  - DTFoundation/DTAnimatedGIF (1.7.6)
-  - DTFoundation/DTHTMLParser (1.7.6):
+  - DTFoundation/Core (1.7.7)
+  - DTFoundation/DTAnimatedGIF (1.7.7)
+  - DTFoundation/DTHTMLParser (1.7.7):
     - DTFoundation/Core
-  - DTFoundation/UIKit (1.7.6):
+  - DTFoundation/UIKit (1.7.7):
     - DTFoundation/Core
   - EmailChecker (0.1)
   - Expecta (0.3.2)
@@ -140,7 +140,7 @@ PODS:
     - UIAlertView+Blocks (~> 0.8.1)
     - WordPress-iOS-Shared (~> 0.3)
     - WordPressCom-Analytics-iOS (~> 0.0.30)
-  - WordPress-iOS-Shared (0.4.1):
+  - WordPress-iOS-Shared (0.4.2):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
   - WordPressApi (0.3.4):
@@ -195,7 +195,7 @@ DEPENDENCIES:
     `303b8068530389ea87afde38b77466d685fe3210`)
   - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`,
     commit `a983547b5724d5fc3b79865da83e81db2b0b9de4`)
-  - WordPress-iOS-Shared (= 0.4.1)
+  - WordPress-iOS-Shared (= 0.4.2)
   - WordPressApi (~> 0.3.4)
   - WordPressCom-Analytics-iOS (= 0.0.35)
   - WordPressCom-Stats-iOS (= 0.4.3)
@@ -252,7 +252,7 @@ SPEC CHECKSUMS:
   CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
   CrashlyticsLumberjack: 26034b4b6d8b0bf547ea9ba201ff53c6cd50f971
   DTCoreText: d90a4dca8e4f7b0eb18f12a967563b77a75694f0
-  DTFoundation: bf431de2292484461ff7d92295fdae7dc15a3820
+  DTFoundation: c9b3362b83f0017389082ec067ede719826a579d
   EmailChecker: 406cf1f1b5cd2efb8401803b580abf4a43b0665c
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
@@ -281,7 +281,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 2eb1070f189a069184611e21b5e8832443e6f8ec
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
   WordPress-iOS-Editor: 3ed3f3f1eb226b34542b471a7db41419815bbf28
-  WordPress-iOS-Shared: 1fa8e955d895f3b14d11fe0ddc54f857332aba2d
+  WordPress-iOS-Shared: 310e1c872584303a6f28f62e83085cdd44051711
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
   WordPressCom-Analytics-iOS: a6c71241b39f1e366a6473ce38f2786481f8acd8
   WordPressCom-Stats-iOS: 2810300d77c2d37594d0e4a79145094c517d6c73

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -32,8 +32,7 @@
 #import "WPFontManager.h"
 #import "WPRichTextView.h"
 #import "WPTableViewCell.h"
-#import "WPTableViewSectionHeaderView.h"
-#import "WPTableViewSectionFooterView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 #import "WPWebViewController.h"
 #import "WPAnalyticsTrackerWPCom.h"
 

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -1,5 +1,5 @@
 #import "WPTableViewHandler.h"
-#import "WPTableViewSectionHeaderView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 #import "WPTableViewCell.h"
 #import "WordPress-Swift.h"
 
@@ -60,7 +60,7 @@ static CGFloat const DefaultCellHeight = 44.0;
 
 - (void)updateTitleForSection:(NSUInteger)section
 {
-    WPTableViewSectionHeaderView *sectionHeaderView = (WPTableViewSectionHeaderView *)[self tableView:self.tableView viewForHeaderInSection:section];
+    WPTableViewSectionHeaderFooterView *sectionHeaderView = (WPTableViewSectionHeaderFooterView *)[self tableView:self.tableView viewForHeaderInSection:section];
     sectionHeaderView.title = [self titleForHeaderInSection:section];
 }
 
@@ -324,8 +324,8 @@ static CGFloat const DefaultCellHeight = 44.0;
     if ([self.sectionHeaders count] > section) {
         return [self.sectionHeaders objectAtIndex:section];
     }
-    CGRect frame = CGRectMake(0.0, 0.0, CGRectGetWidth(self.tableView.bounds), 0.0);
-    WPTableViewSectionHeaderView *header = [[WPTableViewSectionHeaderView alloc] initWithFrame:frame];
+
+    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
     header.title = [self titleForHeaderInSection:section];
     [self.sectionHeaders addObject:header];
     return header;
@@ -338,7 +338,7 @@ static CGFloat const DefaultCellHeight = 44.0;
     }
 
     NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.tableView.bounds)];
+    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.tableView.bounds)];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -23,7 +23,7 @@
 #import "ContextManager.h"
 #import "AccountService.h"
 #import "BlogService.h"
-#import "WPTableViewSectionHeaderView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 #import "BlogDetailHeaderView.h"
 #import "ReachabilityUtils.h"
 #import "WPAccount.h"
@@ -383,18 +383,19 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
     NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
+    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
     NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    if (title.length > 0) {
-        WPTableViewSectionHeaderView *header = [[WPTableViewSectionHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 0)];
-        header.title = title;
-        return header;
+    if (title.length == 0) {
+        return nil;
     }
-    return nil;
+    
+    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
+    header.title = title;
+    return header;
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -18,11 +18,11 @@
 #import "UILabel+SuggestSize.h"
 #import "WordPress-Swift.h"
 #import "WPSearchControllerConfigurator.h"
+#import "WPGUIConstants.h"
 
 static NSString *const AddSiteCellIdentifier = @"AddSiteCell";
 static NSString *const BlogCellIdentifier = @"BlogCell";
 static CGFloat const BLVCHeaderViewLabelPadding = 10.0;
-static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
 
 @interface BlogListViewController () <UIViewControllerRestoration>
 
@@ -383,11 +383,6 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
     return cell;
 }
 
-- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
-{
-    return nil;
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForDeleteConfirmationButtonForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     return NSLocalizedString(@"Remove", @"Button label when removing a blog");
@@ -445,27 +440,20 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
     }
 }
 
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
+{
+    return nil;
+}
+
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
-    NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-    
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
+    return nil;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
-    NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    if (title.length == 0) {
-        // since we show a tableHeaderView while editing, we want to keep the section header short for iPad during edit
-        return (IS_IPHONE || self.tableView.isEditing) ? CGFLOAT_MIN : BLVCSectionHeaderHeightForIPad;
-    }
-    
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
+    // since we show a tableHeaderView while editing, we want to keep the section header short for iPad during edit
+    return (IS_IPHONE || self.tableView.isEditing) ? CGFLOAT_MIN : WPTableHeaderPadFrame.size.height;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -9,7 +9,7 @@
 #import "ContextManager.h"
 #import "Blog.h"
 #import "WPAccount.h"
-#import "WPTableViewSectionHeaderView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 #import "AccountService.h"
 #import "BlogService.h"
 #import "TodayExtensionService.h"
@@ -448,22 +448,24 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
     NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    if (title.length > 0) {
-        WPTableViewSectionHeaderView *header = [[WPTableViewSectionHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 0)];
-        header.title = title;
-        return header;
+    if (title.length == 0) {
+        return nil;
     }
-    return nil;
+    
+    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
+    header.title = title;
+    return header;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
     NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    if (title.length > 0) {
-        return [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
+    if (title.length == 0) {
+        // since we show a tableHeaderView while editing, we want to keep the section header short for iPad during edit
+        return (IS_IPHONE || self.tableView.isEditing) ? CGFLOAT_MIN : BLVCSectionHeaderHeightForIPad;
     }
-    // since we show a tableHeaderView while editing, we want to keep the section header short for iPad during edit
-    return (IS_IPHONE || self.tableView.isEditing) ? CGFLOAT_MIN : BLVCSectionHeaderHeightForIPad;
+    
+    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SettingsMultiTextViewController.m
@@ -1,7 +1,7 @@
 #import "SettingsMultiTextViewController.h"
 #import "WPStyleGuide.h"
 #import "WPTableViewCell.h"
-#import "WPTableViewSectionFooterView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 
 static CGFloat const HorizontalMargin = 10.0f;
 
@@ -84,7 +84,7 @@ static CGFloat const HorizontalMargin = 10.0f;
     if (_hintView) {
         return _hintView;
     }
-    WPTableViewSectionFooterView *footerView = [[WPTableViewSectionFooterView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 0)];
+    WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
     [footerView setTitle:_hint];
     _hintView = footerView;
     return _hintView;

--- a/WordPress/Classes/ViewRelated/Blog/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SettingsTextViewController.m
@@ -1,7 +1,7 @@
 #import "SettingsTextViewController.h"
 #import "WPTextFieldTableViewCell.h"
 #import "WPStyleGuide.h"
-#import "WPTableViewSectionFooterView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 
 static CGFloat const HorizontalMargin = 15.0f;
 
@@ -79,7 +79,7 @@ static CGFloat const HorizontalMargin = 15.0f;
     if (_hintView) {
         return _hintView;
     }
-    WPTableViewSectionFooterView *footerView = [[WPTableViewSectionFooterView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 0)];
+    WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
     [footerView setTitle:_hint];
     _hintView = footerView;
     return _hintView;

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -5,7 +5,7 @@
 #import "ReachabilityUtils.h"
 #import "WPAccount.h"
 #import "Blog.h"
-#import "WPTableViewSectionHeaderView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 #import "SettingTableViewCell.h"
 #import "NotificationsManager.h"
 #import <SVProgressHUD/SVProgressHUD.h>
@@ -374,12 +374,13 @@ NSInteger const EditSiteURLMinimumLabelWidth = 30;
 {
     NSInteger settingsSection = [self.tableSections[section] intValue];
     NSString *title = [self titleForHeaderInSection:settingsSection];
-    if (title.length > 0) {
-        WPTableViewSectionHeaderView *header = [[WPTableViewSectionHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 0)];
-        header.title = title;
-        return header;
+    if (title.length == 0) {
+        return nil;
     }
-    return nil;
+    
+    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
+    header.title = title;
+    return header;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -390,9 +391,7 @@ NSInteger const EditSiteURLMinimumLabelWidth = 30;
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
     NSString *title = [self titleForHeaderInSection:section];
-    CGFloat height = [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
-    
-    return height;
+    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (NSString *)titleForHeaderInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -17,7 +17,7 @@
 #import "WPAccount.h"
 #import "LoginViewController.h"
 #import <WordPress-iOS-Shared/WPTableViewCell.h>
-#import <WordPress-iOS-Shared/WPTableViewSectionHeaderView.h>
+#import <WordPress-iOS-Shared/WPTableViewSectionHeaderFooterView.h>
 #import "HelpshiftUtils.h"
 
 #import "WordPress-Swift.h"
@@ -286,7 +286,7 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
-    WPTableViewSectionHeaderView *header = [[WPTableViewSectionHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 0)];
+    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
     header.title = [self titleForHeaderInSection:section];
     return header;
 }
@@ -298,7 +298,7 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
         return CGFLOAT_MIN;
     }
     
-    return [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
+    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (NSString *)titleForHeaderInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
@@ -6,7 +6,7 @@
 #import "AbstractPost.h"
 #import "PostSettingsSelectionViewController.h"
 #import "UIImageView+AFNetworkingExtra.h"
-#import "WPTableViewSectionHeaderView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 #import "WPGUIConstants.h"
 #import "WordPress-Swift.h"
 
@@ -305,9 +305,8 @@ typedef NS_ENUM(NSUInteger, ImageDetailsTextField) {
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
-    WPTableViewSectionHeaderView *header = [[WPTableViewSectionHeaderView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, CGRectGetWidth(self.view.bounds), 0.0f)];
+    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
     header.title = [self titleForHeaderInSection:section];
-    header.backgroundColor = self.tableView.backgroundColor;
     return header;
 }
 
@@ -318,7 +317,7 @@ typedef NS_ENUM(NSUInteger, ImageDetailsTextField) {
     }
 
     NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
+    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -16,7 +16,7 @@
 #import "WPTextFieldTableViewCell.h"
 #import "WordPressAppDelegate.h"
 #import "WPTableViewActivityCell.h"
-#import "WPTableViewSectionHeaderView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 #import "WPTableImageSource.h"
 #import "ContextManager.h"
 #import "MediaService.h"
@@ -353,9 +353,8 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate>
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
-    WPTableViewSectionHeaderView *header = [[WPTableViewSectionHeaderView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, CGRectGetWidth(self.view.bounds), 0.0f)];
+    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
     header.title = [self titleForHeaderInSection:section];
-    header.backgroundColor = self.tableView.backgroundColor;
     return header;
 }
 
@@ -366,7 +365,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate>
     }
 
     NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
+    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Settings/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Settings/AboutViewController.swift
@@ -43,7 +43,7 @@ public class AboutViewController : UITableViewController
         let calendar                = NSCalendar.currentCalendar()
         let year                    = calendar.components(.CalendarUnitYear, fromDate: NSDate()).year
 
-        let footerView              = WPTableViewSectionFooterView()
+        let footerView              = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
         footerView.title            = NSLocalizedString("© \(year) Automattic, Inc.", comment: "About View's Footer Text")
         footerView.titleAlignment   = .Center
         self.footerView             = footerView
@@ -104,7 +104,7 @@ public class AboutViewController : UITableViewController
             return CGFloat.min
         }
         
-        let height = WPTableViewSectionFooterView.heightForTitle(footerView!.title, andWidth: view.frame.width)
+        let height = WPTableViewSectionHeaderFooterView.heightForFooter(footerView!.title, width: view.frame.width)
         return height + footerBottomPadding
     }
 
@@ -199,7 +199,7 @@ public class AboutViewController : UITableViewController
     private let footerBottomPadding = CGFloat(12)
     
     // MARK: - Private Properties
-    private var footerView : WPTableViewSectionFooterView!
+    private var footerView : WPTableViewSectionHeaderFooterView!
     
     private var rows : [[Row]] {
         let appsBlogHostname = NSURL(string: WPAutomatticAppsBlogURL)?.host ?? String()

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
@@ -2,8 +2,7 @@
 #import "WordPressAppDelegate.h"
 #import "ActivityLogDetailViewController.h"
 #import <DDFileLogger.h>
-#import "WPTableViewSectionHeaderView.h"
-#import "WPTableViewSectionFooterView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 #import "WordPress-Swift.h"
 #import "WPLogger.h"
 
@@ -121,7 +120,7 @@ static CGFloat const ActivityLogRowHeight = 44.0f;
         return nil;
     }
     
-    WPTableViewSectionHeaderView *header = [[WPTableViewSectionHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 0)];
+    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
     header.title = title;
     return header;
 }
@@ -134,7 +133,7 @@ static CGFloat const ActivityLogRowHeight = 44.0f;
         return CGFLOAT_MIN;
     }
     
-    return [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
+    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (NSString *)titleForHeaderInSection:(NSInteger)section
@@ -147,7 +146,7 @@ static CGFloat const ActivityLogRowHeight = 44.0f;
 
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
 {
-    WPTableViewSectionFooterView *header = [[WPTableViewSectionFooterView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 0)];
+    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
     header.title = [self titleForFooterInSection:section];
     return header;
 }
@@ -155,7 +154,7 @@ static CGFloat const ActivityLogRowHeight = 44.0f;
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
 {
     NSString *title = [self titleForFooterInSection:section];
-    return [WPTableViewSectionFooterView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
+    return [WPTableViewSectionHeaderFooterView heightForFooter:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (NSString *)titleForFooterInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Settings/NotificationSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/NotificationSettingsViewController.m
@@ -5,8 +5,7 @@
 #import "WordPressComApi.h"
 #import "NSString+XMLExtensions.h"
 #import "DateUtils.h"
-#import "WPTableViewSectionHeaderView.h"
-#import "WPTableViewSectionFooterView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 #import "WPAccount.h"
 #import "NotificationsManager.h"
 #import "NSDate+StringFormatting.h"
@@ -304,8 +303,7 @@ static CGFloat NotificationFooterExtraPadding       = 10.0f;
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
-    CGRect frame = CGRectMake(0.0f, 0.0f, CGRectGetWidth(self.view.bounds), 0.0f);
-    WPTableViewSectionHeaderView *header = [[WPTableViewSectionHeaderView alloc] initWithFrame:frame];
+    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
     header.title = [self titleForHeaderInSection:section];
     return header;
 }
@@ -317,8 +315,7 @@ static CGFloat NotificationFooterExtraPadding       = 10.0f;
         return nil;
     }
     
-    CGRect frame = CGRectMake(0.0f, 0.0f, CGRectGetWidth(self.view.bounds), 0.0f);
-    WPTableViewSectionFooterView *footer = [[WPTableViewSectionFooterView alloc] initWithFrame:frame];
+    WPTableViewSectionHeaderFooterView *footer = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
     footer.title = title;
     return footer;
 }
@@ -326,7 +323,7 @@ static CGFloat NotificationFooterExtraPadding       = 10.0f;
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
     NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
+    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
@@ -336,10 +333,8 @@ static CGFloat NotificationFooterExtraPadding       = 10.0f;
         return CGFLOAT_MIN;
     }
 
-    CGFloat calculatedHeight = [WPTableViewSectionFooterView heightForTitle:title
-                                                                   andWidth:CGRectGetWidth(self.view.bounds)];
-    
-    return calculatedHeight + NotificationFooterExtraPadding;
+    CGFloat width = CGRectGetWidth(self.view.bounds);
+    return [WPTableViewSectionHeaderFooterView heightForFooter:title width:width] + NotificationFooterExtraPadding;
 }
 
 

--- a/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
@@ -19,7 +19,7 @@
 #import "SupportViewController.h"
 #import "WPAccount.h"
 #import "WPPostViewController.h"
-#import "WPTableViewSectionHeaderView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 #import "SupportViewController.h"
 #import "ContextManager.h"
 #import "NotificationsManager.h"
@@ -248,21 +248,21 @@ static CGFloat const SettingsRowHeight = 44.0;
 {
 	if (section == SettingsSectionEditor && ![WPPostViewController isNewEditorAvailable]) {
 		return nil;
-	} else {
-		WPTableViewSectionHeaderView *header = [[WPTableViewSectionHeaderView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 0)];
-		header.title = [self titleForHeaderInSection:section];
-		return header;
 	}
+    
+    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
+    header.title = [self titleForHeaderInSection:section];
+    return header;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
 	if (section == SettingsSectionEditor && ![WPPostViewController isNewEditorAvailable]) {
 		return 1;
-	} else {
-		NSString *title = [self titleForHeaderInSection:section];
-		return [WPTableViewSectionHeaderView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
 	}
+    
+    NSString *title = [self titleForHeaderInSection:section];
+    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -4,7 +4,7 @@
 #import <UIDeviceIdentifier/UIDeviceHardware.h>
 #import "WordPressAppDelegate.h"
 #import <DDFileLogger.h>
-#import "WPTableViewSectionFooterView.h"
+#import "WPTableViewSectionHeaderFooterView.h"
 #import <Helpshift/Helpshift.h>
 #import "WPAnalytics.h"
 #import <WordPress-iOS-Shared/WPStyleGuide.h>
@@ -419,9 +419,9 @@ typedef NS_ENUM(NSInteger, SettingsSectionFeedbackRows)
         return nil;
     }
     
-    WPTableViewSectionFooterView *header = [[WPTableViewSectionFooterView alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 0)];
-    header.title = title;
-    return header;
+    WPTableViewSectionHeaderFooterView *footer = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
+    footer.title = title;
+    return footer;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
@@ -432,7 +432,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionFeedbackRows)
         return CGFLOAT_MIN;
     }
     
-    return [WPTableViewSectionFooterView heightForTitle:title andWidth:CGRectGetWidth(self.view.bounds)];
+    return [WPTableViewSectionHeaderFooterView heightForFooter:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (NSString *)titleForFooterInSection:(NSInteger)section


### PR DESCRIPTION
The latest WordPress-Shared release replaces **WPTableViewSectionHeaderView** and **WPTableViewSectionFooterView** with **WPTableViewSectionHeaderFooterView**.

In this PR we're updating the 14 ObjC spots in which the two legacy components were wired, plus 1 Swift spot. Please, verify the UI of the following sections:

- `My Sites` > `Blog Details`
- `My Sites` > `Blog Details` > `Settings`
- `New Post` > `Settings`
- `New Post` > `Add an Image` > `Image Details`
- `Me`
- `Me` > `Help and Support`
- `Me` > `Help and Support` > `Activity Log`
- `Me` > `About`
- `Notifications` > `Manage`

Needs Review: @SergioEstevao (Thanks in advance!)
