### PR TITLE
Adding swift style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Handbook: http://make.wordpress.org/mobile/handbook/
 
 ### Style guide
 
-https://github.com/wordpress-mobile/WordPress-iOS/wiki/WordPress-for-iOS-Objective-C-Style-Guide
+https://github.com/wordpress-mobile/WordPress-iOS/wiki/WordPress-for-iOS-Style-Guide
 
 ### To report an issue
 


### PR DESCRIPTION
Pointing to generic style guide that has links to both the Objective-C and Swift style guides

The Objective-C style guide was a page in the wiki while the Swift style guide was its own repo.

I created an Objective-C style guide repo to match the swift style guide, and redirected the `README.md` to point to the generic style guide page which has links now to both repos.

@sendhil this may affect Freshly Pressed(?)