### PR TITLE
Turns off multitasking

### DIFF
--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -92,7 +92,7 @@
 	<key>UIPrerenderedIcon</key>
 	<true/>
 	<key>UIRequiresFullScreen</key>
-	<false/>
+	<true/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleBlackOpaque</string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
Fixes #4463 

Turns off the multitasking for WPiOS as it shouldn't be on yet until 5.8.

This is aimed for 5.7.1 but there isn't a branch yet for it.

Needs Review: @sendhil 