### PR TITLE
Remove WPTableViewSectionHeaderFooterView usage

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -33,7 +33,7 @@ target 'WordPress', :exclusive => true do
   pod 'Simperium', '0.8.10'
   pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
   #pod 'WordPress-iOS-Shared', '0.5.1'
-  pod 'WordPress-iOS-Shared', :path => '../libs/WordPress-iOS-Shared'
+  pod 'WordPress-iOS-Shared', :branch => 'issue/no-more-WPTableViewSectionHeaderFooterView', :git => 'https://github.com/wordpress-mobile/WordPress-Shared-iOS.git'
   pod 'WordPress-iOS-Editor', '1.1.1'
   pod 'WordPressCom-Stats-iOS/UI', '0.6.0'
   pod 'WordPressCom-Analytics-iOS', '0.1.3'
@@ -45,7 +45,7 @@ end
 
 target 'WordPressTodayWidget', :exclusive => true do
   #pod 'WordPress-iOS-Shared', '0.5.1'
-  pod 'WordPress-iOS-Shared', :path => '../libs/WordPress-iOS-Shared'
+  pod 'WordPress-iOS-Shared', :branch => 'issue/no-more-WPTableViewSectionHeaderFooterView', :git => 'https://github.com/wordpress-mobile/WordPress-Shared-iOS.git'
   pod 'WordPressCom-Stats-iOS/Services', '0.6.0'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -32,8 +32,7 @@ target 'WordPress', :exclusive => true do
   pod 'NSObject-SafeExpectations', '0.0.2'
   pod 'Simperium', '0.8.10'
   pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
-  #pod 'WordPress-iOS-Shared', '0.5.1'
-  pod 'WordPress-iOS-Shared', :branch => 'issue/no-more-WPTableViewSectionHeaderFooterView', :git => 'https://github.com/wordpress-mobile/WordPress-Shared-iOS.git'
+  pod 'WordPress-iOS-Shared', '0.5.2'
   pod 'WordPress-iOS-Editor', '1.1.1'
   pod 'WordPressCom-Stats-iOS/UI', '0.6.0'
   pod 'WordPressCom-Analytics-iOS', '0.1.3'
@@ -44,8 +43,7 @@ target 'WordPress', :exclusive => true do
 end
 
 target 'WordPressTodayWidget', :exclusive => true do
-  #pod 'WordPress-iOS-Shared', '0.5.1'
-  pod 'WordPress-iOS-Shared', :branch => 'issue/no-more-WPTableViewSectionHeaderFooterView', :git => 'https://github.com/wordpress-mobile/WordPress-Shared-iOS.git'
+  pod 'WordPress-iOS-Shared', '0.5.2'
   pod 'WordPressCom-Stats-iOS/Services', '0.6.0'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -32,7 +32,8 @@ target 'WordPress', :exclusive => true do
   pod 'NSObject-SafeExpectations', '0.0.2'
   pod 'Simperium', '0.8.10'
   pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
-  pod 'WordPress-iOS-Shared', '0.5.1'
+  #pod 'WordPress-iOS-Shared', '0.5.1'
+  pod 'WordPress-iOS-Shared', :path => '../libs/WordPress-iOS-Shared'
   pod 'WordPress-iOS-Editor', '1.1.1'
   pod 'WordPressCom-Stats-iOS/UI', '0.6.0'
   pod 'WordPressCom-Analytics-iOS', '0.1.3'
@@ -43,7 +44,8 @@ target 'WordPress', :exclusive => true do
 end
 
 target 'WordPressTodayWidget', :exclusive => true do
-  pod 'WordPress-iOS-Shared', '0.5.1'
+  #pod 'WordPress-iOS-Shared', '0.5.1'
+  pod 'WordPress-iOS-Shared', :path => '../libs/WordPress-iOS-Shared'
   pod 'WordPressCom-Stats-iOS/Services', '0.6.0'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -214,7 +214,8 @@ DEPENDENCIES:
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
   - WordPress-iOS-Editor (= 1.1.1)
-  - WordPress-iOS-Shared (from `../libs/WordPress-iOS-Shared`)
+  - WordPress-iOS-Shared (from `https://github.com/wordpress-mobile/WordPress-Shared-iOS.git`,
+    branch `issue/no-more-WPTableViewSectionHeaderFooterView`)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
   - WordPressCom-Analytics-iOS (= 0.1.3)
   - WordPressCom-Stats-iOS/Services (= 0.6.0)
@@ -235,7 +236,8 @@ EXTERNAL SOURCES:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-iOS-Shared:
-    :path: "../libs/WordPress-iOS-Shared"
+    :branch: issue/no-more-WPTableViewSectionHeaderFooterView
+    :git: https://github.com/wordpress-mobile/WordPress-Shared-iOS.git
   WordPressApi:
     :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git
 
