### PR TITLE
Preventing Unauthenticated WebViews

### DIFF
--- a/WordPress/Classes/Utility/WPWebViewController+Auth.swift
+++ b/WordPress/Classes/Utility/WPWebViewController+Auth.swift
@@ -1,0 +1,31 @@
+import UIKit
+
+
+
+/**
+*  @extension       WPWebViewController
+*  @brief           This Extension encapsulates all of the Authentication related features that are 100% 
+*                   tied up to the WordPress data model, so that the main WPWebViewController class
+*                   may be distributed (in the future) in a separate repository.
+*/
+
+extension WPWebViewController {
+
+    /**
+    *  @brief       This class helper method will return a WPWebViewController instance, already
+    *               preinitialized with the Main Account's Username and Bearer Token (if any).
+    */
+    public class func authenticatedWebViewController(URL: NSURL!) -> WPWebViewController {
+        assert(URL != nil)
+        
+        let webViewController = WPWebViewController(URL: URL)
+        let service = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+
+        if let defaultAccount = service.defaultWordPressComAccount() {
+            webViewController.username  = defaultAccount.username
+            webViewController.authToken = defaultAccount.authToken
+        }
+        
+        return webViewController
+    }
+}

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -443,7 +443,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 
 - (void)openWebViewWithURL:(NSURL *)url
 {
-    WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:url];
+    WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:url];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -958,16 +958,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
         return NO;
     }
     
-    WPWebViewController *webViewController  = [WPWebViewController webViewControllerWithURL:url];
-    if (url.isWordPressDotComUrl) {
-        NSManagedObjectContext *context     = [[ContextManager sharedInstance] mainContext];
-        AccountService *accountService      = [[AccountService alloc] initWithManagedObjectContext:context];
-        WPAccount *account                  = accountService.defaultWordPressComAccount;
-        
-        webViewController.username          = account.username;
-        webViewController.authToken         = account.authToken;
-    }
-    
+    WPWebViewController *webViewController  = [WPWebViewController authenticatedWebViewController:url];
     UINavigationController *navController   = [[UINavigationController alloc] initWithRootViewController:webViewController];
     
     [self presentViewController:navController animated:YES completion:nil];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderBrowseSiteViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBrowseSiteViewController.m
@@ -246,7 +246,7 @@
 - (void)attributionViewDidReceiveAvatarAction:(WPContentAttributionView *)attributionView
 {
     NSURL *targetURL = [NSURL URLWithString:self.siteURL];
-    WPWebViewController *controller = [WPWebViewController webViewControllerWithURL:targetURL];
+    WPWebViewController *controller = [WPWebViewController authenticatedWebViewController:targetURL];
     
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:controller];
     [self presentViewController:navController animated:YES completion:nil];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1101,7 +1101,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 
 - (void)commentCell:(UITableViewCell *)cell linkTapped:(NSURL *)url
 {
-    WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:url];
+    WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:url];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];
 }
@@ -1142,7 +1142,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
         linkURL = [NSURL URLWithString:linkURL.path relativeToURL:url];
     }
 
-    WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:linkURL];
+    WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:linkURL];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];
 }
@@ -1155,7 +1155,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
     if (isSupportedNatively) {
         controller = [[WPImageViewController alloc] initWithImage:imageControl.imageView.image andURL:imageControl.linkURL];
     } else if (imageControl.linkURL) {
-        WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:imageControl.linkURL];
+        WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:imageControl.linkURL];
         controller = [[UINavigationController alloc] initWithRootViewController:webViewController];
     } else {
         controller = [[WPImageViewController alloc] initWithImage:imageControl.imageView.image];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
@@ -541,7 +541,7 @@ NSString * const ReaderPixelStatReferrer = @"https://wordpress.com/";
 
 - (void)presentWebViewControllerWithLink:(NSURL *)linkURL
 {
-    WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:linkURL];
+    WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:linkURL];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];
 }

--- a/WordPress/Classes/ViewRelated/Stats/StatsWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsWebViewController.m
@@ -11,6 +11,7 @@
 #import "AccountService.h"
 #import "WPCookie.h"
 #import "UIDevice+Helpers.h"
+#import "WordPress-Swift.h"
 
 NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
 
@@ -408,7 +409,7 @@ NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
 
         if ([host rangeOfString:@"wordpress.com"].location == NSNotFound ||
             [query rangeOfString:@"no-chrome"].location == NSNotFound) {
-            WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:request.URL];
+            WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:request.URL];
             [self.navigationController pushViewController:webViewController animated:YES];
             return NO;
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
 		B535209D1AF7EB9F00B33BA8 /* PushAuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B535209C1AF7EB9F00B33BA8 /* PushAuthenticationService.swift */; };
 		B535209F1AF7EFEC00B33BA8 /* PushAuthenticationServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B535209E1AF7EFEC00B33BA8 /* PushAuthenticationServiceRemote.swift */; };
 		B53FDF6D19B8C336000723B6 /* UIScreen+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53FDF6C19B8C336000723B6 /* UIScreen+Helpers.swift */; };
