### PR TITLE
Reader: Adds analytics for Discover feed.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -92,6 +92,17 @@ public class ReaderHelpers {
     }
 
     /**
+     Check if the specified topic is for Discover
+
+     @param topic A ReaderAbstractTopic
+     @return True if the topic is for Discover
+     */
+    public class func topicIsDiscover(topic: ReaderAbstractTopic) -> Bool {
+        let path = topic.path as NSString!
+        return path.containsString("/read/sites/53424024/posts")
+    }
+
+    /**
     Check if the specified topic is for Following
 
     @param topic A ReaderAbstractTopic
@@ -121,6 +132,10 @@ public class ReaderHelpers {
 
         if topicIsFreshlyPressed(topic) {
             stat = .ReaderFreshlyPressedLoaded
+
+        } else if isTopicDefault(topic) && topicIsDiscover(topic) {
+            // Tracks Discover only if it was one of the default menu items.
+            stat = .ReaderDiscoverViewed
 
         } else if isTopicList(topic) {
             stat = .ReaderListLoaded


### PR DESCRIPTION
Closes #4512 

Some users may still be subscribed to FP.  We'll remove that tracking at a future date. For now we'll just start tracking Discover.

Needs Review: @sendhil 