### PR TITLE
PostList: Fixes issue loading blavatars/site icons.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -226,15 +226,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 }
 
 
-#pragma mark - Helpers
-
-- (NSURL *)blavatarURL
-{
-    NSInteger size = (NSInteger)ceil(CGRectGetWidth(self.avatarImageView.frame) * [[UIScreen mainScreen] scale]);
-    return [self.avatarImageView blavatarURLForHost:[self.contentProvider blavatarForDisplay] withSize:size];
-}
-
-
 #pragma mark - Configuration
 
 - (void)preserveStartingConstraintConstants
@@ -312,8 +303,8 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     self.authorBlogLabel.text = [self.contentProvider blogNameForDisplay];
     self.authorNameLabel.text = [self.contentProvider authorNameForDisplay];
     UIImage *placeholder = [UIImage imageNamed:@"post-blavatar-placeholder"];
-    [self.avatarImageView setImageWithURL:[self blavatarURL]
-                         placeholderImage:placeholder];
+
+    [self.avatarImageView setImageWithSiteIcon:[self.contentProvider blavatarForDisplay] placeholderImage:placeholder];
 }
 
 - (void)configureCardImage


### PR DESCRIPTION
Refs #2076 
This PR fixes an issue where the site blavatar URL was being incorrectly composed. 

To Test:
- Load the post list without the patch and confirm that default avatars are only shown, even when the site *does* have a blavatar present at the top of the site detail. 
- Load the post list *with* this patch and confirm the post list correctly displays the blavatar in the cards. 

Needs review: @oguzkocer 