### PR TITLE
Updates CocoaLumberjack to 2.2.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,41 +7,50 @@ inhibit_all_warnings!
 use_frameworks!
 
 platform :ios, '9.0'
-pod '1PasswordExtension', '1.6.4'
-pod 'AFNetworking',	'2.6.3'
-pod 'Reachability',	'3.2'
-pod 'NSURL+IDN', '0.3'
-pod 'DTCoreText',   '1.6.16'
-pod 'UIDeviceIdentifier', '~> 0.1'
-pod 'SVProgressHUD', '~>1.1.3'
-pod 'AMPopTip', '~> 0.7'
-pod 'wpxmlrpc', '~> 0.8'
-pod 'Mixpanel', '2.8.2'
-pod 'CocoaLumberjack', '= 2.0.0'
-pod 'NSLogger-CocoaLumberjack-connector', :git => 'https://github.com/steipete/NSLogger-CocoaLumberjack-connector.git', :tag => '1.5'
-pod 'google-plus-ios-sdk', '~>1.5'
-pod 'HockeySDK', '~>3.8.0'
-pod 'Helpshift', '~>4.10.0'
-pod 'Lookback', '1.1.4', :configurations => ['Release-Internal']
-pod 'MRProgress', '~>0.7.0'
 
-pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.0.12'
-pod 'EmailChecker', :podspec => 'https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec'
-pod 'MGImageUtilities', :git => 'git://github.com/wordpress-mobile/MGImageUtilities.git', :branch => 'gifsupport'
-pod 'NSObject-SafeExpectations', '0.0.2'
-pod 'Simperium', '0.8.9'
-pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
-pod 'WordPress-iOS-Shared', '0.5.0'
-pod 'WordPress-iOS-Editor', '1.1'
-pod 'WordPressCom-Stats-iOS', '0.5.0'
-pod 'WordPressCom-Analytics-iOS', '0.1.0'
-pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
-pod 'WPMediaPicker', '~> 0.7.0'
-pod 'ReactiveCocoa', '~> 2.4.7'
-pod 'FormatterKit', '~> 1.8.0'
+target 'WordPress', :exclusive => true do
+  pod '1PasswordExtension', '1.6.4'
+  pod 'AFNetworking',	'2.6.3'
+  pod 'Reachability',	'3.2'
+  pod 'NSURL+IDN', '0.3'
+  pod 'DTCoreText',   '1.6.16'
+  pod 'UIDeviceIdentifier', '~> 0.1'
+  pod 'SVProgressHUD', '~>1.1.3'
+  pod 'AMPopTip', '~> 0.7'
+  pod 'wpxmlrpc', '~> 0.8'
+  pod 'Mixpanel', '2.8.2'
+  pod 'CocoaLumberjack', '~> 2.2.0'
+  pod 'google-plus-ios-sdk', '~>1.5'
+  pod 'HockeySDK', '~>3.8.0'
+  pod 'Helpshift', '~>4.10.0'
+  pod 'Lookback', '1.1.4', :configurations => ['Release-Internal']
+  pod 'MRProgress', '~>0.7.0'
+
+  #pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.0.12'
+  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'try/cocoalumberjack-update'
+  pod 'EmailChecker', :podspec => 'https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec'
+  pod 'MGImageUtilities', :git => 'git://github.com/wordpress-mobile/MGImageUtilities.git', :branch => 'gifsupport'
+  pod 'NSObject-SafeExpectations', '0.0.2'
+  pod 'Simperium', '0.8.9'
+  pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
+  #pod 'WordPress-iOS-Shared', '0.5.0'
+  pod 'WordPress-iOS-Shared', :branch => 'try/cocoalumberjack-update', :git => 'https://github.com/wordpress-mobile/WordPress-Shared-iOS.git'
+  #pod 'WordPress-iOS-Editor', '1.1'
+  pod 'WordPress-iOS-Editor', :branch => 'try/cocoalumberjack-update', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git'
+  #pod 'WordPressCom-Stats-iOS', '0.5.0'
+  pod 'WordPressCom-Stats-iOS', :branch => 'try/cocoalumberjack-update', :git => 'https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git'
+  pod 'WordPressCom-Analytics-iOS', '0.1.0'
+  pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
+  pod 'WPMediaPicker', '~> 0.7.0'
+  pod 'ReactiveCocoa', '~> 2.4.7'
+  pod 'FormatterKit', '~> 1.8.0'
+end
 
 target 'WordPressTodayWidget', :exclusive => true do
