### PR TITLE
Resets a derived context before merging posts.

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -612,6 +612,13 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
       skippingSave:(BOOL)skippingSave
     callingSuccess:(void (^)(NSInteger count, BOOL hasMore))success
 {
+    if (self.managedObjectContext.parentContext) {
+        // Its possible the ReaderTopic was deleted in the parent context.
+        // If so, and we merge and save, it will cause a crash.
+        // Reset the context so it will be current with its parent context.
+        [self.managedObjectContext reset];
+    }
+
     // Use a performBlock here so the work to merge does not block the main thread.
     [self.managedObjectContext performBlock:^{
 

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -612,8 +612,8 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
       skippingSave:(BOOL)skippingSave
     callingSuccess:(void (^)(NSInteger count, BOOL hasMore))success
 {
-    if (self.managedObjectContext.parentContext) {
-        // Its possible the ReaderTopic was deleted in the parent context.
+    if (self.managedObjectContext.parentContext == [[ContextManager sharedInstance] mainContext]) {
+        // Its possible the ReaderTopic was deleted the parent main context.
         // If so, and we merge and save, it will cause a crash.
         // Reset the context so it will be current with its parent context.
         [self.managedObjectContext reset];

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -612,15 +612,15 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
       skippingSave:(BOOL)skippingSave
     callingSuccess:(void (^)(NSInteger count, BOOL hasMore))success
 {
-    if (self.managedObjectContext.parentContext == [[ContextManager sharedInstance] mainContext]) {
-        // Its possible the ReaderTopic was deleted the parent main context.
-        // If so, and we merge and save, it will cause a crash.
-        // Reset the context so it will be current with its parent context.
-        [self.managedObjectContext reset];
-    }
-
     // Use a performBlock here so the work to merge does not block the main thread.
     [self.managedObjectContext performBlock:^{
+
+        if (self.managedObjectContext.parentContext == [[ContextManager sharedInstance] mainContext]) {
+            // Its possible the ReaderTopic was deleted the parent main context.
+            // If so, and we merge and save, it will cause a crash.
+            // Reset the context so it will be current with its parent context.
+            [self.managedObjectContext reset];
+        }
 
         NSError *error;
         ReaderTopic *readerTopic = (ReaderTopic *)[self.managedObjectContext existingObjectWithID:topicObjectID error:&error];


### PR DESCRIPTION
Fixes #4163 

To test:
1. Be signed into a WordPress.com account
2. Switch to the reader. Open the topics menu and choose a new topic to kick off a sync.
3. Very quickly switch to the Me tab and log out of WPcom before the sync finishes. 
You can use a network link conditioner to gain a bit of time if syncs are happening too quickly. 

cc @sendhil (Turned out to be a rather simple fix.)

Needs review: @astralbodies 
