### PR TITLE
Media picker update version

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -35,7 +35,7 @@ pod 'WordPress-iOS-Editor', '1.0.1'
 pod 'WordPressCom-Stats-iOS', '0.4.12'
 pod 'WordPressCom-Analytics-iOS', '0.0.41'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
-pod 'WPMediaPicker', '~> 0.7.0'
+pod 'WPMediaPicker', '~> 0.7.1'
 pod 'ReactiveCocoa', '~> 2.4.7'
 pod 'FormatterKit', '~> 1.8.0'
 

--- a/Podfile
+++ b/Podfile
@@ -35,7 +35,7 @@ pod 'WordPress-iOS-Editor', '1.0.1'
 pod 'WordPressCom-Stats-iOS', '0.4.12'
 pod 'WordPressCom-Analytics-iOS', '0.0.41'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
-pod 'WPMediaPicker', '~> 0.7.1'
+pod 'WPMediaPicker', '~>0.7.2'
 pod 'ReactiveCocoa', '~> 2.4.7'
 pod 'FormatterKit', '~> 1.8.0'
 

--- a/Podfile
+++ b/Podfile
@@ -35,7 +35,7 @@ pod 'WordPress-iOS-Editor', '1.0.1'
 pod 'WordPressCom-Stats-iOS', '0.4.12'
 pod 'WordPressCom-Analytics-iOS', '0.0.41'
 pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
-pod 'WPMediaPicker', '~>0.7.2'
+pod 'WPMediaPicker', '~>0.7.3'
 pod 'ReactiveCocoa', '~> 2.4.7'
 pod 'FormatterKit', '~> 1.8.0'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -175,7 +175,7 @@ PODS:
     - WordPress-iOS-Shared (~> 0.4.4)
     - WordPressCom-Analytics-iOS (~> 0.0.41)
     - WordPressCom-Stats-iOS/Services
-  - WPMediaPicker (0.7.1)
+  - WPMediaPicker (0.7.2)
   - wpxmlrpc (0.8.1)
 
 DEPENDENCIES:
@@ -219,7 +219,7 @@ DEPENDENCIES:
   - WordPressCom-Analytics-iOS (= 0.0.41)
   - WordPressCom-Stats-iOS (= 0.4.12)
   - WordPressCom-Stats-iOS/Services (= 0.4.12)
-  - WPMediaPicker (~> 0.7.1)
+  - WPMediaPicker (~> 0.7.2)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -296,7 +296,7 @@ SPEC CHECKSUMS:
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
   WordPressCom-Analytics-iOS: 73de8c9a0f1a43bac03fd2fcd881389be73ee820
   WordPressCom-Stats-iOS: 950454010791a4661952f92e3935ba03951caf94
-  WPMediaPicker: d3d46adfbc9f34a4350f0f2defdafb04f32701f2
+  WPMediaPicker: 22beabf079a54ece002208efd934e472eaedeed4
   wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0
 
 COCOAPODS: 0.39.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -175,7 +175,7 @@ PODS:
     - WordPress-iOS-Shared (~> 0.4.4)
     - WordPressCom-Analytics-iOS (~> 0.0.41)
     - WordPressCom-Stats-iOS/Services
-  - WPMediaPicker (0.7.2)
+  - WPMediaPicker (0.7.3)
   - wpxmlrpc (0.8.1)
 
 DEPENDENCIES:
@@ -219,7 +219,7 @@ DEPENDENCIES:
   - WordPressCom-Analytics-iOS (= 0.0.41)
   - WordPressCom-Stats-iOS (= 0.4.12)
   - WordPressCom-Stats-iOS/Services (= 0.4.12)
-  - WPMediaPicker (~> 0.7.2)
+  - WPMediaPicker (~> 0.7.3)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -296,7 +296,7 @@ SPEC CHECKSUMS:
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
   WordPressCom-Analytics-iOS: 73de8c9a0f1a43bac03fd2fcd881389be73ee820
   WordPressCom-Stats-iOS: 950454010791a4661952f92e3935ba03951caf94
-  WPMediaPicker: 22beabf079a54ece002208efd934e472eaedeed4
+  WPMediaPicker: 6bbce465f5a5c071267ae28bdf31d0fd6e109721
   wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0
 
 COCOAPODS: 0.39.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -175,7 +175,7 @@ PODS:
     - WordPress-iOS-Shared (~> 0.4.4)
     - WordPressCom-Analytics-iOS (~> 0.0.41)
     - WordPressCom-Stats-iOS/Services
-  - WPMediaPicker (0.7.0)
+  - WPMediaPicker (0.7.1)
   - wpxmlrpc (0.8.1)
 
 DEPENDENCIES:
@@ -219,7 +219,7 @@ DEPENDENCIES:
   - WordPressCom-Analytics-iOS (= 0.0.41)
   - WordPressCom-Stats-iOS (= 0.4.12)
   - WordPressCom-Stats-iOS/Services (= 0.4.12)
-  - WPMediaPicker (~> 0.7.0)
+  - WPMediaPicker (~> 0.7.1)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -296,7 +296,7 @@ SPEC CHECKSUMS:
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
   WordPressCom-Analytics-iOS: 73de8c9a0f1a43bac03fd2fcd881389be73ee820
   WordPressCom-Stats-iOS: 950454010791a4661952f92e3935ba03951caf94
-  WPMediaPicker: f721cacd4113c6e718a1c7296083b9fd4a040536
+  WPMediaPicker: d3d46adfbc9f34a4350f0f2defdafb04f32701f2
   wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0
 
 COCOAPODS: 0.39.0

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -103,10 +103,8 @@
         }
     }];
     id<NSObject> secondKey = [self.mediaLibraryDataSource registerChangeObserverBlock:^{
-        if (weakSelf.currentDataSource == weakSelf.mediaLibraryDataSource) {
-            if (callback) {
-                callback();
-            }
+        if (callback) {
+            callback();
         }
     }];
     

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4979,7 +4979,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "57dc168b-a7c9-4d2a-ae8d-909384bf79de";
+				PROVISIONING_PROFILE = "9da9c00f-12e2-4dc7-a862-03c008e8609e";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -5592,7 +5592,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.wordpress.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_MODULE_NAME = WordPressWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "46751253-974d-4c6a-a2cd-7f0eaeb32bc6";
+				PROVISIONING_PROFILE = "747f8fbd-7126-479c-aa55-3d800e6284e4";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressTodayWidget/WordPressTodayWidget-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";


### PR DESCRIPTION
This MediaPicker version update fixes the following bugs:

https://github.com/wordpress-mobile/MediaPicker-iOS/issues/85
https://github.com/wordpress-mobile/MediaPicker-iOS/issues/86
https://github.com/wordpress-mobile/MediaPicker-iOS/issues/73
https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/749 -> associated PR https://github.com/wordpress-mobile/MediaPicker-iOS/pull/91

and also improves the accessibility on the component:

https://github.com/wordpress-mobile/MediaPicker-iOS/pull/81

Needs Review: @astralbodies 