### PR TITLE
Doubles location timeout duration

### DIFF
--- a/WordPress/Classes/Utility/LocationService.m
+++ b/WordPress/Classes/Utility/LocationService.m
@@ -4,7 +4,7 @@
 
 static LocationService *instance;
 static NSInteger const LocationHorizontalAccuracyThreshold = 100; // Meters
-static NSInteger const LocationServiceTimeoutDuration = 5; // Seconds
+static NSInteger const LocationServiceTimeoutDuration = 10; // Seconds
 NSString *const LocationServiceErrorDomain = @"LocationServiceErrorDomain";
 
 @interface LocationService()<CLLocationManagerDelegate>


### PR DESCRIPTION
Increases the time out duration so places that are very slow to resolve can have a better chance of not failing. 
Prompted by a user's request: https://ios.forums.wordpress.org/topic/set-location-post-error-again?replies=4

Needs Review: @diegoreymendez 