### PR TITLE
Use custom User-Agent HTTP header in all UIWebViews

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -404,7 +404,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     // Networking setup
     [[AFNetworkActivityIndicatorManager sharedManager] setEnabled:YES];
     self.userAgent = [[WPUserAgent alloc] init];
-    [self.userAgent useWordPressUserAgent];
+    [self.userAgent useWordPressUserAgentInUIWebViews];
     [self setupSingleSignOn];
 
     // WORKAROUND: Preload the Merriweather regular font to ensure it is not overridden

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -404,6 +404,7 @@ static NSString * const MustShowWhatsNewPopup                   = @"MustShowWhat
     // Networking setup
     [[AFNetworkActivityIndicatorManager sharedManager] setEnabled:YES];
     self.userAgent = [[WPUserAgent alloc] init];
+    [self.userAgent useWordPressUserAgent];
     [self setupSingleSignOn];
 
     // WORKAROUND: Preload the Merriweather regular font to ensure it is not overridden

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerWPCom.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerWPCom.m
@@ -31,7 +31,7 @@
 {
     int x = arc4random();
     NSString *statsURL = [NSString stringWithFormat:@"%@%@%@%@%d" , WPMobileReaderURL, @"&template=stats&stats_name=", statName, @"&rnd=", x];
-    NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent currentUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent wordPressUserAgent];
     
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:statsURL]];
     [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];

--- a/WordPress/Classes/Utility/WPUserAgent.h
+++ b/WordPress/Classes/Utility/WPUserAgent.h
@@ -6,14 +6,10 @@
  */
 @interface WPUserAgent : NSObject
 
-#pragma mark - Changing the user agent
-
 /**
  *  @brief      Sets User-Agent header of all UIWebViews to be the WordPress one.
  */
 - (void)useWordPressUserAgentInUIWebViews;
-
-#pragma mark - Getting the user agent
 
 /**
  *  @brief      Get WordPress User-Agent header.

--- a/WordPress/Classes/Utility/WPUserAgent.h
+++ b/WordPress/Classes/Utility/WPUserAgent.h
@@ -9,11 +9,6 @@
 #pragma mark - Changing the user agent
 
 /**
- *  @brief      Sets the App's user agent to be the default one.
- */
-- (void)useDefaultUserAgent;
-
-/**
  *  @brief      Sets the App's user agent to be the WordPress one.
  */
 - (void)useWordPressUserAgent;

--- a/WordPress/Classes/Utility/WPUserAgent.h
+++ b/WordPress/Classes/Utility/WPUserAgent.h
@@ -7,15 +7,13 @@
 @interface WPUserAgent : NSObject
 
 /**
+ *  @brief      WordPress custom User-Agent header.
+ */
+@property (nonatomic, strong, readonly) NSString *wordPressUserAgent;
+
+/**
  *  @brief      Sets User-Agent header of all UIWebViews to be the WordPress one.
  */
 - (void)useWordPressUserAgentInUIWebViews;
-
-/**
- *  @brief      Get WordPress User-Agent header.
- *
- *  @returns    WordPress custom User-Agent header.
- */
-- (NSString *)wordPressUserAgent;
 
 @end

--- a/WordPress/Classes/Utility/WPUserAgent.h
+++ b/WordPress/Classes/Utility/WPUserAgent.h
@@ -16,6 +16,13 @@
 #pragma mark - Getting the user agent
 
 /**
+ *  @brief      Get WordPress User-Agent header.
+ *
+ *  @returns    WordPress custom User-Agent header.
+ */
+- (NSString *)wordPressUserAgent;
+
+/**
  *  @brief      Call this method to get the current user agent.
  *
  *  @returns    The current user agent.

--- a/WordPress/Classes/Utility/WPUserAgent.h
+++ b/WordPress/Classes/Utility/WPUserAgent.h
@@ -9,9 +9,9 @@
 #pragma mark - Changing the user agent
 
 /**
- *  @brief      Sets the App's user agent to be the WordPress one.
+ *  @brief      Sets User-Agent header of all UIWebViews to be the WordPress one.
  */
-- (void)useWordPressUserAgent;
+- (void)useWordPressUserAgentInUIWebViews;
 
 #pragma mark - Getting the user agent
 

--- a/WordPress/Classes/Utility/WPUserAgent.h
+++ b/WordPress/Classes/Utility/WPUserAgent.h
@@ -22,11 +22,4 @@
  */
 - (NSString *)wordPressUserAgent;
 
