### PR TITLE
Feature/4105 sharing networking

### DIFF
--- a/WordPress/Classes/Networking/Remote Objects/RemotePublicizeConnection.swift
+++ b/WordPress/Classes/Networking/Remote Objects/RemotePublicizeConnection.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@objc public class RemotePublicizeConnection : NSObject
+{
+    public var connectionID: NSNumber = 0
+    public var dateIssued = NSDate()
+    public var dateExpires:NSDate? = nil
+    public var externalID = ""
+    public var externalName = ""
+    public var externalDisplay = ""
+    public var externalProfilePicture = ""
+    public var externalProfileURL = ""
+    public var externalFollowerCount: NSNumber = 0
+    public var keyringConnectionID: NSNumber = 0
+    public var keyringConnectionUserID: NSNumber = 0
+    public var label = ""
+    public var refreshURL = ""
+    public var service = ""
+    public var shared = false
+    public var status = ""
+    public var siteID: NSNumber = 0
+    public var userID: NSNumber = 0
+}

--- a/WordPress/Classes/Networking/Remote Objects/RemotePublicizeService.swift
+++ b/WordPress/Classes/Networking/Remote Objects/RemotePublicizeService.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+@objc public class RemotePublicizeService : NSObject
+{
+    public var connectURL = ""
+    public var detail = ""
+    public var icon = ""
+    public var jetpackSupport = false
+    public var jetpackModuleRequired = ""
+    public var label = ""
+    public var multipleExternalUserIDSupport = false
+    public var order: NSNumber = 0
+    public var serviceID = ""
+    public var type = ""
+}

