### PR TITLE
Notifications: Fixes Stats bridge

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -908,8 +908,8 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *service            = [[BlogService alloc] initWithManagedObjectContext:context];
     Blog *blog                      = [service blogByBlogId:siteID];
-    BOOL success                    = blog.isHostedAtWPcom;
-    
+    BOOL success                    = [blog supports:BlogFeatureStats];
+
     if (success) {
         // TODO: Update StatsViewController to work with initWithCoder!
         StatsViewController *vc     = [[StatsViewController alloc] init];


### PR DESCRIPTION
#### Steps:
1. Receive a Stats notification
2. Launch the app
3. Open the Notifications tab, and open the new notification
4. Tap your site's name (last visible link).

As a result, the native Stats view should be onscreen.

Closes #4313
Needs Review: @koke  (Thanks in advance!)
