### PR TITLE
Implements SafariViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -2,7 +2,6 @@
 #import "SiteSettingsViewController.h"
 #import "CommentsViewController.h"
 #import "StatsViewController.h"
-#import "WPWebViewController.h"
 #import "WPTableViewCell.h"
 #import "ContextManager.h"
 #import "AccountService.h"
@@ -16,6 +15,7 @@
 #import "WPThemeSettings.h"
 #import "WPGUIConstants.h"
 #import "Wordpress-Swift.h"
+#import <SafariServices/SafariServices.h>
 
 const NSInteger BlogDetailsRowViewSite = 0;
 const NSInteger BlogDetailsRowViewAdmin = 1;
@@ -496,14 +496,8 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     [WPAnalytics track:WPAnalyticsStatOpenedViewSite];
 
     NSURL *targetURL = [NSURL URLWithString:blog.homeURL];
-    WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:targetURL];
-    webViewController.authToken = blog.authToken;
-    webViewController.username = blog.usernameForSite;
-    webViewController.password = blog.password;
-    webViewController.wpLoginURL = [NSURL URLWithString:blog.loginUrl];
-    
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
-    [self presentViewController:navController animated:YES completion:nil];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:targetURL];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 - (void)showViewAdminForBlog:(Blog *)blog
@@ -516,7 +510,9 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     [WPAnalytics track:WPAnalyticsStatOpenedViewAdmin];
 
     NSString *dashboardUrl = [blog.xmlrpc stringByReplacingOccurrencesOfString:@"xmlrpc.php" withString:@"wp-admin/"];
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:dashboardUrl]];
+    NSURL *targetURL = [NSURL URLWithString:dashboardUrl];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:targetURL];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -1,7 +1,6 @@
 #import "SiteSettingsViewController.h"
 #import "NSURL+IDN.h"
 #import "SupportViewController.h"
-#import "WPWebViewController.h"
 #import "ReachabilityUtils.h"
 #import "WPAccount.h"
 #import "Blog.h"
@@ -26,6 +25,7 @@
 #import "BlogSiteVisibilityHelper.h"
 #import "RelatedPostsSettingsViewController.h"
 #import "WordPress-Swift.h"
+#import <SafariServices/SafariServices.h>
 
 
 NS_ENUM(NSInteger, SiteSettingsGeneral) {
@@ -807,15 +807,8 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     }
 
     NSURL *targetURL = [NSURL URLWithString:path];
-    WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:targetURL];
-    webViewController.authToken = self.authToken;
-    webViewController.username = self.username;
-    webViewController.password = self.password;
-    webViewController.wpLoginURL = [NSURL URLWithString:self.blog.loginUrl];
-    webViewController.shouldScrollToBottom = YES;
-    
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
-    [self presentViewController:navController animated:YES completion:nil];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:targetURL];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 #pragma mark - Saving methods

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -1,5 +1,4 @@
 #import "CommentViewController.h"
-#import "WPWebViewController.h"
 #import "CommentService.h"
 #import "ContextManager.h"
 #import "WordPress-Swift.h"
@@ -15,6 +14,7 @@
 #import "BlogService.h"
 #import "SuggestionsTableView.h"
 #import "SuggestionService.h"
+#import <SafariServices/SafariServices.h>
 
 
 
@@ -442,9 +442,8 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 
 - (void)openWebViewWithURL:(NSURL *)url
 {
-    WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:url];
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
-    [self presentViewController:navController animated:YES completion:nil];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:url];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 - (void)toggleLikeForComment

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -12,7 +12,6 @@
 #import "WPWalkthroughOverlayView.h"
 #import "SelectWPComLanguageViewController.h"
 #import "WPNUXUtility.h"
-#import "WPWebViewController.h"
 #import "WPStyleGuide.h"
 #import "WPFontManager.h"
 #import "UILabel+SuggestSize.h"
@@ -29,6 +28,7 @@
 #import "WordPress-Swift.h"
 
 #import <1PasswordExtension/OnePasswordExtension.h>
