### PR TITLE
Fix: Gravatar rounding wrong on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/CircularImageView.swift
+++ b/WordPress/Classes/ViewRelated/Views/CircularImageView.swift
@@ -34,11 +34,16 @@ class CircularImageView : UIImageView
 
     override var frame: CGRect {
         didSet {
-            if (shouldRoundCorners) {
-                layer.cornerRadius = (frame.width * 0.5)
-            } else {
-                layer.cornerRadius = 0;
-            }
+            refreshRadius()
         }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        refreshRadius()
+    }
+    
+    private func refreshRadius() {
+        layer.cornerRadius = shouldRoundCorners ? (frame.width * 0.5) : 0
     }
 }


### PR DESCRIPTION
#### Steps:
1. Launch WPiOS on an iPad Air Simulator
2. Tap over the Notifications tab
3. Open any 'Likes' / 'Follower' notification

As a result, the list of new Followers / Likers should be onscreen. Note that the corners should be rounded.

Closes #4186
Needs Review: @diegoreymendez 
