### PR TITLE
Don't load images when computing layout.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.h
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.h
@@ -7,4 +7,8 @@
 
 - (void)configureCell:(id<WPPostContentViewProvider>)contentProvider;
 
+@optional
+
+- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider loadingImages:(BOOL)loadMedia;
+
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -51,6 +51,7 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 @property (nonatomic, assign) CGFloat dateViewLowerMargin;
 @property (nonatomic, assign) CGFloat statusViewHeight;
 @property (nonatomic, assign) CGFloat statusViewLowerMargin;
+@property (nonatomic, assign) BOOL loadImagesWhenConfigured;
 
 @end
 
@@ -247,6 +248,12 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 - (void)configureCell:(id<WPPostContentViewProvider>)contentProvider
 {
+    [self configureCell:contentProvider loadingImages:YES];
+}
+
+- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider loadingImages:(BOOL)loadImages
+{
+    self.loadImagesWhenConfigured = loadImages;
     self.contentProvider = contentProvider;
 }
 
@@ -264,12 +271,22 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
     self.headerViewLowerConstraint.constant = self.headerViewLowerMargin;
     self.authorBlogLabel.text = [self.contentProvider blogNameForDisplay];
     self.authorNameLabel.text = [self.contentProvider authorNameForDisplay];
-    [self.avatarImageView setImageWithURL:[self blavatarURL]
-                         placeholderImage:[UIImage imageNamed:@"post-blavatar-placeholder"]];
+
+    UIImage *placeholder =[UIImage imageNamed:@"post-blavatar-placeholder"];
+    if (self.loadImagesWhenConfigured) {
+        [self.avatarImageView setImageWithURL:[self blavatarURL]
+                             placeholderImage:placeholder];
+    } else {
+        self.avatarImageView.image = placeholder;
+    }
 }
 
 - (void)configureCardImage
 {
+    if (!self.loadImagesWhenConfigured) {
+        return;
+    }
+
     if (!self.postCardImageView) {
         return;
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -384,7 +384,8 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     postCell.delegate = self;
     Post *post = (Post *)[self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
 
-    [postCell configureCell:post];
+    BOOL loadImages = !([cell isEqual:self.imageCellForLayout] || [cell isEqual:self.textCellForLayout]);
+    [postCell configureCell:post loadingImages:loadImages];
 }
 
 - (NSString *)cellIdentifierForPost:(Post *)post


### PR DESCRIPTION
Performance optimization
Avoids a deadlock when rapidly starting and cancelling requests that's triggered in `PrivateSiteURLProtocol`
Refs: #4090 

Needs Review: @astralbodies 