+#import <SafariServices/SafariServices.h>
 
 
 @interface CreateAccountAndBlogViewController ()<UITextFieldDelegate,UIGestureRecognizerDelegate> {
@@ -582,10 +582,8 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
 - (IBAction)TOSLabelWasTapped
 {
     NSURL *targetURL = [NSURL URLWithString:WPAutomatticTermsOfServiceURL];
-    WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:targetURL];
-    
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
-    [self presentViewController:navController animated:YES completion:nil];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:targetURL];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 - (void)keyboardWillShow:(NSNotification *)notification

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -2,6 +2,7 @@
 #import <Helpshift/Helpshift.h>
 #import <WordPress-iOS-Shared/WPFontManager.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
+#import <SafariServices/SafariServices.h>
 
 #import "CreateAccountAndBlogViewController.h"
 #import "SupportViewController.h"
@@ -16,7 +17,6 @@
 #import "WPTabBarController.h"
 #import "WPWalkthroughTextField.h"
 #import "WPWalkthroughOverlayView.h"
-#import "WPWebViewController.h"
 
 #import "WordPressComOAuthClient.h"
 #import "ContextManager.h"
@@ -1039,14 +1039,8 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
 
 - (void)displayWebViewForURL:(NSURL *)url username:(NSString *)username password:(NSString *)password;
 {
-    WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:url];
-    if (username.length > 0 && password.length > 0) {
-        webViewController.username = username;
-        webViewController.password = password;
-    }
-
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
-    [self presentViewController:navController animated:YES completion:nil];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:url];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 - (void)endViewEditing

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -5,6 +5,7 @@
 
 #import "Blog.h"
 #import "Notification.h"
+#import <SafariServices/SafariServices.h>
 #import <SVProgressHUD/SVProgressHUD.h>
 
 #import "ContextManager.h"
@@ -13,7 +14,6 @@
 #import "CommentService.h"
 #import "ReaderSiteService.h"
 
-#import "WPWebViewController.h"
 #import "WPImageViewController.h"
 
 #import "ReaderPostDetailViewController.h"
@@ -968,10 +968,8 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
         return NO;
     }
     
-    WPWebViewController *webViewController  = [WPWebViewController authenticatedWebViewController:url];
-    UINavigationController *navController   = [[UINavigationController alloc] initWithRootViewController:webViewController];
-    
-    [self presentViewController:navController animated:YES completion:nil];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:url];
+    [self presentViewController:safariViewController animated:YES completion:nil];
     
     return success;
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -1,13 +1,11 @@
 #import "NotificationsViewController.h"
 
-#import <Simperium/Simperium.h>
 #import "WordPressAppDelegate.h"
 #import "ContextManager.h"
 #import "Constants.h"
 #import "WPGUIConstants.h"
 
 #import "WPTableViewHandler.h"
-#import "WPWebViewController.h"
 #import "WPNoResultsView.h"
 #import "WPTabBarController.h"
 
@@ -29,6 +27,8 @@
 
 #import "AppRatingUtility.h"
 
+#import <SafariServices/SafariServices.h>
+#import <Simperium/Simperium.h>
 #import <WordPress-AppbotX/ABXPromptView.h>
 #import <WordPress-AppbotX/ABXAppStore.h>
 #import <WordPress-AppbotX/ABXFeedbackViewController.h>
@@ -952,13 +952,11 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 
 - (void)didTapNoResultsView:(WPNoResultsView *)noResultsView
 {
-    NSURL *targetURL                        = [NSURL URLWithString:WPJetpackInformationURL];
-    WPWebViewController *webViewController  = [WPWebViewController webViewControllerWithURL:targetURL];
- 
-    UINavigationController *navController   = [[UINavigationController alloc] initWithRootViewController:webViewController];
-    [self presentViewController:navController animated:YES completion:nil];
- 
     [WPAnalytics track:WPAnalyticsStatSelectedLearnMoreInConnectToJetpackScreen withProperties:@{@"source": @"notifications"}];
+    
+    NSURL *targetURL = [NSURL URLWithString:WPJetpackInformationURL];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:targetURL];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="doV-5W-Rtg">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="doV-5W-Rtg">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <scenes>
         <!--Notifications View Controller-->
