### PR TITLE
Notifications: Comment Actions + UIStackView

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -16,27 +16,27 @@ import Foundation
 
     public var isReplyEnabled: Bool = false {
         didSet {
-            updateButton(btnReply, enabled: isReplyEnabled)
+            btnReply.hidden = !isReplyEnabled
         }
     }
     public var isLikeEnabled: Bool = false {
         didSet {
-            updateButton(btnLike, enabled: isLikeEnabled)
+            btnLike.hidden = !isLikeEnabled
         }
     }
     public var isApproveEnabled: Bool = false {
         didSet {
-            updateButton(btnApprove, enabled: isApproveEnabled)
+            btnApprove.hidden = !isApproveEnabled
         }
     }
     public var isTrashEnabled: Bool = false {
         didSet {
-            updateButton(btnTrash, enabled: isTrashEnabled)
+            btnTrash.hidden = !isTrashEnabled
         }
     }
     public var isSpamEnabled: Bool = false {
         didSet {
-            updateButton(btnSpam, enabled: isSpamEnabled)
+            btnSpam.hidden = !isSpamEnabled
         }
     }
     public var isLikeOn: Bool {
@@ -106,107 +106,49 @@ import Foundation
         btnTrash.accessibilityLabel = trashTitle
     }
     
-    public override func updateConstraints() {
-        super.updateConstraints()
-        
-        // Update Button Constraints:  [ Leading - Button ]
-        let buttons = [btnReply, btnLike, btnApprove, btnTrash, btnSpam]
-        for button in buttons {
-            refreshButtonConstraints(button)
-        }
-        
-        // Update the last buttons Trailing constraint
-        refreshActionsTrailingConstraint()
-        
-        // Spacing!
-        refreshBottomSpacing()
+    public override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        actionsView.spacing = buttonSpacingForCurrentTraits
     }
     
     
     
     // MARK: - IBActions
     @IBAction public func replyWasPressed(sender: AnyObject) {
-        hitEventHandler(onReplyClick, sender: sender)
+        onReplyClick?(sender: sender)
     }
     
     @IBAction public func likeWasPressed(sender: AnyObject) {
-        let handler = isLikeOn ? onUnlikeClick : onLikeClick
-        hitEventHandler(handler, sender: sender)
+        let onClick = isLikeOn ? onUnlikeClick : onLikeClick
+        onClick?(sender: sender)
         isLikeOn = !isLikeOn
     }
     
     @IBAction public func approveWasPressed(sender: AnyObject) {
-        let handler = isApproveOn ? onUnapproveClick : onApproveClick
-        hitEventHandler(handler, sender: sender)
+        let onClick = isApproveOn ? onUnapproveClick : onApproveClick
+        onClick?(sender: sender)
         isApproveOn = !isApproveOn
     }
     
     @IBAction public func trashWasPressed(sender: AnyObject) {
-        hitEventHandler(onTrashClick, sender: sender)
+        onTrashClick?(sender: sender)
     }
     
     @IBAction public func spamWasPressed(sender: AnyObject) {
-        hitEventHandler(onSpamClick, sender: sender)
-    }
-
-    
-    
-    // MARK: - Event Handlers
-    private func hitEventHandler(handler: EventHandler?, sender: AnyObject) {
-        if let listener = handler {
-            listener(sender: sender)
-        }
+        onSpamClick?(sender: sender)
     }
     
 
