### PR TITLE
DiscussionSettingsViewController: Updates setting footer text

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -243,10 +243,10 @@ public class DiscussionSettingsViewController : UITableViewController
         pickerViewController.switchVisible      = true
         pickerViewController.switchOn           = settings.commentsCloseAutomatically
         pickerViewController.switchText         = NSLocalizedString("Automatically Close", comment: "Discussion Settings")
-        pickerViewController.selectionText      = NSLocalizedString("Close after", comment: "")
-        pickerViewController.selectionFormat    = NSLocalizedString("%d days", comment: "")
-        pickerViewController.pickerHint         = NSLocalizedString("Automatically close comments on posts after a certain number of days.", comment: "")
-        pickerViewController.pickerFormat       = NSLocalizedString("%d days", comment: "")
+        pickerViewController.selectionText      = NSLocalizedString("Close after", comment: "Close comments after a given number of days")
+        pickerViewController.selectionFormat    = NSLocalizedString("%d days", comment: "Number of days")
+        pickerViewController.pickerHint         = NSLocalizedString("Automatically close comments on content after a certain number of days.", comment: "Discussion Settings: Comments Auto-close")
+        pickerViewController.pickerFormat       = NSLocalizedString("%d days", comment: "Number of days")
         pickerViewController.pickerMinimumValue = commentsAutocloseMinimumValue
         pickerViewController.pickerMaximumValue = commentsAutocloseMaximumValue
         pickerViewController.pickerSelectedValue = settings.commentsCloseAutomaticallyAfterDays as? Int

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -245,7 +245,7 @@ public class DiscussionSettingsViewController : UITableViewController
         pickerViewController.switchText         = NSLocalizedString("Automatically Close", comment: "Discussion Settings")
         pickerViewController.selectionText      = NSLocalizedString("Close after", comment: "")
         pickerViewController.selectionFormat    = NSLocalizedString("%d days", comment: "")
-        pickerViewController.pickerHint         = NSLocalizedString("Automatically close comments on articles.", comment: "")
+        pickerViewController.pickerHint         = NSLocalizedString("Automatically close comments on posts after a certain number of days.", comment: "")
         pickerViewController.pickerFormat       = NSLocalizedString("%d days", comment: "")
         pickerViewController.pickerMinimumValue = commentsAutocloseMinimumValue
         pickerViewController.pickerMaximumValue = commentsAutocloseMaximumValue


### PR DESCRIPTION
#### Testing:
1. Launch WPiOS
2. Open `My Sites` tab
3. Open any WordPress.com site
4. Tap over the `Settings` row, and open the `Discussion` settings
5. Open the `Close Commenting` row

As a result, the table onscreen should have the following legend:

```
Automatically close comments on posts after a certain number of days.
```

Needs Review: @SergioEstevao (Thanks in advance Sergio!)
Props to @drw158 for reporting this!
