### PR TITLE
Fixes Notifications Separators

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteSeparatorsView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteSeparatorsView.swift
@@ -62,6 +62,7 @@ public class NoteSeparatorsView : UIView
         let scale = UIScreen.mainScreen().scale
         let ctx = UIGraphicsGetCurrentContext()
         CGContextClearRect(ctx, rect);
+        CGContextSetShouldAntialias(ctx, false);
 
         // Left Separator
         if leftVisible {

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteSeparatorsView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteSeparatorsView.swift
@@ -14,7 +14,7 @@ public class NoteSeparatorsView : UIView
             setNeedsDisplay()
         }
     }
-    public var leftWidth : CGFloat = CGFloat(3) {
+    public var leftWidthInPoints = CGFloat(3) {
         didSet {
             setNeedsDisplay()
         }
@@ -29,7 +29,7 @@ public class NoteSeparatorsView : UIView
             setNeedsDisplay()
         }
     }
-    public var bottomHeight : CGFloat = CGFloat(0.5) {
+    public var bottomHeightInPoints = CGFloat(0.5) {
         didSet {
             setNeedsDisplay()
         }
@@ -66,7 +66,7 @@ public class NoteSeparatorsView : UIView
         // Left Separator
         if leftVisible {
             leftColor.setStroke()
-            CGContextSetLineWidth(ctx, leftWidth * scale);
+            CGContextSetLineWidth(ctx, leftWidthInPoints * scale);
             CGContextMoveToPoint(ctx, bounds.minX, bounds.minY)
             CGContextAddLineToPoint(ctx, bounds.minX, bounds.maxY)
             CGContextStrokePath(ctx);
@@ -75,7 +75,7 @@ public class NoteSeparatorsView : UIView
         // Bottom Separator
         if bottomVisible {
             bottomColor.setStroke()
-            CGContextSetLineWidth(ctx, bottomHeight * scale);
+            CGContextSetLineWidth(ctx, bottomHeightInPoints * scale);
             CGContextMoveToPoint(ctx, bottomInsets.left, bounds.height)
             CGContextAddLineToPoint(ctx, bounds.maxX - bottomInsets.right, bounds.height)
             CGContextStrokePath(ctx);

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteSeparatorsView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteSeparatorsView.swift
@@ -29,7 +29,7 @@ public class NoteSeparatorsView : UIView
             setNeedsDisplay()
         }
     }
-    public var bottomHeightInPoints = CGFloat(0.5) {
+    public var bottomHeightInPixels = CGFloat(1) {
         didSet {
             setNeedsDisplay()
         }
@@ -76,7 +76,7 @@ public class NoteSeparatorsView : UIView
         // Bottom Separator
         if bottomVisible {
             bottomColor.setStroke()
-            CGContextSetLineWidth(ctx, bottomHeightInPoints * scale);
+            CGContextSetLineWidth(ctx, bottomHeightInPixels / scale);
             CGContextMoveToPoint(ctx, bottomInsets.left, bounds.height)
             CGContextAddLineToPoint(ctx, bounds.maxX - bottomInsets.right, bounds.height)
             CGContextStrokePath(ctx);

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteSeparatorsView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteSeparatorsView.swift
@@ -4,12 +4,12 @@ import Foundation
 public class NoteSeparatorsView : UIView
 {
     // MARK: - Public Properties
-    public var leftVisible : Bool = false {
+    public var leftVisible = false {
         didSet {
             setNeedsDisplay()
         }
     }
-    public var leftColor : UIColor = UIColor.clearColor() {
+    public var leftColor = UIColor.clearColor() {
         didSet {
             setNeedsDisplay()
         }
@@ -19,12 +19,12 @@ public class NoteSeparatorsView : UIView
             setNeedsDisplay()
         }
     }
-    public var bottomVisible : Bool = false {
+    public var bottomVisible = false {
         didSet {
             setNeedsDisplay()
         }
     }
-    public var bottomColor : UIColor = WPStyleGuide.Notifications.blockSeparatorColor {
+    public var bottomColor = WPStyleGuide.Notifications.blockSeparatorColor {
         didSet {
             setNeedsDisplay()
         }
@@ -34,7 +34,7 @@ public class NoteSeparatorsView : UIView
             setNeedsDisplay()
         }
     }
-    public var bottomInsets : UIEdgeInsets = UIEdgeInsetsZero {
+    public var bottomInsets = UIEdgeInsetsZero {
         didSet {
             setNeedsDisplay()
         }


### PR DESCRIPTION
#### Details:
I've noticed a glitch in iPad Mini 1st gen (SD screen!). Notifications separators are currently being displayed in a color that looks slightly dimmer than expected.

In this PR we're patching up `NoteSeparatorsView`, which is the class in charge of drawing the Notification Separators.

#### Steps:
1. Receive a Comment-Y Notification
2. Open the Notifications tab and tap on it

As a result, the Notification Details should be onscreen, and there should be separators between the three cells onscreen. Try disapproving / approving the notification, and notice that the separators color is way too clear.


--


#### Broken Screenshots: 1x Devices (iPad 2) 

![1x broken unapproved](https://cloud.githubusercontent.com/assets/1195260/9009920/8eb7a850-377a-11e5-9d17-dc1354838cf3.png)


![1x broken approved](https://cloud.githubusercontent.com/assets/1195260/9009921/8eec08d4-377a-11e5-9e31-56c8239999fe.png)


--


#### Fixed Screenshots: 1x Devices (iPad 2)

![1x fixed approved](https://cloud.githubusercontent.com/assets/1195260/9009930/9ec33480-377a-11e5-887d-75dacffedaf8.png)


![1x fixed unapproved](https://cloud.githubusercontent.com/assets/1195260/9009929/9ec21f78-377a-11e5-8076-440505ce596a.png)


--


#### Fixed Screenshots: 2x Devices (iPhone 5s)

![2x fixed approved](https://cloud.githubusercontent.com/assets/1195260/9009941/a7866326-377a-11e5-96b4-8610825252b0.png)


![2x fixed unapproved](https://cloud.githubusercontent.com/assets/1195260/9009940/a7851a20-377a-11e5-84f7-14e963add447.png)


--


#### Fixed Screenshots: 3x Devices (iPhone 6)

![3x fixed unapproved](https://cloud.githubusercontent.com/assets/1195260/9009946/afa63090-377a-11e5-8ce0-9af4b7c5077b.png)


![3x fixed approved](https://cloud.githubusercontent.com/assets/1195260/9009945/afa3bdce-377a-11e5-94f4-f627131193cc.png)


--


**Needs review:** @aerych mind taking a quick look?. 

I missed a `CGContextSetShouldAntialias(ctx, false)`, and, as a result, the separators were being drawn in a different color.

Thank you!
