### PR TITLE
NotificationSettings: Updates wpcom Settings Description

### DIFF
--- a/WordPress/Classes/Models/Notifications/NotificationSettings.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationSettings.swift
@@ -92,7 +92,7 @@ public class NotificationSettings
             case .Other:
                 return NSLocalizedString("Comments on Other Sites", comment: "Notification Settings Channel")
             case .WordPressCom:
-                return NSLocalizedString("Updates from WordPress.com", comment: "Notification Settings Channel")
+                return NSLocalizedString("Email from WordPress.com", comment: "Notification Settings Channel")
             }
         }
     }


### PR DESCRIPTION
#### Steps:
1. Log into the app
2. Tap over `Me` > `Notification Settings`

The last row should say `Email from WordPress.com`.

Needs Review: @diegoreymendez (Thank you Diego!
Closes #4252
