### PR TITLE
make geotagging setting available when not admin

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -113,10 +113,8 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         self.tableSections = @[@(SiteSettingsSectionGeneral)];
     } else {
         self.tableSections = @[@(SiteSettingsSectionGeneral), @(SiteSettingsSectionAccount)];
-    }    
-    if (self.blog.isAdmin) {
-        self.tableSections = [self.tableSections arrayByAddingObject:@(SiteSettingsSectionWriting)];
     }
+    self.tableSections = [self.tableSections arrayByAddingObject:@(SiteSettingsSectionWriting)];
     if ([self.blog supports:BlogFeatureRemovable]) {
         self.tableSections = [self.tableSections arrayByAddingObject:@(SiteSettingsSectionRemoveSite)];
     }
@@ -173,6 +171,10 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             return SiteSettingsAccountCount;
         break;
         case SiteSettingsSectionWriting: {
+            if (!self.blog.isAdmin) {
+                // If we're not admin, we just want to show the geotagging cell
+                return 1;
+            }
             NSInteger rowsToHide = 0;
             if (![self.blog supports:BlogFeatureWPComRESTAPI]) {
                 //  NOTE: Sergio Estevao (2015-09-23): Hides the related post for self-hosted sites not in jetpack


### PR DESCRIPTION
refs #4355 - of the writing settings, enabling or disabling geo-tagging is up to the user whatever its role on the blog is. This change keeps the geotagging switch visible when the user is not admin.

Validation: 
- made sure the setting was persisted and consistent for each blog
- verified that enabling geo-tagging for one blog, doesn't enable it for all the blogs
- verified that location was sent when geo-tagging is active, and not sent when geo-tagging is not active

Note:
- when dealing with a self-hosted blog, the option will still show up (as it did before this change)