@@ -12,6 +11,7 @@
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="XCV-Uv-qac">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <inset key="separatorInset" minX="12" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <connections>
@@ -35,6 +35,7 @@
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZnY-3K-upT" userLabel="Ratings View" customClass="ABXPromptView">
                             <rect key="frame" x="0.0" y="0.0" width="600" height="100"/>
+                            <animations/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="100" id="R1T-Iv-5Q8"/>
@@ -45,6 +46,7 @@
                             <subviews>
                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" apportionsSegmentWidthsByContent="YES" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="W2i-rX-Pc4">
                                     <rect key="frame" x="8" y="8" width="584" height="29"/>
+                                    <animations/>
                                     <segments>
                                         <segment title="All"/>
                                         <segment title="Unread"/>
@@ -57,6 +59,7 @@
                                     </connections>
                                 </segmentedControl>
                             </subviews>
+                            <animations/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             <constraints>
                                 <constraint firstItem="W2i-rX-Pc4" firstAttribute="top" secondItem="pEF-oN-cih" secondAttribute="top" constant="8" id="5Uj-Sc-fd3"/>
@@ -80,6 +83,7 @@
                             </variation>
                         </view>
                     </subviews>
+                    <animations/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <constraints>
                         <constraint firstItem="pEF-oN-cih" firstAttribute="leading" secondItem="Uvo-9e-l6I" secondAttribute="leading" identifier="FiltersLeading" id="0TE-M7-WfE"/>
@@ -110,7 +114,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="59U-6R-KoD" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2949.375" y="-1982.7464788732393"/>
+            <point key="canvasLocation" x="2925" y="-1999"/>
         </scene>
         <!--Reader Post Details-->
         <scene sceneID="ET8-9p-ZLz">
@@ -120,17 +124,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="h51-jr-fqU" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2949.375" y="-1270.7746478873239"/>
-        </scene>
-        <!--WebView-->
-        <scene sceneID="1zS-D4-F1Z">
-            <objects>
-                <viewController id="Bbj-DX-KQ7" userLabel="WebView" customClass="WPWebViewController" sceneMemberID="viewController">
-                    <navigationItem key="navigationItem" id="Ggf-4b-Gwr"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="fEj-cd-uMn" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2949.375" y="-587.32394366197184"/>
+            <point key="canvasLocation" x="2925" y="-1271"/>
         </scene>
         <!--Notification Details-->
         <scene sceneID="0B7-mU-JSs">
@@ -146,6 +140,7 @@
                         <subviews>
                             <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="Dcn-Il-AtN">
                                 <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                                <animations/>
                                 <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
                                 <gestureRecognizers/>
                                 <inset key="separatorInset" minX="12" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -156,6 +151,7 @@
                                 </connections>
                             </tableView>
                         </subviews>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="6LW-NS-qSh" firstAttribute="top" secondItem="Dcn-Il-AtN" secondAttribute="bottom" priority="250" id="9mt-16-fFT"/>
@@ -169,7 +165,6 @@
                         <outlet property="tableGesturesRecognizer" destination="a20-Yr-RdT" id="Ap0-WK-Z2n"/>
                         <outlet property="tableView" destination="Dcn-Il-AtN" id="Mjf-q7-Lkn"/>
                         <segue destination="8p8-88-FGK" kind="show" identifier="StatsViewController" id="EAn-K1-ofm"/>
-                        <segue destination="Bbj-DX-KQ7" kind="show" identifier="WPWebViewController" id="ygK-a3-WEJ"/>
                         <segue destination="xj3-6N-2Jy" kind="show" identifier="ReaderPostDetailViewController" id="ODX-zz-S1G"/>
                         <segue destination="kOE-dH-qnb" kind="show" identifier="ReaderCommentsViewController" id="Puk-pn-rGi"/>
                     </connections>
@@ -192,7 +187,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KeQ-Nv-SGg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2949.375" y="148.94366197183098"/>
+            <point key="canvasLocation" x="2925" y="-516"/>
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1,5 +1,6 @@
 #import "ReaderCommentsViewController.h"
 
