### PR TITLE
NotificationSettingsViewController: Implements Nil Site Icon Failsafe

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -249,7 +249,13 @@ public class NotificationSettingsViewController : UIViewController
             cell.textLabel?.text            = settings.blog?.blogName ?? settings.channel.description()
             cell.detailTextLabel?.text      = settings.blog?.displayURL ?? String()
             cell.accessoryType              = .DisclosureIndicator
-            cell.imageView?.setImageWithSiteIcon(settings.blog?.icon)
+            
+            if let siteIconURL = settings.blog?.icon {
+                cell.imageView?.setImageWithSiteIcon(settings.blog?.icon)
+            } else {
+                cell.imageView?.image = WPStyleGuide.Notifications.blavatarPlaceholderImage
+            }
+        
             WPStyleGuide.configureTableViewSmallSubtitleCell(cell)
             
         default:

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -28,7 +28,8 @@ extension WPStyleGuide
         public static let noteSeparatorColor        = blockSeparatorColor
 
         public static let gravatarPlaceholderImage  = UIImage(named: "gravatar")
-
+        public static let blavatarPlaceholderImage  = UIImage(named: "blavatar-default")
+        
         //  NoteUndoOverlayView
         public static let noteUndoBackgroundColor   = WPStyleGuide.errorRed()
         public static let noteUndoTextColor         = UIColor.whiteColor()


### PR DESCRIPTION
#### Steps:
1. Launch WPiOS
2. Open `Me` > `Notification Settings`
3. Scroll all the way down, until you find a blog with a `nil` site icon

As a result, the app shouldn't crash.

Needs Review: @diegoreymendez 

Thanks for helping me out Diego!
