### PR TITLE
Update media picker version.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -36,7 +36,7 @@ pod 'WordPressCom-Stats-iOS', '0.4.6'
 pod 'WordPressCom-Analytics-iOS', '0.0.36'
 pod 'SocketRocket', :git => 'https://github.com/jleandroperez/SocketRocket.git', :commit => '3ff6038ad95fb94fd9bd4021f5ecf07fc53a6927'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '303b8068530389ea87afde38b77466d685fe3210'
-pod 'WPMediaPicker', '~>0.5.0'
+pod 'WPMediaPicker', '0.6.0'
 pod 'ReactiveCocoa', '~> 2.4.7'
 pod 'FormatterKit', '~> 1.8.0'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -154,8 +154,8 @@ PODS:
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.3)
     - WordPressCom-Analytics-iOS (~> 0.0.34)
-  - WPMediaPicker (0.5.0)
   - wpxmlrpc (0.8)
+  - WPMediaPicker (0.6.0)
 
 DEPENDENCIES:
   - 1PasswordExtension (= 1.1.2)
@@ -286,7 +286,7 @@ SPEC CHECKSUMS:
   WordPressApi: 51f1b2a07b0c51bf5527c744a4deed2b4159c69f
   WordPressCom-Analytics-iOS: a54b61f75be5a43fe32be98c0b286cb18fc2abee
   WordPressCom-Stats-iOS: d8114636166036ab42f091ad4e018617d2ffbeb9
-  WPMediaPicker: 0757988f1519c20b92c91f470c41633ac42e3a0e
   wpxmlrpc: 053c9cbed13dcec08515a4ffeb51780f6e858cc7
+  WPMediaPicker: 6e7904663b386ad4eea2f2e3dc30fd15babceb66
 
 COCOAPODS: 0.37.2


### PR DESCRIPTION
Update new media picker version with the ImageCacheManager. This should solve the non-retina iPad crashes

Needs Review: @sendhil 