### PR TITLE
ReaderCommentsViewController: canComment property is now calculated

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -64,7 +64,6 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 @property (nonatomic, assign) UIDeviceOrientation previousOrientation;
 @property (nonatomic, strong) NSLayoutConstraint *replyTextViewHeightConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *replyTextViewBottomConstraint;
-@property (nonatomic) BOOL canComment;
 @property (nonatomic) BOOL isLoggedIn;
 
 @end
@@ -102,7 +101,6 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 
     self.mediaCellCache = [NSMutableDictionary dictionary];
     [self checkIfLoggedIn];
-    [self checkIfCanComment];
 
     [self configureNavbar];
     [self configurePostHeader];
@@ -559,11 +557,6 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
     }];
 }
 
-- (void)checkIfCanComment
-{
-    self.canComment = self.post.commentsOpen && self.isLoggedIn;
-}
-
 - (void)checkIfLoggedIn
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
@@ -611,6 +604,11 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 - (BOOL)isLoadingPost
 {
     return self.post == nil;
+}
+
+- (BOOL)canComment
+{
+    return self.post.commentsOpen && self.isLoggedIn;
 }
 
 - (BOOL)shouldDisplayReplyTextView


### PR DESCRIPTION
#### Steps:
1. Receive a Comment-Y notification
2. Open the Notifications tab
3. Tap over the *Notification Header*
4. As a result, Reader Comments should be onscreen.

Please, verify that: if you've got reply permissions on that blog, the `ReplyTextView` component should show up.

Closes #4312

Needs Review: @aerych 
cc @sendhil 

Thanks gentleman!
