### PR TITLE
Disable My Profile on App Store builds

### DIFF
--- a/WordPress/Classes/ViewRelated/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/MeViewController.swift
@@ -118,23 +118,42 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         let wordPressComAccount = NSLocalizedString("WordPress.com Account", comment: "WordPress.com sign-in/sign-out section header title")
 
         if loggedIn {
-            return ImmuTable(
-                sections: [
-                    ImmuTableSection(rows: [
-                        myProfile,
-                        accountSettings,
-                        notificationSettings
-                        ]),
-                    ImmuTableSection(rows: [
-                        helpAndSupport,
-                        about
-                        ]),
-                    ImmuTableSection(
-                        headerText: wordPressComAccount,
-                        rows: [
-                            logOut
-                        ])
-                ])
+            if Feature.enabled(.MyProfile) {
+                return ImmuTable(
+                    sections: [
+                        ImmuTableSection(rows: [
+                            myProfile,
+                            accountSettings,
+                            notificationSettings
+                            ]),
+                        ImmuTableSection(rows: [
+                            helpAndSupport,
+                            about
+                            ]),
+                        ImmuTableSection(
+                            headerText: wordPressComAccount,
+                            rows: [
+                                logOut
+                            ])
+                    ])
+            } else {
+                return ImmuTable(
+                    sections: [
+                        ImmuTableSection(rows: [
+                            accountSettings,
+                            notificationSettings
+                            ]),
+                        ImmuTableSection(rows: [
+                            helpAndSupport,
+                            about
+                            ]),
+                        ImmuTableSection(
+                            headerText: wordPressComAccount,
+                            rows: [
+                                logOut
+                            ])
+                    ])
+            }
         } else { // Logged out
             return ImmuTable(
                 sections: [

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5012,6 +5012,7 @@
 					"-l\"sqlite3.0\"",
 					"-l\"z\"",
 				);
+				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress;
 				PRODUCT_NAME = WordPress;
 				PROVISIONING_PROFILE = "943e2dea-aa61-472d-b7db-4033fe6cae19";
@@ -5241,6 +5242,7 @@
 					"-l\"sqlite3.0\"",
 					"-l\"z\"",
 				);
+				OTHER_SWIFT_FLAGS = "-D ALPHA_BUILD -D INTERNAL_BUILD";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.alpha;
 				PRODUCT_NAME = WordPress;
 				PROVISIONING_PROFILE = "f277d7c2-eff6-46cd-aaa3-6784e2b4dcfc";
@@ -5506,6 +5508,7 @@
 					"-l\"sqlite3.0\"",
 					"-l\"z\"",
 				);
+				OTHER_SWIFT_FLAGS = "-D INTERNAL_BUILD";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.internal;
 				PRODUCT_NAME = WordPress;
 				PROVISIONING_PROFILE = "bd27f648-b38b-41f1-a48e-765fd10701cf";


### PR DESCRIPTION
My Profile should only be visible on Debug/Internal builds, not on the App Store version.

I'm not too happy with repeating the whole ImmuTable tree for each check, but it seemed simpler and more readable than any of the alternatives, and should be gone in a few weeks when My Profile is finished.

Needs Review: @jleandroperez 