### PR TITLE
Editor updates for iOS9

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -31,7 +31,7 @@ pod 'NSObject-SafeExpectations', '0.0.2'
 pod 'Simperium', '0.8.3'
 pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
 pod 'WordPress-iOS-Shared', '0.4.4'
-pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => '1b614724fbc005be4346c7870498658c8b537267'
+pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => 'bfc8fab8725ec316612f5f67760eaaf154dacb6a'
 pod 'WordPressCom-Stats-iOS', '0.4.8'
 pod 'WordPressCom-Analytics-iOS', '0.0.38'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -138,15 +138,13 @@ PODS:
   - Simperium/SSKeychain (0.8.3)
   - Specta (1.0.3)
   - SVProgressHUD (1.1.3)
-  - UIAlertView+Blocks (0.8.1)
   - UIDeviceIdentifier (0.4.5)
   - WordPress-AppbotX (1.0.6)
-  - WordPress-iOS-Editor (0.8.1):
+  - WordPress-iOS-Editor (1.0):
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (~> 0.0.2)
-    - UIAlertView+Blocks (~> 0.8.1)
-    - WordPress-iOS-Shared (~> 0.3)
-    - WordPressCom-Analytics-iOS (~> 0.0.30)
+    - WordPress-iOS-Shared (~> 0.4.4)
+    - WordPressCom-Analytics-iOS (~> 0.0.38)
   - WordPress-iOS-Shared (0.4.4):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
