### PR TITLE
NotificationsManager: Revamp Mark II

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -257,7 +257,7 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   DTCoreText: 934a16fe9ffdd169c96261721b39dc312b75713d
   DTFoundation: 46e2b2fafe78d67febfd8d1f85fe9845a093f00e
-  EmailChecker: 1b9c5a58c994bc638f842a4d69523b6ab57e706e
+  EmailChecker: 78dd8dfa9d004826c8b5889be6c380b72b837d44
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
   Helpshift: 9c84a5e4ffd881c7e7eb395c2afc8d6a46eb2187

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -79,7 +79,8 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         NSManagedObject *accountInContext = [mainContext existingObjectWithID:accountID error:nil];
         [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:accountInContext];
 
-        [[PushNotificationsManager sharedInstance] registerForPushNotifications];
+        [[PushNotificationsManager sharedInstance] registerForRemoteNotifications];
+        [[InteractiveNotificationsHandler sharedInstance] registerForUserNotifications];
     });
 }
 

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -8,6 +8,7 @@
 
 #import "Blog.h"
 #import "BlogService.h"
+#import "CommentService.h"
 
 #import "Constants.h"
 #import "ContextManager.h"

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -379,8 +379,9 @@ int ddLogLevel                                                  = DDLogLevelInfo
 
     [self customizeAppearance];
     
-    // Push notifications
-    [[PushNotificationsManager sharedInstance] registerForPushNotifications];
+    // Notifications
+    [[PushNotificationsManager sharedInstance] registerForRemoteNotifications];
+    [[InteractiveNotificationsHandler sharedInstance] registerForUserNotifications];
     
     // Deferred tasks to speed up app launch
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -426,7 +426,7 @@ int ddLogLevel                                                  = DDLogLevelInfo
                                         forRemoteNotification:(NSDictionary *)remoteNotification
                                             completionHandler:(void (^)())completionHandler
 {
-    [NotificationsManager handleActionWithIdentifier:identifier forRemoteNotification:remoteNotification];
+    [[InteractiveNotificationsHandler sharedInstance] handleActionWithIdentifier:identifier remoteNotification:remoteNotification];
     
     completionHandler();
 }

--- a/WordPress/Classes/Utility/InteractiveNotificationsHandler.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsHandler.swift
@@ -4,9 +4,37 @@ import Foundation
 /// In this class, we'll encapsulate all of the code related to UIUserNotificationCategory and
 /// UIUserNotificationAction instantiation, along with the required handlers.
 ///
