### PR TITLE
CommentViewController: Fixing clipped text

### DIFF
--- a/WordPress/Classes/Extensions/NSAttributedString+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSAttributedString+Helpers.swift
@@ -4,9 +4,12 @@ import Foundation
 extension NSAttributedString
 {
     /**
-        Note:
-        This method will embed a collection of assets, in the specified NSRange's. Since NSRange is an ObjC struct,
-        you'll need to wrap it up into a NSValue instance!
+    *  @brief       Checks if a given Push Notification is a Push Authentication.
+    *  @details     This method will embed a collection of assets, in the specified NSRange's.
+    *               Since NSRange is an ObjC struct, you'll need to wrap it up into a NSValue instance!
+    *
+    *  @param       embeds  A colleciton of embeds. NSRange > UIImage.
+    *  @returns             An attributed string with all of the embeds specified, inlined.
     */
     public func stringByEmbeddingImageAttachments(embeds: [NSValue: UIImage]?) -> NSAttributedString {
         // Allow nil embeds: behave as a simple NO-OP
@@ -40,5 +43,22 @@ extension NSAttributedString
         }
         
         return theString
+    }
+
+    /**
+    *  @details     This helper method return a new NSAttributedString instance, with all of the
+    *               the trailing newLines characters removed.
+    */
+    public func trimTrailingNewlines() -> NSMutableAttributedString {
+        let trimmed         = mutableCopy() as! NSMutableAttributedString
+        let characterSet    = NSCharacterSet.newlineCharacterSet()
+        var range           = (trimmed.string as NSString).rangeOfCharacterFromSet(characterSet, options: .BackwardsSearch)
+
+        while range.length != 0 && NSMaxRange(range) == length {
+            trimmed.replaceCharactersInRange(range, withString: String())
+            range = (trimmed.string as NSString).rangeOfCharacterFromSet(characterSet, options: .BackwardsSearch)
+        }
+
+        return trimmed
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -669,12 +669,13 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     // Merge the Attachments with their ranges: [NSRange: UIImage]
     NSDictionary *mediaMap          = [self.mediaDownloader imagesForUrls:commentBlock.imageUrls];
     NSDictionary *mediaRanges       = [commentBlock buildRangesToImagesMap:mediaMap];
+    NSAttributedString *text        = [commentBlock.attributedRichText stringByEmbeddingImageAttachments:mediaRanges];
     
     // Setup the cell
     cell.name                       = userBlock.text;
     cell.timestamp                  = [self.note.timestampAsDate shortString];
     cell.site                       = userBlock.metaTitlesHome ?: userBlock.metaLinksHome.hostname;
-    cell.attributedCommentText      = [commentBlock.attributedRichText stringByEmbeddingImageAttachments:mediaRanges];
+    cell.attributedCommentText      = [text trimTrailingNewlines];
     cell.isApproved                 = [commentBlock isCommentApproved];
     cell.hasReply                   = self.note.hasReply;
     

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
@@ -85,6 +85,17 @@ import Foundation
         // Setup Recognizers
         detailsLabel.gestureRecognizers     = [ UITapGestureRecognizer(target: self, action: "detailsWasPressed:") ]
         detailsLabel.userInteractionEnabled = true
+        
+        // Force iPad Size Class
+        // Why? why, why?. Because, although it's set as a Size Class, Autolayout won't actually apply the 
+        // right Gravatar Size until this view moves to a superview. 
+        // And guess what? Autosizing cells are, of course, broken in iOS 8, non existant in iOS 7, and we need
+        // to perform our own calculation.
+        // 
+        if UIDevice.isPad() {
+            gravatarImageView.updateConstraint(.Width, constant: gravatarPadSize.width)
+            gravatarImageView.updateConstraint(.Height, constant: gravatarPadSize.height)
+        }
     }
     
 
@@ -152,6 +163,7 @@ import Foundation
     private let separatorApprovedInsets             = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 12.0)
     private let separatorUnapprovedInsets           = UIEdgeInsetsZero
     private let separatorRepliedInsets              = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 0.0)
+    private let gravatarPadSize                     = CGSize(width: 37.0, height: 37.0)
     
     // MARK: - Private Properties
     private var gravatarURL                         : NSURL?

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.xib
@@ -14,7 +14,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="84"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="B30-uC-0a3" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="B30-uC-0a3" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                         <rect key="frame" x="12" y="12" width="32" height="32"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="32" id="Sje-MT-U6A">
@@ -53,11 +53,11 @@
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rgQ-sb-b7a" userLabel="RichTextView" customClass="RichTextView" customModule="WordPress">
+                    <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="rgQ-sb-b7a" userLabel="RichTextView" customClass="RichTextView" customModule="WordPress">
                         <rect key="frame" x="12" y="49" width="296" height="32"/>
                         <color key="backgroundColor" red="0.9215686917" green="0.93333339689999995" blue="0.94901967050000002" alpha="1" colorSpace="deviceRGB"/>
                         <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="250" constant="28" id="HVC-nW-KvN"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="28" id="HVC-nW-KvN"/>
                         </constraints>
                     </view>
                 </subviews>
