### PR TITLE
Post list cards layout tweaks

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -257,7 +257,7 @@ SPEC CHECKSUMS:
   CrashlyticsLumberjack: 5094b659ecf9a11550f7dd7a885c0cef077f1ffa
   DTCoreText: d90a4dca8e4f7b0eb18f12a967563b77a75694f0
   DTFoundation: c9b3362b83f0017389082ec067ede719826a579d
-  EmailChecker: 1b9c5a58c994bc638f842a4d69523b6ab57e706e
+  EmailChecker: 406cf1f1b5cd2efb8401803b580abf4a43b0665c
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
   google-plus-ios-sdk: 47adbe03ea904bdb7aa1c0eca282a23c4686e1bc
@@ -282,7 +282,7 @@ SPEC CHECKSUMS:
   UIAlertView+Blocks: 45c3d3b7194906702d3e9a14c7ece5581505646d
   UIDeviceIdentifier: f7b32c087f4d4957badbb6181a4c78520c5806ae
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
-  WordPress-iOS-Editor: 81d1f10e548c9fabd2ea99dbf0bcfa0669078667
+  WordPress-iOS-Editor: 3ed3f3f1eb226b34542b471a7db41419815bbf28
   WordPress-iOS-Shared: 345f7c1c49d298114353c3856c53317f0d826078
   WordPressApi: cb145d3c92ed54d4dbe70108d15f17ce3da3ad5d
   WordPressCom-Analytics-iOS: bd1744d61f731461725674792413c0a258d44858

--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,6 +11,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="448"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="CUK-Fg-fJ5" id="lmn-sx-Q9M">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="447.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="00o-oC-uzQ">
@@ -41,7 +42,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbp-gj-1hE">
-                                                <rect key="frame" x="48" y="33" width="232" height="15"/>
+                                                <rect key="frame" x="48" y="33.5" width="232" height="14.5"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -100,7 +101,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xhs-nZ-clP">
-                                                <rect key="frame" x="19" y="2" width="184" height="15"/>
+                                                <rect key="frame" x="19" y="2.5" width="184" height="14.5"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -130,7 +131,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mYl-tz-yRu">
-                                                <rect key="frame" x="19" y="2" width="261" height="15"/>
+                                                <rect key="frame" x="19" y="2.5" width="261" height="14.5"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -318,6 +319,7 @@
                 <outlet property="metaView" destination="U6E-MB-03K" id="XZt-Fn-PJ2"/>
                 <outlet property="postCardImageView" destination="Y9d-Yk-F4X" id="ftE-Cm-xPY"/>
                 <outlet property="postCardImageViewBottomConstraint" destination="N8M-5Y-cWJ" id="lhh-cM-CR0"/>
+                <outlet property="postCardImageViewHeightConstraint" destination="0wl-TX-0Ed" id="lHP-O3-pox"/>
                 <outlet property="postContentBottomConstraint" destination="gQs-6I-fOg" id="1aL-Pl-3MO"/>
                 <outlet property="postContentView" destination="b5E-yQ-veP" id="m4f-f7-d0h"/>
                 <outlet property="shadowView" destination="8uW-Eg-69o" id="Qfj-VW-sqC"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -25,24 +25,24 @@
                                 <rect key="frame" x="6" y="10" width="308" height="426"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rIp-IY-Ng4">
