### PR TITLE
Start to log error message when upload fails.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1755,6 +1755,7 @@ EditImageDetailsViewControllerDelegate
                 [self.editorView markVideo:mediaUniqueId
                    failedUploadWithMessage:NSLocalizedString(@"Failed", @"The message that is overlay on media when the upload to server fails")];
             }
+            DDLogError(@"Failed Media Upload: %@", error.localizedDescription);
         }
     }];
     [uploadProgress setUserInfoObject:mediaUniqueId forKey:WPProgressMediaID];


### PR DESCRIPTION
This PR adds a log message when upload fails in order for us to get more information on the debug logs.

This will help our happiness engineers to debug these issues with our users.

Needs Review:@sendhil