### PR TITLE
Updated to stats pod 0.4.8. EmailChecker got bumped too for some reason.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -32,7 +32,7 @@ pod 'Simperium', '0.8.3'
 pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
 pod 'WordPress-iOS-Shared', '0.4.4'
 pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => '1b614724fbc005be4346c7870498658c8b537267'
-pod 'WordPressCom-Stats-iOS', '0.4.7'
+pod 'WordPressCom-Stats-iOS', '0.4.8'
 pod 'WordPressCom-Analytics-iOS', '0.0.37'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
 pod 'WPMediaPicker', '~>0.6.0'
@@ -40,7 +40,7 @@ pod 'ReactiveCocoa', '~> 2.4.7'
 pod 'FormatterKit', '~> 1.8.0'
 
 target 'WordPressTodayWidget', :exclusive => true do
-  pod 'WordPressCom-Stats-iOS', '0.4.7'
+  pod 'WordPressCom-Stats-iOS', '0.4.8'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -154,12 +154,12 @@ PODS:
     - AFNetworking (~> 2.6.0)
     - wpxmlrpc (~> 0.7)
   - WordPressCom-Analytics-iOS (0.0.37)
-  - WordPressCom-Stats-iOS (0.4.7):
-    - AFNetworking (~> 2.5)
+  - WordPressCom-Stats-iOS (0.4.8):
+    - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.3)
-    - WordPressCom-Analytics-iOS (~> 0.0.34)
+    - WordPress-iOS-Shared (~> 0.4)
+    - WordPressCom-Analytics-iOS (~> 0.0.37)
   - WPMediaPicker (0.6.0)
   - wpxmlrpc (0.8.1)
 
@@ -203,7 +203,7 @@ DEPENDENCIES:
   - WordPress-iOS-Shared (= 0.4.4)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
   - WordPressCom-Analytics-iOS (= 0.0.37)
-  - WordPressCom-Stats-iOS (= 0.4.7)
+  - WordPressCom-Stats-iOS (= 0.4.8)
   - WPMediaPicker (~> 0.6.0)
   - wpxmlrpc (~> 0.8)
 
@@ -257,7 +257,7 @@ SPEC CHECKSUMS:
   CrashlyticsLumberjack: 5094b659ecf9a11550f7dd7a885c0cef077f1ffa
   DTCoreText: d90a4dca8e4f7b0eb18f12a967563b77a75694f0
   DTFoundation: c9b3362b83f0017389082ec067ede719826a579d
-  EmailChecker: 406cf1f1b5cd2efb8401803b580abf4a43b0665c
+  EmailChecker: 1b9c5a58c994bc638f842a4d69523b6ab57e706e
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
   google-plus-ios-sdk: 47adbe03ea904bdb7aa1c0eca282a23c4686e1bc
@@ -286,7 +286,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Shared: 345f7c1c49d298114353c3856c53317f0d826078
   WordPressApi: cb145d3c92ed54d4dbe70108d15f17ce3da3ad5d
   WordPressCom-Analytics-iOS: bd1744d61f731461725674792413c0a258d44858
-  WordPressCom-Stats-iOS: 55e3a2063dd466eabe60dda74c834fe820043515
+  WordPressCom-Stats-iOS: d2e035e0b06dd1cde2e09ed71d717b48a069b9df
   WPMediaPicker: 6e7904663b386ad4eea2f2e3dc30fd15babceb66
   wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0
 


### PR DESCRIPTION
Closes #4333 

Updates to the latest stats pod which includes the following updates:
* Adds latest post summary to Insights
* Persists the last selected tab in stats so the user comes back to the same section they left off with
* Fixes issues with sizing and layout on iOS 9 and iPad multitasking

Testing was done with StatsDemo on the stats project but a good once-over with rotations, iPad multitasking, iPhone 6 Plus and non-iPhone 6 Plus would be good. Getting some iOS 7 testing in would be beneficial too.

Needs Review: @sendhil, @jleandroperez