-                                        <rect key="frame" x="14" y="0.0" width="280" height="49"/>
+                                        <rect key="frame" x="16" y="15" width="276" height="34"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="DWo-S7-Yu2">
-                                                <rect key="frame" x="0.0" y="16" width="32" height="32"/>
+                                                <rect key="frame" x="0.0" y="1" width="32" height="32"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="32" id="MkS-EF-k5K"/>
                                                     <constraint firstAttribute="height" constant="32" id="y6f-IQ-yFt"/>
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LUv-id-3Yc">
-                                                <rect key="frame" x="48" y="15" width="232" height="17"/>
+                                                <rect key="frame" x="42" y="0.0" width="234" height="17"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbp-gj-1hE">
-                                                <rect key="frame" x="48" y="33.5" width="232" height="14.5"/>
+                                                <rect key="frame" x="42" y="18" width="234" height="14.5"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -52,24 +52,18 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="bbp-gj-1hE" secondAttribute="trailing" id="3WE-jM-XJb"/>
-                                            <constraint firstAttribute="centerY" secondItem="DWo-S7-Yu2" secondAttribute="centerY" id="VXQ-36-pyt"/>
-                                            <constraint firstItem="LUv-id-3Yc" firstAttribute="leading" secondItem="DWo-S7-Yu2" secondAttribute="trailing" constant="16" id="fyX-PF-hal"/>
-                                            <constraint firstItem="bbp-gj-1hE" firstAttribute="leading" secondItem="DWo-S7-Yu2" secondAttribute="trailing" constant="16" id="g5j-Ku-I7r"/>
-                                            <constraint firstAttribute="height" constant="49" id="hQY-s6-IDE"/>
+                                            <constraint firstItem="LUv-id-3Yc" firstAttribute="leading" secondItem="DWo-S7-Yu2" secondAttribute="trailing" constant="10" id="fyX-PF-hal"/>
+                                            <constraint firstItem="bbp-gj-1hE" firstAttribute="leading" secondItem="DWo-S7-Yu2" secondAttribute="trailing" constant="10" id="g5j-Ku-I7r"/>
+                                            <constraint firstAttribute="height" constant="34" id="hQY-s6-IDE"/>
                                             <constraint firstAttribute="bottom" secondItem="bbp-gj-1hE" secondAttribute="bottom" constant="1" id="jYA-gw-mUG"/>
                                             <constraint firstAttribute="bottom" secondItem="LUv-id-3Yc" secondAttribute="bottom" constant="17" id="m5z-2V-aNd"/>
                                             <constraint firstAttribute="bottom" secondItem="DWo-S7-Yu2" secondAttribute="bottom" constant="1" id="oFG-Wx-6aR"/>
                                             <constraint firstAttribute="trailing" secondItem="LUv-id-3Yc" secondAttribute="trailing" id="xQ7-iO-jkF"/>
                                             <constraint firstItem="DWo-S7-Yu2" firstAttribute="leading" secondItem="rIp-IY-Ng4" secondAttribute="leading" id="xwc-7q-5QP"/>
                                         </constraints>
-                                        <variation key="default">
-                                            <mask key="constraints">
-                                                <exclude reference="VXQ-36-pyt"/>
-                                            </mask>
-                                        </variation>
                                     </view>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Y9d-Yk-F4X">
-                                        <rect key="frame" x="0.0" y="65" width="308" height="196"/>
+                                        <rect key="frame" x="0.0" y="64" width="308" height="196"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="196" id="0wl-TX-0Ed">
                                                 <variation key="heightClass=regular-widthClass=regular" constant="226"/>
@@ -77,21 +71,21 @@
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="E9Y-IT-TUt">
-                                        <rect key="frame" x="14" y="277" width="280" height="24"/>
+                                        <rect key="frame" x="16" y="274" width="276" height="24"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Cbe-bm-gnv">
-                                        <rect key="frame" x="14" y="307" width="280" height="17"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Cbe-bm-gnv">
+                                        <rect key="frame" x="16" y="307" width="276" height="18"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zle-VU-ygo">
-                                        <rect key="frame" x="14" y="332" width="203" height="18"/>
+                                        <rect key="frame" x="16" y="334" width="196" height="18"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="ed0-E7-1lw">
                                                 <rect key="frame" x="0.0" y="1" width="16" height="16"/>
@@ -101,7 +95,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xhs-nZ-clP">
-                                                <rect key="frame" x="19" y="2.5" width="184" height="14.5"/>
+                                                <rect key="frame" x="19" y="2" width="177" height="14.5"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -121,7 +115,7 @@
                                         </constraints>
                                     </view>
                                     <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="2OR-ox-Csb">
-                                        <rect key="frame" x="14" y="358" width="280" height="18"/>
+                                        <rect key="frame" x="16" y="358" width="276" height="18"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="WhA-sd-qfz">
                                                 <rect key="frame" x="0.0" y="1" width="16" height="16"/>