--- a/WordPress/Classes/Networking/SharingServiceRemote.swift
+++ b/WordPress/Classes/Networking/SharingServiceRemote.swift
@@ -1,0 +1,301 @@
+import Foundation
+import AFNetworking
+import NSObject_SafeExpectations
+
+
+/**
+ SharingServiceRemote is responsible for wrangling the REST API calls related to 
+ publiczice services, publicize connections, and keyring connections.
+*/
+
+public class SharingServiceRemote : ServiceRemoteREST
+{
+
+    /**
+    *  @brief      Fetches the list of Publicize services.
+    *
+    *  @param      success     An optional success block accepting an array of `RemotePublicizeService` objects.
+    *  @param      failure     An optional failure block accepting an `NSError` argument.
+    */
+    public func getPublicizeServices(success: ([RemotePublicizeService] -> Void)?, failure: (NSError! -> Void)?) {
+        let endpoint = "meta/external-services"
+        let path = self.pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_1)
+        let params = NSDictionary(object: "publicize", forKey: "type")
+
+        api.GET(path,
+            parameters: params,
+            success: { (operation:AFHTTPRequestOperation!, response:AnyObject!) -> Void in
+                guard let onSuccess = success else {
+                    return
+                }
+
+                let responseString = operation.responseString! as NSString
+                let responseDict = response as! NSDictionary
+                let services:NSDictionary = responseDict.dictionaryForKey(ServiceDictionaryKeys.services)
+
+                let publicizeServices:[RemotePublicizeService] = services.allKeys.map { (key) -> RemotePublicizeService in
+                    let dict:NSDictionary = services.dictionaryForKey(key)
+                    let pub = RemotePublicizeService()
+
+                    pub.connectURL = dict.stringForKey(ServiceDictionaryKeys.connectURL)
+                    pub.detail = dict.stringForKey(ServiceDictionaryKeys.description)
+                    pub.icon = dict.stringForKey(ServiceDictionaryKeys.icon);
+                    pub.serviceID = dict.stringForKey(ServiceDictionaryKeys.ID)
+                    pub.jetpackModuleRequired = dict.stringForKey(ServiceDictionaryKeys.jetpackModuleRequired)
+                    pub.jetpackSupport = dict.numberForKey(ServiceDictionaryKeys.jetpackSupport).boolValue
+                    pub.label = dict.stringForKey(ServiceDictionaryKeys.label)
+                    pub.multipleExternalUserIDSupport = dict.numberForKey(ServiceDictionaryKeys.multipleExternalUserIDSupport).boolValue
+                    pub.type = dict.stringForKey(ServiceDictionaryKeys.type)
+
+                    // We're not guarenteed to get the right order by inspecting the
+                    // response dictionary's keys. Instead, we can check the index
+                    // of each service in the response string.
+                    pub.order = responseString.rangeOfString(pub.serviceID).location
+
+                    return pub
+                }
+
+                onSuccess(publicizeServices)
+
+            },
+            failure: { (operation: AFHTTPRequestOperation?, error: NSError) -> Void in
+                failure?(error)
+            })
+    }
+
+
+    /**
+    *  @brief      Fetches the current user's list of keyring connections.
+    *
+    *  @param      success     An optional success block accepting an array of `KeyringConnection` objects.
+    *  @param      failure     An optional failure block accepting an `NSError` argument.
+    */
+    public func getKeyringConnections(success: ([KeyringConnection] -> Void)?, failure: (NSError! -> Void)?) {
+        let endpoint = "me/keyring-connections"
+        let path = self.pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_1)
+
+        api.GET(path,
+            parameters: nil,
+            success: { (operation:AFHTTPRequestOperation!, response:AnyObject!) -> Void in
+                guard let onSuccess = success else {
+                    return
+                }
+
+                let responseDict = response as! NSDictionary
+                let connections:Array = responseDict.arrayForKey(ConnectionDictionaryKeys.connections)
+                let keyringConnections:[KeyringConnection] = connections.map { (let dict) -> KeyringConnection in
+                    let conn = KeyringConnection()
+                    // TODO: Need to see how this guy is formatted.
+                    // conn.additionalExternalUsers = dict.arrayForKey(ConnectionDictionaryKeys.additionalExternalUsers)
+                    conn.dateExpires = DateUtils.dateFromISOString(dict.stringForKey(ConnectionDictionaryKeys.expires))
+                    conn.dateIssued = DateUtils.dateFromISOString(dict.stringForKey(ConnectionDictionaryKeys.issued))
+                    conn.externalDisplay = dict.stringForKey(ConnectionDictionaryKeys.externalDisplay) ?? conn.externalDisplay
+                    conn.externalID = dict.stringForKey(ConnectionDictionaryKeys.externalID) ?? conn.externalID
+                    conn.externalName = dict.stringForKey(ConnectionDictionaryKeys.externalName) ?? conn.externalName
+                    conn.externalProfilePicture = dict.stringForKey(ConnectionDictionaryKeys.externalProfilePicture) ?? conn.externalProfilePicture
+                    conn.keyringID = dict.numberForKey(ConnectionDictionaryKeys.ID) ?? conn.keyringID
+                    conn.label = dict.stringForKey(ConnectionDictionaryKeys.label) ?? conn.label
+                    conn.refreshURL = dict.stringForKey(ConnectionDictionaryKeys.refreshURL) ?? conn.refreshURL
+                    conn.status = dict.stringForKey(ConnectionDictionaryKeys.status) ?? conn.status
+                    conn.service = dict.stringForKey(ConnectionDictionaryKeys.service) ?? conn.service
+                    conn.type = dict.stringForKey(ConnectionDictionaryKeys.type) ?? conn.type
+                    conn.userID = dict.numberForKey(ConnectionDictionaryKeys.userID) ?? conn.userID
+
+                    return conn
+                }
+
+                onSuccess(keyringConnections)
+            },
+            failure: { (operation: AFHTTPRequestOperation?, error: NSError) -> Void in
+                failure?(error)
+        })
+    }
+
+
+    /**
+     *  @brief      Fetches the current user's list of Publicize connections for the specified site's ID.
+     *
+     *  @param      siteID      The WordPress.com ID of the site.
+     *  @param      success     An optional success block accepting an array of `RemotePublicizeConnection` objects.
+     *  @param      failure     An optional failure block accepting an `NSError` argument.
+     */
+    public func getPublicizeConnections(siteID:NSNumber, success: ([RemotePublicizeConnection] -> Void)?, failure: (NSError! -> Void)?) {
+        let endpoint = "sites/\(siteID)/publicize-connections"
+        let path = self.pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_1)
+
+        api.GET(path,
+            parameters: nil,
+            success: {(operation:AFHTTPRequestOperation!, response:AnyObject!) -> Void in
+                guard let onSuccess = success else {
+                    return
+                }
+
+                let responseDict = response as! NSDictionary
+                let connections:Array = responseDict.arrayForKey(ConnectionDictionaryKeys.connections)
+                let publicizeConnections:[RemotePublicizeConnection] = connections.map { (let dict) -> RemotePublicizeConnection in
+                    let conn = self.remotePublicizeConnectionFromDictionary(dict as! NSDictionary)
+                    return conn
+                }
+
+                onSuccess(publicizeConnections)
+            },
+            failure: { (operation: AFHTTPRequestOperation?, error: NSError) -> Void in
+                failure?(error)
+        })
+    }
+
+
+    /**
+     *  @brief      Create a new Publicize connection bweteen the specified blog and
+     *              the third-pary service represented by the keyring.
+     *
+     *  @param      siteID                  The WordPress.com ID of the site.
+     *  @param      keyringConnectionID     The ID of the third-party site's keyring connection.
+     *  @param      success     An optional success block accepting a `RemotePublicizeConnection` object.
+     *  @param      failure     An optional failure block accepting an `NSError` argument.
+     */
+    public func createPublicizeConnection(siteID:NSNumber,
+        keyringConnectionID:NSNumber,
+        externalUserID:String?,
+        success: (RemotePublicizeConnection -> Void)?, failure: (NSError! -> Void)?)
+    {
+
+            let endpoint = "sites/\(siteID)/publicize-connections/new"
+            let path = self.pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_1)
+
+            let parameters = NSMutableDictionary()
+            parameters.setObject(keyringConnectionID, forKey: PublicizeConnectionParams.keyringConnectionID)
+            if let userID = externalUserID {
+                parameters.setObject(userID, forKey: PublicizeConnectionParams.externalUserID)
+            }
+
+            api.POST(path,
+                parameters: NSDictionary(dictionary:parameters),
+                success: {(operation:AFHTTPRequestOperation!, response:AnyObject!) -> Void in
+                    guard let onSuccess = success else {
+                        return
+                    }
+
+                    let dict = response as! NSDictionary
+                    let conn = self.remotePublicizeConnectionFromDictionary(dict)
+
+                    onSuccess(conn)
+                },
+                failure: { (operation: AFHTTPRequestOperation?, error: NSError) -> Void in
+                    failure?(error)
+            })
+    }
+
+
+    /**
+     *  @brief      Disconnect's (deletes) the specified publicize connection
+     *
+     *  @param      siteID       The WordPress.com ID of the site.
+     *  @param      connectionID The ID of the publicize connection.
+     *  @param      success      An optional success block accepting no arguments.
+     *  @param      failure      An optional failure block accepting an `NSError` argument.
+     */
+    public func deletePublicizeConnection(siteID:NSNumber, connectionID:NSNumber, success: (() -> Void)?, failure: (NSError! -> Void)?) {
+        let endpoint = "sites/\(siteID)/publicize-connections/\(connectionID)/delete"
+        let path = self.pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_1)
+
+        api.POST(path,
+            parameters: nil,
+            success: { (operation:AFHTTPRequestOperation!, response:AnyObject!) -> Void in
+                success?()
+            },
+            failure: { (operation: AFHTTPRequestOperation?, error: NSError) -> Void in
+                failure?(error)
+        })
+    }
+
+    /**
+     *  @brief      Composees a `RemotePublicizeConnection` populated with values from the passed `NSDictionary`
+     *
+     *  @param      dict    An `NSDictionary` representing a `RemotePublicizeConnection`.
+     *
+     *  @return     A `RemotePublicizeConnection` object.
+     */
+    private func remotePublicizeConnectionFromDictionary(dict:NSDictionary) -> RemotePublicizeConnection {
+        let conn = RemotePublicizeConnection()
+
+        conn.connectionID = dict.numberForKey(ConnectionDictionaryKeys.ID) ?? conn.connectionID
+        conn.dateExpires = DateUtils.dateFromISOString(dict.stringForKey(ConnectionDictionaryKeys.expires))
+        conn.dateIssued = DateUtils.dateFromISOString(dict.stringForKey(ConnectionDictionaryKeys.issued))
+        conn.externalDisplay = dict.stringForKey(ConnectionDictionaryKeys.externalDisplay) ?? conn.externalDisplay
+        conn.externalID = dict.stringForKey(ConnectionDictionaryKeys.externalID) ?? conn.externalID
+        conn.externalName = dict.stringForKey(ConnectionDictionaryKeys.externalName) ?? conn.externalName
+        conn.externalProfilePicture = dict.stringForKey(ConnectionDictionaryKeys.externalProfilePicture) ?? conn.externalProfilePicture
+        conn.externalProfileURL = dict.stringForKey(ConnectionDictionaryKeys.externalProfileURL) ?? conn.externalProfileURL
+        conn.keyringConnectionID = dict.numberForKey(ConnectionDictionaryKeys.keyringConnectionID) ?? conn.keyringConnectionID
+        conn.keyringConnectionUserID = dict.numberForKey(ConnectionDictionaryKeys.keyringConnectionUserID) ?? conn.keyringConnectionUserID
+        conn.label = dict.stringForKey(ConnectionDictionaryKeys.label) ?? conn.label
+        conn.refreshURL = dict.stringForKey(ConnectionDictionaryKeys.refreshURL) ?? conn.refreshURL
+        conn.status = dict.stringForKey(ConnectionDictionaryKeys.status) ?? conn.status
+        conn.service = dict.stringForKey(ConnectionDictionaryKeys.service) ?? conn.service
+        conn.shared = dict.numberForKey(ConnectionDictionaryKeys.shared).boolValue ?? conn.shared
+        conn.siteID = dict.numberForKey(ConnectionDictionaryKeys.siteID) ?? conn.siteID
+        conn.userID = dict.numberForKey(ConnectionDictionaryKeys.userID) ?? conn.userID
+
+        return conn
+    }
+
+}
+
+
+// Keys for PublicizeService dictionaries
+private struct ServiceDictionaryKeys
+{
+    static let connectURL = "connect_URL"
+    static let description = "description"
+    static let ID = "ID"
+    static let icon = "icon"
+    static let jetpackModuleRequired = "jetpack_module_required"
+    static let jetpackSupport = "jetpack_support"
+    static let label = "label"
+    static let multipleExternalUserIDSupport = "multiple_external_user_ID_support"
+    static let services = "services"
+    static let type = "type"
+}
+
+
+// Keys for both KeyringConnection and PublicizeConnection dictionaries
+private struct ConnectionDictionaryKeys
+{
+    // shared keys
+    static let connections = "connections"
+    static let expires = "expires"
+    static let externalID = "external_ID"
+    static let externalName = "external_name"
+    static let externalDisplay = "external_display"
+    static let externalProfilePicture = "external_profile_picture"
+    static let issued = "issued"
+    static let ID = "ID"
+    static let label = "label"
+    static let refreshURL = "refresh_URL"
+    static let service = "service"
+    static let sites = "sites"
+    static let status = "status"
+    static let userID = "user_ID"
+
+    // only KeyringConnections
+    static let additionalExternalUsers = "additional_external_users"
+    static let type = "type"
+
+    // only PublicizeConnections
+    static let externalFollowerCount = "external_follower_count"
+    static let externalProfileURL = "external_profile_URL"
+    static let keyringConnectionID = "keyring_connection_ID"
+    static let keyringConnectionUserID = "keyring_connection_user_ID"
+    static let shared = "shared"
+    static let siteID = "site_ID"
+}
+
+
+// Names of parameters passed when creating a new publicize connection
+private struct PublicizeConnectionParams
+{
+    static let keyringConnectionID = "keyring_connection_ID"
+    static let externalUserID = "external_user_ID"
+}
+

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -572,6 +572,9 @@
 		E6374DBF1C444D8B00F24720 /* KeyringConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6374DBC1C444D8B00F24720 /* KeyringConnection.swift */; };
 		E6374DC01C444D8B00F24720 /* PublicizeConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6374DBD1C444D8B00F24720 /* PublicizeConnection.swift */; };
 		E6374DC11C444D8B00F24720 /* PublicizeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6374DBE1C444D8B00F24720 /* PublicizeService.swift */; };
