### PR TITLE
Notification Details Refactor

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -98,61 +98,26 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     _tableView.dataSource = nil;
 }
 
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        self.restorationClass = [self class];
+    }
+    
+    return self;
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];
     
-    self.restorationClass                   = [self class];
-    self.view.backgroundColor               = [WPStyleGuide itsEverywhereGrey];
+    [self setupNavigationBar];
+    [self setupMainView];
+    [self setupTableView];
+    [self setupMediaDownloader];
+    [self setupNotificationListeners];
     
-    // Don't show the notification title in the next-view's back button
-    UIBarButtonItem *backButton             = [[UIBarButtonItem alloc] initWithTitle:[NSString string] style:UIBarButtonItemStylePlain target:nil action:nil];
-    self.navigationItem.backBarButtonItem   = backButton;
-
-    self.reuseIdentifierMap = @{
-        @(NoteBlockGroupTypeHeader)         : NoteBlockHeaderTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeFooter)         : NoteBlockTextTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeText)           : NoteBlockTextTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeComment)        : NoteBlockCommentTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeActions)        : NoteBlockActionsTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeImage)          : NoteBlockImageTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeUser)           : NoteBlockUserTableViewCell.reuseIdentifier
-    };
-    
-    // Register Cell Nibs
-    NSArray *cellClassNames = @[
-        NSStringFromClass([NoteBlockHeaderTableViewCell class]),
-        NSStringFromClass([NoteBlockTextTableViewCell class]),
-        NSStringFromClass([NoteBlockActionsTableViewCell class]),
-        NSStringFromClass([NoteBlockCommentTableViewCell class]),
-        NSStringFromClass([NoteBlockImageTableViewCell class]),
-        NSStringFromClass([NoteBlockUserTableViewCell class])
-    ];
-    
-    for (NSString *cellClassName in cellClassNames) {
-        Class cellClass                     = NSClassFromString(cellClassName);
-        NSString *className                 = [cellClass classNameWithoutNamespaces];
-        UINib *tableViewCellNib             = [UINib nibWithNibName:className bundle:[NSBundle mainBundle]];
-        
-        [self.tableView registerNib:tableViewCellNib forCellReuseIdentifier:[cellClass reuseIdentifier]];
-        [self.tableView registerNib:tableViewCellNib forCellReuseIdentifier:[cellClass layoutIdentifier]];
-    }
-    
-    // TableView
-    self.tableView.separatorStyle           = UITableViewCellSeparatorStyleNone;
-    self.tableView.backgroundColor          = [WPStyleGuide itsEverywhereGrey];
-    self.tableView.accessibilityIdentifier  = @"Notification Details Table";
-    self.tableView.backgroundColor          = [WPStyleGuide itsEverywhereGrey];
-    
-    // Media
-    self.mediaDownloader                    = [NotificationMediaDownloader new];
-    
-    NSManagedObjectContext *context = self.note.managedObjectContext;
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleNotificationChange:)
-                                                 name:NSManagedObjectContextObjectsDidChangeNotification
-                                               object:context];
-
     [AppRatingUtility incrementSignificantEventForSection:@"notifications"];
 }
 