@@ -131,7 +125,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mYl-tz-yRu">
-                                                <rect key="frame" x="19" y="2.5" width="261" height="14.5"/>
+                                                <rect key="frame" x="19" y="2" width="257" height="14.5"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -151,10 +145,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U6E-MB-03K">
-                                        <rect key="frame" x="217" y="332" width="77" height="18"/>
+                                        <rect key="frame" x="212" y="334" width="80" height="18"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U4X-fn-9uf" customClass="PostMetaButton">
-                                                <rect key="frame" x="47" y="0.0" width="30" height="18"/>
+                                                <rect key="frame" x="50" y="0.0" width="30" height="18"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="18" id="YVF-bx-Qxo"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="bog-Fu-vOf"/>
@@ -180,7 +174,7 @@
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstItem="U4X-fn-9uf" firstAttribute="leading" secondItem="f2K-8g-nnA" secondAttribute="trailing" constant="13" id="LNj-rX-kqd"/>
+                                            <constraint firstItem="U4X-fn-9uf" firstAttribute="leading" secondItem="f2K-8g-nnA" secondAttribute="trailing" constant="16" id="LNj-rX-kqd"/>
                                             <constraint firstAttribute="trailing" secondItem="U4X-fn-9uf" secondAttribute="trailing" id="QZF-fS-FFc"/>
                                             <constraint firstAttribute="centerY" secondItem="U4X-fn-9uf" secondAttribute="centerY" id="VcK-NY-1yM"/>
                                             <constraint firstItem="f2K-8g-nnA" firstAttribute="leading" secondItem="U6E-MB-03K" secondAttribute="leading" constant="4" id="dBi-M9-Rs2"/>
@@ -200,58 +194,58 @@
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="Cbe-bm-gnv" secondAttribute="trailing" constant="14" id="27Y-c8-O7j">
+                                    <constraint firstAttribute="trailing" secondItem="Cbe-bm-gnv" secondAttribute="trailing" constant="16" id="27Y-c8-O7j">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstItem="2OR-ox-Csb" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="14" id="2Wh-mV-Zph">
+                                    <constraint firstItem="2OR-ox-Csb" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="2Wh-mV-Zph">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstItem="zle-VU-ygo" firstAttribute="top" secondItem="Cbe-bm-gnv" secondAttribute="bottom" constant="8" id="54w-4V-wCw">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="12"/>
+                                    <constraint firstItem="zle-VU-ygo" firstAttribute="top" secondItem="Cbe-bm-gnv" secondAttribute="bottom" constant="9" id="54w-4V-wCw">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="9"/>
                                     </constraint>
                                     <constraint firstAttribute="trailing" secondItem="pkq-mO-MBJ" secondAttribute="trailing" id="94D-vc-Bfy"/>
-                                    <constraint firstItem="Cbe-bm-gnv" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="14" id="AAS-zA-QSN">
+                                    <constraint firstItem="Cbe-bm-gnv" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="AAS-zA-QSN">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstItem="rIp-IY-Ng4" firstAttribute="top" secondItem="b5E-yQ-veP" secondAttribute="top" id="Af8-lU-jWg"/>
+                                    <constraint firstItem="rIp-IY-Ng4" firstAttribute="top" secondItem="b5E-yQ-veP" secondAttribute="top" constant="15" id="Af8-lU-jWg"/>
                                     <constraint firstItem="Y9d-Yk-F4X" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" id="JnV-Io-ZDa"/>
-                                    <constraint firstAttribute="trailing" secondItem="E9Y-IT-TUt" secondAttribute="trailing" constant="14" id="Ll1-Y8-bQN">
+                                    <constraint firstAttribute="trailing" secondItem="E9Y-IT-TUt" secondAttribute="trailing" constant="16" id="Ll1-Y8-bQN">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstItem="zle-VU-ygo" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="14" id="MPI-RN-znl">
+                                    <constraint firstItem="zle-VU-ygo" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="MPI-RN-znl">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstItem="E9Y-IT-TUt" firstAttribute="top" secondItem="Y9d-Yk-F4X" secondAttribute="bottom" constant="16" id="N8M-5Y-cWJ"/>
-                                    <constraint firstItem="E9Y-IT-TUt" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="14" id="NBs-7e-hP4">
+                                    <constraint firstItem="E9Y-IT-TUt" firstAttribute="top" secondItem="Y9d-Yk-F4X" secondAttribute="bottom" constant="14" id="N8M-5Y-cWJ"/>
+                                    <constraint firstItem="E9Y-IT-TUt" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="NBs-7e-hP4">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
                                     <constraint firstItem="U6E-MB-03K" firstAttribute="centerY" secondItem="zle-VU-ygo" secondAttribute="centerY" id="NCb-6E-SND"/>
