### PR TITLE
Fix Jetpack blog detection

### DIFF
--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -102,6 +102,8 @@
 
 - (BOOL)hasVisibleWPComAccounts;
 
+- (BOOL)hasAnyJetpackBlogs;
+
 - (NSInteger)blogCountForAllAccounts;
 
 - (NSInteger)blogCountSelfHosted;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -343,6 +343,22 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     return [self blogCountVisibleForWPComAccounts] > 0;
 }
 
+- (BOOL)hasAnyJetpackBlogs
+{
+    NSPredicate *jetpackManagedPredicate = [NSPredicate predicateWithFormat:@"account != NULL AND isHostedAtWPcom = NO"];
+    NSInteger jetpackManagedCount = [self blogCountWithPredicate:jetpackManagedPredicate];
+    if (jetpackManagedCount > 0) {
+        return YES;
+    }
+
+    NSArray *selfHostedBlogs = [self blogsWithNoAccount];
+    NSArray *jetpackUnmanagedBlogs = [selfHostedBlogs wp_filter:^BOOL(Blog *blog) {
+        return blog.jetpack.isConnected;
+    }];
+
+    return [jetpackUnmanagedBlogs count] > 0;
+}
+
 - (NSInteger)blogCountForAllAccounts
 {
     return [self blogCountWithPredicate:nil];

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -91,28 +91,24 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
         
         blogCount = [blogService blogCountForAllAccounts];
+        jetpackBlogsPresent = [blogService hasAnyJetpackBlogs];
         if (account != nil) {
             username = account.username;
             userID = nil;
             emailAddress = account.email;
             accountPresent = YES;
-            jetpackBlogsPresent = [account jetpackBlogs].count > 0;
         }
     }];
     
     BOOL dotcom_user = NO;
-    BOOL jetpack_user = NO;
     if (accountPresent) {
         dotcom_user = YES;
-        if (jetpackBlogsPresent) {
-            jetpack_user = YES;
-        }
     }
     
     NSMutableDictionary *userProperties = [NSMutableDictionary new];
     userProperties[@"platform"] = @"iOS";
     userProperties[@"dotcom_user"] = @(dotcom_user);
-    userProperties[@"jetpack_user"] = @(jetpack_user);
+    userProperties[@"jetpack_user"] = @(jetpackBlogsPresent);
     userProperties[@"number_of_blogs"] = @(blogCount);
     userProperties[@"accessibility_voice_over_enabled"] = @(UIAccessibilityIsVoiceOverRunning());
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -117,27 +117,23 @@ NSString *const SessionCount = @"session_count";
         BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
         
         blogCount = [blogService blogCountForAllAccounts];
+        jetpackBlogsPresent = [blogService hasAnyJetpackBlogs];
         if (account != nil) {
             username = account.username;
             emailAddress = account.email;
             accountPresent = YES;
-            jetpackBlogsPresent = [account jetpackBlogs].count > 0;
         }
     }];
     
     BOOL dotcom_user = NO;
-    BOOL jetpack_user = NO;
     if (accountPresent) {
         dotcom_user = YES;
-        if (jetpackBlogsPresent) {
-            jetpack_user = YES;
-        }
     }
 
     NSMutableDictionary *superProperties = [NSMutableDictionary new];
     superProperties[@"platform"] = @"iOS";
     superProperties[@"dotcom_user"] = @(dotcom_user);
-    superProperties[@"jetpack_user"] = @(jetpack_user);
+    superProperties[@"jetpack_user"] = @(jetpackBlogsPresent);
     superProperties[@"number_of_blogs"] = @(blogCount);
     superProperties[@"accessibility_voice_over_enabled"] = @(UIAccessibilityIsVoiceOverRunning());
     [self.mixpanelProxy registerSuperProperties:superProperties];

--- a/WordPress/WordPressTest/WPAnalyticsTrackerMixpanelTests.m
+++ b/WordPress/WordPressTest/WPAnalyticsTrackerMixpanelTests.m
@@ -63,7 +63,6 @@ void (^createBlog)() = ^{
                              @"readonly": @YES,
                              },
                      };
-    blog.account = account;
     [testContextManager.mainContext save:nil];
 };
 
@@ -148,21 +147,20 @@ describe(@"refreshMetadata", ^{
                 createBlog();
             });
             
-            it(@"should be NO when the user isn't connected to Jetpack", ^{
+            it(@"should be YES when the blog has Jetpack installed", ^{
                 interceptSuperProperties(^(NSDictionary *superProperties){
-                    expect(superProperties[@"jetpack_user"]).to.beFalsy();
+                    expect(superProperties[@"jetpack_user"]).to.beTruthy();
                 });
                 
                 [mixpanelTracker refreshMetadata];
             });
             
-            it(@"should be YES when the user is connected to Jetpack", ^{
-                blog.jetpackAccount = account;
-                [account addJetpackBlogsObject:blog];
+            it(@"should be NO when the blog doesn't have Jetpack installed", ^{
+                blog.options = @{};
                 [testContextManager.mainContext save:nil];
                 
                 interceptSuperProperties(^(NSDictionary *superProperties){
-                    expect(superProperties[@"jetpack_user"]).to.beTruthy();
+                    expect(superProperties[@"jetpack_user"]).to.beFalsy();
                 });
                 
                 [mixpanelTracker refreshMetadata];


### PR DESCRIPTION
The old code would only work for the pre-REST Jetpack sites connected to
the default account.

It now takes into account managed Jetpack sites, sites connected to a
different account, and sites that have Jetpack installed but not
configured in the app

Fixes #4480 

Needs Review: @sendhil 