### PR TITLE
Comments: Ensure objectID of a newly created hierarchical comment is not a temp

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -801,10 +801,7 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
     if (error) {
         DDLogError(@"%@ error obtaining permanent ID for a hierarchical comment %@: %@", NSStringFromSelector(_cmd), comment, error);
     }
-
-    [self.managedObjectContext performBlock:^{
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-    }];
+    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
 
     return comment;
 }

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -797,6 +797,17 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
     // Update depth and hierarchy
     [self setHierarchAndDepthOnComment:comment withParentComment:parentComment];
 
+    [self.managedObjectContext obtainPermanentIDsForObjects:@[comment] error:&error];
+    if (error) {
+        DDLogError(@"%@ error obtaining permanent ID for a hierarchical comment %@: %@", NSStringFromSelector(_cmd), comment, error);
+    }
+
+    [self.managedObjectContext save:&error];
+    if (error) {
+        DDLogError(@"%@ error saving a managed object context: %@", NSStringFromSelector(_cmd), error);
+    }
+
+    // Go ahead and save the context via the ContextManager. In case we're working with a derived context.
     [self.managedObjectContext performBlock:^{
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
     }];

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -802,12 +802,6 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
         DDLogError(@"%@ error obtaining permanent ID for a hierarchical comment %@: %@", NSStringFromSelector(_cmd), comment, error);
     }
 
-    [self.managedObjectContext save:&error];
-    if (error) {
-        DDLogError(@"%@ error saving a managed object context: %@", NSStringFromSelector(_cmd), error);
-    }
-
-    // Go ahead and save the context via the ContextManager. In case we're working with a derived context.
     [self.managedObjectContext performBlock:^{
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
     }];


### PR DESCRIPTION
Fixes #4369 

To test:
- While on the Reader tab, view the comments for a post.  My approach was to Like a post on my test blog, switch to the Liked feed and view comments for that post. 
- Tap the "Reply" button on one of the comments, enter some text and submit the reply. 

Confirm that the reply shows up in the list as a child comment in the correct location.

Needs Review: @kurzee would you do the honors? 