### PR TITLE
Unregister data source observer on media library.

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -118,7 +118,7 @@
         return;
     }
     [self.deviceLibraryDataSource unregisterChangeObserver:keys[0]];
-    [self.mediaLibraryDataSource registerChangeObserverBlock:keys[1]];
+    [self.mediaLibraryDataSource unregisterChangeObserver:keys[1]];
 }
 
 - (void)loadDataWithSuccess:(WPMediaChangesBlock)successBlock


### PR DESCRIPTION
Fix crash on media picker.

To test it just open the media picker on a new post, switch to WP media library and the switch back again to other library. 

Needs Review: @sendhil 