+		B54106901B6FE38400C880D0 /* WPWebViewController+Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = B541068F1B6FE38400C880D0 /* WPWebViewController+Auth.swift */; };
 		B548458219A258890077E7A5 /* UIActionSheet+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = B548458119A258890077E7A5 /* UIActionSheet+Helpers.m */; };
 		B54866CA1A0D7042004AC79D /* NSAttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54866C91A0D7042004AC79D /* NSAttributedString+Helpers.swift */; };
 		B54E1DF01A0A7BAA00807537 /* ReplyBezierView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54E1DED1A0A7BAA00807537 /* ReplyBezierView.swift */; };
@@ -1219,6 +1220,7 @@
 		B535209C1AF7EB9F00B33BA8 /* PushAuthenticationService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationService.swift; sourceTree = "<group>"; };
 		B535209E1AF7EFEC00B33BA8 /* PushAuthenticationServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationServiceRemote.swift; sourceTree = "<group>"; };
 		B53FDF6C19B8C336000723B6 /* UIScreen+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIScreen+Helpers.swift"; sourceTree = "<group>"; };
+		B541068F1B6FE38400C880D0 /* WPWebViewController+Auth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPWebViewController+Auth.swift"; sourceTree = "<group>"; };
 		B54810F61AA656B40081B54D /* WordPress 28.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 28.xcdatamodel"; sourceTree = "<group>"; };
 		B548458019A258890077E7A5 /* UIActionSheet+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIActionSheet+Helpers.h"; sourceTree = "<group>"; };
 		B548458119A258890077E7A5 /* UIActionSheet+Helpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIActionSheet+Helpers.m"; sourceTree = "<group>"; };
@@ -2759,6 +2761,7 @@
 				5D6C4B011B603D1F005E3C43 /* WPWebViewController.xib */,
 				E1B62A7913AA61A100A6FCA4 /* WPWebViewController.h */,
 				E1B62A7A13AA61A100A6FCA4 /* WPWebViewController.m */,
+				B541068F1B6FE38400C880D0 /* WPWebViewController+Auth.swift */,
 				B526DC271B1E47FC002A8C5F /* WPStyleGuide+WebView.h */,
 				B526DC281B1E47FC002A8C5F /* WPStyleGuide+WebView.m */,
 			);
@@ -4037,6 +4040,7 @@
 				5D2415CB1A8842C9009BD444 /* ReaderPreviewHeaderView.m in Sources */,
 				5D1EE80215E7AF3E007F1F02 /* JetpackSettingsViewController.m in Sources */,
 				5D3E334E15EEBB6B005FC6F2 /* ReachabilityUtils.m in Sources */,
+				B54106901B6FE38400C880D0 /* WPWebViewController+Auth.swift in Sources */,
 				BE13B3E71B2B58D800A4211D /* BlogListViewController.m in Sources */,
 				5DC3A44D1610B9BC00A890BE /* UINavigationController+Rotation.m in Sources */,
 				B532D4E9199D4357006E4DF6 /* NoteBlockCommentTableViewCell.swift in Sources */,


### PR DESCRIPTION
I've recently come across a problem in which opening a link to a private blog, from within the Reader Post Details VC, would result in a WebView Authentication request.

Sadly, simply toggling `PrivateSiteURLProtocol` doesn't do the trick: the **bearerToken** must be sent to the `wp-login.php` endpoint, so that UIWebView gets the required cookie. 

For this reason, i've opted for implementing a simple **WPWebViewController** extension, that will pre-initialize the `username` and `bearerToken` fields with the default WordPress.com account's values, so that we just don't duplicate the same snippet all over.

--

#### Scenario A: Protected Blog from Reader Details
1. Fresh install
2. Log into your main WordPress.com account
3. Open a post that contains a link to a private blog, and tap on it

As a result, the WPWebViewController should be onscreen, but the contents should become visible shortly after: we shouldn't require further authentication.


--

#### Scenario B: Protected Blog from Reader Comments
1. Fresh install
2. Log into your main WordPress.com account
3. Open a Post's comments that contains links to a private site, and tap on it

As a result, the WPWebViewController should be onscreen, but the contents should become visible shortly after: we shouldn't require further authentication.


--

#### Scenario C: Protected Blog from Notification Details
1. Fresh install
2. Log into your main WordPress.com account
3. Open a Notification that contains links to protected sites (ie. a Stats / Badge notification), and tap over the link

As a result, the WPWebViewController should be onscreen, but the contents should become visible shortly after: we shouldn't require further authentication.


--

#### Scenario D: Protected Blog from Site Comments
1. Fresh install
2. Log into your main WordPress.com account
3. Open a Site
4. Open the Comments List
5. Tap over a comment that contains a link to a protected site, and open the link

As a result, the WPWebViewController should be onscreen, but the contents should become visible shortly after: we shouldn't require further authentication.


--

#### Scenario E: Protected Blog from Browse Site
1. Fresh install
2. Log into your main WordPress.com account
3. Open the Browse Site screen, for a protected blog
4. Tap over the Site's icon

As a result, the WPWebViewController should be onscreen, but the contents should become visible shortly after: we shouldn't require further authentication.


Needs Review: @aerych (Thanks!!!)
