### PR TITLE
Fix 404 error following sites from menu.

### DIFF
--- a/WordPress/Classes/Networking/ReaderSiteServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderSiteServiceRemote.m
@@ -178,12 +178,8 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 
 - (void)checkSiteExistsAtURL:(NSURL *)siteURL success:(void (^)())success failure:(void(^)(NSError *error))failure
 {
-    NSString *path = [siteURL absoluteString];
-    NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteRESTApiVersion_1_1];
-    
     // Just ping the URL and make sure we don't get back a 40x error.
-    [self.api HEAD:requestUrl parameters:nil success:^(AFHTTPRequestOperation *operation) {
+    [self.api HEAD:[siteURL absoluteString] parameters:nil success:^(AFHTTPRequestOperation *operation) {
         if (success) {
             success();
         }

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -146,6 +146,10 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 #if !defined(NS_BLOCK_ASSERTIONS)
 - (void)assertApiVersion:(NSString *)URLString
 {
+    // Skip asserts for non API calls
+    if ([URLString rangeOfString:WordPressComApiClientEndpointURL].location == NSNotFound) {
+        return;
+    }
     NSAssert([URLString rangeOfString:@"/v1/"].length > 0
              || [URLString rangeOfString:@"v1.1"].length > 0
              || [URLString rangeOfString:@"v1.2"].length > 0,


### PR DESCRIPTION
Fixes an issue checking the existence of a site before following it.  The original call was just a HEAD request to the site to ensure it did not 404, but was accidentally included in the rest endpoint refactor.

To Test: 
Open the Reader's menu and try to follow `ma.tt`
Confirm you do not see a 404 error and are able to successfully follow the blog.

Needs review: @sendhil 