+		E6374DC31C4454EA00F24720 /* SharingServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6374DC21C4454EA00F24720 /* SharingServiceRemote.swift */; };
+		E6374DC61C44550700F24720 /* RemotePublicizeConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6374DC41C44550700F24720 /* RemotePublicizeConnection.swift */; };
+		E6374DC71C44550700F24720 /* RemotePublicizeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6374DC51C44550700F24720 /* RemotePublicizeService.swift */; };
 		E6396E1F1BED91E00058B374 /* RemoteReaderCrossPostMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6396E1E1BED91E00058B374 /* RemoteReaderCrossPostMeta.swift */; };
 		E65219F91B8D10C2000B1217 /* ReaderBlockedSiteCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65219F81B8D10C2000B1217 /* ReaderBlockedSiteCell.xib */; };
 		E65219FB1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65219FA1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift */; };
@@ -1627,6 +1630,9 @@
 		E6374DBC1C444D8B00F24720 /* KeyringConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyringConnection.swift; sourceTree = "<group>"; };
 		E6374DBD1C444D8B00F24720 /* PublicizeConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublicizeConnection.swift; sourceTree = "<group>"; };
 		E6374DBE1C444D8B00F24720 /* PublicizeService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublicizeService.swift; sourceTree = "<group>"; };
+		E6374DC21C4454EA00F24720 /* SharingServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingServiceRemote.swift; sourceTree = "<group>"; };
+		E6374DC41C44550700F24720 /* RemotePublicizeConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RemotePublicizeConnection.swift; path = "Remote Objects/RemotePublicizeConnection.swift"; sourceTree = "<group>"; };
+		E6374DC51C44550700F24720 /* RemotePublicizeService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RemotePublicizeService.swift; path = "Remote Objects/RemotePublicizeService.swift"; sourceTree = "<group>"; };
 		E6396E1E1BED91E00058B374 /* RemoteReaderCrossPostMeta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RemoteReaderCrossPostMeta.swift; path = "Remote Objects/RemoteReaderCrossPostMeta.swift"; sourceTree = "<group>"; };
 		E65219F81B8D10C2000B1217 /* ReaderBlockedSiteCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderBlockedSiteCell.xib; sourceTree = "<group>"; };
 		E65219FA1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderBlockedSiteCell.swift; sourceTree = "<group>"; };
@@ -2497,6 +2503,7 @@
 				59E2AAE21B2096BF0051DC06 /* ServiceRemoteREST.m */,
 				E1249B471940AE550035E895 /* ServiceRemoteXMLRPC.h */,
 				FF19340B1BB2F892006825B8 /* ServiceRemoteXMLRPC.m */,
