### PR TITLE
Fix: Go to iPhone Settings should be iOS Settings 

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -127,7 +127,7 @@ public class NotificationSettingDetailsViewController : UITableViewController
     }
     
     private func sectionsForDisabledDeviceStream() -> [Section] {
-        let description     = NSLocalizedString("Go to iPhone Settings", comment: "Opens WPiOS Settings.app Section")
+        let description     = NSLocalizedString("Go to iOS Settings", comment: "Opens WPiOS Settings.app Section")
         let row             = Row(kind: .Text, description: description, key: nil, value: nil)
         
         let footerText      = NSLocalizedString("Push Notifications have been turned off in iOS Settings App. " +


### PR DESCRIPTION
#### Steps:
1. Launch WPiOS with Push Notifications disabled
2. Open `Me` tab
3. Open `Notification Settings`
4. Open any site and tap over `Push Notifications`

As a result, the user should be informed that Push Notifications are disabled, and a legend offering to `Go to iOS Settings` should show up.

Needs Review: @astralbodies  (Thanks!)
Closes #4627
