### PR TITLE
Adds a method for easier WPCom account verification.

### DIFF
--- a/WordPress/Classes/Models/WPAccount.h
+++ b/WordPress/Classes/Models/WPAccount.h
@@ -53,4 +53,15 @@
 - (void)addJetpackBlogs:(NSSet *)values;
 - (void)removeJetpackBlogs:(NSSet *)values;
 
+#pragma mark - WordPress.com support methods
+
+/**
+ *  @brief      Call this method to know if the account is a WordPress.com account.
+ *  @details    This is the same as checking if restApi != nil, but it conveys its own meaning
+ *              in a cleaner way to the reader.
+ *
+ *  @returns    YES if this account is a WordPress.com account, NO otherwise.
+ */
+- (BOOL)isWPComAccount;
+
 @end

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -94,7 +94,8 @@
         if (error) {
             DDLogError(@"Error while updating WordPressComOAuthKeychainServiceName token: %@", error);
         }
-
+        
+        _restApi = [[WordPressComApi alloc] initWithOAuthToken:authToken];
     } else {
         NSError *error = nil;
         [SFHFKeychainUtils deleteItemForUsername:self.username
@@ -103,10 +104,9 @@
         if (error) {
             DDLogError(@"Error while deleting WordPressComOAuthKeychainServiceName token: %@", error);
         }
+        
+        _restApi = nil;
     }
-    
-    // Make sure to release any RestAPI alloc'ed, since it might have an invalid token
-    _restApi = nil;
 }
 
 - (NSArray *)visibleBlogs
@@ -114,16 +114,6 @@
     NSSet *visibleBlogs = [self.blogs filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"visible = YES"]];
     NSArray *sortedBlogs = [visibleBlogs sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"blogName" ascending:YES selector:@selector(localizedCaseInsensitiveCompare:)]]];
     return sortedBlogs;
-}
-
-#pragma mark - API Helpers
-
-- (WordPressComApi *)restApi
-{
-    if (!_restApi) {
-        _restApi = [[WordPressComApi alloc] initWithOAuthToken:self.authToken];
-    }
-    return _restApi;
 }
 
 #pragma mark - WordPress.com support methods

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -126,4 +126,11 @@
     return _restApi;
 }
 
+#pragma mark - WordPress.com support methods
+
+- (BOOL)isWPComAccount
+{
+    return self.restApi != nil;
+}
+
 @end


### PR DESCRIPTION
This method will be used by a [larger upcoming PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/4070).

- Adds a method to more easily identify WPCom accounts from non-WPCom accounts.
- Converts a lazy initializer into a safer one: with the lazy initializer it was possible to get a `restApi` allocd even if there was no `authToken`.

/cc @SergioEstevao 