### PR TITLE
Fixes an issue with like icon not updating with changes on post detail.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
@@ -265,6 +265,32 @@ NSString * const ReaderPixelStatReferrer = @"https://wordpress.com/";
 
 #pragma mark - Accessor methods
 
+- (void)setPost:(ReaderPost *)post
+{
+    if (post == _post) {
+        return;
+    }
+
+    if (!post) {
+        _post = nil;
+        return;
+    }
+
+    _post = [self postInContext:post.objectID];
+}
+
+- (ReaderPost *)postInContext:(NSManagedObjectID *)objectID
+{
+    NSError *error;
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    ReaderPost *post = [context existingObjectWithID:objectID error:&error];
+    if (error) {
+        DDLogError([error localizedDescription]);
+        return nil;
+    }
+    return post;
+}
+
 - (UIBarButtonItem *)shareButton
 {
     if (_shareButton) {


### PR DESCRIPTION
Closes #4292 

There were two issues:
- The post was being updated in the wrong context. The post powering the detail was from a child of the main context, while the update was happening in the main.
- The optimistic update was happening asynchronously resulting in the call to refresh the action button happening *before* the changes were made.

This patch fetches the post in the correct context, and fixes the async issue. 

To test: 
Follow the steps outlined in #4292 

Needs review @jleandroperez 