-    
-    // MARK: - Layout Helpers
-    private func updateButton(button: UIButton, enabled: Bool) {
-        button.hidden = !enabled
-        button.enabled = enabled
-        setNeedsUpdateConstraints()
-    }
-    
-    private func refreshButtonConstraints(button: UIButton) {
-        let newWidth   = button.hidden ? CGFloat.min : buttonWidth
-        let newSpacing = button.hidden ? CGFloat.min : buttonSpacingForCurrentTraits()
-        
-        // When disabled, let's hide the button by shrinking it's width
-        button.updateConstraint(.Width, constant: newWidth)
-        
-        // Update Leading Constraint
-        actionsView.updateConstraintWithFirstItem(button, attribute: .Leading, constant: newSpacing)
-    }
-    
-    private func refreshActionsTrailingConstraint() {
-        let newSpacing   = buttonSpacingForCurrentTraits()
-        actionsView.updateConstraintWithFirstItem(actionsView, attribute: .Trailing, constant: newSpacing)
-    }
-    
-    private func refreshBottomSpacing() {
-        //  Let's remove the bottom space when every action button is disabled
-        let hasActions   = isReplyEnabled || isLikeEnabled || isTrashEnabled || isApproveEnabled || isSpamEnabled
-        let newTop       = hasActions ? actionsTop    : CGFloat.min
-        let newHeight    = hasActions ? actionsHeight : CGFloat.min
-        
-        contentView.updateConstraintWithFirstItem(actionsView, attribute: .Top, constant: newTop)
-        actionsView.updateConstraint(.Height, constant: newHeight)
-        actionsView.hidden = !hasActions
-        setNeedsLayout()
-    }
-    
-    private func buttonSpacingForCurrentTraits() -> CGFloat {
+
+    // MARK: - Computed Properties
+    private var buttonSpacingForCurrentTraits : CGFloat {
         let isHorizontallyCompact = traitCollection.horizontalSizeClass == .Compact && UIDevice.isPad()
         return isHorizontallyCompact ? buttonSpacingCompact : buttonSpacing
     }
     
-    
     // MARK: - Private Constants
-    private let buttonWidth                         = CGFloat(55)
-    private let buttonSpacing                       = CGFloat(20)
-    private let buttonSpacingCompact                = CGFloat(10)
-    private let actionsHeight                       = CGFloat(34)
-    private let actionsTop                          = CGFloat(11)
+    private let buttonSpacing           = CGFloat(20)
+    private let buttonSpacingCompact    = CGFloat(10)
     
     // MARK: - IBOutlets
     @IBOutlet private var actionsView   : UIStackView!

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -209,10 +209,10 @@ import Foundation
     private let actionsTop                          = CGFloat(11)
     
     // MARK: - IBOutlets
-    @IBOutlet private weak var actionsView          : UIView!
-    @IBOutlet private weak var btnReply             : UIButton!
-    @IBOutlet private weak var btnLike              : UIButton!
-    @IBOutlet private weak var btnApprove           : UIButton!
-    @IBOutlet private weak var btnTrash             : UIButton!
-    @IBOutlet private weak var btnSpam              : UIButton!
+    @IBOutlet private var actionsView   : UIStackView!
+    @IBOutlet private var btnReply      : UIButton!
+    @IBOutlet private var btnLike       : UIButton!
+    @IBOutlet private var btnApprove    : UIButton!
+    @IBOutlet private var btnTrash      : UIButton!
+    @IBOutlet private var btnSpam       : UIButton!
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.xib
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="44" id="vbp-eh-kPo" userLabel="Actions" customClass="NoteBlockActionsTableViewCell" customModule="WordPress">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="50" id="vbp-eh-kPo" userLabel="Actions" customClass="NoteBlockActionsTableViewCell" customModule="WordPress">
+            <rect key="frame" x="0.0" y="0.0" width="389" height="57"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="vbp-eh-kPo" id="g83-Wv-yJ5">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="389" height="56.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="7aS-Nh-Fkn" userLabel="Actions">
-                        <rect key="frame" x="50" y="3" width="220" height="29.5"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="V3D-QS-G4g">
+                        <rect key="frame" x="17" y="11" width="355" height="34.5"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DXE-y2-DWd" userLabel="Reply" customClass="VerticallyStackedButton">
-                                <rect key="frame" x="20" y="0.0" width="20" height="34"/>
+                                <rect key="frame" x="0.0" y="0.5" width="55" height="34"/>
+                                <animations/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="20" id="bGa-bG-COl"/>
+                                    <constraint firstAttribute="width" constant="55" id="bGa-bG-COl"/>
+                                    <constraint firstAttribute="height" priority="750" constant="34" id="pOv-Wo-AuU"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <state key="normal" title="Like" image="notifications-reply">
@@ -35,9 +35,11 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e8r-Uo-uFk" customClass="VerticallyStackedButton">
-                                <rect key="frame" x="60" y="0.0" width="20" height="34"/>
+                                <rect key="frame" x="75" y="0.5" width="55" height="34"/>
+                                <animations/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="20" id="bXC-wE-QDO"/>
+                                    <constraint firstAttribute="height" priority="750" constant="34" id="4s5-KZ-g7U"/>
+                                    <constraint firstAttribute="width" constant="55" id="bXC-wE-QDO"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <state key="normal" title="Like" image="notifications-like">
@@ -51,9 +53,11 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Agc-K2-0vs" customClass="VerticallyStackedButton">
-                                <rect key="frame" x="100" y="0.0" width="20" height="34"/>
+                                <rect key="frame" x="150" y="0.5" width="55" height="34"/>
+                                <animations/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="20" id="2hn-PC-Yxs"/>
+                                    <constraint firstAttribute="width" constant="55" id="2hn-PC-Yxs"/>
+                                    <constraint firstAttribute="height" priority="750" constant="34" id="Tfs-lE-WZO"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <state key="normal" title="Approve" image="notifications-approve">
@@ -67,9 +71,11 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TYK-fl-vc7" customClass="VerticallyStackedButton">
-                                <rect key="frame" x="140" y="0.0" width="20" height="34"/>
+                                <rect key="frame" x="225" y="0.5" width="55" height="34"/>
+                                <animations/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="20" id="Cvd-xS-e5I"/>
+                                    <constraint firstAttribute="height" priority="750" constant="34" id="0ou-ht-WQC"/>
+                                    <constraint firstAttribute="width" constant="55" id="Cvd-xS-e5I"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <state key="normal" title="Trash" image="notifications-trash">
@@ -81,10 +87,11 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hU3-yd-ZtO" customClass="VerticallyStackedButton">
-                                <rect key="frame" x="180" y="0.0" width="20" height="34"/>
+                                <rect key="frame" x="300" y="0.5" width="55" height="34"/>
+                                <animations/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="34" id="OBj-Qu-Mty"/>
-                                    <constraint firstAttribute="width" constant="20" id="Rq6-Ta-vBZ"/>
+                                    <constraint firstAttribute="height" priority="750" constant="34" id="OBj-Qu-Mty"/>
+                                    <constraint firstAttribute="width" constant="55" id="Rq6-Ta-vBZ"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <state key="normal" title="Spam" image="notifications-spam">
@@ -96,40 +103,26 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <constraints>
-                            <constraint firstItem="TYK-fl-vc7" firstAttribute="top" secondItem="7aS-Nh-Fkn" secondAttribute="top" id="0sD-Qa-CGa"/>
-                            <constraint firstItem="Agc-K2-0vs" firstAttribute="top" secondItem="7aS-Nh-Fkn" secondAttribute="top" id="4d3-NO-7we"/>
-                            <constraint firstItem="e8r-Uo-uFk" firstAttribute="top" secondItem="7aS-Nh-Fkn" secondAttribute="top" id="Boh-Di-4ek"/>
-                            <constraint firstItem="hU3-yd-ZtO" firstAttribute="height" secondItem="DXE-y2-DWd" secondAttribute="height" id="CzD-na-SOX"/>
-                            <constraint firstItem="DXE-y2-DWd" firstAttribute="top" secondItem="7aS-Nh-Fkn" secondAttribute="top" id="LRj-KB-nRs"/>
-                            <constraint firstItem="e8r-Uo-uFk" firstAttribute="leading" secondItem="DXE-y2-DWd" secondAttribute="trailing" constant="20" id="LpT-dK-A3g"/>
-                            <constraint firstItem="DXE-y2-DWd" firstAttribute="leading" secondItem="7aS-Nh-Fkn" secondAttribute="leading" constant="20" id="Ozb-Jd-fS7"/>
-                            <constraint firstItem="e8r-Uo-uFk" firstAttribute="height" secondItem="hU3-yd-ZtO" secondAttribute="height" id="Z8d-nZ-uPw"/>
-                            <constraint firstAttribute="trailing" secondItem="hU3-yd-ZtO" secondAttribute="trailing" constant="20" id="b8X-Xh-yav"/>
-                            <constraint firstItem="Agc-K2-0vs" firstAttribute="leading" secondItem="e8r-Uo-uFk" secondAttribute="trailing" constant="20" id="bjL-bL-DlE"/>
-                            <constraint firstItem="hU3-yd-ZtO" firstAttribute="leading" secondItem="TYK-fl-vc7" secondAttribute="trailing" constant="20" id="cCJ-rQ-DbA"/>
-                            <constraint firstItem="TYK-fl-vc7" firstAttribute="leading" secondItem="Agc-K2-0vs" secondAttribute="trailing" constant="20" id="iC1-AT-QOl"/>
-                            <constraint firstItem="hU3-yd-ZtO" firstAttribute="height" secondItem="Agc-K2-0vs" secondAttribute="height" id="jnB-D7-ep5"/>
-                            <constraint firstAttribute="height" priority="750" constant="34" id="k05-Zf-Pnk"/>
-                            <constraint firstItem="hU3-yd-ZtO" firstAttribute="height" secondItem="TYK-fl-vc7" secondAttribute="height" id="ojT-Hh-TeB"/>
-                            <constraint firstItem="hU3-yd-ZtO" firstAttribute="top" secondItem="7aS-Nh-Fkn" secondAttribute="top" id="vMb-9V-FZx"/>
-                        </constraints>
-                    </view>
+                        <animations/>
+                    </stackView>
                 </subviews>
+                <animations/>
                 <constraints>
-                    <constraint firstAttribute="centerX" secondItem="7aS-Nh-Fkn" secondAttribute="centerX" id="aja-dN-aFu"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="7aS-Nh-Fkn" secondAttribute="bottom" constant="3" id="n78-il-JTa"/>
-                    <constraint firstItem="7aS-Nh-Fkn" firstAttribute="top" secondItem="g83-Wv-yJ5" secondAttribute="top" constant="3" id="yZg-Jv-scK"/>
+                    <constraint firstAttribute="bottom" secondItem="V3D-QS-G4g" secondAttribute="bottom" constant="11" id="GLY-kj-VXh"/>
+                    <constraint firstItem="V3D-QS-G4g" firstAttribute="centerX" secondItem="g83-Wv-yJ5" secondAttribute="centerX" id="aAu-xH-Q6m"/>
+                    <constraint firstItem="V3D-QS-G4g" firstAttribute="top" secondItem="g83-Wv-yJ5" secondAttribute="top" constant="11" id="ftQ-8C-2wA"/>
                 </constraints>
             </tableViewCellContentView>
+            <animations/>
             <connections>
-                <outlet property="actionsView" destination="7aS-Nh-Fkn" id="3Hu-jw-co3"/>
+                <outlet property="actionsView" destination="V3D-QS-G4g" id="JZg-7z-Y8g"/>
                 <outlet property="btnApprove" destination="Agc-K2-0vs" id="7mX-9C-ieh"/>
                 <outlet property="btnLike" destination="e8r-Uo-uFk" id="zQu-vq-aFT"/>
                 <outlet property="btnReply" destination="DXE-y2-DWd" id="a3c-Jw-2bD"/>
                 <outlet property="btnSpam" destination="hU3-yd-ZtO" id="H1K-eP-bp7"/>
                 <outlet property="btnTrash" destination="TYK-fl-vc7" id="amO-Qa-IZv"/>
             </connections>
+            <point key="canvasLocation" x="240.5" y="382.5"/>
         </tableViewCell>
     </objects>
     <resources>


### PR DESCRIPTION
#### Details:
In this PR we implement UIStackView, in the CommentActions Cell. This enables us to kill a whole lot of code that took care of conditionally displaying actions.

#### Steps: Everything Enabled
1. Please, [edit this snippet](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m#L719) and make sure all of the actions are enabled
2. Launch the app
3. Open the notifications tab, and tap over any (*comment*) notification

As a result, the Notification Actions shoul show up as usual (all of the buttons enabled, centered).
**Please:** test this on iPhone / iPad devices, with multitasking.

#### Steps: Everything Disabled
Repeat the same steps as above, but [disable everything in this spot](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m#L719)

Also, make sure of testing this on iPhone / iPad + Multitasking.


Needs Review: @aerych (Thaaank you!)
Closes #4453
