### PR TITLE
Updates UIAlertController Helper

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -257,7 +257,7 @@ SPEC CHECKSUMS:
   CrashlyticsLumberjack: 5094b659ecf9a11550f7dd7a885c0cef077f1ffa
   DTCoreText: d90a4dca8e4f7b0eb18f12a967563b77a75694f0
   DTFoundation: c9b3362b83f0017389082ec067ede719826a579d
-  EmailChecker: 406cf1f1b5cd2efb8401803b580abf4a43b0665c
+  EmailChecker: 1b9c5a58c994bc638f842a4d69523b6ab57e706e
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
   google-plus-ios-sdk: 47adbe03ea904bdb7aa1c0eca282a23c4686e1bc

--- a/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
@@ -27,7 +27,7 @@ extension UIAlertController
         // This method is required because the presenter ViewController must be visible, and we've got several
         // flows in which the VC that triggers the alert, might not be visible anymore.
         //
-        guard let rootViewController = UIApplication.sharedApplication().delegate?.window??.rootViewController else {
+        guard let rootViewController = UIApplication.sharedApplication().keyWindow?.rootViewController else {
             print("Error loading the rootViewController")
             return
         }


### PR DESCRIPTION
Instead of loading the UIApplicationDelegate's *window*, we should be loading the *keyWindow*.
This will, potentially, save us few headaches, if apps ever get multiple windows. iOSX!

Needs Review: @sendhil 
