### PR TITLE
Reader: Hides action buttons when showing attribution.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -472,7 +472,7 @@ import Foundation
             actionButtonRight
         ]
 
-        if contentProvider == nil {
+        if contentProvider == nil || contentProvider?.sourceAttributionStyle() != SourceAttributionStyle.None {
             resetActionButtons(buttons)
             return
         }


### PR DESCRIPTION
Closes #4508 

To test:
Open the Reader, and switch to the Discover feed. 
Scroll through the list of posts.  Posts that show attribution should not show a like or comment buttons. Posts that are original content and do not show attribution *may* show like and comment buttons. 

Needs review: @diegoreymendez 