+#import <SafariServices/SafariServices.h>
 #import <WordPress-iOS-Shared/UIImage+Util.h>
 
 #import "Comment.h"
@@ -18,7 +19,6 @@
 #import "WPImageViewController.h"
 #import "WPRichTextView.h"
 #import "WPTableViewHandler.h"
-#import "WPWebViewController.h"
 #import "SuggestionsTableView.h"
 #import "SuggestionService.h"
 #import "WordPress-Swift.h"
@@ -1132,9 +1132,8 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 
 - (void)commentCell:(UITableViewCell *)cell linkTapped:(NSURL *)url
 {
-    WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:url];
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
-    [self presentViewController:navController animated:YES completion:nil];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:url];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 - (void)handleReplyTapped:(id<WPContentViewProvider>)contentProvider
@@ -1173,9 +1172,8 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
         linkURL = [NSURL URLWithString:linkURL.path relativeToURL:url];
     }
 
-    WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:linkURL];
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
-    [self presentViewController:navController animated:YES completion:nil];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:linkURL];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 - (void)richTextView:(WPRichTextView *)richTextView didReceiveImageLinkAction:(WPRichTextImage *)imageControl
@@ -1186,8 +1184,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
     if (isSupportedNatively) {
         controller = [[WPImageViewController alloc] initWithImage:imageControl.imageView.image andURL:imageControl.linkURL];
     } else if (imageControl.linkURL) {
-        WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:imageControl.linkURL];
-        controller = [[UINavigationController alloc] initWithRootViewController:webViewController];
+        controller = [[SFSafariViewController alloc] initWithURL:imageControl.linkURL];
     } else {
         controller = [[WPImageViewController alloc] initWithImage:imageControl.imageView.image];
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
@@ -14,10 +14,11 @@
 #import "WPImageViewController.h"
 #import "WPNoResultsView+AnimatedBox.h"
 #import "WPTableImageSource.h"
-#import "WPWebViewController.h"
 #import "WordPressAppDelegate.h"
 #import "WordPress-Swift.h"
 #import "WPUserAgent.h"
+
+#import <SafariServices/SafariServices.h>
 
 static CGFloat const VerticalMargin = 40;
 static NSInteger const ReaderPostDetailImageQuality = 65;
@@ -580,9 +581,8 @@ NSString * const ReaderPixelStatReferrer = @"https://wordpress.com/";
 
 - (void)presentWebViewControllerWithLink:(NSURL *)linkURL
 {
-    WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:linkURL];
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
-    [self presentViewController:navController animated:YES completion:nil];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:linkURL];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 # pragma mark - Rich Text Delegate Methods

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SafariServices
 
 @objc public class ReaderStreamViewController : UIViewController,
     WPContentSyncHelperDelegate,
@@ -610,9 +611,8 @@ import Foundation
 
     private func visitSiteForPost(post:ReaderPost) {
         let siteURL = NSURL(string: post.blogURL)!
-        let controller = WPWebViewController(URL: siteURL)
-        let navController = UINavigationController(rootViewController: controller)
-        presentViewController(navController, animated: true, completion: nil)
+        let safariViewController = SFSafariViewController(URL: siteURL)
+        presentViewController(safariViewController, animated: true, completion: nil)
     }
 
     private func showAttributionForPost(post: ReaderPost) {
@@ -632,10 +632,12 @@ import Foundation
             return
         }
 
