### PR TITLE
Make primary blog first

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -613,7 +613,10 @@ static CGFloat const BLVCSiteRowHeight = 54.0;
 
     NSManagedObjectContext *moc = [[ContextManager sharedInstance] mainContext];
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Blog"];
-    [fetchRequest setSortDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"blogName" ascending:YES selector:@selector(localizedCaseInsensitiveCompare:)]]];
+    [fetchRequest setSortDescriptors:@[
+                                       [NSSortDescriptor sortDescriptorWithKey:@"accountForDefaultBlog" ascending:NO],
+                                       [NSSortDescriptor sortDescriptorWithKey:@"blogName" ascending:YES selector:@selector(localizedCaseInsensitiveCompare:)]
+                                       ]];
     [fetchRequest setPredicate:[self fetchRequestPredicate]];
 
     _resultsController = [[NSFetchedResultsController alloc]

--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
@@ -226,7 +226,10 @@ static NSString *const BlogCellIdentifier = @"BlogCell";
 
     NSManagedObjectContext *moc = [[ContextManager sharedInstance] mainContext];
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Blog"];
-    [fetchRequest setSortDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"blogName" ascending:YES selector:@selector(localizedCaseInsensitiveCompare:)]]];
+    [fetchRequest setSortDescriptors:@[
+                                       [NSSortDescriptor sortDescriptorWithKey:@"accountForDefaultBlog" ascending:NO],
+                                       [NSSortDescriptor sortDescriptorWithKey:@"blogName" ascending:YES selector:@selector(localizedCaseInsensitiveCompare:)]
+                                       ]];
     [fetchRequest setPredicate:[self fetchRequestPredicate]];
 
     _resultsController = [[NSFetchedResultsController alloc]


### PR DESCRIPTION
Sort the site list and site picker so that the primary blog appears first.

I'm not too happy with the readability of the code but it seemed like the simplest option: since core data relationships have to have an inverse, `accountForDefaultBlog` will only be set for the default
account's default blog. It will be nil for all the other blogs.

Fixes #2599 

Needs Review: @astralbodies 