@@ -199,7 +197,7 @@ DEPENDENCIES:
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
   - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`,
-    commit `1b614724fbc005be4346c7870498658c8b537267`)
+    commit `bfc8fab8725ec316612f5f67760eaaf154dacb6a`)
   - WordPress-iOS-Shared (= 0.4.4)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
   - WordPressCom-Analytics-iOS (= 0.0.38)
@@ -223,7 +221,7 @@ EXTERNAL SOURCES:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-iOS-Editor:
-    :commit: 1b614724fbc005be4346c7870498658c8b537267
+    :commit: bfc8fab8725ec316612f5f67760eaaf154dacb6a
     :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
   WordPressApi:
     :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git
@@ -242,7 +240,7 @@ CHECKOUT OPTIONS:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-iOS-Editor:
-    :commit: 1b614724fbc005be4346c7870498658c8b537267
+    :commit: bfc8fab8725ec316612f5f67760eaaf154dacb6a
     :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
   WordPressApi:
     :commit: 4bc8da6f5ec461cb980170a14d8b149c59d847b5
@@ -257,7 +255,7 @@ SPEC CHECKSUMS:
   CrashlyticsLumberjack: 5094b659ecf9a11550f7dd7a885c0cef077f1ffa
   DTCoreText: d90a4dca8e4f7b0eb18f12a967563b77a75694f0
   DTFoundation: c9b3362b83f0017389082ec067ede719826a579d
-  EmailChecker: 406cf1f1b5cd2efb8401803b580abf4a43b0665c
+  EmailChecker: 1b9c5a58c994bc638f842a4d69523b6ab57e706e
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
   google-plus-ios-sdk: 47adbe03ea904bdb7aa1c0eca282a23c4686e1bc
@@ -279,10 +277,9 @@ SPEC CHECKSUMS:
   Simperium: 7a2d7e5ac67526477084a35a5ef9a77b6423b1ac
   Specta: cf3e4188cf35375c3ee2cd03f8db8f1f4ef98234
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
-  UIAlertView+Blocks: 45c3d3b7194906702d3e9a14c7ece5581505646d
   UIDeviceIdentifier: f7b32c087f4d4957badbb6181a4c78520c5806ae
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
-  WordPress-iOS-Editor: 3ed3f3f1eb226b34542b471a7db41419815bbf28
+  WordPress-iOS-Editor: 5077745deb77e472cae796a6b38d1abcd627709c
   WordPress-iOS-Shared: 345f7c1c49d298114353c3856c53317f0d826078
   WordPressApi: cb145d3c92ed54d4dbe70108d15f17ce3da3ad5d
   WordPressCom-Analytics-iOS: 79bb95bf36a152caea98c0ad9cef6fa679174524

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -46,7 +46,6 @@
 #import "SourcePostAttribution.h"
 #import "SuggestionsTableView.h"
 
-#import "UIAlertView+Blocks.h"
 #import "UIAlertControllerProxy.h"
 #import "UIDevice+Helpers.h"
 #import "UIImage+Tint.h"

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -27,7 +27,6 @@
 #import "NSBundle+VersionNumberHelper.h"
 #import "NSProcessInfo+Util.h"
 #import "NSString+Helpers.h"
-#import "UIAlertView+Blocks.h"
 #import "UIDevice+Helpers.h"
 
 // Data model

--- a/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
+++ b/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
@@ -3,7 +3,6 @@
 #import "BlogService.h"
 #import "ContextManager.h"
 #import "LoginViewController.h"
-#import "UIAlertView+Blocks.h"
 #import "WPAccount.h"
 
 @implementation WPAuthTokenIssueSolver
@@ -100,15 +99,22 @@
     NSString *deleteButtonTitle = NSLocalizedString(@"Delete",
                                                     @"Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.");
     
-    [UIAlertView showWithTitle:alertTitle
-                       message:alertMessage
-             cancelButtonTitle:cancelButtonTitle
-             otherButtonTitles:@[deleteButtonTitle]
-                      tapBlock:^(UIAlertView *alertView, NSInteger buttonIndex) {
-                          if (buttonIndex == alertView.firstOtherButtonIndex) {
-                              okBlock();
-                          }
-                      }];
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:alertTitle
+                                                                             message:alertMessage
+                                                                      preferredStyle:UIAlertControllerStyleAlert];
+    
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:cancelButtonTitle
+                                                           style:UIAlertActionStyleCancel
+                                                         handler:^(UIAlertAction *action){}];
+    
+    UIAlertAction *deleteAction = [UIAlertAction actionWithTitle:deleteButtonTitle
+                                                         style:UIAlertActionStyleDestructive
+                                                         handler:okBlock];
+    [alertController addAction:cancelAction];
+    [alertController addAction:deleteAction];
+    [[[UIApplication sharedApplication] keyWindow].rootViewController presentViewController:alertController
+                                                                                   animated:YES
+                                                                                 completion:nil];
 }
 
 /**
@@ -123,11 +129,17 @@
     NSString *okButtonTitle = NSLocalizedString(@"OK",
                                                 @"OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.");
     
-    [UIAlertView showWithTitle:alertTitle
-                       message:alertMessage
-             cancelButtonTitle:nil
-             otherButtonTitles:@[okButtonTitle]
-                      tapBlock:nil];
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:alertTitle
+                                                                             message:alertMessage
+                                                                      preferredStyle:UIAlertControllerStyleAlert];
+    
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:okButtonTitle
+                                                           style:UIAlertActionStyleDefault
+                                                         handler:^(UIAlertAction *action){}];
+    [alertController addAction:okAction];
+    [[[UIApplication sharedApplication] keyWindow].rootViewController presentViewController:alertController
+                                                                                   animated:YES
+                                                                                 completion:nil];
 }
 
 @end

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -9,7 +9,6 @@
 #import "WPCookie.h"
 #import "Constants.h"
 #import "WPError.h"
-#import "UIAlertView+Blocks.h"
 #import "UIImage+Util.h"
 #import "WPStyleGuide+WebView.h"
 #import "WordPress-Swift.h"

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -2,7 +2,6 @@
 #import "WPWebViewController.h"
 #import "CommentService.h"
 #import "ContextManager.h"
-#import "UIAlertView+Blocks.h"
 #import "WordPress-Swift.h"
 #import "UIActionSheet+Helpers.h"
 #import "Comment.h"
@@ -493,70 +492,76 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 {
     __typeof(self) __weak weakSelf = self;
 
-    // Callback Block
-    UIAlertViewCompletionBlock completion = ^(UIAlertView *alertView, NSInteger buttonIndex) {
-        if (buttonIndex == alertView.cancelButtonIndex) {
-            return;
-        }
-
-        NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
-        
-        NSError *error = nil;
-        Comment *reloadedComment = (Comment *)[context existingObjectWithID:weakSelf.comment.objectID error:&error];
-        
-        if (error) {
-            DDLogError(@"Comment was deleted while awaiting for alertView confirmation");
-            return;
-        }
-        
-        [commentService deleteComment:reloadedComment success:nil failure:nil];
-
-        // Note: the parent class of CommentsViewController will pop this as a result of NSFetchedResultsChangeDelete
-    };
-
     // Show the alertView
     NSString *message = NSLocalizedString(@"Are you sure you want to delete this comment?",
                                           @"Message asking for confirmation on comment deletion");
 
-    [UIAlertView showWithTitle:NSLocalizedString(@"Confirm", @"Confirm")
-                       message:message
-             cancelButtonTitle:NSLocalizedString(@"Cancel", @"Cancel")
-             otherButtonTitles:@[NSLocalizedString(@"Delete", @"Delete")]
-                      tapBlock:completion];
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Confirm", @"Confirm")
+                                                                             message:message
+                                                                      preferredStyle:UIAlertControllerStyleAlert];
+    
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Cancel")
+                                                           style:UIAlertActionStyleCancel
+                                                         handler:^(UIAlertAction *action){}];
+    
+    UIAlertAction *deleteAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Delete", @"Delete")
+                                                           style:UIAlertActionStyleDestructive
+                                                         handler:^(UIAlertAction *action){
+                                                             NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+                                                             CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
+                                                             
+                                                             NSError *error = nil;
+                                                             Comment *reloadedComment = (Comment *)[context existingObjectWithID:weakSelf.comment.objectID error:&error];
+                                                             
+                                                             if (error) {
+                                                                 DDLogError(@"Comment was deleted while awaiting for alertView confirmation");
+                                                                 return;
+                                                             }
+                                                             
+                                                             [commentService deleteComment:reloadedComment success:nil failure:nil];
+                                                             
+                                                             // Note: the parent class of CommentsViewController will pop this as a result of NSFetchedResultsChangeDelete
+                                                         }];
+    [alertController addAction:cancelAction];
+    [alertController addAction:deleteAction];
+    [self presentViewController:alertController animated:YES completion:nil];
 }
 
 - (void)spamComment
 {
     __typeof(self) __weak weakSelf = self;
 
-    UIAlertViewCompletionBlock completion = ^(UIAlertView *alertView, NSInteger buttonIndex) {
-        if (buttonIndex == alertView.cancelButtonIndex) {
-            return;
-        }
-
-        NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
-        
-        NSError *error = nil;
-        Comment *reloadedComment = (Comment *)[context existingObjectWithID:weakSelf.comment.objectID error:&error];
-        
-        if (error) {
-            DDLogError(@"Comment was deleted while awaiting for alertView confirmation");
-            return;
-        }
-        
-        [commentService spamComment:reloadedComment success:nil failure:nil];
-    };
-
     NSString *message = NSLocalizedString(@"Are you sure you want to mark this comment as Spam?",
                                           @"Message asking for confirmation before marking a comment as spam");
-
-    [UIAlertView showWithTitle:NSLocalizedString(@"Confirm", @"Confirm")
-                       message:message
-             cancelButtonTitle:NSLocalizedString(@"Cancel", @"Cancel")
-             otherButtonTitles:@[NSLocalizedString(@"Spam", @"Spam")]
-                      tapBlock:completion];
+    
+    
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Confirm", @"Confirm")
+                                                                             message:message
+                                                                      preferredStyle:UIAlertControllerStyleAlert];
+    
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Cancel")
+                                                           style:UIAlertActionStyleCancel
+                                                         handler:^(UIAlertAction *action){}];
+    
+    UIAlertAction *spamAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Spam", @"Spam")
+                                                           style:UIAlertActionStyleDestructive
+                                                         handler:^(UIAlertAction *action){
+                                                             NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+                                                             CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
+                                                             
+                                                             NSError *error = nil;
+                                                             Comment *reloadedComment = (Comment *)[context existingObjectWithID:weakSelf.comment.objectID error:&error];
+                                                             
+                                                             if (error) {
+                                                                 DDLogError(@"Comment was deleted while awaiting for alertView confirmation");
+                                                                 return;
+                                                             }
+                                                             
+                                                             [commentService spamComment:reloadedComment success:nil failure:nil];
+                                                         }];
+    [alertController addAction:cancelAction];
+    [alertController addAction:spamAction];
+    [self presentViewController:alertController animated:YES completion:nil];
 }
 
 
@@ -601,19 +606,26 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
                           } failure:^(NSError *error) {
                               NSString *message = NSLocalizedString(@"There has been an unexpected error while editing your comment",
                                                                     @"Error displayed if a comment fails to get updated");
-                              [UIAlertView showWithTitle:nil
-                                                 message:message
-                                       cancelButtonTitle:NSLocalizedString(@"Cancel", @"Verb, Cancel an action")
-                                       otherButtonTitles:@[ NSLocalizedString(@"Try Again", @"Retry an action that failed") ]
-                                                tapBlock:^(UIAlertView *alertView, NSInteger buttonIndex) {
-                                                    if (buttonIndex == alertView.cancelButtonIndex) {
-                                                        [weakSelf.comment.managedObjectContext refreshObject:weakSelf.comment mergeChanges:false];
-                                                        [weakSelf reloadData];
-                                                    } else {
-                                                        [weakSelf updateCommentForNewContent:content];
-                                                    }
-                                                }
-                               ];
+                              
+                              UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil
+                                                                                                       message:message
+                                                                                                preferredStyle:UIAlertControllerStyleAlert];
+                              
+                              UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Verb, Cancel an action")
+                                                                                     style:UIAlertActionStyleCancel
+                                                                                   handler:^(UIAlertAction *action){
+                                                                                       [weakSelf.comment.managedObjectContext refreshObject:weakSelf.comment mergeChanges:false];
+                                                                                       [weakSelf reloadData];
+                                                                                   }];
+                              
+                              UIAlertAction *retryAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Try Again", @"Retry an action that failed")
+                                                                                   style:UIAlertActionStyleDestructive
+                                                                                 handler:^(UIAlertAction *action){
+                                                                                     [weakSelf updateCommentForNewContent:content];
+                                                                                 }];
+                              [alertController addAction:cancelAction];
+                              [alertController addAction:retryAction];
+                              [weakSelf presentViewController:alertController animated:YES completion:nil];
                           }];
 }
 
@@ -652,15 +664,25 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     };
 
     void (^failureBlock)(NSError *error) = ^void(NSError *error) {
-        [UIAlertView showWithTitle:nil
-                           message:NSLocalizedString(@"There has been an unexpected error while sending your reply", nil)
-                 cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
-                 otherButtonTitles:@[ NSLocalizedString(@"Try Again", nil) ]
-                          tapBlock:^(UIAlertView *alertView, NSInteger buttonIndex) {
-                              if (buttonIndex != alertView.cancelButtonIndex) {
-                                  [weakSelf sendReplyWithNewContent:content];
-                              }
-                          }];
+        
+        NSString *message = NSLocalizedString(@"There has been an unexpected error while sending your reply", nil);
+        
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil
+                                                                                 message:message
+                                                                          preferredStyle:UIAlertControllerStyleAlert];
+        
+        UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Verb, Cancel an action")
+                                                               style:UIAlertActionStyleCancel
+                                                             handler:^(UIAlertAction *action){}];
+        
+        UIAlertAction *retryAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Try Again", @"Retry an action that failed")
+                                                              style:UIAlertActionStyleDestructive
+                                                            handler:^(UIAlertAction *action){
+                                                                [weakSelf sendReplyWithNewContent:content];
+                                                            }];
+        [alertController addAction:cancelAction];
+        [alertController addAction:retryAction];
+        [weakSelf presentViewController:alertController animated:YES completion:nil];
     };
 
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -33,7 +33,6 @@
 #import "NSURL+Util.h"
 #import "NSScanner+Helpers.h"
 #import "UIActionSheet+Helpers.h"
-#import "UIAlertView+Blocks.h"
 #import "NSObject+Helpers.h"
 #import "NSDate+StringFormatting.h"
 #import "NSString+Helpers.h"

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -12,7 +12,6 @@
 #import "ReaderPostService.h"
 #import "ReaderPostHeaderView.h"
 #import "ReaderPostDetailViewController.h"
-#import "UIAlertView+Blocks.h"
 #import "UIView+Subviews.h"
 #import "WPAvatarSource.h"
 #import "WPNoResultsView.h"

--- a/WordPress/WordPressTest/WordPressTest-Bridging-Header.h
+++ b/WordPress/WordPressTest/WordPressTest-Bridging-Header.h
@@ -10,7 +10,6 @@
 #import "Post.h"
 #import "Page.h"
 #import "ReaderPost.h"
-#import "UIAlertView+Blocks.h"
 #import "NSDictionary+SafeExpectations.h"
 #import "UIAlertControllerProxy.h"
 #import <WordPressCom-Analytics-iOS/WPAnalytics.h>


### PR DESCRIPTION
**Note:** This PR has a dependency on [this PR](https://github.com/wordpress-mobile/WordPress-Editor-iOS/pull/728) in the editor project.

This PR accomplishes two things:

1) It integrates the iOS 9 updates from the editor (no multitasking). 
2) It addresses the fact that `UIAlertView+Blocks` has been removed from the editor pod and therefore is removed from WPiOS.

**Things to test:**

* Alert views during comment management
* Alert views in `WPAuthTokenIssueSolver`
* General editing behavior

/cc @sendhil 