### PR TITLE
Fixes some deprecation warnings in reader comments.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
+++ b/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
@@ -72,7 +72,7 @@ static const UIEdgeInsets ReplyAndLikeButtonEdgeInsets = {0.0f, 4.0f, 0.0f, -4.0
 
 - (void)refreshMediaLayout
 {
-    [self.textContentView refreshMediaLayout];
+    [self.textContentView refreshLayout];
 }
 
 - (void)preventPendingMediaLayout:(BOOL)prevent

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -61,7 +61,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 @property (nonatomic, strong) ReaderPostHeaderView *postHeaderView;
 @property (nonatomic, strong) NSMutableDictionary *mediaCellCache;
 @property (nonatomic, strong) NSIndexPath *indexPathForCommentRepliedTo;
-@property (nonatomic, assign) UIDeviceOrientation previousOrientation;
+@property (nonatomic, assign) CGSize previousViewGeometry;
 @property (nonatomic, strong) NSLayoutConstraint *replyTextViewHeightConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *replyTextViewBottomConstraint;
 @property (nonatomic) BOOL isLoggedIn;
@@ -98,6 +98,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    self.previousViewGeometry = self.view.frame.size;
 
     self.mediaCellCache = [NSMutableDictionary dictionary];
     [self checkIfLoggedIn];
@@ -122,8 +123,9 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 {
     [super viewWillAppear:animated];
 
-    if (self.previousOrientation != UIInterfaceOrientationUnknown) {
-        if (UIInterfaceOrientationIsPortrait(self.previousOrientation) != UIInterfaceOrientationIsPortrait(self.interfaceOrientation)) {
+    if (!CGSizeEqualToSize(self.previousViewGeometry, CGSizeZero)) {
+        if (! CGSizeEqualToSize(self.previousViewGeometry, self.view.frame.size)) {
+            // Refresh cached row heights based on the new width
             [self.tableViewHandler refreshCachedRowHeightsForWidth:CGRectGetWidth(self.view.frame)];
             [self.tableView reloadData];
         }
@@ -148,7 +150,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 {
     [super viewWillDisappear:animated];
 
-    self.previousOrientation = self.interfaceOrientation;
+    self.previousViewGeometry = self.view.frame.size;
 
     [self.replyTextView resignFirstResponder];
 
@@ -157,48 +159,30 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
 }
 
-- (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     // Remove the no results view or else the position will abruptly adjust after rotation
     // due to the table view sizing for image preloading
     [self refreshNoResultsView];
 
-    [super willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 
     // Avoid refreshing cells when there is no need.
-    if ([UIDevice isPad] && WPTableViewFixedWidth <= CGRectGetWidth(self.tableView.frame)) {
-        return;
-    }
-    // Refresh cached row heights based on the width for the orientation.
-    // If changing orientation, this must happen before the table view calculates
-    // its content size / offset for the new orientation.
-    CGFloat width = CGRectGetWidth(self.tableView.frame);
-    [self updateCellsAndRefreshMediaForWidth:width];
-}
-
-- (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation
-{
-    [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
-
-    NSIndexPath *selectedIndexPath = [self.tableView indexPathForSelectedRow];
-
-    // Avoid refreshing cells when there is no need.
-    if (![UIDevice isPad] || WPTableViewFixedWidth > CGRectGetWidth(self.tableView.frame)) {
-        // DTCoreText can be cranky about refreshing its rendered text when its
-        // frame changes, even when setting its relayoutMask. Setting setNeedsLayout
-        // on the cell prior to reloading seems to force the cell's
-        // DTAttributedTextContentView to behave.
-        [[self.tableView visibleCells] makeObjectsPerformSelector:@selector(setNeedsLayout)];
-        [self.tableView reloadRowsAtIndexPaths:[self.tableView indexPathsForVisibleRows] withRowAnimation:UITableViewRowAnimationNone];
-    }
-    
-    // Make sure a selected comment is visible after rotating, and that the replyTextView is still the first responder.
-    if (selectedIndexPath) {
-        [self.replyTextView becomeFirstResponder];
-        [self.tableView selectRowAtIndexPath:selectedIndexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+    if (![UIDevice isPad] && WPTableViewFixedWidth > CGRectGetWidth(self.tableView.frame)) {
+        // Refresh cached row heights based on the new width
+        [self updateCellsAndRefreshMediaForWidth:size.width];
     }
 
-    [self refreshNoResultsView];
+    [coordinator animateAlongsideTransition:nil completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        NSIndexPath *selectedIndexPath = [self.tableView indexPathForSelectedRow];
+        // Make sure a selected comment is visible after rotating, and that the replyTextView is still the first responder.
+        if (selectedIndexPath) {
+            [self.replyTextView becomeFirstResponder];
+            [self.tableView selectRowAtIndexPath:selectedIndexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+        }
+        
+        [self refreshNoResultsView];
+    }];
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection

--- a/WordPress/Classes/ViewRelated/Views/WPRichTextView.m
+++ b/WordPress/Classes/ViewRelated/Views/WPRichTextView.m
@@ -271,7 +271,7 @@ NSString * const WPRichTextDefaultFontName = @"Merriweather";
     // this point has no effect.  Dispatch async will let us refresh layout in a new loop
     // and correctly update.
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self refreshMediaLayout];
+        [self refreshLayout];
 
         if ([self.delegate respondsToSelector:@selector(richTextViewDidLoadMediaBatch:)]) {
             [self.delegate richTextViewDidLoadMediaBatch:self]; // So the delegate can correct its size.


### PR DESCRIPTION
This is a short refactor to clean up some deprecated methods in the reader comments feature. 

To test on both iPhone and iPad:

- Launch the reader and view comments for a post with at least a half dozen comments. 
- Confirm that comments are correctly laid out. 
- Rotate the device and confirm that comments layout was updated for the new screen size. 

@SergioEstevao  Would you do the honors sir? 

Needs review: @SergioEstevao 