### PR TITLE
Issue/4475: Disables blog selector button in editor when user only has a single site

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -636,11 +636,6 @@ EditImageDetailsViewControllerDelegate
  */
 - (void)showBlogSelectorPrompt:(WPBlogSelectorButton*)sender
 {
-    if (sender.buttonMode == WPBlogSelectorButtonSingleSite) {
-        [self cancelEditingOrDismiss];
-        return;
-    }
-    
     if (![self.post hasSiteSpecificChanges]) {
         [self showBlogSelector];
         return;

--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
@@ -71,8 +71,12 @@
         UIImage *blankFillerImage = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
         [self setImage:blankFillerImage forState:UIControlStateNormal];
+        
+        self.userInteractionEnabled = NO;
     } else {
         [self setImage:[UIImage imageNamed:@"icon-navbar-dropdown.png"] forState:UIControlStateNormal];
+        
+        self.userInteractionEnabled = YES;
     }
 }
 


### PR DESCRIPTION
Fixes #4475. I've disabled user interaction on the blog selector button in the navigation bar of the editor. 

### To Test:

1. Add a single self-hosted blog to the app. 
2. Tap the center tab button to open the editor. 
3. Attempt to tap the name of the blog at the top of the editor. You shouldn't be able to.
4. Also verify that with multiple blogs added, you _can_ tap the name of the blog to switch blog.

Needs review: @aerych - thank you!