@@ -69,7 +69,7 @@
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="J2Y-Yo-5I1" secondAttribute="trailing" constant="12" id="LXd-FQ-8Ae"/>
                     <constraint firstItem="rgQ-sb-b7a" firstAttribute="leading" secondItem="GbU-dc-vAM" secondAttribute="leading" constant="12" id="QTB-tP-wi2"/>
                     <constraint firstItem="0nV-U0-dRc" firstAttribute="top" secondItem="J2Y-Yo-5I1" secondAttribute="bottom" id="Uin-gr-pfZ"/>
-                    <constraint firstAttribute="bottom" secondItem="rgQ-sb-b7a" secondAttribute="bottom" constant="8" id="VBO-oK-bJU"/>
+                    <constraint firstAttribute="bottom" secondItem="rgQ-sb-b7a" secondAttribute="bottom" priority="750" constant="8" id="VBO-oK-bJU"/>
                     <constraint firstAttribute="trailing" secondItem="rgQ-sb-b7a" secondAttribute="trailing" constant="12" id="daK-C6-Tws"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="0nV-U0-dRc" secondAttribute="trailing" constant="12" id="m06-h3-RyG"/>
                     <constraint firstItem="B30-uC-0a3" firstAttribute="leading" secondItem="GbU-dc-vAM" secondAttribute="leading" constant="12" id="pGd-sN-jcQ"/>

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.xib
@@ -7,8 +7,8 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="90" id="zZv-EA-ZPR" userLabel="Comment" customClass="NoteBlockCommentTableViewCell" customModule="WordPress">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="90"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="100" id="zZv-EA-ZPR" userLabel="Comment" customClass="NoteBlockCommentTableViewCell" customModule="WordPress">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="100"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zZv-EA-ZPR" id="GbU-dc-vAM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="84"/>
@@ -54,7 +54,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="rgQ-sb-b7a" userLabel="RichTextView" customClass="RichTextView" customModule="WordPress">
-                        <rect key="frame" x="12" y="49" width="296" height="32"/>
+                        <rect key="frame" x="12" y="49" width="296" height="28"/>
                         <color key="backgroundColor" red="0.9215686917" green="0.93333339689999995" blue="0.94901967050000002" alpha="1" colorSpace="deviceRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="28" id="HVC-nW-KvN"/>
@@ -69,7 +69,7 @@
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="J2Y-Yo-5I1" secondAttribute="trailing" constant="12" id="LXd-FQ-8Ae"/>
                     <constraint firstItem="rgQ-sb-b7a" firstAttribute="leading" secondItem="GbU-dc-vAM" secondAttribute="leading" constant="12" id="QTB-tP-wi2"/>
                     <constraint firstItem="0nV-U0-dRc" firstAttribute="top" secondItem="J2Y-Yo-5I1" secondAttribute="bottom" id="Uin-gr-pfZ"/>
-                    <constraint firstAttribute="bottom" secondItem="rgQ-sb-b7a" secondAttribute="bottom" priority="750" constant="8" id="VBO-oK-bJU"/>
+                    <constraint firstAttribute="bottom" secondItem="rgQ-sb-b7a" secondAttribute="bottom" priority="750" constant="24" id="VBO-oK-bJU"/>
                     <constraint firstAttribute="trailing" secondItem="rgQ-sb-b7a" secondAttribute="trailing" constant="12" id="daK-C6-Tws"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="0nV-U0-dRc" secondAttribute="trailing" constant="12" id="m06-h3-RyG"/>
                     <constraint firstItem="B30-uC-0a3" firstAttribute="leading" secondItem="GbU-dc-vAM" secondAttribute="leading" constant="12" id="pGd-sN-jcQ"/>


### PR DESCRIPTION
#### Steps:
1. Receive a comment on a testing blog, with the following content:
    `Logged in as dennis after linking to dmsnell on WordPress.com (and disabling the login renamer)`
2. Launch WPiOS
3. Tap over `My Sites` > `Comments`
4. Open the new comment

As a result, the text *should not* get clipped. Please, verify this one on both, iPhone and iPad devices.

#### Notes:
- The comment itself is rendered by `NoteBlockTextTableViewCell`, which is a shared component between `CommentViewController` and `NotificationDetailsViewController`.
- This bug caused by Size Classes not being applied for the layout cell.
- In order to fix this, we've both, applied a workaround for the glitch outlined above, and updated the Content Hugging priorities.
- Extra padding at the bottom of the comment has been added.
- In order to have a consistent bottom padding, `NotificationDetailsViewController` is now trimming any trailing newlines that might appear at the bottom of the Notification Comment text.

Fixes #4150

Needs review: @aerych 
Thank you!!