@@ -249,6 +251,9 @@ CHECKOUT OPTIONS:
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
+  WordPress-iOS-Shared:
+    :commit: 9882a89e3549f5be42361de4e3eddaaf750523d1
+    :git: https://github.com/wordpress-mobile/WordPress-Shared-iOS.git
   WordPressApi:
     :commit: a7dc27935fb30b1978942cb1c791d4040fe65395
     :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -214,7 +214,7 @@ DEPENDENCIES:
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
   - WordPress-iOS-Editor (= 1.1.1)
-  - WordPress-iOS-Shared (= 0.5.1)
+  - WordPress-iOS-Shared (from `../libs/WordPress-iOS-Shared`)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
   - WordPressCom-Analytics-iOS (= 0.1.3)
   - WordPressCom-Stats-iOS/Services (= 0.6.0)
@@ -234,6 +234,8 @@ EXTERNAL SOURCES:
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
+  WordPress-iOS-Shared:
+    :path: "../libs/WordPress-iOS-Shared"
   WordPressApi:
     :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -156,7 +156,7 @@ PODS:
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.1)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
-  - WordPress-iOS-Shared (0.5.1):
+  - WordPress-iOS-Shared (0.5.2):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (~> 2.2.0)
   - WordPressApi (0.3.6):
@@ -214,8 +214,7 @@ DEPENDENCIES:
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
   - WordPress-iOS-Editor (= 1.1.1)
-  - WordPress-iOS-Shared (from `https://github.com/wordpress-mobile/WordPress-Shared-iOS.git`,
-    branch `issue/no-more-WPTableViewSectionHeaderFooterView`)
+  - WordPress-iOS-Shared (= 0.5.2)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
   - WordPressCom-Analytics-iOS (= 0.1.3)
   - WordPressCom-Stats-iOS/Services (= 0.6.0)
@@ -235,9 +234,6 @@ EXTERNAL SOURCES:
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPress-iOS-Shared:
-    :branch: issue/no-more-WPTableViewSectionHeaderFooterView
-    :git: https://github.com/wordpress-mobile/WordPress-Shared-iOS.git
   WordPressApi:
     :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git
 
@@ -251,9 +247,6 @@ CHECKOUT OPTIONS:
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPress-iOS-Shared:
-    :commit: 9882a89e3549f5be42361de4e3eddaaf750523d1
-    :git: https://github.com/wordpress-mobile/WordPress-Shared-iOS.git
   WordPressApi:
     :commit: a7dc27935fb30b1978942cb1c791d4040fe65395
     :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git
@@ -291,7 +284,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
   WordPress-iOS-Editor: 563239f9f42f80a3ca20e61f1d5aeed58698c846
-  WordPress-iOS-Shared: ced218039d88c91572f3205882832f7a05c61f97
+  WordPress-iOS-Shared: af84c229bd1cb0206f6015fd8fec9e262a88c780
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
   WordPressCom-Analytics-iOS: 55c52378f752ad8a8bbbd8bd75db0eb4b5a93d34
   WordPressCom-Stats-iOS: 590f774981552c894f6b66140e00266535fefd27

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -71,6 +71,5 @@
 #import <WordPressShared/WPTableViewCell.h>
 #import "WPStyleGuide+ReadableMargins.h"
 #import "WPTableViewHandler.h"
-#import <WordPressShared/WPTableViewSectionHeaderFooterView.h>
 #import "WPWebViewController.h"
 #import "WPTabBarController.h"

--- a/WordPress/Classes/Utility/WPTableViewHandler.h
+++ b/WordPress/Classes/Utility/WPTableViewHandler.h
@@ -59,7 +59,7 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath;
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section;
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section;
 
 #pragma mark - Inserting or deleting table rows
 
@@ -91,7 +91,6 @@
 @property (nonatomic) UITableViewRowAnimation sectionRowAnimation;
 
 - (instancetype)initWithTableView:(UITableView *)tableView;
-- (void)updateTitleForSection:(NSUInteger)section;
 - (void)clearCachedRowHeights;
 - (void)refreshCachedRowHeightsForWidth:(CGFloat)width;
 - (void)invalidateCachedRowHeightAtIndexPath:(NSIndexPath *)indexPath;

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -480,10 +480,13 @@ static CGFloat const DefaultCellHeight = 44.0;
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
+    id <NSFetchedResultsSectionInfo> sectionInfo = [[self.resultsController sections] objectAtIndex:section];
+    if ([sectionInfo numberOfObjects] == 0) {
+        return nil;
+    }
     if ([self.delegate respondsToSelector:@selector(tableView:titleForHeaderInSection:)]) {
         return [self.delegate tableView:tableView titleForHeaderInSection:section];
     }
