### PR TITLE
Adds usage of WPMapFilterReduce

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -261,13 +261,9 @@ NSString * const PostFormatStandard = @"standard";
 
 - (NSArray *)sortedPostFormatNames
 {
-    NSMutableArray *sortedNames = [NSMutableArray arrayWithCapacity:[self.postFormats count]];
-
-    for (NSString *key in self.sortedPostFormats) {
-        [sortedNames addObject:self.postFormats[key]];
-    }
-
-    return [NSArray arrayWithArray:sortedNames];
+    return [[self sortedPostFormats] wp_map:^id(NSString *key) {
+        return self.postFormats[key];
+    }];
 }
 
 - (NSString *)defaultPostFormatText

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -88,7 +88,7 @@ static NSString * const UserDictionaryAvatarURLKey = @"avatar_URL";
         }];
     }
     return [blogs wp_map:^id(NSDictionary *jsonBlog) {
-        return [self remoteUserFromDictionary:jsonBlog];
+        return [self remoteBlogFromJSONDictionary:jsonBlog];
     }];
 }
 

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -80,14 +80,16 @@ static NSString * const UserDictionaryAvatarURLKey = @"avatar_URL";
 
 - (NSArray *)remoteBlogsFromJSONArray:(NSArray *)jsonBlogs
 {
-    NSMutableArray *remoteBlogs = [NSMutableArray arrayWithCapacity:[jsonBlogs count]];
-    for (NSDictionary *jsonBlog in jsonBlogs) {
-        BOOL isJetpack = [jsonBlog[@"jetpack"] boolValue];
-        if (!isJetpack || JetpackREST.enabled) {
-            [remoteBlogs addObject:[self remoteBlogFromJSONDictionary:jsonBlog]];
-        }
+    NSArray *blogs = jsonBlogs;
+    if (!JetpackREST.enabled) {
+        blogs = [blogs wp_filter:^BOOL(NSDictionary *jsonBlog) {
+            BOOL isJetpack = [jsonBlog[@"jetpack"] boolValue];
+            return !isJetpack;
+        }];
     }
-    return [NSArray arrayWithArray:remoteBlogs];
+    return [blogs wp_map:^id(NSDictionary *jsonBlog) {
+        return [self remoteUserFromDictionary:jsonBlog];
+    }];
 }
 
 - (RemoteBlog *)remoteBlogFromJSONDictionary:(NSDictionary *)jsonBlog

--- a/WordPress/Classes/Networking/CommentServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteREST.m
@@ -378,11 +378,9 @@ static const NSInteger NumberOfCommentsToSync = 100;
 
 - (NSArray *)remoteCommentsFromJSONArray:(NSArray *)jsonComments
 {
-    NSMutableArray *comments = [NSMutableArray arrayWithCapacity:jsonComments.count];
-    for (NSDictionary *jsonComment in jsonComments) {
-        [comments addObject:[self remoteCommentFromJSONDictionary:jsonComment]];
-    }
-    return [NSArray arrayWithArray:comments];
+    return [jsonComments wp_map:^id(NSDictionary *jsonComment) {
+        return [self remoteCommentFromJSONDictionary:jsonComment];
+    }];
 }
 
 - (RemoteComment *)remoteCommentFromJSONDictionary:(NSDictionary *)jsonDictionary

--- a/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
@@ -181,11 +181,9 @@ static const NSInteger NumberOfCommentsToSync = 100;
 
 - (NSArray *)remoteCommentsFromXMLRPCArray:(NSArray *)xmlrpcArray
 {
-    NSMutableArray *comments = [NSMutableArray arrayWithCapacity:xmlrpcArray.count];
-    for (NSDictionary *xmlrpcComment in xmlrpcArray) {
-        [comments addObject:[self remoteCommentFromXMLRPCDictionary:xmlrpcComment]];
-    }
-    return [NSArray arrayWithArray:comments];
+    return [xmlrpcArray wp_map:^id(NSDictionary *xmlrpcComment) {
+        return [self remoteCommentFromXMLRPCDictionary:xmlrpcComment];
+    }];
 }
 
 - (RemoteComment *)remoteCommentFromXMLRPCDictionary:(NSDictionary *)xmlrpcDictionary

--- a/WordPress/Classes/Networking/MediaServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteREST.m
@@ -189,11 +189,9 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 
 - (NSArray *)remoteMediaFromJSONArray:(NSArray *)jsonMedia
 {
-    NSMutableArray *remoteMedia = [NSMutableArray arrayWithCapacity:jsonMedia.count];
-    for (NSDictionary *json in jsonMedia) {
-        [remoteMedia addObject:[self remoteMediaFromJSONDictionary:json]];
-    }
-    return [NSArray arrayWithArray:remoteMedia];
+    return [jsonMedia wp_map:^id(NSDictionary *json) {
+        return [self remoteMediaFromJSONDictionary:json];
+    }];
 }
 
 - (RemoteMedia *)remoteMediaFromJSONDictionary:(NSDictionary *)jsonMedia

--- a/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
@@ -203,11 +203,9 @@
 
 - (NSArray *)remoteMediaFromXMLRPCArray:(NSArray *)xmlrpcArray
 {
-    NSMutableArray *remoteMedia = [NSMutableArray arrayWithCapacity:xmlrpcArray.count];
-    for (NSDictionary *xmlrpcMedia in xmlrpcArray) {
-        [remoteMedia addObject:[self remoteMediaFromXMLRPCDictionary:xmlrpcMedia]];
-    }
-    return [NSArray arrayWithArray:remoteMedia];
+    return [xmlrpcArray wp_map:^id(NSDictionary *xmlrpcMedia) {
+        return [self remoteMediaFromUploadXMLRPCDictionary:xmlrpcMedia];
+    }];
 }
 
 - (RemoteMedia *)remoteMediaFromXMLRPCDictionary:(NSDictionary*)xmlRPC

--- a/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
@@ -204,7 +204,7 @@
 - (NSArray *)remoteMediaFromXMLRPCArray:(NSArray *)xmlrpcArray
 {
     return [xmlrpcArray wp_map:^id(NSDictionary *xmlrpcMedia) {
-        return [self remoteMediaFromUploadXMLRPCDictionary:xmlrpcMedia];
+        return [self remoteMediaFromXMLRPCDictionary:xmlrpcMedia];
     }];
 }
 

--- a/WordPress/Classes/Networking/PostCategoryServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostCategoryServiceRemoteREST.m
@@ -58,11 +58,9 @@
 
 - (NSArray *)remoteCategoriesWithJSONArray:(NSArray *)jsonArray
 {
-    NSMutableArray *categories = [NSMutableArray arrayWithCapacity:jsonArray.count];
-    for (NSDictionary *jsonCategory in jsonArray) {
-        [categories addObject:[self remoteCategoryWithJSONDictionary:jsonCategory]];
-    }
-    return [NSArray arrayWithArray:categories];
+    return [jsonArray wp_map:^id(NSDictionary *jsonCategory) {
+        return [self remoteCategoryWithJSONDictionary:jsonCategory];
+    }];
 }
 
 - (RemotePostCategory *)remoteCategoryWithJSONDictionary:(NSDictionary *)jsonCategory

--- a/WordPress/Classes/Networking/PostCategoryServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostCategoryServiceRemoteXMLRPC.m
@@ -80,11 +80,9 @@
 
 - (NSArray *)remoteCategoriesFromXMLRPCArray:(NSArray *)xmlrpcArray
 {
-    NSMutableArray *categories = [NSMutableArray arrayWithCapacity:xmlrpcArray.count];
-    for (NSDictionary *xmlrpcCategory in xmlrpcArray) {
-        [categories addObject:[self remoteCategoryFromXMLRPCDictionary:xmlrpcCategory]];
-    }
-    return [NSArray arrayWithArray:categories];
+    return [xmlrpcArray wp_map:^id(NSDictionary *xmlrpcCategory) {
+        return [self remoteCategoryFromXMLRPCDictionary:xmlrpcCategory];
+    }];
 }
 
 - (RemotePostCategory *)remoteCategoryFromXMLRPCDictionary:(NSDictionary *)xmlrpcDictionary

--- a/WordPress/Classes/Networking/PostServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.m
@@ -221,11 +221,9 @@
 #pragma mark - Private methods
 
 - (NSArray *)remotePostsFromJSONArray:(NSArray *)jsonPosts {
-    NSMutableArray *posts = [NSMutableArray arrayWithCapacity:jsonPosts.count];
-    for (NSDictionary *jsonPost in jsonPosts) {
-        [posts addObject:[self remotePostFromJSONDictionary:jsonPost]];
-    }
-    return [NSArray arrayWithArray:posts];
+    return [jsonPosts wp_map:^id(NSDictionary *jsonPost) {
+        return [self remotePostFromJSONDictionary:jsonPost];
+    }];
 }
 
 - (RemotePost *)remotePostFromJSONDictionary:(NSDictionary *)jsonPost {
@@ -349,8 +347,7 @@
 }
 
 - (NSArray *)metadataForPost:(RemotePost *)post {
-    NSMutableArray *metadata = [NSMutableArray arrayWithCapacity:post.metadata.count];
-    for (NSDictionary *meta in post.metadata) {
+    return [post.metadata wp_map:^id(NSDictionary *meta) {
         NSNumber *metaID = [meta objectForKey:@"id"];
         NSString *metaValue = [meta objectForKey:@"value"];
         NSString *operation = @"update";
@@ -361,17 +358,14 @@
         }
         NSMutableDictionary *modifiedMeta = [meta mutableCopy];
         modifiedMeta[@"operation"] = operation;
-        [metadata addObject:[NSDictionary dictionaryWithDictionary:modifiedMeta]];
-    }
-    return [NSArray arrayWithArray:metadata];
+        return [NSDictionary dictionaryWithDictionary:modifiedMeta];
+    }];
 }
 
 - (NSArray *)remoteCategoriesFromJSONArray:(NSArray *)jsonCategories {
-    NSMutableArray *categories = [NSMutableArray arrayWithCapacity:jsonCategories.count];
-    for (NSDictionary *jsonCategory in jsonCategories) {
-        [categories addObject:[self remoteCategoryFromJSONDictionary:jsonCategory]];
-    }
-    return [NSArray arrayWithArray:categories];
+    return [jsonCategories wp_map:^id(NSDictionary *jsonCategory) {
+        return [self remoteCategoryFromJSONDictionary:jsonCategory];
+    }];
 }
 
 - (RemotePostCategory *)remoteCategoryFromJSONDictionary:(NSDictionary *)jsonCategory {

--- a/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
@@ -287,7 +287,7 @@ const NSInteger HTTP404ErrorCode = 404;
 
 - (NSArray *)remoteCategoriesFromXMLRPCTermsArray:(NSArray *)terms {
     return [[terms wp_filter:^BOOL(NSDictionary *category) {
-        return [category[@"taxonomy"] isEqualToString:@"category"];
+        return [[category stringForKey:@"taxonomy"] isEqualToString:@"category"];
     }] wp_map:^id(NSDictionary *category) {
         return [self remoteCategoryFromXMLRPCDictionary:category];
     }];

--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -243,11 +243,10 @@
                       return;
                   }
 
-                  NSArray *arr = [responseObject arrayForKey:@"posts"];
-                  NSMutableArray *posts = [NSMutableArray array];
-                  for (NSDictionary *dict in arr) {
-                      [posts addObject:[self formatPostDictionary:dict]];
-                  }
+                  NSArray *jsonPosts = [responseObject arrayForKey:@"posts"];
+                  NSArray *posts = [jsonPosts wp_map:^id(NSDictionary *jsonPost) {
+                      return [self formatPostDictionary:jsonPost];
+                  }];
                   success(posts);
 
               } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
