### PR TITLE
Reader, Post List: Improves scrolling performance in reader and post lists

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -257,7 +257,7 @@ SPEC CHECKSUMS:
   CrashlyticsLumberjack: 5094b659ecf9a11550f7dd7a885c0cef077f1ffa
   DTCoreText: d90a4dca8e4f7b0eb18f12a967563b77a75694f0
   DTFoundation: c9b3362b83f0017389082ec067ede719826a579d
-  EmailChecker: 1b9c5a58c994bc638f842a4d69523b6ab57e706e
+  EmailChecker: 406cf1f1b5cd2efb8401803b580abf4a43b0665c
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
   google-plus-ios-sdk: 47adbe03ea904bdb7aa1c0eca282a23c4686e1bc
@@ -282,7 +282,7 @@ SPEC CHECKSUMS:
   UIAlertView+Blocks: 45c3d3b7194906702d3e9a14c7ece5581505646d
   UIDeviceIdentifier: f7b32c087f4d4957badbb6181a4c78520c5806ae
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
-  WordPress-iOS-Editor: 81d1f10e548c9fabd2ea99dbf0bcfa0669078667
+  WordPress-iOS-Editor: 3ed3f3f1eb226b34542b471a7db41419815bbf28
   WordPress-iOS-Shared: 345f7c1c49d298114353c3856c53317f0d826078
   WordPressApi: cb145d3c92ed54d4dbe70108d15f17ce3da3ad5d
   WordPressCom-Analytics-iOS: bd1744d61f731461725674792413c0a258d44858

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.h
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.h
@@ -9,6 +9,6 @@
 
 @optional
 
-- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider loadingImages:(BOOL)loadMedia;
+- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider layoutOnly:(BOOL)layoutOnly;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -10,6 +10,13 @@
 
 static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
+typedef NS_ENUM(NSUInteger, ActionBarMode) {
+    ActionBarModePublish = 1,
+    ActionBarModeDraft,
+    ActionBarModeTrash,
+};
+
+
 @interface PostCardTableViewCell()
 
 @property (nonatomic, strong) IBOutlet UIView *innerContentView;
@@ -44,15 +51,16 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *postCardImageViewBottomConstraint;
 
 @property (nonatomic, weak) id<WPPostContentViewProvider>contentProvider;
-@property (nonatomic, assign) CGFloat headerViewHeight;
-@property (nonatomic, assign) CGFloat headerViewLowerMargin;
-@property (nonatomic, assign) CGFloat titleViewLowerMargin;
-@property (nonatomic, assign) CGFloat snippetViewLowerMargin;
-@property (nonatomic, assign) CGFloat dateViewLowerMargin;
-@property (nonatomic, assign) CGFloat statusViewHeight;
-@property (nonatomic, assign) CGFloat statusViewLowerMargin;
-@property (nonatomic, assign) BOOL loadImagesWhenConfigured;
-@property (nonatomic, assign) BOOL didPreserveStartingConstraintConstants;
+@property (nonatomic) CGFloat headerViewHeight;
+@property (nonatomic) CGFloat headerViewLowerMargin;
+@property (nonatomic) CGFloat titleViewLowerMargin;
+@property (nonatomic) CGFloat snippetViewLowerMargin;
+@property (nonatomic) CGFloat dateViewLowerMargin;
+@property (nonatomic) CGFloat statusViewHeight;
+@property (nonatomic) CGFloat statusViewLowerMargin;
+@property (nonatomic) BOOL configureForLayoutOnly;
+@property (nonatomic) BOOL didPreserveStartingConstraintConstants;
+@property (nonatomic) ActionBarMode currentActionBarMode;
 
 @end
 
@@ -92,7 +100,7 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
     // the cell if needed.
     [self preserveStartingConstraintConstants];
     if (self.contentProvider) {
-        [self configureCell:self.contentProvider loadingImages:self.loadImagesWhenConfigured];
+        [self configureCell:self.contentProvider layoutOnly:self.configureForLayoutOnly];
     }
 }
 
@@ -256,12 +264,12 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 - (void)configureCell:(id<WPPostContentViewProvider>)contentProvider
 {
-    [self configureCell:contentProvider loadingImages:YES];
+    [self configureCell:contentProvider layoutOnly:NO];
 }
 
-- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider loadingImages:(BOOL)loadImages
+- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider layoutOnly:(BOOL)layoutOnly
 {
-    self.loadImagesWhenConfigured = loadImages;
+    self.configureForLayoutOnly = layoutOnly;
     self.contentProvider = contentProvider;
 
     if (!self.didPreserveStartingConstraintConstants) {
@@ -292,21 +300,22 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
     self.headerView.hidden = NO;
     self.headerViewHeightConstraint.constant = self.headerViewHeight;
     self.headerViewLowerConstraint.constant = self.headerViewLowerMargin;
+
+    // No need to worry about text or image when configuring only layout
+    if (self.configureForLayoutOnly) {
+        return;
+    }
+
     self.authorBlogLabel.text = [self.contentProvider blogNameForDisplay];
     self.authorNameLabel.text = [self.contentProvider authorNameForDisplay];
-
-    UIImage *placeholder =[UIImage imageNamed:@"post-blavatar-placeholder"];
-    if (self.loadImagesWhenConfigured) {
-        [self.avatarImageView setImageWithURL:[self blavatarURL]
-                             placeholderImage:placeholder];
-    } else {
-        self.avatarImageView.image = placeholder;
-    }
+    UIImage *placeholder = [UIImage imageNamed:@"post-blavatar-placeholder"];
+    [self.avatarImageView setImageWithURL:[self blavatarURL]
+                         placeholderImage:placeholder];
 }
 
 - (void)configureCardImage
 {
-    if (!self.loadImagesWhenConfigured) {
+    if (self.configureForLayoutOnly) {
         return;
     }
 
@@ -394,6 +403,10 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 - (void)configureMetaButtons
 {
+    if (self.configureForLayoutOnly) {
+        return;
+    }
+
     [self resetMetaButton:self.metaButtonRight];
     [self resetMetaButton:self.metaButtonLeft];
 
@@ -436,6 +449,10 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 - (void)configureActionBar
 {
+    if (self.configureForLayoutOnly) {
+        return;
+    }
+
     NSString *status = [self.contentProvider status];
     if ([status isEqualToString:PostStatusPublish] || [status isEqualToString:PostStatusPrivate]) {
         [self configurePublishedActionBar];
@@ -450,6 +467,11 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 - (void)configurePublishedActionBar
 {
+    if (self.currentActionBarMode == ActionBarModePublish) {
+        return;
+    }
+    self.currentActionBarMode = ActionBarModePublish;
+
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *items = [NSMutableArray array];
     PostCardActionBarItem *item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"Edit", @"Label for the edit post button. Tapping displays the editor.")
@@ -492,6 +514,11 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 - (void)configureDraftActionBar
 {
+    if (self.currentActionBarMode == ActionBarModeDraft) {
+        return;
+    }
+    self.currentActionBarMode = ActionBarModeDraft;
+
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *items = [NSMutableArray array];
     PostCardActionBarItem *item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"Edit", @"Label for the edit post button. Tapping displays the editor.")
@@ -531,6 +558,11 @@ static const UIEdgeInsets ViewButtonImageInsets = {2.0, 0.0, 0.0, 0.0};
 
 - (void)configureTrashedActionBar
 {
+    if (self.currentActionBarMode == ActionBarModeTrash) {
+        return;
+    }
+    self.currentActionBarMode = ActionBarModeTrash;
+
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *items = [NSMutableArray array];
     PostCardActionBarItem *item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"Restore", @"Label for restoring a trashed post.")

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -384,8 +384,8 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     postCell.delegate = self;
     Post *post = (Post *)[self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
 
-    BOOL loadImages = !([cell isEqual:self.imageCellForLayout] || [cell isEqual:self.textCellForLayout]);
-    [postCell configureCell:post loadingImages:loadImages];
+    BOOL layoutOnly = ([cell isEqual:self.imageCellForLayout] || [cell isEqual:self.textCellForLayout]);
+    [postCell configureCell:post layoutOnly:layoutOnly];
 }
 
 - (NSString *)cellIdentifierForPost:(Post *)post

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.m
@@ -65,7 +65,7 @@
     self.contentProvider = contentProvider;
 }
 
-- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider loadingImages:(BOOL)loadMedia
+- (void)configureCell:(id<WPPostContentViewProvider>)contentProvider layoutOnly:(BOOL)layoutOnly
 {
     [self configureCell:contentProvider];
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -64,7 +64,7 @@ import Foundation
     private var actionButtonViewHeightConstraintConstant = CGFloat(0.0)
 
     private var didPreserveStartingConstraintConstants = false
-    private var loadMediaWhenConfigured = true
+    private var configureForLayoutOnly = false
 
     private let summaryMaxNumberOfLines = 3
     private let maxAttributionViewHeight: CGFloat = 200.0 // 200 is an arbitrary height, but should be a sufficiently high number.
@@ -250,11 +250,11 @@ import Foundation
     }
 
     public func configureCell(contentProvider:ReaderPostContentProvider) {
-        configureCell(contentProvider, loadingMedia: true)
+        configureCell(contentProvider, layoutOnly: false)
     }
 
-    public func configureCell(contentProvider:ReaderPostContentProvider, loadingMedia:Bool) {
-        loadMediaWhenConfigured = loadingMedia
+    public func configureCell(contentProvider:ReaderPostContentProvider, layoutOnly:Bool) {
+        configureForLayoutOnly = layoutOnly
         self.contentProvider = contentProvider
 
         if !didPreserveStartingConstraintConstants {
@@ -282,7 +282,7 @@ import Foundation
 
         let size = avatarImageView.frame.size.width * UIScreen.mainScreen().scale
         let url = contentProvider?.siteIconForDisplayOfSize(Int(size))
-        if loadMediaWhenConfigured && url != nil {
+        if !configureForLayoutOnly && url != nil {
             avatarImageView.setImageWithURL(url!, placeholderImage: placeholder)
         } else {
             avatarImageView.image = placeholder
@@ -306,7 +306,7 @@ import Foundation
             featuredMediaHeightConstraint.constant = featuredMediaHeightConstraintConstant
             featuredMediaBottomConstraint.constant = featuredMediaBottomConstraintConstant
 
-            if loadMediaWhenConfigured {
+            if !configureForLayoutOnly {
                 if featuredImageURL.absoluteString == currentLoadedCardImageURL && featuredImageView.image != nil {
                     return; // Don't reload an image already being displayed.
                 }
@@ -463,8 +463,7 @@ import Foundation
     }
 
     private func configureActionButtons() {
-        resetActionButtons()
-        if contentProvider == nil {
+        if configureForLayoutOnly {
             return
         }
 
@@ -472,6 +471,11 @@ import Foundation
             actionButtonLeft,
             actionButtonRight
         ]
+
+        if contentProvider == nil {
+            resetActionButtons(buttons)
+            return
+        }
 
         // Show likes if logged in, or if likes exist, but not if external
         if (enableLoggedInFeatures || contentProvider!.likeCount().integerValue > 0) && !contentProvider!.isExternal() {
@@ -488,11 +492,14 @@ import Foundation
                 configureCommentActionButton(button)
             }
         }
+
+        resetActionButtons(buttons)
     }
 
-    private func resetActionButtons() {
-        resetActionButton(actionButtonLeft)
-        resetActionButton(actionButtonRight)
+    private func resetActionButtons(buttons:[UIButton!]) {
+        for button in buttons {
+            resetActionButton(button)
+        }
     }
 
     private func resetActionButton(button:UIButton) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1059,11 +1059,11 @@ import Foundation
         let postCell = cell as! ReaderPostCardCell
         let posts = tableViewHandler.resultsController.fetchedObjects as! [ReaderPost]
         let post = posts[indexPath.row]
-        let shouldLoadMedia = postCell != cellForLayout
+        let layoutOnly = postCell == cellForLayout
 
         postCell.enableLoggedInFeatures = isLoggedIn
         postCell.blogNameButtonIsEnabled = !ReaderHelpers.isTopicSite(readerTopic!)
-        postCell.configureCell(post, loadingMedia: shouldLoadMedia)
+        postCell.configureCell(post, layoutOnly: layoutOnly)
         postCell.delegate = self
     }
 


### PR DESCRIPTION
After noticing some jank scrolling in the post lists, I used the Time Profiler to take a look at performance. There was a bit of wasteful work being done when cells were configured.  This PR improves scrolling by avoiding unnecessary work when computing layout and redundant work to configure views already properly configured.

To test: 
Run this branch on a device and observe the scrolling performance compared to scrolling in the develop branch for the Reader post list, and the My Sites post list. 

Needs review : @astralbodies 