-        let linkURL = NSURL(string: post.sourceAttribution.blogURL)
-        let controller = WPWebViewController(URL: linkURL)
-        let navController = UINavigationController(rootViewController: controller)
-        presentViewController(navController, animated: true, completion: nil)
+        guard let linkURL = NSURL(string: post.sourceAttribution.blogURL) else {
+            return
+        }
+        
+        let safariViewController = SFSafariViewController(URL: linkURL)
+        presentViewController(safariViewController, animated: true, completion: nil)
     }
 
     private func toggleLikeForPost(post: ReaderPost) {

--- a/WordPress/Classes/ViewRelated/Settings/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Settings/AboutViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SafariServices
 
 
 public class AboutViewController : UITableViewController
@@ -128,13 +129,8 @@ public class AboutViewController : UITableViewController
     
     // MARK: - Private Helpers
     private func displayWebView(url: String) {
-        let webViewController = WPWebViewController(URL: NSURL(string: url)!)
-        if presentingViewController != nil {
-            navigationController?.pushViewController(webViewController, animated: true)
-        } else {
-            let navController = UINavigationController(rootViewController: webViewController)
-            presentViewController(navController, animated: true, completion: nil)
-        }
+        let safariViewController = SFSafariViewController(URL: NSURL(string: url)!)
+        presentViewController(safariViewController, animated: true, completion: nil)
     }
 
     private func displayRatingPrompt() {

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -1,5 +1,4 @@
 #import "SupportViewController.h"
-#import "WPWebViewController.h"
 #import "ActivityLogViewController.h"
 #import <UIDeviceIdentifier/UIDeviceHardware.h>
 #import "WordPressAppDelegate.h"

--- a/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
@@ -1,7 +1,6 @@
 #import "JetpackSettingsViewController.h"
 #import "Blog.h"
 #import "WordPressComApi.h"
-#import "WPWebViewController.h"
 #import "WPAccount.h"
 #import "WPNUXUtility.h"
 #import "WPNUXMainButton.h"
@@ -15,6 +14,7 @@
 #import "JetpackService.h"
 #import "ContextManager.h"
 
+#import <SafariServices/SafariServices.h>
 
 
 #pragma mark ====================================================================================
@@ -630,26 +630,17 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 {
     [WPAnalytics track:WPAnalyticsStatSelectedInstallJetpack];
 
-    NSString *targetURL = [_blog adminUrlWithPath:JetpackInstallRelativePath];
-    [self openURL:[NSURL URLWithString:targetURL] username:_blog.usernameForSite password:_blog.password wpLoginURL:[NSURL URLWithString:_blog.loginUrl]];
+    NSString *targetPath = [_blog adminUrlWithPath:JetpackInstallRelativePath];
+    NSURL *targetURL = [NSURL URLWithString:targetPath];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:targetURL];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 - (void)openMoreInformationURL
 {
     NSURL *targetURL = [NSURL URLWithString:JetpackMoreInformationURL];
-    [self openURL:targetURL username:nil password:nil wpLoginURL:nil];
-}
-
-- (void)openURL:(NSURL *)url username:(NSString *)username password:(NSString *)password wpLoginURL:(NSURL *)wpLoginURL
-{
-    WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:url];
-    webViewController.username = username;
-    webViewController.password = password;
-    webViewController.wpLoginURL = wpLoginURL;
-
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
-    navController.modalPresentationStyle = UIModalPresentationPageSheet;
-    [self presentViewController:navController animated:YES completion:nil];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:targetURL];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 - (void)updateMessage

--- a/WordPress/Classes/ViewRelated/Stats/StatsWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsWebViewController.m
@@ -2,7 +2,6 @@
 #import "Blog.h"
 #import "WordPressAppDelegate.h"
 #import "WPAccount.h"
-#import "WPWebViewController.h"
 #import "JetpackSettingsViewController.h"
 #import "SiteSettingsViewController.h"
 #import "ReachabilityUtils.h"
@@ -12,6 +11,7 @@
 #import "WPCookie.h"
 #import "UIDevice+Helpers.h"
 #import "WordPress-Swift.h"
+#import <SafariServices/SafariServices.h>
 
 NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
 
@@ -409,8 +409,8 @@ NSString * const WPStatsWebBlogKey = @"WPStatsWebBlogKey";
 
         if ([host rangeOfString:@"wordpress.com"].location == NSNotFound ||
             [query rangeOfString:@"no-chrome"].location == NSNotFound) {
-            WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:request.URL];
-            [self.navigationController pushViewController:webViewController animated:YES];
+            SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:request.URL];
+            [self.navigationController presentViewController:safariViewController animated:YES completion:nil];
             return NO;
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/WPChromelessWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/WPChromelessWebViewController.m
@@ -1,6 +1,7 @@
 #import "WPChromelessWebViewController.h"
 #import "WordPressAppDelegate.h"
