### PR TITLE
Ignore core emoji images.

### DIFF
--- a/WordPress/Classes/Utility/DisplayableImageHelper.m
+++ b/WordPress/Classes/Utility/DisplayableImageHelper.m
@@ -80,6 +80,11 @@ static NSString * const AttachmentsDictionaryKeyMimeType = @"mime_type";
         NSString *tag = [content substringWithRange:match.range];
         NSString *src = [self extractSrcFromImgTag:tag];
 
+        // Ignore WordPress core emoji images
+        if ([src rangeOfString:@"/images/core/emoji/"].location != NSNotFound) {
+            continue;
+        }
+
         // Check the tag for a good width
         NSInteger width = MAX([self widthFromElementAttribute:tag], [self widthFromQueryString:src]);
         if (width > currentMaxWidth) {


### PR DESCRIPTION
Closes #4296 

Prevents WP core emoji images from being picked up as featured images by the reader. 

To test:
View a post in the reader that contains only wp core emoji images, like [this one](https://wordpress.com/read/post/feed/18/813616864).  The easiest way might be to LIKE the post, then check your LIKED feed.
Confirm that the emoji is not chosen as the featured image, both in the list and the detail.

@SergioEstevao would you be game for a quick review?

Needs Review: @SergioEstevao 