-    id <NSFetchedResultsSectionInfo> sectionInfo = [[self.resultsController sections] objectAtIndex:section];
     return [sectionInfo name];
 }
 

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -1,5 +1,4 @@
 #import "WPTableViewHandler.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 #import "WPTableViewCell.h"
 #import "WordPress-Swift.h"
 
@@ -56,12 +55,6 @@ static CGFloat const DefaultCellHeight = 44.0;
 
 
 #pragma mark - Public Methods
-
-- (void)updateTitleForSection:(NSUInteger)section
-{
-    WPTableViewSectionHeaderFooterView *sectionHeaderView = (WPTableViewSectionHeaderFooterView *)[self tableView:self.tableView viewForHeaderInSection:section];
-    sectionHeaderView.title = [self titleForHeaderInSection:section];
-}
 
 - (void)clearCachedRowHeights
 {
@@ -281,14 +274,6 @@ static CGFloat const DefaultCellHeight = 44.0;
     return nil;
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
-{
-    if ([self.delegate respondsToSelector:@selector(titleForHeaderInSection:)]) {
-        return [self.delegate titleForHeaderInSection:section];
-    }
-    return nil;
-}
-
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {
     if ([self.delegate respondsToSelector:@selector(tableView:canEditRowAtIndexPath:)]) {
@@ -420,22 +405,23 @@ static CGFloat const DefaultCellHeight = 44.0;
     }
 }
 
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionHeader:view];
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
+}
+
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
     if ([self.delegate respondsToSelector:@selector(tableView:viewForHeaderInSection:)]) {
         return [self.delegate tableView:tableView viewForHeaderInSection:section];
     }
 
-    WPTableViewSectionHeaderFooterView *header;
-    if ([self.sectionHeaders count] > section) {
-        header = [self.sectionHeaders objectAtIndex:section];
-    } else {
-        header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-        [self.sectionHeaders addObject:header];
-    }
-
-    header.title = [self titleForHeaderInSection:section];
-    return header;
+    return nil;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
@@ -444,8 +430,7 @@ static CGFloat const DefaultCellHeight = 44.0;
         return [self.delegate tableView:tableView heightForHeaderInSection:section];
     }
 
-    NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.tableView.bounds)];
+    return UITableViewAutomaticDimension;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
@@ -454,8 +439,7 @@ static CGFloat const DefaultCellHeight = 44.0;
         return [self.delegate tableView:tableView heightForFooterInSection:section];
     }
 
-    // Remove footer height for all but last section
-    return section == [[self.resultsController sections] count] - 1 ? UITableViewAutomaticDimension : 1.0;
+    return UITableViewAutomaticDimension;
 }
 
 
@@ -496,6 +480,9 @@ static CGFloat const DefaultCellHeight = 44.0;
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
+    if ([self.delegate respondsToSelector:@selector(tableView:titleForHeaderInSection:)]) {
+        return [self.delegate tableView:tableView titleForHeaderInSection:section];
+    }
     id <NSFetchedResultsSectionInfo> sectionInfo = [[self.resultsController sections] objectAtIndex:section];
     return [sectionInfo name];
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -7,7 +7,6 @@
 #import "ContextManager.h"
 #import "AccountService.h"
 #import "BlogService.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 #import "BlogDetailHeaderView.h"
 #import "ReachabilityUtils.h"
 #import "WPAccount.h"
@@ -384,24 +383,6 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     return WPTableViewDefaultRowHeight;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-    
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSString *headingTitle = nil;
@@ -423,6 +404,11 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
         break;
     }
     return headingTitle;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 #pragma mark - Private methods

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -9,7 +9,6 @@
 #import "ContextManager.h"
 #import "Blog.h"
 #import "WPAccount.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 #import "AccountService.h"
 #import "BlogService.h"
 #import "TodayExtensionService.h"

--- a/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
@@ -5,7 +5,6 @@
 #import "ContextManager.h"
 #import "SettingTableViewCell.h"
 #import "RelatedPostsPreviewTableViewCell.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 #import "WPStyleGuide+ReadableMargins.h"
 
 #import <WordPressShared/WPStyleGuide.h>
@@ -99,82 +98,31 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
     return 0;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
