### PR TITLE
Fixed Settings controller restoration

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -404,7 +404,7 @@ static NSString *const MVCCellReuseIdentifier = @"MVCCellReuseIdentifier";
 {
     [WPAnalytics track:WPAnalyticsStatOpenedSettings];
 
-    SettingsViewController *settingsViewController = [[SettingsViewController alloc] initWithStyle:UITableViewStyleGrouped];
+    SettingsViewController *settingsViewController = [[SettingsViewController alloc] init];
     [self.navigationController pushViewController:settingsViewController animated:YES];
 }
 

--- a/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
@@ -63,9 +63,9 @@ static CGFloat const SettingsRowHeight = 44.0;
     return [[self alloc] init];
 }
 
-- (instancetype)initWithStyle:(UITableViewStyle)style
+- (instancetype)init
 {
-    self = [super initWithStyle:style];
+    self = [super initWithStyle:UITableViewStyleGrouped];
     if (self) {
         self.restorationIdentifier = WPSettingsRestorationID;
         self.restorationClass = [self class];


### PR DESCRIPTION
Since the restoration method called init, it would restore as a plain table view and look all weird.

![settings-restoration](https://cloud.githubusercontent.com/assets/8739/11208843/bd1838b0-8d1d-11e5-9eec-a923f6640f09.png)

Needs Review: @oguzkocer 