### PR TITLE
Skip syncing reader when test suite is running.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.h
+++ b/WordPress/Classes/System/WordPressAppDelegate.h
@@ -20,6 +20,7 @@
 @property (nonatomic, strong,  readonly) Simperium                      *simperium;
 @property (nonatomic, assign,  readonly) BOOL                           connectionAvailable;
 @property (nonatomic, strong,  readonly) WPUserAgent                    *userAgent;
+@property (nonatomic, assign, readonly) BOOL                            testSuiteIsRunning;
 
 + (WordPressAppDelegate *)sharedInstance;
 

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -1069,4 +1069,10 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     [[NSUserDefaults standardUserDefaults] setBool:mustShow forKey:MustShowWhatsNewPopup];
 }
 
+- (BOOL)testSuiteIsRunning
+{
+    Class testSuite = NSClassFromString(@"XCTestCase");
+    return testSuite != nil;
+}
+
 @end

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -762,6 +762,9 @@ import Foundation
         - The current time must be greater than the last sync interval.
     */
     func syncIfAppropriate() {
+        if WordPressAppDelegate.sharedInstance().testSuiteIsRunning {
+            return
+        }
         let lastSynced = readerTopic?.lastSynced == nil ? NSDate(timeIntervalSince1970: 0) : readerTopic!.lastSynced
         if canSync() && Int(lastSynced.timeIntervalSinceNow) < refreshInterval {
             syncHelper.syncContentWithUserInteraction(false)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderViewController.m
@@ -9,6 +9,7 @@
 #import "ReaderPostDetailViewController.h"
 #import "ReaderSubscriptionViewController.h"
 #import "ReaderTopicService.h"
+#import "WordPressAppDelegate.h"
 #import "WPTabBarController.h"
 #import "WordPress-Swift.h"
 
@@ -129,6 +130,10 @@
 
 - (void)syncTopics
 {
+    if ([WordPressAppDelegate sharedInstance].testSuiteIsRunning) {
+        // Skip syncing when running the test suite.
+        return;
+    }
     __weak __typeof(self) weakSelf = self;
     ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:[self managedObjectContext]];
     [topicService fetchReaderMenuWithSuccess:^{


### PR DESCRIPTION
Adds a new check to see if the test suite is running. 
If the suite is running, skips syncing the Reader.  We could likely extend this to other "sync" tasks as well. 

Not %100 sure that `WordPressAppDelegate` is the best place for the check to live but I didn't see a better candidate and I'm reluctant to create a new category just for a single check. 

Needs review @jleandroperez 