### PR TITLE
Hides the filters in Notifications if not connected to Jetpack.

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -302,6 +302,24 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     [WPStyleGuide configureSegmentedControl:self.filtersSegmentedControl];
 }
 
+- (void)showFiltersSegmentedControlIfApplicable
+{
+    if (!self.showsJetpackMessage && self.tableHeaderView.alpha == WPAlphaZero) {
+        [UIView animateWithDuration:WPAnimationDurationDefault delay:0.0 options:UIViewAnimationCurveEaseIn animations:^{
+            self.tableHeaderView.alpha = WPAlphaFull;
+        } completion:nil];
+    }
+}
+
+- (void)hideFiltersSegmentedControlIfApplicable
+{
+    if (self.showsJetpackMessage && self.tableHeaderView.alpha == WPAlphaFull) {
+        [UIView animateWithDuration:WPAnimationDurationDefault delay:0.0 options:UIViewAnimationCurveEaseOut animations:^{
+            self.tableHeaderView.alpha  = WPAlphaZero;
+        } completion:nil];
+    }
+}
+
 - (void)setupNotificationsBucketDelegate
 {
     Simperium *simperium            = [[WordPressAppDelegate sharedInstance] simperium];
@@ -879,6 +897,10 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     // Remove If Needed
     if (self.tableViewHandler.resultsController.fetchedObjects.count) {
         [self.noResultsView removeFromSuperview];
+        
+        // Show filters if we have results
+        [self showFiltersSegmentedControlIfApplicable];
+        
         return;
     }
     
@@ -887,6 +909,9 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     if (!noResultsView.superview) {
         [self.tableView addSubviewWithFadeAnimation:noResultsView];
     }
+    
+    // Hide the filter header if we're showing the Jetpack prompt
+    [self hideFiltersSegmentedControlIfApplicable];
     
     // Refresh its properties: The user may have signed into WordPress.com
     noResultsView.titleText         = self.noResultsTitleText;


### PR DESCRIPTION
Fixes #4593 – Hides the filters in Notifications if we're displaying the "Connect to Jetpack" prompt, shows it otherwise.

### To Test

1. Sign in with a self-hosted site that's not connected to Jetpack.
2. Visit Notifications and check that the filter bar is not visible.
3. Sign into a .com account and check that the filter bar is now visible.
4. Sign back out of .com (and sign back into a self-hosted non-Jetpack site) and check that the bar is hidden again.

Also verify that if you add a self-hosted site with Jetpack (but don't sign into .com) then the bar is hidden.

Needs Review: @jleandroperez
Thanks!