### PR TITLE
Adds nullability to AccountService

### DIFF
--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 #import "LocalCoreDataService.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class WPAccount, Blog;
 
 extern NSString *const WPAccountDefaultWordPressComAccountChangedNotification;
@@ -21,7 +23,7 @@ extern NSString *const WPAccountEmailAndDefaultBlogUpdatedNotification;
  @see setDefaultWordPressComAccount:
  @see removeDefaultWordPressComAccount
  */
-- (WPAccount *)defaultWordPressComAccount;
+- (nullable WPAccount *)defaultWordPressComAccount;
 
 /**
  Sets the default WordPress.com account
@@ -93,3 +95,5 @@ extern NSString *const WPAccountEmailAndDefaultBlogUpdatedNotification;
 - (void)setVisibility:(BOOL)visible forBlogs:(NSArray *)blogs;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -351,12 +351,14 @@ import Foundation
             requestURL = NSURL(string: sslURL)!
         }
 
+        let request = NSMutableURLRequest(URL: requestURL)
 
         let acctServ = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        let token = acctServ.defaultWordPressComAccount().authToken
-        let request = NSMutableURLRequest(URL: requestURL)
-        let headerValue = String(format: "Bearer %@", token)
-        request.addValue(headerValue, forHTTPHeaderField: "Authorization")
+        if let account = acctServ.defaultWordPressComAccount() {
+            let token = account.authToken
+            let headerValue = String(format: "Bearer %@", token)
+            request.addValue(headerValue, forHTTPHeaderField: "Authorization")
+        }
 
         return request
     }


### PR DESCRIPTION
Adds nullability annotations to `AccountService` for better Swift integration.

Extracting this from #4510

Needs Review: @aerych 