### PR TITLE
Fix media filtering on picker.

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -236,10 +236,10 @@
     NSPredicate *predicate;
     switch (filter) {
         case WPMediaTypeImage: {
-            predicate = [NSPredicate predicateWithFormat:@"mediaTypeString = %@", @"image && blog = %@", blog];
+            predicate = [NSPredicate predicateWithFormat:@"mediaTypeString = %@ && blog = %@",  @"image", blog];
         } break;
         case WPMediaTypeVideo: {
-            predicate = [NSPredicate predicateWithFormat:@"mediaTypeString = %@", @"video && blog = %@", blog];
+            predicate = [NSPredicate predicateWithFormat:@"mediaTypeString = %@ && blog = %@", @"video", blog];
         } break;
         case WPMediaTypeAll: {
             predicate = [NSPredicate predicateWithFormat:@"(mediaTypeString = %@ || mediaTypeString = %@)  && blog = %@", @"image", @"video", blog];


### PR DESCRIPTION
Fix bug when using filtering on the WordPress Media Library for just images or videos.

How to test:

Create a post
Go to Post->Settings
Add a feature image.
Chose the media library
Check if the images from the media library.

If tested on the current version on the store or internal you will always see an empty list :(

Needs Review: @bummytime 