### PR TITLE
Code quality improvements to WordPressComServiceRemote

### DIFF
--- a/WordPress/Classes/Networking/WordPressComServiceRemote.h
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.h
@@ -6,25 +6,60 @@ typedef NS_ENUM(NSUInteger, WordPressComServiceBlogVisibility) {
     WordPressComServiceBlogVisibilityHidden = 2,
 };
 
+typedef void(^WordPressComServiceSuccessBlock)(NSDictionary *responseDictionary);
+typedef void(^WordPressComServiceFailureBlock)(NSError *error);
+
+/**
+ *  @class      WordPressComServiceRemote
+ *  @brief      Encapsulates exclusive WordPress.com services.
+ */
 @interface WordPressComServiceRemote : ServiceRemoteREST
 
+/**
+ *  @brief      Creates a WordPress.com account with the specified parameters.
+ *
+ *  @param      email       The email to use for the new account.  Cannot be nil.
+ *  @param      username    The username of the new account.  Cannot be nil.
+ *  @param      password    The password of the new account.  Cannot be nil.
+ *  @param      success     The block to execute on success.  Can be nil.
+ *  @param      failure     The block to execute on failure.  Can be nil.
+ */
 - (void)createWPComAccountWithEmail:(NSString *)email
                         andUsername:(NSString *)username
                         andPassword:(NSString *)password
-                            success:(void (^)(id responseObject))success
-                            failure:(void (^)(NSError *error))failure;
+                            success:(WordPressComServiceSuccessBlock)success
+                            failure:(WordPressComServiceFailureBlock)failure;
 
+/**
+ *  @brief      Validates a WordPress.com blog with the specified parameters.
+ *
+ *  @param      blogUrl     The url of the blog to validate.  Cannot be nil.
+ *  @param      blogTitle   The title of the blog.  Can be nil.
+ *  @param      password    The language ID of the blog.  Cannot be nil.
+ *  @param      success     The block to execute on success.  Can be nil.
+ *  @param      failure     The block to execute on failure.  Can be nil.
+ */
 - (void)validateWPComBlogWithUrl:(NSString *)blogUrl
                     andBlogTitle:(NSString *)blogTitle
                    andLanguageId:(NSNumber *)languageId
-                         success:(void (^)(id))success
-                         failure:(void (^)(NSError *))failure;
+                         success:(WordPressComServiceSuccessBlock)success
+                         failure:(WordPressComServiceFailureBlock)failure;
 
+/**
+ *  @brief      Creates a WordPress.com blog with the specified parameters.
+ *
+ *  @param      blogUrl     The url of the blog to validate.  Cannot be nil.
+ *  @param      blogTitle   The title of the blog.  Can be nil.
+ *  @param      password    The language ID of the blog.  Cannot be nil.
+ *  @param      visibility  The visibility of the new blog.
+ *  @param      success     The block to execute on success.  Can be nil.
+ *  @param      failure     The block to execute on failure.  Can be nil.
+ */
 - (void)createWPComBlogWithUrl:(NSString *)blogUrl
                   andBlogTitle:(NSString *)blogTitle
                  andLanguageId:(NSNumber *)languageId
              andBlogVisibility:(WordPressComServiceBlogVisibility)visibility
-                       success:(void (^)(id))success
-                       failure:(void (^)(NSError *))failure;
+                       success:(WordPressComServiceSuccessBlock)success
+                       failure:(WordPressComServiceFailureBlock)failure;
 
 @end

--- a/WordPress/Classes/Networking/WordPressComServiceRemote.h
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.h
@@ -41,7 +41,7 @@ typedef void(^WordPressComServiceFailureBlock)(NSError *error);
  */
 - (void)validateWPComBlogWithUrl:(NSString *)blogUrl
                     andBlogTitle:(NSString *)blogTitle
-                   andLanguageId:(NSNumber *)languageId
+                   andLanguageId:(NSString *)languageId
                          success:(WordPressComServiceSuccessBlock)success
                          failure:(WordPressComServiceFailureBlock)failure;
 
@@ -57,7 +57,7 @@ typedef void(^WordPressComServiceFailureBlock)(NSError *error);
  */
 - (void)createWPComBlogWithUrl:(NSString *)blogUrl
                   andBlogTitle:(NSString *)blogTitle
-                 andLanguageId:(NSNumber *)languageId
+                 andLanguageId:(NSString *)languageId
              andBlogVisibility:(WordPressComServiceBlogVisibility)visibility
                        success:(WordPressComServiceSuccessBlock)success
                        failure:(WordPressComServiceFailureBlock)failure;

--- a/WordPress/Classes/Networking/WordPressComServiceRemote.m
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.m
@@ -100,7 +100,7 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
              andBlogVisibility:(WordPressComServiceBlogVisibility)visibility
                        success:(WordPressComServiceSuccessBlock)success
                        failure:(WordPressComServiceFailureBlock)failure
