### PR TITLE
Updates Simperium to Mark 0.8.10

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,7 +30,7 @@ target 'WordPress', :exclusive => true do
   pod 'EmailChecker', :podspec => 'https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec'
   pod 'MGImageUtilities', :git => 'git://github.com/wordpress-mobile/MGImageUtilities.git', :branch => 'gifsupport'
   pod 'NSObject-SafeExpectations', '0.0.2'
-  pod 'Simperium', '0.8.9'
+  pod 'Simperium', '0.8.10'
   pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
   pod 'WordPress-iOS-Shared', '0.5.1'
   pod 'WordPress-iOS-Editor', '1.1.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -136,17 +136,17 @@ PODS:
   - ReactiveCocoa/no-arc (2.4.7)
   - ReactiveCocoa/UI (2.4.7):
     - ReactiveCocoa/Core
-  - Simperium (0.8.9):
-    - Simperium/DiffMatchPach (= 0.8.9)
-    - Simperium/JRSwizzle (= 0.8.9)
-    - Simperium/SocketRocket (= 0.8.9)
-    - Simperium/SPReachability (= 0.8.9)
-    - Simperium/SSKeychain (= 0.8.9)
-  - Simperium/DiffMatchPach (0.8.9)
-  - Simperium/JRSwizzle (0.8.9)
-  - Simperium/SocketRocket (0.8.9)
-  - Simperium/SPReachability (0.8.9)
-  - Simperium/SSKeychain (0.8.9)
+  - Simperium (0.8.10):
+    - Simperium/DiffMatchPach (= 0.8.10)
+    - Simperium/JRSwizzle (= 0.8.10)
+    - Simperium/SocketRocket (= 0.8.10)
+    - Simperium/SPReachability (= 0.8.10)
+    - Simperium/SSKeychain (= 0.8.10)
+  - Simperium/DiffMatchPach (0.8.10)
+  - Simperium/JRSwizzle (0.8.10)
+  - Simperium/SocketRocket (0.8.10)
+  - Simperium/SPReachability (0.8.10)
+  - Simperium/SSKeychain (0.8.10)
   - Specta (1.0.5)
   - SVProgressHUD (1.1.3)
   - UIDeviceIdentifier (0.5.0)
@@ -215,7 +215,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (~> 4.6.0)
   - Reachability (= 3.2)
   - ReactiveCocoa (~> 2.4.7)
-  - Simperium (= 0.8.9)
+  - Simperium (= 0.8.10)
   - Specta (= 1.0.5)
   - SVProgressHUD (~> 1.1.3)
   - UIDeviceIdentifier (~> 0.1)
@@ -286,7 +286,7 @@ SPEC CHECKSUMS:
   PDKTZipArchive: 81c4824eb5587131e422fc58b92c043c4aa96466
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   ReactiveCocoa: eb38dee0a0e698f73a9b25e5c1faea2bb4c79240
-  Simperium: 6c3b944c7d72477d83b3355331b8fa879b35afb2
+  Simperium: f507d9b400c499048a98fe728a0b2b9956fd14c1
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46


### PR DESCRIPTION
This fixes a warning in Xcode 7.2.

Needs Review: @astralbodies 
Thanks Aaron!
