### PR TITLE
Editor navbar fix for compact size class.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -67,6 +67,9 @@ NSString *const kWPEditorConfigURLParamEnabled = @"enabled";
 
 static CGFloat const SpacingBetweeenNavbarButtons = 40.0f;
 static CGFloat const RightSpacingOnExitNavbarButton = 5.0f;
+static CGFloat const CompactTitleButtonWidth = 125.0f;
+static CGFloat const RegularTitleButtonWidth = 300.0f;
+static CGFloat const RegularTitleButtonHeight = 30.0f;
 static NSDictionary *DisabledButtonBarStyle;
 static NSDictionary *EnabledButtonBarStyle;
 
@@ -1097,6 +1100,14 @@ EditImageDetailsViewControllerDelegate
 
 #pragma mark - Custom UI elements
 
+- (BOOL)isViewHorizontallyCompact
+{
+    if ([self respondsToSelector:@selector(traitCollection)] == false) {
+        return ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) == false;
+    }
+    return self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;
+}
+
 - (WPButtonForNavigationBar*)buttonForBarWithImageNamed:(NSString*)imageName
 												  frame:(CGRect)frame
 												 target:(id)target
@@ -1269,7 +1280,7 @@ EditImageDetailsViewControllerDelegate
                                                                                       attributes:@{ NSFontAttributeName : [WPFontManager openSansSemiBoldFontOfSize:16.0] }];
         
         [blogButton setAttributedTitle:titleText forState:UIControlStateNormal];
-        if (IS_IPAD) {
+        if (![self isViewHorizontallyCompact]) {
             //size to fit here so the iPad popover works properly
             [blogButton sizeToFit];
         }
@@ -1292,18 +1303,17 @@ EditImageDetailsViewControllerDelegate
 - (UIButton *)blogPickerButton
 {
     if (!_blogPickerButton) {
-        CGFloat titleButtonWidth = 140.0f;
-        
-        if ([WPDeviceIdentification isiPhoneSixPlus] || [WPDeviceIdentification isiPhoneSix]) {
-            titleButtonWidth = 190.0f;
-        } else if (IS_IPAD) {
-            titleButtonWidth = 300.0f;
-        }
-        
-        UIButton *button = [WPBlogSelectorButton buttonWithFrame:CGRectMake(0.0f, 0.0f, titleButtonWidth , 30.0f) buttonStyle:WPBlogSelectorButtonTypeSingleLine];
+        UIButton *button = [WPBlogSelectorButton buttonWithFrame:CGRectMake(0.0f, 0.0f, RegularTitleButtonWidth , RegularTitleButtonHeight) buttonStyle:WPBlogSelectorButtonTypeSingleLine];
         [button addTarget:self action:@selector(showBlogSelectorPrompt:) forControlEvents:UIControlEventTouchUpInside];
         _blogPickerButton = button;
     }
+    
+    // Update the width to the appropriate size for the horizontal size class
+    CGFloat titleButtonWidth = CompactTitleButtonWidth;
+    if (![self isViewHorizontallyCompact]) {
+        titleButtonWidth = RegularTitleButtonWidth;
+    }
+    _blogPickerButton.frame = CGRectMake(_blogPickerButton.frame.origin.x, _blogPickerButton.frame.origin.y, titleButtonWidth, RegularTitleButtonHeight);
     
     return _blogPickerButton;
 }
@@ -1311,7 +1321,7 @@ EditImageDetailsViewControllerDelegate
 - (UIBarButtonItem *)uploadStatusButton
 {
     if (!_uploadStatusButton) {
-        UIButton *button = [WPUploadStatusButton buttonWithFrame:CGRectMake(0.0f, 0.0f, 125.0f , 30.0f)];
+        UIButton *button = [WPUploadStatusButton buttonWithFrame:CGRectMake(0.0f, 0.0f, CompactTitleButtonWidth , RegularTitleButtonHeight)];
         button.titleLabel.text = NSLocalizedString(@"Media Uploading...", @"Message to indicate progress of uploading media to server");
         [button addTarget:self action:@selector(showCancelMediaUploadPrompt) forControlEvents:UIControlEventTouchUpInside];
         _uploadStatusButton = [[UIBarButtonItem alloc] initWithCustomView:button];

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -92,7 +92,7 @@
 	<key>UIPrerenderedIcon</key>
 	<true/>
 	<key>UIRequiresFullScreen</key>
-	<true/>
+	<false/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleBlackOpaque</string>
 	<key>UISupportedInterfaceOrientations</key>

--- a/WordPress/Wordpress-Alpha-Info.plist
+++ b/WordPress/Wordpress-Alpha-Info.plist
@@ -76,7 +76,7 @@
 	<key>UILaunchStoryboardName</key>
 	<string>Launch Screen</string>
 	<key>UIRequiresFullScreen</key>
-	<true/>
+	<false/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleBlackOpaque</string>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/724

This PR should prevent the editor's navbar blog picker from overflowing into the buttons on the right side of the screen (when WPiOS is in the compact size class). 

<img width="1024" alt="screen shot 2015-11-24 at 12 44 01 pm" src="https://cloud.githubusercontent.com/assets/154014/11377240/7682d238-92aa-11e5-801e-1eabbdde5e9e.png">
<img width="1026" alt="screen shot 2015-11-24 at 12 44 21 pm" src="https://cloud.githubusercontent.com/assets/154014/11377241/76832b0c-92aa-11e5-85db-87740dd9a991.png">

**How to test:**
Run WPiOS on small + large devices (and also in multitasking modes)...try and get it to look like this:

<img width="386" alt="screen shot 2015-11-24 at 12 57 03 pm" src="https://cloud.githubusercontent.com/assets/154014/11377340/fbfcad6c-92aa-11e5-8d28-3690df532170.png">
<img width="231" alt="screen shot 2015-11-24 at 12 57 22 pm" src="https://cloud.githubusercontent.com/assets/154014/11377341/fbfd8494-92aa-11e5-9235-310418fc9665.png">

/cc @sendhil would you mind looking at this?