### PR TITLE
Reader: Fixes issue bumping the accessed state.

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -131,6 +131,17 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
     [[UIApplication sharedApplication] removeObserver:self forKeyPath:WPApplicationIconBadgeNumberKeyPath];
 }
 
+- (void)setSelectedIndex:(NSUInteger)selectedIndex
+{
+    [super setSelectedIndex:selectedIndex];
+    if (selectedIndex == WPTabReader) {
+        // Bumping the stat in this method works for cases where the selected tab is
+        // set in response to other feature behavior (e.g. a notifications), and
+        // when set via state restoration.
+        [WPAnalytics track:WPAnalyticsStatReaderAccessed];
+    }
+}
+
 #pragma mark - UIViewControllerRestoration methods
 
 - (void)encodeRestorableStateWithCoder:(NSCoder *)coder
@@ -272,7 +283,6 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
 - (void)showReaderTab
 {
     [self showTabForIndex:WPTabReader];
-    [WPAnalytics track:WPAnalyticsStatReaderAccessed];
 }
 
 - (void)showPostTab
@@ -421,6 +431,9 @@ static NSInteger const WPNotificationBadgeIconHorizontalOffsetFromCenter = 8;
                 }
             }
         }
+    } else if ([tabBarController.viewControllers indexOfObject:viewController] == WPTabReader && tabBarController.selectedIndex != WPTabReader) {
+        // Bump the accessed stat when switching to the reader tab, but not if the tab is tapped when already selected.
+        [WPAnalytics track:WPAnalyticsStatReaderAccessed];
     }
 
     // If the current view controller is selected already and it's at its root then scroll to the top


### PR DESCRIPTION
In #4308 it was intended to start bumping the `WPAnalyticsStatReaderAccessed` stat whenever the Reader tab was accessed.  Prior to release/5.7 this stat was bumped whenever the post list was viewed for the first time, an imperfect approach that allowed for incorrect counts depending on user behavior.  The change introduced in #4308 incorrectly assumed that `showReaderTab` would be called in every case the reader tab would be accessed, however `showReaderTab` is not called when the user taps directly on a tab.  The change in this PR fixes the issue.

To test:

Scenario 1: Switching tabs
Set a break point on line 436.  
Launch the app and switch to the reader tab, to a different tab, then back to the reader. 
Confirm that the stat is bumped when tapping on the reader tab, but not other tabs.

Scenario 2: State Restoration - Reader
Have the reader as the selected tab. 
Set a break point on line 141
Press the home key to send the app to the background
Force quit the app (or stop the debug session in the simulator)
Launch the app. 
Confirm that the stat is bumped when the reader is restored. 

Scenario 3: State Restoration - Not Reader
Repeat scenario 2 but with a different tab selected. 
When launching the app, ensure the stat is not bumped.

Needs review: @sendhil 