### PR TITLE
Fixes the new-user and new-site services.

### DIFF
--- a/WordPress/Classes/Networking/WordPressComServiceRemote.m
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.m
@@ -79,7 +79,6 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
     [self.api POST:requestUrl parameters:params success:successBlock failure:failureBlock];
-    
 }
 
 - (void)validateWPComBlogWithUrl:(NSString *)blogUrl

--- a/WordPress/Classes/Networking/WordPressComServiceRemote.m
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.m
@@ -75,7 +75,10 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
                              @"client_secret" : [WordPressComApiCredentials secret]
                              };
     
-    [self.api POST:@"users/new" parameters:params success:successBlock failure:failureBlock];
+    NSString *requestUrl = [self pathForEndpoint:@"users/new"
+                                     withVersion:ServiceRemoteRESTApiVersion_1_1];
+    
+    [self.api POST:requestUrl parameters:params success:successBlock failure:failureBlock];
     
 }
 
@@ -183,10 +186,11 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
                              @"client_secret": [WordPressComApiCredentials secret]
                              };
     
-    [self.api POST:@"sites/new"
-        parameters:params
-           success:successBlock
-           failure:failureBlock];
+    
+    NSString *requestUrl = [self pathForEndpoint:@"sites/new"
+                                     withVersion:ServiceRemoteRESTApiVersion_1_1];
+    
+    [self.api POST:requestUrl parameters:params success:successBlock failure:failureBlock];
 }
 
 #pragma mark - Error localization


### PR DESCRIPTION
Fixes the new-user and new-site services that were causing issues in WPiOS 5.6.

**How to test:**
1. Launch an HTTP-request intercepting app (such as Charles).  Configure it to work with WPiOS.
2. Launch WPiOS.
3. At the login screen create a new account.
4. Make sure the account and blog are created properly.
5. Review the HTTP request logs to make sure the endpoints `v1.1/users/new` and `v1.1/sites/new` were called.

**Not to testers:** don't rely on the account and site being created only, since there's a hack @ the server side to allow this to work even if the version isn't set in the request.  That's the reason why I mention above that we should make sure the request URL contains the proper version number in its path.

/cc @sendhil, @jleandroperez