-  pod 'WordPressCom-Stats-iOS/Services', '0.5.0'
+  #pod 'WordPress-iOS-Shared', '0.5.0'
+  pod 'WordPress-iOS-Shared', :branch => 'try/cocoalumberjack-update', :git => 'https://github.com/wordpress-mobile/WordPress-Shared-iOS.git'
+  #pod 'WordPressCom-Stats-iOS/Services', '0.5.0'
+  pod 'WordPressCom-Stats-iOS/Services', :branch => 'try/cocoalumberjack-update', :git => 'https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile
+++ b/Podfile
@@ -26,19 +26,15 @@ target 'WordPress', :exclusive => true do
   pod 'Lookback', '1.1.4', :configurations => ['Release-Internal']
   pod 'MRProgress', '~>0.7.0'
 
-  #pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.0.12'
-  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'try/cocoalumberjack-update'
+  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.0.13'
   pod 'EmailChecker', :podspec => 'https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec'
   pod 'MGImageUtilities', :git => 'git://github.com/wordpress-mobile/MGImageUtilities.git', :branch => 'gifsupport'
   pod 'NSObject-SafeExpectations', '0.0.2'
   pod 'Simperium', '0.8.9'
   pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
-  #pod 'WordPress-iOS-Shared', '0.5.0'
-  pod 'WordPress-iOS-Shared', :branch => 'try/cocoalumberjack-update', :git => 'https://github.com/wordpress-mobile/WordPress-Shared-iOS.git'
-  #pod 'WordPress-iOS-Editor', '1.1'
-  pod 'WordPress-iOS-Editor', :branch => 'try/cocoalumberjack-update', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git'
-  #pod 'WordPressCom-Stats-iOS', '0.5.0'
-  pod 'WordPressCom-Stats-iOS', :branch => 'try/cocoalumberjack-update', :git => 'https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git'
+  pod 'WordPress-iOS-Shared', '0.5.1'
+  pod 'WordPress-iOS-Editor', '1.1.1'
+  pod 'WordPressCom-Stats-iOS', '0.5.1'
   pod 'WordPressCom-Analytics-iOS', '0.1.0'
   pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
   pod 'WPMediaPicker', '~> 0.7.0'
@@ -47,10 +43,8 @@ target 'WordPress', :exclusive => true do
 end
 
 target 'WordPressTodayWidget', :exclusive => true do
-  #pod 'WordPress-iOS-Shared', '0.5.0'
-  pod 'WordPress-iOS-Shared', :branch => 'try/cocoalumberjack-update', :git => 'https://github.com/wordpress-mobile/WordPress-Shared-iOS.git'
-  #pod 'WordPressCom-Stats-iOS/Services', '0.5.0'
-  pod 'WordPressCom-Stats-iOS/Services', :branch => 'try/cocoalumberjack-update', :git => 'https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git'
+  pod 'WordPress-iOS-Shared', '0.5.1'
+  pod 'WordPressCom-Stats-iOS/Services', '0.5.1'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - AMPopTip (0.9.13)
-  - Automattic-Tracks-iOS (0.0.12):
+  - Automattic-Tracks-iOS (0.0.13):
     - CocoaLumberjack (~> 2.2.0)
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 0.4)
@@ -150,37 +150,37 @@ PODS:
   - SVProgressHUD (1.1.3)
   - UIDeviceIdentifier (0.5.0)
   - WordPress-AppbotX (1.0.6)
-  - WordPress-iOS-Editor (1.1):
+  - WordPress-iOS-Editor (1.1.1):
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.0)
+    - WordPress-iOS-Shared (~> 0.5.1)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
-  - WordPress-iOS-Shared (0.5.0):
+  - WordPress-iOS-Shared (0.5.1):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (~> 2.2.0)
   - WordPressApi (0.3.6):
     - AFNetworking (~> 2.6.0)
     - wpxmlrpc (~> 0.7)
   - WordPressCom-Analytics-iOS (0.1.0)
-  - WordPressCom-Stats-iOS (0.5.0):
+  - WordPressCom-Stats-iOS (0.5.1):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.0)
+    - WordPress-iOS-Shared (~> 0.5.1)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
-    - WordPressCom-Stats-iOS/Services (= 0.5.0)
-    - WordPressCom-Stats-iOS/UI (= 0.5.0)
-  - WordPressCom-Stats-iOS/Services (0.5.0):
+    - WordPressCom-Stats-iOS/Services (= 0.5.1)
+    - WordPressCom-Stats-iOS/UI (= 0.5.1)
+  - WordPressCom-Stats-iOS/Services (0.5.1):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.0)
+    - WordPress-iOS-Shared (~> 0.5.1)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
-  - WordPressCom-Stats-iOS/UI (0.5.0):
+  - WordPressCom-Stats-iOS/UI (0.5.1):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.0)
+    - WordPress-iOS-Shared (~> 0.5.1)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
     - WordPressCom-Stats-iOS/Services
   - WPMediaPicker (0.7.2)