-                                    <constraint firstItem="Y9d-Yk-F4X" firstAttribute="top" secondItem="rIp-IY-Ng4" secondAttribute="bottom" constant="16" id="QbH-qP-NR7"/>
+                                    <constraint firstItem="Y9d-Yk-F4X" firstAttribute="top" secondItem="rIp-IY-Ng4" secondAttribute="bottom" constant="15" id="QbH-qP-NR7"/>
                                     <constraint firstAttribute="width" priority="900" constant="600" id="Qi6-dA-tg8"/>
-                                    <constraint firstItem="rIp-IY-Ng4" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="14" id="SmN-xb-mWD">
+                                    <constraint firstItem="rIp-IY-Ng4" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="SmN-xb-mWD">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="U6E-MB-03K" secondAttribute="trailing" constant="14" id="T0c-A5-khY">
+                                    <constraint firstAttribute="trailing" secondItem="U6E-MB-03K" secondAttribute="trailing" constant="16" id="T0c-A5-khY">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="rIp-IY-Ng4" secondAttribute="trailing" constant="14" id="U9A-yx-smS">
+                                    <constraint firstAttribute="trailing" secondItem="rIp-IY-Ng4" secondAttribute="trailing" constant="16" id="U9A-yx-smS">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstItem="2OR-ox-Csb" firstAttribute="top" secondItem="zle-VU-ygo" secondAttribute="bottom" constant="8" id="cCR-ch-CxK">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="12"/>
+                                    <constraint firstItem="2OR-ox-Csb" firstAttribute="top" secondItem="zle-VU-ygo" secondAttribute="bottom" constant="6" id="cCR-ch-CxK">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="8"/>
                                     </constraint>
-                                    <constraint firstItem="Cbe-bm-gnv" firstAttribute="top" secondItem="E9Y-IT-TUt" secondAttribute="bottom" constant="6" id="hdt-ZQ-dHo">
+                                    <constraint firstItem="Cbe-bm-gnv" firstAttribute="top" secondItem="E9Y-IT-TUt" secondAttribute="bottom" constant="9" id="hdt-ZQ-dHo">
                                         <variation key="heightClass=regular-widthClass=regular" constant="7"/>
                                     </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="2OR-ox-Csb" secondAttribute="trailing" constant="14" id="iO3-Io-6Bk">
+                                    <constraint firstAttribute="trailing" secondItem="2OR-ox-Csb" secondAttribute="trailing" constant="16" id="iO3-Io-6Bk">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
                                     <constraint firstItem="pkq-mO-MBJ" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" id="pl8-s7-Mjm"/>
                                     <constraint firstAttribute="trailing" secondItem="Y9d-Yk-F4X" secondAttribute="trailing" id="rWg-Oz-OEh"/>
                                     <constraint firstAttribute="bottom" secondItem="pkq-mO-MBJ" secondAttribute="bottom" id="tgK-m9-bll"/>
                                     <constraint firstItem="U6E-MB-03K" firstAttribute="leading" secondItem="zle-VU-ygo" secondAttribute="trailing" id="wYq-9R-DJF"/>
-                                    <constraint firstItem="pkq-mO-MBJ" firstAttribute="top" secondItem="2OR-ox-Csb" secondAttribute="bottom" priority="900" constant="16" id="waW-2I-Gom">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="20"/>
+                                    <constraint firstItem="pkq-mO-MBJ" firstAttribute="top" secondItem="2OR-ox-Csb" secondAttribute="bottom" priority="900" constant="13" id="waW-2I-Gom">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="16"/>
                                     </constraint>
                                 </constraints>
                                 <variation key="default">
@@ -311,6 +305,7 @@
                 <outlet property="dateViewLowerConstraint" destination="cCR-ch-CxK" id="rqF-oL-bTl"/>
                 <outlet property="headerView" destination="rIp-IY-Ng4" id="7zf-me-hFG"/>
                 <outlet property="headerViewHeightConstraint" destination="hQY-s6-IDE" id="JE0-4W-dHL"/>
