### PR TITLE
Fixes a crash due to mismatch creating constraint.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
+++ b/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
@@ -156,7 +156,7 @@ static const UIEdgeInsets ReplyAndLikeButtonEdgeInsets = {0.0f, 4.0f, 0.0f, -4.0
                                                                        attribute:NSLayoutAttributeLeading
                                                                        relatedBy:NSLayoutRelationEqual
                                                                           toItem:self.commentMeta
-                                                                       attribute:NSLayoutAttributeLeftMargin
+                                                                       attribute:NSLayoutAttributeLeading
                                                                       multiplier:1.0
                                                                         constant:0];
     [self.commentMeta addConstraint:self.likeButtonLeftMarginConstraint];
@@ -172,7 +172,7 @@ static const UIEdgeInsets ReplyAndLikeButtonEdgeInsets = {0.0f, 4.0f, 0.0f, -4.0
                                                                                attribute:NSLayoutAttributeLeading
                                                                                relatedBy:NSLayoutRelationEqual
                                                                                   toItem:self.commentMeta
-                                                                               attribute:NSLayoutAttributeLeftMargin
+                                                                               attribute:NSLayoutAttributeLeading
                                                                               multiplier:1.0
                                                                                 constant:0];
     [self.commentMeta addConstraint:self.numberOfLikesLabelLeftMarginConstraint];


### PR DESCRIPTION
Fixes a crash in iOS 9 due to a type mix match defining two constraints. 

Exception:
>  *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** +[NSLayoutConstraint constraintWithItem:attribute:relatedBy:toItem:attribute:multiplier:constant:]: A constraint cannot be made between a leading/trailing attribute and a right/left attribute. Use leading/trailing for both or neither.'

To test: 
Confirm the crash by launching an iOS 9 simulator and viewing comments in the reader. 
Confirm the fix by repeating the steps and ensuring there is no crash.

Needs Review: @jleandroperez 