### PR TITLE
Reader: Better handling of URL

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -194,8 +194,10 @@ public class ReaderCrossPostCell: UITableViewCell
     }
 
     private func subDomainNameFromPath(path:String) -> String {
-        let url = NSURL(string: path)!
-        let arr = url.host!.componentsSeparatedByString(".");
-        return "+\(arr.first!)"
+        if let url = NSURL(string: path), host = url.host {
+            let arr = host.componentsSeparatedByString(".")
+            return "+\(arr.first!)"
+        }
+        return ""
     }
 }


### PR DESCRIPTION
Refs #4477 

The cause of the crash is unknown but it seems to be due to a problem getting a blog's subdomain.  Its potentially due to a specific post being returned from the REST API but feedback from an affected user indicates the crash happens as soon as the Reader tab is accessed. This leaves us unable to confirm which posts are being viewed.

This PR improves the way a url path is parsed for a subdomain.  It also should handle the rare situation where the passed string has a zero length -- potentially happening if a cached v1 REST endpoint is being queried. 

@jleandroperez may I call on your Swift expertise since this is a code change we probably can't vet by reproducing the crash.

Needs Review: @jleandroperez 