### PR TITLE
Reader: Fix for #4419 take tre

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -42,6 +42,7 @@ import Foundation
     private var syncIsFillingGap = false
     private var indexPathForGapMarker: NSIndexPath?
     private var needsRefreshCachedCellHeightsBeforeLayout = false
+    private var didSetupView = false
 
     private var siteID:NSNumber? {
         didSet {
@@ -62,7 +63,7 @@ import Foundation
     public var readerTopic: ReaderAbstractTopic? {
         didSet {
             if readerTopic != nil && readerTopic != oldValue {
-                if isViewLoaded() {
+                if didSetupView {
                     configureControllerForTopic()
                 }
                 // Discard the siteID (if there was one) now that we have a good topic
@@ -128,6 +129,8 @@ import Foundation
 
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
 
+        didSetupView = true
+
         if readerTopic != nil {
             configureControllerForTopic()
         } else if siteID != nil || tagSlug != nil {
@@ -139,10 +142,9 @@ import Foundation
         super.viewDidLayoutSubviews()
 
         // There appears to be a scenario where this method can be called prior to
-        // the view being fully setup in viewDidLoad. As a safety net, make sure
-        // that the tableView is not nil.
+        // the view being fully setup in viewDidLoad.
         // See: https://github.com/wordpress-mobile/WordPress-iOS/issues/4419
-        if tableView != nil {
+        if didSetupView {
             refreshTableViewHeaderLayout()
         }
     }
@@ -165,10 +167,9 @@ import Foundation
         super.viewWillLayoutSubviews()
 
         // There appears to be a scenario where this method can be called prior to
-        // the view being fully setup in viewDidLoad. As a safety net, make sure
-        // that the tableViewHandler is not nil.
+        // the view being fully setup in viewDidLoad.
         // See: https://github.com/wordpress-mobile/WordPress-iOS/issues/4419
-        if tableViewHandler != nil && needsRefreshCachedCellHeightsBeforeLayout {
+        if didSetupView && needsRefreshCachedCellHeightsBeforeLayout {
             needsRefreshCachedCellHeightsBeforeLayout = false
 
             let width = view.frame.width


### PR DESCRIPTION
Refs #4419 

I started to go this route in #4469 but decided against adding a new bool and instead to just check for nil.  That approach worked fine but then we discovered a new edge case where the topic could be assigned after the view was loaded but before `viewDidLoad` was called.  (Seriously, wtf.)  

This PR adds a bool flag to check if the view has been setup in `viewDidLoad` before doing anything that would trigger the related crash cases. 

cc @jleandroperez as an FYI cos of the upcoming merge back to 5.8. 

Needs Review: @sendhil  