### PR TITLE
Fixes for Swift 2.2

### DIFF
--- a/WordPress/Classes/Extensions/PHAsset+Exporters.swift
+++ b/WordPress/Classes/Extensions/PHAsset+Exporters.swift
@@ -100,7 +100,8 @@ extension PHAsset {
         for attribute in attributes {
             resultingMetadata.removeValueForKey(attribute)
             if attribute == "Orientation" {
-                if var tiffMetadata = resultingMetadata[kCGImagePropertyTIFFDictionary as String] as? [String:AnyObject]{
+                if let tiffMetadata = resultingMetadata[kCGImagePropertyTIFFDictionary as String] as? [String:AnyObject]{
+                    var tiffMetadata = tiffMetadata
                     tiffMetadata[kCGImagePropertyTIFFOrientation as String] = 1
                     resultingMetadata[kCGImagePropertyTIFFDictionary as String] = tiffMetadata
                 }


### PR DESCRIPTION
`var` in pattern matching is being removed from Swift
https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-parameters-patterns.md

Needs Review: @SergioEstevao 