### PR TITLE
Notifications: Fixing blogName clipping

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
@@ -85,12 +85,6 @@ import Foundation
         // Setup Recognizers
         detailsLabel.gestureRecognizers     = [ UITapGestureRecognizer(target: self, action: "detailsWasPressed:") ]
         detailsLabel.userInteractionEnabled = true
-
-        // iPad: Use a bigger image size!
-        if UIDevice.isPad() {
-            gravatarImageView.updateConstraint(.Height, constant: gravatarImageSizePad.width)
-            gravatarImageView.updateConstraint(.Width,  constant: gravatarImageSizePad.height)
-        }
     }
     
 
@@ -155,7 +149,6 @@ import Foundation
     }
     
     // MARK: - Private Constants
-    private let gravatarImageSizePad                = CGSize(width: 37.0, height: 37.0)
     private let separatorApprovedInsets             = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 12.0)
     private let separatorUnapprovedInsets           = UIEdgeInsetsZero
     private let separatorRepliedInsets              = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 0.0)

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -17,15 +17,21 @@
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="B30-uC-0a3" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                         <rect key="frame" x="12" y="12" width="32" height="32"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="32" id="Sje-MT-U6A"/>
-                            <constraint firstAttribute="width" constant="32" id="irJ-0r-By6"/>
+                            <constraint firstAttribute="height" constant="32" id="Sje-MT-U6A">
+                                <variation key="heightClass=regular-widthClass=regular" constant="37"/>
+                            </constraint>
+                            <constraint firstAttribute="width" constant="32" id="irJ-0r-By6">
+                                <variation key="heightClass=regular-widthClass=regular" constant="37"/>
+                            </constraint>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J2Y-Yo-5I1">
                         <rect key="frame" x="54" y="8" width="24" height="18"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="188" id="nPH-Us-pyd"/>
-                            <constraint firstAttribute="height" constant="18" id="uUO-Vw-CUK"/>
+                            <constraint firstAttribute="height" constant="18" id="uUO-Vw-CUK">
+                                <variation key="heightClass=regular-widthClass=regular" constant="20"/>
+                            </constraint>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
@@ -39,7 +45,9 @@
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="749" text="Details" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0nV-U0-dRc">
                         <rect key="frame" x="54" y="26" width="38" height="18"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="18" id="q8Z-Ct-DNF"/>
+                            <constraint firstAttribute="height" constant="18" id="q8Z-Ct-DNF">
+                                <variation key="heightClass=regular-widthClass=regular" constant="21"/>
+                            </constraint>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>


### PR DESCRIPTION
#### Steps:
1. Hack [this spot](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m#L677) and replace it with something like: `cell.commentText = @"The Dangling Pointer"`
2. Receive a Comment-Y Notification
3. Run the app using an iPad Simulator
4. Open the Notifications tab, and select the new notification

Verify that the Blog Name doesn't get clipped.

@astralbodies your blog's name was breaking the Notifications interface. You may either rename your blog to something that doesn't have descending characters issues... or review this PR please!

Needs Review: @astralbodies (Thanks in advance Aaron!)
Closes #4102
