### PR TITLE
Use more detailed HTTP "User-Agent" header so web servers won't fallback to XHTML / WML

### DIFF
--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -24,7 +24,7 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
 - (void)setupUserAgent
 {
     // Keep a copy of the original userAgent for use with certain webviews in the app.
-    NSString *defaultUA = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    NSString *defaultUA = [self defaultUserAgent];
     NSString *wordPressUserAgent = [self wordPressUserAgent];
 
     NSDictionary *dictionary = @{
@@ -35,7 +35,13 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
     [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
 }
 
-#pragma mark - WordPress User-Agent
+#pragma mark - Default and WordPress User-Agents
+
+- (NSString *)defaultUserAgent
+{
+    NSString *userAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    return userAgent;
+}
 
 - (NSString *)wordPressUserAgent
 {

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -39,9 +39,20 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
 
 - (NSString *)defaultUserAgent
 {
+    // Temporarily unset "UserAgent" from registered user defaults so that we
+    // always get the default value, independently from what's currently set as
+    // User-Agent
+    NSDictionary *originalRegisteredDefaults = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSRegistrationDomain];
+
+    NSMutableDictionary *tempRegisteredDefaults = [NSMutableDictionary dictionaryWithDictionary:originalRegisteredDefaults];
+    [tempRegisteredDefaults removeObjectForKey:WPUserAgentKeyUserAgent];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:tempRegisteredDefaults];
+    
     NSString *userAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
     NSAssert(userAgent != nil, @"User agent shouldn't be nil");
     NSAssert(! [userAgent isEmpty], @"User agent shouldn't be empty");
+    
+    [[NSUserDefaults standardUserDefaults] registerDefaults:originalRegisteredDefaults];
     
     return userAgent;
 }

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -59,13 +59,9 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
 
 - (NSString *)wordPressUserAgent
 {
-    UIDevice *device = [UIDevice currentDevice];
+    NSString *defaultUA = [self defaultUserAgent];
     NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-    NSString *userAgent = [NSString stringWithFormat:@"wp-iphone/%@ (%@ %@, %@) Mobile",
-                           appVersion,
-                           device.systemName,
-                           device.systemVersion,
-                           device.model];
+    NSString *userAgent = [NSString stringWithFormat:@"%@ wp-iphone/%@", defaultUA, appVersion];
     
     return userAgent;
 }

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -40,6 +40,9 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
 - (NSString *)defaultUserAgent
 {
     NSString *userAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    NSAssert(userAgent != nil, @"User agent shouldn't be nil");
+    NSAssert(! [userAgent isEmpty], @"User agent shouldn't be empty");
+    
     return userAgent;
 }
 

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -45,13 +45,9 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
  */
 - (NSString *)wordPressUserAgent
 {
-    UIDevice *device = [UIDevice currentDevice];
+    NSString *defaultUA = [self defaultUserAgent];
     NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-    NSString *userAgent = [NSString stringWithFormat:@"wp-iphone/%@ (%@ %@, %@) Mobile",
-                           appVersion,
-                           device.systemName,
-                           device.systemVersion,
-                           device.model];
+    NSString *userAgent = [NSString stringWithFormat:@"%@ wp-iphone/%@", defaultUA, appVersion];
     
     return userAgent;
 }

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -20,6 +20,9 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
 - (NSString *)defaultUserAgent
 {
     NSString *userAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    XCTAssertNotNil(userAgent, @"User agent shouldn't be nil");
+    XCTAssertTrue([userAgent length] > 0, @"User agent shouldn't be empty");
+    
     return userAgent;
 }
 

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -12,6 +12,18 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
 @implementation WPUserAgentTests
 
 /**
+ *  @brief      Returns default UA for this device.
+ *  @details    This method is duplicated on purpose since we want to make sure that any change to
+ *              the WP UA in the app makes this test show an error unless updated.  This way we
+ *              ensure the change is intentional.
+ */
+- (NSString *)defaultUserAgent
+{
+    NSString *userAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    return userAgent;
+}
+
+/**
  *  @brief      Calculates the wordpress UA for this device.
  *  @details    This method is duplicated on purpose since we want to make sure that any change to
  *              the WP UA in the app makes this test show an error unless updated.  This way we
@@ -32,7 +44,7 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
 
 - (void)testUseDefaultUserAgent
 {
-    NSString *defaultUA = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    NSString *defaultUA = [self defaultUserAgent];
     WPUserAgent *userAgent = nil;
     
     XCTAssertNoThrow(userAgent = [[WPUserAgent alloc] init]);

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -16,12 +16,23 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
  *  @details    This method is duplicated on purpose since we want to make sure that any change to
  *              the WP UA in the app makes this test show an error unless updated.  This way we
  *              ensure the change is intentional.
+ *              Also, the method temporarily unsets "UserAgent" from registered
+ *              user defaults so that we always get the default value,
+ *              independently from what's currently set as User-Agent.
  */
 - (NSString *)defaultUserAgent
 {
+    NSDictionary *originalRegisteredDefaults = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSRegistrationDomain];
+    
+    NSMutableDictionary *tempRegisteredDefaults = [NSMutableDictionary dictionaryWithDictionary:originalRegisteredDefaults];
+    [tempRegisteredDefaults removeObjectForKey:WPUserAgentKeyUserAgent];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:tempRegisteredDefaults];
+    
     NSString *userAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
     XCTAssertNotNil(userAgent, @"User agent shouldn't be nil");
     XCTAssertTrue([userAgent length] > 0, @"User agent shouldn't be empty");
+    
+    [[NSUserDefaults standardUserDefaults] registerDefaults:originalRegisteredDefaults];
     
     return userAgent;
 }

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -77,7 +77,7 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
     XCTAssertNoThrow(userAgent = [[WPUserAgent alloc] init]);
     XCTAssertTrue([userAgent isKindOfClass:[WPUserAgent class]]);
     
-    [userAgent useDefaultUserAgent];
+    [userAgent useWordPressUserAgent];
     
     XCTAssertTrue([[userAgent currentUserAgent] isEqualToString:wordPressUA]);
 }


### PR DESCRIPTION
Some web servers (e.g. Facebook video) misinterpret the current `User-Agent` string as if the app was a feature phone and was only able to parse WML content, e.g.:

    wp-iphone/5.7 (iPhone OS 9.1, iPhone) Mobile

So, append "wp-iphone/<version>" to the UIWebView's default `User-Agent` string and use it instead:

    Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13B137 wp-iphone/5.7

Fixes #4295.