-#import "WPWebViewController.h"
+
+#import <SafariServices/SafariServices.h>
 
 @interface WPChromelessWebViewController ()
 @property (nonatomic, strong) WPWebView *webView;
@@ -119,8 +120,8 @@
         // If the url points off-site we want to handle it differently.
         NSString *host = request.URL.host;
         if ([host rangeOfString:@"wordpress.com"].location == NSNotFound) {
-            WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:request.URL];
-            [self.navigationController pushViewController:webViewController animated:YES];
+            SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:request.URL];
+            [self.navigationController presentViewController:safariViewController animated:YES completion:nil];
             return NO;
         }
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SafariServices
 
 @objc public class ThemeBrowserViewController : UICollectionViewController, UICollectionViewDelegateFlowLayout, NSFetchedResultsControllerDelegate, UISearchBarDelegate, WPContentSyncHelperDelegate {
     
@@ -253,17 +254,12 @@ import Foundation
     // MARK: - Theme actions
     
     private func showDemoForTheme(theme: Theme) {
+        guard let url = NSURL(string: theme.demoUrl) else {
+            return
+        }
         
-        let url = NSURL(string: theme.demoUrl)
-        let webViewController = WPWebViewController(URL: url)
-        
-        webViewController.authToken = blog.authToken
-        webViewController.username = blog.usernameForSite
-        webViewController.password = blog.password
-        webViewController.wpLoginURL = NSURL(string: blog.loginUrl())
-        
-        let navController = UINavigationController(rootViewController: webViewController)
-        presentViewController(navController, animated: true, completion: nil)
+        let safariViewController = SFSafariViewController(URL: url)
+        presentViewController(safariViewController, animated: true, completion: nil)
     }
     
 }

--- a/WordPress/Classes/ViewRelated/Themes/ThemeDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeDetailsViewController.h
@@ -4,6 +4,6 @@
 
 @interface ThemeDetailsViewController : UIViewController
 
-- (id)initWithTheme:(Theme*)theme;
+- (instancetype)initWithTheme:(Theme*)theme;
 
 @end

--- a/WordPress/Classes/ViewRelated/Themes/ThemeDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeDetailsViewController.m
@@ -28,7 +28,7 @@
 
 @implementation ThemeDetailsViewController
 
-- (id)initWithTheme:(Theme *)theme
+- (instancetype)initWithTheme:(Theme *)theme
 {
     self = [super init];
     if (self) {

--- a/WordPress/Classes/ViewRelated/Themes/ThemeDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeDetailsViewController.m
@@ -1,7 +1,6 @@
 #import "ThemeDetailsViewController.h"
 #import "Theme.h"
 #import "WPImageSource.h"
-#import "WPWebViewController.h"
 #import "WPAccount.h"
 #import "WPStyleGuide.h"
 #import "Blog.h"
@@ -9,6 +8,7 @@
 #import "WordPressAppDelegate.h"
 #import "ContextManager.h"
 #import "AccountService.h"
+#import <SafariServices/SafariServices.h>
 
 @interface ThemeDetailsViewController ()
 
@@ -223,18 +223,9 @@
 - (IBAction)livePreviewPressed:(id)sender
 {
     // Live preview URL yields the same result as 'view current site'.
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-
     NSURL *targetURL = [NSURL URLWithString:self.theme.previewUrl];
-    WPWebViewController *livePreviewController = [WPWebViewController webViewControllerWithURL:targetURL];
-    livePreviewController.authToken = defaultAccount.authToken;
-    livePreviewController.username = defaultAccount.username;
-    livePreviewController.wpLoginURL = [NSURL URLWithString:self.theme.blog.loginUrl];
-    
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:livePreviewController];
-    [self presentViewController:navController animated:YES completion:nil];
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:targetURL];
+    [self presentViewController:safariViewController animated:YES completion:nil];
 }
 
 - (IBAction)activatePressed:(id)sender


