### PR TITLE
Site Settings: Adds nil check when updating site settings.

### DIFF
--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -125,12 +125,24 @@ static NSInteger const BlogRemoteUncategorizedCategory = 1;
                    failure:(void (^)(NSError *error))failure;
 {
     NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    NSMutableDictionary *parameters = [@{ @"blogname" : remoteBlogSettings.name,
-                                  @"blogdescription" : remoteBlogSettings.desc,
-                                  @"default_category" : remoteBlogSettings.defaultCategory,
-                                  @"default_post_format" : remoteBlogSettings.defaultPostFormat,
-                                  @"blog_public" : remoteBlogSettings.privacy,
-                                  } mutableCopy];
+
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+    if (remoteBlogSettings.name) {
+        parameters[@"blogname"] = remoteBlogSettings.name;
+    }
+    if (remoteBlogSettings.desc) {
+        parameters[@"blogdescription"] = remoteBlogSettings.desc;
+    }
+    if (remoteBlogSettings.defaultCategory) {
+        parameters[@"default_category"] = remoteBlogSettings.defaultCategory;
+    }
+    if (remoteBlogSettings.defaultPostFormat) {
+        parameters[@"default_post_format"] = remoteBlogSettings.defaultPostFormat;
+    }
+    if (remoteBlogSettings.privacy) {
+        parameters[@"blog_public"] = remoteBlogSettings.privacy;
+    }
+
     if (remoteBlogSettings.relatedPostsEnabled) {
         parameters[@"jetpack_relatedposts_enabled"] = remoteBlogSettings.relatedPostsEnabled;
         parameters[@"jetpack_relatedposts_show_headline"] = remoteBlogSettings.relatedPostsShowHeadline;


### PR DESCRIPTION
Closes #4517 

This is a stopgap for a crash when the value assigned to the parameters dictionary is nil.
A more robust treatment is commited in #4445 but targets the 5.9 release.
When merging back to develop this patch can be discarded in favor of #4445.

Needs Review @jleandroperez 