@@ -602,12 +601,9 @@
 
 - (NSArray *)slugsFromDiscoverPostTaxonomies:(NSArray *)discoverPostTaxonomies
 {
-    NSMutableArray *slugs = [NSMutableArray array];
-    for (NSDictionary *dict in discoverPostTaxonomies) {
-        NSString *slug = [dict stringForKey:@"slug"];
-        [slugs addObject:slug];
-    }
-    return slugs;
+    return [discoverPostTaxonomies wp_map:^id(NSDictionary *dict) {
+        return [dict stringForKey:@"slug"];
+    }];
 }
 
 @end

--- a/WordPress/Classes/Networking/ReaderTopicServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderTopicServiceRemote.m
@@ -203,15 +203,11 @@ static NSString * const SiteDictionaryFollowingKey = @"is_following";
 
 - (NSArray *)normalizeMenuTopicsList:(NSArray *)rawTopics subscribed:(BOOL)subscribed recommended:(BOOL)recommended
 {
-    NSMutableArray *topics = [NSMutableArray array];
-    for (NSDictionary *topicDict in rawTopics) {
-        // Failsafe
-        if (![topicDict isKindOfClass:[NSDictionary class]]) {
-            continue;
-        }
-        [topics addObject:[self normalizeMenuTopicDictionary:topicDict subscribed:subscribed recommended:recommended]];
-    }
-    return [topics copy]; // Return immutable array.
+    return [[rawTopics wp_filter:^BOOL(id obj) {
+        return [obj isKindOfClass:[NSDictionary class]];
+    }] wp_map:^id(NSDictionary *topic) {
+        return [self normalizeMenuTopicDictionary:topic subscribed:subscribed recommended:recommended];
+    }];
 }
 
 - (RemoteReaderTopic *)normalizeMenuTopicDictionary:(NSDictionary *)topicDict subscribed:(BOOL)subscribed recommended:(BOOL)recommended

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -690,11 +690,9 @@ const NSInteger PostServiceNumberToFetch = 40;
 
 - (NSArray *)remoteCategoriesForPost:(Post *)post
 {
-    NSMutableArray *remoteCategories = [NSMutableArray arrayWithCapacity:post.categories.count];
-    for (PostCategory *category in post.categories) {
-        [remoteCategories addObject:[self remoteCategoryWithCategory:category]];
-    }
-    return [NSArray arrayWithArray:remoteCategories];
+    return [[post.categories allObjects] wp_map:^id(PostCategory *category) {
+        return [self remoteCategoryWithCategory:category];
+    }];
 }
 
 - (RemotePostCategory *)remoteCategoryWithCategory:(PostCategory *)category