-/**
- *  @brief      Call this method to get the current user agent.
- *
- *  @returns    The current user agent.
- */
-- (NSString *)currentUserAgent;
-
 @end

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -57,11 +57,8 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
 
 - (void)useWordPressUserAgentInUIWebViews
 {
-    [self setUserAgentForUIWebViews:[self wordPressUserAgent]];
-}
+    NSString *userAgent = [self wordPressUserAgent];
 
-- (void)setUserAgentForUIWebViews:(NSString *)userAgent
-{
     NSParameterAssert([userAgent isKindOfClass:[NSString class]]);
     
     NSDictionary *dictionary = @{WPUserAgentKeyUserAgent: userAgent};

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -4,7 +4,9 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
 
 @interface WPUserAgent ()
 
-@property (nonatomic, strong, readwrite) NSString *defaultUserAgent;
+// Default UA to append "wp-iphone/<version>" to
+- (NSString *)defaultUserAgent;
+
 @property (nonatomic, strong, readwrite) NSString *wordPressUserAgent;
 
 @end
@@ -24,24 +26,22 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
 
 - (NSString *)defaultUserAgent
 {
-    if (! _defaultUserAgent) {
-        // Temporarily unset "UserAgent" from registered user defaults so that we
-        // always get the default value, independently from what's currently set as
-        // User-Agent
-        NSDictionary *originalRegisteredDefaults = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSRegistrationDomain];
+    // Temporarily unset "UserAgent" from registered user defaults so that we
+    // always get the default value, independently from what's currently set as
+    // User-Agent
+    NSDictionary *originalRegisteredDefaults = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSRegistrationDomain];
 
-        NSMutableDictionary *tempRegisteredDefaults = [NSMutableDictionary dictionaryWithDictionary:originalRegisteredDefaults];
-        [tempRegisteredDefaults removeObjectForKey:WPUserAgentKeyUserAgent];
-        [[NSUserDefaults standardUserDefaults] registerDefaults:tempRegisteredDefaults];
-        
-        _defaultUserAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
-        NSAssert(_defaultUserAgent != nil, @"User agent shouldn't be nil");
-        NSAssert(! [_defaultUserAgent isEmpty], @"User agent shouldn't be empty");
-        
-        [[NSUserDefaults standardUserDefaults] registerDefaults:originalRegisteredDefaults];
-    }
+    NSMutableDictionary *tempRegisteredDefaults = [NSMutableDictionary dictionaryWithDictionary:originalRegisteredDefaults];
+    [tempRegisteredDefaults removeObjectForKey:WPUserAgentKeyUserAgent];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:tempRegisteredDefaults];
     
-    return _defaultUserAgent;
+    NSString *defaultUserAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    NSAssert(defaultUserAgent != nil, @"User agent shouldn't be nil");
+    NSAssert([defaultUserAgent length] > 0, @"User agent shouldn't be empty");
+    
+    [[NSUserDefaults standardUserDefaults] registerDefaults:originalRegisteredDefaults];
+    
+    return defaultUserAgent;
 }
 
 - (NSString *)wordPressUserAgent

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -48,12 +48,12 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
 
 #pragma mark - Changing the user agent
 
-- (void)useWordPressUserAgent
+- (void)useWordPressUserAgentInUIWebViews
 {
-    [self setUserAgent:[self wordPressUserAgent]];
+    [self setUserAgentForUIWebViews:[self wordPressUserAgent]];
 }
 
-- (void)setUserAgent:(NSString*)userAgent
+- (void)setUserAgentForUIWebViews:(NSString *)userAgent
 {
     NSParameterAssert([userAgent isKindOfClass:[NSString class]]);
     

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -64,12 +64,4 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     DDLogVerbose(@"User-Agent set to: %@", userAgent);
 }
 
