### PR TITLE
Media - Featured image cleanup

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -198,7 +198,7 @@
     }
 
     for (Media *media in self.media) {
-        if (media.mediaType == MediaTypeImage || media.mediaType == MediaTypeFeatured) {
+        if (media.mediaType == MediaTypeImage) {
             return true;
         }
     }

--- a/WordPress/Classes/Models/Media.h
+++ b/WordPress/Classes/Models/Media.h
@@ -12,7 +12,6 @@ typedef NS_ENUM(NSUInteger, MediaRemoteStatus) {
 
 typedef NS_ENUM(NSUInteger, MediaType) {
     MediaTypeImage,
-    MediaTypeFeatured,
     MediaTypeVideo,
     MediaTypeDocument,
     MediaTypePowerpoint
@@ -35,7 +34,6 @@ typedef NS_ENUM(NSUInteger, MediaOrientation) {
 @property (nonatomic, strong) NSNumber * mediaID;
 @property (nonatomic, strong) NSString * mediaTypeString;
 @property (nonatomic, assign) MediaType mediaType;
-@property (weak, nonatomic, readonly) NSString * mediaTypeName;
 @property (nonatomic, strong) NSString * remoteURL;
 @property (nonatomic, strong) NSString * localURL;
 @property (nonatomic, strong) NSString * shortcode;
@@ -48,7 +46,7 @@ typedef NS_ENUM(NSUInteger, MediaOrientation) {
 @property (nonatomic, strong) NSString * orientation DEPRECATED_ATTRIBUTE;
 @property (nonatomic, strong) NSDate * creationDate;
 @property (nonatomic, strong) NSString *videopressGUID;
-@property (weak, nonatomic, readonly) NSString * html;
+@property (nonatomic, weak, readonly) NSString * html;
 @property (nonatomic, strong) NSNumber * remoteStatusNumber;
 @property (nonatomic, assign) MediaRemoteStatus remoteStatus;
 @property (nonatomic, strong) NSString * caption;
@@ -56,14 +54,13 @@ typedef NS_ENUM(NSUInteger, MediaOrientation) {
 @property (nonatomic, strong) Blog * blog;
 @property (nonatomic, strong) NSMutableSet * posts;
 @property (nonatomic, assign, readonly) BOOL unattached;
-@property (nonatomic, assign) BOOL featured;
+@property (nonatomic, assign, readonly) BOOL featured;
 @property (nonatomic, strong) NSString *absoluteLocalURL;
 @property (nonatomic, strong) NSString *remoteThumbnailURL;
 @property (nonatomic, strong) NSString *localThumbnailURL;
 @property (nonatomic, strong) NSString *absoluteThumbnailLocalURL;
-@property (nonatomic, readonly, strong) NSString *posterImageURL;
+@property (nonatomic, strong, readonly) NSString *posterImageURL;
 
-+ (NSString *)mediaTypeForFeaturedImage;
 
 - (void)mediaTypeFromUrl:(NSString *)ext;
 

--- a/WordPress/Classes/Models/Media.h
+++ b/WordPress/Classes/Models/Media.h
@@ -63,8 +63,6 @@ typedef NS_ENUM(NSUInteger, MediaOrientation) {
 @property (nonatomic, strong) NSString *absoluteThumbnailLocalURL;
 @property (nonatomic, readonly, strong) NSString *posterImageURL;
 
-+ (Media *)newMediaForPost:(AbstractPost *)post;
-+ (Media *)newMediaForBlog:(Blog *)blog;
 + (NSString *)mediaTypeForFeaturedImage;
 
 - (void)mediaTypeFromUrl:(NSString *)ext;

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -26,23 +26,6 @@
 
 @synthesize unattached;
 
-+ (Media *)newMediaForPost:(AbstractPost *)post
-{
-    Media *media = [NSEntityDescription insertNewObjectForEntityForName:@"Media" inManagedObjectContext:post.managedObjectContext];
-    media.blog = post.blog;
-    media.posts = [NSMutableSet setWithObject:post];
-    media.mediaID = @0;
-    return media;
-}
-
-+ (Media *)newMediaForBlog:(Blog *)blog
-{
-    Media *media = [NSEntityDescription insertNewObjectForEntityForName:@"Media" inManagedObjectContext:blog.managedObjectContext];
-    media.blog = blog;
-    media.mediaID = @0;
-    return media;
-}
-
 - (void)mediaTypeFromUrl:(NSString *)ext
 {
     CFStringRef fileExt = (__bridge CFStringRef)ext;

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -63,7 +63,8 @@
     } else if ([self.mediaTypeString isEqualToString:@"document"]) {
         return MediaTypeDocument;
     } else if ([self.mediaTypeString isEqualToString:@"featured"]) {
-        return MediaTypeFeatured;
+        // this is for object that where still storing the old value.
+        return MediaTypeImage;
     }
     return MediaTypeDocument;
 }
@@ -73,9 +74,6 @@
     switch (mediaType) {
         case MediaTypeImage:
             self.mediaTypeString = @"image";
-            break;
-        case MediaTypeFeatured:
-            self.mediaTypeString = @"featured";
             break;
         case MediaTypeVideo:
             self.mediaTypeString = @"video";
@@ -89,31 +87,16 @@
     }
 }
 
-- (NSString *)mediaTypeName
-{
-    if (self.mediaType == MediaTypeImage) {
-        return NSLocalizedString(@"Image", @"");
-    } else if (self.mediaType == MediaTypeVideo) {
-        return NSLocalizedString(@"Video", @"");
-    }
-
-    return self.mediaTypeString;
-}
-
 - (BOOL)featured
 {
-    return self.mediaType == MediaTypeFeatured;
+    for (AbstractPost *post in self.posts) {
+        if ([post.post_thumbnail isEqualToNumber:self.mediaID]){
+            return YES;
+        }
+    }
+    return NO;
 }
 
-- (void)setFeatured:(BOOL)featured
-{
-    self.mediaType = featured ? MediaTypeFeatured : MediaTypeImage;
-}
-
-+ (NSString *)mediaTypeForFeaturedImage
-{
-    return @"image";
-}
 
 #pragma mark -
 

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -511,14 +511,14 @@ static NSString * const MediaDirectory = @"Media";
     media.remoteThumbnailURL = remoteMedia.remoteThumbnailURL;
 }
 
-- (RemoteMedia *) remoteMediaFromMedia:(Media *)media
+- (RemoteMedia *)remoteMediaFromMedia:(Media *)media
 {
     RemoteMedia *remoteMedia = [[RemoteMedia alloc] init];
     remoteMedia.mediaID = media.mediaID;
     remoteMedia.url = [NSURL URLWithString:media.remoteURL];
     remoteMedia.date = media.creationDate;
     remoteMedia.file = media.filename;
-    remoteMedia.extension = media.mediaTypeString;
+    remoteMedia.extension = [media.filename pathExtension] ? :@"unknown";
     remoteMedia.title = media.title;
     remoteMedia.caption = media.caption;
     remoteMedia.descriptionText = media.desc;

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -486,8 +486,10 @@ static NSString * const MediaDirectory = @"Media";
             [self.managedObjectContext deleteObject:deleteMedia];
         }
     }
-
-    [self.managedObjectContext save:nil];
+    NSError *error;
+    if (![self.managedObjectContext save:&error]){
+        DDLogError(@"Error saving context afer adding media %@", [error localizedDescription]);
+    }
     if (completion) {
         completion();
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -236,10 +236,10 @@
     NSPredicate *predicate;
     switch (filter) {
         case WPMediaTypeImage: {
-            predicate = [NSPredicate predicateWithFormat:@"mediaTypeString = %@", @"image && blog = %@", blog];
+            predicate = [NSPredicate predicateWithFormat:@"mediaTypeString = %@ && blog = %@",  @"image", blog];
         } break;
         case WPMediaTypeVideo: {
-            predicate = [NSPredicate predicateWithFormat:@"mediaTypeString = %@", @"video && blog = %@", blog];
+            predicate = [NSPredicate predicateWithFormat:@"mediaTypeString = %@ && blog = %@", @"video", blog];
         } break;
         case WPMediaTypeAll: {
             predicate = [NSPredicate predicateWithFormat:@"(mediaTypeString = %@ || mediaTypeString = %@)  && blog = %@", @"image", @"video", blog];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -990,7 +990,6 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
             strongSelf.isUploadingMedia = NO;
             return;
         }
-        media.mediaType = MediaTypeFeatured;
         [self uploadFeaturedMedia:media];
     }];
 }


### PR DESCRIPTION
Cleans code around the media model and detection of a feature image.

The MediaTypeFeatured enum didn't make sense, because the same Media model object can be used in two different posts and be featured on one and not in the other. 

The proper checks need to be done using ```post.post_thumbnail```.

Needs Review: @astralbodies 