### PR TITLE
Corrects a minor UI glitch due to using the wrong values for constraint constants

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -52,6 +52,7 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 @property (nonatomic, assign) CGFloat statusViewHeight;
 @property (nonatomic, assign) CGFloat statusViewLowerMargin;
 @property (nonatomic, assign) BOOL loadImagesWhenConfigured;
+@property (nonatomic, assign) BOOL didPreserveStartingConstraintConstants;
 
 @end
 
@@ -65,14 +66,6 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
     [super awakeFromNib];
 
     [self applyStyles];
-
-    self.headerViewHeight = self.headerViewHeightConstraint.constant;
-    self.headerViewLowerMargin = self.headerViewLowerConstraint.constant;
-    self.titleViewLowerMargin = self.titleLowerConstraint.constant;
-    self.snippetViewLowerMargin = self.snippetLowerConstraint.constant;
-    self.dateViewLowerMargin = self.dateViewLowerConstraint.constant;
-    self.statusViewHeight = self.statusHeightConstraint.constant;
-    self.statusViewLowerMargin = self.statusViewLowerConstraint.constant;
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
@@ -84,6 +77,24 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
     return [super hitTest:point withEvent:event];
 }
 
+- (void)didMoveToSuperview
+{
+    [super didMoveToSuperview];
+    if (self.didPreserveStartingConstraintConstants) {
+        return;
+    }
+    // When awakeFromNib is called, constraint constants have the default values for
+    // any w, any h. The constant values for the correct size class are not applied until
+    // the view is first moved to its superview. When this happens, it will override any
+    // value that has been assigned in the interrum.
+    // Preserve starting constraint constants once the view has been added to a window
+    // (thus getting a layout pass) and flag that they've been preserved. Then configure
+    // the cell if needed.
+    [self preserveStartingConstraintConstants];
+    if (self.contentProvider) {
+        [self configureCell:self.contentProvider loadingImages:self.loadImagesWhenConfigured];
+    }
+}
 
 #pragma mark - Accessors
 
@@ -147,22 +158,6 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 {
     [super setBackgroundColor:backgroundColor];
     self.innerContentView.backgroundColor = backgroundColor;
-}
-
-- (void)setContentProvider:(id<WPPostContentViewProvider>)contentProvider
-{
-    _contentProvider = contentProvider;
-
-    [self configureHeader];
-    [self configureCardImage];
-    [self configureTitle];
-    [self configureSnippet];
-    [self configureDate];
-    [self configureStatusView];
-    [self configureMetaButtons];
-    [self configureActionBar];
-
-    [self setNeedsUpdateConstraints];
 }
 
 - (id<WPPostContentViewProvider>)providerOrRevision
@@ -231,6 +226,19 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 #pragma mark - Configuration
 
+- (void)preserveStartingConstraintConstants
+{
+    self.headerViewHeight = self.headerViewHeightConstraint.constant;
+    self.headerViewLowerMargin = self.headerViewLowerConstraint.constant;
+    self.titleViewLowerMargin = self.titleLowerConstraint.constant;
+    self.snippetViewLowerMargin = self.snippetLowerConstraint.constant;
+    self.dateViewLowerMargin = self.dateViewLowerConstraint.constant;
+    self.statusViewHeight = self.statusHeightConstraint.constant;
+    self.statusViewLowerMargin = self.statusViewLowerConstraint.constant;
+
+    self.didPreserveStartingConstraintConstants = YES;
+}
+
 - (void)applyStyles
 {
     [WPStyleGuide applyPostCardStyle:self];
@@ -255,6 +263,21 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 {
     self.loadImagesWhenConfigured = loadImages;
     self.contentProvider = contentProvider;
+
+    if (!self.didPreserveStartingConstraintConstants) {
+        return;
+    }
+
+    [self configureHeader];
+    [self configureCardImage];
+    [self configureTitle];
+    [self configureSnippet];
+    [self configureDate];
+    [self configureStatusView];
+    [self configureMetaButtons];
+    [self configureActionBar];
+
+    [self setNeedsUpdateConstraints];
 }
 
 - (void)configureHeader


### PR DESCRIPTION
This addresses a minor positioning glitch in some post cards due to the wrong value for constraint constants being used. 

When awakeFromNib is called, constraint constants have the default values for any w, any h. The constant values for the correct size class are not applied until the view is first moved to its superview. When this happens, it will override any value that has been assigned in the interrum. Hence the glitch. 

This patch implements a work around to preserve constant values after they have been updated for the relevant size class, and to configure a cell after this occurs.

Needs Review: @jleandroperez 

#### Before:
![ios simulator screen shot aug 6 2015 3 52 41 pm](https://cloud.githubusercontent.com/assets/1435271/9123279/23a014ce-3c54-11e5-90b6-9446244a4096.png)


#### After:
![ios simulator screen shot aug 6 2015 3 52 56 pm](https://cloud.githubusercontent.com/assets/1435271/9123285/28cfedca-3c54-11e5-90e5-31516b047777.png)
