### PR TITLE
Issue/4595: End editing in site list when signing out of .com account

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -58,6 +58,7 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 @interface BlogDetailsViewController () <UIActionSheetDelegate, UIAlertViewDelegate>
 
 @property (nonatomic, strong) BlogDetailHeaderView *headerView;
+@property (nonatomic, strong) NSArray *headerViewHorizontalConstraints;
 @property (nonatomic, strong) NSArray *tableSections;
 
 @end
@@ -158,14 +159,36 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     self.headerView.translatesAutoresizingMaskIntoConstraints = NO;
     [headerWrapper addSubview:self.headerView];
     
-    NSDictionary *views = NSDictionaryOfVariableBindings(_headerView, headerWrapper);
-    NSDictionary *metrics = @{@"horizontalMargin": @(BlogDetailHeaderViewHorizontalMarginiPhone),
-                              @"verticalMargin": @(BlogDetailHeaderViewVerticalMargin)};
+    NSDictionary *views = NSDictionaryOfVariableBindings(_headerView);
+    NSDictionary *metrics = @{@"verticalMargin": @(BlogDetailHeaderViewVerticalMargin)};
+    
+    // Constrain the headerView vertically
+    [headerWrapper addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(verticalMargin)-[_headerView]-(verticalMargin)-|"
+                                                                          options:0
+                                                                          metrics:metrics
+                                                                            views:views]];
+}
 
-    if (IS_IPAD) {
-        // Set the header width
+- (void)updateHeaderViewConstraintsForTraitCollection:(UITraitCollection *)traitCollection
+{
+    UIView *headerWrapper = self.tableView.tableHeaderView;
+    
+    // We only remove the constraints we've added, not the view's autoresizing constraints
+    [headerWrapper removeConstraints:self.headerViewHorizontalConstraints];
+    
+    if (traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact || traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
+        NSDictionary *views = NSDictionaryOfVariableBindings(_headerView);
+        NSDictionary *metrics = @{@"horizontalMargin": @(BlogDetailHeaderViewHorizontalMarginiPhone)};
+        
+        self.headerViewHorizontalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"|-(horizontalMargin)-[_headerView]-(horizontalMargin)-|"
+                                                                                       options:0
+                                                                                       metrics:metrics
+                                                                                         views:views];
+    } else {
+        NSMutableArray *constraints = [NSMutableArray new];
+        
         CGFloat headerWidth = WPTableViewFixedWidth;
-        [headerWrapper addConstraint:[NSLayoutConstraint constraintWithItem:self.headerView
+        [constraints addObject:[NSLayoutConstraint constraintWithItem:self.headerView
                                                                   attribute:NSLayoutAttributeWidth
                                                                   relatedBy:NSLayoutRelationEqual
                                                                      toItem:nil
@@ -173,33 +196,37 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
                                                                  multiplier:1.0
                                                                    constant:headerWidth]];
         // Center the headerView inside the wrapper
-        [headerWrapper addConstraint:[NSLayoutConstraint constraintWithItem:self.headerView
+        [constraints addObject:[NSLayoutConstraint constraintWithItem:self.headerView
                                                                   attribute:NSLayoutAttributeCenterX
                                                                   relatedBy:NSLayoutRelationEqual
                                                                      toItem:headerWrapper
                                                                   attribute:NSLayoutAttributeCenterX
                                                                  multiplier:1.0
                                                                    constant:0.0]];
-    } else {
-        // Pin the headerWrapper to its superview AND wrap the headerView in horizontal margins
-        [headerWrapper addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-(horizontalMargin)-[_headerView]-(horizontalMargin)-|"
-                                                                              options:0
-                                                                              metrics:metrics
-                                                                                views:views]];
+        self.headerViewHorizontalConstraints = [constraints copy];
     }
 
-    // Constrain the headerWrapper and headerView vertically
-    [headerWrapper addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(verticalMargin)-[_headerView]-(verticalMargin)-|"
-                                                                          options:0
-                                                                          metrics:metrics
-                                                                            views:views]];
+    [headerWrapper addConstraints:self.headerViewHorizontalConstraints];
+    [headerWrapper layoutIfNeeded];
 }
 
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
+    
     [self.headerView setBlog:self.blog];
+    [self updateHeaderViewConstraintsForTraitCollection:self.traitCollection];
+
     [self.tableView reloadData];
+}
+
+- (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
+    
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        [self updateHeaderViewConstraintsForTraitCollection:newCollection];
+    } completion:nil];
 }
 
 - (void)setBlog:(Blog *)blog

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -188,21 +188,11 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
         NSMutableArray *constraints = [NSMutableArray new];
         
         CGFloat headerWidth = WPTableViewFixedWidth;
-        [constraints addObject:[NSLayoutConstraint constraintWithItem:self.headerView
-                                                                  attribute:NSLayoutAttributeWidth
-                                                                  relatedBy:NSLayoutRelationEqual
-                                                                     toItem:nil
-                                                                  attribute:NSLayoutAttributeNotAnAttribute
-                                                                 multiplier:1.0
-                                                                   constant:headerWidth]];
+        [constraints addObject:[self.headerView.widthAnchor constraintEqualToConstant:headerWidth]];
+         
         // Center the headerView inside the wrapper
-        [constraints addObject:[NSLayoutConstraint constraintWithItem:self.headerView
-                                                                  attribute:NSLayoutAttributeCenterX
-                                                                  relatedBy:NSLayoutRelationEqual
-                                                                     toItem:headerWrapper
-                                                                  attribute:NSLayoutAttributeCenterX
-                                                                 multiplier:1.0
-                                                                   constant:0.0]];
+        [constraints addObject:[self.headerView.centerXAnchor constraintEqualToAnchor:headerWrapper.centerXAnchor]];
+         
         self.headerViewHorizontalConstraints = [constraints copy];
     }
 


### PR DESCRIPTION
Fixes #4595 – The sites list now listens out for `WPAccountDefaultWordPressComAccountChangedNotification` and ends editing if a notification comes in. I also moved some other notifications code to be grouped under the existing 'Notifications' `pragma mark`.

**To Test** 

1. Sign in to to a self-hosted site not connected to Jetpack.
2. Sign in to a wpcom account.
3. Go to the My Sites tab, and tap the Edit button at the top of the site list to display the site picker.
4. Switch to the Me tab and sign out of wpcom. This should leave just the self-hosted blog still in the app.
5. Switch back to the My Sites tab. The list should no longer be in edit mode (so the remaining site is visible). As there's only one site there now, the user will be automatically taken to its details.
6. Also try logging back into the wpcom account. There was an issue when tapping on My Sites again where the fetched results controller wouldn't have updated, so the sites list would think there was still only 1 site and would navigate you into the first one automatically. Now, it'll correctly keep you on the sites list.

Needs review: @kwonye - thanks!