-    switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            WPTableViewSectionHeaderFooterView *headerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-            return headerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            WPTableViewSectionHeaderFooterView *headerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-            headerView.title = NSLocalizedString(@"Preview", @"Section title for related posts section preview");
-            return headerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
+    if (section == RelatedPostsSettingsSectionPreview) {
+        return NSLocalizedString(@"Preview", @"Section title for related posts section preview");
     }
     return nil;
 
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil
-                                                                                                                           style:WPTableViewSectionStyleFooter];
-            footerView.title = NSLocalizedString(@"Related Posts displays relevant content from your site below your posts", @"Information of what related post are and how they are presented");
-            return footerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil
-                                                                                                                           style:WPTableViewSectionStyleFooter];
-            return footerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
+    if (section == RelatedPostsSettingsSectionOptions) {
+        return NSLocalizedString(@"Related Posts displays relevant content from your site below your posts", @"Information of what related post are and how they are presented");
     }
     return nil;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            return [WPTableViewSectionHeaderFooterView heightForHeader:@"" width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            return [WPTableViewSectionHeaderFooterView heightForHeader:NSLocalizedString(@"Preview", @"Section title for related posts section preview") width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
-    }
-    return 0;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
 {
-    switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            return [WPTableViewSectionHeaderFooterView heightForFooter:NSLocalizedString(@"Related Posts displays relevant content from your site below your posts.", @"Information of what related post are and how they are presented.")
-                                                                 width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            return [WPTableViewSectionHeaderFooterView heightForFooter:@"" width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
-    }
-    return 0;
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -5,7 +5,6 @@
 #import "ReachabilityUtils.h"
 #import "WPAccount.h"
 #import "Blog.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 #import "SettingTableViewCell.h"
 #import "NotificationsManager.h"
 #import <SVProgressHUD/SVProgressHUD.h>
@@ -418,33 +417,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 
 #pragma mark - UITableViewDelegate
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
-    NSInteger settingsSection = [self.tableSections[section] intValue];
-    NSString *title = [self titleForHeaderInSection:settingsSection];
-    if (title.length == 0) {
-        return [UIView new];
-    }
-    
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    return WPTableViewDefaultRowHeight;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSInteger settingsSection = [self.tableSections[section] intValue];
-    NSString *title = [self titleForHeaderInSection:settingsSection];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (NSString *)titleForHeaderInSection:(NSInteger)section
-{
+    section = [self.tableSections[section] intValue];
     NSString *headingTitle = nil;
     switch (section) {
         case SiteSettingsSectionGeneral:
@@ -458,6 +433,11 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             break;
     }
     return headingTitle;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (void)showPrivacySelector

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.m
@@ -17,7 +17,6 @@
 #import "WPAccount.h"
 #import "LoginViewController.h"
 #import <WordPressShared/WPTableViewCell.h>
-#import <WordPressShared/WPTableViewSectionHeaderFooterView.h>
 #import "HelpshiftUtils.h"
 #import "WordPress-Swift.h"
 
@@ -306,29 +305,17 @@ static NSString *const MVCCellReuseIdentifier = @"MVCCellReuseIdentifier";
     return cell;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = [self titleForHeaderInSection:section];
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self titleForHeaderInSection:section];
-    if (!title) {
-        return CGFLOAT_MIN;
-    }
-    
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     if (section == MeSectionsWpCom) {
         return NSLocalizedString(@"WordPress.com Account", @"WordPress.com sign-in/sign-out section header title");
     }
     return nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 #pragma mark - UITableViewDelegate methods

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -163,26 +163,15 @@ public class NotificationSettingDetailsViewController : UITableViewController
         
         return cell!
     }
-    
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        if let footerText = sections[section].footerText {
-            return WPTableViewSectionHeaderFooterView.heightForFooter(footerText, width: view.bounds.width)
-        }
 
-        return CGFloat.min
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return sections[section].footerText
     }
-    
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        if let footerText = sections[section].footerText {
-            let footerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-            footerView.title    = footerText
-            return footerView
-        }
 
-        return nil
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
-    
-    
+
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         tableView.deselectSelectedRowWithAnimation(true)
         

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -109,20 +109,16 @@ public class NotificationSettingStreamsViewController : UITableViewController
         
         return cell!
     }
-    
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        let headerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        headerView.title = footerForStream(streamAtSection(section))
-        return headerView
+
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return footerForStream(streamAtSection(section))
     }
-    
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        let title = footerForStream(streamAtSection(section))
-        let width = view.frame.width
-        return WPTableViewSectionHeaderFooterView.heightForFooter(title, width: width)
+
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
-    
-    
+
+
     
     // MARK: - UITableView Delegate Methods
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -10,7 +10,7 @@ import WordPressComAnalytics
 *                   push the Details View itself, which is in charge of rendering the actual available settings.
 */
 
