### PR TITLE
iPad Pro: Notification Icon Position

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -26,6 +26,7 @@ static NSString * const WPBlogListNavigationRestorationID = @"WPBlogListNavigati
 static NSString * const WPReaderNavigationRestorationID = @"WPReaderNavigationID";
 static NSString * const WPMeNavigationRestorationID = @"WPMeNavigationID";
 static NSString * const WPNotificationsNavigationRestorationID  = @"WPNotificationsNavigationID";
+static NSString * const WPTabBarButtonClassname = @"UITabBarButton";
 
 // used to restore the last selected tab bar item
 static NSString * const WPTabBarSelectedIndexKey = @"WPTabBarSelectedIndexKey";
@@ -580,8 +581,9 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
     // *If* this ever breaks, worst case scenario, we'll notice the assertion below (and of course, we'll fix it!).
     //
     CGRect lastButtonRect = CGRectZero;
+    
     for (UIView *subview in self.tabBar.subviews) {
-        if ([@"UITabBarButton" isEqualToString:NSStringFromClass([subview class])]) {
+        if ([WPTabBarButtonClassname isEqualToString:NSStringFromClass([subview class])]) {
             if (CGRectGetMinX(subview.frame) > CGRectGetMinX(lastButtonRect)) {
                 lastButtonRect = subview.frame;
             }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -603,16 +603,21 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 
     __weak __typeof(self) weakSelf = self;
-    [coordinator animateAlongsideTransition:nil completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
-        [weakSelf updateNotificationBadgeIconPosition];
-    }];
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+                                                [weakSelf updateNotificationBadgeIconPosition];
+                                            }
+                                 completion:nil];
 }
 
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
+- (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
-    [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-
-    [self updateNotificationBadgeIconPosition];
+    [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
+    
+    __weak __typeof(self) weakSelf = self;
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+                                                [weakSelf updateNotificationBadgeIconPosition];
+                                            }
+                                 completion:nil];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -542,6 +542,14 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
 
 - (void)animateNotificationBadgeIcon
 {
+    // Note:
+    // We need to force a layout pass (*if needed*) right now. Otherwise, the view may get layed out
+    // at the middle of the animation, which may lead to inconsistencies.
+    //
+    [self.view layoutIfNeeded];
+    
+    // Scotty, beam me up!
+    //
     __weak __typeof(self) weakSelf = self;
     [UIView animateWithDuration:0.3 animations:^{
         weakSelf.notificationBadgeIconView.transform = CGAffineTransformMakeScale(1.5, 1.5);

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -526,9 +526,6 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
     self.notificationBadgeIconView.layer.borderWidth = 1.0;
     self.notificationBadgeIconView.hidden = YES;
     [self.tabBar addSubview:self.notificationBadgeIconView];
-
-    [self updateNotificationBadgeIconPosition];
-    [self updateNotificationBadgeVisibility];
 }
 
 - (void)updateNotificationBadgeIconPosition
@@ -574,7 +571,6 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
     }];
 }
 
-#pragma mark - Handling Rotations
 - (CGRect)lastTabBarButtonFrame
 {
     // Hack:
@@ -597,6 +593,19 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
 }
 
 
+#pragma mark - Handling Layout
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    [self updateNotificationBadgeVisibility];
+}
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+    [self updateNotificationBadgeIconPosition];
+}
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {


### PR DESCRIPTION
#### Description:
In this PR we implement **a violent hack** to address iPad Pro's Notification Icon misplacement.
I've opted in favor of this mechanism... because in one shot, we can solve the layout in all of the available devices (even in Multitasking), instead of adding more constraints per screen size.

Please, verify this in (as many devices as possible), and in Multitasking mode.
[You may hack this spot](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/ViewRelated/System/WPTabBarController.m#L494) to simulate "Pending Unread Notifications".

Needs Review: @kwonye 
Thank you sir!
