### PR TITLE
Fix crash on iPad 2

### DIFF
--- a/WordPress/Classes/Models/AccountSettings.swift
+++ b/WordPress/Classes/Models/AccountSettings.swift
@@ -24,7 +24,7 @@ extension AccountSettings {
 
         username = managed.username
         email = managed.email
-        primarySiteID = managed.primarySiteID
+        primarySiteID = managed.primarySiteID.integerValue
         webAddress = managed.webAddress
         language = managed.language
     }

--- a/WordPress/Classes/Models/ManagedAccountSettings+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/ManagedAccountSettings+CoreDataProperties.swift
@@ -9,7 +9,7 @@ extension ManagedAccountSettings {
 
     @NSManaged var username: String
     @NSManaged var email: String
-    @NSManaged var primarySiteID: Int
+    @NSManaged var primarySiteID: NSNumber
     @NSManaged var webAddress: String
     @NSManaged var language: String
 

--- a/WordPress/Classes/Models/ManagedAccountSettings.swift
+++ b/WordPress/Classes/Models/ManagedAccountSettings.swift
@@ -63,7 +63,7 @@ class ManagedAccountSettings: NSManagedObject {
         case .Email(_):
             return .Email(self.email)
         case .PrimarySite(_):
-            return .PrimarySite(self.primarySiteID)
+            return .PrimarySite(self.primarySiteID.integerValue)
         case .WebAddress(_):
             return .WebAddress(self.webAddress)
         case .Language(_):


### PR DESCRIPTION
Use NSNumber for NSManagedObject attributes. The model type is Int64, and Int
seemed to work fine, I guess because I just tested on 64 bit simulators.

The iPad 2 crashed when visiting My Profile. Switching to NSNumber seems to fix
it.

Fixes #4604 

Needs Review: @astralbodies 