### PR TITLE
Custom section header/footer for ImmuTable

### DIFF
--- a/WordPress/Classes/Utility/ImmuTable+WordPress.swift
+++ b/WordPress/Classes/Utility/ImmuTable+WordPress.swift
@@ -1,0 +1,47 @@
+import WordPressShared
+
+/*
+Until https://github.com/wordpress-mobile/WordPress-iOS/pull/4591 is fixed, we
+need to use the custom WPTableViewSectionHeaderFooterView.
+
+This lives as an extension on a separate file because it's specific to our UI
+implementation and shouldn't be in a generic ImmuTable that we might eventually
+release as a standalone library.
+*/
+extension ImmuTableViewHandler {
+    public func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if let title = self.tableView(tableView, titleForHeaderInSection: section) {
+            return WPTableViewSectionHeaderFooterView.heightForHeader(title, width: tableView.frame.width)
+        } else {
+            return UITableViewAutomaticDimension
+        }
+    }
+
+    public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let title = self.tableView(tableView, titleForHeaderInSection: section) else {
+            return nil
+        }
+
+        let view = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
+        view.title = title
+        return view
+    }
+
+    public func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        if let title = self.tableView(tableView, titleForFooterInSection: section) {
+            return WPTableViewSectionHeaderFooterView.heightForFooter(title, width: tableView.frame.width)
+        } else {
+            return UITableViewAutomaticDimension
+        }
+    }
+
+    public func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        guard let title = self.tableView(tableView, titleForFooterInSection: section) else {
+            return nil
+        }
+
+        let view = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
+        view.title = title
+        return view
+    }
+}

--- a/WordPress/Classes/ViewRelated/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/MeViewController.swift
@@ -3,13 +3,7 @@ import WordPressShared
 
 class MeViewController: UITableViewController, UIViewControllerRestoration {
     static let restorationIdentifier = "WPMeRestorationID"
-    var tableViewModel = ImmuTable(sections: []) {
-        didSet {
-            if isViewLoaded() {
-                tableView.reloadData()
-            }
-        }
-    }
+    var handler: ImmuTableViewHandler!
 
     static func viewControllerWithRestorationIdentifierPath(identifierComponents: [AnyObject], coder: NSCoder) -> UIViewController? {
         return self.init()
@@ -50,6 +44,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
             DestructiveButtonRow.self
             ], tableView: self.tableView)
 
+        handler = ImmuTableViewHandler(takeOver: self)
         reloadViewModel()
         // FIXME: @koke 2015-12-17
         // See https://github.com/wordpress-mobile/WordPress-iOS/issues/4416
@@ -79,7 +74,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         // My guess is the table view adjusts the height of the first section
         // based on if there's a header or not.
         tableView.tableHeaderView = account.map(headerView)
-        tableViewModel = tableViewModel(loggedIn, helpshiftBadgeCount: badgeCount)
+        handler.viewModel = tableViewModel(loggedIn, helpshiftBadgeCount: badgeCount)
     }
 
     func headerView(account: WPAccount) -> MeHeaderView {
@@ -176,46 +171,6 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
                         ])
                 ])
         }
