### PR TITLE
Removes Facebook URL Scheme

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -194,6 +194,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
 {
+    DDLogInfo(@"Application launched with URL: %@", url);
     BOOL returnValue = NO;
 
     if ([[BITHockeyManager sharedHockeyManager].authenticator handleOpenURL:url
@@ -216,7 +217,6 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
 
     if ([url isKindOfClass:[NSURL class]] && [[url absoluteString] hasPrefix:WPCOM_SCHEME]) {
         NSString *URLString = [url absoluteString];
-        DDLogInfo(@"Application launched with URL: %@", URLString);
 
         if ([URLString rangeOfString:@"newpost"].length) {
             returnValue = [self handleNewPostRequestWithURL:url];

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -31,7 +31,6 @@
 			<array>
 				<string>wordpress-oauth-v2</string>
 				<string>${WPCOM_SCHEME}</string>
-				<string>fb249643311490</string>
 				<string>pocketapp12013</string>
 			</array>
 		</dict>

--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -39,7 +39,6 @@
 			<array>
 				<string>wordpress-oauth-v2</string>
 				<string>${WPCOM_SCHEME}</string>
-				<string>fb249643311490</string>
 				<string>pocketapp12013</string>
 			</array>
 		</dict>


### PR DESCRIPTION
Fixes #4161 

We had left the Facebook URL scheme in the application from an old-SSO method from 2013 or earlier. Since we don't have the Facebook SDK in the app any more and we aren't handling the URLs being opened, remove it from the PLIST.

I noticed there was a problem when tapping on some posts from the Facebook iOS app caused WPiOS to launch. Nothing would appear in the WPiOS app.

Needs Review: @sendhil