### PR TITLE
Update to stats 0.4.6

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -32,7 +32,7 @@ pod 'Simperium', '0.7.9'
 pod 'WordPressApi', '~> 0.3.4'
 pod 'WordPress-iOS-Shared', '0.4.4'
 pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => '1b614724fbc005be4346c7870498658c8b537267'
-pod 'WordPressCom-Stats-iOS', '0.4.5'
+pod 'WordPressCom-Stats-iOS', '0.4.6'
 pod 'WordPressCom-Analytics-iOS', '0.0.36'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '303b8068530389ea87afde38b77466d685fe3210'
@@ -41,7 +41,7 @@ pod 'ReactiveCocoa', '~> 2.4.7'
 pod 'FormatterKit', '~> 1.8.0'
 
 target 'WordPressTodayWidget', :exclusive => true do
-  pod 'WordPressCom-Stats-iOS', '0.4.5'
+  pod 'WordPressCom-Stats-iOS', '0.4.6'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -148,7 +148,7 @@ PODS:
     - AFNetworking (~> 2.5.1)
     - wpxmlrpc (~> 0.7)
   - WordPressCom-Analytics-iOS (0.0.36)
-  - WordPressCom-Stats-iOS (0.4.5):
+  - WordPressCom-Stats-iOS (0.4.6):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (= 0.0.2)
@@ -199,7 +199,7 @@ DEPENDENCIES:
   - WordPress-iOS-Shared (= 0.4.4)
   - WordPressApi (~> 0.3.4)
   - WordPressCom-Analytics-iOS (= 0.0.36)
-  - WordPressCom-Stats-iOS (= 0.4.5)
+  - WordPressCom-Stats-iOS (= 0.4.6)
   - WPMediaPicker (~> 0.5.0)
   - wpxmlrpc (~> 0.8)
 
@@ -285,7 +285,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Shared: 345f7c1c49d298114353c3856c53317f0d826078
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
   WordPressCom-Analytics-iOS: a54b61f75be5a43fe32be98c0b286cb18fc2abee
-  WordPressCom-Stats-iOS: fae392ee157953d27f247b0303a4d772852aa257
+  WordPressCom-Stats-iOS: d8114636166036ab42f091ad4e018617d2ffbeb9
   WPMediaPicker: 0757988f1519c20b92c91f470c41633ac42e3a0e
   wpxmlrpc: 053c9cbed13dcec08515a4ffeb51780f6e858cc7
 


### PR DESCRIPTION
Closes #4196 

Two bug fixes included:

* Prevent segmented control from being oversized when a translation makes it too wide.
* Provide a slightly better UX on Insights when data can't be fetched.

Needs Review: @sendhil