### PR TITLE
Remove deprecation alerts from post editors

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -266,7 +266,7 @@ SPEC CHECKSUMS:
   CrashlyticsLumberjack: 5094b659ecf9a11550f7dd7a885c0cef077f1ffa
   DTCoreText: d90a4dca8e4f7b0eb18f12a967563b77a75694f0
   DTFoundation: 46e2b2fafe78d67febfd8d1f85fe9845a093f00e
-  EmailChecker: 1b9c5a58c994bc638f842a4d69523b6ab57e706e
+  EmailChecker: 78dd8dfa9d004826c8b5889be6c380b72b837d44
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
   google-plus-ios-sdk: 47adbe03ea904bdb7aa1c0eca282a23c4686e1bc

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -311,6 +311,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     CGRect titleRect = self.navigationItem.titleView.frame;
     titleRect = [self.navigationController.view convertRect:titleRect fromView:self.navigationItem.titleView.superview];
     navController.popoverPresentationController.sourceRect = titleRect;
+    navController.popoverPresentationController.sourceView = self.navigationItem.titleView.superview;
     navController.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
     navController.popoverPresentationController.backgroundColor = [WPStyleGuide wordPressBlue];
     [self presentViewController:navController animated:YES completion:nil];

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -241,9 +241,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     [alertController addDefaultActionWithTitle:NSLocalizedString(@"OK",@"") handler:^(UIAlertAction *action) {
         [self showBlogSelector];
     }];
-    [alertController addCancelActionWithTitle:NSLocalizedString(@"Cancel",@"") handler:^(UIAlertAction *action) {
-        
-    }];
+    [alertController addCancelActionWithTitle:NSLocalizedString(@"Cancel",@"") handler:nil];
     [self presentViewController:alertController animated:YES completion:nil];
 
 }

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -244,13 +244,17 @@ NS_ENUM(NSInteger, WPLegacyEditPostViewControllerActionSheet)
         [self showBlogSelector];
         return;
     }
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Change Site", @"Title of an alert prompting the user that they are about to change the blog they are posting to.")
-                                                        message:NSLocalizedString(@"Choosing a different site will lose edits to site specific content like media and categories. Are you sure?", @"And alert message warning the user they will loose blog specific edits like categories, and media if they change the blog being posted to.")
-                                                       delegate:self
-                                              cancelButtonTitle:NSLocalizedString(@"Cancel",@"")
-                                              otherButtonTitles:NSLocalizedString(@"OK",@""), nil];
-    alertView.tag = EditPostViewControllerAlertTagSwitchBlogs;
-    [alertView show];
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Change Site", @"Title of an alert prompting the user that they are about to change the blog they are posting to.")
+                                                                             message:NSLocalizedString(@"Choosing a different site will lose edits to site specific content like media and categories. Are you sure?", @"And alert message warning the user they will loose blog specific edits like categories, and media if they change the blog being posted to.")
+                                                                      preferredStyle:UIAlertControllerStyleAlert];
+    [alertController addDefaultActionWithTitle:NSLocalizedString(@"OK",@"") handler:^(UIAlertAction *action) {
+        [self showBlogSelector];
+    }];
+    [alertController addCancelActionWithTitle:NSLocalizedString(@"Cancel",@"") handler:^(UIAlertAction *action) {
+        
+    }];
+    [self presentViewController:alertController animated:YES completion:nil];
+
 }
 
 - (void)showBlogSelector
@@ -1078,10 +1082,6 @@ NS_ENUM(NSInteger, WPLegacyEditPostViewControllerActionSheet)
             [self dismissEditView];
         }
         _failedMediaAlertView = nil;
-    } else if (alertView.tag == EditPostViewControllerAlertTagSwitchBlogs) {
-        if (buttonIndex == 1) {
-            [self showBlogSelector];
-        }
     } else if (alertView.tag == EditPostViewControllerAlertCancelMediaUpload) {
         if (buttonIndex == 1) {
             [self cancelMediaUploads];

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -32,7 +32,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 @property (nonatomic, strong) UIButton *titleBarButton;
 @property (nonatomic, strong) UIButton *uploadStatusButton;
-@property (nonatomic, strong) UIPopoverController *mediaProgressPopover;
 @property (nonatomic) BOOL dismissingBlogPicker;
 @property (nonatomic) CGPoint scrollOffsetRestorePoint;
 @property (nonatomic, strong) NSProgress * mediaGlobalProgress;
@@ -88,7 +87,6 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)dealloc
 {
     [_mediaGlobalProgress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted))];
-    _mediaProgressPopover.delegate = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
@@ -726,23 +724,13 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];
     navController.navigationBar.translucent = NO;
     navController.navigationBar.barStyle = UIBarStyleBlack;
