### PR TITLE
Updating stats pod to 0.6.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -34,7 +34,7 @@ target 'WordPress', :exclusive => true do
   pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
   pod 'WordPress-iOS-Shared', '0.5.1'
   pod 'WordPress-iOS-Editor', '1.1.1'
-  pod 'WordPressCom-Stats-iOS/UI', '0.6.0'
+  pod 'WordPressCom-Stats-iOS/UI', '0.6.1'
   pod 'WordPressCom-Analytics-iOS', '0.1.3'
   pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
   pod 'WPMediaPicker', '~> 0.7.3'
@@ -44,7 +44,7 @@ end
 
 target 'WordPressTodayWidget', :exclusive => true do
   pod 'WordPress-iOS-Shared', '0.5.1'
-  pod 'WordPressCom-Stats-iOS/Services', '0.6.0'
+  pod 'WordPressCom-Stats-iOS/Services', '0.6.1'
 end
 
 target :WordPressTest, :exclusive => true do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -163,13 +163,13 @@ PODS:
     - AFNetworking (~> 2.6.0)
     - wpxmlrpc (~> 0.7)
   - WordPressCom-Analytics-iOS (0.1.3)
-  - WordPressCom-Stats-iOS/Services (0.6.0):
+  - WordPressCom-Stats-iOS/Services (0.6.1):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.1)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
-  - WordPressCom-Stats-iOS/UI (0.6.0):
+  - WordPressCom-Stats-iOS/UI (0.6.1):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
@@ -217,8 +217,8 @@ DEPENDENCIES:
   - WordPress-iOS-Shared (= 0.5.1)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
   - WordPressCom-Analytics-iOS (= 0.1.3)
-  - WordPressCom-Stats-iOS/Services (= 0.6.0)
-  - WordPressCom-Stats-iOS/UI (= 0.6.0)
+  - WordPressCom-Stats-iOS/Services (= 0.6.1)
+  - WordPressCom-Stats-iOS/UI (= 0.6.1)
   - WPMediaPicker (~> 0.7.3)
   - wpxmlrpc (~> 0.8)
 
@@ -287,7 +287,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Shared: ced218039d88c91572f3205882832f7a05c61f97
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
   WordPressCom-Analytics-iOS: 55c52378f752ad8a8bbbd8bd75db0eb4b5a93d34
-  WordPressCom-Stats-iOS: 590f774981552c894f6b66140e00266535fefd27
+  WordPressCom-Stats-iOS: 1eff7faca675ed77819d2fa49528f91bea9fdbcc
   WPMediaPicker: 6bbce465f5a5c071267ae28bdf31d0fd6e109721
   wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0
 


### PR DESCRIPTION
Closes #4631 

Updated stats to latest release which includes these fixes:
* Adds blog and post ID to stats analytics events
* Improve the graph on days/weeks/months/years to handle iPad multitasking better
* Fixes a glitch with date selection in graph going funky after viewing all or post details and coming back
* Re-enables tapping rows to see post details

Needs Review: @sendhil 
cc: @daniloercoli 