### PR TITLE
Fixes the background color for BlogDetailsViewController.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -133,6 +133,8 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 {
     [super viewDidLoad];
     
+    self.tableView.backgroundColor = [WPStyleGuide greyLighten30];
+    
     self.tableSections = @[@(TableViewSectionGeneralType),
                            @(TableViewSectionPublishType)
                           ];


### PR DESCRIPTION
Title has it.  The default color used throughout the rest of the app is `[WPStyleGuide greyLighten30];` so I just replicated that in the blog details screen.

/cc @koke 