-public class NotificationSettingsViewController : UIViewController
+public class NotificationSettingsViewController : UIViewController, UITableViewDataSource, UITableViewDelegate
 {
     // MARK: - View Lifecycle
     public override func viewDidLoad() {
@@ -162,56 +162,34 @@ public class NotificationSettingsViewController : UIViewController
         
         return isBlogSection && isNotPagination ? blogRowHeight : WPTableViewDefaultRowHeight
     }
-    
-    public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        // Hide when the section is empty!
-        if isSectionEmpty(section) {
-            return nil
-        }
-        
-        let theSection      = Section(rawValue: section)!
-        let footerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        footerView.title    = theSection.headerText()
-        return footerView
-    }
-    
-    public func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        // Hide when the section is empty!
-        if isSectionEmpty(section) {
-            return CGFloat.min
-        }
-        
-        let theSection      = Section(rawValue: section)!
-        let width           = view.frame.width
-        return WPTableViewSectionHeaderFooterView.heightForHeader(theSection.headerText(), width: width)
-    }
-    
-    public func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        // Hide when the section is empty!
-        if isSectionEmpty(section) {
-            return nil
-        }
-        
-        let theSection      = Section(rawValue: section)!
-        let footerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title    = theSection.footerText()
-        
-        return footerView
-    }
-    
-    public func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        // Hide when the section is empty!
-        if isSectionEmpty(section) {
-            return CGFloat.min
-        }
-        
-        let section         = Section(rawValue: section)!
-        let padding         = section.footerPadding()
-        let height          = WPTableViewSectionHeaderFooterView.heightForFooter(section.footerText(), width: view.frame.width)
 
-        return height + padding
+    public func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        // Hide when the section is empty!
+        if isSectionEmpty(section) {
+            return nil
+        }
+        
+        let theSection = Section(rawValue: section)!
+        return theSection.headerText()
     }
-    
+
+    public func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        // Hide when the section is empty!
+        if isSectionEmpty(section) {
+            return nil
+        }
+        
+        let theSection = Section(rawValue: section)!
+        return theSection.footerText()
+    }
+
+    public func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
+    }
+
+    public func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
+    }
 
     
     // MARK: - UITableView Delegate Methods

--- a/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
@@ -6,7 +6,6 @@
 #import "AbstractPost.h"
 #import "SettingsSelectionViewController.h"
 #import "UIImageView+AFNetworkingExtra.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 #import "WPGUIConstants.h"
 #import "WordPress-Swift.h"
 
@@ -55,6 +54,11 @@ typedef NS_ENUM(NSUInteger, ImageDetailsTextField) {
     controller.imageDetails = details;
     controller.post = post;
     return controller;
+}
+
+- (instancetype)init
+{
+    return [self initWithStyle:UITableViewStyleGrouped];
 }
 
 - (void)viewDidLoad