@@ -191,7 +191,7 @@ DEPENDENCIES:
   - AFNetworking (= 2.6.3)
   - AMPopTip (~> 0.7)
   - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`,
-    branch `try/cocoalumberjack-update`)
+    tag `0.0.13`)
   - CocoaLumberjack (~> 2.2.0)
   - DTCoreText (= 1.6.16)
   - EmailChecker (from `https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec`)
@@ -219,23 +219,19 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
-  - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`,
-    branch `try/cocoalumberjack-update`)
-  - WordPress-iOS-Shared (from `https://github.com/wordpress-mobile/WordPress-Shared-iOS.git`,
-    branch `try/cocoalumberjack-update`)
+  - WordPress-iOS-Editor (= 1.1.1)
+  - WordPress-iOS-Shared (= 0.5.1)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
   - WordPressCom-Analytics-iOS (= 0.1.0)
-  - WordPressCom-Stats-iOS (from `https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git`,
-    branch `try/cocoalumberjack-update`)
-  - WordPressCom-Stats-iOS/Services (from `https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git`,
-    branch `try/cocoalumberjack-update`)
+  - WordPressCom-Stats-iOS (= 0.5.1)
+  - WordPressCom-Stats-iOS/Services (= 0.5.1)
   - WPMediaPicker (~> 0.7.0)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
-    :branch: try/cocoalumberjack-update
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
+    :tag: 0.0.13
   EmailChecker:
     :podspec: https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec
   MGImageUtilities:
@@ -244,46 +240,28 @@ EXTERNAL SOURCES:
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPress-iOS-Editor:
-    :branch: try/cocoalumberjack-update
-    :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
-  WordPress-iOS-Shared:
-    :branch: try/cocoalumberjack-update
-    :git: https://github.com/wordpress-mobile/WordPress-Shared-iOS.git
   WordPressApi:
     :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git
-  WordPressCom-Stats-iOS:
-    :branch: try/cocoalumberjack-update
-    :git: https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
-    :commit: b6168fcdc2fa2c39a52604cd1cc4c2a05e17c796
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
+    :tag: 0.0.13
   MGImageUtilities:
     :commit: e946cf3d97eb95372f4fc4478bf2e0099e73f4b0
     :git: git://github.com/wordpress-mobile/MGImageUtilities.git
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPress-iOS-Editor:
-    :commit: 6ff672c388d672a4f103eb46ad9b7f8d10cee3a1
-    :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
-  WordPress-iOS-Shared:
-    :commit: 6b81f8a31f182780be6719bbd4f449f6a8262579
-    :git: https://github.com/wordpress-mobile/WordPress-Shared-iOS.git
   WordPressApi:
     :commit: a7dc27935fb30b1978942cb1c791d4040fe65395
     :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git
-  WordPressCom-Stats-iOS:
-    :commit: b7779897f8462509e10395f7359b79d8790f243c
-    :git: https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 9f471645d378283cb88c6d4bf502e4381a42c0ad
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
   AMPopTip: 17c0fc2bffc9d81314228073f63ea0320f204b11
-  Automattic-Tracks-iOS: 5803df8b288429ed835af071433ff3b6a19be26f
+  Automattic-Tracks-iOS: ba47c35576a07376facc7a91740fb78867831e1c
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   DTCoreText: 934a16fe9ffdd169c96261721b39dc312b75713d
   DTFoundation: 46e2b2fafe78d67febfd8d1f85fe9845a093f00e
@@ -310,11 +288,11 @@ SPEC CHECKSUMS:
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
-  WordPress-iOS-Editor: 56cf09ada5b5f7637b232199b34aa642b0adebc8
-  WordPress-iOS-Shared: 3b04feef4e3667c66e4867d2e9e3ae313cad1e2a
+  WordPress-iOS-Editor: 563239f9f42f80a3ca20e61f1d5aeed58698c846
+  WordPress-iOS-Shared: ced218039d88c91572f3205882832f7a05c61f97
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
   WordPressCom-Analytics-iOS: 355b8c6cf1d50d64ca7667e6f9e94c989e466775