+				E6374DC21C4454EA00F24720 /* SharingServiceRemote.swift */,
 				FFC6ADDB1B56F3D2002F3C84 /* ThemeServiceRemote.h */,
 				FFC6ADDC1B56F3D2002F3C84 /* ThemeServiceRemote.m */,
 				5997383E1B87AD2600EC1C30 /* WordPressComServiceRemote.h */,
@@ -3466,6 +3473,8 @@
 				E1A6DBD719DC7D080071AC1E /* RemotePostCategory.m */,
 				E1A6DBD819DC7D080071AC1E /* RemotePost.h */,
 				E1A6DBD919DC7D080071AC1E /* RemotePost.m */,
+				E6374DC41C44550700F24720 /* RemotePublicizeConnection.swift */,
+				E6374DC51C44550700F24720 /* RemotePublicizeService.swift */,
 				E1249B4119408C910035E895 /* RemoteComment.h */,
 				E1249B4219408C910035E895 /* RemoteComment.m */,
 				5D12FE1A1988243700378BD6 /* RemoteReaderPost.h */,
@@ -4466,6 +4475,7 @@
 				B56A70181B5040B9001D5815 /* SwitchTableViewCell.swift in Sources */,
 				E66969E21B9E67A000EC9C00 /* ReaderTopicToReaderSiteTopic37to38.swift in Sources */,
 				8350E49611D2C71E00A7B073 /* Media.m in Sources */,
