### PR TITLE
Reader: url should be an NSURL not a String.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -17,8 +17,10 @@ public class ReaderHelpers {
         }
 
         activityItems.append(postDictionary)
-        if let url = link {
-            activityItems.append(url)
+        if let urlPath = link {
+            if let url = NSURL(string: urlPath) {
+                activityItems.append(url)
+            }
         }
 
         let activities = WPActivityDefaults.defaultActivities() as! [UIActivity]

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -17,10 +17,8 @@ public class ReaderHelpers {
         }
 
         activityItems.append(postDictionary)
-        if let urlPath = link {
-            if let url = NSURL(string: urlPath) {
-                activityItems.append(url)
-            }
+        if let urlPath = link, url = NSURL(string: urlPath) {
+            activityItems.append(url)
         }
 
         let activities = WPActivityDefaults.defaultActivities() as! [UIActivity]


### PR DESCRIPTION
Closes #4402 
The share link was being set as a String instead of an NSURL. This was causing our application share targets to not appear. 

To test: 
Go to the reader post list, tap the ( ... ) icon in one of the post cards and choose "Share" in the action sheet.  Confirm that WordPress, etc. are included as share options. 

Needs Review: @astralbodies 

@astralbodies The optional unboxing in this PR works but I think its a bit ugly.  I'd be game to go a different route but couldn't think of one I liked better. Suggestions welcome!