### PR TITLE
Disallow spaces in every field except password

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -700,7 +700,7 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
 
 - (BOOL)fieldsValid
 {
-    return [self fieldsFilled] && [self isUsernameUnderFiftyCharacters];
+    return [self fieldsFilled] && [self isUsernameUnderFiftyCharacters] && ![self emailOrUsernameOrSiteAddressContainsSpaces];
 }
 
 - (NSString *)generateSiteTitleFromUsername:(NSString *)username
@@ -715,9 +715,20 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
 {
     if (![self isUsernameUnderFiftyCharacters]) {
         [self showError:NSLocalizedString(@"Username must be less than fifty characters.", nil)];
+    } else if ([self emailOrUsernameOrSiteAddressContainsSpaces]) {
+        [self showError:NSLocalizedString(@"Email, Username, and Site Address cannot contain spaces", @"No spaces error message")];
     } else {
         [self showFieldsNotFilledError];
     }
+}
+
+- (BOOL)emailOrUsernameOrSiteAddressContainsSpaces {
+    NSString *space = @" ";
+    NSString *emailTrimmed = [_emailField.text trim];
+    NSString *userNameTrimmed = [_usernameField.text trim];
+    NSString *siteAddressTrimmed = [_siteAddressField.text trim];
+    
+    return ([emailTrimmed containsString:space] || [userNameTrimmed containsString:space] || [siteAddressTrimmed containsString:space]);
 }
 
 - (void)showFieldsNotFilledError

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -151,6 +151,10 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range
                                                        replacementString:(NSString *)string
 {
+    if ([string isEqualToString:@" "] && ![textField isEqual:_passwordField]) { // Disallow spaces in every field except password
+        return NO;
+    }
+    
     NSArray *fields = @[_emailField, _usernameField, _passwordField, _siteAddressField];
 
     NSMutableString *updatedString = [[NSMutableString alloc] initWithString:textField.text];


### PR DESCRIPTION
Addresses #4459 

Decided to go with option 1 (Disallow them to input a space in relevant fields) with the relevant fields being email, username, and site address as other apps follow this strategy.

Needs review: @koke