### PR TITLE
Issue/4634: Retrieve 2FA code from 1Password if available

### DIFF
--- a/WordPress/Classes/Services/OnePasswordFacade.h
+++ b/WordPress/Classes/Services/OnePasswordFacade.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-typedef void (^OnePasswordFacadeCallback)(NSString *username, NSString *password, NSError *);
+typedef void (^OnePasswordFacadeCallback)(NSString *username, NSString *password,  NSString *oneTimePassword, NSError *);
 
 /**
  *  This protocol is a Facade that hides some of the implementation details for interacting with 1Password.

--- a/WordPress/Classes/Services/OnePasswordFacade.m
+++ b/WordPress/Classes/Services/OnePasswordFacade.m
@@ -11,11 +11,13 @@
     
     [[OnePasswordExtension sharedExtension] findLoginForURLString:loginUrl forViewController:viewController sender:sender completion:^(NSDictionary *loginDict, NSError *error) {
         if (error != nil && error.code != AppExtensionErrorCodeCancelledByUser) {
-            completion(nil, nil, error);
+            completion(nil, nil, nil, error);
         } else {
             NSString *username = loginDict[AppExtensionUsernameKey];
             NSString *password = loginDict[AppExtensionPasswordKey];
-            completion(username, password, error);
+            NSString *oneTimePassword = loginDict[AppExtensionTOTPKey];
+            
+            completion(username, password, oneTimePassword, error);
         }
     }];
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -273,7 +273,7 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
 
 - (IBAction)backgroundTapGestureAction:(UITapGestureRecognizer *)tapGestureRecognizer
 {
-    CGPoint location = [tapGestureRecognizer locationInView:self.onePasswordButton];
+    CGPoint location = [tapGestureRecognizer locationOfTouch:0 inView:self.onePasswordButton];
     if (CGRectContainsPoint(self.onePasswordButton.bounds, location)) {
         [self findLoginFromOnePassword:self];
     } else {

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -273,6 +273,9 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
 
 - (IBAction)backgroundTapGestureAction:(UITapGestureRecognizer *)tapGestureRecognizer
 {
+    // When the verification code field is displayed, the username field is disabled which
+    // means that the 1Password button cannot be tapped directly (because it's the rightView of the username field).
+    // Instead, we can trigger 1Password if the background gesture recognizer detects a tap on the 1Password button.
     CGPoint location = [tapGestureRecognizer locationOfTouch:0 inView:self.onePasswordButton];
     if (CGRectContainsPoint(self.onePasswordButton.bounds, location)) {
         [self findLoginFromOnePassword:self];

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -273,8 +273,13 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
 
 - (IBAction)backgroundTapGestureAction:(UITapGestureRecognizer *)tapGestureRecognizer
 {
-    [self.view endEditing:YES];
-    [self hideMultifactorTextfieldIfNeeded];
+    CGPoint location = [tapGestureRecognizer locationInView:self.onePasswordButton];
+    if (CGRectContainsPoint(self.onePasswordButton.bounds, location)) {
+        [self findLoginFromOnePassword:self];
+    } else {
+        [self.view endEditing:YES];
+        [self hideMultifactorTextfieldIfNeeded];
+    }
 }
 
 - (IBAction)signInButtonAction:(id)sender

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -916,6 +916,11 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
     self.multifactorText.enabled = enabled;
 }
 
+- (void)setMultifactorTextValue:(NSString *)multifactorText
+{
+    self.multifactorText.text = multifactorText;
+}
+
 - (void)setCancelButtonHidden:(BOOL)hidden
 {
     self.cancelButton.hidden = hidden;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
@@ -200,11 +200,12 @@ typedef void (^OverlayViewCallback)(WPWalkthroughOverlayView *);
 - (void)setPasswordTextValue:(NSString *)password;
 - (void)setPasswordSecureEntry:(BOOL)secureTextEntry;
 
-- (void)setSiteAlpha:(CGFloat)alpha;
 - (void)setMultiFactorAlpha:(CGFloat)alpha;
-
-- (void)setSiteUrlEnabled:(BOOL)enabled;
 - (void)setMultifactorEnabled:(BOOL)enabled;
+- (void)setMultifactorTextValue:(NSString *)multifactorText;
+
+- (void)setSiteAlpha:(CGFloat)alpha;
+- (void)setSiteUrlEnabled:(BOOL)enabled;
 - (void)setCancelButtonHidden:(BOOL)hidden;
 - (void)setForgotPasswordHidden:(BOOL)hidden;
 - (void)setSendVerificationCodeButtonHidden:(BOOL)hidden;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -128,8 +128,6 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
         
         if (oneTimePassword) {
             self.isMultifactorEnabled = YES;
-            
-            [self displayMultifactorTextField];
         }
         
         [WPAnalytics track:WPAnalyticsStatOnePasswordLogin];

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -108,7 +108,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
  
     NSString *loginURL = self.userIsDotCom ? WPOnePasswordWordPressComURL : self.siteUrl;
     
-    [self.onePasswordFacade findLoginForURLString:loginURL viewController:viewController sender:sender completion:^(NSString *username, NSString *password, NSError *error) {
+    [self.onePasswordFacade findLoginForURLString:loginURL viewController:viewController sender:sender completion:^(NSString *username, NSString *password, NSString *oneTimePassword, NSError *error) {
         BOOL blankUsernameOrPassword = (username.length == 0) || (password.length == 0);
         if (blankUsernameOrPassword || (error != nil)) {
             if (error != nil) {

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -120,8 +120,17 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
         
         self.username = username;
         self.password = password;
+        self.multifactorCode = oneTimePassword;
+        
         [self.presenter setUsernameTextValue:username];
         [self.presenter setPasswordTextValue:password];
+        [self.presenter setMultifactorTextValue:oneTimePassword];
+        
+        if (oneTimePassword) {
+            self.isMultifactorEnabled = YES;
+            
+            [self displayMultifactorTextField];
+        }
         
         [WPAnalytics track:WPAnalyticsStatOnePasswordLogin];
         [self signInButtonAction];


### PR DESCRIPTION
Implements #4634. The `OnePasswordFacade` now retrieves the current one-time password for the user's WordPress account, if available. The verification code field is _not_ displayed on the login screen unless there is an issue logging in – everything's just handled magically in the background for the user.

### Steps to test

1. Ensure you have a WordPress.com account (with 2FA) set up in 1Password with username, password, and one-time password.
2. If you're already logged in to a wpcom account in the app, log out.
3. In Me, tap Connect to WordPress.com (or launch the app for the first time).
4. Tap the 1Password button. Choose 1Password from the popup.
5. Log into the 1Password extension and select your WP account.
6. Check that you're signed in correctly.

It's probably worth trying to catch your one-time password when it's about to expire. You can tap the 'i' in the 1Password extension to view the countdown for the code. The user should see the invalid verification code error screen, and can tap to head back to login. I've been unable to trigger this in real user of the app, but I've checked the flow by passing back a bogus OTP from `-[OnePasswordFacade findLoginForURLString:viewController:sender:completion:]`. 

### Also Test...

I've also made it so that the 1Password extension can be activated when the verification code field is visible (and the username field is disabled). Previously you had to tap the username field to enable it, and then tap the 1Password button.

1. Attempt to log in to an account with 2FA, but don't use autofill from 1Password (so it doesn't try to log in with the code automatically).
2. Tap Sign In so that the verification code field appears.
3. Try to tap the 1Password button – the 1Password extension should appear.

Needs Review: @jleandroperez - thank you!
