### PR TITLE
Rotation causes search bar to sized incorrectly

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -160,15 +160,14 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
     self.resultsController.delegate = nil;
 }
 
-- (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
-    [super willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
-    if (self.tableView.tableHeaderView == self.headerView) {
-        [self updateHeaderSize];
-
-        // this forces the tableHeaderView to resize
-        self.tableView.tableHeaderView = self.headerView;
-    }
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        if (![UIDevice isPad]) {
+            self.searchWrapperViewHeightConstraint.constant = [self heightForSearchWrapperView];
+        }
+    } completion:nil];
 }
 
 - (void)registerForKeyboardNotifications

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -164,6 +164,13 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        if (self.tableView.tableHeaderView == self.headerView) {
+            [self updateHeaderSize];
+            
+            // this forces the tableHeaderView to resize
+            self.tableView.tableHeaderView = self.headerView;
+        }
+        
         if (![UIDevice isPad]) {
             self.searchWrapperViewHeightConstraint.constant = [self heightForSearchWrapperView];
         }

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -171,7 +171,7 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
             self.tableView.tableHeaderView = self.headerView;
         }
         
-        if (![UIDevice isPad]) {
+        if (![UIDevice isPad] && (self.searchWrapperViewHeightConstraint.constant > 0)) {
             self.searchWrapperViewHeightConstraint.constant = [self heightForSearchWrapperView];
         }
     } completion:nil];

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -329,7 +329,7 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
 - (CGFloat)heightForSearchWrapperView
 {
     UINavigationBar *navBar = self.navigationController.navigationBar;
-    CGFloat height = CGRectGetHeight(navBar.frame) + self.topLayoutGuide.length;
+    CGFloat height = CGRectGetHeight(navBar.frame) + [UIApplication sharedApplication].statusBarFrame.size.height;
     return MAX(height, SearchWrapperViewMinHeight);
 }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -685,7 +685,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 - (CGFloat)heightForSearchWrapperView
 {
     UINavigationBar *navBar = self.navigationController.navigationBar;
-    CGFloat height = CGRectGetHeight(navBar.frame) + self.topLayoutGuide.length;
+    CGFloat height = CGRectGetHeight(navBar.frame) + [UIApplication sharedApplication].statusBarFrame.size.height;
     return MAX(height, SearchWrapperViewMinHeight);
 }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -74,7 +74,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-        if (![UIDevice isPad]) {
+        if (![UIDevice isPad] && (self.searchWrapperViewHeightConstraint.constant > 0)) {
             self.searchWrapperViewHeightConstraint.constant = [self heightForSearchWrapperView];
         }
     } completion:nil];

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -70,15 +70,14 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
 }
 
-- (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
-    [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
-    if ([UIDevice isPad]) {
-        return;
-    }
-    if (self.searchWrapperViewHeightConstraint.constant > 0) {
-        self.searchWrapperViewHeightConstraint.constant = [self heightForSearchWrapperView];
-    }
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        if (![UIDevice isPad]) {
+            self.searchWrapperViewHeightConstraint.constant = [self heightForSearchWrapperView];
+        }
+    } completion:nil];
 }
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration


### PR DESCRIPTION
Resolves #4466

Fixes it for both the `BlogListViewController` and `PostListViewController`

Repro steps:
1. Open search in portrait
2. Rotate to landscape
3. Rotate back to portrait

Expected:
The search bar is correctly sized in both landscape and portrait mode

Needs review: @aerych 