-  WordPressCom-Stats-iOS: 424c11f2212c258da83d429921831a187f258aa3
+  WordPressCom-Stats-iOS: 9346d0e9441113eca614a6a9a333216571e4adc8
   WPMediaPicker: 22beabf079a54ece002208efd934e472eaedeed4
   wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,16 +23,16 @@ PODS:
     - AFNetworking/NSURLSession
   - AMPopTip (0.9.13)
   - Automattic-Tracks-iOS (0.0.12):
-    - CocoaLumberjack (= 2.0.0)
+    - CocoaLumberjack (~> 2.2.0)
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 0.4)
-  - CocoaLumberjack (2.0.0):
-    - CocoaLumberjack/Default (= 2.0.0)
-    - CocoaLumberjack/Extensions (= 2.0.0)
-  - CocoaLumberjack/Core (2.0.0)
-  - CocoaLumberjack/Default (2.0.0):
+  - CocoaLumberjack (2.2.0):
+    - CocoaLumberjack/Default (= 2.2.0)
+    - CocoaLumberjack/Extensions (= 2.2.0)
+  - CocoaLumberjack/Core (2.2.0)
+  - CocoaLumberjack/Default (2.2.0):
     - CocoaLumberjack/Core
-  - CocoaLumberjack/Extensions (2.0.0):
+  - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
   - DTCoreText (1.6.16):
     - DTFoundation/Core (~> 1.7.5)
@@ -108,12 +108,6 @@ PODS:
   - MRProgress/ProgressBaseClass (0.7.0)
   - MRProgress/Stopable (0.7.0):
     - MRProgress/Helper
-  - NSLogger (1.5.1):
-    - NSLogger/Standard (= 1.5.1)
-  - NSLogger-CocoaLumberjack-connector (1.5):
-    - CocoaLumberjack (~> 2.0)
-    - NSLogger
-  - NSLogger/Standard (1.5.1)
   - NSObject-SafeExpectations (0.0.2)
   - NSURL+IDN (0.3)
   - OCMock (3.1.2)
@@ -157,20 +151,20 @@ PODS:
   - UIDeviceIdentifier (0.5.0)
   - WordPress-AppbotX (1.0.6)
   - WordPress-iOS-Editor (1.1):
-    - CocoaLumberjack (= 2.0.0)
+    - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.0)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
   - WordPress-iOS-Shared (0.5.0):
     - AFNetworking (~> 2.5)
-    - CocoaLumberjack (= 2.0.0)
+    - CocoaLumberjack (~> 2.2.0)
   - WordPressApi (0.3.6):
     - AFNetworking (~> 2.6.0)
     - wpxmlrpc (~> 0.7)
   - WordPressCom-Analytics-iOS (0.1.0)
   - WordPressCom-Stats-iOS (0.5.0):
     - AFNetworking (~> 2.6.0)
-    - CocoaLumberjack (= 2.0.0)
+    - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.0)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
@@ -178,13 +172,13 @@ PODS:
     - WordPressCom-Stats-iOS/UI (= 0.5.0)
   - WordPressCom-Stats-iOS/Services (0.5.0):
     - AFNetworking (~> 2.6.0)
-    - CocoaLumberjack (= 2.0.0)
+    - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.0)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
   - WordPressCom-Stats-iOS/UI (0.5.0):
     - AFNetworking (~> 2.6.0)
-    - CocoaLumberjack (= 2.0.0)
+    - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.0)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
@@ -197,8 +191,8 @@ DEPENDENCIES:
   - AFNetworking (= 2.6.3)
   - AMPopTip (~> 0.7)
   - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`,
-    tag `0.0.12`)
-  - CocoaLumberjack (= 2.0.0)
+    branch `try/cocoalumberjack-update`)
+  - CocoaLumberjack (~> 2.2.0)
   - DTCoreText (= 1.6.16)
   - EmailChecker (from `https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec`)
   - Expecta (= 0.3.2)
@@ -212,8 +206,6 @@ DEPENDENCIES:
     branch `gifsupport`)
   - Mixpanel (= 2.8.2)
   - MRProgress (~> 0.7.0)
-  - NSLogger-CocoaLumberjack-connector (from `https://github.com/steipete/NSLogger-CocoaLumberjack-connector.git`,
-    tag `1.5`)
   - NSObject-SafeExpectations (= 0.0.2)
   - NSURL+IDN (= 0.3)
   - OCMock (= 3.1.2)
