### PR TITLE
WebViewController: Don't retryWithLogin when not needed

### DIFF
--- a/WordPress/Classes/Categories/NSURL+Util.m
+++ b/WordPress/Classes/Categories/NSURL+Util.m
@@ -1,15 +1,12 @@
 #import "NSURL+Util.h"
 #import "NSString+Util.h"
+#import "NSString+Helpers.h"
 
 @implementation NSURL (Util)
 
 - (BOOL)isWordPressDotComUrl
 {
-    NSString *url = [self absoluteString];
-    NSRegularExpression *protocol = [NSRegularExpression regularExpressionWithPattern:@"wordpress\\.com" options:NSRegularExpressionCaseInsensitive error:nil];
-    NSArray *result = [protocol matchesInString:[url trim] options:NSRegularExpressionCaseInsensitive range:NSMakeRange(0, [[url trim] length])];
-
-    return [result count] != 0;
+    return [self.absoluteString isWordPressComPath];
 }
 
 - (NSURL *)ensureSecureURL

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -183,8 +183,9 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
         return;
     }
 
-    if (!self.needsLogin && self.hasCredentials && ![WPCookie hasCookieForURL:self.url andUsername:self.username]) {
-        DDLogWarn(@"We have login credentials but no cookie, let's try login first");
+    BOOL hasCookies = [WPCookie hasCookieForURL:self.url andUsername:self.username];
+    if (self.url.isWordPressDotComUrl && !self.needsLogin && self.hasCredentials && !hasCookies) {
+        DDLogWarn(@"WordPress.com URL: We have login credentials but no cookie, let's try login first");
         [self retryWithLogin];
         return;
     }


### PR DESCRIPTION
I've noticed that the `WPWebViewController` tool was appending, almost always, `wp-login.php`. Even to 3rd party URL's, such as github links, and self hosted blogs that didn't really require authentication.

Logic was patched, so that we only retry with credentials whenever we hit a `wp-login.php` url.

Plus, `NSURL`'s `isWordPressDotComUrl` helper has been patched to reuse `NSString`'s `isWordPressDotComUrl`. Reason for that is: the NSString implementation is (A) already unit tested, and (B) is more robust. Links such as `https://href.li/?https://lanteanartest.wordpress.com/` are no longer detected as `WordPress.com`, and thus, won't fail to load.

#### Steps:
1. Launch WPiOS and open the reader
2. Find any post that contains links to a github // elsewhere
3. Attempt to load those links. They should open without further issues
4. Attempt to load a WordPress `private` link. It should also load without issues

Needs Review: @diegoreymendez 
Thanks in advance Diego!

Fixes #4242
