### PR TITLE
Nil checks for preventing crash when using dotComIDs for Tracks.

### DIFF
--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -67,7 +67,13 @@
                 WPAccount *account = [accountService findAccountWithUsername:dotcomUsername];
                 if (account) {
                     blog.jetpackAccount = account;
-                    [WPAnalytics track:WPAnalyticsStatSignedInToJetpack withProperties:@{ WPAppAnalyticsKeyBlogID:blog.dotComID }];
+                    
+                    NSNumber *dotComID = blog.dotComID;
+                    if(dotComID) {
+                        [WPAnalytics track:WPAnalyticsStatSignedInToJetpack withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID }];
+                    }else {
+                        [WPAnalytics track:WPAnalyticsStatSignedInToJetpack];
+                    }
                 }
             }
         } else {

--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -69,7 +69,7 @@
                     blog.jetpackAccount = account;
                     
                     NSNumber *dotComID = blog.dotComID;
-                    if(dotComID) {
+                    if (dotComID) {
                         [WPAnalytics track:WPAnalyticsStatSignedInToJetpack withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID }];
                     }else {
                         [WPAnalytics track:WPAnalyticsStatSignedInToJetpack];

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -138,9 +138,17 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
         void (^successBlock)() = ^void() {
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (like) {
-                    [WPAnalytics track:WPAnalyticsStatReaderArticleLiked withProperties:@{ WPAppAnalyticsKeyBlogID:readerPost.siteID }];
+                    if(readerPost.siteID) {
+                        [WPAnalytics track:WPAnalyticsStatReaderArticleLiked withProperties:@{ WPAppAnalyticsKeyBlogID:readerPost.siteID }];
+                    }else {
+                        [WPAnalytics track:WPAnalyticsStatReaderArticleLiked];
+                    }
                 } else {
-                    [WPAnalytics track:WPAnalyticsStatReaderArticleUnliked withProperties:@{ WPAppAnalyticsKeyBlogID:readerPost.siteID }];
+                    if(readerPost.siteID) {
+                        [WPAnalytics track:WPAnalyticsStatReaderArticleUnliked withProperties:@{ WPAppAnalyticsKeyBlogID:readerPost.siteID }];
+                    }else {
+                        [WPAnalytics track:WPAnalyticsStatReaderArticleUnliked];
+                    }
                 }
                 if (success) {
                     success();

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -87,7 +87,13 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
             if (success) {
                 success();
             }
-            [WPAnalytics track:WPAnalyticsStatReaderSiteFollowed withProperties:@{ WPAppAnalyticsKeyBlogID:@(siteID) }];
+            
+            if(siteID) {
+                [WPAnalytics track:WPAnalyticsStatReaderSiteFollowed withProperties:@{ WPAppAnalyticsKeyBlogID:@(siteID) }];
+            }else {
+                [WPAnalytics track:WPAnalyticsStatReaderSiteFollowed];
+            }
+            
         } failure:failure];
 
     } failure:^(NSError *error) {
@@ -112,7 +118,13 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
         if (success) {
             success();
         }
-        [WPAnalytics track:WPAnalyticsStatReaderSiteUnfollowed withProperties:@{ WPAppAnalyticsKeyBlogID:@(siteID) }];
+        
+        if(siteID) {
+            [WPAnalytics track:WPAnalyticsStatReaderSiteUnfollowed withProperties:@{ WPAppAnalyticsKeyBlogID:@(siteID) }];
+        }else {
+            [WPAnalytics track:WPAnalyticsStatReaderSiteUnfollowed];
+        }
+        
     } failure:failure];
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -441,8 +441,13 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
 - (NSDictionary *)propertiesForAnalytics
 {
+    NSNumber *dotComID = self.blog.dotComID;
+    if(!dotComID) {
+        return nil;
+    }
+    
     return @{
-             WPAppAnalyticsKeyBlogID:self.blog.dotComID,
+             WPAppAnalyticsKeyBlogID:dotComID,
              };
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -439,21 +439,15 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
 #pragma mark - Private methods
 
-- (NSDictionary *)propertiesForAnalytics
-{
-    NSNumber *dotComID = self.blog.dotComID;
-    if(!dotComID) {
-        return nil;
-    }
-    
-    return @{
-             WPAppAnalyticsKeyBlogID:dotComID,
-             };
-}
-
 - (void)showCommentsForBlog:(Blog *)blog
 {
-    [WPAnalytics track:WPAnalyticsStatOpenedComments withProperties:[self propertiesForAnalytics]];
+    NSNumber *dotComID = blog.dotComID;
+    if(dotComID) {
+        [WPAnalytics track:WPAnalyticsStatOpenedComments withProperties:@{WPAppAnalyticsKeyBlogID:dotComID}];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatOpenedComments];
+    }
+    
     CommentsViewController *controller = [[CommentsViewController alloc] initWithStyle:UITableViewStyleGrouped];
     controller.blog = blog;
     [self.navigationController pushViewController:controller animated:YES];
@@ -461,14 +455,26 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
 - (void)showPostListForBlog:(Blog *)blog
 {
-    [WPAnalytics track:WPAnalyticsStatOpenedPosts withProperties:[self propertiesForAnalytics]];
+    NSNumber *dotComID = blog.dotComID;
+    if(dotComID) {
+        [WPAnalytics track:WPAnalyticsStatOpenedPosts withProperties:@{WPAppAnalyticsKeyBlogID:dotComID}];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatOpenedPosts];
+    }
+    
     PostListViewController *controller = [PostListViewController controllerWithBlog:blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
 
 - (void)showPageListForBlog:(Blog *)blog
 {
-    [WPAnalytics track:WPAnalyticsStatOpenedPages withProperties:[self propertiesForAnalytics]];
+    NSNumber *dotComID = blog.dotComID;
+    if(dotComID) {
+        [WPAnalytics track:WPAnalyticsStatOpenedPages withProperties:@{WPAppAnalyticsKeyBlogID:dotComID}];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatOpenedPages];
+    }
+    
     PageListViewController *controller = [PageListViewController controllerWithBlog:blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
@@ -483,14 +489,26 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
 - (void)showSettingsForBlog:(Blog *)blog
 {
-    [WPAnalytics track:WPAnalyticsStatOpenedSettings withProperties:[self propertiesForAnalytics]];
+    NSNumber *dotComID = blog.dotComID;
+    if(dotComID) {
+        [WPAnalytics track:WPAnalyticsStatOpenedSettings withProperties:@{WPAppAnalyticsKeyBlogID:dotComID}];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatOpenedSettings];
+    }
+    
     SiteSettingsViewController *controller = [[SiteSettingsViewController alloc] initWithBlog:blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
 
 - (void)showStatsForBlog:(Blog *)blog
 {
-    [WPAnalytics track:WPAnalyticsStatStatsAccessed withProperties:[self propertiesForAnalytics]];
+    NSNumber *dotComID = blog.dotComID;
+    if(dotComID) {
+        [WPAnalytics track:WPAnalyticsStatStatsAccessed withProperties:@{WPAppAnalyticsKeyBlogID:dotComID}];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatStatsAccessed];
+    }
+    
     StatsViewController *statsView = [StatsViewController new];
     statsView.blog = blog;
     [self.navigationController pushViewController:statsView animated:YES];
@@ -498,7 +516,13 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
 - (void)showThemesForBlog:(Blog *)blog
 {
-    [WPAnalytics track:WPAnalyticsStatThemesAccessedThemeBrowser withProperties:[self propertiesForAnalytics]];
+    NSNumber *dotComID = blog.dotComID;
+    if(dotComID) {
+        [WPAnalytics track:WPAnalyticsStatThemesAccessedThemeBrowser withProperties:@{WPAppAnalyticsKeyBlogID:dotComID}];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatThemesAccessedThemeBrowser];
+    }
+    
     ThemeBrowserViewController *viewController = [ThemeBrowserViewController browserWithBlog:blog];
     [self.navigationController pushViewController:viewController
                                          animated:YES];
@@ -506,8 +530,13 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
 - (void)showViewSiteForBlog:(Blog *)blog
 {
-    [WPAnalytics track:WPAnalyticsStatOpenedViewSite withProperties:[self propertiesForAnalytics]];
-
+    NSNumber *dotComID = blog.dotComID;
+    if(dotComID) {
+        [WPAnalytics track:WPAnalyticsStatOpenedViewSite withProperties:@{WPAppAnalyticsKeyBlogID:dotComID}];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatOpenedViewSite];
+    }
+    
     NSURL *targetURL = [NSURL URLWithString:blog.homeURL];
     WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:targetURL];
     webViewController.authToken = blog.authToken;
@@ -526,8 +555,13 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
         return;
     }
 
-    [WPAnalytics track:WPAnalyticsStatOpenedViewAdmin withProperties:[self propertiesForAnalytics]];
-
+    NSNumber *dotComID = blog.dotComID;
+    if(dotComID) {
+        [WPAnalytics track:WPAnalyticsStatOpenedViewAdmin withProperties:@{WPAppAnalyticsKeyBlogID:dotComID}];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatOpenedViewAdmin];
+    }
+    
     NSString *dashboardUrl = [blog.xmlrpc stringByReplacingOccurrencesOfString:@"xmlrpc.php" withString:@"wp-admin/"];
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:dashboardUrl]];
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -442,7 +442,7 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 - (void)showCommentsForBlog:(Blog *)blog
 {
     NSNumber *dotComID = blog.dotComID;
-    if(dotComID) {
+    if (dotComID) {
         [WPAnalytics track:WPAnalyticsStatOpenedComments withProperties:@{WPAppAnalyticsKeyBlogID:dotComID}];
     }else {
         [WPAnalytics track:WPAnalyticsStatOpenedComments];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -1010,7 +1010,12 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 - (void)followSiteWithBlock:(NotificationBlock *)block
 {
-    [WPAnalytics track:WPAnalyticsStatNotificationsSiteFollowAction withProperties:@{ WPAppAnalyticsKeyBlogID:block.metaSiteID }];
+    NSNumber *metaSiteID = block.metaSiteID;
+    if(metaSiteID) {
+        [WPAnalytics track:WPAnalyticsStatNotificationsSiteFollowAction withProperties:@{ WPAppAnalyticsKeyBlogID:metaSiteID }];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatNotificationsSiteFollowAction];
+    }
     
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     ReaderSiteService *service      = [[ReaderSiteService alloc] initWithManagedObjectContext:context];
@@ -1026,7 +1031,12 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 - (void)unfollowSiteWithBlock:(NotificationBlock *)block
 {
-    [WPAnalytics track:WPAnalyticsStatNotificationsSiteUnfollowAction withProperties:@{ WPAppAnalyticsKeyBlogID:block.metaSiteID }];
+    NSNumber *metaSiteID = block.metaSiteID;
+    if(metaSiteID) {
+        [WPAnalytics track:WPAnalyticsStatNotificationsSiteUnfollowAction withProperties:@{ WPAppAnalyticsKeyBlogID:metaSiteID }];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatNotificationsSiteUnfollowAction];
+    }
     
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     ReaderSiteService *service      = [[ReaderSiteService alloc] initWithManagedObjectContext:context];
@@ -1042,7 +1052,12 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 - (void)likeCommentWithBlock:(NotificationBlock *)block
 {
-    [WPAnalytics track:WPAnalyticsStatNotificationsCommentLiked withProperties:@{ WPAppAnalyticsKeyBlogID:block.metaSiteID }];
+    NSNumber *metaSiteID = block.metaSiteID;
+    if(metaSiteID) {
+        [WPAnalytics track:WPAnalyticsStatNotificationsCommentLiked withProperties:@{ WPAppAnalyticsKeyBlogID:metaSiteID }];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatNotificationsCommentLiked];
+    }
 
     // If the associated comment is *not* approved, let's attempt to auto-approve it, automatically
     if (!block.isCommentApproved) {
@@ -1064,7 +1079,12 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 - (void)unlikeCommentWithBlock:(NotificationBlock *)block
 {
-    [WPAnalytics track:WPAnalyticsStatNotificationsCommentUnliked withProperties:@{ WPAppAnalyticsKeyBlogID:block.metaSiteID }];
+    NSNumber *metaSiteID = block.metaSiteID;
+    if(metaSiteID) {
+        [WPAnalytics track:WPAnalyticsStatNotificationsCommentUnliked withProperties:@{ WPAppAnalyticsKeyBlogID:metaSiteID }];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatNotificationsCommentUnliked];
+    }
     
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     CommentService *service         = [[CommentService alloc] initWithManagedObjectContext:context];
@@ -1080,7 +1100,12 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 - (void)approveCommentWithBlock:(NotificationBlock *)block
 {
-    [WPAnalytics track:WPAnalyticsStatNotificationsCommentApproved withProperties:@{ WPAppAnalyticsKeyBlogID:block.metaSiteID }];
+    NSNumber *metaSiteID = block.metaSiteID;
+    if(metaSiteID) {
+        [WPAnalytics track:WPAnalyticsStatNotificationsCommentApproved withProperties:@{ WPAppAnalyticsKeyBlogID:metaSiteID }];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatNotificationsCommentApproved];
+    }
     
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     CommentService *service         = [[CommentService alloc] initWithManagedObjectContext:context];
@@ -1100,7 +1125,12 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 - (void)unapproveCommentWithBlock:(NotificationBlock *)block
 {
-    [WPAnalytics track:WPAnalyticsStatNotificationsCommentUnapproved withProperties:@{ WPAppAnalyticsKeyBlogID:block.metaSiteID }];
+    NSNumber *metaSiteID = block.metaSiteID;
+    if(metaSiteID) {
+        [WPAnalytics track:WPAnalyticsStatNotificationsCommentUnapproved withProperties:@{ WPAppAnalyticsKeyBlogID:metaSiteID }];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatNotificationsCommentUnapproved];
+    }
     
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     CommentService *service         = [[CommentService alloc] initWithManagedObjectContext:context];
@@ -1136,7 +1166,12 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
             onCompletion(NO);
         }];
         
-        [WPAnalytics track:WPAnalyticsStatNotificationsCommentFlaggedAsSpam withProperties:@{ WPAppAnalyticsKeyBlogID:block.metaSiteID }];
+        NSNumber *metaSiteID = block.metaSiteID;
+        if(metaSiteID) {
+            [WPAnalytics track:WPAnalyticsStatNotificationsCommentFlaggedAsSpam withProperties:@{ WPAppAnalyticsKeyBlogID:metaSiteID }];
+        }else {
+            [WPAnalytics track:WPAnalyticsStatNotificationsCommentFlaggedAsSpam];
+        }
     };
     
     // Confirmation AlertView
@@ -1174,7 +1209,12 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
             onCompletion(NO);
         }];
         