+				E6374DC31C4454EA00F24720 /* SharingServiceRemote.swift in Sources */,
 				B53AD9BC1BE95687009AB87E /* SettingsTextViewController.m in Sources */,
 				8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */,
 				E1B912891BB01288003C25B9 /* PeopleViewController.swift in Sources */,
@@ -4627,6 +4637,7 @@
 				B587797A19B799D800E57C5A /* NSDate+Helpers.swift in Sources */,
 				E142007A1C117A3B00B3B115 /* ManagedAccountSettings+CoreDataProperties.swift in Sources */,
 				B535209D1AF7EB9F00B33BA8 /* PushAuthenticationService.swift in Sources */,
+				E6374DC61C44550700F24720 /* RemotePublicizeConnection.swift in Sources */,
 				B57273611B66CCEF000D1C4F /* AlertView.swift in Sources */,
 				3101866B1A373B01008F7DF6 /* WPTabBarController.m in Sources */,
 				85E105861731A597001071A3 /* WPWalkthroughOverlayView.m in Sources */,
@@ -4687,6 +4698,7 @@
 				85D239B01AE5A5FC0074768D /* LoginFacade.m in Sources */,
 				E1209FA41BB4978B00D69778 /* PeopleService.swift in Sources */,
 				E13A8C9B1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift in Sources */,
