### PR TITLE
Adds *.xcscmblueprint to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ WordPress.xcworkspace/*.xcuserdata
 WordPress.xcworkspace/project.xcworkspace
 WordPress.xcworkspace/xcuserdata
 WordPress.xcworkspace/xcshareddata/WordPress.xccheckout
+WordPress.xcworkspace/xcshareddata/*.xcscmblueprint
 WordPress/Entitlements.plist
 WordPress/WordPress.xcodeproj/*.mode1v3
 WordPress/WordPress.xcodeproj/*.mode2v3
@@ -52,7 +53,6 @@ WordPress/WordPress.xcodeproj/*.pbxuser
 WordPress/WordPress.xcodeproj/*.perspectivev3
 WordPress/WordPress.xcodeproj/project.xcworkspace
 WordPress/WordPress.xcodeproj/xcuserdata
-WordPress.xcworkspace/xcshareddata/WordPress.xcscmblueprint
 /build
 .hockey_app_credentials
 WordPress/InfoPlist.h

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ WordPress/WordPress.xcodeproj/*.pbxuser
 WordPress/WordPress.xcodeproj/*.perspectivev3
 WordPress/WordPress.xcodeproj/project.xcworkspace
 WordPress/WordPress.xcodeproj/xcuserdata
+WordPress.xcworkspace/xcshareddata/WordPress.xcscmblueprint
 /build
 .hockey_app_credentials
 WordPress/InfoPlist.h


### PR DESCRIPTION
`WordPress.xcscmblueprint` is newly added with Xcode 7.  It contains info specific to an individuals local dev environment that we probably don't adding to the repo.  

Needs Review: @diegoreymendez 