### PR TITLE
Adds default http scheme if absent from url.

### DIFF
--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -260,7 +260,14 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
     if (_url == theURL) {
         return;
     }
-    
+
+    // If the URL has no scheme defined, default to http.
+    if (![theURL.scheme hasPrefix:@"http"]) {
+        NSURLComponents *components = [NSURLComponents componentsWithURL:theURL resolvingAgainstBaseURL:NO];
+        components.scheme = @"http";
+        theURL = [components URL];
+    }
+
     _url = theURL;
     
     // Prevent double load in viewDidLoad Method


### PR DESCRIPTION
Closes #4113 

To test:
You will need a notification, or a post, or comment in the reader that includes a link without a scheme. Something to the effect of `//aerychtest.wordpress.com`.  In the reader any p2 theme site mention (+blogname) should do. 

Set a break point in `setUrl:` to observe the value being passed and confirm its missing a scheme. 
Set a break point after the patch to confirm the default scheme was added. 
Set a break point inside the patch to confirm that URLs with a scheme already defined are not edited. 

Needs Review : @jleandroperez 

