### PR TITLE
Fixes an issue showing empty posts when editing them.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -31,7 +31,7 @@ pod 'NSObject-SafeExpectations', '0.0.2'
 pod 'Simperium', '0.8.9'
 pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
 pod 'WordPress-iOS-Shared', '0.4.4'
-pod 'WordPress-iOS-Editor', '1.0'
+pod 'WordPress-iOS-Editor', '1.0.1'
 pod 'WordPressCom-Stats-iOS', '0.4.12'
 pod 'WordPressCom-Analytics-iOS', '0.0.41'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -142,7 +142,7 @@ PODS:
   - SVProgressHUD (1.1.3)
   - UIDeviceIdentifier (0.4.5)
   - WordPress-AppbotX (1.0.6)
-  - WordPress-iOS-Editor (1.0):
+  - WordPress-iOS-Editor (1.0.1):
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPress-iOS-Shared (~> 0.4.4)
@@ -213,7 +213,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
-  - WordPress-iOS-Editor (= 1.0)
+  - WordPress-iOS-Editor (= 1.0.1)
   - WordPress-iOS-Shared (= 0.4.4)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
   - WordPressCom-Analytics-iOS (= 0.0.41)
@@ -291,7 +291,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
   UIDeviceIdentifier: f7b32c087f4d4957badbb6181a4c78520c5806ae
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
-  WordPress-iOS-Editor: 5d9939949c36613c7ab97451c921cf62af212baa
+  WordPress-iOS-Editor: b5b736456f14510af9e79a54af6e3a6e6c3c063e
   WordPress-iOS-Shared: 345f7c1c49d298114353c3856c53317f0d826078
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
   WordPressCom-Analytics-iOS: 73de8c9a0f1a43bac03fd2fcd881389be73ee820

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1370,7 +1370,7 @@ EditImageDetailsViewControllerDelegate
     // by deferring the cloning and UI update.
     // Slower devices have the effect of the content appearing after
     // a short delay
-    [self.post.managedObjectContext performBlock:^{
+    [self.post.managedObjectContext performBlockAndWait:^{
         self.post = [self.post createRevision];
         [self.post save];
         [self refreshUIForCurrentPost];


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/747).

Applies a local change to fix this, and changes by @bummytime in the editor pod.

**How to test:**
1. Launch app
2. Go to any blog with posts you can edit
3. Tap on a post with title and content to edit it
4. Editor should open up with title and description properly set
5. Go back to the post list
6. The post should show the proper title and description