### PR TITLE
If there is only one site (or less), then do not show the search button

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -148,6 +148,7 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
     [self.resultsController performFetch:nil];
     [self.tableView reloadData];
     [self updateEditButton];
+    [self updateSearchButton];
     [self maybeShowNUX];
     [self syncBlogs];
 }
@@ -213,6 +214,15 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
         self.navigationItem.leftBarButtonItem = self.editButtonItem;
     } else {
         self.navigationItem.leftBarButtonItem = nil;
+    }
+}
+
+- (void)updateSearchButton
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+    if ([blogService blogCountForAllAccounts] <= 1) {
+        self.navigationItem.rightBarButtonItem = nil;
     }
 }
 


### PR DESCRIPTION
Addresses #4476

Using @aerych's suggestion: 
> Maybe don't show the search button when there is only a single blog.