### PR TITLE
Reader: Replace images from core emoji with emoji strings.

### DIFF
--- a/WordPress/Classes/Categories/NSString+Helpers.m
+++ b/WordPress/Classes/Categories/NSString+Helpers.m
@@ -91,28 +91,34 @@ static NSString *const Ellipsis =  @"\u2026";
     NSMutableString *result = [NSMutableString stringWithString:self];
 
     NSDictionary *replacements = @{
-                                   @"arrow": @"➡",
-                                   @"biggrin": @"😃",
-                                   @"confused": @"😕",
-                                   @"cool": @"😎",
-                                   @"cry": @"😭",
-                                   @"eek": @"😮",
-                                   @"evil": @"😈",
-                                   @"exclaim": @"❗",
-                                   @"idea": @"💡",
-                                   @"lol": @"😄",
-                                   @"mad": @"😠",
-                                   @"mrgreen": @"🐸",
-                                   @"neutral": @"😐",
-                                   @"question": @"❓",
-                                   @"razz": @"😛",
-                                   @"redface": @"😊",
-                                   @"rolleyes": @"😒",
-                                   @"sad": @"😞",
-                                   @"smile": @"😊",
-                                   @"surprised": @"😮",
-                                   @"twisted": @"👿",
-                                   @"wink": @"😉"
+                                   @"icon_arrow": @"➡",
+                                   @"icon_biggrin": @"😃",
+                                   @"icon_confused": @"😕",
+                                   @"icon_cool": @"😎",
+                                   @"icon_cry": @"😭",
+                                   @"icon_eek": @"😮",
+                                   @"icon_evil": @"😈",
+                                   @"icon_exclaim": @"❗",
+                                   @"icon_idea": @"💡",
+                                   @"icon_lol": @"😄",
+                                   @"icon_mad": @"😠",
+                                   @"icon_mrgreen": @"🐸",
+                                   @"icon_neutral": @"😐",
+                                   @"icon_question": @"❓",
+                                   @"icon_razz": @"😛",
+                                   @"icon_redface": @"😊",
+                                   @"icon_rolleyes": @"😒",
+                                   @"icon_sad": @"😞",
+                                   @"icon_smile": @"😊",
+                                   @"icon_surprised": @"😮",
+                                   @"icon_twisted": @"👿",
+                                   @"icon_wink": @"😉",
+                                   // NOTE: There is not a perfect match for the following four with
+                                   // currently supported emoji. We'll try to get as close as we can.
+                                   @"frownie":@"😞",
+                                   @"mrgreen":@"😊",
+                                   @"rolleyes":@"😒",
+                                   @"simple-smile":@"😊"
                                    };
 
     static NSRegularExpression *smiliesRegex;
@@ -120,7 +126,7 @@ static NSString *const Ellipsis =  @"\u2026";
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSError *error;
-        smiliesRegex = [NSRegularExpression regularExpressionWithPattern:@"<img src=['\"].*?wp-includes/images/smilies/icon_(.+?).gif['\"].*?class=['\"]wp-smiley['\"] ?/?>" options:NSRegularExpressionCaseInsensitive error:&error];
+        smiliesRegex = [NSRegularExpression regularExpressionWithPattern:@"<img.*?src=['\"].*?wp-includes/images/smilies/(.+?)(?:.gif|.png)[^'\"]*['\"].*?class=['\"]wp-smiley['\"].*?/?>" options:NSRegularExpressionCaseInsensitive error:&error];
         coreEmojiRegex = [NSRegularExpression regularExpressionWithPattern:@"<img .*?src=['\"].*?images/core/emoji/[^/]+/(.+?).png['\"].*?class=['\"]wp-smiley['\"][^//]+/?>" options:NSRegularExpressionCaseInsensitive error:&error];
     });
 

--- a/WordPress/Classes/Utility/DisplayableImageHelper.m
+++ b/WordPress/Classes/Utility/DisplayableImageHelper.m
@@ -80,8 +80,9 @@ static NSString * const AttachmentsDictionaryKeyMimeType = @"mime_type";
         NSString *tag = [content substringWithRange:match.range];
         NSString *src = [self extractSrcFromImgTag:tag];
 