-        [WPAnalytics track:WPAnalyticsStatNotificationsCommentTrashed withProperties:@{ WPAppAnalyticsKeyBlogID:block.metaSiteID }];
+        NSNumber *metaSiteID = block.metaSiteID;
+        if(metaSiteID) {
+            [WPAnalytics track:WPAnalyticsStatNotificationsCommentTrashed withProperties:@{ WPAppAnalyticsKeyBlogID:metaSiteID }];
+        }else {
+            [WPAnalytics track:WPAnalyticsStatNotificationsCommentTrashed];
+        }
     };
     
     // Confirmation AlertView

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
@@ -357,8 +357,13 @@ static NSString * const CurrentPageListStatusFilterKey = @"CurrentPageListStatus
 
     [self presentViewController:navController animated:YES completion:nil];
 
-    [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
-        withProperties:@{ @"tap_source": @"posts_view",  WPAppAnalyticsKeyBlogID:self.blog.dotComID }];
+    NSNumber *dotComId = self.blog.dotComID;
+    if(dotComId) {
+        [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
+            withProperties:@{ @"tap_source": @"posts_view",  WPAppAnalyticsKeyBlogID:dotComId }];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"posts_view"}];
+    }
 }
 
 - (void)editPage:(AbstractPost *)apost

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
@@ -357,10 +357,10 @@ static NSString * const CurrentPageListStatusFilterKey = @"CurrentPageListStatus
 
     [self presentViewController:navController animated:YES completion:nil];
 
