### PR TITLE
Reader: Prevent a crash when a slug is nil.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -282,7 +282,7 @@ SPEC CHECKSUMS:
   UIAlertView+Blocks: 45c3d3b7194906702d3e9a14c7ece5581505646d
   UIDeviceIdentifier: f7b32c087f4d4957badbb6181a4c78520c5806ae
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
-  WordPress-iOS-Editor: 81d1f10e548c9fabd2ea99dbf0bcfa0669078667
+  WordPress-iOS-Editor: 3ed3f3f1eb226b34542b471a7db41419815bbf28
   WordPress-iOS-Shared: 345f7c1c49d298114353c3856c53317f0d826078
   WordPressApi: cb145d3c92ed54d4dbe70108d15f17ce3da3ad5d
   WordPressCom-Analytics-iOS: 79bb95bf36a152caea98c0ad9cef6fa679174524

--- a/WordPress/Classes/Networking/ReaderTopicServiceRemote.h
+++ b/WordPress/Classes/Networking/ReaderTopicServiceRemote.h
@@ -81,4 +81,13 @@ extern NSString * const WordPressComReaderEndpointURL;
                            success:(void (^)(RemoteReaderSiteInfo *siteInfo))success
                            failure:(void (^)(NSError *error))failure;
 
+/**
+ Takes a topic name and santitizes it, returning what *should* be its slug.
+ 
+ @param topicName The natural language name of a topic. 
+ 
+ @return The sanitized name, as a topic slug.
+ */
+- (NSString *)slugForTopicName:(NSString *)topicName;
+
 @end

--- a/WordPress/Classes/Networking/ReaderTopicServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderTopicServiceRemote.m
@@ -106,8 +106,8 @@ static NSString * const SiteDictionarySubscriptionsKey = @"subscribers_count";
              withSuccess:(void (^)(NSNumber *topicID))success
                  failure:(void (^)(NSError *error))failure
 {
-    topicName = [self sanitizeTopicNameForAPI:topicName];
-    [self followTopicWithSlug:topicName withSuccess:success failure:failure];
+    NSString *slug = [self slugForTopicName:topicName];
+    [self followTopicWithSlug:slug withSuccess:success failure:failure];
 }
 
 - (void)followTopicWithSlug:(NSString *)slug
@@ -249,7 +249,7 @@ static NSString * const SiteDictionarySubscriptionsKey = @"subscribers_count";
  @param topicName The string to be formatted.
  @return The formatted string.
  */
-- (NSString *)sanitizeTopicNameForAPI:(NSString *)topicName
+- (NSString *)slugForTopicName:(NSString *)topicName
 {
     if (!topicName || [topicName length] == 0) {
         return @"";


### PR DESCRIPTION
Closes #4404 

I wasn't able to reproduce the crash case.  I have a theory that the slug might just be missing from the data returned by the endpoints in some weird scenario but I can't account for that either.  
In lieu of an answer I'm adding a fallback to compose a slug if one is missing. 

@bummytime would you mind a review since you're familiar with this one? 

Needs Review: @bummytime 