-    }
-    // MARK: Table View Data Source
-
-    override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
-        return tableViewModel.sections.count
-    }
-
-    override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return tableViewModel.sections[section].rows.count
-    }
-
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        let row = tableViewModel.rowAtIndexPath(indexPath)
-        let cell = tableView.dequeueReusableCellWithIdentifier(row.reusableIdentifier, forIndexPath: indexPath)
-
-        row.configureCell(cell)
-
-        return cell
-    }
-
-    override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return tableViewModel.sections[section].headerText
-    }
-
-    // MARK: Table View Delegate
-
-    override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        let row = tableViewModel.rowAtIndexPath(indexPath)
-        row.action?(row)
-    }
-
-    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let view = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil)
-        view.title = self.tableView(tableView, titleForHeaderInSection: section)
-        return view
-    }
-
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        let title = self.tableView(tableView, titleForHeaderInSection: section)
-        return WPTableViewSectionHeaderFooterView.heightForHeader(title, width: tableView.frame.width)
     }
 
     // MARK: - Actions

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -458,6 +458,7 @@
 		E131CB5616CACF1E004B0314 /* get-user-blogs_has-blog.json in Resources */ = {isa = PBXBuildFile; fileRef = E131CB5516CACF1E004B0314 /* get-user-blogs_has-blog.json */; };
 		E131CB5816CACFB4004B0314 /* get-user-blogs_doesnt-have-blog.json in Resources */ = {isa = PBXBuildFile; fileRef = E131CB5716CACFB4004B0314 /* get-user-blogs_doesnt-have-blog.json */; };
 		E131F5351C2930FC00D2D975 /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E131F5341C2930FC00D2D975 /* String+Helpers.swift */; };
+		E13A8C9B1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13A8C9A1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift */; };
 		E13EB7A5157D230000885780 /* WordPressComApi.m in Sources */ = {isa = PBXBuildFile; fileRef = E13EB7A4157D230000885780 /* WordPressComApi.m */; };
 		E13F23C314FE84600081D9CC /* NSMutableDictionary+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = E13F23C214FE84600081D9CC /* NSMutableDictionary+Helpers.m */; };
 		E14200781C117A2E00B3B115 /* ManagedAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14200771C117A2E00B3B115 /* ManagedAccountSettings.swift */; };
@@ -1450,6 +1451,7 @@
 		E131CB5716CACFB4004B0314 /* get-user-blogs_doesnt-have-blog.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "get-user-blogs_doesnt-have-blog.json"; sourceTree = "<group>"; };
 		E131F5341C2930FC00D2D975 /* String+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		E133DB40137AE180003C0AF9 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Localizable.strings; sourceTree = "<group>"; };
+		E13A8C9A1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ImmuTable+WordPress.swift"; sourceTree = "<group>"; };
 		E13EB7A3157D230000885780 /* WordPressComApi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressComApi.h; sourceTree = "<group>"; };
 		E13EB7A4157D230000885780 /* WordPressComApi.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressComApi.m; sourceTree = "<group>"; };
 		E13F23C114FE84600081D9CC /* NSMutableDictionary+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableDictionary+Helpers.h"; sourceTree = "<group>"; };
@@ -2598,6 +2600,7 @@
 				E1266D2C1BBE8B9A00FCB6B6 /* Gravatar.swift */,
 				313692781A5D6F7900EBE645 /* HelpshiftUtils.m */,
 				E1EBC36E1C118EA500F638E0 /* ImmuTable.swift */,
+				E13A8C9A1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift */,
 				5DB4683918A2E718004A89A9 /* LocationService.h */,
 				5DB4683A18A2E718004A89A9 /* LocationService.m */,
 				5D3E334C15EEBB6B005FC6F2 /* ReachabilityUtils.h */,
@@ -4668,6 +4671,7 @@
 				E6D3E8491BEBD871002692E8 /* ReaderCrossPostCell.swift in Sources */,
 				85D239B01AE5A5FC0074768D /* LoginFacade.m in Sources */,
 				E1209FA41BB4978B00D69778 /* PeopleService.swift in Sources */,
+				E13A8C9B1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift in Sources */,
 				B5899AE41B422D990075A3D6 /* NotificationSettings.swift in Sources */,
 				FFB1FAA01BF0EC4E0090C761 /* PHAsset+Exporters.swift in Sources */,
 				5D18FE9F1AFBB17400EFEED0 /* RestorePageTableViewCell.m in Sources */,


### PR DESCRIPTION
In #4609 I implemented a quick workaround so we still used `WPTableViewSectionHeaderFooterView` in the refactored `MeViewController`.

This is a more generic solution until we can get rid of `WPTableViewSectionHeaderFooterView` completely (#4591).

Needs Review: @aerych 