-#pragma mark - Getting the user agent
-
-- (NSString *)currentUserAgent
-{
-    return [[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent];
-}
-
-
 @end

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -11,8 +11,6 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
 
 @implementation WPUserAgent
 
-#pragma mark - Default and WordPress User-Agents
-
 - (NSString *)defaultUserAgent
 {
     if (! _defaultUserAgent) {
@@ -45,8 +43,6 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     
     return _wordPressUserAgent;
 }
-
-#pragma mark - Changing the user agent
 
 - (void)useWordPressUserAgentInUIWebViews
 {

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -4,8 +4,8 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
 
 @interface WPUserAgent ()
 
-@property (nonatomic, strong) NSString *defaultUserAgent;
-@property (nonatomic, strong) NSString *wordPressUserAgent;
+@property (nonatomic, strong, readwrite) NSString *defaultUserAgent;
+@property (nonatomic, strong, readwrite) NSString *wordPressUserAgent;
 
 @end
 

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -1,85 +1,56 @@
 #import "WPUserAgent.h"
 
 static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
-static NSString* const WPUserAgentKeyDefaultUserAgent = @"DefaultUserAgent";
-static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
+
+@interface WPUserAgent ()
+
+@property (nonatomic, strong) NSString *defaultUserAgent;
+@property (nonatomic, strong) NSString *wordPressUserAgent;
+
+@end
 
 @implementation WPUserAgent
-
-#pragma mark - Init
-
-- (instancetype)init
-{
-    self = [super init];
-    
-    if (self) {
-        [self setupUserAgent];
-    }
-    
-    return self;
-}
-
-#pragma mark - One time setup
-
-- (void)setupUserAgent
-{
-    // Keep a copy of the original userAgent for use with certain webviews in the app.
-    NSString *defaultUA = [self defaultUserAgent];
-    NSString *wordPressUserAgent = [self wordPressUserAgent];
-
-    NSDictionary *dictionary = @{
-                                 WPUserAgentKeyUserAgent : wordPressUserAgent,
-                                 WPUserAgentKeyDefaultUserAgent : defaultUA,
-                                 WPUserAgentKeyWordPressUserAgent : wordPressUserAgent
-                                 };
-    [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
-}
 
 #pragma mark - Default and WordPress User-Agents
 
 - (NSString *)defaultUserAgent
 {
-    // Temporarily unset "UserAgent" from registered user defaults so that we
-    // always get the default value, independently from what's currently set as
-    // User-Agent
-    NSDictionary *originalRegisteredDefaults = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSRegistrationDomain];
+    if (! _defaultUserAgent) {
+        // Temporarily unset "UserAgent" from registered user defaults so that we
+        // always get the default value, independently from what's currently set as
+        // User-Agent
+        NSDictionary *originalRegisteredDefaults = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSRegistrationDomain];
 
-    NSMutableDictionary *tempRegisteredDefaults = [NSMutableDictionary dictionaryWithDictionary:originalRegisteredDefaults];
-    [tempRegisteredDefaults removeObjectForKey:WPUserAgentKeyUserAgent];
-    [[NSUserDefaults standardUserDefaults] registerDefaults:tempRegisteredDefaults];
+        NSMutableDictionary *tempRegisteredDefaults = [NSMutableDictionary dictionaryWithDictionary:originalRegisteredDefaults];
+        [tempRegisteredDefaults removeObjectForKey:WPUserAgentKeyUserAgent];
+        [[NSUserDefaults standardUserDefaults] registerDefaults:tempRegisteredDefaults];
+        
+        _defaultUserAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+        NSAssert(_defaultUserAgent != nil, @"User agent shouldn't be nil");
+        NSAssert(! [_defaultUserAgent isEmpty], @"User agent shouldn't be empty");
+        
+        [[NSUserDefaults standardUserDefaults] registerDefaults:originalRegisteredDefaults];
+    }
     
-    NSString *userAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
-    NSAssert(userAgent != nil, @"User agent shouldn't be nil");
-    NSAssert(! [userAgent isEmpty], @"User agent shouldn't be empty");
-    
-    [[NSUserDefaults standardUserDefaults] registerDefaults:originalRegisteredDefaults];
-    
-    return userAgent;
+    return _defaultUserAgent;
 }
 
 - (NSString *)wordPressUserAgent
 {
-    NSString *defaultUA = [self defaultUserAgent];
-    NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-    NSString *userAgent = [NSString stringWithFormat:@"%@ wp-iphone/%@", defaultUA, appVersion];
+    if (! _wordPressUserAgent) {
+        NSString *defaultUA = [self defaultUserAgent];
+        NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+        _wordPressUserAgent = [NSString stringWithFormat:@"%@ wp-iphone/%@", defaultUA, appVersion];
+    }
     
-    return userAgent;
+    return _wordPressUserAgent;
 }
 
 #pragma mark - Changing the user agent
 
-- (void)useDefaultUserAgent
-{
-    NSString *ua = [[NSUserDefaults standardUserDefaults] stringForKey:WPUserAgentKeyDefaultUserAgent];
-    
-    [self setUserAgent:ua];
-}
-
 - (void)useWordPressUserAgent
 {
-    NSString *ua = [[NSUserDefaults standardUserDefaults] stringForKey:WPUserAgentKeyWordPressUserAgent];
-    
-    [self setUserAgent:ua];
+    [self setUserAgent:[self wordPressUserAgent]];
 }
 
 - (void)setUserAgent:(NSString*)userAgent

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -11,6 +11,17 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
 
 @implementation WPUserAgent
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        // Cleanup unused NSUserDefaults keys from older WPUserAgent implementation
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"DefaultUserAgent"];
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"AppUserAgent"];
+    }
+    return self;
+}
+
 - (NSString *)defaultUserAgent
 {
     if (! _defaultUserAgent) {

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -438,7 +438,7 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
 
 - (NSURLRequest *)newRequestForWebsite
 {
-    NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent currentUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent wordPressUserAgent];
     if (!self.needsLogin) {
         return [WPURLRequest requestWithURL:self.url userAgent:userAgent];
     }

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -22,7 +22,6 @@
 
 - (void)dealloc
 {
-    [[WordPressAppDelegate sharedInstance].userAgent useWordPressUserAgent];
     [self.webView stopLoading];
     self.webView.delegate = nil;
 }
@@ -56,14 +55,12 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    [[WordPressAppDelegate sharedInstance].userAgent useDefaultUserAgent];
     [self refreshWebView];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    [[WordPressAppDelegate sharedInstance].userAgent useWordPressUserAgent];
     [self.webView stopLoading];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostDetailViewController.m
@@ -472,7 +472,7 @@ NSString * const ReaderPixelStatReferrer = @"https://wordpress.com/";
                         ];
 
     NSString *path = [NSString stringWithFormat:@"%@?%@", pixel, [params componentsJoinedByString:@"&"]];
-    NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent currentUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent wordPressUserAgent];
 
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:path]];
     [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];