@@ -224,6 +189,66 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 }
 
 
+#pragma mark - Setup Helpers
+
+- (void)setupNavigationBar
+{
+    // Don't show the notification title in the next-view's back button
+    self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:[NSString string]
+                                                                             style:UIBarButtonItemStylePlain
+                                                                            target:nil
+                                                                            action:nil];
+}
+
+- (void)setupMainView
+{
+    self.view.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+}
+
+- (void)setupTableView
+{
+    // Register Cell Nibs
+    NSArray *cellClassNames = @[
+        NSStringFromClass([NoteBlockHeaderTableViewCell class]),
+        NSStringFromClass([NoteBlockTextTableViewCell class]),
+        NSStringFromClass([NoteBlockActionsTableViewCell class]),
+        NSStringFromClass([NoteBlockCommentTableViewCell class]),
+        NSStringFromClass([NoteBlockImageTableViewCell class]),
+        NSStringFromClass([NoteBlockUserTableViewCell class])
+    ];
+    
+    for (NSString *cellClassName in cellClassNames) {
+        Class cellClass                     = NSClassFromString(cellClassName);
+        NSString *className                 = [cellClass classNameWithoutNamespaces];
+        UINib *tableViewCellNib             = [UINib nibWithNibName:className bundle:[NSBundle mainBundle]];
+        
+        [self.tableView registerNib:tableViewCellNib forCellReuseIdentifier:[cellClass reuseIdentifier]];
+        [self.tableView registerNib:tableViewCellNib forCellReuseIdentifier:[cellClass layoutIdentifier]];
+    }
+    
+    // TableView
+    self.tableView.separatorStyle           = UITableViewCellSeparatorStyleNone;
+    self.tableView.backgroundColor          = [WPStyleGuide itsEverywhereGrey];
+    self.tableView.accessibilityIdentifier  = @"Notification Details Table";
+    self.tableView.backgroundColor          = [WPStyleGuide itsEverywhereGrey];
+    self.tableView.keyboardDismissMode      = UIScrollViewKeyboardDismissModeInteractive;
+}
+
+- (void)setupMediaDownloader
+{
+    self.mediaDownloader = [NotificationMediaDownloader new];
+}
+
+- (void)setupNotificationListeners
+{
+    NSManagedObjectContext *context = self.note.managedObjectContext;
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleNotificationChange:)
+                                                 name:NSManagedObjectContextObjectsDidChangeNotification
+                                               object:context];
+}
+
+
 #pragma mark - Autolayout Helpers
 
 - (NSDictionary *)layoutCellMap
@@ -244,6 +269,19 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     };
     
     return _layoutCellMap;
+}
+
+- (NSDictionary *)reuseIdentifierMap
+{
+    return @{
+        @(NoteBlockGroupTypeHeader)         : NoteBlockHeaderTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeFooter)         : NoteBlockTextTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeText)           : NoteBlockTextTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeComment)        : NoteBlockCommentTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeActions)        : NoteBlockActionsTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeImage)          : NoteBlockImageTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeUser)           : NoteBlockUserTableViewCell.reuseIdentifier
+    };
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -227,7 +227,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     
     // TableView
     self.tableView.separatorStyle           = UITableViewCellSeparatorStyleNone;
-    self.tableView.backgroundColor          = [WPStyleGuide itsEverywhereGrey];
+    self.tableView.backgroundColor          = [WPStyleGuide greyLighten30];
     self.tableView.accessibilityIdentifier  = @"Notification Details Table";
     self.tableView.backgroundColor          = [WPStyleGuide itsEverywhereGrey];
     self.tableView.keyboardDismissMode      = UIScrollViewKeyboardDismissModeInteractive;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -159,9 +159,8 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 {
     // Hide the header, if needed
     NSMutableArray *blockGroups = [NSMutableArray array];
-    BOOL hasHeaderBlocks        = (_note.headerBlockGroup != nil);
     
-    if (hasHeaderBlocks) {
+    if (_note.headerBlockGroup) {
         [blockGroups addObject:_note.headerBlockGroup];
     }
     
@@ -274,13 +273,13 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 - (NSDictionary *)reuseIdentifierMap
 {
     return @{
-        @(NoteBlockGroupTypeHeader)         : NoteBlockHeaderTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeFooter)         : NoteBlockTextTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeText)           : NoteBlockTextTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeComment)        : NoteBlockCommentTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeActions)        : NoteBlockActionsTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeImage)          : NoteBlockImageTableViewCell.reuseIdentifier,
-        @(NoteBlockGroupTypeUser)           : NoteBlockUserTableViewCell.reuseIdentifier
+        @(NoteBlockGroupTypeHeader)     : NoteBlockHeaderTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeFooter)     : NoteBlockTextTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeText)       : NoteBlockTextTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeComment)    : NoteBlockCommentTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeActions)    : NoteBlockActionsTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeImage)      : NoteBlockImageTableViewCell.reuseIdentifier,
+        @(NoteBlockGroupTypeUser)       : NoteBlockUserTableViewCell.reuseIdentifier
     };
 }
 


### PR DESCRIPTION
In this PR we're splitting *NotificationDetailsViewController.viewDidLoad* method, just to keep things readable (long overdue minor touch).

Please, test opening few Notification Details, just for safety!.

Needs Review: @aerych 
Thanks in advance Eric!