--- a/WordPress/Classes/Utility/WPMapFilterReduce.h
+++ b/WordPress/Classes/Utility/WPMapFilterReduce.h
@@ -13,12 +13,12 @@ typedef id (^WPReduceBlock)(id accumulator, id obj);
  the receiver array objects. If mapBlock returns nil that value will be missing
  from the resulting array.
  */
-- (instancetype)wp_map:(WPMapBlock)mapBlock;
+- (NSArray *)wp_map:(WPMapBlock)mapBlock;
 
 /**
  Filters an array to only include values that satisfy the filter block
  */
-- (instancetype)wp_filter:(WPFilterBlock)filterBlock;
+- (NSArray *)wp_filter:(WPFilterBlock)filterBlock;
 
 /**
  Combines the array values into a single value

--- a/WordPress/Classes/Utility/WPMapFilterReduce.m
+++ b/WordPress/Classes/Utility/WPMapFilterReduce.m
@@ -11,7 +11,7 @@
             [results addObject:objectToAdd];
         }
     }
-    return [[self class] arrayWithArray:results];
+    return [NSArray arrayWithArray:results];
 }
 
 - (instancetype)wp_filter:(WPFilterBlock)filterBlock
@@ -22,7 +22,7 @@
             [results addObject:obj];
         }
     }
-    return [[self class] arrayWithArray:results];
+    return [NSArray arrayWithArray:results];
 }
 
 - (id)wp_reduce:(WPReduceBlock)reduceBlock withInitialValue:(id)initial

--- a/WordPress/Classes/Utility/WPMapFilterReduce.m
+++ b/WordPress/Classes/Utility/WPMapFilterReduce.m
@@ -2,7 +2,7 @@
 
 @implementation NSArray (WPMapFilterReduce)
 
-- (instancetype)wp_map:(WPMapBlock)mapBlock
+- (NSArray *)wp_map:(WPMapBlock)mapBlock
 {
     NSMutableArray *results = [NSMutableArray arrayWithCapacity:self.count];
     for (id obj in self) {
@@ -14,7 +14,7 @@
     return [NSArray arrayWithArray:results];
 }
 
-- (instancetype)wp_filter:(WPFilterBlock)filterBlock
+- (NSArray *)wp_filter:(WPFilterBlock)filterBlock
 {
     NSMutableArray *results = [NSMutableArray arrayWithCapacity:self.count];
     for (id obj in self) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -762,10 +762,9 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 
 - (void)displayFilters
 {
-    NSMutableArray *titles = [NSMutableArray array];
-    for (PostListFilter *filter in self.postListFilters) {
-        [titles addObject:filter.title];
-    }
+    NSArray *titles = [self.postListFilters wp_map:^id(PostListFilter *filter) {
+        return filter.title;
+    }];
     NSDictionary *dict = @{
                            SettingsSelectionDefaultValueKey   : [self.postListFilters firstObject],
                            SettingsSelectionTitleKey          : NSLocalizedString(@"Filters", @"Title of the list of post status filters."),

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -752,10 +752,9 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     }
 
     NSArray *statuses = [self.apost availableStatusesForEditing];
-    NSMutableArray *titles = [NSMutableArray array];
-    for (NSString *status in statuses) {
-        [titles addObject:[BasePost titleForStatus:status]];
-    }
+    NSArray *titles = [statuses wp_map:^id(NSString *status) {
+        return [BasePost titleForStatus:status];
+    }];
 
     NSDictionary *statusDict = @{
                                  @"DefaultValue": PostStatusPublish,

--- a/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
@@ -605,16 +605,10 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 
 - (NSArray *)controlsToHideWithKeyboardOffset:(CGFloat)offset
 {
-    NSMutableArray *controlsToHide = [NSMutableArray array];
-    
-    // Find  controls that fall off the screen
-    for (UIView *control in self.controlsToMoveForTextEntry) {
-        if (control.frame.origin.y - offset <= 0) {
-            [controlsToHide addObject:control];
-        }
-    }
-    
-    return controlsToHide;
+    return [self.controlsToMoveForTextEntry wp_filter:^BOOL(UIView *control) {
+        // Find  controls that fall off the screen
+        return (control.frame.origin.y - offset <= 0);
+    }];
 }
 
 

--- a/WordPress/WordPress_Prefix.pch
+++ b/WordPress/WordPress_Prefix.pch
@@ -22,6 +22,7 @@
     #import "NSString+Util.h"
     #import "WPError.h"
     #import "UIColor+Helpers.h"
+    #import "WPMapFilterReduce.h"
 
 #ifndef IS_IPAD
 #define IS_IPAD   ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)


### PR DESCRIPTION
Replaces common map/filter patterns with the new methods from #4156 

I've tried to replace only very obvious cases, and I've left alone a few things that could match the map pattern, but performed some other side effects (e.g. Service classes that could create new core data objects inside the map block).

Needs Review: @jleandroperez 