-{    
+{
     [self createWPComBlogWithUrl:blogUrl
                     andBlogTitle:blogTitle
                    andLanguageId:languageId

--- a/WordPress/Classes/Networking/WordPressComServiceRemote.m
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.m
@@ -81,7 +81,7 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
 
 - (void)validateWPComBlogWithUrl:(NSString *)blogUrl
                     andBlogTitle:(NSString *)blogTitle
-                   andLanguageId:(NSNumber *)languageId
+                   andLanguageId:(NSString *)languageId
                          success:(WordPressComServiceSuccessBlock)success
                          failure:(WordPressComServiceFailureBlock)failure
 {
@@ -96,7 +96,7 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
 
 - (void)createWPComBlogWithUrl:(NSString *)blogUrl
                   andBlogTitle:(NSString *)blogTitle
-                 andLanguageId:(NSNumber *)languageId
+                 andLanguageId:(NSString *)languageId
              andBlogVisibility:(WordPressComServiceBlogVisibility)visibility
                        success:(WordPressComServiceSuccessBlock)success
                        failure:(WordPressComServiceFailureBlock)failure
@@ -112,14 +112,14 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
 
 - (void)createWPComBlogWithUrl:(NSString *)blogUrl
                   andBlogTitle:(NSString *)blogTitle
-                 andLanguageId:(NSNumber *)languageId
+                 andLanguageId:(NSString *)languageId
              andBlogVisibility:(WordPressComServiceBlogVisibility)visibility
                       validate:(BOOL)validate
                        success:(WordPressComServiceSuccessBlock)success
                        failure:(WordPressComServiceFailureBlock)failure
 {
     NSParameterAssert([blogUrl isKindOfClass:[NSString class]]);
-    NSParameterAssert([languageId isKindOfClass:[NSNumber class]]);
+    NSParameterAssert([languageId isKindOfClass:[NSString class]]);
     
     void (^successBlock)(AFHTTPRequestOperation *, id) = ^(AFHTTPRequestOperation *operation, id responseObject) {
         NSDictionary *response = responseObject;

--- a/WordPress/Classes/Networking/WordPressComServiceRemote.m
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.m
@@ -12,22 +12,31 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
 - (void)createWPComAccountWithEmail:(NSString *)email
                         andUsername:(NSString *)username
                         andPassword:(NSString *)password
-                            success:(void (^)(id responseObject))success
-                            failure:(void (^)(NSError *error))failure
+                            success:(WordPressComServiceSuccessBlock)success
+                            failure:(WordPressComServiceFailureBlock)failure
 {
-    [self createWPComAccountWithEmail:email andUsername:username andPassword:password validate:NO success:success failure:failure];
+    NSParameterAssert([email isKindOfClass:[NSString class]]);
+    NSParameterAssert([username isKindOfClass:[NSString class]]);
+    NSParameterAssert([password isKindOfClass:[NSString class]]);
+    
+    [self createWPComAccountWithEmail:email
+                          andUsername:username
+                          andPassword:password
+                             validate:NO
+                              success:success
+                              failure:failure];
 }
 
 - (void)createWPComAccountWithEmail:(NSString *)email
                         andUsername:(NSString *)username
                         andPassword:(NSString *)password
                            validate:(BOOL)validate
-                            success:(void (^)(id responseObject))success
-                            failure:(void (^)(NSError *error))failure
+                            success:(WordPressComServiceSuccessBlock)success
+                            failure:(WordPressComServiceFailureBlock)failure
 {
-    NSParameterAssert(email != nil);
-    NSParameterAssert(username != nil);
-    NSParameterAssert(password != nil);
+    NSParameterAssert([email isKindOfClass:[NSString class]]);
+    NSParameterAssert([username isKindOfClass:[NSString class]]);
+    NSParameterAssert([password isKindOfClass:[NSString class]]);
     
     void (^successBlock)(AFHTTPRequestOperation *, id) = ^(AFHTTPRequestOperation *operation, id responseObject) {
         success(responseObject);
@@ -73,14 +82,15 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
 - (void)validateWPComBlogWithUrl:(NSString *)blogUrl
                     andBlogTitle:(NSString *)blogTitle
                    andLanguageId:(NSNumber *)languageId
-                         success:(void (^)(id))success
-                         failure:(void (^)(NSError *))failure
+                         success:(WordPressComServiceSuccessBlock)success
+                         failure:(WordPressComServiceFailureBlock)failure
 {
     [self createWPComBlogWithUrl:blogUrl
                     andBlogTitle:blogTitle
                    andLanguageId:languageId
                andBlogVisibility:WordPressComServiceBlogVisibilityPublic
-                        validate:YES success:success
+                        validate:YES
+                         success:success
                          failure:failure];
 }
 
@@ -88,9 +98,9 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
                   andBlogTitle:(NSString *)blogTitle
                  andLanguageId:(NSNumber *)languageId
              andBlogVisibility:(WordPressComServiceBlogVisibility)visibility
-                       success:(void (^)(id))success
-                       failure:(void (^)(NSError *))failure
-{
+                       success:(WordPressComServiceSuccessBlock)success
+                       failure:(WordPressComServiceFailureBlock)failure
+{    
     [self createWPComBlogWithUrl:blogUrl
                     andBlogTitle:blogTitle
                    andLanguageId:languageId
@@ -105,11 +115,11 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
                  andLanguageId:(NSNumber *)languageId
              andBlogVisibility:(WordPressComServiceBlogVisibility)visibility
                       validate:(BOOL)validate
-                       success:(void (^)(id))success
-                       failure:(void (^)(NSError *))failure
+                       success:(WordPressComServiceSuccessBlock)success
+                       failure:(WordPressComServiceFailureBlock)failure
 {
-    NSParameterAssert(blogUrl != nil);
-    NSParameterAssert(languageId != nil);
+    NSParameterAssert([blogUrl isKindOfClass:[NSString class]]);
+    NSParameterAssert([languageId isKindOfClass:[NSNumber class]]);
     
     void (^successBlock)(AFHTTPRequestOperation *, id) = ^(AFHTTPRequestOperation *operation, id responseObject) {
         NSDictionary *response = responseObject;

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -769,7 +769,7 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
             [self displayRemoteError:error];
         };
 
-        NSNumber *languageId = [_currentLanguage objectForKey:@"lang_id"];
+        NSString *languageId = [_currentLanguage stringForKey:@"lang_id"];
         
         WordPressComApi *api = [WordPressComApi anonymousApi];
         WordPressComServiceRemote *service = [[WordPressComServiceRemote alloc] initWithApi:api];
@@ -873,7 +873,7 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
             [self displayRemoteError:error];
         };
 
-        NSNumber *languageId = [_currentLanguage objectForKey:@"lang_id"];
+        NSString *languageId = [_currentLanguage stringForKey:@"lang_id"];
         
         WordPressComApi *api = [_account restApi];
         WordPressComServiceRemote *service = [[WordPressComServiceRemote alloc] initWithApi:api];

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -782,10 +782,11 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
     }];
 
     WPAsyncBlockOperation *userCreation = [WPAsyncBlockOperation operationWithBlock:^(WPAsyncBlockOperation *operation){
-        void (^createUserSuccess)(id) = ^(id responseObject){
+        WordPressComServiceSuccessBlock createUserSuccess = ^(NSDictionary *responseDictionary){
             [operation didSucceed];
         };
-        void (^createUserFailure)(NSError *) = ^(NSError *error) {
+        
+        WordPressComServiceFailureBlock createUserFailure = ^(NSError *error) {
             DDLogError(@"Failed creating user: %@", error);
             [operation didFail];
             [self setAuthenticating:NO];

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -760,10 +760,10 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
     // the situation could exist where a user account is created, but the site creation
     // fails.
     WPAsyncBlockOperation *siteValidation = [WPAsyncBlockOperation operationWithBlock:^(WPAsyncBlockOperation *operation) {
-        void (^blogValidationSuccess)(id) = ^(id responseObject) {
+        WordPressComServiceSuccessBlock blogValidationSuccess = ^(NSDictionary *responseDictionary) {
             [operation didSucceed];
         };
-        void (^blogValidationFailure)(NSError *) = ^(NSError *error) {
+        WordPressComServiceFailureBlock blogValidationFailure = ^(NSError *error) {
             [operation didFail];
             [self setAuthenticating:NO];
             [self displayRemoteError:error];
@@ -833,11 +833,11 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
     }];
 
     WPAsyncBlockOperation *blogCreation = [WPAsyncBlockOperation operationWithBlock:^(WPAsyncBlockOperation *operation){
-        void (^createBlogSuccess)(id) = ^(id responseObject){
+        WordPressComServiceSuccessBlock createBlogSuccess = ^(NSDictionary *responseDictionary){
             [WPAnalytics track:WPAnalyticsStatCreatedAccount];
             [operation didSucceed];
 
-            NSMutableDictionary *blogOptions = [[responseObject dictionaryForKey:@"blog_details"] mutableCopy];
+            NSMutableDictionary *blogOptions = [[responseDictionary dictionaryForKey:@"blog_details"] mutableCopy];
             if ([blogOptions objectForKey:@"blogname"]) {
                 [blogOptions setObject:[blogOptions objectForKey:@"blogname"] forKey:@"blogName"];
                 [blogOptions removeObjectForKey:@"blogname"];
@@ -866,7 +866,7 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
             [self setAuthenticating:NO];
             [self dismissViewControllerAnimated:YES completion:nil];
         };
-        void (^createBlogFailure)(NSError *error) = ^(NSError *error) {
+        WordPressComServiceFailureBlock createBlogFailure = ^(NSError *error) {
             DDLogError(@"Failed creating blog: %@", error);
             [self setAuthenticating:NO];
             [operation didFail];


### PR DESCRIPTION
This PR improves `WordPressComServiceRemote` by:

- Documenting its methods.
- Naming the block types used.
- Adding a few missing assertions.
- The assertions added made me realize that even though we were treating `languageId` as a number, it was actually a string object.  I fixed the data type.

**To test:**
1. Launch the app
2. At the login screen tap on "Create account"
3. Fill the forms
4. Make sure the account and blog are created.

/cc @jleandroperez 