### PR TITLE
Add object to the other side of relationship.

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -9,7 +9,7 @@
 
 // Relationships
 @property (nonatomic, strong) Blog *blog;
-@property (nonatomic, strong) NSMutableSet *media;
+@property (nonatomic, strong) NSSet *media;
 @property (weak, readonly) AbstractPost *original;
 @property (weak, readonly) AbstractPost *revision;
 @property (nonatomic, strong) NSMutableSet *comments;
@@ -75,5 +75,14 @@
  *  @returns    YES if there are unsaved changes, NO otherwise.
  */
 - (BOOL)hasRemoteChanges;
+
+@end
+
+@interface AbstractPost (CoreDataGeneratedAccessors)
+
+- (void)addMediaObject:(Media *)value;
+- (void)removeMediaObject:(Media *)value;
+- (void)addMedia:(NSSet *)values;
+- (void)removeMedia:(NSSet *)values;
 
 @end

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -190,35 +190,35 @@
 - (BOOL)hasPhoto
 {
     if ([self.media count] == 0) {
-        return false;
+        return NO;
     }
 
     if (self.featuredImage != nil) {
-        return true;
+        return YES;
     }
 
     for (Media *media in self.media) {
         if (media.mediaType == MediaTypeImage || media.mediaType == MediaTypeFeatured) {
-            return true;
+            return YES;
         }
     }
 
-    return false;
+    return NO;
 }
 
 - (BOOL)hasVideo
 {
     if ([self.media count] == 0) {
-        return false;
+        return NO;
     }
 
     for (Media *media in self.media) {
         if (media.mediaType ==  MediaTypeVideo) {
-            return true;
+            return YES;
         }
     }
 
-    return false;
+    return NO;
 }
 
 - (BOOL)hasCategories

--- a/WordPress/Classes/Models/Media.h
+++ b/WordPress/Classes/Models/Media.h
@@ -54,7 +54,7 @@ typedef NS_ENUM(NSUInteger, MediaOrientation) {
 @property (nonatomic, strong) NSString * caption;
 @property (nonatomic, strong) NSString * desc;
 @property (nonatomic, strong) Blog * blog;
-@property (nonatomic, strong) NSMutableSet * posts;
+@property (nonatomic, strong) NSSet *posts;
 @property (nonatomic, assign, readonly) BOOL unattached;
 @property (nonatomic, assign) BOOL featured;
 @property (nonatomic, strong) NSString *absoluteLocalURL;
@@ -71,5 +71,16 @@ typedef NS_ENUM(NSUInteger, MediaOrientation) {
 
 - (void)remove;
 - (void)save;
+
+@end
+
+@class AbstractPost;
+
+@interface Media (CoreDataGeneratedAccessors)
+
+- (void)addPostsObject:(AbstractPost *)value;
+- (void)removePostsObject:(AbstractPost *)value;
+- (void)addPosts:(NSSet *)values;
+- (void)removePosts:(NSSet *)values;
 
 @end

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -375,6 +375,7 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
 {
     Media *media = [self newMediaForBlog:post.blog];
     [media.posts addObject:post];
+    [post.media addObject:media];
     return media;
 }
 

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -374,8 +374,7 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
 - (Media *)newMediaForPost:(AbstractPost *)post
 {
     Media *media = [self newMediaForBlog:post.blog];
-    [media.posts addObject:post];
-    [post.media addObject:media];
+    [media addPostsObject:post];
     return media;
 }
 


### PR DESCRIPTION
Closes #4096 

This goes against my knowledge of CoreData, that says that relationships with inverse are automatic filled but after some tests it looks they don't :(. Maybe it's because of the relationship being multiple to multiple?

Needs Review: @astralbodies 