### PR TITLE
[Analytics] - Track push notifications 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -35,7 +35,7 @@ target 'WordPress', :exclusive => true do
   pod 'WordPress-iOS-Shared', '0.5.1'
   pod 'WordPress-iOS-Editor', '1.1.1'
   pod 'WordPressCom-Stats-iOS', '0.5.1'
-  pod 'WordPressCom-Analytics-iOS', '0.1.0'
+  pod 'WordPressCom-Analytics-iOS', '0.1.1'
   pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
   pod 'WPMediaPicker', '~> 0.7.0'
   pod 'ReactiveCocoa', '~> 2.4.7'

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -470,6 +470,9 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         case WPAnalyticsStatPushNotificationAlertPressed:
             eventName = @"push_notification_alert_tapped";
             break;
+        case WPAnalyticsStatPushNotificationReceived:
+            eventName = @"push_notification_received";
+            break;
         case WPAnalyticsStatReaderAccessed:
             eventName = @"reader_accessed";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -480,6 +480,9 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatPushNotificationAlertPressed:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Push Notification - Alert Tapped"];
             break;
+        case WPAnalyticsStatPushNotificationReceived:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Push Notification - Received"];
+            break;
         case WPAnalyticsStatEditorUpdatedPost:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Updated Post"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_editor_updated_post"];

--- a/WordPress/Classes/Utility/NotificationsManager.m
+++ b/WordPress/Classes/Utility/NotificationsManager.m
@@ -244,7 +244,6 @@ static NSString *const NotificationActionCommentApprove             = @"COMMENT_
         // Token should be always available here
         [mutablePushProperties setObject:token forKey:@"push_notification_token"];
     }
-    [mutablePushProperties setObject:@"apple" forKey:@"push_notification_device_type"];
     
     if (state == UIApplicationStateBackground) {
         // The notification is delivered when the app isn’t running in the foreground.
@@ -253,7 +252,6 @@ static NSString *const NotificationActionCommentApprove             = @"COMMENT_
         // The user taps the notification item in the notifications center
         [WPAnalytics track:WPAnalyticsStatPushNotificationAlertPressed withProperties:mutablePushProperties];
     }
-
     
     // Notification-Y Push Notifications
     if (state == UIApplicationStateInactive) {

--- a/WordPress/Classes/Utility/NotificationsManager.m
+++ b/WordPress/Classes/Utility/NotificationsManager.m
@@ -241,14 +241,14 @@ static NSString *const NotificationActionCommentApprove             = @"COMMENT_
     }
     NSString *token = [[NSUserDefaults standardUserDefaults] objectForKey:NotificationsDeviceToken];
     if (token) {
-        // Token should be always here
+        // Token should be always available here
         [mutablePushProperties setObject:token forKey:@"push_notification_token"];
     }
     [mutablePushProperties setObject:@"apple" forKey:@"push_notification_device_type"];
     
     if (state == UIApplicationStateBackground) {
         // The notification is delivered when the app isn’t running in the foreground.
-        // [WPAnalytics track:stat withProperties:mutablePushProperties];
+        [WPAnalytics track:WPAnalyticsStatPushNotificationReceived withProperties:mutablePushProperties];
     } else if (state == UIApplicationStateInactive) {
         // The user taps the notification item in the notifications center
         [WPAnalytics track:WPAnalyticsStatPushNotificationAlertPressed withProperties:mutablePushProperties];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -438,9 +438,6 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     if (notification) {
         DDLogInfo(@"Pushing Notification Details for: [%@]", notificationID);
         
-        NSDictionary *properties = notification.type ? @{ @"type" : notification.type } : nil;
-        [WPAnalytics track:WPAnalyticsStatPushNotificationAlertPressed withProperties:properties];
-        
         [self showDetailsForNotification:notification];
     } else {
         DDLogInfo(@"Notification Details for [%@] cannot be pushed right now. Waiting %f secs", notificationID, NotificationPushMaxWait);


### PR DESCRIPTION
Fix #4544 

- **PN Received on the device:** we can bump stats here – 100% accuracy, we have the noteID.
- **The user taped on a single entry in Notifications center:** we can bump stats here – 100% accuracy, we have the noteID.

Android Ref: https://github.com/wordpress-mobile/WordPress-Android/pull/3448