### PR TITLE
Normalizes Row Heights

### DIFF
--- a/WordPress/Classes/System/WPGUIConstants.h
+++ b/WordPress/Classes/System/WPGUIConstants.h
@@ -11,6 +11,7 @@ extern const CGFloat WPAnimationDurationFast;
 extern const CGFloat WPAnimationDurationFaster;
 
 extern const CGFloat WPTableViewTopMargin;
+extern const CGFloat WPTableViewDefaultRowHeight;
 extern const CGRect WPTableHeaderPadFrame;
 extern const CGRect WPTableFooterPadFrame;
 extern const UIEdgeInsets WPTableViewContentInsets;

--- a/WordPress/Classes/System/WPGUIConstants.m
+++ b/WordPress/Classes/System/WPGUIConstants.m
@@ -11,6 +11,7 @@ const CGFloat WPAnimationDurationFast       = 0.15;
 const CGFloat WPAnimationDurationFaster     = 0.07;
 
 const CGFloat WPTableViewTopMargin          = 40.0;
+const CGFloat WPTableViewDefaultRowHeight   = 44.0;
 const CGRect WPTableHeaderPadFrame          = {0.0, 0.0, 0.0, 40.0};
 const CGRect WPTableFooterPadFrame          = {0.0, 0.0, 0.0, 48.0};
 const UIEdgeInsets WPTableViewContentInsets = {40.0, 0.0, 0.0, 0.0};

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -30,6 +30,7 @@
 #import "PostListViewController.h"
 #import "PageListViewController.h"
 #import "WPThemeSettings.h"
+#import "WPGUIConstants.h"
 
 const NSInteger BlogDetailsRowViewSite = 0;
 const NSInteger BlogDetailsRowViewAdmin = 1;
@@ -377,7 +378,7 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    return 48;
+    return WPTableViewDefaultRowHeight;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -19,10 +19,18 @@
 #import "WordPress-Swift.h"
 #import "WPSearchControllerConfigurator.h"
 
+typedef NS_ENUM(NSInteger, BlogListSections) {
+    BlogListSectionsAllSites = 0,
+    BlogListSectionsNewSite,
+    BlogListSectionsCount
+};
+
 static NSString *const AddSiteCellIdentifier = @"AddSiteCell";
 static NSString *const BlogCellIdentifier = @"BlogCell";
 static CGFloat const BLVCHeaderViewLabelPadding = 10.0;
 static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
+static CGFloat const BLVCSiteRowHeight = 54.0;
+
 
 @interface BlogListViewController () <UIViewControllerRestoration>
 
@@ -342,9 +350,9 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
     if (self.tableView.isEditing || [self.searchController isActive]) { // Don't show "Add Site"
-        return 1;
+        return BlogListSectionsCount - 1;
     } else {
-        return 2;
+        return BlogListSectionsCount;
     }
 }
 
@@ -516,7 +524,7 @@ static CGFloat const BLVCSectionHeaderHeightForIPad = 40.0;
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    return 54;
+    return (indexPath.section == BlogListSectionsNewSite) ? WPTableViewDefaultRowHeight : BLVCSiteRowHeight;
 }
 
 # pragma mark - WPSeachController delegate methods

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -18,6 +18,7 @@
 #import "WPTextFieldTableViewCell.h"
 #import "SettingsTextViewController.h"
 #import "SettingsMultiTextViewController.h"
