### PR TITLE
Notification+Interface: Cleaning up dead code

### DIFF
--- a/WordPress/Classes/Extensions/Notifications/Notification+Interface.swift
+++ b/WordPress/Classes/Extensions/Notifications/Notification+Interface.swift
@@ -37,19 +37,11 @@ extension Notification
     }
     
     public class func descriptionForSectionIdentifier(identifier: String) -> String {
-        let components = identifier.componentsSeparatedByString(":")
-        if components.first == nil || components.last == nil {
+        guard let kind = Int(identifier) else {
             return String()
         }
         
-        let wrappedKind    = Int(components.first!)
-        let wrappedPayload = Int(components.last!)
-        
-        if wrappedKind == nil || wrappedPayload == nil {
-            return String()
-        }
-        
-        switch wrappedKind! {
+        switch kind {
         case Sections.Months:
             return NSLocalizedString("Older than a Month",  comment: "Notifications Months Section Header")
         case Sections.Weeks:


### PR DESCRIPTION
During our Swift 2.0 migration, i've found this snippet, from ancient times. Notifications Section Identifiers used to have two attributes, joined by a `:` character.

This is no longer the case. In this PR we're cleaning up the code that used to process this.

#### Steps:
1. Launch WPiOS
2. Open the Notifications Tab
3. Make sure that the Section Titles look okay

Needs Review: @astralbodies (Thanks in advance!)
