### PR TITLE
Fix CoreData relationships using ns mutable set

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -4,6 +4,7 @@
 #import "WPPostContentViewProvider.h"
 
 @class Media;
+@class Comment;
 
 @interface AbstractPost : BasePost<WPPostContentViewProvider>
 
@@ -12,7 +13,7 @@
 @property (nonatomic, strong) NSSet *media;
 @property (weak, readonly) AbstractPost *original;
 @property (weak, readonly) AbstractPost *revision;
-@property (nonatomic, strong) NSMutableSet *comments;
+@property (nonatomic, strong) NSSet *comments;
 @property (nonatomic, strong) Media *featuredImage;
 
 // By convention these should be treated as read only and not manually set.
@@ -84,5 +85,10 @@
 - (void)removeMediaObject:(Media *)value;
 - (void)addMedia:(NSSet *)values;
 - (void)removeMedia:(NSSet *)values;
+
+- (void)addCommentsObject:(Comment *)value;
+- (void)removeCommentsObject:(Comment *)value;
+- (void)addComments:(NSSet *)values;
+- (void)removeComments:(NSSet *)values;
 
 @end

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -241,7 +241,7 @@
     NSSet *comments = [self.blog.comments filteredSetUsingPredicate:
                        [NSPredicate predicateWithFormat:@"(postID == %@) AND (post == NULL)", self.postID]];
     if ([comments count] > 0) {
-        [self.comments unionSet:comments];
+        [self addComments:comments];
     }
 }
 

--- a/WordPress/Classes/Models/Post.h
+++ b/WordPress/Classes/Models/Post.h
@@ -15,7 +15,7 @@
 @property (nonatomic, strong) NSString *tags;
 @property (nonatomic, strong) NSString *postFormat;
 @property (nonatomic, strong) NSString *postFormatText;
-@property (nonatomic, strong) NSMutableSet *categories;
+@property (nonatomic, strong) NSSet *categories;
 
 // We shouldn't need to store this, but if we don't send IDs on edits
 // custom fields get duplicated and stop working
@@ -44,5 +44,16 @@
  @param categoryNames a `NSArray` with the names of the categories for this post. If a given category name doesn't exist it's ignored.
  */
 - (void)setCategoriesFromNames:(NSArray *)categoryNames;
+
+@end
+
+@class PostCategory;
+
+@interface Post (CoreDataGeneratedAccessors)
+
+- (void)addCategoriesObject:(PostCategory *)value;
+- (void)removeCategoriesObject:(PostCategory *)value;
+- (void)addCategories:(NSSet *)values;
+- (void)removeCategories:(NSSet *)values;
 
 @end

--- a/WordPress/Classes/Models/Post.m
+++ b/WordPress/Classes/Models/Post.m
@@ -89,7 +89,7 @@
 
 - (void)setCategoriesFromNames:(NSArray *)categoryNames
 {
-    [self.categories removeAllObjects];
+    [self removeCategories:self.categories];
     NSMutableSet *categories = nil;
 
     for (NSString *categoryName in categoryNames) {
@@ -104,7 +104,7 @@
     }
 
     if (categories && (categories.count > 0)) {
-        self.categories = categories;
+        [self addCategories:categories];
     }
 }
 

--- a/WordPress/Classes/Models/PostCategory.h
+++ b/WordPress/Classes/Models/PostCategory.h
@@ -9,7 +9,18 @@ extern const NSInteger PostCategoryUncategorized;
 @property (nonatomic, strong) NSNumber *categoryID;
 @property (nonatomic, strong) NSString *categoryName;
 @property (nonatomic, strong) NSNumber *parentID;
-@property (nonatomic, strong) NSMutableSet *posts;
+@property (nonatomic, strong) NSSet *posts;
 @property (nonatomic, strong) Blog *blog;
+
+@end
+
+@class Post;
+
+@interface PostCategory (CoreDataGeneratedAccessors)
+
+- (void)addPostsObject:(Post *)value;
+- (void)removePostsObject:(Post *)value;
+- (void)addPosts:(NSSet *)values;
+- (void)removePosts:(NSSet *)values;
 
 @end

--- a/WordPress/Classes/Models/ReaderPost.h
+++ b/WordPress/Classes/Models/ReaderPost.h
@@ -5,6 +5,7 @@
 
 @class ReaderTopic;
 @class SourcePostAttribution;
+@class Comment;
 
 extern NSString * const ReaderPostStoredCommentIDKey;
 extern NSString * const ReaderPostStoredCommentTextKey;
@@ -32,7 +33,7 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 @property (nonatomic, strong) NSDate *sortDate;
 @property (nonatomic, strong) NSString *storedComment; // Formatted as commentID,string
 @property (nonatomic, strong) NSString *summary;
-@property (nonatomic, strong) NSMutableSet *comments;
+@property (nonatomic, strong) NSSet *comments;
 @property (nonatomic, readonly, strong) NSURL *featuredImageURL;
 @property (nonatomic, strong) NSString *tags;
 @property (nonatomic, strong) ReaderTopic *topic;
@@ -52,3 +53,13 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 - (BOOL)isSourceAttributionWPCom;
 
 @end
+
+@interface ReaderPost (CoreDataGeneratedAccessors)
+
+- (void)addCommentsObject:(Comment *)value;
+- (void)removeCommentsObject:(Comment *)value;
+- (void)addComments:(NSSet *)values;
+- (void)removeComments:(NSSet *)values;
+
+@end
+

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -33,7 +33,7 @@ const NSInteger PostServiceNumberToFetch = 40;
     PostCategoryService *postCategoryService = [[PostCategoryService alloc] initWithManagedObjectContext:self.managedObjectContext];
     PostCategory *category = [postCategoryService findWithBlogObjectID:blog.objectID andCategoryID:blog.defaultCategoryID];
     if (category) {
-        [post.categories addObject:category];
+        [post addCategoriesObject:category];
     }
     post.postFormat = blog.defaultPostFormat;
     return post;


### PR DESCRIPTION
Fix the relationships that where using NSMutableSet with this recommendations:

See what they say here: https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/CoreData/Articles/cdAccessorMethods.html#//apple_ref/doc/uid/TP40002154-SW7

```
You declare attributes and relationships as you would properties for any other object, as illustrated in the
 following example. When you declare a to-many relationship, the property type should be NSSet *. (The
value returned from the get accessor is not a KVO-compliant mutable proxy—for more details, see To-many relationships.)
```

Needs Review: @astralbodies 