### PR TITLE
Comment Details Top Padding

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -345,25 +345,6 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
                 break;
         }
     }
-
-    // Check if the controller is already on the screen
-    if ([self.navigationController.visibleViewController isMemberOfClass:controllerClass]) {
-        if ([self.navigationController.visibleViewController respondsToSelector:@selector(setBlog:)]) {
-            [self.navigationController.visibleViewController performSelector:@selector(setBlog:) withObject:self.blog];
-        }
-        [self.navigationController popToRootViewControllerAnimated:NO];
-
-        return;
-    }
-
-    UIViewController *viewController = (UIViewController *)[[controllerClass alloc] init];
-    viewController.restorationIdentifier = NSStringFromClass(controllerClass);
-    viewController.restorationClass = controllerClass;
-    if ([viewController respondsToSelector:@selector(setBlog:)]) {
-        [viewController performSelector:@selector(setBlog:) withObject:self.blog];
-        [self.navigationController pushViewController:viewController animated:YES];
-    }
-
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -317,6 +317,9 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
             case BlogDetailsRowEditSite:
                 [self showSettingsForBlog:self.blog];
                 break;
+            default:
+                NSAssert(false, @"Row Handling not implemented");
+                break;
         }
     } else if ([self isGeneralSection:indexPath.section]) {
         switch (indexPath.row) {
@@ -330,6 +333,7 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
                 [self showStatsForBlog:self.blog];
                 break;
             default:
+                NSAssert(false, @"Row Handling not implemented");
                 break;
         }
     } else if ([self isPublishSection:indexPath.section]) {
@@ -342,6 +346,9 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
                 return;
             case BlogDetailsRowComments:
                 [self showCommentsForBlog:self.blog];
+                break;
+            default:
+                NSAssert(false, @"Row Handling not implemented");
                 break;
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -312,13 +312,13 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
-    if ([self isConfigurationSection:indexPath.section] && indexPath.row == BlogDetailsRowEditSite) {
-        SiteSettingsViewController *editSiteViewController = [[SiteSettingsViewController alloc] initWithBlog:self.blog];
-        [self.navigationController pushViewController:editSiteViewController animated:YES];
-    }
-
-    Class controllerClass;
-    if ([self isGeneralSection:indexPath.section]) {
+    if ([self isConfigurationSection:indexPath.section]) {
+        switch (indexPath.row) {
+            case BlogDetailsRowEditSite:
+                [self showSettingsForBlog:self.blog];
+                break;
+        }
+    } else if ([self isGeneralSection:indexPath.section]) {
         switch (indexPath.row) {
             case BlogDetailsRowViewSite:
                 [self showViewSiteForBlog:self.blog];
@@ -327,8 +327,7 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
                 [self showViewAdminForBlog:self.blog];
                 break;
             case BlogDetailsRowStats:
-                [WPAnalytics track:WPAnalyticsStatStatsAccessed];
-                controllerClass =  [StatsViewController class];
+                [self showStatsForBlog:self.blog];
                 break;
             default:
                 break;
@@ -336,16 +335,13 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     } else if ([self isPublishSection:indexPath.section]) {
         switch (indexPath.row) {
             case BlogDetailsRowBlogPosts:
-                [self showPostList];
+                [self showPostListForBlog:self.blog];
                 return;
             case BlogDetailsRowPages:
-                [self showPageList];
+                [self showPageListForBlog:self.blog];
                 return;
             case BlogDetailsRowComments:
-                [WPAnalytics track:WPAnalyticsStatOpenedComments];
-                controllerClass = [CommentsViewController class];
-                break;
-            default:
+                [self showCommentsForBlog:self.blog];
                 break;
         }
     }
@@ -437,6 +433,14 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
 #pragma mark - Private methods
 
+- (void)showCommentsForBlog:(Blog *)blog
+{
+    [WPAnalytics track:WPAnalyticsStatOpenedComments];
+    CommentsViewController *controller = [[CommentsViewController alloc] initWithStyle:UITableViewStyleGrouped];
+    controller.blog = blog;
+    [self.navigationController pushViewController:controller animated:YES];
+}
+
 - (void)showPostListForBlog:(Blog *)blog
 {
     [WPAnalytics track:WPAnalyticsStatOpenedPosts];
@@ -449,6 +453,21 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     [WPAnalytics track:WPAnalyticsStatOpenedPages];
     PageListViewController *controller = [PageListViewController controllerWithBlog:blog];
     [self.navigationController pushViewController:controller animated:YES];
+}
+
+- (void)showSettingsForBlog:(Blog *)blog
+{
+    [WPAnalytics track:WPAnalyticsStatOpenedSettings];
+    SiteSettingsViewController *controller = [[SiteSettingsViewController alloc] initWithBlog:blog];
+    [self.navigationController pushViewController:controller animated:YES];
+}
+
+- (void)showStatsForBlog:(Blog *)blog
+{
+    [WPAnalytics track:WPAnalyticsStatStatsAccessed];
+    StatsViewController *statsView = [StatsViewController new];
+    statsView.blog = blog;
+    [self.navigationController pushViewController:statsView animated:YES];
 }
 
 - (void)showViewSiteForBlog:(Blog *)blog
@@ -480,6 +499,7 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     NSString *dashboardUrl = [blog.xmlrpc stringByReplacingOccurrencesOfString:@"xmlrpc.php" withString:@"wp-admin/"];
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:dashboardUrl]];
 }