+				E6374DC71C44550700F24720 /* RemotePublicizeService.swift in Sources */,
 				B5899AE41B422D990075A3D6 /* NotificationSettings.swift in Sources */,
 				FFB1FAA01BF0EC4E0090C761 /* PHAsset+Exporters.swift in Sources */,
 				5D18FE9F1AFBB17400EFEED0 /* RestorePageTableViewCell.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -575,6 +575,7 @@
 		E6374DC31C4454EA00F24720 /* SharingServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6374DC21C4454EA00F24720 /* SharingServiceRemote.swift */; };
 		E6374DC61C44550700F24720 /* RemotePublicizeConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6374DC41C44550700F24720 /* RemotePublicizeConnection.swift */; };
 		E6374DC71C44550700F24720 /* RemotePublicizeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6374DC51C44550700F24720 /* RemotePublicizeService.swift */; };
+		E6374DC91C445ABF00F24720 /* SharingServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E6374DC81C445ABF00F24720 /* SharingServiceRemoteTests.m */; };
 		E6396E1F1BED91E00058B374 /* RemoteReaderCrossPostMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6396E1E1BED91E00058B374 /* RemoteReaderCrossPostMeta.swift */; };
 		E65219F91B8D10C2000B1217 /* ReaderBlockedSiteCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65219F81B8D10C2000B1217 /* ReaderBlockedSiteCell.xib */; };
 		E65219FB1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65219FA1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift */; };
@@ -1633,6 +1634,7 @@
 		E6374DC21C4454EA00F24720 /* SharingServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingServiceRemote.swift; sourceTree = "<group>"; };
 		E6374DC41C44550700F24720 /* RemotePublicizeConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RemotePublicizeConnection.swift; path = "Remote Objects/RemotePublicizeConnection.swift"; sourceTree = "<group>"; };
 		E6374DC51C44550700F24720 /* RemotePublicizeService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RemotePublicizeService.swift; path = "Remote Objects/RemotePublicizeService.swift"; sourceTree = "<group>"; };
+		E6374DC81C445ABF00F24720 /* SharingServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SharingServiceRemoteTests.m; sourceTree = "<group>"; };
 		E6396E1E1BED91E00058B374 /* RemoteReaderCrossPostMeta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RemoteReaderCrossPostMeta.swift; path = "Remote Objects/RemoteReaderCrossPostMeta.swift"; sourceTree = "<group>"; };
 		E65219F81B8D10C2000B1217 /* ReaderBlockedSiteCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderBlockedSiteCell.xib; sourceTree = "<group>"; };
 		E65219FA1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderBlockedSiteCell.swift; sourceTree = "<group>"; };
@@ -2750,6 +2752,7 @@
 				85F8E19E1B0186D0000859BB /* MockWordPressComApi.swift */,
 				E61084C31B9DC09C008050C5 /* ReaderPostServiceRemoteTests.m */,
 				E66969C91B9E0C4F00EC9C00 /* ReaderTopicServiceRemoteTests.m */,
