### PR TITLE
Issues/4200 fix site topics

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -363,6 +363,10 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     topic.topicDescription = post.blogDescription;
     topic.path = path;
 
+    [self.managedObjectContext performBlockAndWait:^{
+        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+    }];
+
     return topic;
 }
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -333,6 +333,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
 - (ReaderTopic *)siteTopicForPost:(ReaderPost *)post
 {
+    NSAssert([NSThread isMainThread], @"siteTopicForPost should only be called from the main thread");
     NSString *path;
     if (post.isWPCom) {
         path = [NSString stringWithFormat:@"%@read/sites/%@/posts/", WordPressRestApiEndpointURL, post.siteID];
@@ -363,9 +364,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     topic.topicDescription = post.blogDescription;
     topic.path = path;
 
-    [self.managedObjectContext performBlockAndWait:^{
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-    }];
+    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
 
     return topic;
 }


### PR DESCRIPTION
Fixes #4200 
A site topics constructed from a post was not being saved when it was created. This made it possible for the topic to be discarded when a derived context was reset when merging posts.
There was also a race condition with saving the main context and displaying the no results view.  This patch addresses both issues.

To tests:

Scenario 1:
- Open the reader to any tag or list.
- Tap an avatar to preview the site.
- Ensure the site details screen displays the posts it syncs.

Scenario 2: 
- Open notifications
- Tap to preview a site from any follow notification (or notification that supports previewing a site). 
- Ensure the site details screen displays the posts it syncs. 

@jleandroperez may I trouble you for a quick review?

Needs Review : @jleandroperez 