### PR TITLE
BlogSettings: Updating Parser

### DIFF
--- a/WordPress/Classes/Extensions/NSString+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSString+Helpers.swift
@@ -4,11 +4,10 @@ import Foundation
 extension NSString
 {
     /**
-     *  @details Splits the words contained in the current string, and returns its
-     *           unique values in a NSSet instance.
+     *  @details Splits the lines contained in the current string, and returns its unique values in a NSSet instance.
      */
-    public func uniqueStringComponentsSeparatedByWhitespace() -> NSSet {
-        let components = componentsSeparatedByCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
+    public func uniqueStringComponentsSeparatedByNewline() -> NSSet {
+        let components = componentsSeparatedByCharactersInSet(NSCharacterSet.newlineCharacterSet())
         
         let uniqueSet = NSMutableSet()
         uniqueSet.addObjectsFromArray(components)

--- a/WordPress/Classes/Extensions/NSString+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSString+Helpers.swift
@@ -9,8 +9,10 @@ extension NSString
     public func uniqueStringComponentsSeparatedByNewline() -> NSSet {
         let components = componentsSeparatedByCharactersInSet(NSCharacterSet.newlineCharacterSet())
         
+        let filtered = components.filter { !$0.isEmpty }
+        
         let uniqueSet = NSMutableSet()
-        uniqueSet.addObjectsFromArray(components)
+        uniqueSet.addObjectsFromArray(filtered)
         
         return uniqueSet
     }

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -781,8 +781,8 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     NSParameterAssert(remoteSettings);
     
     // Transformables
-    NSSet *separatedBlacklistKeys = [remoteSettings.commentsBlacklistKeys uniqueStringComponentsSeparatedByWhitespace];
-    NSSet *separatedModerationKeys = [remoteSettings.commentsModerationKeys uniqueStringComponentsSeparatedByWhitespace];
+    NSSet *separatedBlacklistKeys = [remoteSettings.commentsBlacklistKeys uniqueStringComponentsSeparatedByNewline];
+    NSSet *separatedModerationKeys = [remoteSettings.commentsModerationKeys uniqueStringComponentsSeparatedByNewline];
     
     // General
     settings.name = remoteSettings.name;
@@ -831,8 +831,8 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     RemoteBlogSettings *remoteSettings = [RemoteBlogSettings new];
 
     // Transformables
-    NSString *joinedBlacklistKeys = [[settings.commentsBlacklistKeys allObjects] componentsJoinedByString:@" "];
-    NSString *joinedModerationKeys = [[settings.commentsModerationKeys allObjects] componentsJoinedByString:@" "];
+    NSString *joinedBlacklistKeys = [[settings.commentsBlacklistKeys allObjects] componentsJoinedByString:@"\n"];
+    NSString *joinedModerationKeys = [[settings.commentsModerationKeys allObjects] componentsJoinedByString:@"\n"];
     
     // General
     remoteSettings.name = settings.name;

--- a/WordPress/WordPressTest/NSStringHelpersTest.m
+++ b/WordPress/WordPressTest/NSStringHelpersTest.m
@@ -198,4 +198,11 @@
     XCTAssert([testSet count] == 5, @"Invalid count");
 }
 
+- (void)testUniqueStringComponentsSeparatedByWhitespaceDoesntAddEmptyStrings
+{
+    NSString *testString = @"";
+    NSSet *testSet = [testString uniqueStringComponentsSeparatedByNewline];
+    XCTAssert([testSet count] == 0, @"Invalid count");
+}
+
 @end

--- a/WordPress/WordPressTest/NSStringHelpersTest.m
+++ b/WordPress/WordPressTest/NSStringHelpersTest.m
@@ -188,14 +188,12 @@
 
 - (void)testUniqueStringComponentsSeparatedByWhitespaceCorrectlyReturnsASetWithItsWords
 {
-    NSString *testString = @"first second third fourth fifth";
-    NSSet *testSet = [testString uniqueStringComponentsSeparatedByWhitespace];
-    XCTAssert([testSet containsObject:@"first"], @"Missing word");
-    XCTAssert([testSet containsObject:@"second"], @"Missing word");
-    XCTAssert([testSet containsObject:@"third"], @"Missing word");
-    XCTAssert([testSet containsObject:@"fourth"], @"Missing word");
-    XCTAssert([testSet containsObject:@"fifth"], @"Missing word");
-    XCTAssert([testSet count] == 5, @"Invalid count");
+    NSString *testString = @"first\nsecond third\nfourth fifth";
+    NSSet *testSet = [testString uniqueStringComponentsSeparatedByNewline];
+    XCTAssert([testSet containsObject:@"first"], @"Missing line");
+    XCTAssert([testSet containsObject:@"second third"], @"Missing line");
+    XCTAssert([testSet containsObject:@"fourth fifth"], @"Missing line");
+    XCTAssert([testSet count] == 3, @"Invalid count");
 }
 
 - (void)testUniqueStringComponentsSeparatedByWhitespaceDoesntAddEmptyStrings


### PR DESCRIPTION
#### Description:
BlogSettings entity contains two Transformable fields: `Blacklist` + `Moderation`.
In this PR we update the parser: strings should get split using the `\n` character, instead of `space`.

Unit tests updated =)

Reference: #4397

Needs Review: @astralbodies 
Thanks in advance Aaron!