### PR TITLE
Removes unused code from WPAccount.

### DIFF
--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -4,7 +4,6 @@
 
 @interface WPAccount ()
 @property (nonatomic, strong, readwrite) WordPressComApi *restApi;
-@property (nonatomic, strong, readwrite) WordPressXMLRPCApi *xmlrpcApi;
 @end
 
 @implementation WPAccount
@@ -19,7 +18,6 @@
 @dynamic userID;
 @dynamic avatarURL;
 @synthesize restApi = _restApi;
-@synthesize xmlrpcApi = _xmlrpcApi;
 
 #pragma mark - NSManagedObject subclass methods
 
@@ -33,8 +31,6 @@
     // Beware: Lazy getters below. Let's hit directly the ivar
     [_restApi.operationQueue cancelAllOperations];
     [_restApi reset];
-
-    [_xmlrpcApi.operationQueue cancelAllOperations];
     
     self.authToken = nil;
 }
@@ -44,7 +40,6 @@
     [super didTurnIntoFault];
     
     self.restApi = nil;
-    self.xmlrpcApi = nil;
 }
 
 #pragma mark - Custom accessors


### PR DESCRIPTION
Removes unused code from `WPAccount`.

**How to test:**
- Make sure no other references exist to the removed property.
- Make sure the unit tests run as usual.
- Make sure the app builds as usual.

/cc @aerych 