### PR TITLE
Fixing Unit Tests

### DIFF
--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -13,6 +13,10 @@ class ContextManagerTests: XCTestCase {
     
     override func tearDown() {
         super.tearDown()
+        
+        // Note: We'll force TestContextManager override reset, since, for (unknown reasons) the TestContextManager
+        // might be retained more than expected, and it may break other core data based tests.
+        ContextManager.overrideSharedInstance(nil)
     }
 
     func testIterativeMigration() {

--- a/WordPress/WordPressTest/WordPressTest-Bridging-Header.h
+++ b/WordPress/WordPressTest/WordPressTest-Bridging-Header.h
@@ -3,6 +3,7 @@
 //
 
 #import "ContextManager.h"
+#import "ContextManager-Internals.h"
 #import "TestContextManager.h"
 #import "WPAccount.h"
 #import "Blog.h"


### PR DESCRIPTION
#### Details:
We've found several unit tests breaking on different dev environments. After a brief debugging session, we've found out that the `TestContextManager`, for unknown reasons, might get retained more than expected.

When this happens, there may be side effects in other unit tests, that would impact the incorrect Core Data model.

In this PR we're forcing a `TestContextManager` cleanup, when needed. 

Needs Review: @aerych 
Thanks Eric!!


--

<img width="1213" alt="screen shot 2016-01-08 at 14 20 27" src="https://cloud.githubusercontent.com/assets/1195260/12205028/d996b954-b616-11e5-8b25-7ac09411f111.png">