-    
-    if (IS_IPAD) {
-        vc.preferredContentSize = CGSizeMake(320.0, 500);
-        
-        CGRect titleRect = self.navigationItem.titleView.frame;
-        titleRect = [self.navigationController.view convertRect:titleRect fromView:self.navigationItem.titleView.superview];
-        
-        self.mediaProgressPopover = [[UIPopoverController alloc] initWithContentViewController:navController];
-        self.mediaProgressPopover.delegate = self;
-        [self.mediaProgressPopover presentPopoverFromRect:titleRect inView:self.navigationController.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
-        
-    } else {
-        navController.modalPresentationStyle = UIModalPresentationPageSheet;
-        navController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
-        
-        [self presentViewController:navController animated:YES completion:nil];
-    }
+    CGRect titleRect = self.navigationItem.titleView.frame;
+    titleRect = [self.navigationController.view convertRect:titleRect fromView:self.navigationItem.titleView.superview];
+    navController.modalPresentationStyle = UIModalPresentationPopover;
+    navController.popoverPresentationController.sourceRect = titleRect;
+    navController.popoverPresentationController.sourceView = self.navigationController.view;
+    navController.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
+    [self presentViewController:navController animated:YES completion:nil];
 }
 
 - (void)showCancelMediaUploadPrompt

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -327,7 +327,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 {
     Post *post = (Post *)self.post;
     UIViewController *vc = [[[self classForSettingsViewController] alloc] initWithPost:post shouldHideStatusBar:NO];
-    UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Back", nil) style:UIBarButtonItemStyleBordered target:nil action:nil];
+    UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Back", nil) style:UIBarButtonItemStylePlain target:nil action:nil];
     self.navigationItem.backBarButtonItem = backButton;
     [self.navigationController pushViewController:vc animated:YES];
 }
@@ -335,7 +335,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)showPreview
 {
     PostPreviewViewController *vc = [[PostPreviewViewController alloc] initWithPost:self.post shouldHideStatusBar:NO];
-    UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Back", nil) style:UIBarButtonItemStyleBordered target:nil action:nil];
+    UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Back", nil) style:UIBarButtonItemStylePlain target:nil action:nil];
     self.navigationItem.backBarButtonItem = backButton;
     [self.navigationController pushViewController:vc animated:YES];
 }

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController_Internal.h
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController_Internal.h
@@ -7,7 +7,6 @@ typedef NS_ENUM(NSInteger, EditPostViewControllerAlertTag) {
     EditPostViewControllerAlertTagNone,
     EditPostViewControllerAlertTagLinkHelper,
     EditPostViewControllerAlertTagFailedMedia,
-    EditPostViewControllerAlertTagSwitchBlogs,
     EditPostViewControllerAlertCancelMediaUpload,
 };
 

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController_Internal.h
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController_Internal.h
@@ -8,14 +8,12 @@ typedef NS_ENUM(NSUInteger, EditPostViewControllerMode) {
     EditPostViewControllerModeEditPost
 };
 
-@interface WPLegacyEditPostViewController () <UIActionSheetDelegate, UITextFieldDelegate, UITextViewDelegate, UIViewControllerRestoration>
+@interface WPLegacyEditPostViewController () <UITextFieldDelegate, UITextViewDelegate, UIViewControllerRestoration>
 
 @property (nonatomic, strong) PostSettingsViewController *postSettingsViewController;
 @property (nonatomic, assign) EditPostViewControllerMode editMode;
 @property (nonatomic, strong) AbstractPost *post;
 @property (readonly) BOOL hasChanges;
-
-@property (nonatomic, strong) UIActionSheet *currentActionSheet;
 
 - (void)didSaveNewPost;
 

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController_Internal.h
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController_Internal.h
@@ -3,13 +3,6 @@
 #import "PostPreviewViewController.h"
 #import "AbstractPost.h"
 