@@ -290,7 +294,7 @@ typedef NS_ENUM(NSUInteger, ImageDetailsTextField) {
     return 0;
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSInteger sec = [[self.sections objectAtIndex:section] integerValue];
     if (sec == ImageDetailsSectionDetails) {
@@ -300,30 +304,12 @@ typedef NS_ENUM(NSUInteger, ImageDetailsTextField) {
         return NSLocalizedString(@"Web Display Settings", @"The title of the option group for editing an image's size, alignment, etc. on the image details screen.");
     }
 
-    return @"";
+    return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = [self titleForHeaderInSection:section];
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    if (section == 0) {
-        return WPTableViewTopMargin;
-    }
-
-    NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    // Remove extra padding caused by section footers in grouped table views
-    return 1.0f;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -16,7 +16,6 @@
 #import "WPTextFieldTableViewCell.h"
 #import "WordPressAppDelegate.h"
 #import "WPTableViewActivityCell.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 #import "WPTableImageSource.h"
 #import "ContextManager.h"
 #import "MediaService.h"
@@ -331,7 +330,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     return 0;
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSInteger sec = [[self.sections objectAtIndex:section] integerValue];
     if (sec == PostSettingsSectionTaxonomy) {
@@ -350,30 +349,12 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         return NSLocalizedString(@"Geolocation", @"Label for the geolocation feature (tagging posts by their physical location).");
 
     }
-    return @"";
+    return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = [self titleForHeaderInSection:section];
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    if (IS_IPAD && section == 0) {
-        return WPTableViewTopMargin;
-    }
-
-    NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    // Remove extra padding caused by section footers in grouped table views
-    return 1.0f;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
@@ -206,16 +206,18 @@ static CGFloat const FollowSitesRowHeight = 54.0;
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
-    if ([[self.tableViewHandler.resultsController fetchedObjects] count] > 0) {
-        return NSLocalizedString(@"Sites", @"Section title for sites the user has followed.");
-    }
-    // Return an space instead of empty string or nil to preserve the section
-    // header's height if all items are removed and then one added back.
-    return @" ";
+    return NSLocalizedString(@"Sites", @"Section title for sites the user has followed.");
 }
 
 - (void)tableViewDidChangeContent:(UITableView *)tableView
 {
+    // Since we're not managing sections using the results controller, it will
+    // not call the delegate methods to notify that the sections changed.
+    // This causes a glitch where the section header would still be visible with
+    // an empty table until the user scrolls or reloads the view.
+    if ([self.tableView numberOfRowsInSection:0] == 0) {
+        [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:0] withRowAnimation:UITableViewRowAnimationNone];
+    }
     [self configureNoResultsView];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
@@ -204,7 +204,7 @@ static CGFloat const FollowSitesRowHeight = 54.0;
     return NSLocalizedString(@"Unfollow", @"Label of the table view cell's delete button, when unfollowing a site.");
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     if ([[self.tableViewHandler.resultsController fetchedObjects] count] > 0) {
         return NSLocalizedString(@"Sites", @"Section title for sites the user has followed.");
@@ -216,7 +216,6 @@ static CGFloat const FollowSitesRowHeight = 54.0;
 
 - (void)tableViewDidChangeContent:(UITableView *)tableView
 {
-    [self.tableViewHandler updateTitleForSection:0];
     [self configureNoResultsView];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
@@ -168,7 +168,7 @@
     }
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     id <NSFetchedResultsSectionInfo> sectionInfo = [self.tableViewHandler.resultsController.sections objectAtIndex:section];
 
@@ -180,7 +180,8 @@
         return NSLocalizedString(@"Tags", @"Section title for reader tags you can browse");
     }
 
-    return nil;}
+    return nil;
+}
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {

--- a/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
@@ -182,7 +182,7 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:ReaderTopicDidChangeViaUserInteractionNotification object:nil];
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     id <NSFetchedResultsSectionInfo> sectionInfo = [self.tableViewHandler.resultsController.sections objectAtIndex:section];
 

--- a/WordPress/Classes/ViewRelated/Settings/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Settings/AboutViewController.swift
@@ -106,6 +106,7 @@ public class AboutViewController : UITableViewController
     }
 
     public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        guard let view = view as? UITableViewHeaderFooterView else { return }
         WPStyleGuide.configureTableViewSectionFooter(view)
         view.textLabel?.textAlignment = .Center
     }

--- a/WordPress/Classes/ViewRelated/Settings/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Settings/AboutViewController.swift
@@ -9,7 +9,6 @@ public class AboutViewController : UITableViewController
         super.viewDidLoad()
         
         setupNavigationItem()
-        setupTableViewFooter()
         setupTableView()
         setupDismissButtonIfNeeded()
     }
@@ -41,14 +40,11 @@ public class AboutViewController : UITableViewController
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
     
-    private func setupTableViewFooter() {
+    private func footerText() -> String {
         let calendar                = NSCalendar.currentCalendar()
         let year                    = calendar.components(.Year, fromDate: NSDate()).year
 
-        let footerView              = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title            = NSLocalizedString("© \(year) Automattic, Inc.", comment: "About View's Footer Text")
-        footerView.titleAlignment   = .Center
-        self.footerView             = footerView
+        return NSLocalizedString("© \(year) Automattic, Inc.", comment: "About View's Footer Text")
     }
     
     private func setupDismissButtonIfNeeded() {
@@ -99,23 +95,20 @@ public class AboutViewController : UITableViewController
         
         return cell!
     }
-    
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        let isLastSection = section == (rows.count - 1)
-        if isLastSection == false || footerView == nil {
-            return CGFloat.min
-        }
-        
-        let height = WPTableViewSectionHeaderFooterView.heightForFooter(footerView!.title, width: view.frame.width)
-        return height + footerBottomPadding
-    }
 
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        if section != (rows.count - 1) {
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        let isLastSection = section == (rows.count - 1)
+        if !isLastSection {
             return nil
         }
-        
-        return footerView
+
+        return footerText()
+    }
+
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        guard let view = view as? UITableViewHeaderFooterView else { return }
+        WPStyleGuide.configureTableViewSectionFooter(view)
+        view.textLabel?.textAlignment = .Center
     }
     
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
@@ -175,8 +168,6 @@ public class AboutViewController : UITableViewController
     private let footerBottomPadding = CGFloat(12)
     
     // MARK: - Private Properties
