### PR TITLE
BlogServiceRemoteREST: Fixing settings parsing crash

### DIFF
--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -4,6 +4,14 @@
 #import "PostCategory.h"
 #import "RemoteBlogSettings.h"
 
+
+static NSString const *BlogRemoteNameKey                = @"name";
+static NSString const *BlogRemoteDescriptionKey         = @"description";
+static NSString const *BlogRemoteSettingsKey            = @"settings";
+static NSString const *BlogRemoteDefaultCategoryKey     = @"default_category";
+static NSString const *BlogRemoteDefaultPostFormatKey   = @"default_post_format";
+
+
 @implementation BlogServiceRemoteREST
 
 - (void)checkMultiAuthorForBlog:(Blog *)blog
@@ -210,23 +218,23 @@
 
 - (RemoteBlogSettings *)remoteBlogSettingFromJSONDictionary:(NSDictionary *)json
 {
-    NSDictionary *rawSettings = [json dictionaryForKey:@"settings"];
+    NSDictionary *rawSettings = [json dictionaryForKey:BlogRemoteSettingsKey];
     
     RemoteBlogSettings *remoteSettings = [RemoteBlogSettings new];
     
-    remoteSettings.name = [json stringForKey:@"name"];
-    remoteSettings.desc = [json stringForKey:@"description"];
-    remoteSettings.defaultCategory = [rawSettings numberForKey:@"default_category"] ?: @(PostCategoryUncategorized);
+    remoteSettings.name = [json stringForKey:BlogRemoteNameKey];
+    remoteSettings.desc = [json stringForKey:BlogRemoteDescriptionKey];
+    remoteSettings.defaultCategory = [rawSettings numberForKey:BlogRemoteDefaultCategoryKey] ?: @(PostCategoryUncategorized);
 
     // Note:
     // YES, the backend might send '0' as a number, OR a string value.
     // Reference: https://github.com/wordpress-mobile/WordPress-iOS/issues/4187
     //
-    if ([[rawSettings numberForKey:@"default_post_format"] isEqualToNumber:@(0)] ||
-        [[rawSettings stringForKey:@"default_post_format"] isEqualToString:@"0"]) {
+    if ([[rawSettings numberForKey:BlogRemoteDefaultPostFormatKey] isEqualToNumber:@(0)] ||
+        [[rawSettings stringForKey:BlogRemoteDefaultPostFormatKey] isEqualToString:@"0"]) {
         remoteSettings.defaultPostFormat = PostFormatStandard;
     } else {
-        remoteSettings.defaultPostFormat = [rawSettings stringForKey:@"default_post_format"];
+        remoteSettings.defaultPostFormat = [rawSettings stringForKey:BlogRemoteDefaultPostFormatKey];
     }
     
     return remoteSettings;

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -210,20 +210,21 @@
 
 - (RemoteBlogSettings *)remoteBlogSettingFromJSONDictionary:(NSDictionary *)json
 {
-    RemoteBlogSettings *remoteSettings = [[RemoteBlogSettings alloc] init];
+    NSDictionary *rawSettings = [json dictionaryForKey:@"settings"];
+    
+    RemoteBlogSettings *remoteSettings = [RemoteBlogSettings new];
     
     remoteSettings.name = [json stringForKey:@"name"];
     remoteSettings.desc = [json stringForKey:@"description"];
-    
-    if (json[@"settings"][@"default_category"]) {
-        remoteSettings.defaultCategory = [json numberForKeyPath:@"settings.default_category"];
-    } else {
-        remoteSettings.defaultCategory = @(PostCategoryUncategorized);
-    }
-    if ([json[@"settings"][@"default_post_format"] isEqualToString:@"0"]) {
+    remoteSettings.defaultCategory = [rawSettings numberForKey:@"default_category"] ?: @(PostCategoryUncategorized);
+
+    // Note:
+    // YES, the backend might send '0' as a number, OR a string value.
+    //
+    if ([[rawSettings numberForKey:@"default_post_format"] isEqualToNumber:@(0)]) {
         remoteSettings.defaultPostFormat = PostFormatStandard;
     } else {
-        remoteSettings.defaultPostFormat = [json stringForKeyPath:@"settings.default_post_format"];
+        remoteSettings.defaultPostFormat = [rawSettings stringForKey:@"default_post_format"];
     }
     
     return remoteSettings;

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -221,7 +221,8 @@
     // Note:
     // YES, the backend might send '0' as a number, OR a string value.
     //
-    if ([[rawSettings numberForKey:@"default_post_format"] isEqualToNumber:@(0)]) {
+    if ([[rawSettings numberForKey:@"default_post_format"] isEqualToNumber:@(0)] ||
+        [[rawSettings stringForKey:@"default_post_format"] isEqualToString:@"0"]) {
         remoteSettings.defaultPostFormat = PostFormatStandard;
     } else {
         remoteSettings.defaultPostFormat = [rawSettings stringForKey:@"default_post_format"];

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -220,6 +220,7 @@
 
     // Note:
     // YES, the backend might send '0' as a number, OR a string value.
+    // Reference: https://github.com/wordpress-mobile/WordPress-iOS/issues/4187
     //
     if ([[rawSettings numberForKey:@"default_post_format"] isEqualToNumber:@(0)] ||
         [[rawSettings stringForKey:@"default_post_format"] isEqualToString:@"0"]) {


### PR DESCRIPTION
#### Steps:
1. Launch WPiOS
2. Tap over My Sites
3. Open any of your blogs
4. Tap over the `Settings` row

As a result, the app _should not_ crash.

Fixes #4187
Needs Review: @diegoreymendez  || @sendhil 
 