### PR TITLE
Use a generic request when testing if a site exists.

### DIFF
--- a/WordPress/Classes/Networking/ReaderSiteServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderSiteServiceRemote.m
@@ -179,11 +179,12 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 - (void)checkSiteExistsAtURL:(NSURL *)siteURL success:(void (^)())success failure:(void(^)(NSError *error))failure
 {
     // Just ping the URL and make sure we don't get back a 40x error.
-    [self.api HEAD:[siteURL absoluteString] parameters:nil success:^(AFHTTPRequestOperation *operation) {
+    AFHTTPRequestOperationManager *mgr = [[AFHTTPRequestOperationManager alloc] init];
+    [mgr HEAD:[siteURL absoluteString] parameters:nil success:^(AFHTTPRequestOperation * _Nonnull operation) {
         if (success) {
             success();
         }
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
         if (failure) {
             failure(error);
         }

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -146,10 +146,6 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 #if !defined(NS_BLOCK_ASSERTIONS)
 - (void)assertApiVersion:(NSString *)URLString
 {
-    // Skip asserts for non API calls
-    if ([URLString rangeOfString:WordPressComApiClientEndpointURL].location == NSNotFound) {
-        return;
-    }
     NSAssert([URLString rangeOfString:@"/v1/"].length > 0
              || [URLString rangeOfString:@"v1.1"].length > 0
              || [URLString rangeOfString:@"v1.2"].length > 0,


### PR DESCRIPTION
Rolls back cef0d7de8b8622295e197498e62135f184202a95 and replaces it with a generic check.

To test: 
Try to follow a site via the reader's menu such as:
ma.tt, or gizmodo.com

Needs review: @koke 