--- a/WordPress/Classes/ViewRelated/Views/WPWebView.m
+++ b/WordPress/Classes/ViewRelated/Views/WPWebView.m
@@ -124,7 +124,7 @@ NSString *refreshedWithOutValidRequestNotification = @"refreshedWithOutValidRequ
     [self setDefaultHeader:@"Accept-Language" value:[NSString stringWithFormat:@"%@, en-us;q=0.8", preferredLanguageCodes]];
 
     // User-Agent Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.43
-    NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent currentUserAgent];
+    NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent wordPressUserAgent];
     [self setDefaultHeader:@"User-Agent" value:userAgent];
 }
 

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -80,7 +80,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 		
         [self setAuthorizationHeaderWithToken:_authToken];
 		
-        NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent currentUserAgent];
+        NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent wordPressUserAgent];
 		[self.requestSerializer setValue:userAgent forHTTPHeaderField:@"User-Agent"];
 	}
 	
@@ -238,7 +238,7 @@ constructingBodyWithBlock:block
         DDLogVerbose(@"Initializing anonymous API");
         _anonymousApi = [[self alloc] initWithBaseURL:[NSURL URLWithString:WordPressComApiClientEndpointURL] ];
 
-        NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent currentUserAgent];
+        NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent wordPressUserAgent];
 		[_anonymousApi.requestSerializer setValue:userAgent forHTTPHeaderField:@"User-Agent"];
     });
 

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -52,19 +52,6 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
     return userAgent;
 }
 
-- (void)testUseDefaultUserAgent
-{
-    NSString *defaultUA = [self defaultUserAgent];
-    WPUserAgent *userAgent = nil;
-    
-    XCTAssertNoThrow(userAgent = [[WPUserAgent alloc] init]);
-    XCTAssertTrue([userAgent isKindOfClass:[WPUserAgent class]]);
-    
-    [userAgent useDefaultUserAgent];
-    
-    XCTAssertTrue([[userAgent currentUserAgent] isEqualToString:defaultUA]);
-}
-
 - (void)testUseWordPressUserAgent
 {
     NSString *wordPressUA = [self wordPressUserAgent];

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -52,7 +52,7 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
     return userAgent;
 }
 
-- (void)testUseWordPressUserAgent
+- (void)testUseWordPressUserAgentInUIWebViews
 {
     NSString *wordPressUA = [self wordPressUserAgent];
     WPUserAgent *userAgent = nil;
@@ -60,7 +60,7 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
     XCTAssertNoThrow(userAgent = [[WPUserAgent alloc] init]);
     XCTAssertTrue([userAgent isKindOfClass:[WPUserAgent class]]);
     
-    [userAgent useWordPressUserAgent];
+    [userAgent useWordPressUserAgentInUIWebViews];
     
     XCTAssertTrue([[userAgent currentUserAgent] isEqualToString:wordPressUA]);
 }

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -3,8 +3,6 @@
 #import "WPUserAgent.h"
 
 static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