-    NSNumber *dotComId = self.blog.dotComID;
-    if(dotComId) {
+    NSNumber *dotComID = self.blog.dotComID;
+    if (dotComID) {
         [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
-            withProperties:@{ @"tap_source": @"posts_view",  WPAppAnalyticsKeyBlogID:dotComId }];
+            withProperties:@{ @"tap_source": @"posts_view",  WPAppAnalyticsKeyBlogID:dotComID }];
     }else {
         [WPAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"posts_view"}];
     }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -284,7 +284,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     properties[@"filter"] = self.currentPostListFilter.title;
     
     NSNumber *dotComID = self.blog.dotComID;
-    if(dotComID) {
+    if (dotComID) {
         properties[WPAppAnalyticsKeyBlogID] = dotComID;
     }
     

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -279,11 +279,16 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 
 - (NSDictionary *)propertiesForAnalytics
 {
-    return @{
-             @"type":[self postTypeToSync],
-             @"filter":self.currentPostListFilter.title,
-             WPAppAnalyticsKeyBlogID:self.blog.dotComID,
-             };
+    NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:3];
+    properties[@"type"] = [self postTypeToSync];
+    properties[@"filter"] = self.currentPostListFilter.title;
+    
+    NSNumber *dotComID = self.blog.dotComID;
+    if(dotComID) {
+        properties[WPAppAnalyticsKeyBlogID] = dotComID;
+    }
+    
+    return properties;
 }
 
 #pragma mark - Actions

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -437,10 +437,10 @@ static const CGFloat PostListHeightForFooterView = 34.0;
 
     [self presentViewController:navController animated:YES completion:nil];
     