### PR DESCRIPTION
#### Details:

In this PR we're switching away from `WPWebViewController`, in favor of the new `SFSafariViewController` tool

Needs Review: @sendhil (Thank you!)
Closes #4101

--

#### Test 1: Login
1. Edit [this snippet](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m#L474) and make sure the `displayErrorMessageForXMLRPC` method gets executed, no matter what.
2. Fresh install WPiOS
3. Tap over the 'Add Self-Hosted Site' label
4. Enter invalid credentials, and hit Sign In
5. Tap over the `Enable Now` button at the bottom right corner

**Expected:** SafariViewController Onscreen

--

#### Test 2: Create Account
1. Launch WPiOS
2. Tap over Create Account
3. Tap the Terms of Service label

**Expected:** SafariViewController Onscreen

--

#### Test 3: About
1. Log into WPiOS
2. Tap over the Me tab, and hit the *Help & Support* row
3. Tap over About, and pick any of the links

**Expected:** SafariViewController Onscreen

--

#### Test 4: View Site
1. Launch WPiOS and log into your account
2. Tap over My Sites, and pick a random blog
3. Tap over the *View Site* label

**Expected:** SafariViewController Onscreen

--

#### Test 5: Site Admin
1. Launch WPiOS and log into your account
2. Tap over My Sites, and pick a random blog
3. Tap over the *WP Admin* label

**Expected:** SafariViewController Onscreen

--

#### Test 6: Reader Post Link
1. Launch WPiOS and log into your account
2. Tap over the Reader and pick any article
3. Tap over any external links

**Expected:** SafariViewController Onscreen

--

#### Test 7: Reader Post Image
1. Launch WPiOS and log into your account
2. Tap over the Reader and pick any article
3. Tap over an image that's not PNG | JPG | GIF

**Expected:** SafariViewController Onscreen
**Note:** This is way easier to test if you just hack *WPImageViewController*'s isUrlSupported method, to always return NO.

--

#### Test 8: Reader Comment Link
1. Launch WPiOS and log into your account
2. Tap over the Reader, pick any article, and open its comments
3. Tap over any external links

**Expected:** SafariViewController Onscreen

--

#### Test 9: Reader Comment Image
1. Launch WPiOS and log into your account
2. Tap over the Reader, pick any article, and open its comments
3. Tap over an image that's not PNG | JPG | GIF

**Expected:** SafariViewController Onscreen

--

#### Test 10: Notifications Jetpack
1. Launch WPiOS and log into a self hosted blog, with no Jetpack
2. Tap over the Notifications tab
3. Tap over the "Learn More" button

**Expected:** SafariViewController Onscreen

--

#### Test 11: Notification Details
1. Launch WPiOS and log into your account
2. Tap over the Notifications tab, and tap over any notification that contains a web link (ie. badge / comment)
3. Tap over the link

**Expected:** SafariViewController Onscreen

--

#### Test 12: Comments
1. Launch WPiOS and log into your account
2. Tap over My Sites, and pick a random blog
3. Tap over 'Comments', and pick a comment that contains a web link
4. Tap over the link

**Expected:** SafariViewController Onscreen

--

#### Test 13: Edit Site
1. Log into a self hosted blog
2. Tap over My Sites, and pick up the blog
3. Force an error 405 (easiest way: hack the *validationDidFail* method in EditSiteViewController, change the password onscreen, and hit save).

**Expected:** SafariViewController Onscreen

-- 

#### Test 14: Install Jetpack
1. Log into a self hosted blog, that doesn't have Jetpack installed
2. Tap over My Sites > Stats
3. Tap over the 'Install Jetpack' button

**Expected:** SafariViewController Onscreen

--

#### Test 15: Themes Browser
1. Enable Themes Support (`wpdebug://themes?enabled=1` in Safari)
2. Open `My Sites` tab and tap over any dotcom site
3. Open the `Themes` section
4. Tap over any theme

**Expected:** SafariViewController Onscreen