+
 
 #pragma mark - Notification handlers
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -437,15 +437,17 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
 #pragma mark - Private methods
 
-- (void)showPostList {
+- (void)showPostListForBlog:(Blog *)blog
+{
     [WPAnalytics track:WPAnalyticsStatOpenedPosts];
-    UIViewController *controller = [PostListViewController controllerWithBlog:self.blog];
+    PostListViewController *controller = [PostListViewController controllerWithBlog:blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)showPageList {
+- (void)showPageListForBlog:(Blog *)blog
+{
     [WPAnalytics track:WPAnalyticsStatOpenedPages];
-    UIViewController *controller = [PageListViewController controllerWithBlog:self.blog];
+    PageListViewController *controller = [PageListViewController controllerWithBlog:blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -291,7 +291,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
-    return CGFLOAT_MIN;
+    return [UIDevice isPad] ? UITableViewAutomaticDimension : CGFLOAT_MIN;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -41,6 +41,16 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     _tableViewHandler.delegate = nil;
 }
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.restorationClass = [self class];
+        self.restorationIdentifier = NSStringFromClass([self class]);
+    }
+    return self;
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -167,9 +167,14 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 #pragma mark - UITableViewDelegate Methods
 
-- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
-    return nil;
+    return [UIView new];
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    return [UIDevice isPad] ? UITableViewAutomaticDimension : CGFLOAT_MIN;
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
@@ -177,19 +182,9 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    return [UIView new];
-}
-
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
 {
     return [UIView new];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    return CGFLOAT_MIN;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -143,15 +143,12 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (void)configureTableViewFooter
 {
-    // iPad Fix: contentInset breaks tableSectionViews
-    if (UIDevice.isPad) {
-        self.tableView.tableHeaderView      = [[UIView alloc] initWithFrame:WPTableHeaderPadFrame];
-        self.tableView.tableFooterView      = [[UIView alloc] initWithFrame:WPTableFooterPadFrame];
-        
-    // iPhone Fix: Hide the cellSeparators, when the table is empty
-    } else {
-        self.tableView.tableFooterView      = [UIView new];
-    }
+    // Notes:
+    //  -   iPhone: Hide the cellSeparators, when the table is empty
+    //  -   iPad: contentInset breaks tableSectionViews
+    CGRect footerFrame = UIDevice.isPad ? WPTableFooterPadFrame : CGRectZero;
+    
+    self.tableView.tableFooterView = [[UIView alloc] initWithFrame:footerFrame];
 }
 
 - (void)configureTableViewLayoutCell

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -25,10 +25,12 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 @implementation StatsViewController
 
-- (id)init
+- (instancetype)init
 {
     self = [super init];
     if (self) {
+        self.restorationClass = [self class];
+        self.restorationIdentifier = NSStringFromClass([self class]);
     }
     return self;
 }


### PR DESCRIPTION
#### Details:
In this PR we're adding a top padding to `CommentViewController `, on iPad devices. Towards the #4128 goal, we're also normalizing the topPadding -within the commentsView- to be iOS's default (35pt instead of 40pt)


--


#### Steps: Comments Top Padding
1. Launch WPiOS and log into your account
2. Tap over `My Sites`
3. Open any site
4. Tap over Comments

Expected: iPhone devices should have no top padding, while iPads should get 35pt top


--


#### Steps: Comment Details Top Padding
1. Launch WPiOS and log into your account
2. Tap over `My Sites`
3. Open any site
4. Tap over Comments and open any comment

Expected: iPhone devices should have no top padding, while iPads should get 35pt top


--


#### Steps:
1. Launch WPiOS and log into your account
2. Tap over `My Sites`

Please, test all of the rows, since the handling code has been normalized / cleaned up.


Closes #4151

Needs review: @aerych 
Thank you sir!