+                <outlet property="headerViewLeftConstraint" destination="SmN-xb-mWD" id="sB9-to-eqY"/>
                 <outlet property="headerViewLowerConstraint" destination="QbH-qP-NR7" id="yVA-nc-yCf"/>
                 <outlet property="innerContentView" destination="00o-oC-uzQ" id="wq9-Kq-6nW"/>
                 <outlet property="maxIPadWidthConstraint" destination="Qi6-dA-tg8" id="CNS-yZ-LO9"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -32,6 +32,7 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 @property (nonatomic, strong) IBOutlet UIButton *metaButtonRight;
 @property (nonatomic, strong) IBOutlet UIButton *metaButtonLeft;
 @property (nonatomic, strong) IBOutlet PostCardActionBar *actionBar;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint *headerViewLeftConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *headerViewHeightConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *headerViewLowerConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *titleLowerConstraint;
@@ -141,7 +142,7 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 - (CGFloat)innerWidthForSize:(CGSize)size
 {
     CGFloat width = 0.0;
-    CGFloat horizontalMargin = CGRectGetMinX(self.headerView.frame);
+    CGFloat horizontalMargin = self.headerViewLeftConstraint.constant;
     // FIXME: Ideally we'd check `self.maxIPadWidthConstraint.isActive` but that
     // property is iOS 8 only. When iOS 7 support is ended update this and check
     // the constraint. 

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -42,6 +42,7 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *postContentBottomConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *maxIPadWidthConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *postCardImageViewBottomConstraint;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint *postCardImageViewHeightConstraint;
 
 @property (nonatomic, weak) id<WPPostContentViewProvider>contentProvider;
 @property (nonatomic, assign) CGFloat headerViewHeight;
@@ -114,7 +115,7 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
     if (self.postCardImageView) {
         // the image cell xib
-        height += CGRectGetHeight(self.postCardImageView.frame);
+        height += self.postCardImageViewHeightConstraint.constant;
         height += self.postCardImageViewBottomConstraint.constant;
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,6 +11,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="238"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="sqZ-hd-ibO" id="MWK-lj-FaS">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="237.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P6C-o2-FTR">

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -25,7 +25,7 @@
                                 <rect key="frame" x="6" y="10" width="308" height="216"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OuO-i7-2Ds">
-                                        <rect key="frame" x="14" y="15" width="280" height="34"/>
+                                        <rect key="frame" x="16" y="15" width="276" height="34"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="tB9-qp-pdv">
                                                 <rect key="frame" x="0.0" y="1" width="32" height="32"/>
@@ -35,14 +35,14 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Glg-dS-0y2">
-                                                <rect key="frame" x="48" y="0.0" width="232" height="17"/>
+                                                <rect key="frame" x="42" y="0.0" width="234" height="17"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l4E-Qn-Vgl">
-                                                <rect key="frame" x="48" y="18" width="232" height="15"/>
+                                                <rect key="frame" x="42" y="18" width="234" height="14.5"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -51,10 +51,10 @@
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstItem="l4E-Qn-Vgl" firstAttribute="leading" secondItem="tB9-qp-pdv" secondAttribute="trailing" constant="16" id="ONX-Wv-JNt"/>
+                                            <constraint firstItem="l4E-Qn-Vgl" firstAttribute="leading" secondItem="tB9-qp-pdv" secondAttribute="trailing" constant="10" id="ONX-Wv-JNt"/>
                                             <constraint firstAttribute="height" constant="34" id="XPo-Pz-YMq"/>
                                             <constraint firstAttribute="centerY" secondItem="tB9-qp-pdv" secondAttribute="centerY" id="XcJ-0j-93o"/>
-                                            <constraint firstItem="Glg-dS-0y2" firstAttribute="leading" secondItem="tB9-qp-pdv" secondAttribute="trailing" constant="16" id="a7e-Y3-7xM"/>
+                                            <constraint firstItem="Glg-dS-0y2" firstAttribute="leading" secondItem="tB9-qp-pdv" secondAttribute="trailing" constant="10" id="a7e-Y3-7xM"/>
                                             <constraint firstItem="l4E-Qn-Vgl" firstAttribute="top" secondItem="OuO-i7-2Ds" secondAttribute="top" constant="18" id="bSY-9k-nBq"/>
                                             <constraint firstItem="Glg-dS-0y2" firstAttribute="top" secondItem="OuO-i7-2Ds" secondAttribute="top" id="cyI-Sx-yRb"/>
                                             <constraint firstAttribute="trailing" secondItem="l4E-Qn-Vgl" secondAttribute="trailing" id="k2B-kw-1aC"/>
@@ -63,21 +63,21 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="xIT-FJ-g43">
-                                        <rect key="frame" x="14" y="65" width="280" height="24"/>
+                                        <rect key="frame" x="16" y="61" width="276" height="24"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="POV-pe-wu8">
-                                        <rect key="frame" x="14" y="95" width="280" height="17"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="POV-pe-wu8">
+                                        <rect key="frame" x="16" y="90" width="276" height="25"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z3W-ou-g2J">
-                                        <rect key="frame" x="14" y="120" width="203" height="18"/>
+                                        <rect key="frame" x="16" y="124" width="196" height="18"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="38V-Vw-GfJ">
                                                 <rect key="frame" x="0.0" y="1" width="16" height="16"/>
@@ -87,7 +87,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q5D-nc-yvr">
-                                                <rect key="frame" x="19" y="2" width="184" height="15"/>
+                                                <rect key="frame" x="19" y="2" width="177" height="14.5"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -107,7 +107,7 @@
                                         </constraints>
                                     </view>
                                     <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="O28-fP-tpX">
-                                        <rect key="frame" x="14" y="146" width="280" height="18"/>
+                                        <rect key="frame" x="16" y="148" width="276" height="18"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="8Cs-fq-wSe">
                                                 <rect key="frame" x="0.0" y="1" width="16" height="16"/>
@@ -117,7 +117,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbu-l3-L8G">
-                                                <rect key="frame" x="19" y="2" width="261" height="15"/>
+                                                <rect key="frame" x="19" y="2" width="257" height="14.5"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -137,10 +137,10 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YwV-AJ-Nvl">
-                                        <rect key="frame" x="217" y="120" width="77" height="18"/>
+                                        <rect key="frame" x="212" y="124" width="80" height="18"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ovg-ci-Pfb" customClass="PostMetaButton">
-                                                <rect key="frame" x="47" y="0.0" width="30" height="18"/>
+                                                <rect key="frame" x="50" y="0.0" width="30" height="18"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="18" id="SlV-Re-dd7"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="i4C-dQ-DIP"/>
@@ -166,7 +166,7 @@
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstItem="Ovg-ci-Pfb" firstAttribute="leading" secondItem="uDE-AO-Rii" secondAttribute="trailing" constant="13" id="I0b-Dk-6Hj"/>
+                                            <constraint firstItem="Ovg-ci-Pfb" firstAttribute="leading" secondItem="uDE-AO-Rii" secondAttribute="trailing" constant="16" id="I0b-Dk-6Hj"/>
                                             <constraint firstAttribute="height" constant="18" id="L5g-Oq-HvR">
                                                 <variation key="heightClass=regular-widthClass=regular" constant="22"/>
                                             </constraint>
@@ -187,54 +187,54 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstItem="BlB-Gp-P6A" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="0LN-fC-xEM"/>
-                                    <constraint firstItem="OuO-i7-2Ds" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="14" id="2pB-iJ-nFa">
+                                    <constraint firstItem="OuO-i7-2Ds" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="2pB-iJ-nFa">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstItem="Z3W-ou-g2J" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="14" id="3cg-8s-lSo">
+                                    <constraint firstItem="Z3W-ou-g2J" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="3cg-8s-lSo">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstItem="POV-pe-wu8" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="14" id="7ce-1f-hAw">
+                                    <constraint firstItem="POV-pe-wu8" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="7ce-1f-hAw">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="OuO-i7-2Ds" secondAttribute="trailing" constant="14" id="9p6-eN-M0a">
+                                    <constraint firstAttribute="trailing" secondItem="OuO-i7-2Ds" secondAttribute="trailing" constant="16" id="9p6-eN-M0a">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
                                     <constraint firstAttribute="trailing" secondItem="BlB-Gp-P6A" secondAttribute="trailing" id="EAF-04-Ort"/>
-                                    <constraint firstItem="O28-fP-tpX" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="14" id="EvA-em-Rnw">
+                                    <constraint firstItem="O28-fP-tpX" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="EvA-em-Rnw">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstItem="BlB-Gp-P6A" firstAttribute="top" secondItem="O28-fP-tpX" secondAttribute="bottom" priority="900" constant="16" id="KPL-Ie-Sml">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="20"/>
+                                    <constraint firstItem="BlB-Gp-P6A" firstAttribute="top" secondItem="O28-fP-tpX" secondAttribute="bottom" priority="900" constant="13" id="KPL-Ie-Sml">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="16"/>
                                     </constraint>
                                     <constraint firstAttribute="bottom" secondItem="BlB-Gp-P6A" secondAttribute="bottom" id="SVN-uV-BWH"/>
                                     <constraint firstItem="OuO-i7-2Ds" firstAttribute="top" secondItem="Lk7-nZ-b0t" secondAttribute="top" constant="15" id="Seu-o3-dkG"/>
-                                    <constraint firstAttribute="trailing" secondItem="POV-pe-wu8" secondAttribute="trailing" constant="14" id="SjY-e4-XWL">
+                                    <constraint firstAttribute="trailing" secondItem="POV-pe-wu8" secondAttribute="trailing" constant="16" id="SjY-e4-XWL">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
                                     <constraint firstAttribute="width" priority="900" constant="600" id="UEv-b1-gAx"/>
-                                    <constraint firstItem="Z3W-ou-g2J" firstAttribute="top" secondItem="POV-pe-wu8" secondAttribute="bottom" constant="8" id="cgz-3E-MrQ">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="12"/>
+                                    <constraint firstItem="Z3W-ou-g2J" firstAttribute="top" secondItem="POV-pe-wu8" secondAttribute="bottom" constant="9" id="cgz-3E-MrQ">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="9"/>
                                     </constraint>
-                                    <constraint firstItem="xIT-FJ-g43" firstAttribute="top" secondItem="OuO-i7-2Ds" secondAttribute="bottom" constant="16" id="gXH-oU-BWB"/>
-                                    <constraint firstAttribute="trailing" secondItem="O28-fP-tpX" secondAttribute="trailing" constant="14" id="hDs-3W-qUQ">
+                                    <constraint firstItem="xIT-FJ-g43" firstAttribute="top" secondItem="OuO-i7-2Ds" secondAttribute="bottom" constant="12" id="gXH-oU-BWB"/>
+                                    <constraint firstAttribute="trailing" secondItem="O28-fP-tpX" secondAttribute="trailing" constant="16" id="hDs-3W-qUQ">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
                                     <constraint firstItem="YwV-AJ-Nvl" firstAttribute="leading" secondItem="Z3W-ou-g2J" secondAttribute="trailing" id="jZK-gy-wGK"/>
-                                    <constraint firstAttribute="trailing" secondItem="xIT-FJ-g43" secondAttribute="trailing" constant="14" id="la2-OA-0qr">
+                                    <constraint firstAttribute="trailing" secondItem="xIT-FJ-g43" secondAttribute="trailing" constant="16" id="la2-OA-0qr">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="YwV-AJ-Nvl" secondAttribute="trailing" constant="14" id="pcg-aA-VMp">
+                                    <constraint firstAttribute="trailing" secondItem="YwV-AJ-Nvl" secondAttribute="trailing" constant="16" id="pcg-aA-VMp">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstItem="xIT-FJ-g43" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="14" id="uD9-vO-cJn">
+                                    <constraint firstItem="xIT-FJ-g43" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="uD9-vO-cJn">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
                                     <constraint firstItem="YwV-AJ-Nvl" firstAttribute="centerY" secondItem="Z3W-ou-g2J" secondAttribute="centerY" id="uVU-DQ-Fre"/>
-                                    <constraint firstItem="POV-pe-wu8" firstAttribute="top" secondItem="xIT-FJ-g43" secondAttribute="bottom" constant="6" id="wZc-29-y5d">
+                                    <constraint firstItem="POV-pe-wu8" firstAttribute="top" secondItem="xIT-FJ-g43" secondAttribute="bottom" constant="5" id="wZc-29-y5d">
                                         <variation key="heightClass=regular-widthClass=regular" constant="7"/>
                                     </constraint>
-                                    <constraint firstItem="O28-fP-tpX" firstAttribute="top" secondItem="Z3W-ou-g2J" secondAttribute="bottom" constant="8" id="zdK-e3-7HD">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="12"/>
+                                    <constraint firstItem="O28-fP-tpX" firstAttribute="top" secondItem="Z3W-ou-g2J" secondAttribute="bottom" constant="6" id="zdK-e3-7HD">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="8"/>
                                     </constraint>
                                 </constraints>
                                 <variation key="default">
@@ -294,6 +294,7 @@
                 <outlet property="dateViewLowerConstraint" destination="zdK-e3-7HD" id="0n8-x0-TrH"/>
                 <outlet property="headerView" destination="OuO-i7-2Ds" id="E0y-NW-njY"/>
                 <outlet property="headerViewHeightConstraint" destination="XPo-Pz-YMq" id="Hrp-nb-6G0"/>
+                <outlet property="headerViewLeftConstraint" destination="2pB-iJ-nFa" id="1Ha-rq-koT"/>
                 <outlet property="headerViewLowerConstraint" destination="gXH-oU-BWB" id="DR5-aJ-6Ye"/>
                 <outlet property="innerContentView" destination="P6C-o2-FTR" id="iBv-yh-YB0"/>
                 <outlet property="maxIPadWidthConstraint" destination="UEv-b1-gAx" id="hOO-m5-lsB"/>

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -102,6 +102,17 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     self.title = NSLocalizedString(@"Posts", @"Tile of the screen showing the list of posts for a blog.");
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+
+    [self forceUpdateCellLayout:self.textCellForLayout];
+    [self forceUpdateCellLayout:self.imageCellForLayout];
+
+    [self.tableViewHandler clearCachedRowHeights];
+    [self.tableView reloadRowsAtIndexPaths:[self.tableView indexPathsForVisibleRows] withRowAnimation:UITableViewRowAnimationNone];
+}
+
 
 #pragma mark - Configuration
 
@@ -124,8 +135,6 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     // Force a layout pass to ensure that constrants are configured for the
     // proper size class.
     [self.view addSubview:cell];
-    [cell updateConstraintsIfNeeded];
-    [cell layoutIfNeeded];
     [cell removeFromSuperview];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -122,8 +122,8 @@
 
 + (NSDictionary *)postCardTitleAttributes
 {
-    CGFloat fontSize = [UIDevice isPad] ? 24.0 : 16.0;
-    CGFloat lineHeight = [UIDevice isPad] ? 32.0 : 21.0;
+    CGFloat fontSize = [UIDevice isPad] ? 24.0 : 18.0;
+    CGFloat lineHeight = [UIDevice isPad] ? 32.0 : 24.0;
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
@@ -133,7 +133,7 @@
 + (NSDictionary *)postCardSnippetAttributes
 {
     CGFloat fontSize = [UIDevice isPad] ? 16.0 : 14.0;
-    CGFloat lineHeight = [UIDevice isPad] ? 24.0 : 21.0;
+    CGFloat lineHeight = [UIDevice isPad] ? 26.0 : 22.0;
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
@@ -143,7 +143,7 @@
 + (NSDictionary *)postCardDateAttributes
 {
     CGFloat fontSize = [UIDevice isPad] ? 14.0 : 12.0;
-    CGFloat lineHeight = [UIDevice isPad] ? 21.0 : 18.0;
+    CGFloat lineHeight = [UIDevice isPad] ? 22.0 : 18.0;
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
@@ -153,7 +153,7 @@
 + (NSDictionary *)postCardStatusAttributes
 {
     CGFloat fontSize = [UIDevice isPad] ? 14.0 : 12.0;
-    CGFloat lineHeight = [UIDevice isPad] ? 21.0 : 18.0;
+    CGFloat lineHeight = [UIDevice isPad] ? 22.0 : 18.0;
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;


### PR DESCRIPTION
Closes #4332 
Closes #4285 

Tweaks margins and spacing in the post cards, and fixes an issue where row height was incorrectly computed, resulting in some content being cropped. 

Pinging @mnt and @shaunandrews for a pixel sanity check. Shaun this is the PR we chatted about (much) earlier that updates the post cards to match the margins in the reader cards.  To get the right spacing between text field I'm taking the delta of the font-size (which seems to match the cap-height) and line-height for each element and then adding to make a multiple of eight.  It seemed like the right approach but some of the vertical spacing looked off so I've fudged it in a few places.  Maybe there is a more reliable way?

The iPad keeps the larger font sizes, line heights, and left/right margins which it had before.

Here is a gallery of screen shots from a test blog showing the updated margins and spacing. @mnt, @shaunandrews please let me know if you see something we need to nudge a bit. 
https://cloudup.com/cJpNDYg2R2M

@diegoreymendez would you be up for the code review in addition to the design review?

Needs review: @diegoreymendez 