+#import "WPGUIConstants.h"
 
 NS_ENUM(NSInteger, SiteSettingsGeneral) {
     SiteSettingsGeneralTitle = 0,
@@ -49,7 +50,6 @@ NS_ENUM(NSInteger, SiteSettinsAlertTag) {
     SiteSettinsAlertTagSiteRemoval = 201,
 };
 
-static CGFloat const EditSiteRowHeight = 48.0;
 NSInteger const EditSiteURLMinimumLabelWidth = 30;
 
 @interface SiteSettingsViewController () <UITableViewDelegate, UITextFieldDelegate, UIAlertViewDelegate, UIActionSheetDelegate>
@@ -384,7 +384,7 @@ NSInteger const EditSiteURLMinimumLabelWidth = 30;
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    return EditSiteRowHeight;
+    return WPTableViewDefaultRowHeight;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -51,8 +51,6 @@ typedef NS_ENUM(NSInteger, MeSectionWpCom) {
 static NSString *const WPMeRestorationID = @"WPMeRestorationID";
 static NSString *const MVCCellReuseIdentifier = @"MVCCellReuseIdentifier";
 
-static CGFloat const MVCTableViewRowHeight = 50.0;
-
 @interface MeViewController () <UIViewControllerRestoration, UITableViewDataSource, UITableViewDelegate, UIActionSheetDelegate>
 
 @property (nonatomic, strong) UITableView *tableView;
@@ -120,7 +118,7 @@ static CGFloat const MVCTableViewRowHeight = 50.0;
     self.tableView = [[UITableView alloc] initWithFrame:self.view.bounds style:UITableViewStyleGrouped];
     self.tableView.dataSource = self;
     self.tableView.delegate = self;
-    self.tableView.rowHeight = MVCTableViewRowHeight;
+    self.tableView.rowHeight = WPTableViewDefaultRowHeight;
     self.tableView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:MVCCellReuseIdentifier];
     [self.view addSubview:self.tableView];

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
@@ -6,9 +6,9 @@
 #import "WPTableViewSectionFooterView.h"
 #import "WordPress-Swift.h"
 #import "WPLogger.h"
+#import "WPGUIConstants.h"
 
 static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
-static CGFloat const ActivityLogRowHeight = 44.0f;
 
 @interface ActivityLogViewController ()
 
@@ -44,12 +44,7 @@ static CGFloat const ActivityLogRowHeight = 44.0f;
 {
     [super viewDidLoad];
     
-    if ([UIDevice isOS8]) { // iOS8 or higher
-        [self.tableView setEstimatedRowHeight:ActivityLogRowHeight];
-        [self.tableView setRowHeight:UITableViewAutomaticDimension];
-    } else {
-        [self.tableView setRowHeight:ActivityLogRowHeight];
-    }
+    [self.tableView setRowHeight:WPTableViewDefaultRowHeight];
     
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self loadLogFiles];

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -33,8 +33,6 @@ int const kHelpshiftWindowTypeConversation = 2;
 
 static NSString *const FeedbackCheckUrl = @"https://api.wordpress.org/iphoneapp/feedback-check/1.0/";
 
-static CGFloat const SupportRowHeight = 44.0f;
-
 @interface SupportViewController () <UIViewControllerRestoration>
 
 @property (nonatomic, assign) BOOL feedbackEnabled;
@@ -147,12 +145,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionFeedbackRows)
 {
     [super viewDidLoad];
     
-    if ([UIDevice isOS8]) { // iOS8 or higher
-        [self.tableView setEstimatedRowHeight:SupportRowHeight];
-        [self.tableView setRowHeight:UITableViewAutomaticDimension];
-    } else {
-        [self.tableView setRowHeight:SupportRowHeight];
-    }
+    [self.tableView setRowHeight:WPTableViewDefaultRowHeight];
     
     if (UIDevice.isPad) {
         self.tableView.tableHeaderView = [[UIView alloc] initWithFrame:WPTableHeaderPadFrame];


### PR DESCRIPTION
We've noticed that row heights are inconsistent in several spots of the app. Standard UITableViewCell's should be 44pt in height, while the `Site Row` [ Icon + Title + Description ] should be 54pt.

Props to @drw158 for the metrics / feedback on this one.

-- 

#### Steps:
1. Log into your account
2. Verify that the following sections look great:
2.A. `My Sites`: Blogs rows should be 54pt height (44pt for the rest)
2.B. `My Sites` > `Site Details`
2.C. `My Sites` > `Site Details` > `Settings`
2.D. `Me`
2.E. `Me` > `Help + Support`
2.F. `Me` > `Help + Support` > `Activity Logs`

Needs Review: @aerych mind taking a look at this one?

[Sample Screenshots (Broken vs Fixed) can be found here](https://cloudup.com/cD1K4xN2oZs)
Thanks in advance!