### PR TITLE
Reader: Adds nil check before reloading row for updated attachments.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1124,6 +1124,10 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 {
     Comment *comment = (Comment *)contentProvider;
     NSIndexPath *indexPath = [self.tableViewHandler.resultsController indexPathForObject:comment];
+    if (!indexPath) {
+        return;
+    }
+
     [self.tableViewHandler invalidateCachedRowHeightAtIndexPath:indexPath];
 
     // HACK:


### PR DESCRIPTION
Closes #4650 

This is another one I haven't been able to reproduce.  However, the stack trace shows a nil value was assigned to an array in this method which pretty much identifies the problem. 

Its unclear under what circumstances the `NSIndexPath` returned from the results controller would be `nil` but adding a nil check should prevent the crash. 

Needs review: @diegoreymendez 