-    NSNumber *dotComId = self.blog.dotComID;
-    if(dotComId) {
+    NSNumber *dotComID = self.blog.dotComID;
+    if (dotComID) {
         [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
-            withProperties:@{ @"tap_source": @"posts_view", WPAppAnalyticsKeyBlogID:dotComId}];
+            withProperties:@{ @"tap_source": @"posts_view", WPAppAnalyticsKeyBlogID:dotComID}];
     }else {
         [WPAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"posts_view"}];
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -440,7 +440,9 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     NSNumber *dotComId = self.blog.dotComID;
     if(dotComId) {
         [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
-            withProperties:@{ @"tap_source": @"posts_view",  WPAppAnalyticsKeyBlogID:dotComId}];
+            withProperties:@{ @"tap_source": @"posts_view", WPAppAnalyticsKeyBlogID:dotComId}];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"posts_view"}];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -437,8 +437,11 @@ static const CGFloat PostListHeightForFooterView = 34.0;
 
     [self presentViewController:navController animated:YES completion:nil];
     
-    [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
-        withProperties:@{ @"tap_source": @"posts_view",  WPAppAnalyticsKeyBlogID:self.blog.dotComID }];
+    NSNumber *dotComId = self.blog.dotComID;
+    if(dotComId) {
+        [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
+            withProperties:@{ @"tap_source": @"posts_view",  WPAppAnalyticsKeyBlogID:dotComId}];
+    }
 }
 
 - (void)previewEditPost:(AbstractPost *)apost

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -367,7 +367,10 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     }
 
     if (![self.post hasUnsavedChanges]) {
-        [WPAnalytics track:WPAnalyticsStatEditorClosed withProperties:@{ WPAppAnalyticsKeyBlogID:self.post.blog.dotComID} ];
+        NSNumber *dotComId = self.post.blog.dotComID;
+        if(dotComId) {
+            [WPAnalytics track:WPAnalyticsStatEditorClosed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+        }
         [self discardChanges];
         [self dismissEditView];
         return;
@@ -384,7 +387,10 @@ static void *ProgressObserverContext = &ProgressObserverContext;
                                 handler:^(UIAlertAction * action) {
                                     [self discardChanges];
                                     [self dismissEditView];
-                                    [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges withProperties:@{ WPAppAnalyticsKeyBlogID:self.post.blog.dotComID} ];
+                                    NSNumber *dotComId = self.post.blog.dotComID;
+                                    if(dotComId) {
+                                        [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+                                    }
                                 }];
     
     if ([self.post.original.status isEqualToString:PostStatusDraft]) {
@@ -665,7 +671,10 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         properties[@"word_diff_count"] = @(wordCount - originalWordCount);
     }
 
-    properties[WPAppAnalyticsKeyBlogID] = [self.post blog].dotComID;
+    NSNumber *dotComId = [self.post blog].dotComID;
+    if(dotComId) {
+        properties[WPAppAnalyticsKeyBlogID] = dotComId;
+    }
     
     if ([buttonTitle isEqualToString:NSLocalizedString(@"Publish", nil)]) {
         properties[WPAnalyticsStatEditorPublishedPostPropertyCategory] = @([self.post hasCategories]);
@@ -961,7 +970,10 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)insertMedia:(Media *)media
 {
-    [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:[self.post blog].dotComID} ];
+    NSNumber *dotComId = [self.post blog].dotComID;
+    if(dotComId) {
+        [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+    }
     
     NSString *prefix = @"<br /><br />";
 

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -367,9 +367,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     }
 
     if (![self.post hasUnsavedChanges]) {
-        NSNumber *dotComId = self.post.blog.dotComID;
-        if(dotComId) {
-            [WPAnalytics track:WPAnalyticsStatEditorClosed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+        NSNumber *dotComID = self.post.blog.dotComID;
+        if (dotComID) {
+            [WPAnalytics track:WPAnalyticsStatEditorClosed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID} ];
         }else {
             [WPAnalytics track:WPAnalyticsStatEditorClosed];
         }
@@ -389,9 +389,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
                                 handler:^(UIAlertAction * action) {
                                     [self discardChanges];
                                     [self dismissEditView];
-                                    NSNumber *dotComId = self.post.blog.dotComID;
-                                    if(dotComId) {
-                                        [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+                                    NSNumber *dotComID = self.post.blog.dotComID;
+                                    if (dotComID) {
+                                        [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID} ];
                                     }else {
                                         [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges];
                                     }
@@ -675,9 +675,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         properties[@"word_diff_count"] = @(wordCount - originalWordCount);
     }
 
-    NSNumber *dotComId = [self.post blog].dotComID;
-    if(dotComId) {
-        properties[WPAppAnalyticsKeyBlogID] = dotComId;
+    NSNumber *dotComID = [self.post blog].dotComID;
+    if (dotComID) {
+        properties[WPAppAnalyticsKeyBlogID] = dotComID;
     }
     
     if ([buttonTitle isEqualToString:NSLocalizedString(@"Publish", nil)]) {
@@ -974,9 +974,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)insertMedia:(Media *)media
 {
-    NSNumber *dotComId = [self.post blog].dotComID;
-    if(dotComId) {
-        [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+    NSNumber *dotComID = [self.post blog].dotComID;
+    if (dotComID) {
+        [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID} ];
     }else {
         [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary];
     }

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -370,6 +370,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         NSNumber *dotComId = self.post.blog.dotComID;
         if(dotComId) {
             [WPAnalytics track:WPAnalyticsStatEditorClosed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+        }else {
+            [WPAnalytics track:WPAnalyticsStatEditorClosed];
         }
         [self discardChanges];
         [self dismissEditView];
@@ -390,6 +392,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
                                     NSNumber *dotComId = self.post.blog.dotComID;
                                     if(dotComId) {
                                         [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+                                    }else {
+                                        [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges];
                                     }
                                 }];
     
@@ -973,6 +977,8 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     NSNumber *dotComId = [self.post blog].dotComID;
     if(dotComId) {
         [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary];
     }
     
     NSString *prefix = @"<br /><br />";

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1376,6 +1376,11 @@ EditImageDetailsViewControllerDelegate
     NSAssert([context isKindOfClass:[NSManagedObjectContext class]],
              @"The object should be related to a managed object context here.");
     
+    NSNumber *dotComId = [self.post blog].dotComID;
+    if(dotComId) {
+        [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+    }
+    
     self.post = self.post.original;
     [self.post deleteRevision];
     
@@ -1385,8 +1390,6 @@ EditImageDetailsViewControllerDelegate
     }
     
     [[ContextManager sharedInstance] saveContext:context];
-    
-    [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges withProperties:@{ WPAppAnalyticsKeyBlogID:[self.post blog].dotComID}];
 }
 
 /**
@@ -1407,6 +1410,11 @@ EditImageDetailsViewControllerDelegate
 
 - (void)dismissEditViewAnimated:(BOOL)animated
 {
+    NSNumber *dotComId = [self.post blog].dotComID;
+    if(dotComId) {
+        [WPAnalytics track:WPAnalyticsStatEditorClosed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+    }
+    
     if (self.onClose) {
         self.onClose();
         self.onClose = nil;
@@ -1415,8 +1423,6 @@ EditImageDetailsViewControllerDelegate
     } else {
         [self.navigationController popViewControllerAnimated:animated];
     }
-    
-    [WPAnalytics track:WPAnalyticsStatEditorClosed withProperties:@{ WPAppAnalyticsKeyBlogID:[self.post blog].dotComID}];
 }
 
 - (void)dismissEditView
@@ -1526,7 +1532,10 @@ EditImageDetailsViewControllerDelegate
         properties[@"word_diff_count"] = @(wordCount - originalWordCount);
     }
 
-    properties[WPAppAnalyticsKeyBlogID] = [self.post blog].dotComID;
+    NSNumber *dotComId = [self.post blog].dotComID;
+    if(dotComId) {
+        properties[WPAppAnalyticsKeyBlogID] = dotComId;
+    }
     
     if ([buttonTitle isEqualToString:NSLocalizedString(@"Post", nil)]) {
         properties[WPAnalyticsStatEditorPublishedPostPropertyCategory] = @([self.post hasCategories]);
@@ -1707,10 +1716,16 @@ EditImageDetailsViewControllerDelegate
     NSProgress *uploadProgress = nil;
     [mediaService uploadMedia:media progress:&uploadProgress success:^{
         if (media.mediaType == MediaTypeImage) {
-            [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:[self.post blog].dotComID}];
+            NSNumber *dotComId = [self.post blog].dotComID;
+            if(dotComId) {
+                [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+            }
             [self.editorView replaceLocalImageWithRemoteImage:media.remoteURL uniqueId:mediaUniqueId];
         } else if (media.mediaType == MediaTypeVideo) {
-            [WPAnalytics track:WPAnalyticsStatEditorAddedVideoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:[self.post blog].dotComID}];
+            NSNumber *dotComId = [self.post blog].dotComID;
+            if(dotComId) {
+                [WPAnalytics track:WPAnalyticsStatEditorAddedVideoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+            }
             [self.editorView replaceLocalVideoWithID:mediaUniqueId
                                       forRemoteVideo:media.remoteURL
                                         remotePoster:media.posterImageURL
@@ -1727,7 +1742,10 @@ EditImageDetailsViewControllerDelegate
             [media remove];
         } else {
             DDLogError(@"Failed Media Upload: %@", error.localizedDescription);
-            [WPAnalytics track:WPAnalyticsStatEditorUploadMediaFailed withProperties:@{ WPAppAnalyticsKeyBlogID:[self.post blog].dotComID}];
+            NSNumber *dotComId = [self.post blog].dotComID;
+            if(dotComId) {
+                [WPAnalytics track:WPAnalyticsStatEditorUploadMediaFailed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+            }
             [self dismissAssociatedAlertControllerIfVisible:mediaUniqueId];
             self.mediaGlobalProgress.completedUnitCount++;
             if (media.mediaType == MediaTypeImage) {
@@ -1747,7 +1765,10 @@ EditImageDetailsViewControllerDelegate
 
 - (void)retryUploadOfMediaWithId:(NSString *)imageUniqueId
 {
-    [WPAnalytics track:WPAnalyticsStatEditorUploadMediaRetried withProperties:@{ WPAppAnalyticsKeyBlogID:[self.post blog].dotComID} ];
+    NSNumber *dotComId = [self.post blog].dotComID;
+    if(dotComId) {
+        [WPAnalytics track:WPAnalyticsStatEditorUploadMediaRetried withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+    }
 
     NSProgress *progress = self.mediaInProgress[imageUniqueId];
     if (!progress) {
@@ -1996,7 +2017,10 @@ EditImageDetailsViewControllerDelegate
 
 - (void)displayImageDetailsForMeta:(WPImageMeta *)imageMeta
 {
-    [WPAnalytics track:WPAnalyticsStatEditorEditedImage withProperties:@{ WPAppAnalyticsKeyBlogID:[self.post blog].dotComID} ];
+    NSNumber *dotComId = [self.post blog].dotComID;
+    if(dotComId) {
+        [WPAnalytics track:WPAnalyticsStatEditorEditedImage withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+    }
     
     EditImageDetailsViewController *controller = [EditImageDetailsViewController controllerForDetails:imageMeta forPost:self.post];
     controller.delegate = self;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1379,6 +1379,8 @@ EditImageDetailsViewControllerDelegate
     NSNumber *dotComId = [self.post blog].dotComID;
     if(dotComId) {
         [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges];
     }
     
     self.post = self.post.original;
@@ -1413,6 +1415,8 @@ EditImageDetailsViewControllerDelegate
     NSNumber *dotComId = [self.post blog].dotComID;
     if(dotComId) {
         [WPAnalytics track:WPAnalyticsStatEditorClosed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatEditorClosed];
     }
     
     if (self.onClose) {
@@ -1719,12 +1723,16 @@ EditImageDetailsViewControllerDelegate
             NSNumber *dotComId = [self.post blog].dotComID;
             if(dotComId) {
                 [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+            }else {
+                [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary];
             }
             [self.editorView replaceLocalImageWithRemoteImage:media.remoteURL uniqueId:mediaUniqueId];
         } else if (media.mediaType == MediaTypeVideo) {
             NSNumber *dotComId = [self.post blog].dotComID;
             if(dotComId) {
                 [WPAnalytics track:WPAnalyticsStatEditorAddedVideoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+            }else {
+                [WPAnalytics track:WPAnalyticsStatEditorAddedVideoViaLocalLibrary];
             }
             [self.editorView replaceLocalVideoWithID:mediaUniqueId
                                       forRemoteVideo:media.remoteURL
@@ -1745,6 +1753,8 @@ EditImageDetailsViewControllerDelegate
             NSNumber *dotComId = [self.post blog].dotComID;
             if(dotComId) {
                 [WPAnalytics track:WPAnalyticsStatEditorUploadMediaFailed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+            }else {
+                [WPAnalytics track:WPAnalyticsStatEditorUploadMediaFailed];
             }
             [self dismissAssociatedAlertControllerIfVisible:mediaUniqueId];
             self.mediaGlobalProgress.completedUnitCount++;
@@ -1768,6 +1778,8 @@ EditImageDetailsViewControllerDelegate
     NSNumber *dotComId = [self.post blog].dotComID;
     if(dotComId) {
         [WPAnalytics track:WPAnalyticsStatEditorUploadMediaRetried withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatEditorUploadMediaRetried];
     }
 
     NSProgress *progress = self.mediaInProgress[imageUniqueId];
@@ -2020,6 +2032,8 @@ EditImageDetailsViewControllerDelegate
     NSNumber *dotComId = [self.post blog].dotComID;
     if(dotComId) {
         [WPAnalytics track:WPAnalyticsStatEditorEditedImage withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+    }else {
+        [WPAnalytics track:WPAnalyticsStatEditorEditedImage];
     }
     
     EditImageDetailsViewController *controller = [EditImageDetailsViewController controllerForDetails:imageMeta forPost:self.post];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1376,9 +1376,9 @@ EditImageDetailsViewControllerDelegate
     NSAssert([context isKindOfClass:[NSManagedObjectContext class]],
              @"The object should be related to a managed object context here.");
     
-    NSNumber *dotComId = [self.post blog].dotComID;
-    if(dotComId) {
-        [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+    NSNumber *dotComID = [self.post blog].dotComID;
+    if (dotComID) {
+        [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID}];
     }else {
         [WPAnalytics track:WPAnalyticsStatEditorDiscardedChanges];
     }
@@ -1412,9 +1412,9 @@ EditImageDetailsViewControllerDelegate
 
 - (void)dismissEditViewAnimated:(BOOL)animated
 {
-    NSNumber *dotComId = [self.post blog].dotComID;
-    if(dotComId) {
-        [WPAnalytics track:WPAnalyticsStatEditorClosed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+    NSNumber *dotComID = [self.post blog].dotComID;
+    if (dotComID) {
+        [WPAnalytics track:WPAnalyticsStatEditorClosed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID}];
     }else {
         [WPAnalytics track:WPAnalyticsStatEditorClosed];
     }
@@ -1536,9 +1536,9 @@ EditImageDetailsViewControllerDelegate
         properties[@"word_diff_count"] = @(wordCount - originalWordCount);
     }
 
-    NSNumber *dotComId = [self.post blog].dotComID;
-    if(dotComId) {
-        properties[WPAppAnalyticsKeyBlogID] = dotComId;
+    NSNumber *dotComID = [self.post blog].dotComID;
+    if (dotComID) {
+        properties[WPAppAnalyticsKeyBlogID] = dotComID;
     }
     
     if ([buttonTitle isEqualToString:NSLocalizedString(@"Post", nil)]) {
@@ -1720,17 +1720,17 @@ EditImageDetailsViewControllerDelegate
     NSProgress *uploadProgress = nil;
     [mediaService uploadMedia:media progress:&uploadProgress success:^{
         if (media.mediaType == MediaTypeImage) {
-            NSNumber *dotComId = [self.post blog].dotComID;
-            if(dotComId) {
-                [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+            NSNumber *dotComID = [self.post blog].dotComID;
+            if (dotComID) {
+                [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID}];
             }else {
                 [WPAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary];
             }
             [self.editorView replaceLocalImageWithRemoteImage:media.remoteURL uniqueId:mediaUniqueId];
         } else if (media.mediaType == MediaTypeVideo) {
-            NSNumber *dotComId = [self.post blog].dotComID;
-            if(dotComId) {
-                [WPAnalytics track:WPAnalyticsStatEditorAddedVideoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+            NSNumber *dotComID = [self.post blog].dotComID;
+            if (dotComID) {
+                [WPAnalytics track:WPAnalyticsStatEditorAddedVideoViaLocalLibrary withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID}];
             }else {
                 [WPAnalytics track:WPAnalyticsStatEditorAddedVideoViaLocalLibrary];
             }
@@ -1750,9 +1750,9 @@ EditImageDetailsViewControllerDelegate
             [media remove];
         } else {
             DDLogError(@"Failed Media Upload: %@", error.localizedDescription);
-            NSNumber *dotComId = [self.post blog].dotComID;
-            if(dotComId) {
-                [WPAnalytics track:WPAnalyticsStatEditorUploadMediaFailed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId}];
+            NSNumber *dotComID = [self.post blog].dotComID;
+            if (dotComID) {
+                [WPAnalytics track:WPAnalyticsStatEditorUploadMediaFailed withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID}];
             }else {
                 [WPAnalytics track:WPAnalyticsStatEditorUploadMediaFailed];
             }
@@ -1775,9 +1775,9 @@ EditImageDetailsViewControllerDelegate
 
 - (void)retryUploadOfMediaWithId:(NSString *)imageUniqueId
 {
-    NSNumber *dotComId = [self.post blog].dotComID;
-    if(dotComId) {
-        [WPAnalytics track:WPAnalyticsStatEditorUploadMediaRetried withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+    NSNumber *dotComID = [self.post blog].dotComID;
+    if (dotComID) {
+        [WPAnalytics track:WPAnalyticsStatEditorUploadMediaRetried withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID} ];
     }else {
         [WPAnalytics track:WPAnalyticsStatEditorUploadMediaRetried];
     }
@@ -2029,9 +2029,9 @@ EditImageDetailsViewControllerDelegate
 
 - (void)displayImageDetailsForMeta:(WPImageMeta *)imageMeta
 {
-    NSNumber *dotComId = [self.post blog].dotComID;
-    if(dotComId) {
-        [WPAnalytics track:WPAnalyticsStatEditorEditedImage withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId} ];
+    NSNumber *dotComID = [self.post blog].dotComID;
+    if (dotComID) {
+        [WPAnalytics track:WPAnalyticsStatEditorEditedImage withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID} ];
     }else {
         [WPAnalytics track:WPAnalyticsStatEditorEditedImage];
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -783,7 +783,13 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 {
     __typeof(self) __weak weakSelf = self;
     void (^successBlock)() = ^void() {
-        [WPAnalytics track:WPAnalyticsStatReaderArticleCommentedOn withProperties:@{ WPAppAnalyticsKeyBlogID:self.post.siteID }];
+        NSNumber *siteID = self.post.siteID;
+        if(siteID) {
+            [WPAnalytics track:WPAnalyticsStatReaderArticleCommentedOn withProperties:@{ WPAppAnalyticsKeyBlogID:siteID}];
+        }else {
+            [WPAnalytics track:WPAnalyticsStatReaderArticleCommentedOn];
+        }
+        
         [weakSelf.tableView deselectSelectedRowWithAnimation:YES];
         [weakSelf refreshReplyTextViewPlaceholder];
     };

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
@@ -430,11 +430,16 @@ NSString * const ReaderPixelStatReferrer = @"https://wordpress.com/";
     self.didBumpStats = YES;
     NSString *isOfflineView = [ReachabilityUtils isInternetReachable] ? @"no" : @"yes";
     NSString *detailType = (self.post.topic.type == ReaderSiteTopic.TopicType) ? ReaderDetailTypePreviewSite : ReaderDetailTypeNormal;
-    NSDictionary *properties = @{
-                                 ReaderDetailTypeKey:detailType,
-                                 ReaderDetailOfflineKey:isOfflineView,
-                                 WPAppAnalyticsKeyBlogID:self.post.siteID
-                                 };
+
+    NSMutableDictionary *properties = [NSMutableDictionary dictionaryWithCapacity:3];
+    properties[ReaderDetailTypeKey] = detailType;
+    properties[ReaderDetailOfflineKey] = isOfflineView;
+    
+    NSNumber *siteID = self.post.siteID;
+    if(siteID) {
+        properties[WPAppAnalyticsKeyBlogID] = siteID;
+    }
+    
     [WPAnalytics track:WPAnalyticsStatReaderArticleOpened withProperties:properties];
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -143,6 +143,9 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
             if(dotComId) {
                 [WPAnalytics track:WPAnalyticsStatSignedInToJetpack withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId }];
                 [WPAnalytics track:WPAnalyticsStatPerformedJetpackSignInFromStatsScreen withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId }];
+            }else {
+                [WPAnalytics track:WPAnalyticsStatSignedInToJetpack];
+                [WPAnalytics track:WPAnalyticsStatPerformedJetpackSignInFromStatsScreen];
             }
             [safeController.view removeFromSuperview];
             [safeController removeFromParentViewController];

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -138,8 +138,12 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     __weak JetpackSettingsViewController *safeController = controller;
     [controller setCompletionBlock:^(BOOL didAuthenticate) {
         if (didAuthenticate) {
-            [WPAnalytics track:WPAnalyticsStatSignedInToJetpack withProperties:@{ WPAppAnalyticsKeyBlogID:self.blog.dotComID }];
-            [WPAnalytics track:WPAnalyticsStatPerformedJetpackSignInFromStatsScreen withProperties:@{ WPAppAnalyticsKeyBlogID:self.blog.dotComID }];
+            
+            NSNumber *dotComId = self.blog.dotComID;
+            if(dotComId) {
+                [WPAnalytics track:WPAnalyticsStatSignedInToJetpack withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId }];
+                [WPAnalytics track:WPAnalyticsStatPerformedJetpackSignInFromStatsScreen withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId }];
+            }
             [safeController.view removeFromSuperview];
             [safeController removeFromParentViewController];
             self.showingJetpackLogin = NO;

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -139,10 +139,10 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     [controller setCompletionBlock:^(BOOL didAuthenticate) {
         if (didAuthenticate) {
             
-            NSNumber *dotComId = self.blog.dotComID;
-            if(dotComId) {
-                [WPAnalytics track:WPAnalyticsStatSignedInToJetpack withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId }];
-                [WPAnalytics track:WPAnalyticsStatPerformedJetpackSignInFromStatsScreen withProperties:@{ WPAppAnalyticsKeyBlogID:dotComId }];
+            NSNumber *dotComID = self.blog.dotComID;
+            if (dotComID) {
+                [WPAnalytics track:WPAnalyticsStatSignedInToJetpack withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID }];
+                [WPAnalytics track:WPAnalyticsStatPerformedJetpackSignInFromStatsScreen withProperties:@{ WPAppAnalyticsKeyBlogID:dotComID }];
             }else {
                 [WPAnalytics track:WPAnalyticsStatSignedInToJetpack];
                 [WPAnalytics track:WPAnalyticsStatPerformedJetpackSignInFromStatsScreen];

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -297,8 +297,13 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
     if ([WPPostViewController isNewEditorEnabled]) {
         WPPostViewController *editPostViewController;
         if (!options) {
-            [WPAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar", WPAppAnalyticsKeyBlogID:[editPostViewController post].blog.dotComID}];
+
             editPostViewController = [[WPPostViewController alloc] initWithDraftForLastUsedBlog];
+            NSNumber *dotComId = [editPostViewController post].blog.dotComID;
+            if(dotComId) {
+                [WPAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar", WPAppAnalyticsKeyBlogID:dotComId}];
+            }
+            
         } else {
             if (options[WPPostViewControllerOptionOpenMediaPicker]) {
                 editPostViewController = [[WPPostViewController alloc] initWithDraftForLastUsedBlogAndPhotoPost];
@@ -323,8 +328,11 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
             NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
             BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
             Blog *blog = [blogService lastUsedOrFirstBlog];
-            [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
-                withProperties:@{ @"tap_source": @"tab_bar", WPAppAnalyticsKeyBlogID:blog.dotComID}];
+            NSNumber *dotComId = blog.dotComID;
+            if(dotComId) {
+                [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
+                    withProperties:@{ @"tap_source": @"tab_bar", WPAppAnalyticsKeyBlogID:dotComId}];
+            }
         } else {
             editPostLegacyViewController = [[WPLegacyEditPostViewController alloc] initWithTitle:[options stringForKey:WPNewPostURLParamTitleKey]
                                                                                       andContent:[options stringForKey:WPNewPostURLParamContentKey]

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -299,9 +299,9 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
         if (!options) {
 
             editPostViewController = [[WPPostViewController alloc] initWithDraftForLastUsedBlog];
-            NSNumber *dotComId = [editPostViewController post].blog.dotComID;
-            if(dotComId) {
-                [WPAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar", WPAppAnalyticsKeyBlogID:dotComId}];
+            NSNumber *dotComID = [editPostViewController post].blog.dotComID;
+            if (dotComID) {
+                [WPAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar", WPAppAnalyticsKeyBlogID:dotComID}];
             }else {
                 [WPAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar"}];
             }
@@ -330,10 +330,10 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
             NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
             BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
             Blog *blog = [blogService lastUsedOrFirstBlog];
-            NSNumber *dotComId = blog.dotComID;
-            if(dotComId) {
+            NSNumber *dotComID = blog.dotComID;
+            if (dotComID) {
                 [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
-                    withProperties:@{ @"tap_source": @"tab_bar", WPAppAnalyticsKeyBlogID:dotComId}];
+                    withProperties:@{ @"tap_source": @"tab_bar", WPAppAnalyticsKeyBlogID:dotComID}];
             }else {
                 [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
                     withProperties:@{ @"tap_source": @"tab_bar"}];

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -302,6 +302,8 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
             NSNumber *dotComId = [editPostViewController post].blog.dotComID;
             if(dotComId) {
                 [WPAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar", WPAppAnalyticsKeyBlogID:dotComId}];
+            }else {
+                [WPAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar"}];
             }
             
         } else {
@@ -332,6 +334,9 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
             if(dotComId) {
                 [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
                     withProperties:@{ @"tap_source": @"tab_bar", WPAppAnalyticsKeyBlogID:dotComId}];
+            }else {
+                [WPAnalytics track:WPAnalyticsStatEditorCreatedPost
+                    withProperties:@{ @"tap_source": @"tab_bar"}];
             }
         } else {
             editPostLegacyViewController = [[WPLegacyEditPostViewController alloc] initWithTitle:[options stringForKey:WPNewPostURLParamTitleKey]


### PR DESCRIPTION
Changes in https://github.com/wordpress-mobile/WordPress-iOS/commit/0b7e2da6103874db4da49dda77f35321310db38a created multiple crash cases for when the `dotComID` method returns `nil`.

Testing for crash:
1. Open app
2. Hit Post button on TabBar (crash)
3. Dismiss TabBar (crash)

UPDATE:
Also additional crash issues of `nil` IDs in https://github.com/wordpress-mobile/WordPress-iOS/pull/4443

@alexcurylo please review the simple `nil` checks added here for protection against crashing.

@daniloercoli Please take a look at these changes and refactor for what should be tracked or passed when the `dotComID` returns `nil` instead.