### PR TITLE
Reader: Safer optional unboxing for indexPathsForVisibleRows.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -180,11 +180,13 @@ import WordPressComAnalytics
 
             let width = view.frame.width
             tableViewHandler.refreshCachedRowHeightsForWidth(width)
-            tableView.reloadRowsAtIndexPaths(tableView.indexPathsForVisibleRows!, withRowAnimation: .None)
+
+            if let indexPaths = tableView.indexPathsForVisibleRows {
+                tableView.reloadRowsAtIndexPaths(indexPaths, withRowAnimation: .None)
+            }
         }
     }
 
-    @available(iOS 8.0, *)
     public override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         needsRefreshCachedCellHeightsBeforeLayout = true


### PR DESCRIPTION
Rather than force unwrap the `indexPathsForVisibleRows` optional, this pr uses a safer method.  This is an attempt at addressing a crash case with a somewhat unhelpful stack trace and description.

```
Thread : Crashed: Thread
0  WordPress                      0x10024bee8 ReaderStreamViewController.viewWillLayoutSubviews() -> () (ReaderStreamViewController.swift:182)
1  WordPress                      0x10024bf08 @objc ReaderStreamViewController.viewWillLayoutSubviews() -> () (ReaderStreamViewController.swift)
2  UIKit                          0x1895bb688 -[UIView(CALayerDelegate) layoutSublayersOfLayer:] + 416
3  QuartzCore                     0x186fcab2c -[CALayer layoutSublayers] + 148
4  QuartzCore                     0x186fc5738 CA::Layer::layout_if_needed(CA::Transaction*) + 292
5  QuartzCore                     0x186fc55f8 CA::Layer::layout_and_display_if_needed(CA::Transaction*) + 32
6  QuartzCore                     0x186fc4c94 CA::Context::commit_transaction(CA::Transaction*) + 252
7  QuartzCore                     0x186fc49dc CA::Transaction::commit() + 512
8  UIKit                          0x1895b1c78 _afterCACommitHandler + 180
9  CoreFoundation                 0x184884588 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 32
```

Needs review: @sendhil 