### PR TITLE
Improved checks for request of media based on identifiers.

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -212,10 +212,19 @@
 
 -(id<WPMediaAsset>)mediaWithIdentifier:(NSString *)identifier
 {
+    if (!identifier) {
+        return nil;
+    }
     NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
     __block Media *media = nil;
+    NSURL *assetURL = [NSURL URLWithString:identifier];
+    if (!assetURL) {
+        return nil;
+    }
+    if (![[assetURL scheme] isEqualToString:@"x-coredata"]){
+        return nil;
+    }
     [mainContext performBlockAndWait:^{
-        NSURL *assetURL = [NSURL URLWithString:identifier];
         NSManagedObjectID *assetID = [[[ContextManager sharedInstance] persistentStoreCoordinator] managedObjectIDForURIRepresentation:assetURL];
         media = (Media *)[mainContext objectWithID:assetID];
     }];

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -80,6 +80,9 @@
 
 - (id<WPMediaAsset>)mediaWithIdentifier:(NSString *)identifier
 {
+    if (!identifier) {
+        return nil;
+    }
     id<WPMediaAsset> result = [self.deviceLibraryDataSource mediaWithIdentifier:identifier];
     if (result) {
         return result;


### PR DESCRIPTION
Fixes a less frequent crash when using the media picker. This should only happen when a selected media is deleted/removed on the background by the Photos/iCloud app.

Needs Review: @sendhil 