@@ -227,56 +219,72 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
-  - WordPress-iOS-Editor (= 1.1)
-  - WordPress-iOS-Shared (= 0.5.0)
+  - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`,
+    branch `try/cocoalumberjack-update`)
+  - WordPress-iOS-Shared (from `https://github.com/wordpress-mobile/WordPress-Shared-iOS.git`,
+    branch `try/cocoalumberjack-update`)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
   - WordPressCom-Analytics-iOS (= 0.1.0)
-  - WordPressCom-Stats-iOS (= 0.5.0)
-  - WordPressCom-Stats-iOS/Services (= 0.5.0)
+  - WordPressCom-Stats-iOS (from `https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git`,
+    branch `try/cocoalumberjack-update`)
+  - WordPressCom-Stats-iOS/Services (from `https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git`,
+    branch `try/cocoalumberjack-update`)
   - WPMediaPicker (~> 0.7.0)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
+    :branch: try/cocoalumberjack-update
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.0.12
   EmailChecker:
     :podspec: https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec
   MGImageUtilities:
     :branch: gifsupport
     :git: git://github.com/wordpress-mobile/MGImageUtilities.git
-  NSLogger-CocoaLumberjack-connector:
-    :git: https://github.com/steipete/NSLogger-CocoaLumberjack-connector.git
-    :tag: '1.5'
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
+  WordPress-iOS-Editor:
+    :branch: try/cocoalumberjack-update
+    :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
+  WordPress-iOS-Shared:
+    :branch: try/cocoalumberjack-update
+    :git: https://github.com/wordpress-mobile/WordPress-Shared-iOS.git
   WordPressApi:
     :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git
+  WordPressCom-Stats-iOS:
+    :branch: try/cocoalumberjack-update
+    :git: https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
+    :commit: b6168fcdc2fa2c39a52604cd1cc4c2a05e17c796
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.0.12
   MGImageUtilities:
     :commit: e946cf3d97eb95372f4fc4478bf2e0099e73f4b0
     :git: git://github.com/wordpress-mobile/MGImageUtilities.git
-  NSLogger-CocoaLumberjack-connector:
-    :git: https://github.com/steipete/NSLogger-CocoaLumberjack-connector.git
-    :tag: '1.5'
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
+  WordPress-iOS-Editor:
+    :commit: 6ff672c388d672a4f103eb46ad9b7f8d10cee3a1
+    :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
+  WordPress-iOS-Shared:
+    :commit: 6b81f8a31f182780be6719bbd4f449f6a8262579
+    :git: https://github.com/wordpress-mobile/WordPress-Shared-iOS.git
   WordPressApi:
     :commit: a7dc27935fb30b1978942cb1c791d4040fe65395
     :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git
+  WordPressCom-Stats-iOS:
+    :commit: b7779897f8462509e10395f7359b79d8790f243c
+    :git: https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 9f471645d378283cb88c6d4bf502e4381a42c0ad
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
   AMPopTip: 17c0fc2bffc9d81314228073f63ea0320f204b11
-  Automattic-Tracks-iOS: 0fe58abad2aee92dd9d57132589e03556cd9a96a
-  CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
+  Automattic-Tracks-iOS: 5803df8b288429ed835af071433ff3b6a19be26f
+  CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   DTCoreText: 934a16fe9ffdd169c96261721b39dc312b75713d
   DTFoundation: 46e2b2fafe78d67febfd8d1f85fe9845a093f00e
   EmailChecker: 78dd8dfa9d004826c8b5889be6c380b72b837d44
@@ -290,8 +298,6 @@ SPEC CHECKSUMS:
   MGImageUtilities: b54a815970e231903c495fff33699467158f61a0
   Mixpanel: f4d71ac2a306e7cda6ad03d4a2be249a0fd7a967
   MRProgress: 1cb0051b678be4a2ef4881414cd316768fc70028
-  NSLogger: 5ed223a2436df96244e033be750656dacdeec034
-  NSLogger-CocoaLumberjack-connector: 5d03d0d59a5f40093f1b1bdd66df6a71647d4a9c
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   NSURL+IDN: 82355a0afd532fe1de08f6417c134b49b1a1c4b3
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
@@ -304,11 +310,11 @@ SPEC CHECKSUMS:
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
-  WordPress-iOS-Editor: 71a7112d49e5d2ad817914bc72e50928901dd21f
-  WordPress-iOS-Shared: 5480e7b5c9c55158ea22c89ff44fca5597852224
+  WordPress-iOS-Editor: 56cf09ada5b5f7637b232199b34aa642b0adebc8
+  WordPress-iOS-Shared: 3b04feef4e3667c66e4867d2e9e3ae313cad1e2a
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
   WordPressCom-Analytics-iOS: 355b8c6cf1d50d64ca7667e6f9e94c989e466775
