### PR TITLE
Fixed a service path that was missing the API version.

### DIFF
--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -226,7 +226,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionFeedbackRows)
 
         [metaData addEntriesFromDictionary:@{@"WPCom Username": defaultAccount.username}];
 
-        [defaultAccount.restApi GET:@"me"
+        [defaultAccount.restApi GET:@"v1.1/me"
                          parameters:nil
                             success:^(AFHTTPRequestOperation *operation, id responseObject) {
                                 [self hideLoadingSpinner];


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/4211).

**How to test:**
1. Go to the "Me" tab
2. Go into "Help & support"
3. Tap on "WordPress Help Center"
4. Make sure that the VC opens normally and the app doesn't crash.

(the same steps can be performed in an older version to reproduce the crash)

/cc @SergioEstevao, @jleandroperez, @sendhil (tagging three so this bugfix goes out quickly as it crashes for our testers)