### PR TITLE
Notifications Control Center: WordPress.com Footers

### DIFF
--- a/WordPress/Classes/Models/Notifications/NotificationSettings.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationSettings.swift
@@ -48,6 +48,13 @@ public class NotificationSettings
         return Keys.localizedDescriptionMap[preferenceKey] ?? String()
     }
     
+    /**
+    *  @details Returns the details for a given preference key
+    */
+    public func localizedDetails(preferenceKey: String) -> String? {
+        return Keys.localizedDetailsMap[preferenceKey]
+    }
+    
     
     /**
     *  @details Returns an array of the sorted Preference Keys
@@ -160,16 +167,35 @@ public class NotificationSettings
         static let community        = "community"
         
         static let localizedDescriptionMap = [
-            commentAdded     : NSLocalizedString("Comments on my site",      comment: "Setting: indicates if New Comments will be notified"),
-            commentLiked     : NSLocalizedString("Likes on my comments",     comment: "Setting: indicates if Comment Likes will be notified"),
-            postLiked        : NSLocalizedString("Likes on my posts",        comment: "Setting: indicates if Replies to your comments will be notified"),
-            follower         : NSLocalizedString("Site follows",             comment: "Setting: indicates if New Follows will be notified"),
-            achievement      : NSLocalizedString("Site achievements",        comment: "Setting: indicates if Achievements will be notified"),
-            mention          : NSLocalizedString("Username mentions",        comment: "Setting: indicates if Mentions will be notified"),
-            commentReplied   : NSLocalizedString("Replies to your comments", comment: "Setting: indicates if Replies to Comments will be notified"),
-            marketing        : NSLocalizedString("Suggestions",              comment: "Setting: WordPress.com Suggestions"),
-            research         : NSLocalizedString("Research",                 comment: "Setting: WordPress.com Surveys"),
-            community        : NSLocalizedString("Community",                comment: "Setting: WordPress.com Community")
+            commentAdded    : NSLocalizedString("Comments on my site",
+                                comment: "Setting: indicates if New Comments will be notified"),
+            commentLiked    : NSLocalizedString("Likes on my comments",
+                                comment: "Setting: indicates if Comment Likes will be notified"),
+            postLiked       : NSLocalizedString("Likes on my posts",
+                                comment: "Setting: indicates if Replies to your comments will be notified"),
+            follower        : NSLocalizedString("Site follows",
+                                comment: "Setting: indicates if New Follows will be notified"),
+            achievement     : NSLocalizedString("Site achievements",
+                                comment: "Setting: indicates if Achievements will be notified"),
+            mention         : NSLocalizedString("Username mentions",
+                                comment: "Setting: indicates if Mentions will be notified"),
+            commentReplied  : NSLocalizedString("Replies to your comments",
+                                comment: "Setting: indicates if Replies to Comments will be notified"),
+            marketing       : NSLocalizedString("Suggestions",
+                                comment: "Setting: WordPress.com Suggestions"),
+            research        : NSLocalizedString("Research",
+                                comment: "Setting: WordPress.com Surveys"),
+            community       : NSLocalizedString("Community",
+                                comment: "Setting: WordPress.com Community")
+        ]
+        
+        static let localizedDetailsMap = [
+            marketing       : NSLocalizedString("Tips for getting the most out of WordPress.com.",
+                                comment: "WordPress.com Marketing Footer Text"),
+            research        : NSLocalizedString("Opportunities to participate in WordPress.com research & surveys.",
+                                comment: "WordPress.com Research Footer Text"),
+            community       : NSLocalizedString("Information on WordPress.com courses and events (online & in-person).",
+                                comment: "WordPress.com Community Footer Text")
         ]
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -12,13 +12,13 @@ public class NotificationSettingDetailsViewController : UITableViewController
 {
     // MARK: - Initializers
     public convenience init(settings: NotificationSettings) {
-        self.init(style: .Grouped)
-        setupWithSettings(settings, stream: settings.streams.first!)
+        self.init(settings: settings, stream: settings.streams.first!)
     }
     
     public convenience init(settings: NotificationSettings, stream: NotificationSettings.Stream) {
         self.init(style: .Grouped)
-        setupWithSettings(settings, stream: stream)
+        self.settings = settings
+        self.stream = stream
     }
     
     
@@ -28,6 +28,7 @@ public class NotificationSettingDetailsViewController : UITableViewController
         super.viewDidLoad()
         setupNotifications()
         setupTableView()
+        reloadTable()
     }
     
     public override func viewWillAppear(animated: Bool) {
@@ -43,6 +44,15 @@ public class NotificationSettingDetailsViewController : UITableViewController
     
     
     // MARK: - Setup Helpers
+    private func setupTitle() {
+        switch settings!.channel {
+        case .WordPressCom:
+            title = NSLocalizedString("WordPress.com Updates", comment: "WordPress.com Notification Settings Title")
+        default:
+            title = stream!.kind.description()
+        }
+    }
+    
     private func setupNotifications() {
         // Reload whenever the app becomes active again since Push Settings may have changed in the meantime!
         let notificationCenter = NSNotificationCenter.defaultCenter()
@@ -64,27 +74,7 @@ public class NotificationSettingDetailsViewController : UITableViewController
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
     
-    
-    
-    // MARK: - Public Helpers
-    public func setupWithSettings(settings: NotificationSettings, stream: NotificationSettings.Stream) {
-        // Title
-        switch settings.channel {
-        case .WordPressCom:
-            title = NSLocalizedString("WordPress.com Updates", comment: "WordPress.com Notification Settings Title")
-        default:
-            title = stream.kind.description()
-        }
-        
-        // Keep References
-        self.settings   = settings
-        self.stream     = stream
-        
-        // At last, reload!
-        reloadTable()
-    }
-
-    public func reloadTable() {
+    @IBAction private func reloadTable() {
         self.rows = rowsForSettings(settings!, stream: stream!)
         tableView.reloadData()
     }
@@ -260,7 +250,6 @@ public class NotificationSettingDetailsViewController : UITableViewController
     private let switchIdentifier    = SwitchTableViewCell.classNameWithoutNamespaces()
     private let sectionCount        = 1
     private let disabledRowCount    = 1
-    private let headerTitleInsets   = UIEdgeInsets(top: 16.0, left: 16.0, bottom: 16.0, right: 16.0)
     
     // MARK: - Private Properties
     private var settings            : NotificationSettings?


### PR DESCRIPTION
#### Steps:
1. Launch WPiOS
2. Tap over the `Me` tab
3. Open the `Notification Settings` row
4. Open `Updates from WordPress.com`

As a result, each one of the rows should have a descriptive footer. Please, try updating any of those settings, closing the NCC, and opening it back, to verify it effectively gets stored.

Closes #4202
Needs Review: @aerych 

Thanks in advance Eric!
