### PR TITLE
Allow v1 REST api calls.

### DIFF
--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -146,7 +146,8 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 #if !defined(NS_BLOCK_ASSERTIONS)
 - (void)assertApiVersion:(NSString *)URLString
 {
-    NSAssert([URLString rangeOfString:@"v1.1"].length > 0
+    NSAssert([URLString rangeOfString:@"/v1/"].length > 0
+             || [URLString rangeOfString:@"v1.1"].length > 0
              || [URLString rangeOfString:@"v1.2"].length > 0,
              @"Unexpected API version in URL: %@", URLString);
 }


### PR DESCRIPTION
Fixes the following crash in `release/5.6`.

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Unexpected API version in URL: https://public-api.wordpress.com/rest/v1/read/a8c'
```

/cc @sendhil 