-  WordPressCom-Stats-iOS: 2564e78a4584381da8fc884a7b7d840bb57f4a9a
+  WordPressCom-Stats-iOS: 424c11f2212c258da83d429921831a187f258aa3
   WPMediaPicker: 22beabf079a54ece002208efd934e472eaedeed4
   wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -229,7 +229,6 @@
 		74BB6F1A19AE7B9400FB7829 /* WPLegacyEditPageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 74BB6F1919AE7B9400FB7829 /* WPLegacyEditPageViewController.m */; };
 		74D5FFD619ACDF6700389E8F /* WPLegacyEditPostViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 74D5FFD519ACDF6700389E8F /* WPLegacyEditPostViewController.m */; };
 		74F313EF1A9B97A200AA8B45 /* WPTooltip.m in Sources */ = {isa = PBXBuildFile; fileRef = 74F313EE1A9B97A200AA8B45 /* WPTooltip.m */; };
-		7E83042CB0F69860BDA2E03C /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7556D1D8CFA5CEAEAC481B9 /* Pods.framework */; };
 		83043E55126FA31400EC9953 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83043E54126FA31400EC9953 /* MessageUI.framework */; };
 		83418AAA11C9FA6E00ACF00C /* Comment.m in Sources */ = {isa = PBXBuildFile; fileRef = 83418AA911C9FA6E00ACF00C /* Comment.m */; };
 		834CAE7C122D528A003DDF49 /* UIImage+Resize.m in Sources */ = {isa = PBXBuildFile; fileRef = 834CAE7B122D528A003DDF49 /* UIImage+Resize.m */; };
@@ -608,6 +607,7 @@
 		F1564E5B18946087009F8F97 /* NSStringHelpersTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F1564E5A18946087009F8F97 /* NSStringHelpersTest.m */; };
 		F1A0C49C1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F1A0C49B1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m */; };
 		F1FA2C4E1AED07FC00255FCD /* MFMailComposeViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F1FA2C491AECEE1900255FCD /* MFMailComposeViewController+StatusBarStyle.m */; };
+		F477725AA87B0B631A004DAF /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC4C9905B8DB309BFF649BE9 /* Pods_WordPress.framework */; };
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
 		FAFB84061BBF3638000BBA8E /* get-multiple-themes-v1.2.json in Resources */ = {isa = PBXBuildFile; fileRef = FAFB84051BBF3638000BBA8E /* get-multiple-themes-v1.2.json */; };
 		FD21397F13128C5300099582 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FD21397E13128C5300099582 /* libiconv.dylib */; };
