### PR TITLE
Issue/3649: Broken login layout on rotation

### DIFF
--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -48,6 +48,8 @@
 #import "ReaderTopicService.h"
 #import "RemoteReaderTopic.h"
 
+#import "RotationAwareNavigationViewController.h"
+
 #import "ServiceRemoteREST.h"
 #import "SettingsSelectionViewController.h"
 #import "SettingsMultiTextViewController.h"

--- a/WordPress/Classes/ViewRelated/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/MeViewController.swift
@@ -222,7 +222,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
                 self.dismissViewControllerAnimated(true, completion: nil)
             }
 
-            let navigation = UINavigationController(rootViewController: controller)
+            let navigation = RotationAwareNavigationViewController(rootViewController: controller)
             self.presentViewController(navigation, animated: true, completion: nil)
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -174,7 +174,16 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
     [nc addObserver:self selector:@selector(helpshiftUnreadCountUpdated:) name:HelpshiftUnreadCountUpdatedNotification object:nil];
     
     [HelpshiftUtils refreshUnreadNotificationCount];
+}
 
+- (void)viewWillLayoutSubviews
+{
+    [super viewWillLayoutSubviews];
+    
+    // Previously we reloaded the interface in viewWillAppear:, however there were certain situations
+    // where the view's frame would be in the wrong orientation (e.g. after viewing the support view controller
+    // in landscape and then dismissing it) resulting in an incorrect layout.
+    // Fortunately, the frame is correct in viewWillLayoutSubviews.
     [self reloadInterface];
 }
 
@@ -189,13 +198,6 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
 {
     return [UIDevice isPad] ? UIInterfaceOrientationMaskAll : UIInterfaceOrientationMaskPortrait;
 }
-
-- (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
-                                         duration:(NSTimeInterval)duration
-{
-    [self layoutControls];
-}
-
 
 #pragma mark - UITextField delegate methods
 


### PR DESCRIPTION
Fixes #3649. The login screen's layout was incorrect after rotating the device, viewing the support screen (which supports rotation) and dismissing it. See To Test for full details.

The login screen was also incorrectly rotating on iPhone when it shouldn't. I've made use of `RotationAwareNavigationViewController` to pass through the relevant rotation method. Login should now never rotate on iPhone!

### To Test

1. While signed out of the app and viewing the sign-in screen, rotate to landscape orientation. The Sign-in screen requires portrait orientation and should not rotate.
2. Tap the info (?) icon to view the support screen.
3. Rotate to Portrait orientation.
4. Dismiss the support screen. The sign-in screen's layout should not have changed.

Please also check the following:

- Check the sign-in screen both when launching the app, and when tapping 'Connect' from the Me tab, as these both present `LoginViewController` from different places.
- Ensure that the sign-in screen still rotates correctly on iPad.

Needs review: @jleandroperez 
Thanks!