+				E6374DC81C445ABF00F24720 /* SharingServiceRemoteTests.m */,
 			);
 			name = Networking;
 			sourceTree = "<group>";
@@ -4847,6 +4850,7 @@
 				B5AEEC721ACACF2F008BF2A4 /* NotificationTests.m in Sources */,
 				BE1071FF1BC75FFA00906AFF /* WPStyleGuide+BlogTests.swift in Sources */,
 				85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */,
+				E6374DC91C445ABF00F24720 /* SharingServiceRemoteTests.m in Sources */,
 				E1B921BC1C0ED5A3003EA3CB /* MediaSizeSliderCellTest.swift in Sources */,
 				E19A10CA1B010AA0006192B0 /* WPURLRequestTest.m in Sources */,
 				591CFB091B28AC8C009E61B3 /* BlogServiceRemoteRESTTests.m in Sources */,

--- a/WordPress/WordPressTest/SharingServiceRemoteTests.m
+++ b/WordPress/WordPressTest/SharingServiceRemoteTests.m
@@ -1,0 +1,131 @@
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+
+#import "Blog.h"
+#import "ServiceRemoteREST.h"
+#import "WordPressComApi.h"
+#import "WordPressTests-Swift.h"
+#import "WordPress-Swift.h"
+
+@interface SharingServiceRemoteTests : XCTestCase
+
+@end
+
+
+@implementation SharingServiceRemoteTests
+
+#pragma mark - Synchronizing connections for a blog
+
+- (void)testGetPublicizeServices
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    SharingServiceRemote *service = nil;
+
+    NSString *url = @"v1.1/meta/external-services";
+    NSDictionary *params = @{@"type":@"publicize"};
+
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isEqual:params]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+
+    [service getPublicizeServices:^(NSArray *services) {
+    } failure:^(NSError *error) {
+    }];
+}
+
+
+- (void)testGetKeyringServices
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    SharingServiceRemote *service = nil;
+
+    NSString *url = @"v1.1/me/keyring-connections";
+
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+
+    [service getKeyringConnections:^(NSArray *connections) {
+    } failure:^(NSError *error) {
+    }];
+}
+
+
+- (void)testGetPublicizeConnections
+{
+    NSNumber *mockID = @10;
+
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    SharingServiceRemote *service = nil;
+
+    NSString *url = [NSString stringWithFormat:@"v1.1/sites/%@/publicize-connections", mockID];
+
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+
+    [service getPublicizeConnections:mockID
+                             success:^(NSArray *connections) {
+                             } failure:^(NSError *error) {
+                             }];
+}
+
+
+- (void)testCreatePublicizeConnection
+{
+    NSNumber *mockID = @10;
+
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    SharingServiceRemote *service = nil;
+
+    NSString *url = [NSString stringWithFormat:@"v1.1/sites/%@/publicize-connections/new", mockID];
+
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg isNotNil]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+
+    [service createPublicizeConnection:mockID
+                   keyringConnectionID:mockID
+                        externalUserID:nil
+                               success:^(RemotePublicizeConnection *remotePubConn) {
+                               } failure:^(NSError *error) {
+                               }];
+
+}
+
+
+- (void)testDeletePublicizeConnection
+{
+    NSNumber *mockID = @10;
+
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    SharingServiceRemote *service = nil;
+
+    NSString *url = [NSString stringWithFormat:@"v1.1/sites/%@/publicize-connections/%@/delete", mockID, mockID];
+
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg isNil]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+
+    [service deletePublicizeConnection:mockID connectionID:mockID success:^{
+    } failure:^(NSError *error) {
+    }];
+}
+
+
+@end


### PR DESCRIPTION
Refs #4105

This is part two of splitting up the [current main branch for the sharing feature](https://github.com/wordpress-mobile/WordPress-iOS/tree/feature/4105-sharing). See #4652 for background.

This PR contains just the changes to the networking layer.  The original commit was f8accea.  It depends on changes in #4652 so wait til #4652 is merged to develop before reviewing / merging this PR. 

Needs review: @diegoreymendez 