@@ -717,6 +717,8 @@
 
 /* Begin PBXFileReference section */
 		052EFF90F810139789A446FB /* Pods-WordPressTodayWidget.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTodayWidget.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTodayWidget/Pods-WordPressTodayWidget.release-internal.xcconfig"; sourceTree = "<group>"; };
+		0B2A5E7CD1F8E32549F3DC7E /* Pods-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release.xcconfig"; sourceTree = "<group>"; };
+		0CE0577B6AC0CF064C42E6EA /* Pods-WordPress.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release-internal.xcconfig"; sourceTree = "<group>"; };
 		0CF877DC71756EFA3346E26F /* Pods-WordPressTodayWidget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTodayWidget.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTodayWidget/Pods-WordPressTodayWidget.debug.xcconfig"; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D3623240D0F684500981E51 /* WordPressAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressAppDelegate.h; sourceTree = "<group>"; };
@@ -1081,6 +1083,7 @@
 		74D5FFD519ACDF6700389E8F /* WPLegacyEditPostViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPLegacyEditPostViewController.m; sourceTree = "<group>"; usesTabs = 0; };
 		74F313ED1A9B97A200AA8B45 /* WPTooltip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPTooltip.h; sourceTree = "<group>"; };
 		74F313EE1A9B97A200AA8B45 /* WPTooltip.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPTooltip.m; sourceTree = "<group>"; };
+		7A2C5111E37C5233A1AE8E41 /* Pods-WordPress.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.debug.xcconfig"; sourceTree = "<group>"; };
 		83043E54126FA31400EC9953 /* MessageUI.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		833AF259114575A50016DE8F /* PostAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostAnnotation.h; sourceTree = "<group>"; };
 		833AF25A114575A50016DE8F /* PostAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostAnnotation.m; sourceTree = "<group>"; };
@@ -1267,6 +1270,7 @@
 		93FA0F0518E451A80007903B /* localize.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; name = localize.py; path = ../localize.py; sourceTree = "<group>"; };
 		93FA59DB18D88C1C001446BC /* PostCategoryService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = PostCategoryService.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		93FA59DC18D88C1C001446BC /* PostCategoryService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PostCategoryService.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		9BD01C5941FDF790A0A1C733 /* Pods-WordPress.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		A01C542D0E24E88400D411F2 /* SystemConfiguration.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		A01C55470E25E0D000D411F2 /* defaultPostTemplate.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = defaultPostTemplate.html; path = Resources/HTML/defaultPostTemplate.html; sourceTree = "<group>"; };
 		A0E293EF0E21027E00C6919C /* WPAddPostCategoryViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAddPostCategoryViewController.h; sourceTree = "<group>"; };
@@ -1450,7 +1454,9 @@
 		CC24E5F41577E16B00A6D5B5 /* Accounts.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Accounts.framework; path = System/Library/Frameworks/Accounts.framework; sourceTree = SDKROOT; };
 		CEBD3EA90FF1BA3B00C1396E /* Blog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Blog.h; sourceTree = "<group>"; };
 		CEBD3EAA0FF1BA3B00C1396E /* Blog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Blog.m; sourceTree = "<group>"; };
+		D1EF4126815D101CC41FB7DF /* Pods-WordPress.distribution.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.distribution.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.distribution.xcconfig"; sourceTree = "<group>"; };
 		DA67DF58196D8F6A005B5BC8 /* WordPress 20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 20.xcdatamodel"; sourceTree = "<group>"; };
+		DC4C9905B8DB309BFF649BE9 /* Pods_WordPress.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPress.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-11-12.xcmappingmodel"; sourceTree = "<group>"; };
 		E105E9CD1726955600C0D9E7 /* WPAccount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAccount.h; sourceTree = "<group>"; };
 		E105E9CE1726955600C0D9E7 /* WPAccount.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAccount.m; sourceTree = "<group>"; };
@@ -1825,7 +1831,7 @@
 				FF3BD2EA1B061B9A0042E989 /* Fabric.framework in Frameworks */,
 				FD3D6D2C1349F5D30061136A /* ImageIO.framework in Frameworks */,
 				B5AA54D51A8E7510003BDD12 /* WebKit.framework in Frameworks */,
-				7E83042CB0F69860BDA2E03C /* Pods.framework in Frameworks */,
+				F477725AA87B0B631A004DAF /* Pods_WordPress.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2042,6 +2048,7 @@
 				FEA17846268DCBBC24066B34 /* Pods_UITests.framework */,
 				319EFA4C50275C720B7C8A35 /* Pods_WordPressTest.framework */,
 				BD8A4A8FA463E3CB668C322B /* Pods_WordPressTodayWidget.framework */,
+				DC4C9905B8DB309BFF649BE9 /* Pods_WordPress.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -3360,6 +3367,11 @@
 				E183E3D82448158B8BAD8975 /* Pods-UITests.release-alpha.xcconfig */,
 				4AACD85BFF0E9B208BED08CB /* Pods-WordPressTest.release-alpha.xcconfig */,
 				5E832683461888C51037AF39 /* Pods-WordPressTodayWidget.release-alpha.xcconfig */,