-typedef NS_ENUM(NSInteger, EditPostViewControllerAlertTag) {
-    EditPostViewControllerAlertTagNone,
-    EditPostViewControllerAlertTagLinkHelper,
-    EditPostViewControllerAlertTagFailedMedia,
-    EditPostViewControllerAlertCancelMediaUpload,
-};
-
 typedef NS_ENUM(NSUInteger, EditPostViewControllerMode) {
     EditPostViewControllerModeNewPost,
     EditPostViewControllerModeEditPost
@@ -23,7 +16,6 @@ typedef NS_ENUM(NSUInteger, EditPostViewControllerMode) {
 @property (readonly) BOOL hasChanges;
 
 @property (nonatomic, strong) UIActionSheet *currentActionSheet;
-@property (nonatomic, strong) UIAlertView *failedMediaAlertView;
 
 - (void)didSaveNewPost;
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
@@ -49,9 +49,6 @@ typedef void (^EditPostCompletionHandler)(void);
 @property (nonatomic, strong) PostSettingsViewController *postSettingsViewController;
 @property (readonly) BOOL hasChanges;
 
-@property (nonatomic, strong) UIActionSheet *currentActionSheet;
-@property (nonatomic, strong) UIAlertView *failedMediaAlertView;
-
 #pragma mark - Initializers
 
 /*

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -87,7 +87,6 @@ EditImageDetailsViewControllerDelegate
 #pragma mark - Misc properties
 @property (nonatomic, strong) UIButton *blogPickerButton;
 @property (nonatomic, strong) UIBarButtonItem *uploadStatusButton;
-@property (nonatomic) BOOL dismissingBlogPicker;
 @property (nonatomic) CGPoint scrollOffsetRestorePoint;
 @property (nonatomic) BOOL isOpenedDirectlyForEditing;
 @property (nonatomic) CGRect keyboardRect;
@@ -643,9 +642,7 @@ EditImageDetailsViewControllerDelegate
 - (void)showBlogSelector
 {
     void (^dismissHandler)() = ^(void) {
-        self.dismissingBlogPicker = YES;
         [self dismissViewControllerAnimated:YES completion:nil];
-        self.dismissingBlogPicker = NO;
     };
     void (^selectedCompletion)(NSManagedObjectID *) = ^(NSManagedObjectID *selectedObjectID) {
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -47,7 +47,6 @@ typedef NS_ENUM(NSInteger, EditPostViewControllerAlertTag) {
     EditPostViewControllerAlertTagFailedMedia,
     EditPostViewControllerAlertTagFailedMediaBeforeEdit,
     EditPostViewControllerAlertTagFailedMediaBeforeSave,
-    EditPostViewControllerAlertTagSwitchBlogs,
     EditPostViewControllerAlertCancelMediaUpload,
 };
 
@@ -654,13 +653,16 @@ EditImageDetailsViewControllerDelegate
         [self showBlogSelector];
         return;
     }
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Change Site", @"Title of an alert prompting the user that they are about to change the blog they are posting to.")
-                                                        message:NSLocalizedString(@"Choosing a different site will lose edits to site specific content like media and categories. Are you sure?", @"And alert message warning the user they will loose blog specific edits like categories, and media if they change the blog being posted to.")
-                                                       delegate:self
-                                              cancelButtonTitle:NSLocalizedString(@"Cancel",@"")
-                                              otherButtonTitles:NSLocalizedString(@"OK",@""), nil];
-    alertView.tag = EditPostViewControllerAlertTagSwitchBlogs;
-    [alertView show];
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Change Site", @"Title of an alert prompting the user that they are about to change the blog they are posting to.")
+                                                                             message:NSLocalizedString(@"Choosing a different site will lose edits to site specific content like media and categories. Are you sure?", @"And alert message warning the user they will loose blog specific edits like categories, and media if they change the blog being posted to.")
+                                                                      preferredStyle:UIAlertControllerStyleAlert];
+    [alertController addDefaultActionWithTitle:NSLocalizedString(@"OK",@"") handler:^(UIAlertAction *action) {
+       [self showBlogSelector]; 
+    }];
+    [alertController addCancelActionWithTitle:NSLocalizedString(@"Cancel",@"") handler:^(UIAlertAction *action) {
+        
+    }];
+    [self presentViewController:alertController animated:YES completion:nil];
 }
 
 - (void)showBlogSelector
@@ -1888,11 +1890,6 @@ EditImageDetailsViewControllerDelegate
                 [self savePostAndDismissVC];
             }
             self.failedMediaAlertView = nil;
-        } break;
-        case (EditPostViewControllerAlertTagSwitchBlogs): {
-            if (buttonIndex == alertView.firstOtherButtonIndex) {
-                [self showBlogSelector];
-            }
         } break;
         case (EditPostViewControllerAlertCancelMediaUpload): {
             if (buttonIndex == alertView.firstOtherButtonIndex) {

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -570,13 +570,11 @@ EditImageDetailsViewControllerDelegate
     NSString *message = NSLocalizedString(@"This post has local changes that were not saved. You can now save them or discard them.",
                                           @"Message of the alert that lets the users know there are unsaved changes in a post they're opening.");
     
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title
-                                                        message:message
-                                                       delegate:self
-                                              cancelButtonTitle:nil
-                                              otherButtonTitles:NSLocalizedString(@"OK",@""), nil];
-    
-    [alertView show];
+    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+    [alertController addActionWithTitle:NSLocalizedString(@"OK",@"") style:UIAlertActionStyleDefault handler:^(UIAlertAction *alertAction) {
+        
+    }];
+    [self presentViewController:alertController animated:YES completion:nil];
 }
 
 #pragma mark - Onboarding


### PR DESCRIPTION
Update all the code that use UIAlertView, UIActionSheet and UIPopover to be compatible iOS 9 code.

As a side effect this code also makes things work better on iPad on multitask mode and iPhone Plus on landscape mode.

In order to test it some scenarios that use these views need to be reviewed on regular iPhone, iPhone Plus and iPad

- Edit post and click on the X button to see the discard alert/actions
- Add images and/or video and click on them while the upload is happening
- Click on the blog selector
- While uploads are going click on the HTML switch or try to close the editor.

Needs Review: @jleandroperez, thanks in advance!