### PR TITLE
BlogDetailsViewController: View Site should always post credentials

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -464,12 +464,10 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
     NSURL *targetURL = [NSURL URLWithString:blog.homeURL];
     WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:targetURL];
-    if (blog.isPrivate) {
-        webViewController.authToken = blog.authToken;
-        webViewController.username = blog.usernameForSite;
-        webViewController.password = blog.password;
-        webViewController.wpLoginURL = [NSURL URLWithString:blog.loginUrl];
-    }
+    webViewController.authToken = blog.authToken;
+    webViewController.username = blog.usernameForSite;
+    webViewController.password = blog.password;
+    webViewController.wpLoginURL = [NSURL URLWithString:blog.loginUrl];
     
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];


### PR DESCRIPTION
#### Steps:
1. Launch WPiOS
2. Tap over My Sites
3. Pick any of your sites and tap over `View Site`

As a result, the WebView should display your website, in a logged state. The visit shouldn't increase the Site Stats, and the user should get the admin bar.

Fixes #3461
Needs Review: @astralbodies (Thanks in advance Aaron!)