-    private var footerView : WPTableViewSectionHeaderFooterView!
-    
     private var rows : [[Row]] {
         let appsBlogHostname = NSURL(string: WPAutomatticAppsBlogURL)?.host ?? String()
         

--- a/WordPress/Classes/ViewRelated/Settings/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Settings/AboutViewController.swift
@@ -106,7 +106,6 @@ public class AboutViewController : UITableViewController
     }
 
     public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
-        guard let view = view as? UITableViewHeaderFooterView else { return }
         WPStyleGuide.configureTableViewSectionFooter(view)
         view.textLabel?.textAlignment = .Center
     }

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
@@ -2,7 +2,6 @@
 #import "WordPressAppDelegate.h"
 #import "ActivityLogDetailViewController.h"
 #import <CocoaLumberjack/DDFileLogger.h>
-#import "WPTableViewSectionHeaderFooterView.h"
 #import "WordPress-Swift.h"
 #import "WPLogger.h"
 #import "WPGUIConstants.h"
@@ -109,30 +108,7 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
     return cell;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self titleForHeaderInSection:section];
-    if (!title) {
-        return nil;
-    }
-    
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self titleForHeaderInSection:section];
-    if (!title) {
-        // Fix: Prevents extra spacing when dealing with empty footers
-        return CGFLOAT_MIN;
-    }
-    
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     if (section == 0) {
         return NSLocalizedString(@"Log Files By Created Date", @"");
@@ -140,25 +116,22 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
-{
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    header.title = [self titleForFooterInSection:section];
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    NSString *title = [self titleForFooterInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForFooter:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (NSString *)titleForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     if (section == 0) {
         return NSLocalizedString(@"Seven days worth of log files are kept on file.", @"");
     }
     return nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionHeader:view];
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 #pragma mark - Table view delegate

--- a/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SettingsViewController.m
@@ -13,7 +13,6 @@
 #import "SupportViewController.h"
 #import "WPAccount.h"
 #import "WPPostViewController.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 #import "SupportViewController.h"
 #import "ContextManager.h"
 #import "NotificationsManager.h"
@@ -160,39 +159,7 @@ static NSInteger const MediaSizeSliderStep = 50;
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    if (section == SettingsSectionEditor && ![WPPostViewController isNewEditorAvailable]) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = [self titleForHeaderInSection:section];
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    if (section == SettingsSectionEditor && ![WPPostViewController isNewEditorAvailable]) {
-        return 1;
-    }
-
-    NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    static const CGFloat kDefaultFooterHeight = 16.0f;
-
-    if (section == SettingsSectionEditor && ![WPPostViewController isNewEditorAvailable]) {
-        return 1;
-    } else {
-        return kDefaultFooterHeight;
-    }
-}
-
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     if (section == SettingsSectionMedia) {
         return NSLocalizedString(@"Media", @"Title label for the media settings section in the app settings");
@@ -203,12 +170,15 @@ static NSInteger const MediaSizeSliderStep = 50;
     } else if (section == SettingsSectionInternalBeta) {
         if (self.showInternalBetaSection) {
             return NSLocalizedString(@"Internal Beta", @"");
-        } else {
-            return @"";
         }
     }
 
     return nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -4,7 +4,6 @@
 #import <UIDeviceIdentifier/UIDeviceHardware.h>
 #import "WordPressAppDelegate.h"
 #import <CocoaLumberjack/DDFileLogger.h>
-#import "WPTableViewSectionHeaderFooterView.h"
 #import <Helpshift/Helpshift.h>
 #import "WPAnalytics.h"
 #import <WordPressShared/WPStyleGuide.h>
@@ -406,30 +405,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionFeedbackRows)
     return CGFLOAT_MIN;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