-        // Ignore WordPress core emoji images
-        if ([src rangeOfString:@"/images/core/emoji/"].location != NSNotFound) {
+        // Ignore WordPress emoji images
+        if ([src rangeOfString:@"/images/core/emoji/"].location != NSNotFound ||
+            [src rangeOfString:@"/wp-includes/images/smilies/"].location != NSNotFound) {
             continue;
         }
 

--- a/WordPress/WordPressTest/NSStringHelpersTest.m
+++ b/WordPress/WordPressTest/NSStringHelpersTest.m
@@ -1,6 +1,10 @@
 #import <XCTest/XCTest.h>
 #import "NSString+Helpers.h"
 
+@interface NSString ()
+- (NSString *)emojiUnicodeFromCoreEmojiFilename:(NSString *)filename;
+@end
+
 @interface NSStringHelpersTest : XCTestCase
 
 @end
@@ -133,6 +137,28 @@
     NSString *testPhrasePortuguese = @"A raposa preguiçosa saltou a cerca.";
     XCTAssert([testPhrasePortuguese wordCount] == 6, @"Word count should be six");
 
+}
+
+- (void)testStringByReplacingHTMLEmoticonsWithEmoji
+{
+    NSString *emoji = @"\U0001F600";
+    NSString *imageTag = @"<img src=\"http://s.w.org/images/core/emoji/72x72/1f600.png\" alt=\"&#128512;\" class=\"wp-smiley\" style=\"height: 1em; max-height: 1em;\">";
+    NSString *replacedString = [imageTag stringByReplacingHTMLEmoticonsWithEmoji];
+
+    XCTAssert([replacedString isEqualToString:emoji], @"The image tag was not replaced with an emoji string");
+}
+
+- (void)testEmojiUnicodeFromCoreEmojiFilename
+{
+    NSString *copyright = @"A9";
+    // Test emoji <= 0xFFFF
+    NSString *emojiString = [copyright emojiUnicodeFromCoreEmojiFilename:copyright];
+    XCTAssert([emojiString isEqualToString:@"\u00A9"], @"The emoji filename was not converted to a unicode code point.");
+
+    NSString *smilingImp = @"1F608";
+    // Test emoji > 0xFFFF
+    emojiString = [copyright emojiUnicodeFromCoreEmojiFilename:smilingImp];
+    XCTAssert([emojiString isEqualToString:@"\U0001F608"], @"The emoji filename was not converted to a unicode code point.");
 }
 
 @end

--- a/WordPress/WordPressTest/NSStringHelpersTest.m
+++ b/WordPress/WordPressTest/NSStringHelpersTest.m
@@ -2,7 +2,8 @@
 #import "NSString+Helpers.h"
 
 @interface NSString ()
-- (NSString *)emojiUnicodeFromCoreEmojiFilename:(NSString *)filename;
++ (NSString *)emojiCharacterFromCoreEmojiFilename:(NSString *)filename;
++ (NSString *)emojiFromCoreEmojiImageTag:(NSString *)tag;
 @end
 
 @interface NSStringHelpersTest : XCTestCase
@@ -136,7 +137,6 @@
 
     NSString *testPhrasePortuguese = @"A raposa preguiçosa saltou a cerca.";
     XCTAssert([testPhrasePortuguese wordCount] == 6, @"Word count should be six");
-
 }
 
 - (void)testStringByReplacingHTMLEmoticonsWithEmoji
@@ -148,17 +148,41 @@
     XCTAssert([replacedString isEqualToString:emoji], @"The image tag was not replaced with an emoji string");
 }
 
+- (void)testEmojiFromCoreEmojiImageTag
+{
+    NSString *emoji = @"😜";
+    NSString *imageTagTestingAlt = @"<img class=\"emoji\" draggable=\"false\" alt=\"😜\" src=\"http://s.w.org/images/core/emoji/72x72/1f600.png\" scale=\"0\">";
+    NSString *imageTagTestingFilename = @"<img class=\"emoji\" draggable=\"false\" src=\"http://s.w.org/images/core/emoji/72x72/1f61c.png\" scale=\"0\">";
+
+    // Test emoji found from alt text
+    NSString *str = [NSString emojiFromCoreEmojiImageTag:imageTagTestingAlt];
+    XCTAssert([str isEqualToString:emoji], @"The expected emoji was not retrieved from the image tag's alt text");
+
+    // Test emoji found from file path
+    str = [NSString emojiFromCoreEmojiImageTag:imageTagTestingFilename];
+    XCTAssert([str isEqualToString:emoji], @"The expected emoji was not retrieved from the image tag's  image file name");
+}
+
 - (void)testEmojiUnicodeFromCoreEmojiFilename
 {
     NSString *copyright = @"A9";
     // Test emoji <= 0xFFFF
-    NSString *emojiString = [copyright emojiUnicodeFromCoreEmojiFilename:copyright];
+    NSString *emojiString = [NSString emojiCharacterFromCoreEmojiFilename:copyright];
     XCTAssert([emojiString isEqualToString:@"\u00A9"], @"The emoji filename was not converted to a unicode code point.");
 
     NSString *smilingImp = @"1F608";
     // Test emoji > 0xFFFF
-    emojiString = [copyright emojiUnicodeFromCoreEmojiFilename:smilingImp];
+    emojiString = [NSString emojiCharacterFromCoreEmojiFilename:smilingImp];
     XCTAssert([emojiString isEqualToString:@"\U0001F608"], @"The emoji filename was not converted to a unicode code point.");
+
+    NSString *flag = @"1f1fa-1f1f8";
+    // Test surrogate pair
+    emojiString = [NSString emojiCharacterFromCoreEmojiFilename:flag];
+    XCTAssert([emojiString isEqualToString:@"\U0001f1fa\U0001f1f8"], @"The emoji filename was not converted to a unicode code point.");
+
+    NSString *invalid = @"ZZZZZ";
+    emojiString = [NSString emojiCharacterFromCoreEmojiFilename:invalid];
+    XCTAssert([emojiString length] == 0, @"Should return an empty string for an invalid file name.");
 }
 
 @end


### PR DESCRIPTION
Closes #4298 
Adds a check for images that are core emoji. 
Converts matches to their emoji string equivalent. 
Adds unit tests.

To test: 
Confirm the emoji shown in #4298 is showing the correct size. 

Need Review: @koke 