+				7A2C5111E37C5233A1AE8E41 /* Pods-WordPress.debug.xcconfig */,
+				0B2A5E7CD1F8E32549F3DC7E /* Pods-WordPress.release.xcconfig */,
+				0CE0577B6AC0CF064C42E6EA /* Pods-WordPress.release-internal.xcconfig */,
+				9BD01C5941FDF790A0A1C733 /* Pods-WordPress.release-alpha.xcconfig */,
+				D1EF4126815D101CC41FB7DF /* Pods-WordPress.distribution.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -4215,7 +4227,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-WordPress/Pods-WordPress-resources.sh\"\n";
 		};
 		855804B81A5C5EED008D5A77 /* Generate Build Icon */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -4284,7 +4296,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-WordPress/Pods-WordPress-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		BD568EA7006B338911997D59 /* Copy Pods Resources */ = {
@@ -5029,7 +5041,7 @@
 /* Begin XCBuildConfiguration section */
 		1D6058940D05DD3E006BFB54 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AC055AD29E203B2021E7F39B /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 7A2C5111E37C5233A1AE8E41 /* Pods-WordPress.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -5040,7 +5052,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -5093,7 +5104,7 @@
 		};
 		1D6058950D05DD3E006BFB54 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AEFB66560B716519236CEE67 /* Pods.release.xcconfig */;
+			baseConfigurationReference = 0B2A5E7CD1F8E32549F3DC7E /* Pods-WordPress.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -5104,7 +5115,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc. (PZYM8XX95Q)";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -5174,7 +5184,7 @@
 		};
 		2F30B4C20E342FDF00211B15 /* Distribution */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 501C8A355B53A6971F731ECA /* Pods.distribution.xcconfig */;
+			baseConfigurationReference = D1EF4126815D101CC41FB7DF /* Pods-WordPress.distribution.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -5185,7 +5195,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc. (PZYM8XX95Q)";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -5256,7 +5265,7 @@
 		};
 		8546B4441BEAD39700193C07 /* Release-Alpha */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AB830EB2431BD467F7034C8C /* Pods.release-alpha.xcconfig */;
+			baseConfigurationReference = 9BD01C5941FDF790A0A1C733 /* Pods-WordPress.release-alpha.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -5267,7 +5276,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -5520,7 +5528,7 @@
 		};
 		93DEAA9E182D567A004E34D1 /* Release-Internal */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C9F5071C28C57CE611E00B1F /* Pods.release-internal.xcconfig */;
+			baseConfigurationReference = 0CE0577B6AC0CF064C42E6EA /* Pods-WordPress.release-internal.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -5531,7 +5539,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/WordPress/WordPressTest/BlogJetpackTest.m
+++ b/WordPress/WordPressTest/BlogJetpackTest.m
@@ -190,7 +190,7 @@
     jetpackLegacyBlog.jetpackAccount = wpComAccount;
 
     // Wait on the merge to be completed
-    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     // test.blog + wp.com + jetpack
     XCTAssertEqual(1, [accountService numberOfAccounts]);

--- a/WordPress/WordPressTest/BlogJetpackTest.m
+++ b/WordPress/WordPressTest/BlogJetpackTest.m
@@ -188,6 +188,7 @@
                                           },
                                   };
     jetpackLegacyBlog.jetpackAccount = wpComAccount;
+    [[ContextManager sharedInstance] saveContextAndWait:self.testContextManager.mainContext];
 
     // Wait on the merge to be completed
     [self waitForExpectationsWithTimeout:2.0 handler:nil];

--- a/WordPress/WordPressTest/BlogJetpackTest.m
+++ b/WordPress/WordPressTest/BlogJetpackTest.m
@@ -188,7 +188,6 @@
                                           },
                                   };
     jetpackLegacyBlog.jetpackAccount = wpComAccount;
-    [[ContextManager sharedInstance] saveContextAndWait:self.testContextManager.mainContext];
 
     // Wait on the merge to be completed
     [self waitForExpectationsWithTimeout:2.0 handler:nil];

--- a/WordPress/WordPressTest/BlogJetpackTest.m
+++ b/WordPress/WordPressTest/BlogJetpackTest.m
@@ -42,6 +42,7 @@
                               @"readonly": @YES,
                               },
                       };
+    _blog.settings = (BlogSettings *)[NSEntityDescription insertNewObjectForEntityForName:@"BlogSettings" inManagedObjectContext:self.testContextManager.mainContext];
 }
 
 - (void)tearDown {

--- a/WordPress/WordPressTest/BlogJetpackTest.m
+++ b/WordPress/WordPressTest/BlogJetpackTest.m
@@ -190,7 +190,7 @@
     jetpackLegacyBlog.jetpackAccount = wpComAccount;
 
     // Wait on the merge to be completed
-    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
 
     // test.blog + wp.com + jetpack
     XCTAssertEqual(1, [accountService numberOfAccounts]);
@@ -209,7 +209,7 @@
     } failure:^(NSError *error) {
         XCTFail(@"Sync blogs shouldn't fail");
     }];
-    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
     // test.blog + wp.com
     XCTAssertEqual(1, [accountService numberOfAccounts]);


### PR DESCRIPTION
Things that I've changed to get this to build:

- Update CocoaLumberjack to 2.2.0
- Updated our pods to the versions that support CocoaLumberjack 2.2.0
- Removed NSLogger-CocoaLumberjack-connector. Nothing was using it, and
  the project is abandoned.
- Moved most of the dependencies to the WordPress target. This gets rid
  of most of the duplication errors

Fixes #4371

Needs Review: @diegoreymendez 