-static NSString* const WPUserAgentKeyDefaultUserAgent = @"DefaultUserAgent";
-static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
 
 @interface WPUserAgentTests : XCTestCase
 @end

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -50,17 +50,25 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     return userAgent;
 }
 
+- (NSString *)currentUserAgentFromUserDefaults
+{
+    return [[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent];
+}
+
 - (void)testUseWordPressUserAgentInUIWebViews
 {
+    NSString *defaultUA = [self defaultUserAgent];
     NSString *wordPressUA = [self wordPressUserAgent];
     WPUserAgent *userAgent = nil;
     
     XCTAssertNoThrow(userAgent = [[WPUserAgent alloc] init]);
     XCTAssertTrue([userAgent isKindOfClass:[WPUserAgent class]]);
     
+    XCTAssertTrue([[self currentUserAgentFromUserDefaults] isEqualToString:defaultUA]);
+    
     [userAgent useWordPressUserAgentInUIWebViews];
     
-    XCTAssertTrue([[[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent] isEqualToString:wordPressUA]);
+    XCTAssertTrue([[self currentUserAgentFromUserDefaults] isEqualToString:wordPressUA]);
 }
 
 @end

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -62,7 +62,7 @@ static NSString* const WPUserAgentKeyWordPressUserAgent = @"AppUserAgent";
     
     [userAgent useWordPressUserAgentInUIWebViews];
     
-    XCTAssertTrue([[userAgent currentUserAgent] isEqualToString:wordPressUA]);
+    XCTAssertTrue([[[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent] isEqualToString:wordPressUA]);
 }
 
 @end

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -26,7 +26,7 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     [tempRegisteredDefaults removeObjectForKey:WPUserAgentKeyUserAgent];
     [[NSUserDefaults standardUserDefaults] registerDefaults:tempRegisteredDefaults];
     
-    NSString *userAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    NSString *userAgent = [self currentUserAgentFromUIWebView];
     XCTAssertNotNil(userAgent, @"User agent shouldn't be nil");
     XCTAssertTrue([userAgent length] > 0, @"User agent shouldn't be empty");
     
@@ -55,6 +55,11 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     return [[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent];
 }
 
+- (NSString *)currentUserAgentFromUIWebView
+{
+    return [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+}
+
 - (void)testWordPressUserAgent
 {
     NSString *wordPressUA = [self wordPressUserAgent];
@@ -76,10 +81,12 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     XCTAssertTrue([userAgent isKindOfClass:[WPUserAgent class]]);
     
     XCTAssertTrue([[self currentUserAgentFromUserDefaults] isEqualToString:defaultUA]);
+    XCTAssertTrue([[self currentUserAgentFromUIWebView] isEqualToString:defaultUA]);
     
     [userAgent useWordPressUserAgentInUIWebViews];
     
     XCTAssertTrue([[self currentUserAgentFromUserDefaults] isEqualToString:wordPressUA]);
+    XCTAssertTrue([[self currentUserAgentFromUIWebView] isEqualToString:wordPressUA]);
 }
 
 @end

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -55,6 +55,17 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     return [[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent];
 }
 
+- (void)testWordPressUserAgent
+{
+    NSString *wordPressUA = [self wordPressUserAgent];
+    WPUserAgent *userAgent = nil;
+    
+    XCTAssertNoThrow(userAgent = [[WPUserAgent alloc] init]);
+    XCTAssertTrue([userAgent isKindOfClass:[WPUserAgent class]]);
+    
+    XCTAssertTrue([[self wordPressUserAgent] isEqualToString:wordPressUA]);
+}
+
 - (void)testUseWordPressUserAgentInUIWebViews
 {
     NSString *defaultUA = [self defaultUserAgent];


### PR DESCRIPTION
Here's my proposed WPUserAgent cleanup:

* A custom HTTP User-Agent header (the default UA with appended `wp-iphone/<version>` string) is set in app delegate and gets used in all UIWebViews indiscriminately.
* WPUserAgent stores cached versions of default and custom UAs in local variables and not in NSUserDefaults.
* Non-UIWebView code that wants to use the custom UA can call `wordPressUserAgent` to get the preferred client UA string.
* Added some more unit tests.

Fixes #4491.