### PR TITLE
Issue/4416: Updates account details / avatar on login

### DIFF
--- a/WordPress/Classes/Models/ManagedAccountSettings.swift
+++ b/WordPress/Classes/Models/ManagedAccountSettings.swift
@@ -46,7 +46,7 @@ class ManagedAccountSettings: NSManagedObject {
         case .Language(let value):
             self.language = value
         }
-
+        
         return reverse
     }
 
@@ -69,6 +69,19 @@ class ManagedAccountSettings: NSManagedObject {
         case .Language(_):
             return .Language(self.language)
         }
+    }
+}
+
+extension WPAccount {
+    /// Applies a change to the account. Currently only the DisplayName can be modified in-app.
+    func applyChange(change: AccountSettingsChange) {
+        switch change {
+        case .DisplayName(let value):
+            self.displayName = value
+        default: break
+        }
+        
+        NSNotificationCenter.defaultCenter().postNotificationName(WPAccountDefaultWordPressComAccountDetailsUpdatedNotification, object: nil)
     }
 }
 
@@ -103,3 +116,4 @@ enum AccountSettingsChange {
         }
     }
 }
+

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class WPAccount, Blog;
 
 extern NSString *const WPAccountDefaultWordPressComAccountChangedNotification;
-extern NSString *const WPAccountEmailAndDefaultBlogUpdatedNotification;
+extern NSString *const WPAccountDefaultWordPressComAccountDetailsUpdatedNotification;
 
 @interface AccountService : LocalCoreDataService
 

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -16,7 +16,7 @@ static NSString * const DefaultDotcomAccountPasswordRemovedKey = @"DefaultDotcom
 
 static NSString * const WordPressDotcomXMLRPCKey = @"https://wordpress.com/xmlrpc.php";
 NSString * const WPAccountDefaultWordPressComAccountChangedNotification = @"WPAccountDefaultWordPressComAccountChangedNotification";
-NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEmailAndDefaultBlogUpdatedNotification";
+NSString * const WPAccountDefaultWordPressComAccountDetailsUpdatedNotification = @"WPAccountDefaultWordPressComAccountDetailsUpdatedNotification";
 
 @implementation AccountService
 
@@ -234,6 +234,8 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         [blogService flagBlogAsLastUsed:account.defaultBlog];
     }
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountDetailsUpdatedNotification object:nil];
 }
 
 - (void)purgeAccount:(WPAccount *)account

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -15,6 +15,7 @@ static NSString * const DefaultDotcomAccountUUIDDefaultsKey = @"AccountDefaultDo
 static NSString * const DefaultDotcomAccountPasswordRemovedKey = @"DefaultDotcomAccountPasswordRemovedKey";
 
 static NSString * const WordPressDotcomXMLRPCKey = @"https://wordpress.com/xmlrpc.php";
+
 NSString * const WPAccountDefaultWordPressComAccountChangedNotification = @"WPAccountDefaultWordPressComAccountChangedNotification";
 NSString * const WPAccountDefaultWordPressComAccountDetailsUpdatedNotification = @"WPAccountDefaultWordPressComAccountDetailsUpdatedNotification";
 

--- a/WordPress/Classes/ViewRelated/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/MeViewController.swift
@@ -29,6 +29,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         self.init(style: .Grouped)
         let notificationCenter = NSNotificationCenter.defaultCenter()
         notificationCenter.addObserver(self, selector: "refreshModelWithNotification:", name: WPAccountDefaultWordPressComAccountChangedNotification, object: nil)
+        notificationCenter.addObserver(self, selector: "refreshModelWithNotification:", name: WPAccountDefaultWordPressComAccountDetailsUpdatedNotification, object: nil)
         notificationCenter.addObserver(self, selector: "refreshModelWithNotification:", name: HelpshiftUnreadCountUpdatedNotification, object: nil)
     }
 
@@ -78,11 +79,13 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         //
         // My guess is the table view adjusts the height of the first section
         // based on if there's a header or not.
-        tableView.tableHeaderView = account.map(headerView)
+        tableView.tableHeaderView = headerView(account)
         tableViewModel = tableViewModel(loggedIn, helpshiftBadgeCount: badgeCount)
     }
 
-    func headerView(account: WPAccount) -> MeHeaderView {
+    func headerView(account: WPAccount?) -> MeHeaderView? {
+        guard let account = account else { return nil }
+
         let header = cachedHeaderView
         header.setDisplayName(account.displayName)
         header.setUsername(account.username)
@@ -300,6 +303,9 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
     // MARK: - Notification observers
 
     func refreshModelWithNotification(notification: NSNotification) {
+        // Regenerate the header view if the account has changed
+        cachedHeaderView = MeHeaderView()
+
         reloadViewModel()
     }
 


### PR DESCRIPTION
Refs #4416 and #4613. `AccountService` now sends a notification when the user's account details are updated, so that the Me UI can update itself. I've also put in some changes so that local `AccountSettings` changes update the current `WPAccount` and send out the same notification. 

I'm not a big fan of the fact that my `WPAccount` extension sends out the same notification as `AccountService`. I'm not sure if some sort of observer pattern might make more sense here, to watch out for changes to the account object.

Work in progress!