### PR TITLE
Adds check before assigning nil value

### DIFF
--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -111,7 +111,9 @@
 
         for (NSString *key in optionsDirectMapKeys) {
             NSString *sourceKeyPath = [NSString stringWithFormat:@"options.%@", key];
-            options[key] = [response valueForKeyPath:sourceKeyPath];
+            if ([response valueForKeyPath:sourceKeyPath] != nil) {
+                options[key] = [response valueForKeyPath:sourceKeyPath];
+            }
         }
     } else {
         //valid default values


### PR DESCRIPTION
Attempts to fix a crash in 5.4.1 when mapping a nil value to a dictionary.  Stack trace:

```
Fatal Exception: NSInvalidArgumentException
*** setObjectForKey: object cannot be nil (key: allowed_file_types)

Thread : Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x00000001821a422c __exceptionPreprocess
1  libobjc.A.dylib                0x0000000193e700e4 objc_exception_throw
2  CoreFoundation                 0x000000018208d0c8 -[__NSDictionaryM setObject:forKey:]
3  WordPress                      0x0000000100190c04 -[BlogServiceRemoteREST mapOptionsFromResponse:] (BlogServiceRemoteREST.m:114)
4  WordPress                      0x000000010019041c __60-[BlogServiceRemoteREST syncOptionsForBlog:success:failure:]_block_invoke (BlogServiceRemoteREST.m:43)
5  libdispatch.dylib              0x00000001944ed994 _dispatch_call_block_and_release
6  libdispatch.dylib              0x00000001944ed954 _dispatch_client_callout
7  libdispatch.dylib              0x00000001944f220c _dispatch_main_queue_callback_4CF
8  CoreFoundation                 0x000000018215b544 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
9  CoreFoundation                 0x00000001821595ec __CFRunLoopRun
10 CoreFoundation                 0x0000000182084f74 CFRunLoopRunSpecific
11 GraphicsServices               0x000000018badf6fc GSEventRunModal
12 UIKit                          0x0000000186c86d94 UIApplicationMain
13 WordPress                      0x00000001000dfa18 main (main.m:5)
14 libdyld.dylib                  0x000000019451aa08 start
```

Needs Review: @diegoreymendez 