### PR TITLE
Reader: Fix for #4419 take the fourth

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -266,7 +266,7 @@ SPEC CHECKSUMS:
   CrashlyticsLumberjack: 5094b659ecf9a11550f7dd7a885c0cef077f1ffa
   DTCoreText: d90a4dca8e4f7b0eb18f12a967563b77a75694f0
   DTFoundation: 46e2b2fafe78d67febfd8d1f85fe9845a093f00e
-  EmailChecker: 78dd8dfa9d004826c8b5889be6c380b72b837d44
+  EmailChecker: 1b9c5a58c994bc638f842a4d69523b6ab57e706e
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
   google-plus-ios-sdk: 47adbe03ea904bdb7aa1c0eca282a23c4686e1bc


### PR DESCRIPTION
Refs #4419

This is a re-do of #4496 (and friends) targeting the 5.8 branch instead of 5.7.1. 

If there is a "take the fifth" I believe I shall, and then promptly drink it whole. :P 

#4496 already had a :shipit: but pinging again for paranoia sake.

Needs Review : @sendhil 