### PR TITLE
Fixes the sorting of blogs by their default account.

### DIFF
--- a/WordPress/Classes/Models/WPAccount.h
+++ b/WordPress/Classes/Models/WPAccount.h
@@ -68,7 +68,9 @@
 
 /**
  *  @brief      Adds sorting support to this class.
- *  @details    WordPress.com accounts go first, the rest is considered all the same.
+ *  @details    All blogs are the same.  The reason this was added is to be able to use WPAccounts
+ *              in sort descriptors.  When comparing against nil, this method is never called, but
+ *              if it wasn't present it would crash when comparing two real accounts.
  */
 - (NSComparisonResult)compare:(WPAccount *)account;
 

--- a/WordPress/Classes/Models/WPAccount.h
+++ b/WordPress/Classes/Models/WPAccount.h
@@ -64,4 +64,12 @@
  */
 - (BOOL)isWPComAccount;
 
+#pragma mark - Sorting support
+
+/**
+ *  @brief      Adds sorting support to this class.
+ *  @details    WordPress.com accounts go first, the rest is considered all the same.
+ */
+- (NSComparisonResult)compare:(WPAccount *)account;
+
 @end

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -132,17 +132,7 @@
 
 - (NSComparisonResult)compare:(WPAccount *)account
 {
-    BOOL account1IsWPComAccount = [self isWPComAccount];
-    BOOL account2IsWPComAccount = [account isWPComAccount];
-    NSComparisonResult result = NSOrderedSame;
-    
-    if (account1IsWPComAccount && !account2IsWPComAccount) {
-        result = NSOrderedDescending;
-    } else if (!account1IsWPComAccount && account2IsWPComAccount) {
-        result = NSOrderedAscending;
-    }
-    
-    return result;
+	return NSOrderedSame;
 }
 
 @end

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -128,4 +128,21 @@
     return self.restApi != nil;
 }
 
+#pragma mark - Sorting support
+
+- (NSComparisonResult)compare:(WPAccount *)account
+{
+    BOOL account1IsWPComAccount = [self isWPComAccount];
+    BOOL account2IsWPComAccount = [account isWPComAccount];
+    NSComparisonResult result = NSOrderedSame;
+    
+    if (account1IsWPComAccount && !account2IsWPComAccount) {
+        result = NSOrderedDescending;
+    } else if (!account1IsWPComAccount && account2IsWPComAccount) {
+        result = NSOrderedAscending;
+    }
+    
+    return result;
+}
+
 @end


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/4199).

**How to test:**
I got myself into a weird app state in which I had blogs from two different WP.com accounts, so I'm not sure the error case is easy to reproduce.  However this fix is placing all WP.com default blogs at the top of me, and it should be fairly easy to test it's still working properly in a regular situation.

/cc @aerych, @koke 