### PR TITLE
Notifications: Fixing Table Section Separators

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -524,7 +524,7 @@ static NSString const *NotificationsNetworkStatusKey    = @"network_status";
 {
     id <NSFetchedResultsSectionInfo> sectionInfo = [self.tableViewHandler.resultsController.sections objectAtIndex:section];
     
-    NoteTableHeaderView *headerView = [[NoteTableHeaderView alloc] initWithWidth:CGRectGetWidth(tableView.bounds)];
+    NoteTableHeaderView *headerView = [NoteTableHeaderView new];
     headerView.title                = [Notification descriptionForSectionIdentifier:sectionInfo.name];
     headerView.separatorColor       = self.tableView.separatorColor;
     

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteSeparatorsView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteSeparatorsView.swift
@@ -19,6 +19,26 @@ public class NoteSeparatorsView : UIView
             setNeedsDisplay()
         }
     }
+    public var topVisible = false {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    public var topColor = WPStyleGuide.Notifications.blockSeparatorColor {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    public var topHeightInPixels = CGFloat(1) {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    public var topInsets = UIEdgeInsetsZero {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
     public var bottomVisible = false {
         didSet {
             setNeedsDisplay()
@@ -56,7 +76,6 @@ public class NoteSeparatorsView : UIView
     }
     
     public override func drawRect(rect: CGRect) {
-        
         super.drawRect(rect)
         
         let scale = UIScreen.mainScreen().scale
@@ -64,6 +83,12 @@ public class NoteSeparatorsView : UIView
         CGContextClearRect(ctx, rect);
         CGContextSetShouldAntialias(ctx, false);
 
+        // Background
+        if backgroundColor != nil {
+            backgroundColor?.setFill()
+            CGContextFillRect(ctx, rect)
+        }
+        
         // Left Separator
         if leftVisible {
             leftColor.setStroke()
@@ -72,7 +97,17 @@ public class NoteSeparatorsView : UIView
             CGContextAddLineToPoint(ctx, bounds.minX, bounds.maxY)
             CGContextStrokePath(ctx);
         }
-        
+
+        // Top Separator
+        if topVisible {
+            topColor.setStroke()
+            let lineWidth = topHeightInPixels / scale
+            CGContextSetLineWidth(ctx, lineWidth);
+            CGContextMoveToPoint(ctx, topInsets.left, lineWidth)
+            CGContextAddLineToPoint(ctx, bounds.maxX - topInsets.right, lineWidth)
+            CGContextStrokePath(ctx);
+        }
+
         // Bottom Separator
         if bottomVisible {
             bottomColor.setStroke()

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
@@ -14,10 +14,10 @@ import Foundation
     public var title: String? {
         set {
             // For layout reasons, we need to ensure that the titleLabel uses an exact Paragraph Height!
-            if let unwrappedTitle = newValue?.uppercaseString {
-                titleLabel.attributedText = NSAttributedString(string: unwrappedTitle, attributes: Style.sectionHeaderRegularStyle)
-                setNeedsLayout()
-            }
+            let unwrappedTitle = newValue?.uppercaseString ?? String()
+            let attributes = Style.sectionHeaderRegularStyle
+            titleLabel.attributedText = NSAttributedString(string: unwrappedTitle, attributes: attributes)
+            setNeedsLayout()
         }
         get {
             return titleLabel.text
@@ -34,18 +34,14 @@ import Foundation
         }
     }
     
-    // MARK: - Public Methods
-    public class func headerHeight() -> CGFloat {
-        let cellHeight = CGFloat(26)
-        return cellHeight
-    }
     
-    // MARK: - Convenience Inits
+    
+    // MARK: - Convenience Initializers
     public convenience init(width: CGFloat) {
-        let frame = CGRect(x: 0, y: 0, width: width, height: 0)
-        self.init(frame: frame)
+        self.init(frame: CGRect(x: 0.0, y: 0.0, width: width, height: 0.0))
         setupSubviews()
     }
+    
     
     // MARK: - Overriden Properties
     public override var frame: CGRect {
@@ -57,12 +53,14 @@ import Foundation
         }
     }
     
+    
+    
     // MARK: - View Methods
     public override func layoutSubviews() {
         super.layoutSubviews()
         
         let frameWidth              = frame.width
-        let frameHeight             = NoteTableHeaderView.headerHeight()
+        let frameHeight             = NoteTableHeaderView.headerHeight
         let imageOriginY            = floor((frameHeight - imageView.frame.height) * 0.5)
         let titleWidth              = frameWidth - (imageOriginX * 2) - imageView.frame.width
         let titleOriginY            = floor((frameHeight - titleHeight) * 0.5)
@@ -108,6 +106,13 @@ import Foundation
     }
 
     
+    
+    // MARK: - Aliases
+    typealias Style = WPStyleGuide.Notifications
+    
+    // MARK: - Static Properties
+    public static let headerHeight  = CGFloat(26)
+    
     // MARK: - Constants
     private let imageOriginX        = CGFloat(10)
     private let titleOriginX        = CGFloat(30)
@@ -120,9 +125,6 @@ import Foundation
     // MARK: - Properties
     private var topSeparator:       UIView!
     private var bottomSeparator:    UIView!
-    
-    // MARK: - Aliases
-    typealias Style = WPStyleGuide.Notifications
     
     // MARK: - Outlets
     private var imageView:          UIImageView!

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
@@ -26,89 +26,54 @@ import Foundation
     
     public var separatorColor: UIColor? {
         set {
-            topSeparator.backgroundColor    = newValue
-            bottomSeparator.backgroundColor = newValue
+            layoutView.bottomColor  = newValue ?? UIColor.clearColor()
+            layoutView.topColor     = newValue ?? UIColor.clearColor()
         }
         get {
-            return topSeparator.backgroundColor
+            return layoutView.bottomColor
         }
     }
     
     
     
     // MARK: - Convenience Initializers
-    public convenience init(width: CGFloat) {
-        self.init(frame: CGRect(x: 0.0, y: 0.0, width: width, height: 0.0))
-        setupSubviews()
+    public convenience init() {
+        self.init(frame: CGRectZero)
+    }
+    
+    required override public init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required public init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setupView()
     }
     
     
-    
-    // MARK: - Overriden Properties
-    public override var frame: CGRect {
-        didSet {
-            if frame.width <= maximumWidth {
-                return
-            }
-            
-            super.frame.origin.x    = (frame.width - maximumWidth) * 0.5
-            super.frame.size.width  = maximumWidth
-            setNeedsLayout()
-        }
-    }
-    
-    
-    
-    // MARK: - View Methods
-    public override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        let frameWidth              = frame.width
-        let frameHeight             = NoteTableHeaderView.headerHeight
-        let imageOriginY            = floor((frameHeight - imageView.frame.height) * 0.5)
-        let titleWidth              = frameWidth - (imageOriginX * 2) - imageView.frame.width
-        let titleOriginY            = floor((frameHeight - titleHeight) * 0.5)
-        let bottomSeparatorY        = frameHeight - separatorHeight
-        
-        if frameWidth > maximumWidth {
-            frame.origin.x          = (frameWidth - maximumWidth) * 0.5;
-        }
-        
-        frame.size.height           = frameHeight
-        
-        imageView.frame.origin      = CGPoint(x: imageOriginX, y: imageOriginY)
-        
-        titleLabel.frame.origin     = CGPoint(x: titleOriginX, y: titleOriginY)
-        titleLabel.frame.size       = CGSize(width: titleWidth, height: titleHeight)
-        
-        topSeparator.frame          = CGRect(x: 0, y: 0,                width: frameWidth, height: separatorHeight)
-        bottomSeparator.frame       = CGRect(x: 0, y: bottomSeparatorY, width: frameWidth, height: separatorHeight)
-    }
     
     // MARK - Private Helpers
-    private func setupSubviews() {
-        backgroundColor             = Style.sectionHeaderBackgroundColor
+    private func setupView() {
+        NSBundle.mainBundle().loadNibNamed("NoteTableHeaderView", owner: self, options: nil)
+        addSubview(contentView)
         
-        titleLabel                  = UILabel()
-        titleLabel.textAlignment    = .Left
-        titleLabel.numberOfLines    = 0;
-        titleLabel.lineBreakMode    = .ByWordWrapping
-        titleLabel.backgroundColor  = UIColor.clearColor()
-        titleLabel.shadowOffset     = CGSizeZero
-        addSubview(titleLabel)
+        // Make sure the Outlets are loaded
+        assert(contentView  != nil)
+        assert(layoutView   != nil)
+        assert(imageView    != nil)
+        assert(titleLabel   != nil)
         
-        let image                   = UIImage(named: imageName)
-        imageView                   = UIImageView(image: image)
-        imageView.sizeToFit()
-        addSubview(imageView)
+        // Layout
+        contentView.setTranslatesAutoresizingMaskIntoConstraints(false)
+        pinSubviewToAllEdges(contentView)
+        
+        // Background + Separators
+        backgroundColor             = UIColor.clearColor()
 
-        topSeparator                = UIView(frame: CGRectZero)
-        addSubview(topSeparator)
-        
-        bottomSeparator             = UIView(frame: CGRectZero)
-        addSubview(bottomSeparator)
-        
-        clipsToBounds               = true
+        layoutView.backgroundColor  = Style.sectionHeaderBackgroundColor
+        layoutView.bottomVisible    = true
+        layoutView.topVisible       = true
     }
 
     
@@ -119,20 +84,9 @@ import Foundation
     // MARK: - Static Properties
     public static let headerHeight  = CGFloat(26)
     
-    // MARK: - Constants
-    private let imageOriginX        = CGFloat(10)
-    private let titleOriginX        = CGFloat(30)
-    private let titleHeight         = CGFloat(16)
-    private let imageName           = "reader-postaction-time"
-    
-    private let separatorHeight     = CGFloat(1) / UIScreen.mainScreen().scale
-    private let maximumWidth        = UIDevice.isPad() ? WPTableViewFixedWidth : CGFloat.max
-    
-    // MARK: - Properties
-    private var topSeparator:       UIView!
-    private var bottomSeparator:    UIView!
-    
     // MARK: - Outlets
-    private var imageView:          UIImageView!
-    private var titleLabel:         UILabel!
+    @IBOutlet private var contentView:        UIView!
+    @IBOutlet private var layoutView:         NoteSeparatorsView!
+    @IBOutlet private var imageView:          UIImageView!
+    @IBOutlet private var titleLabel:         UILabel!
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
@@ -43,13 +43,17 @@ import Foundation
     }
     
     
+    
     // MARK: - Overriden Properties
     public override var frame: CGRect {
         didSet {
-            if frame.width > maximumWidth {
-                super.frame.origin.x    = (frame.width - maximumWidth) * 0.5
-                super.frame.size.width  = maximumWidth
+            if frame.width <= maximumWidth {
+                return
             }
+            
+            super.frame.origin.x    = (frame.width - maximumWidth) * 0.5
+            super.frame.size.width  = maximumWidth
+            setNeedsLayout()
         }
     }
     
@@ -103,6 +107,8 @@ import Foundation
         
         bottomSeparator             = UIView(frame: CGRectZero)
         addSubview(bottomSeparator)
+        
+        clipsToBounds               = true
     }
 
     

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 
+
+/**
+*  @class      NoteTableHeaderView
+*  @brief      This class renders a view with top and bottom separators, meant to be used as UITableView
+*              section header in NotificationsViewController.
+*/
+
 @objc public class NoteTableHeaderView : UIView
 {
     // MARK: - Public Properties

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
@@ -14,7 +14,7 @@ import Foundation
     public var title: String? {
         set {
             // For layout reasons, we need to ensure that the titleLabel uses an exact Paragraph Height!
-            let unwrappedTitle = newValue?.uppercaseString ?? String()
+            let unwrappedTitle = newValue?.uppercaseStringWithLocale(NSLocale.currentLocale()) ?? String()
             let attributes = Style.sectionHeaderRegularStyle
             titleLabel.attributedText = NSAttributedString(string: unwrappedTitle, attributes: attributes)
             setNeedsLayout()

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NoteTableHeaderView">
+            <connections>
+                <outlet property="contentView" destination="v2Z-s3-Kgc" id="py9-K7-MbW"/>
+                <outlet property="imageView" destination="imt-VI-wdh" id="h5Q-j5-kGO"/>
+                <outlet property="layoutView" destination="AjL-Ni-9e0" id="LKe-Wb-OPn"/>
+                <outlet property="titleLabel" destination="zK2-Ta-Z1W" id="uHP-Wc-QVL"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="v2Z-s3-Kgc" userLabel="ContentView">
+            <rect key="frame" x="0.0" y="0.0" width="700" height="26"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AjL-Ni-9e0" userLabel="LayoutView" customClass="NoteSeparatorsView" customModule="WordPress" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="0.0" width="700" height="26"/>
+                    <subviews>
+                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reader-postaction-time" translatesAutoresizingMaskIntoConstraints="NO" id="imt-VI-wdh" userLabel="Icon">
+                            <rect key="frame" x="10" y="5" width="16" height="16"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="16" id="4kI-NL-bJP"/>
+                                <constraint firstAttribute="height" constant="16" id="G7c-hu-Hc6"/>
+                            </constraints>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zK2-Ta-Z1W" userLabel="Title">
+                            <rect key="frame" x="30" y="4.5" width="660" height="16"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="16" id="YxS-jB-T4A"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                            <nil key="highlightedColor"/>
+                            <size key="shadowOffset" width="0.0" height="0.0"/>
+                            <variation key="heightClass=regular-widthClass=regular" misplaced="YES">
+                                <rect key="frame" x="30" y="4" width="660" height="16"/>
+                            </variation>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" red="0.90196079015731812" green="0.90196079015731812" blue="0.90196079015731812" alpha="1" colorSpace="calibratedRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="600" id="7xv-xJ-X6P"/>
+                        <constraint firstAttribute="width" relation="lessThanOrEqual" priority="250" constant="600" id="E56-KE-cpo"/>
+                        <constraint firstAttribute="trailing" secondItem="zK2-Ta-Z1W" secondAttribute="trailing" constant="10" id="MLS-Ie-b9J"/>
+                        <constraint firstAttribute="centerY" secondItem="imt-VI-wdh" secondAttribute="centerY" id="OQj-Jn-Ne4"/>
+                        <constraint firstItem="zK2-Ta-Z1W" firstAttribute="leading" secondItem="imt-VI-wdh" secondAttribute="trailing" constant="4" id="gJW-0T-qdG"/>
+                        <constraint firstAttribute="centerY" secondItem="zK2-Ta-Z1W" secondAttribute="centerY" id="mQt-8x-xsN"/>
+                        <constraint firstItem="imt-VI-wdh" firstAttribute="leading" secondItem="AjL-Ni-9e0" secondAttribute="leading" constant="10" id="zAJ-ZZ-D9E"/>
+                    </constraints>
+                    <variation key="default">
+                        <mask key="constraints">
+                            <exclude reference="7xv-xJ-X6P"/>
+                            <exclude reference="E56-KE-cpo"/>
+                        </mask>
+                    </variation>
+                    <variation key="heightClass=regular-widthClass=regular">
+                        <mask key="constraints">
+                            <include reference="7xv-xJ-X6P"/>
+                        </mask>
+                    </variation>
+                </view>
+            </subviews>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="AjL-Ni-9e0" firstAttribute="leading" secondItem="v2Z-s3-Kgc" secondAttribute="leading" priority="750" id="KBr-LI-hk5"/>
+                <constraint firstAttribute="trailing" secondItem="AjL-Ni-9e0" secondAttribute="trailing" priority="750" id="SCN-H1-mER"/>
+                <constraint firstAttribute="bottom" secondItem="AjL-Ni-9e0" secondAttribute="bottom" id="TqB-Ef-M2T"/>
+                <constraint firstItem="AjL-Ni-9e0" firstAttribute="top" secondItem="v2Z-s3-Kgc" secondAttribute="top" id="VYd-Ct-yx9"/>
+                <constraint firstAttribute="centerX" secondItem="AjL-Ni-9e0" secondAttribute="centerX" id="yLC-fW-Dz4"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="reader-postaction-time" width="16" height="16"/>
+    </resources>
+</document>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -359,6 +359,7 @@
 		B55853F719630D5400FAF6C3 /* NSAttributedString+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = B55853F619630D5400FAF6C3 /* NSAttributedString+Util.m */; };
 		B55853FC19630E7900FAF6C3 /* Notification.m in Sources */ = {isa = PBXBuildFile; fileRef = B55853F919630E7900FAF6C3 /* Notification.m */; };
 		B558541419631A1000FAF6C3 /* Notifications.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B558541019631A1000FAF6C3 /* Notifications.storyboard */; };
+		B5683DB81B6C03810043447C /* NoteTableHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5683DB71B6C03810043447C /* NoteTableHeaderView.xib */; };
 		B57AF5FA1ACDC73D0075A7D2 /* NoteBlockActionsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57AF5F91ACDC73D0075A7D2 /* NoteBlockActionsTableViewCell.swift */; };
 		B57B99D519A2C20200506504 /* NoteTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57B99D419A2C20200506504 /* NoteTableHeaderView.swift */; };
 		B57B99DE19A2DBF200506504 /* NSObject+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = B57B99DD19A2DBF200506504 /* NSObject+Helpers.m */; };
@@ -1233,6 +1234,7 @@
 		B55853F819630E7900FAF6C3 /* Notification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = Notification.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		B55853F919630E7900FAF6C3 /* Notification.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = Notification.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		B558541019631A1000FAF6C3 /* Notifications.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Notifications.storyboard; sourceTree = "<group>"; };
+		B5683DB71B6C03810043447C /* NoteTableHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NoteTableHeaderView.xib; sourceTree = "<group>"; };
 		B57AF5F91ACDC73D0075A7D2 /* NoteBlockActionsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoteBlockActionsTableViewCell.swift; sourceTree = "<group>"; };
 		B57B99D419A2C20200506504 /* NoteTableHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoteTableHeaderView.swift; sourceTree = "<group>"; };
 		B57B99DC19A2DBF200506504 /* NSObject+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+Helpers.h"; sourceTree = "<group>"; };
@@ -2883,6 +2885,7 @@
 			isa = PBXGroup;
 			children = (
 				B57B99D419A2C20200506504 /* NoteTableHeaderView.swift */,
+				B5683DB71B6C03810043447C /* NoteTableHeaderView.xib */,
 				B52C4C7E199D74AE009FD823 /* NoteTableViewCell.swift */,
 				B5E23BDE19AD0D00000D6879 /* NoteTableViewCell.xib */,
 				B5C66B6D1ACEE0B500F68370 /* NoteSeparatorsView.swift */,
@@ -3570,6 +3573,7 @@
 				B558541419631A1000FAF6C3 /* Notifications.storyboard in Resources */,
 				5DFA7EC81AF814E40072023B /* PageListTableViewCell.xib in Resources */,
 				B5C66B781ACF073900F68370 /* NoteBlockImageTableViewCell.xib in Resources */,
+				B5683DB81B6C03810043447C /* NoteTableHeaderView.xib in Resources */,
 				45C73C25113C36F70024D0D2 /* MainWindow-iPad.xib in Resources */,
 				5D13FA571AF99C2100F06492 /* PageListSectionHeaderView.xib in Resources */,
 				B54E1DF21A0A7BAA00807537 /* ReplyTextView.xib in Resources */,


### PR DESCRIPTION
#### Steps:
1. To ease things out, hack [this method](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m#L202), so that the ratings view is always rendered
2. Launch WPiOS
3. Switch to the Notifications Tab

Few seconds afterwards, the Ratings View should be onscreen. Note that the Section Headers should be displayed correctly, and the top and bottom separator's width should match with the cell's width.

Needs Review: @astralbodies (Thanks Aaron!)

Closes #4097