-final public class InteractiveNotificationsHandler
+final public class InteractiveNotificationsHandler : NSObject
 {
+    // MARK: - Public Properties
+    
+    
+    /// Returns the shared PushNotificationsManager instance.
+    ///
+    static let sharedInstance = InteractiveNotificationsHandler()
+    
+    
+    
     // MARK: - Public Methods
+    
+    
+    /// Registers the device for User Notifications.
+    ///
+    func registerForUserNotifications() {
+        let sharedApplication = UIApplication.sharedApplication()
+        if sharedApplication.isRunningSimulator() || sharedApplication.isAlphaBuild() {
+            return
+        }
+        
+        // User Notifications Registration
+        let categories  = supportedNotificationCategories()
+        let settings    = UIUserNotificationSettings(forTypes: [.Badge, .Sound, .Alert], categories: categories)
+        sharedApplication.registerUserNotificationSettings(settings)
+    }
+    
+    
+    
+    // MARK: - Private Methods
     
     
     /// Returns a collection of *UIUserNotificationCategory* instances, for each one of the
@@ -14,13 +42,10 @@ final public class InteractiveNotificationsHandler
     ///
     /// - Returns: A set of *UIUserNotificationCategory* instances.
     ///
-    func supportedNotificationCategories() -> Set<UIUserNotificationCategory> {
+    private func supportedNotificationCategories() -> Set<UIUserNotificationCategory> {
         return notificationCategories(NoteCategoryDefinition.allDefinitions)
     }
     
-    
-    
-    // MARK: - Private Methods
     
     
     /// Parses a given array of NoteCategoryDefinition, and returns a collection of their

--- a/WordPress/Classes/Utility/InteractiveNotificationsHandler.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsHandler.swift
@@ -1,33 +1,36 @@
 import Foundation
 
 
-/**
- *  @extension      InteractiveNotificationsHandler
- *  @details        In this class, we'll encapsulate all of the code related to UIUserNotificationCategory and 
- *                  UIUserNotificationAction instantiation, along with the required handlers.
- */
-
+/// In this class, we'll encapsulate all of the code related to UIUserNotificationCategory and
+/// UIUserNotificationAction instantiation, along with the required handlers.
+///
 final public class InteractiveNotificationsHandler
 {
-    /**
-     *  @brief      Returns a collection of *UIUserNotificationCategory* instances, for each one of the
-     *              supported NoteCategoryDefinition enum case's.
-     *  @returns    A set of *UIUserNotificationCategory* instances.
-     */
+    // MARK: - Public Methods
     
+    
+    /// Returns a collection of *UIUserNotificationCategory* instances, for each one of the
+    /// supported NoteCategoryDefinition enum case's.
+    ///
+    /// - Returns: A set of *UIUserNotificationCategory* instances.
+    ///
     func supportedNotificationCategories() -> Set<UIUserNotificationCategory> {
         return notificationCategories(NoteCategoryDefinition.allDefinitions)
     }
     
     
     
-    /**
-     *  @brief      Parses a given array of NoteCategoryDefinition, and returns a collection of their
-     *              *UIUserNotificationCategory* counterparts.
-     *
-     *  @param      definitions     A collection of definitions to be instantiated.
-     *  @returns                    A collection of UIUserNotificationCategory instances
-     */
+    // MARK: - Private Methods
+    
+    
+    /// Parses a given array of NoteCategoryDefinition, and returns a collection of their
+    /// *UIUserNotificationCategory* counterparts.
+    ///
+    /// - Parameters:
+    ///     - definitions: A collection of definitions to be instantiated.
+    ///
+    /// - Returns: A collection of UIUserNotificationCategory instances
+    ///
     private func notificationCategories(definitions: [NoteCategoryDefinition]) -> Set<UIUserNotificationCategory> {
         var categories  = Set<UIUserNotificationCategory>()
         let rawActions  = definitions.flatMap { $0.actions }
@@ -48,13 +51,14 @@ final public class InteractiveNotificationsHandler
     
     
     
-    /**
-     *  @brief      Parses a given array of NoteActionDefinition, and returns a collection mapping them
-     *              with their *UIUserNotificationAction* counterparts.
-     *
-     *  @param      definitions     A collection of definitions to be instantiated.
-     *  @returns                    A map of Definition > NotificationAction instances
-     */
+    /// Parses a given array of NoteActionDefinition, and returns a collection mapping them with their
+    /// *UIUserNotificationAction* counterparts.
+    ///
+    /// - Parameters:
+    ///     - definitions: A collection of definitions to be instantiated.
+    ///
+    /// - Returns: A map of Definition > NotificationAction instances
+    ///
     private func notificationActionsMap(definitions: [NoteActionDefinition]) -> [NoteActionDefinition : UIUserNotificationAction] {
         var actionMap = [NoteActionDefinition : UIUserNotificationAction]()
         
@@ -74,11 +78,9 @@ final public class InteractiveNotificationsHandler
     
     
     
-    /**
-     *  @enum       NoteCategoryDefinition
-     *  @brief      Describes information about Custom Actions that WPiOS can perform, as a response to
-     *              a Push Notification event.
-     */
+    /// Describes information about Custom Actions that WPiOS can perform, as a response to
+    /// a Push Notification event.
+    ///
     private enum NoteCategoryDefinition : String {
         case CommentApprove         = "approve-comment"
         case CommentLike            = "like-comment"
@@ -105,10 +107,8 @@ final public class InteractiveNotificationsHandler
     
     
     
-    /**
-     *  @enum       NoteActionDefinition
-     *  @brief      Describes the custom actions that WPiOS can perform in response to a Push notification.
-     */
+    /// Describes the custom actions that WPiOS can perform in response to a Push notification.
+    ///
     private enum NoteActionDefinition : String {
         case CommentApprove = "COMMENT_MODERATE_APPROVE"
         case CommentLike    = "COMMENT_LIKE"

--- a/WordPress/Classes/Utility/InteractiveNotificationsHandler.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsHandler.swift
@@ -14,6 +14,13 @@ final public class InteractiveNotificationsHandler : NSObject
     static let sharedInstance = InteractiveNotificationsHandler()
     
     
+    /// Returns the SharedApplication instance. This is meant for Unit Testing purposes.
+    ///
+    var sharedApplication : UIApplication {
+        return UIApplication.sharedApplication()
+    }
+    
+    
     
     // MARK: - Public Methods
     
@@ -21,7 +28,6 @@ final public class InteractiveNotificationsHandler : NSObject
     /// Registers the device for User Notifications.
     ///
     public func registerForUserNotifications() {
-        let sharedApplication = UIApplication.sharedApplication()
         if sharedApplication.isRunningSimulator() || sharedApplication.isAlphaBuild() {
             return
         }

--- a/WordPress/Classes/Utility/InteractiveNotificationsHandler.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsHandler.swift
@@ -26,15 +26,13 @@ final public class InteractiveNotificationsHandler : NSObject
             return
         }
         
-        // User Notifications Registration
-        let categories  = supportedNotificationCategories()
-        let settings    = UIUserNotificationSettings(forTypes: [.Badge, .Sound, .Alert], categories: categories)
+        let settings = UIUserNotificationSettings(forTypes: [.Badge, .Sound, .Alert], categories: supportedNotificationCategories())
         sharedApplication.registerUserNotificationSettings(settings)
     }
     
     
     
-    // MARK: - Private Methods
+    // MARK: - Private: UIUserNotification Helpers
     
     
     /// Returns a collection of *UIUserNotificationCategory* instances, for each one of the
@@ -43,7 +41,7 @@ final public class InteractiveNotificationsHandler : NSObject
     /// - Returns: A set of *UIUserNotificationCategory* instances.
     ///
     private func supportedNotificationCategories() -> Set<UIUserNotificationCategory> {
-        return notificationCategories(NoteCategoryDefinition.allDefinitions)
+        return notificationCategoriesWithDefinitions(NoteCategoryDefinition.allDefinitions)
     }
     
     
@@ -56,10 +54,10 @@ final public class InteractiveNotificationsHandler : NSObject
     ///
     /// - Returns: A collection of UIUserNotificationCategory instances
     ///
-    private func notificationCategories(definitions: [NoteCategoryDefinition]) -> Set<UIUserNotificationCategory> {
+    private func notificationCategoriesWithDefinitions(definitions: [NoteCategoryDefinition]) -> Set<UIUserNotificationCategory> {
         var categories  = Set<UIUserNotificationCategory>()
         let rawActions  = definitions.flatMap { $0.actions }
-        let actionsMap  = notificationActionsMap(rawActions)
+        let actionsMap  = notificationActionsMapWithDefinitions(rawActions)
         
         for definition in definitions {
             let category = UIMutableUserNotificationCategory()
@@ -84,7 +82,7 @@ final public class InteractiveNotificationsHandler : NSObject
     ///
     /// - Returns: A map of Definition > NotificationAction instances
     ///
-    private func notificationActionsMap(definitions: [NoteActionDefinition]) -> [NoteActionDefinition : UIUserNotificationAction] {
+    private func notificationActionsMapWithDefinitions(definitions: [NoteActionDefinition]) -> [NoteActionDefinition : UIUserNotificationAction] {
         var actionMap = [NoteActionDefinition : UIUserNotificationAction]()
         
         for definition in definitions {

--- a/WordPress/Classes/Utility/NotificationsManager.h
+++ b/WordPress/Classes/Utility/NotificationsManager.h
@@ -25,12 +25,4 @@
  */
 + (void)handleNotificationForApplicationLaunch:(NSDictionary *)launchOptions;
 
-/**
- Handle an action taken from a remote notification
- 
- @param identifier the identifier of the action
- @param remoteNotification the notification object
- */
-+ (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)remoteNotification;
-
 @end

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -79,8 +79,8 @@ final public class PushNotificationsManager : NSObject
     func registerDeviceToken(tokenData: NSData) {
         // We want to register Helpshift regardless so that way if a user isn't logged in
         // they can still get push notifications that we replied to their support ticket.
-        Helpshift.sharedInstance().registerDeviceToken(tokenData)
-        Mixpanel.sharedInstance().people?.addPushDeviceToken(tokenData)
+        Helpshift.sharedInstance()?.registerDeviceToken(tokenData)
+        Mixpanel.sharedInstance()?.people?.addPushDeviceToken(tokenData)
 
         // Don't bother registering for WordPress anything if the user isn't logged in
         if wordPressDotComAvailable() == false {

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -3,42 +3,36 @@ import Mixpanel
 
 
 
-/**
- *  @details        These notifications are sent when the user Registers / Unregisters for Push Notifications.
- */
+/// These notifications are sent when the user Registers / Unregisters for Push Notifications.
+///
 public let NotificationsManagerDidRegisterDeviceToken   = "NotificationsManagerDidRegisterDeviceToken"
 public let NotificationsManagerDidUnregisterDeviceToken = "NotificationsManagerDidUnregisterDeviceToken"
 
 
 
-/**
- *  @class          PushNotificationsManager
- *  @details        The purpose of this helper is to encapsulate all the tasks related to
- *                  Push Notifications Registration + Handling, including iOS "Actionable" Notifications.
- */
-
+/// The purpose of this helper is to encapsulate all the tasks related to Push Notifications Registration + Handling, 
+/// including iOS "Actionable" Notifications.
+///
 final public class PushNotificationsManager : NSObject
 {
     // MARK: - Public Properties
     
-    /**
-     *  @details    Returns the shared PushNotificationsManager instance.
-     */
+    
+    /// Returns the shared PushNotificationsManager instance.
+    ///
     static let sharedInstance = PushNotificationsManager()
     
     
-    /**
-     *  @details    Returns the SharedApplication instance. This is meant for Unit Testing purposes.
-     */
+    /// Returns the SharedApplication instance. This is meant for Unit Testing purposes.
+    ///
     var sharedApplication : UIApplication {
         return UIApplication.sharedApplication()
     }
     
 
 
-    /**
-     *  @details    Stores the Apple's Push Notifications Token
-     */
+    /// Stores the Apple's Push Notifications Token
+    ///
     var deviceToken : String? {
         didSet {
             save()
@@ -46,9 +40,8 @@ final public class PushNotificationsManager : NSObject
     }
 
     
-    /**
-     *  @details    Stores the WordPress.com Device identifier
-     */
+    /// Stores the WordPress.com Device identifier
+    ///
     var deviceId : String? {
         didSet {
             save()
@@ -59,11 +52,11 @@ final public class PushNotificationsManager : NSObject
     
     // MARK: - Public Methods
     
-    /**
-     *  @brief      Registers the device for Remote + User Notifications.
-     *  @details    We'll wire Badge + Sound + Alert notifications, along with support for
-     *              iOS User Notifications Actions.
-     */
+    
+    /// Registers the device for Remote + User Notifications.
+    ///
+    /// - Note: We'll wire Badge + Sound + Alert notifications, along with support for iOS User Notifications Actions.
+    ///
     func registerForPushNotifications() {
         if sharedApplication.isRunningSimulator() || sharedApplication.isAlphaBuild() {
             return;
@@ -80,20 +73,17 @@ final public class PushNotificationsManager : NSObject
     
 
     
-    /**
-     *  @details    Indicates whether Push Notifications are enabled in Settings.app, or not.
-     */
+    /// Indicates whether Push Notifications are enabled in Settings.app, or not.
     func notificationsEnabledInDeviceSettings() -> Bool {
         return (sharedApplication.currentUserNotificationSettings()?.types ?? .None) != .None
     }
     
     
     
-    /**
-     *  @brief      Registers the Device Token agains WordPress.com backend, if there's a default account.
-     *  @details    Both Helpshift and Mixpanel will also be initialized. The token will be persisted across
-     *              App Sessions.
-     */
+    /// Registers the Device Token agains WordPress.com backend, if there's a default account.
+    ///
+    /// - Note: Both Helpshift and Mixpanel will also be initialized. The token will be persisted across App Sessions.
+    ///
     func registerDeviceToken(tokenData: NSData) {
         // We want to register Helpshift regardless so that way if a user isn't logged in
         // they can still get push notifications that we replied to their support ticket.
@@ -135,10 +125,11 @@ final public class PushNotificationsManager : NSObject
     
     
     
-    /**
-     *  @brief     Perform cleanup when the registration for iOS notifications failed
-     *  @param     error detailing the reason for failure
-     */
+    /// Perform cleanup when the registration for iOS notifications failed
+    ///
+    /// - Parameters:
+    ///     - error: Details the reason of failure
+    ///
     func registrationDidFail(error: NSError) {
         DDLogSwift.logError("Failed to register for push notifications: \(error)")
         unregisterDeviceToken()
@@ -146,9 +137,8 @@ final public class PushNotificationsManager : NSObject
     
     
     
-    /**
-     *  @brief      Unregister the device from WordPress.com notifications
-     */
+    /// Unregister the device from WordPress.com notifications
+    ///
     func unregisterDeviceToken() {
         guard let knownDeviceId = deviceId else {
             return
@@ -177,9 +167,9 @@ final public class PushNotificationsManager : NSObject
 
     // MARK: - Private Methods
     
-    /**
-     *  @brief      Indicates whether there is a default WordPress.com accounta available, or not
-     */
+    
+    /// Indicates whether there is a default WordPress.com accounta available, or not
+    ///
     private func wordPressDotComAvailable() -> Bool {
         let mainContext = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: mainContext)
@@ -189,9 +179,8 @@ final public class PushNotificationsManager : NSObject
 
     
     
-    /**
-     *  @brief      Parses the NSData sent by Apple's Push Service, and extracts the Device Token
-     */
+    /// Parses the NSData sent by Apple's Push Service, and extracts the Device Token
+    ///
     private func parseTokenFromAppleData(tokenData: NSData) -> String {
         var newToken = tokenData.description.stringByReplacingOccurrencesOfString("<", withString: "")
         newToken = newToken.stringByReplacingOccurrencesOfString(">", withString: "")
@@ -202,9 +191,8 @@ final public class PushNotificationsManager : NSObject
     
     
     
-    /**
-    *  @brief      Persists the deviceToken + deviceId
-    */
+    /// Persists the deviceToken + deviceId
+    ///
     private func save() {
         let defaults = NSUserDefaults.standardUserDefaults()
         defaults.setObject(deviceToken, forKey: deviceTokenKey)
@@ -214,9 +202,8 @@ final public class PushNotificationsManager : NSObject
     
     
     
-    /**
-     *  @brief      Default Initializer
-     */
+    /// Default Initializer
+    ///
     private override init() {
         let defaults    = NSUserDefaults.standardUserDefaults()
         deviceToken     = defaults.stringForKey(deviceTokenKey) ?? String()

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -53,22 +53,14 @@ final public class PushNotificationsManager : NSObject
     // MARK: - Public Methods
     
     
-    /// Registers the device for Remote + User Notifications.
+    /// Registers the device for Remote Notifications: Badge + Sounds + Alerts
     ///
-    /// - Note: We'll wire Badge + Sound + Alert notifications, along with support for iOS User Notifications Actions.
-    ///
-    func registerForPushNotifications() {
+    func registerForRemoteNotifications() {
         if sharedApplication.isRunningSimulator() || sharedApplication.isAlphaBuild() {
             return;
         }
         
-        // Remote Notifications Registration
         sharedApplication.registerForRemoteNotifications()
-
-        // User Notifications Registration
-        let categories  = interactiveHandler.supportedNotificationCategories()
-        let settings    = UIUserNotificationSettings(forTypes: [.Badge, .Sound, .Alert], categories: categories)
-        sharedApplication.registerUserNotificationSettings(settings)
     }
     
 
@@ -213,9 +205,6 @@ final public class PushNotificationsManager : NSObject
     }
     
     
-    
-    // MARK: - Private Properties
-    private let interactiveHandler = InteractiveNotificationsHandler()
     
     // MARK: - Private Constants
     private let deviceTokenKey  = "apnsDeviceToken"

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 		B57273601B66CCEF000D1C4F /* AlertInternalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B572735D1B66CCEF000D1C4F /* AlertInternalView.swift */; };
 		B57273611B66CCEF000D1C4F /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B572735E1B66CCEF000D1C4F /* AlertView.swift */; };
 		B57273621B66CCEF000D1C4F /* AlertView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B572735F1B66CCEF000D1C4F /* AlertView.xib */; };
+		B5744A1E1C3D8FA700A3B8DC /* InteractiveNotificationsHandlerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B5744A1D1C3D8FA700A3B8DC /* InteractiveNotificationsHandlerTests.m */; };
 		B574CE111B5D8F8600A84FFD /* WPStyleGuide+AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B574CE101B5D8F8600A84FFD /* WPStyleGuide+AlertView.swift */; };
 		B574CE151B5E8EA800A84FFD /* NSMutableAttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B574CE141B5E8EA800A84FFD /* NSMutableAttributedString+Helpers.swift */; };
 		B57AF5FA1ACDC73D0075A7D2 /* NoteBlockActionsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57AF5F91ACDC73D0075A7D2 /* NoteBlockActionsTableViewCell.swift */; };
@@ -1293,6 +1294,7 @@
 		B572735D1B66CCEF000D1C4F /* AlertInternalView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertInternalView.swift; sourceTree = "<group>"; };
 		B572735E1B66CCEF000D1C4F /* AlertView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertView.swift; sourceTree = "<group>"; };
 		B572735F1B66CCEF000D1C4F /* AlertView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AlertView.xib; sourceTree = "<group>"; };
+		B5744A1D1C3D8FA700A3B8DC /* InteractiveNotificationsHandlerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InteractiveNotificationsHandlerTests.m; sourceTree = "<group>"; };
 		B574CE101B5D8F8600A84FFD /* WPStyleGuide+AlertView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+AlertView.swift"; sourceTree = "<group>"; };
 		B574CE141B5E8EA800A84FFD /* NSMutableAttributedString+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Helpers.swift"; sourceTree = "<group>"; };
 		B57AF5F91ACDC73D0075A7D2 /* NoteBlockActionsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoteBlockActionsTableViewCell.swift; sourceTree = "<group>"; };
@@ -2939,6 +2941,7 @@
 				85F8E19A1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift */,
 				85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */,
 				B5416CFD1C1756B900006DD8 /* PushNotificationsManagerTests.m */,
+				B5744A1D1C3D8FA700A3B8DC /* InteractiveNotificationsHandlerTests.m */,
 			);
 			name = Notifications;
 			sourceTree = "<group>";
@@ -4810,6 +4813,7 @@
 				852416D21A12ED690030700C /* AppRatingUtilityTests.m in Sources */,
 				598F86AB1B67BD7600550C9C /* ThemeServiceRemoteTests.m in Sources */,
 				E15618FD16DB8677006532C4 /* UIKitTestHelper.m in Sources */,
+				B5744A1E1C3D8FA700A3B8DC /* InteractiveNotificationsHandlerTests.m in Sources */,
 				B5EFB1C91B333C5A007608A3 /* NotificationsServiceTests.swift in Sources */,
 				B5AEEC721ACACF2F008BF2A4 /* NotificationTests.m in Sources */,
 				BE1071FF1BC75FFA00906AFF /* WPStyleGuide+BlogTests.swift in Sources */,

--- a/WordPress/WordPressTest/InteractiveNotificationsHandlerTests.m
+++ b/WordPress/WordPressTest/InteractiveNotificationsHandlerTests.m
@@ -16,7 +16,7 @@
     // We'll override the check just for evil unit testing purposes.
     
     id mockApplication = [OCMockObject partialMockForObject:[UIApplication sharedApplication]];
-    [[mockApplication expect] registerForUserNotifications];
+    [[mockApplication expect] registerUserNotificationSettings:[OCMArg isNotNil]];
     
     [[[mockApplication stub] andReturnValue:OCMOCK_VALUE(false)] isRunningSimulator];
     

--- a/WordPress/WordPressTest/InteractiveNotificationsHandlerTests.m
+++ b/WordPress/WordPressTest/InteractiveNotificationsHandlerTests.m
@@ -1,0 +1,30 @@
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+#import "WordPress-Swift.h"
+
+
+@interface InteractiveNotificationsHandlerTests : XCTestCase
+
+@end
+
+@implementation InteractiveNotificationsHandlerTests
+
+- (void)testRegisterForUserNotificationsCallsSharedApplicationRegisterForUserNotifications
+{
+    // Note:
+    // PushNotifications registration methods don't crash the sim, anymore, as per iOS 9.
+    // We'll override the check just for evil unit testing purposes.
+    
+    id mockApplication = [OCMockObject partialMockForObject:[UIApplication sharedApplication]];
+    [[mockApplication expect] registerForUserNotifications];
+    
+    [[[mockApplication stub] andReturnValue:OCMOCK_VALUE(false)] isRunningSimulator];
+    
+    id mockManager = [OCMockObject partialMockForObject:[InteractiveNotificationsHandler sharedInstance]];
+    [[[mockManager stub] andReturn:mockApplication] sharedApplication];
+    
+    [mockManager registerForUserNotifications];
+    [mockApplication verify];
+}
+
+@end

--- a/WordPress/WordPressTest/PushNotificationsManagerTests.m
+++ b/WordPress/WordPressTest/PushNotificationsManagerTests.m
@@ -60,7 +60,7 @@
     XCTAssertTrue([mockManager notificationsEnabledInDeviceSettings]);
 }
 
-- (void)testRegisterForPushNotificationsCallsSharedApplicationRegisterForRemoteAndUserNotifications
+- (void)testRegisterForPushNotificationsCallsSharedApplicationRegisterForRemoteNotifications
 {
     // Note:
     // PushNotifications registration methods don't crash the sim, anymore, as per iOS 9.
@@ -68,7 +68,6 @@
     
     id mockApplication = [OCMockObject partialMockForObject:[UIApplication sharedApplication]];
     [[mockApplication expect] registerForRemoteNotifications];
-    [[mockApplication expect] registerUserNotificationSettings:[OCMArg isNotNil]];
     
     [[[mockApplication stub] andReturnValue:OCMOCK_VALUE(false)] isRunningSimulator];
     

--- a/WordPress/WordPressTest/PushNotificationsManagerTests.m
+++ b/WordPress/WordPressTest/PushNotificationsManagerTests.m
@@ -75,7 +75,7 @@
     id mockManager = [OCMockObject partialMockForObject:[PushNotificationsManager sharedInstance]];
     [[[mockManager stub] andReturn:mockApplication] sharedApplication];
     
-    [mockManager registerForPushNotifications];
+    [mockManager registerForRemoteNotifications];
     [mockApplication verify];
 }
 


### PR DESCRIPTION
#### Description:
In this PR we're moving over `Interactive Notifications` specific code over from *NotificationsManager* to *InteractiveNotificationsHandler* helper.

Plus: I've updated the documentation style of the new Notifications-Y handling classes.

Reference: #4069

#### Scenario 1: Comment Reply
1. Fresh install the app, and log into your WordPress.com account
2. Kill (or) close the app
3. Receive a comment in a blog that has comments auto-approval enabled
4. In the springboard, pull the notification to reveal its interactive actions
5. Tap over the *Reply* button

As a result, the app should launch, and the associated Notification should be onscreen (allowing the user to reply right there).

#### Scenario 2: Comment Like
1. Fresh install the app, and log into your WordPress.com account
2. Kill (or) close the app
3. Receive a comment in a blog that has comments auto-approval enabled
4. In the springboard, pull the notification to reveal its interactive actions
5. Tap over the *Like* button

As a result, the comment should receive a like.

#### Scenario 3: Comment Approval
1. Fresh install the app, and log into your WordPress.com account
2. Kill (or) close the app
3. Receive a comment in a blog that has comments auto-approval *disabled*
4. In the springboard, pull the notification to reveal its interactive actions
5. Tap over the *Approve* button

As a result, the comment should get approved.

Needs Review: @aerych 

Eric, may i bother you with a review?
Thanks in advance sir!
