### PR TITLE
Rename editor_video_added Tracks event and add a "via" property.

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -209,10 +209,12 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
             eventProperties = @{ @"via" : @"media_library" };
             break;
         case WPAnalyticsStatEditorAddedVideoViaLocalLibrary:
-            eventName = @"editor_added_video_via_local_library";
+            eventName = @"editor_video_added";
+            eventProperties = @{ @"via" : @"local_library" };
             break;
         case WPAnalyticsStatEditorAddedVideoViaWPMediaLibrary:
-            eventName = @"editor_added_video_via_wp_media_library";
+            eventName = @"editor_video_added";
+            eventProperties = @{ @"via" : @"media_library" };
             break;
         case WPAnalyticsStatEditorClosed:
             eventName = @"editor_closed";


### PR DESCRIPTION
Reproduced the same kind name/properties as "editor_photo_added"
s/editor_added_video_via_local_library/editor_added_video/

Match wpandroid: https://github.com/wordpress-mobile/WordPress-Android/blob/2e98b5a36c64caa7a42066d6c1dcecf7a0eb4937/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java#L155-L162