### PR TITLE
Issues/4642 crash liking post

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -135,16 +135,20 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
 
 
         // Define success block. Make sure work is performed on the main queue
+        NSNumber *postID = readerPost.postID;
+        NSNumber *siteID = readerPost.siteID;
         void (^successBlock)() = ^void() {
             dispatch_async(dispatch_get_main_queue(), ^{
-                NSDictionary *properties = @{
-                                              WPAppAnalyticsKeyPostID: readerPost.postID,
-                                              WPAppAnalyticsKeyBlogID: readerPost.siteID
-                                              };
-                if (like) {
-                    [WPAppAnalytics track:WPAnalyticsStatReaderArticleLiked withProperties:properties];
-                } else {
-                    [WPAppAnalytics track:WPAnalyticsStatReaderArticleUnliked withProperties:properties];
+                if (postID && siteID) {
+                    NSDictionary *properties = @{
+                                                  WPAppAnalyticsKeyPostID: postID,
+                                                  WPAppAnalyticsKeyBlogID: siteID
+                                                  };
+                    if (like) {
+                        [WPAppAnalytics track:WPAnalyticsStatReaderArticleLiked withProperties:properties];
+                    } else {
+                        [WPAppAnalytics track:WPAnalyticsStatReaderArticleUnliked withProperties:properties];
+                    }
                 }
                 if (success) {
                     success();

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -134,7 +134,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
 
 
-        // Define success block. Make sure work is performed on the main queue
+        // Define success block.
         NSNumber *postID = readerPost.postID;
         NSNumber *siteID = readerPost.siteID;
         void (^successBlock)() = ^void() {
@@ -155,7 +155,6 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
         };
 
         // Define failure block. Make sure rollback happens in the moc's queue,
-        // and failure is called on the main queue.
         void (^failureBlock)(NSError *error) = ^void(NSError *error) {
             [self.managedObjectContext performBlockAndWait:^{
                 // Revert changes on failure


### PR DESCRIPTION
Closes #4642 

I was never able to reproduce the crash described in #4642 but the stack trace indicates it was due to a nil value being added to the properties dictionary.  This PR changes the way the `postID` and `siteID` properties are retained by the `success` block and adds a `nil` check for good measure.  It also does a small bit of clean up.  

Needs review: @frosty 