### PR TITLE
NotificationSettingsViewController: Fixes invalid var mapping

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -251,7 +251,7 @@ public class NotificationSettingsViewController : UIViewController
             cell.accessoryType              = .DisclosureIndicator
             
             if let siteIconURL = settings.blog?.icon {
-                cell.imageView?.setImageWithSiteIcon(settings.blog?.icon)
+                cell.imageView?.setImageWithSiteIcon(siteIconURL)
             } else {
                 cell.imageView?.image = WPStyleGuide.Notifications.blavatarPlaceholderImage
             }


### PR DESCRIPTION
#### Steps:
1. Launch WPiOS
2. Tap over `Me` and open the `Notification Settings`

As soon as any of the `Blog` rows show up, they should display an icon at the right side.

Props to @sendhil for pointing this one out!

Needs Review: @sendhil (Thanks sir!!)
