### PR TITLE
Control Theme browser bandwidth

### DIFF
--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
@@ -165,11 +165,12 @@ public class ThemeBrowserCell : UICollectionViewCell
     }
     
     private func refreshScreenshotImage(imageUrl: String) {
-        let imageUrl = NSURL(string: imageUrl)
+        let imageUrlForWidth = imageUrl + "?w=\(presenter!.screenshotWidth)"
+        let screenshotUrl = NSURL(string: imageUrlForWidth)
         
         imageView.backgroundColor = Styles.placeholderColor
         activityView.startAnimating()
-        imageView.downloadImage(imageUrl,
+        imageView.downloadImage(screenshotUrl,
             placeholderImage: nil,
             success: { [weak self] (image: UIImage) in
                 self?.showScreenshot()

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -46,6 +46,8 @@ public enum ThemeType
 public protocol ThemePresenter: class
 {
     var searchType: ThemeType { get set }
+    
+    var screenshotWidth: Int { get }
 
     func currentTheme() -> Theme?
     func activateTheme(theme: Theme?)
@@ -157,6 +159,17 @@ public protocol ThemePresenter: class
     }
     private var presentingTheme: Theme?
    
+    /**
+     *  @brief      Load theme screenshots at maximum displayed width
+     */
+    public var screenshotWidth: Int = {
+        let windowSize = UIApplication.sharedApplication().keyWindow!.bounds.size
+        let vWidth = Styles.imageWidthForFrameWidth(windowSize.width)
+        let hWidth = Styles.imageWidthForFrameWidth(windowSize.height)
+        let maxWidth = Int(max(hWidth, vWidth))
+        return maxWidth
+    }()
+    
     /**
      *  @brief      The themes service we'll use in this VC and its helpers
      */
@@ -372,8 +385,8 @@ public protocol ThemePresenter: class
         
         let cell = collectionView.dequeueReusableCellWithReuseIdentifier(ThemeBrowserCell.reuseIdentifier, forIndexPath: indexPath) as! ThemeBrowserCell
         
-        cell.theme = themeAtIndex(indexPath.row)
         cell.presenter = self
+        cell.theme = themeAtIndex(indexPath.row)
         
         syncMoreIfNeeded(indexPath.row)
         

--- a/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
+++ b/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
@@ -110,6 +110,10 @@ extension WPStyleGuide
             let cellHeight = cellHeightForCellWidth(cellWidth)
             return CGSize(width: cellWidth, height: cellHeight)
         }
+        public static func imageWidthForFrameWidth(width: CGFloat) -> CGFloat {
+            let cellWidth = cellWidthForFrameWidth(width)
+            return cellWidth - cellImageInset
+        }
 
         public static let footerHeight: CGFloat = 50
 


### PR DESCRIPTION
Closes #4564 

To help control Theme browser bandwidth, load screenshots at maximum displayed width on the current device in line with Android practice.

Needs review: @kwonye 