### PR TITLE
Issues/4121 update pod and fonts

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,7 +30,7 @@ pod 'MGImageUtilities', :git => 'git://github.com/wordpress-mobile/MGImageUtilit
 pod 'NSObject-SafeExpectations', '0.0.2'
 pod 'Simperium', '0.7.9'
 pod 'WordPressApi', '~> 0.3.4'
-pod 'WordPress-iOS-Shared', '0.4.2'
+pod 'WordPress-iOS-Shared', '0.4.3'
 pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => 'a983547b5724d5fc3b79865da83e81db2b0b9de4'
 pod 'WordPressCom-Stats-iOS', '0.4.3'
 pod 'WordPressCom-Analytics-iOS', '0.0.35'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -140,7 +140,7 @@ PODS:
     - UIAlertView+Blocks (~> 0.8.1)
     - WordPress-iOS-Shared (~> 0.3)
     - WordPressCom-Analytics-iOS (~> 0.0.30)
-  - WordPress-iOS-Shared (0.4.2):
+  - WordPress-iOS-Shared (0.4.3):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
   - WordPressApi (0.3.4):
@@ -195,7 +195,7 @@ DEPENDENCIES:
     `303b8068530389ea87afde38b77466d685fe3210`)
   - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`,
     commit `a983547b5724d5fc3b79865da83e81db2b0b9de4`)
-  - WordPress-iOS-Shared (= 0.4.2)
+  - WordPress-iOS-Shared (= 0.4.3)
   - WordPressApi (~> 0.3.4)
   - WordPressCom-Analytics-iOS (= 0.0.35)
   - WordPressCom-Stats-iOS (= 0.4.3)
@@ -281,7 +281,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 2eb1070f189a069184611e21b5e8832443e6f8ec
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
   WordPress-iOS-Editor: 3ed3f3f1eb226b34542b471a7db41419815bbf28
-  WordPress-iOS-Shared: 310e1c872584303a6f28f62e83085cdd44051711
+  WordPress-iOS-Shared: 20307f6ca50f833cf6bbf98f3a7ef7643d90ce8c
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
   WordPressCom-Analytics-iOS: a6c71241b39f1e366a6473ce38f2786481f8acd8
   WordPressCom-Stats-iOS: 2810300d77c2d37594d0e4a79145094c517d6c73

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -397,7 +397,13 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     [[AFNetworkActivityIndicatorManager sharedManager] setEnabled:YES];
     self.userAgent = [[WPUserAgent alloc] init];
     [self setupSingleSignOn];
-    
+
+    // WORKAROUND: Preload the Merriweather regular font to ensure it is not overridden
+    // by any of the Merriweather varients.  Size is arbitrary.
+    // See: https://github.com/wordpress-mobile/WordPress-Shared-iOS/issues/79
+    // Remove this when #79 is resolved.
+    [WPFontManager merriweatherRegularFontOfSize:16.0];
+
     [self customizeAppearance];
     
     // Push notifications

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -96,9 +96,9 @@ extension WPStyleGuide
         public static let badgeQuotedStyle          = blockQuotedStyle
         
         //  Blocks
-        public static let contentBlockRegularFont   = WPFontManager.merriweatherLightFontOfSize(blockFontSize)
-        public static let contentBlockBoldFont      = WPFontManager.merriweatherRegularFontOfSize(blockFontSize)
-        public static let contentBlockItalicFont    = WPFontManager.merriweatherLightItalicFontOfSize(blockFontSize)
+        public static let contentBlockRegularFont   = WPFontManager.merriweatherRegularFontOfSize(blockFontSize)
+        public static let contentBlockBoldFont      = WPFontManager.merriweatherBoldFontOfSize(blockFontSize)
+        public static let contentBlockItalicFont    = WPFontManager.merriweatherItalicFontOfSize(blockFontSize)
         public static let blockRegularFont          = WPFontManager.openSansRegularFontOfSize(blockFontSize)
         public static let blockBoldFont             = WPFontManager.openSansSemiBoldFontOfSize(blockFontSize)
 

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Reply.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Reply.swift
@@ -8,7 +8,7 @@ extension WPStyleGuide
         // Styles used by ReplyTextView
         //
         public static let buttonFont       = WPFontManager.openSansBoldFontOfSize(13)
-        public static let textFont         = WPFontManager.merriweatherLightFontOfSize(14)
+        public static let textFont         = WPFontManager.merriweatherRegularFontOfSize(14)
 
         public static let enabledColor     = WPStyleGuide.newKidOnTheBlockBlue()
         public static let disabledColor    = UIColor(red: 0xA1/255.0, green: 0xB9/255.0, blue: 0xCA/255.0, alpha: 0xFF/255.0)

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -137,7 +137,7 @@
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager merriweatherLightFontOfSize:fontSize]};
+    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager merriweatherRegularFontOfSize:fontSize]};
 }
 
 + (NSDictionary *)postCardDateAttributes

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostRichContentView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostRichContentView.m
@@ -92,7 +92,7 @@
 - (NSDictionary *)attributesForAttributedStringForTitle
 {
     CGFloat fontSize = [UIDevice isPad] ? 32.0 : 18.0;
-    UIFont *font = [WPFontManager merriweatherRegularFontOfSize:fontSize];
+    UIFont *font = [WPFontManager merriweatherBoldFontOfSize:fontSize];
 
     CGFloat lineHeight = [UIDevice isPad] ? 40.0 : 24.0;
     NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPreviewHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPreviewHeaderView.m
@@ -35,7 +35,7 @@ static const CGFloat LabelHorizontalMargin = 8.0;
     self.label.translatesAutoresizingMaskIntoConstraints = NO;
     self.label.numberOfLines = 0;
     self.label.backgroundColor = [UIColor clearColor];
-    self.label.font = [WPFontManager openSansRegularFontOfSize:14.0];
+    self.label.font = [WPFontManager merriweatherItalicFontOfSize:14.0];
     self.label.textColor = [WPStyleGuide littleEddieGrey];
     self.label.textAlignment = NSTextAlignmentCenter;
 

--- a/WordPress/Classes/ViewRelated/Reader/WPContentView.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPContentView.m
@@ -590,7 +590,7 @@ const CGFloat WPContentViewBorderHeight = 1.0;
     }
 
     CGFloat fontSize = [UIDevice isPad] ? 16.0 : 14.0;
-    UIFont *font = [WPFontManager merriweatherLightFontOfSize:fontSize];
+    UIFont *font = [WPFontManager merriweatherRegularFontOfSize:fontSize];
 
     CGFloat lineHeight = [UIDevice isPad] ? 24.0 : 21.0;
     NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];

--- a/WordPress/Classes/ViewRelated/Views/WPRichTextView.m
+++ b/WordPress/Classes/ViewRelated/Views/WPRichTextView.m
@@ -11,7 +11,7 @@ static CGSize const WPRichTextMinimumSize = {1, 1};
 static CGFloat WPRichTextDefaultEmbedRatio = 1.778;
 static NSInteger const WPRichTextImageQuality = 65;
 NSString * const WPRichTextDefaultFontFamily = @"Merriweather";
-NSString * const WPRichTextDefaultFontName = @"MerriweatherLight";
+NSString * const WPRichTextDefaultFontName = @"Merriweather";
 
 @interface WPRichTextView()<DTAttributedTextContentViewDelegate, WPTableImageSourceDelegate>
 


### PR DESCRIPTION
Closes #4121 
Updates the shared pod and switches from Merriweather-Light to regular Merriweather for content views. 

To Review: 
Tour the app where we use the Merriweather fonts and look for the wrong font displayed.
- [x] My Sites ( post list, page list )
- [x] Reader (list, detail, comments)
- [x] Editor (visual editor)
- [x] Notifications (comments, details)

@jleandroperez Since this also updates fonts used in Notifications would you mind reviewing? 

Needs Review: @jleandroperez 