### PR TITLE
Updated to Tracks 0.0.8

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -24,7 +24,7 @@ pod 'Helpshift', '~>4.10.0'
 pod 'Lookback', '0.9.2', :configurations => ['Release-Internal']
 pod 'MRProgress', '~>0.7.0'
 
-pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.0.7'
+pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.0.8'
 pod 'EmailChecker', :podspec => 'https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec'
 pod 'MGImageUtilities', :git => 'git://github.com/wordpress-mobile/MGImageUtilities.git', :branch => 'gifsupport'
 pod 'NSObject-SafeExpectations', '0.0.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - AMPopTip (0.9.12)
-  - Automattic-Tracks-iOS (0.0.7):
+  - Automattic-Tracks-iOS (0.0.8):
     - CocoaLumberjack (= 2.0.0)
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 0.4)
@@ -139,7 +139,7 @@ PODS:
   - Specta (1.0.3)
   - SVProgressHUD (1.1.3)
   - UIAlertView+Blocks (0.8.1)
-  - UIDeviceIdentifier (0.4.4)
+  - UIDeviceIdentifier (0.4.5)
   - WordPress-AppbotX (1.0.6)
   - WordPress-iOS-Editor (0.8.1):
     - CocoaLumberjack (= 2.0.0)
@@ -168,7 +168,7 @@ DEPENDENCIES:
   - AFNetworking (~> 2.6.0)
   - AMPopTip (~> 0.7)
   - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`,
-    tag `0.0.7`)
+    tag `0.0.8`)
   - CocoaLumberjack (= 2.0.0)
   - CrashlyticsLumberjack (= 2.0.0)
   - DTCoreText (= 1.6.13)
@@ -210,7 +210,7 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.0.7
+    :tag: 0.0.8
   EmailChecker:
     :podspec: https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec
   MGImageUtilities:
@@ -231,7 +231,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.0.7
+    :tag: 0.0.8
   MGImageUtilities:
     :commit: e946cf3d97eb95372f4fc4478bf2e0099e73f4b0
     :git: git://github.com/wordpress-mobile/MGImageUtilities.git
@@ -252,12 +252,12 @@ SPEC CHECKSUMS:
   1PasswordExtension: 66365c1e1264a83edec6c84c6eb2df41b50a70d3
   AFNetworking: 79f7eb1a0fcfa7beb409332b2ca49afe9ce53b05
   AMPopTip: 3c98a9b38148868366b57765064bd9565f653038
-  Automattic-Tracks-iOS: 8bad8c049458d8767e5a25effdf30c01464eb30a
+  Automattic-Tracks-iOS: d731323e0f33cab21971c9b506577a7b484a077b
   CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
   CrashlyticsLumberjack: 5094b659ecf9a11550f7dd7a885c0cef077f1ffa
   DTCoreText: d90a4dca8e4f7b0eb18f12a967563b77a75694f0
   DTFoundation: c9b3362b83f0017389082ec067ede719826a579d
-  EmailChecker: 406cf1f1b5cd2efb8401803b580abf4a43b0665c
+  EmailChecker: 1b9c5a58c994bc638f842a4d69523b6ab57e706e
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
   google-plus-ios-sdk: 47adbe03ea904bdb7aa1c0eca282a23c4686e1bc
@@ -280,9 +280,9 @@ SPEC CHECKSUMS:
   Specta: cf3e4188cf35375c3ee2cd03f8db8f1f4ef98234
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
   UIAlertView+Blocks: 45c3d3b7194906702d3e9a14c7ece5581505646d
-  UIDeviceIdentifier: 2eb1070f189a069184611e21b5e8832443e6f8ec
+  UIDeviceIdentifier: f7b32c087f4d4957badbb6181a4c78520c5806ae
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
-  WordPress-iOS-Editor: 3ed3f3f1eb226b34542b471a7db41419815bbf28
+  WordPress-iOS-Editor: 81d1f10e548c9fabd2ea99dbf0bcfa0669078667
   WordPress-iOS-Shared: 345f7c1c49d298114353c3856c53317f0d826078
   WordPressApi: cb145d3c92ed54d4dbe70108d15f17ce3da3ad5d
   WordPressCom-Analytics-iOS: bd1744d61f731461725674792413c0a258d44858


### PR DESCRIPTION
Closes #4317 

Updates Tracks client to 0.0.8 which includes:
* Xcode 7 support (which really doesn't affect the pod)
* Reduces the chattiness of the logging in the client

Lockfile got updated with UIDeviceIdentifier as well.

Needs Review: @sendhil, @aerych 
