### PR TITLE
Hiding the password when the user goes into that background

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -884,6 +884,11 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
     self.passwordText.text = passwordText;
 }
 
+- (void)setPasswordSecureEntry:(BOOL)secureTextEntry;
+{
+    [self.passwordText setSecureTextEntry:secureTextEntry];
+}
+
 - (void)setSiteAlpha:(CGFloat)alpha
 {
     self.siteUrlText.alpha = alpha;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
@@ -198,6 +198,7 @@ typedef void (^OverlayViewCallback)(WPWalkthroughOverlayView *);
 - (void)setPasswordAlpha:(CGFloat)alpha;
 - (void)setPasswordEnabled:(BOOL)enabled;
 - (void)setPasswordTextValue:(NSString *)password;
+- (void)setPasswordSecureEntry:(BOOL)secureTextEntry;
 
 - (void)setSiteAlpha:(CGFloat)alpha;
 - (void)setMultiFactorAlpha:(CGFloat)alpha;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -31,6 +31,11 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     return self;
 }
 
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 - (void)initializeFacades
 {
     LoginFacade *loginFacade = [LoginFacade new];
@@ -59,6 +64,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     [self setupObservationForSignInButtonTitle];
     [self setupObserverationForTheSignInButtonsEnabledState];
     [self setupObserverationForTheToggleSignInButtonsVisibility];
+    [self setupObservationForApplicationDidEnterBackground];
 }
 
 - (LoginFields *)loginFields
@@ -359,6 +365,16 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     }] subscribeNext:^(NSNumber *toggleSignInButtonHidden) {
         [self.presenter setToggleSignInButtonHidden:[toggleSignInButtonHidden boolValue]];
     }];
+}
+
+- (void)setupObservationForApplicationDidEnterBackground
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
+}
+
+- (void)didEnterBackground:(NSNotification *)notification
+{
+    [self.presenter setPasswordSecureEntry:YES];
 }
 
 - (BOOL)isUrlValid:(NSString *)url

--- a/WordPress/WordPressTest/LoginViewModelTests.m
+++ b/WordPress/WordPressTest/LoginViewModelTests.m
@@ -1817,4 +1817,14 @@ describe(@"sendVerificationCodeButton visibility", ^{
     
 });
 
+it(@"should secure the password entry when entering the background", ^{
+    OCMExpect([mockViewModelPresenter setPasswordSecureEntry:YES]);
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil];
+    
+    OCMVerifyAll(mockViewModelPresenter);
+});
+
+
+
 SpecEnd


### PR DESCRIPTION
There's a potential security issue where a password can get exposed through the following steps:

1) Open Login Screen
2) Enter password
3) Toggle show password button
4) Exit to home screen
5) Using a tool like iExplore check the snapshots folder, in it will be a snapshot of the app with an exposed password.

To fix this vulnerability I just toggle the password field to hidden if the user should decide to background the app.

cc @diegoreymendez 