### PR TITLE
Removes superfluous (and breaking) constraint.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -181,7 +181,7 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
                                                                   relatedBy:NSLayoutRelationEqual
                                                                      toItem:nil
                                                                   attribute:NSLayoutAttributeNotAnAttribute
-                                                                 multiplier:1.f
+                                                                 multiplier:1.0
                                                                    constant:headerWidth]];
         // Center the headerView inside the wrapper
         [headerWrapper addConstraint:[NSLayoutConstraint constraintWithItem:self.headerView
@@ -189,14 +189,8 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
                                                                   relatedBy:NSLayoutRelationEqual
                                                                      toItem:headerWrapper
                                                                   attribute:NSLayoutAttributeCenterX
-                                                                 multiplier:1.f
-                                                                   constant:0.f]];
-        // Then, horizontally constrain the headerWrapper
-        [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-[headerWrapper]-|"
-                                                                          options:0
-                                                                          metrics:metrics
-                                                                            views:views]];
-        
+                                                                 multiplier:1.0
+                                                                   constant:0.0]];
     } else {
         // Pin the headerWrapper to its superview AND wrap the headerView in horizontal margins
         [headerWrapper addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-(horizontalMargin)-[_headerView]-(horizontalMargin)-|"


### PR DESCRIPTION
Fixes #3822 

The constraint in question is actually not needed. 

To test:

Visit the site detail screen in the iPad simulator and navigate between its different features (stats, comments, posts, pages). 
Confirm the header view maintains its correct layout and position, even during rotation.

Needs Review: @SergioEstevao 