### PR TITLE
Added the URL that's causing the failure in the api version check.

### DIFF
--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -148,7 +148,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 {
     NSAssert([URLString rangeOfString:@"v1.1"].length > 0
              || [URLString rangeOfString:@"v1.2"].length > 0,
-             @"Unexpected API version.");
+             @"Unexpected API version in URL: %@", URLString);
 }
 
 - (AFHTTPRequestOperation *)DELETE:(NSString *)URLString


### PR DESCRIPTION
**How to test:**
1. In `WordPressComApi.m` add the line marked by the comment:
```objective-c
- (void)assertApiVersion:(NSString *)URLString
{
    URLString = @"bad/bad/api"; // Add this line

    NSAssert([URLString rangeOfString:@"v1.1"].length > 0
             || [URLString rangeOfString:@"v1.2"].length > 0,
             @"Unexpected API version in URL: %@", URLString);
}
```
2. Launch the app and make sure any service is called.  The assertion should fail and show the URL added above.


/cc @sendhil 