-{
-    NSString *title = [self titleForFooterInSection:section];
-    if (!title) {
-        return nil;
-    }
-    
-    WPTableViewSectionHeaderFooterView *footer = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    footer.title = title;
-    return footer;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    NSString *title = [self titleForFooterInSection:section];
-    if (!title) {
-        // Fix: Prevents extra spacing when dealing with empty footers
-        return CGFLOAT_MIN;
-    }
-    
-    return [WPTableViewSectionHeaderFooterView heightForFooter:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (NSString *)titleForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     if (section == SettingsSectionFAQForums) {
         return NSLocalizedString(@"Visit the Help Center to get answers to common questions, or visit the Forums to ask new ones.", @"");
@@ -437,6 +413,11 @@ typedef NS_ENUM(NSInteger, SettingsSectionFeedbackRows)
         return NSLocalizedString(@"The Extra Debug feature includes additional information in activity logs, and can help us troubleshoot issues with the app.", @"");
     }
     return nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 #pragma mark - Table view delegate

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -1,7 +1,6 @@
 #import "SettingsMultiTextViewController.h"
 #import "WPStyleGuide.h"
 #import "WPTableViewCell.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 
 static CGFloat const HorizontalMargin = 10.0f;
 
@@ -9,7 +8,6 @@ static CGFloat const HorizontalMargin = 10.0f;
 
 @property (nonatomic, strong) UITableViewCell *textViewCell;
 @property (nonatomic, strong) UITextView *textView;
-@property (nonatomic, strong) UIView *hintView;
 @property (nonatomic, strong) NSString *hint;
 @property (nonatomic, assign) BOOL isPassword;
 @property (nonatomic, strong) NSString *placeholder;
@@ -80,17 +78,6 @@ static CGFloat const HorizontalMargin = 10.0f;
     return _textViewCell;
 }
 
-- (UIView *)hintView
-{
-    if (_hintView) {
-        return _hintView;
-    }
-    WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    [footerView setTitle:_hint];
-    _hintView = footerView;
-    return _hintView;
-}
-
 - (void)viewDidDisappear:(BOOL)animated
 {
     if (self.onValueChanged) {
@@ -118,9 +105,14 @@ static CGFloat const HorizontalMargin = 10.0f;
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    return self.hintView;
+    return self.hint;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (void)textViewDidChange:(UITextView *)textView

--- a/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
@@ -3,7 +3,6 @@
 #import "NSDictionary+SafeExpectations.h"
 #import "NSString+XMLExtensions.h"
 #import "WPTableViewCell.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 
 NSString * const SettingsSelectionTitleKey = @"Title";
 NSString * const SettingsSelectionTitlesKey = @"Titles";
@@ -11,10 +10,6 @@ NSString * const SettingsSelectionValuesKey = @"Values";
 NSString * const SettingsSelectionHintsKey = @"Hints";
 NSString * const SettingsSelectionDefaultValueKey = @"DefaultValue";
 NSString * const SettingsSelectionCurrentValueKey = @"CurrentValue";
-
-@interface SettingsSelectionViewController ()
-@property (nonatomic, strong) WPTableViewSectionHeaderFooterView *hintView;
-@end
 
 @implementation SettingsSelectionViewController
 
@@ -82,20 +77,14 @@ NSString * const SettingsSelectionCurrentValueKey = @"CurrentValue";
     }
 }
 
-- (UIView *)hintView
+- (NSString *)currentHint
 {
     if (!self.hints) {
         return nil;
     }
     
-    if (!_hintView) {
-        _hintView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    }
-    
     NSUInteger position = [self.values indexOfObject:self.currentValue];
-    _hintView.title = (position != NSNotFound) ? self.hints[position] : [NSString string];
-
-    return _hintView;
+    return (position != NSNotFound) ? self.hints[position] : nil;
 }
 
 #pragma mark - Table view data source
@@ -144,9 +133,14 @@ NSString * const SettingsSelectionCurrentValueKey = @"CurrentValue";
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    return self.hintView;
+    return [self currentHint];
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (void)dismiss

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -1,7 +1,6 @@
 #import "SettingsTextViewController.h"
 #import "WPTextFieldTableViewCell.h"
 #import "WPStyleGuide.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 
 static CGFloat const HorizontalMargin = 15.0f;
 
@@ -9,7 +8,6 @@ static CGFloat const HorizontalMargin = 15.0f;
 
 @property (nonatomic, strong) WPTableViewCell *textFieldCell;
 @property (nonatomic, strong) UITextField *textField;
-@property (nonatomic, strong) UIView *hintView;
 @property (nonatomic, strong) NSString *hint;
 @property (nonatomic, assign) BOOL isPassword;
 @property (nonatomic, strong) NSString *placeholder;
@@ -75,17 +73,6 @@ static CGFloat const HorizontalMargin = 15.0f;
     return _textFieldCell;
 }
 
-- (UIView *)hintView
-{
-    if (_hintView) {
-        return _hintView;
-    }
-    WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    [footerView setTitle:_hint];
-    _hintView = footerView;
-    return _hintView;
-}
-
 - (void)viewDidDisappear:(BOOL)animated
 {
     if (self.onValueChanged && ![self.textField.text isEqualToString:self.text]) {
@@ -113,9 +100,14 @@ static CGFloat const HorizontalMargin = 15.0f;
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    return self.hintView;
+    return self.hint;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 @end


### PR DESCRIPTION
Instead of using a subclass to customize font and color, we do that using the table view delegate methods now.

![before-after-wptableviewsectionheaderfooterview](https://cloud.githubusercontent.com/assets/8739/11894590/7dca57ce-a578-11e5-8770-a7af58a3a52e.png)

Needs Review: @aerych 