### PR TITLE
Fix media upload tracking on editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -790,13 +790,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)cancelMediaUploads
 {
     [self.mediaGlobalProgress cancel];
-    NSMutableArray * keys = [NSMutableArray array];
-    [self.mediaInProgress enumerateKeysAndObjectsUsingBlock:^(NSString * key, NSProgress * progress, BOOL *stop) {
-        if (progress.isCancelled){
-            [keys addObject:key];
-        }
-    }];
-    [self.mediaInProgress removeObjectsForKeys:keys];
+    [self.mediaInProgress removeAllObjects];
     [self autosaveContent];
     [self setupNavbar];
 }

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1583,8 +1583,8 @@ EditImageDetailsViewControllerDelegate
 
 - (BOOL)isMediaUploading
 {
-    for(NSProgress * progress in self.mediaInProgress.allValues) {
-        if (progress.totalUnitCount != 0){
+    for(NSProgress *progress in self.mediaInProgress.allValues) {
+        if (!progress.isCancelled && progress.totalUnitCount != 0){
             return YES;
         }
     }
@@ -1636,14 +1636,7 @@ EditImageDetailsViewControllerDelegate
     if (!uniqueMediaId) {
         return;
     }
-    NSProgress * progress = self.mediaInProgress[uniqueMediaId];
     [self.mediaInProgress removeObjectForKey:uniqueMediaId];
-    if (progress.isCancelled){
-        //on iOS 7 cancelled sub progress don't update the parent progress properly so we need to do it
-        if ( ![UIDevice isOS8] ) {
-            self.mediaGlobalProgress.completedUnitCount++;
-        }
-    }
     [self dismissAssociatedAlertControllerIfVisible:uniqueMediaId];
 }
 
@@ -1715,7 +1708,6 @@ EditImageDetailsViewControllerDelegate
             DDLogError(@"Failed Media Upload: %@", error.localizedDescription);
             [WPAnalytics track:WPAnalyticsStatEditorUploadMediaFailed];
             [self dismissAssociatedAlertControllerIfVisible:mediaUniqueId];
-            self.mediaGlobalProgress.completedUnitCount++;
             if (media.mediaType == MediaTypeImage) {
                 [self.editorView markImage:mediaUniqueId
                    failedUploadWithMessage:NSLocalizedString(@"Failed", @"The message that is overlay on media when the upload to server fails")];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1594,15 +1594,13 @@ EditImageDetailsViewControllerDelegate
 - (void)cancelMediaUploads
 {
     [self.mediaGlobalProgress cancel];
-    NSMutableArray * keys = [NSMutableArray array];
     [self.mediaInProgress enumerateKeysAndObjectsUsingBlock:^(NSString * key, NSProgress * progress, BOOL *stop) {
         if (progress.isCancelled){
             [self.editorView removeImage:key];
             [self.editorView removeVideo:key];
-            [keys addObject:key];
         }
     }];
-    [self.mediaInProgress removeObjectsForKeys:keys];
+    [self.mediaInProgress removeAllObjects];
     [self autosaveContent];
     [self refreshNavigationBarButtons:NO];
 }


### PR DESCRIPTION
There where reported situations when doing media uploads to the server where the status bar saying "Media uploading..." was never dismissed when the media finished.

This was track down to the following scenarios:

Scenario 1:

 - Start several media upload by selecting multiple images, 
 - then canceled one of the uploads
 - When the other uploads finished the status bar didn't get updated

Scenario 2:
 - Select one media to upload
 - Then add another media to upload while the first was still going
 - When the media finished upload the status didn't get updated.

Scenario 3:
 - Put yourself offline
 - Start to upload 1 or two medias
 - They should fail after a while but the status bar didn't updated.

This PR fixes this situation by removing some iOS 7 specific hacks and doing proper checks for canceled uploads.

Needs Review: @jleandroperez 