### PR TITLE
iOS 9 Fix: Enabling Arbitrary Loads

### DIFF
--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -94,5 +94,10 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -88,5 +88,10 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
#### Steps:
1. Log into an account with a self hosted blog, that doesn't support HTTPS
2. Tap over `My Sites` and open your blog's details
3. Tap over `View Site`

As a result, the error pasted at the bottom would (normally) show up onscreen. In this PR we allow unencrypted `http` requests (iOS 9 security feature).

Needs Review: @sendhil 

```
UserInfo={NSErrorFailingURLStringKey=http://www.lantean.co/, NSLocalizedDescription=The resource could not be loaded because the App Transport Security policy requires the use of a secure connection., NSErrorFailingURLKey=http://www.lantean.co/}}, NSErrorFailingURLStringKey=http://www.lantean.co/, NSErrorFailingURLKey=http://www.lantean.co/, NSLocalizedDescription=The resource could not be loaded because the App Transport Security policy requires the use of a secure connection.}]
```