### PR TITLE
Implements missing delegate method.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.m
@@ -65,6 +65,11 @@
     self.contentProvider = contentProvider;
 }
 
+- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider loadingImages:(BOOL)loadMedia
+{
+    [self configureCell:contentProvider];
+}
+
 
 #pragma mark - Actions
 


### PR DESCRIPTION
Fixes a crash trashing a post from the My Sites post list.

To test: 
- Navigate to the post list. 
- Tap the more button on a post cell
- Tap the trash button. 
The cell should transition to an "undo" cell and the app should not crash. 

Needs Review: @sendhil 