### PR TITLE
Deprecate blogID in favor of dotComID

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -172,6 +172,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
  @return a WordPressComApi object if available
  */
 - (WordPressComApi *)restApi;
-- (NSNumber *)dotComID;
+@property (readonly) NSNumber *dotComID;
 
 @end

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -43,6 +43,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @interface Blog : NSManagedObject
 
 @property (nonatomic, strong, readwrite) NSNumber *blogID __deprecated_msg("Use dotComID instead");
+@property (nonatomic, strong, readwrite) NSNumber *dotComID;
 @property (nonatomic, strong, readwrite) NSString *xmlrpc;
 @property (nonatomic, strong, readwrite) NSString *apiKey;
 @property (nonatomic, strong, readwrite) NSNumber *hasOlderPosts;
@@ -172,6 +173,5 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
  @return a WordPressComApi object if available
  */
 - (WordPressComApi *)restApi;
-@property (readonly) NSNumber *dotComID;
 
 @end

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -42,7 +42,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 
 @interface Blog : NSManagedObject
 
-@property (nonatomic, strong, readwrite) NSNumber *blogID;
+@property (nonatomic, strong, readwrite) NSNumber *blogID __deprecated_msg("Use dotComID instead");
 @property (nonatomic, strong, readwrite) NSString *xmlrpc;
 @property (nonatomic, strong, readwrite) NSString *apiKey;
 @property (nonatomic, strong, readwrite) NSNumber *hasOlderPosts;

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -453,21 +453,23 @@ NSString * const PostFormatStandard = @"standard";
 
 - (NSNumber *)dotComID
 {
-    /*
-     mergeBlogs isn't atomic so there might be a small window for Jetpack sites
-     where self.account is the WordPress.com account, but self.blogID still has
-     the self hosted ID.
-     
-     Even if the blog is using Jetpack REST, self.jetpack.siteID should still
-     have the correct wp.com blog ID, so let's try that one first
-     */
-    if (self.jetpack.siteID) {
-        return self.jetpack.siteID;
-    } else if (self.account) {
-        return self.blogID;
-    } else {
-        return nil;
+    [self willAccessValueForKey:@"blogID"];
+    NSNumber *dotComID = [self primitiveValueForKey:@"blogID"];
+    if (dotComID.integerValue == 0) {
+        dotComID = self.jetpack.siteID;
+        if (dotComID.integerValue > 0) {
+            self.dotComID = dotComID;
+        }
     }
+    [self didAccessValueForKey:@"blogID"];
+    return dotComID;
+}
+
+- (void)setDotComID:(NSNumber *)dotComID
+{
+    [self willChangeValueForKey:@"blogID"];
+    [self setPrimitiveValue:dotComID forKey:@"blogID"];
+    [self didChangeValueForKey:@"blogID"];
 }
 
 - (NSSet *)allowedFileTypes

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -498,7 +498,7 @@ NSString * const PostFormatStandard = @"standard";
 {
     NSString *extra = @"";
     if (self.account) {
-        extra = [NSString stringWithFormat:@" wp.com account: %@ blogId: %@", self.account ? self.account.username : @"NO", self.blogID];
+        extra = [NSString stringWithFormat:@" wp.com account: %@ blogId: %@", self.account ? self.account.username : @"NO", self.dotComID];
     } else if (self.jetpackAccount) {
         extra = [NSString stringWithFormat:@" jetpack: 🚀🚀 Jetpack %@ fully connected as %@ with site ID %@", self.jetpack.version, self.jetpackAccount.username, self.jetpack.siteID];
     } else {

--- a/WordPress/Classes/Networking/BlogServiceRemote.h
+++ b/WordPress/Classes/Networking/BlogServiceRemote.h
@@ -12,57 +12,47 @@ typedef void (^SuccessHandler)();
 /**
  *  @brief      Checks if a blog has multiple authors.
  *
- *  @param      blog        The blog to check for multi-authors.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
-- (void)checkMultiAuthorForBlogID:(NSNumber *)blogID
-                          success:(MultiAuthorCheckHandler)success
-                          failure:(void (^)(NSError *error))failure;
+- (void)checkMultiAuthorWithSuccess:(MultiAuthorCheckHandler)success
+                            failure:(void (^)(NSError *error))failure;
 
 /**
  *  @brief      Synchronizes a blog's options.
  *
- *  @param      blog        The blog to synchronize.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
-- (void)syncOptionsForBlogID:(NSNumber *)blogID
-                     success:(OptionsHandler)success
-                     failure:(void (^)(NSError *error))failure;
+- (void)syncOptionsWithSuccess:(OptionsHandler)success
+                       failure:(void (^)(NSError *error))failure;
 
 /**
  *  @brief      Synchronizes a blog's post formats.
  *
- *  @param      blog        The blog to synchronize.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
-- (void)syncPostFormatsForBlogID:(NSNumber *)blogID
-                         success:(PostFormatsHandler)success
-                         failure:(void (^)(NSError *error))failure;
+- (void)syncPostFormatsWithSuccess:(PostFormatsHandler)success
+                           failure:(void (^)(NSError *error))failure;
 
 
 /**
  *  @brief      Synchronizes a blog's settings.
  *
- *  @param      blog        The blog to synchronize.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
-- (void)syncSettingsForBlogID:(NSNumber *)blogID
-                      success:(SettingsHandler)success
-                      failure:(void (^)(NSError *error))failure;
+- (void)syncSettingsWithSuccess:(SettingsHandler)success
+                        failure:(void (^)(NSError *error))failure;
 
 /**
  *  @brief      Updates the blog settings.
  *
- *  @param      blog        The blog to update.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)updateBlogSettings:(RemoteBlogSettings *)remoteBlogSettings
-                 forBlogID:(NSNumber *)blogID
                    success:(SuccessHandler)success
                    failure:(void (^)(NSError *error))failure;
 

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.h
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "BlogServiceRemote.h"
-#import "ServiceRemoteREST.h"
+#import "SiteServiceRemoteREST.h"
 
-@interface BlogServiceRemoteREST : ServiceRemoteREST <BlogServiceRemote>
+@interface BlogServiceRemoteREST : SiteServiceRemoteREST <BlogServiceRemote>
 @end

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -47,15 +47,12 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
 
 @implementation BlogServiceRemoteREST
 
-- (void)checkMultiAuthorForBlogID:(NSNumber *)blogID
-                          success:(void(^)(BOOL isMultiAuthor))success
-                          failure:(void (^)(NSError *error))failure
+- (void)checkMultiAuthorWithSuccess:(void(^)(BOOL isMultiAuthor))success
+                            failure:(void (^)(NSError *error))failure
 {
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
     NSDictionary *parameters = @{@"authors_only":@(YES)};
     
-    NSString *path = [NSString stringWithFormat:@"sites/%@/users", blogID];
+    NSString *path = [self pathForUsers];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -74,13 +71,10 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
           }];
 }
 
-- (void)syncOptionsForBlogID:(NSNumber *)blogID
-                     success:(OptionsHandler)success
-                     failure:(void (^)(NSError *))failure
+- (void)syncOptionsWithSuccess:(OptionsHandler)success
+                       failure:(void (^)(NSError *))failure
 {
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
-    NSString *path = [self pathForOptionsWithBlogID:blogID];
+    NSString *path = [self pathForOptions];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -99,13 +93,10 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
           }];
 }
 
-- (void)syncPostFormatsForBlogID:(NSNumber *)blogID
-                         success:(PostFormatsHandler)success
-                         failure:(void (^)(NSError *))failure
+- (void)syncPostFormatsWithSuccess:(PostFormatsHandler)success
+                           failure:(void (^)(NSError *))failure
 {
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
-    NSString *path = [self pathForPostFormatsWithBlogID:blogID];
+    NSString *path = [self pathForPostFormats];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -123,13 +114,10 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
           }];
 }
 
-- (void)syncSettingsForBlogID:(NSNumber *)blogID
-                    success:(SettingsHandler)success
-                    failure:(void (^)(NSError *error))failure
+- (void)syncSettingsWithSuccess:(SettingsHandler)success
+                        failure:(void (^)(NSError *error))failure
 {
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
-    NSString *path = [self pathForSettingsWithBlogID:blogID];
+    NSString *path = [self pathForSettings];
     NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteRESTApiVersion_1_1];
     
     [self.api GET:requestUrl
@@ -153,15 +141,13 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
 }
 
 - (void)updateBlogSettings:(RemoteBlogSettings *)settings
-                 forBlogID:(NSNumber *)blogID
                    success:(SuccessHandler)success
                    failure:(void (^)(NSError *error))failure;
 {
     NSParameterAssert(settings);
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
+
     NSDictionary *parameters = [self remoteSettingsToDictionary:settings];
-    NSString *path = [NSString stringWithFormat:@"sites/%@/settings?context=edit", blogID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/settings?context=edit", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteRESTApiVersion_1_1];
     
     [self.api POST:requestUrl
@@ -190,19 +176,24 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
 
 #pragma mark - API paths
 
-- (NSString *)pathForOptionsWithBlogID:(NSNumber *)blogID
+- (NSString *)pathForUsers
 {
-    return [NSString stringWithFormat:@"sites/%@", blogID];
+    return [NSString stringWithFormat:@"sites/%@/users", self.siteID];
 }
 
-- (NSString *)pathForPostFormatsWithBlogID:(NSNumber *)blogID
+- (NSString *)pathForOptions
 {
-    return [NSString stringWithFormat:@"sites/%@/post-formats", blogID];
+    return [NSString stringWithFormat:@"sites/%@", self.siteID];
 }
 
-- (NSString *)pathForSettingsWithBlogID:(NSNumber *)blogID
+- (NSString *)pathForPostFormats
 {
-    return [NSString stringWithFormat:@"sites/%@/settings", blogID];
+    return [NSString stringWithFormat:@"sites/%@/post-formats", self.siteID];
+}
+
+- (NSString *)pathForSettings
+{
+    return [NSString stringWithFormat:@"sites/%@/settings", self.siteID];
 }
 
 

--- a/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.m
@@ -10,7 +10,7 @@
 {
     NSParameterAssert(blogID != nil);
     NSDictionary *filter = @{@"who":@"authors"};
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:filter];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:filter];
     [self.api callMethod:@"wp.getUsers"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -42,7 +42,7 @@
                     success:(SettingsHandler)success
                     failure:(void (^)(NSError *error))failure
 {
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:nil];
+    NSArray *parameters = [self defaultXMLRPCArguments];
     [self.api callMethod:@"wp.getOptions" parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
         if (![responseObject isKindOfClass:[NSDictionary class]]) {
             if (failure) {
@@ -73,7 +73,7 @@
         @"blog_tagline" : remoteBlogSettings.tagline
     };
     
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:rawParameters];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:rawParameters];
     
     [self.api callMethod:@"wp.setOptions" parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
         if (![responseObject isKindOfClass:[NSDictionary class]]) {
@@ -101,7 +101,7 @@
                                                     success:(OptionsHandler)success
                                                     failure:(void (^)(NSError *error))failure
 {
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:nil];
+    NSArray *parameters = [self defaultXMLRPCArguments];
     WPXMLRPCRequest *request = [self.api XMLRPCRequestWithMethod:@"wp.getOptions" parameters:parameters];
     WPXMLRPCRequestOperation *operation = [self.api XMLRPCRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
         NSAssert([responseObject isKindOfClass:[NSDictionary class]], @"Response should be a dictionary.");
@@ -125,7 +125,7 @@
                                                         failure:(void (^)(NSError *error))failure
 {
     NSDictionary *dict = @{@"show-supported": @"1"};
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:dict];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:dict];
 
     WPXMLRPCRequest *request = [self.api XMLRPCRequestWithMethod:@"wp.getPostFormats" parameters:parameters];
     WPXMLRPCRequestOperation *operation = [self.api XMLRPCRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {

--- a/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.m
@@ -4,11 +4,9 @@
 
 @implementation BlogServiceRemoteXMLRPC
 
-- (void)checkMultiAuthorForBlogID:(NSNumber *)blogID
-                          success:(void(^)(BOOL isMultiAuthor))success
-                          failure:(void (^)(NSError *error))failure
+- (void)checkMultiAuthorWithSuccess:(void(^)(BOOL isMultiAuthor))success
+                            failure:(void (^)(NSError *error))failure
 {
-    NSParameterAssert(blogID != nil);
     NSDictionary *filter = @{@"who":@"authors"};
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:filter];
     [self.api callMethod:@"wp.getUsers"
@@ -26,20 +24,19 @@
                  }];
 }
 
-- (void)syncOptionsForBlogID:(NSNumber *)blogID success:(OptionsHandler)success failure:(void (^)(NSError *))failure
+- (void)syncOptionsWithSuccess:(OptionsHandler)success failure:(void (^)(NSError *))failure
 {
-    WPXMLRPCRequestOperation *operation = [self operationForOptionsWithBlogID:blogID success:success failure:failure];
+    WPXMLRPCRequestOperation *operation = [self operationForOptionsWithSuccess:success failure:failure];
     [self.api enqueueXMLRPCRequestOperation:operation];
 }
 
-- (void)syncPostFormatsForBlogID:(NSNumber *)blogID success:(PostFormatsHandler)success failure:(void (^)(NSError *))failure
+- (void)syncPostFormatsWithSuccess:(PostFormatsHandler)success failure:(void (^)(NSError *))failure
 {
-    WPXMLRPCRequestOperation *operation = [self operationForPostFormatsWithBlogID:blogID success:success failure:failure];
+    WPXMLRPCRequestOperation *operation = [self operationForPostFormatsWithSuccess:success failure:failure];
     [self.api enqueueXMLRPCRequestOperation:operation];
 }
 
-- (void)syncSettingsForBlogID:(NSNumber *)blogID
-                    success:(SettingsHandler)success
+- (void)syncSettingsWithSuccess:(SettingsHandler)success
                     failure:(void (^)(NSError *error))failure
 {
     NSArray *parameters = [self defaultXMLRPCArguments];
@@ -64,7 +61,6 @@
 }
 
 - (void)updateBlogSettings:(RemoteBlogSettings *)remoteBlogSettings
-                 forBlogID:(NSNumber *)blogID
                    success:(SuccessHandler)success
                    failure:(void (^)(NSError *error))failure
 {
@@ -97,8 +93,7 @@
 
 
 
-- (WPXMLRPCRequestOperation *)operationForOptionsWithBlogID:(NSNumber *)blogID
-                                                    success:(OptionsHandler)success
+- (WPXMLRPCRequestOperation *)operationForOptionsWithSuccess:(OptionsHandler)success
                                                     failure:(void (^)(NSError *error))failure
 {
     NSArray *parameters = [self defaultXMLRPCArguments];
@@ -120,8 +115,7 @@
     return operation;
 }
 
-- (WPXMLRPCRequestOperation *)operationForPostFormatsWithBlogID:(NSNumber *)blogID
-                                                        success:(PostFormatsHandler)success
+- (WPXMLRPCRequestOperation *)operationForPostFormatsWithSuccess:(PostFormatsHandler)success
                                                         failure:(void (^)(NSError *error))failure
 {
     NSDictionary *dict = @{@"show-supported": @"1"};

--- a/WordPress/Classes/Networking/CommentServiceRemote.h
+++ b/WordPress/Classes/Networking/CommentServiceRemote.h
@@ -7,32 +7,28 @@
 /**
  Loads all of the comments associated with a blog
  */
-- (void)getCommentsForBlogID:(NSNumber *)blogID
-                     success:(void (^)(NSArray *comments))success
-                     failure:(void (^)(NSError *error))failure;
+- (void)getCommentsWithSuccess:(void (^)(NSArray *comments))success
+                       failure:(void (^)(NSError *error))failure;
 
 
 
 /**
  Loads all of the comments associated with a blog
  */
-- (void)getCommentsForBlogID:(NSNumber *)blogID
-                     options:(NSDictionary *)options
-                     success:(void (^)(NSArray *posts))success
-                     failure:(void (^)(NSError *error))failure;
+- (void)getCommentsWithOptions:(NSDictionary *)options
+                       success:(void (^)(NSArray *posts))success
+                       failure:(void (^)(NSError *error))failure;
 
 /**
  Publishes a new comment
  */
 - (void)createComment:(RemoteComment *)comment
-            forBlogID:(NSNumber *)blogID
               success:(void (^)(RemoteComment *comment))success
               failure:(void (^)(NSError *error))failure;
 /**
  Updates the content of an existing comment
  */
 - (void)updateComment:(RemoteComment *)commen
-            forBlogID:(NSNumber *)blogID
               success:(void (^)(RemoteComment *comment))success
               failure:(void (^)(NSError *error))failure;
 
@@ -40,7 +36,6 @@
  Updates the status of an existing comment
  */
 - (void)moderateComment:(RemoteComment *)comment
-              forBlogID:(NSNumber *)blogID
                 success:(void (^)(RemoteComment *comment))success
                 failure:(void (^)(NSError *error))failure;
 
@@ -48,7 +43,6 @@
  Trashes a comment
  */
 - (void)trashComment:(RemoteComment *)comment
-           forBlogID:(NSNumber *)blogID
              success:(void (^)())success
              failure:(void (^)(NSError *error))failure;
 

--- a/WordPress/Classes/Networking/CommentServiceRemoteREST.h
+++ b/WordPress/Classes/Networking/CommentServiceRemoteREST.h
@@ -1,8 +1,8 @@
 #import <Foundation/Foundation.h>
 #import "CommentServiceRemote.h"
-#import "ServiceRemoteREST.h"
+#import "SiteServiceRemoteREST.h"
 
-@interface CommentServiceRemoteREST : ServiceRemoteREST <CommentServiceRemote>
+@interface CommentServiceRemoteREST : SiteServiceRemoteREST <CommentServiceRemote>
 
 /**
  Fetch a hierarchical list of comments for the specified post on the specified site.
@@ -11,77 +11,68 @@
  depending on the number of child comments.
 
  @param postID The ID of the post.
- @param siteID The ID of the origin site.
  @param page The page number to fetch.
  @param number The number to fetch per page.
  @param success block called on a successful fetch.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
 - (void)syncHierarchicalCommentsForPost:(NSNumber *)postID
-                               fromSite:(NSNumber *)siteID
                                    page:(NSUInteger)page
                                  number:(NSUInteger)number
                                 success:(void (^)(NSArray *comments))success
                                 failure:(void (^)(NSError *error))failure;
 
 /**
- Update a comment with a commentID + siteID
+ Update a comment with a commentID
  */
 - (void)updateCommentWithID:(NSNumber *)commentID
-                     siteID:(NSNumber *)siteID
                     content:(NSString *)content
                     success:(void (^)())success
                     failure:(void (^)(NSError *error))failure;
 
 /**
- Adds a reply to a post with postID + siteID
+ Adds a reply to a post with postID
  */
 - (void)replyToPostWithID:(NSNumber *)postID
-                   siteID:(NSNumber *)siteID
                   content:(NSString *)content
                   success:(void (^)(RemoteComment *comment))success
                   failure:(void (^)(NSError *error))failure;
 
 /**
- Adds a reply to a comment with commentID + siteID
+ Adds a reply to a comment with commentID
  */
 - (void)replyToCommentWithID:(NSNumber *)commentID
-                      siteID:(NSNumber *)siteID
                      content:(NSString *)content
                      success:(void (^)(RemoteComment *comment))success
                      failure:(void (^)(NSError *error))failure;
 
 /**
- Moderate a comment with a commentID + siteID
+ Moderate a comment with a commentID
  */
 - (void)moderateCommentWithID:(NSNumber *)commentID
-                       siteID:(NSNumber *)siteID
                        status:(NSString *)status
                       success:(void (^)())success
                       failure:(void (^)(NSError *error))failure;
 
 /**
- Trashes a comment with a commentID + siteID
+ Trashes a comment with a commentID
  */
 - (void)trashCommentWithID:(NSNumber *)commentID
-                    siteID:(NSNumber *)siteID
                    success:(void (^)())success
                    failure:(void (^)(NSError *error))failure;
 
 /**
- Like a comment with a commentID + siteID
+ Like a comment with a commentID
  */
 - (void)likeCommentWithID:(NSNumber *)commentID
-                   siteID:(NSNumber *)siteID
                   success:(void (^)())success
                   failure:(void (^)(NSError *error))failure;
 
 
 /**
- Unlike a comment with a commentID + siteID
+ Unlike a comment with a commentID
  */
 - (void)unlikeCommentWithID:(NSNumber *)commentID
-                     siteID:(NSNumber *)siteID
                     success:(void (^)())success
                     failure:(void (^)(NSError *error))failure;
 

--- a/WordPress/Classes/Networking/CommentServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteREST.m
@@ -12,19 +12,17 @@ static const NSInteger NumberOfCommentsToSync = 100;
 
 #pragma mark - Blog-centric methods
 
-- (void)getCommentsForBlogID:(NSNumber *)blogID
-                     success:(void (^)(NSArray *))success
-                     failure:(void (^)(NSError *))failure
+- (void)getCommentsWithSuccess:(void (^)(NSArray *))success
+                       failure:(void (^)(NSError *))failure
 {
-    [self getCommentsForBlogID:blogID options:nil success:success failure:failure];
+    [self getCommentsWithOptions:nil success:success failure:failure];
 }
 
-- (void)getCommentsForBlogID:(NSNumber *)blogID
-                     options:(NSDictionary *)options
-                     success:(void (^)(NSArray *posts))success
-                     failure:(void (^)(NSError *error))failure
+- (void)getCommentsWithOptions:(NSDictionary *)options
+                       success:(void (^)(NSArray *posts))success
+                       failure:(void (^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/comments", blogID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -54,15 +52,14 @@ static const NSInteger NumberOfCommentsToSync = 100;
 
 
 - (void)createComment:(RemoteComment *)comment
-            forBlogID:(NSNumber *)blogID
               success:(void (^)(RemoteComment *comment))success
               failure:(void (^)(NSError *))failure
 {
     NSString *path;
     if (comment.parentID) {
-        path = [NSString stringWithFormat:@"sites/%@/comments/%@/replies/new", blogID, comment.parentID];
+        path = [NSString stringWithFormat:@"sites/%@/comments/%@/replies/new", self.siteID, comment.parentID];
     } else {
-        path = [NSString stringWithFormat:@"sites/%@/posts/%@/replies/new", blogID, comment.postID];
+        path = [NSString stringWithFormat:@"sites/%@/posts/%@/replies/new", self.siteID, comment.postID];
     }
     
     NSString *requestUrl = [self pathForEndpoint:path
@@ -88,11 +85,10 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)updateComment:(RemoteComment *)comment
-            forBlogID:(NSNumber *)blogID
               success:(void (^)(RemoteComment *comment))success
               failure:(void (^)(NSError *))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", blogID, comment.commentID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", self.siteID, comment.commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -116,11 +112,10 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)moderateComment:(RemoteComment *)comment
-              forBlogID:(NSNumber *)blogID
                 success:(void (^)(RemoteComment *))success
                 failure:(void (^)(NSError *))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", blogID, comment.commentID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", self.siteID, comment.commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -144,11 +139,10 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)trashComment:(RemoteComment *)comment
-           forBlogID:(NSNumber *)blogID
              success:(void (^)())success
              failure:(void (^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/delete", blogID, comment.commentID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/delete", self.siteID, comment.commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -169,13 +163,12 @@ static const NSInteger NumberOfCommentsToSync = 100;
 #pragma mark Post-centric methods
 
 - (void)syncHierarchicalCommentsForPost:(NSNumber *)postID
-                               fromSite:(NSNumber *)siteID
                                    page:(NSUInteger)page
                                  number:(NSUInteger)number
                                 success:(void (^)(NSArray *comments))success
                                 failure:(void (^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/replies?order=ASC&hierarchical=1&page=%d&number=%d", siteID, postID, page, number];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/replies?order=ASC&hierarchical=1&page=%d&number=%d", self.siteID, postID, page, number];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
 
@@ -196,12 +189,11 @@ static const NSInteger NumberOfCommentsToSync = 100;
 #pragma mark - Public Methods
 
 - (void)updateCommentWithID:(NSNumber *)commentID
-                     siteID:(NSNumber *)siteID
                     content:(NSString *)content
                     success:(void (^)())success
                     failure:(void (^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", siteID, commentID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -223,12 +215,11 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)replyToPostWithID:(NSNumber *)postID
-                   siteID:(NSNumber *)siteID
                   content:(NSString *)content
                   success:(void (^)(RemoteComment *comment))success
                   failure:(void (^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/replies/new", siteID, postID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/replies/new", self.siteID, postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -250,12 +241,11 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)replyToCommentWithID:(NSNumber *)commentID
-                      siteID:(NSNumber *)siteID
                      content:(NSString *)content
                      success:(void (^)(RemoteComment *comment))success
                      failure:(void (^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/replies/new", siteID, commentID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/replies/new", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -279,12 +269,11 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)moderateCommentWithID:(NSNumber *)commentID
-                       siteID:(NSNumber *)siteID
                        status:(NSString *)status
                       success:(void (^)())success
                       failure:(void (^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", siteID, commentID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -307,11 +296,10 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)trashCommentWithID:(NSNumber *)commentID
-                    siteID:(NSNumber *)siteID
                    success:(void (^)())success
                    failure:(void (^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/delete", siteID, commentID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/delete", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -329,11 +317,10 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)likeCommentWithID:(NSNumber *)commentID
-                   siteID:(NSNumber *)siteID
                   success:(void (^)())success
                   failure:(void (^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes/new", siteID, commentID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes/new", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -351,11 +338,10 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)unlikeCommentWithID:(NSNumber *)commentID
-                     siteID:(NSNumber *)siteID
                     success:(void (^)())success
                     failure:(void (^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes/mine/delete", siteID, commentID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes/mine/delete", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     

--- a/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
@@ -6,17 +6,15 @@ static const NSInteger NumberOfCommentsToSync = 100;
 
 @implementation CommentServiceRemoteXMLRPC
 
-- (void)getCommentsForBlogID:(NSNumber *)blogID
-                     success:(void (^)(NSArray *))success
-                     failure:(void (^)(NSError *))failure
+- (void)getCommentsWithSuccess:(void (^)(NSArray *))success
+                       failure:(void (^)(NSError *))failure
 {
-    [self getCommentsForBlogID:blogID options:nil success:success failure:failure];
+    [self getCommentsWithOptions:nil success:success failure:failure];
 }
 
-- (void)getCommentsForBlogID:(NSNumber *)blogID
-                     options:(NSDictionary *)options
-                     success:(void (^)(NSArray *))success
-                     failure:(void (^)(NSError *))failure
+- (void)getCommentsWithOptions:(NSDictionary *)options
+                       success:(void (^)(NSArray *))success
+                       failure:(void (^)(NSError *))failure
 {
     NSMutableDictionary *extraParameters = [NSMutableDictionary dictionaryWithDictionary:@{
                                       @"number": @(NumberOfCommentsToSync)
@@ -40,7 +38,6 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)getCommentWithID:(NSNumber *)commentID
-               forBlogID:(NSNumber *)blogID
                  success:(void (^)(RemoteComment *comment))success
                  failure:(void (^)(NSError *))failure
 {
@@ -58,7 +55,6 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)createComment:(RemoteComment *)comment
-            forBlogID:(NSNumber *)blogID
               success:(void (^)(RemoteComment *comment))success
               failure:(void (^)(NSError *error))failure
 {
@@ -78,7 +74,6 @@ static const NSInteger NumberOfCommentsToSync = 100;
                      NSNumber *commentID = responseObject;
                      // TODO: validate response
                      [self getCommentWithID:commentID
-                                  forBlogID:blogID
                                     success:success
                                     failure:failure];
                  } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
@@ -89,7 +84,6 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)updateComment:(RemoteComment *)comment
-            forBlogID:(NSNumber *)blogID
               success:(void (^)(RemoteComment *comment))success
               failure:(void (^)(NSError *error))failure
 {
@@ -105,7 +99,6 @@ static const NSInteger NumberOfCommentsToSync = 100;
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
                      // TODO: validate response
                      [self getCommentWithID:commentID
-                                  forBlogID:blogID
                                     success:success
                                     failure:failure];
                  } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
@@ -116,7 +109,6 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)moderateComment:(RemoteComment *)comment
-              forBlogID:(NSNumber *)blogID
                 success:(void (^)(RemoteComment *))success
                 failure:(void (^)(NSError *))failure
 {
@@ -132,7 +124,6 @@ static const NSInteger NumberOfCommentsToSync = 100;
                      NSNumber *commentID = responseObject;
                      // TODO: validate response
                      [self getCommentWithID:commentID
-                                  forBlogID:blogID
                                     success:success
                                     failure:failure];
                  } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
@@ -143,7 +134,6 @@ static const NSInteger NumberOfCommentsToSync = 100;
 }
 
 - (void)trashComment:(RemoteComment *)comment
-           forBlogID:(NSNumber *)blogID
              success:(void (^)())success
              failure:(void (^)(NSError *))failure
 {

--- a/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
@@ -24,7 +24,7 @@ static const NSInteger NumberOfCommentsToSync = 100;
     if (options) {
         [extraParameters addEntriesFromDictionary:options];
     }
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:extraParameters];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
     [self.api callMethod:@"wp.getComments"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -44,7 +44,7 @@ static const NSInteger NumberOfCommentsToSync = 100;
                  success:(void (^)(RemoteComment *comment))success
                  failure:(void (^)(NSError *))failure
 {
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:commentID];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:commentID];
     [self.api callMethod:@"wp.getComment"
               parameters:parameters success:^(AFHTTPRequestOperation *operation, id responseObject) {
                   if (success) {
@@ -71,7 +71,7 @@ static const NSInteger NumberOfCommentsToSync = 100;
                                  comment.postID,
                                  commentDictionary,
                                  ];
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:extraParameters];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
     [self.api callMethod:@"wp.newComment"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -99,7 +99,7 @@ static const NSInteger NumberOfCommentsToSync = 100;
                                  comment.commentID,
                                  @{@"content": comment.content},
                                  ];
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:extraParameters];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
     [self.api callMethod:@"wp.editComment"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -125,7 +125,7 @@ static const NSInteger NumberOfCommentsToSync = 100;
                                  comment.commentID,
                                  @{@"status": comment.status},
                                  ];
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:extraParameters];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
     [self.api callMethod:@"wp.editComment"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -148,7 +148,7 @@ static const NSInteger NumberOfCommentsToSync = 100;
              failure:(void (^)(NSError *))failure
 {
     NSParameterAssert(comment.commentID != nil);
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:comment.commentID];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:comment.commentID];
     [self.api callMethod:@"wp.deleteComment"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {

--- a/WordPress/Classes/Networking/MediaServiceRemote.h
+++ b/WordPress/Classes/Networking/MediaServiceRemote.h
@@ -6,12 +6,10 @@
 
 
 - (void)getMediaWithID:(NSNumber *)mediaID
-             forBlogID:(NSNumber *)blogID
                success:(void (^)(RemoteMedia *remoteMedia))success
                failure:(void (^)(NSError *error))failure;
 
 - (void)createMedia:(RemoteMedia *)media
-          forBlogID:(NSNumber *)blogID
            progress:(NSProgress **)progress
             success:(void (^)(RemoteMedia *remoteMedia))success
             failure:(void (^)(NSError *error))failure;
@@ -19,23 +17,19 @@
 /**
  *  Get Media items from blog using the options parameter.
  *
- *  @param blog    from to where fetch the media library.
  *  @param success a block to be executed when the request finishes with success.
  *  @param failure a block to be execute when the request fails.
  */
-- (void)getMediaLibraryForBlogID:(NSNumber *)blogID
-                         success:(void (^)(NSArray *))success
-                         failure:(void (^)(NSError *))failure;
+- (void)getMediaLibraryWithSuccess:(void (^)(NSArray *))success
+                           failure:(void (^)(NSError *))failure;
 
 /**
  *  Get the number of media items available in the blog
  *
- *  @param blog    from to where fetch the media library.
  *  @param success a block to be executed when the request finishes with success.
  *  @param failure a block to be execute when the request fails.
  */
-- (void)getMediaLibraryCountForBlogID:(NSNumber *)blogID
-                              success:(void (^)(NSInteger))success
-                              failure:(void (^)(NSError *))failure;
+- (void)getMediaLibraryCountWithSuccess:(void (^)(NSInteger))success
+                                failure:(void (^)(NSError *))failure;
 
 @end

--- a/WordPress/Classes/Networking/MediaServiceRemoteREST.h
+++ b/WordPress/Classes/Networking/MediaServiceRemoteREST.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "MediaServiceRemote.h"
-#import "ServiceRemoteREST.h"
+#import "SiteServiceRemoteREST.h"
 
-@interface MediaServiceRemoteREST : ServiceRemoteREST <MediaServiceRemote>
+@interface MediaServiceRemoteREST : SiteServiceRemoteREST <MediaServiceRemote>
 @end

--- a/WordPress/Classes/Networking/MediaServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteREST.m
@@ -9,11 +9,10 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 @implementation MediaServiceRemoteREST
 
 - (void)getMediaWithID:(NSNumber *)mediaID
-             forBlogID:(NSNumber *)blogID
                success:(void (^)(RemoteMedia *remoteMedia))success
                failure:(void (^)(NSError *error))failure
 {
-    NSString *apiPath = [NSString stringWithFormat:@"sites/%@/media/%@", blogID, mediaID];
+    NSString *apiPath = [NSString stringWithFormat:@"sites/%@/media/%@", self.siteID, mediaID];
     NSString *requestUrl = [self pathForEndpoint:apiPath
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -31,12 +30,11 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     }];
 }
 
-- (void)getMediaLibraryForBlogID:(NSNumber *)blogID
-                         success:(void (^)(NSArray *))success
-                         failure:(void (^)(NSError *))failure
+- (void)getMediaLibraryWithSuccess:(void (^)(NSArray *))success
+                           failure:(void (^)(NSError *))failure
 {
     NSMutableArray *media = [NSMutableArray array];
-    NSString *path = [NSString stringWithFormat:@"sites/%@/media", blogID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/media", self.siteID];
     [self getMediaLibraryPage:nil
                         media:media
                          path:path
@@ -86,11 +84,10 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
           }];
 }
 
-- (void)getMediaLibraryCountForBlogID:(NSNumber *)blogID
-                              success:(void (^)(NSInteger))success
-                              failure:(void (^)(NSError *))failure
+- (void)getMediaLibraryCountWithSuccess:(void (^)(NSInteger))success
+                                failure:(void (^)(NSError *))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/media", blogID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/media", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -113,7 +110,6 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 }
 
 - (void)createMedia:(RemoteMedia *)media
-          forBlogID:(NSNumber *)blogID
            progress:(NSProgress **)progress
             success:(void (^)(RemoteMedia *remoteMedia))success
             failure:(void (^)(NSError *error))failure
@@ -123,7 +119,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     NSString *type = media.mimeType;
     NSString *filename = media.file;
 
-    NSString *apiPath = [NSString stringWithFormat:@"sites/%@/media/new", blogID];
+    NSString *apiPath = [NSString stringWithFormat:@"sites/%@/media/new", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:apiPath
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     

--- a/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
@@ -9,7 +9,7 @@
                success:(void (^)(RemoteMedia *remoteMedia))success
                failure:(void (^)(NSError *error))failure
 {
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:mediaID];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:mediaID];
     [self.api callMethod:@"wp.getMediaItem"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -29,7 +29,7 @@
                          success:(void (^)(NSArray *))success
                          failure:(void (^)(NSError *))failure
 {
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:nil];
+    NSArray *parameters = [self defaultXMLRPCArguments];
     [self.api callMethod:@"wp.getMediaLibrary"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -49,7 +49,7 @@
                             success:(void (^)(NSInteger))success
                             failure:(void (^)(NSError *))failure
 {
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:nil];
+    NSArray *parameters = [self defaultXMLRPCArguments];
     [self.api callMethod:@"wp.getMediaLibrary"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -125,7 +125,7 @@
                            @"type": type,
                            @"bits": [NSInputStream inputStreamWithFileAtPath:path],
                            };
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:data];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:data];
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
     NSString *directory = [paths objectAtIndex:0];
     NSString *guid = [[NSProcessInfo processInfo] globallyUniqueString];

--- a/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
@@ -5,7 +5,6 @@
 @implementation MediaServiceRemoteXMLRPC
 
 - (void)getMediaWithID:(NSNumber *)mediaID
-             forBlogID:(NSNumber *)blogID
                success:(void (^)(RemoteMedia *remoteMedia))success
                failure:(void (^)(NSError *error))failure
 {
@@ -25,9 +24,8 @@
                  }];
 }
 
-- (void)getMediaLibraryForBlogID:(NSNumber *)blogID
-                         success:(void (^)(NSArray *))success
-                         failure:(void (^)(NSError *))failure
+- (void)getMediaLibraryWithSuccess:(void (^)(NSArray *))success
+                           failure:(void (^)(NSError *))failure
 {
     NSArray *parameters = [self defaultXMLRPCArguments];
     [self.api callMethod:@"wp.getMediaLibrary"
@@ -45,9 +43,8 @@
                  }];
 }
 
-- (void)getMediaLibraryCountForBlogID:(NSNumber *)blogID
-                            success:(void (^)(NSInteger))success
-                            failure:(void (^)(NSError *))failure
+- (void)getMediaLibraryCountWithSuccess:(void (^)(NSInteger))success
+                                failure:(void (^)(NSError *))failure
 {
     NSArray *parameters = [self defaultXMLRPCArguments];
     [self.api callMethod:@"wp.getMediaLibrary"
@@ -108,7 +105,6 @@
 }
 
 - (void)createMedia:(RemoteMedia *)media
-          forBlogID:(NSNumber *)blogID
            progress:(NSProgress **)progress
             success:(void (^)(RemoteMedia *remoteMedia))success
             failure:(void (^)(NSError *error))failure

--- a/WordPress/Classes/Networking/PostCategoryServiceRemote.h
+++ b/WordPress/Classes/Networking/PostCategoryServiceRemote.h
@@ -4,12 +4,10 @@
 
 @protocol PostCategoryServiceRemote <NSObject>
 
-- (void)getCategoriesForBlogID:(NSNumber *)blogID
-                       success:(void (^)(NSArray *categories))success
+- (void)getCategoriesWithSuccess:(void (^)(NSArray *categories))success
                        failure:(void (^)(NSError *error))failure;
 
 - (void)createCategory:(RemotePostCategory *)category
-             forBlogID:(NSNumber *)blogID
                success:(void (^)(RemotePostCategory *category))success
                failure:(void (^)(NSError *error))failure;
 

--- a/WordPress/Classes/Networking/PostCategoryServiceRemoteREST.h
+++ b/WordPress/Classes/Networking/PostCategoryServiceRemoteREST.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "PostCategoryServiceRemote.h"
-#import "ServiceRemoteREST.h"
+#import "SiteServiceRemoteREST.h"
 
-@interface PostCategoryServiceRemoteREST : ServiceRemoteREST <PostCategoryServiceRemote>
+@interface PostCategoryServiceRemoteREST : SiteServiceRemoteREST <PostCategoryServiceRemote>
 
 @end

--- a/WordPress/Classes/Networking/PostCategoryServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostCategoryServiceRemoteREST.m
@@ -4,11 +4,10 @@
 
 @implementation PostCategoryServiceRemoteREST
 
-- (void)getCategoriesForBlogID:(NSNumber *)blogID
-                       success:(void (^)(NSArray *))success
-                       failure:(void (^)(NSError *))failure
+- (void)getCategoriesWithSuccess:(void (^)(NSArray *))success
+                         failure:(void (^)(NSError *))failure
 {
-    NSString *path = [NSString stringWithFormat:@"sites/%@/categories?context=edit", blogID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/categories?context=edit", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -26,12 +25,11 @@
 }
 
 - (void)createCategory:(RemotePostCategory *)category
-             forBlogID:(NSNumber *)blogID
                success:(void (^)(RemotePostCategory *))success
                failure:(void (^)(NSError *))failure
 {
     NSParameterAssert(category.name.length > 0);
-    NSString *path = [NSString stringWithFormat:@"sites/%@/categories/new?context=edit", blogID];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/categories/new?context=edit", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     

--- a/WordPress/Classes/Networking/PostCategoryServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostCategoryServiceRemoteXMLRPC.m
@@ -9,7 +9,7 @@
                        success:(void (^)(NSArray *categories))success
                        failure:(void (^)(NSError *error))failure
 {
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:@"category"];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:@"category"];
     [self.api callMethod:@"wp.getTerms"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -34,7 +34,7 @@
                                       @"parent_id" : category.parentID ?: @0,
                                       @"taxonomy" : @"category",
                                       };
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:extraParameters];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
 
 
     [self.api callMethod:@"wp.newTerm"

--- a/WordPress/Classes/Networking/PostCategoryServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostCategoryServiceRemoteXMLRPC.m
@@ -5,9 +5,8 @@
 
 @implementation PostCategoryServiceRemoteXMLRPC
 
-- (void)getCategoriesForBlogID:(NSNumber *)blogID
-                       success:(void (^)(NSArray *categories))success
-                       failure:(void (^)(NSError *error))failure
+- (void)getCategoriesWithSuccess:(void (^)(NSArray *categories))success
+                         failure:(void (^)(NSError *error))failure
 {
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:@"category"];
     [self.api callMethod:@"wp.getTerms"
@@ -25,7 +24,6 @@
 }
 
 - (void)createCategory:(RemotePostCategory *)category
-             forBlogID:(NSNumber *)blogID
                success:(void (^)(RemotePostCategory *))success
                failure:(void (^)(NSError *))failure
 {

--- a/WordPress/Classes/Networking/PostServiceRemote.h
+++ b/WordPress/Classes/Networking/PostServiceRemote.h
@@ -8,12 +8,10 @@
  *  @brief      Requests the post with the specified ID.
  *
  *  @param      postID      The ID of the post to get.  Cannot be nil.
- *  @param      blogID      The blogID to get the post from.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)getPostWithID:(NSNumber *)postID
-            forBlogID:(NSNumber *)blogID
               success:(void (^)(RemotePost *post))success
               failure:(void (^)(NSError *))failure;
 
@@ -21,12 +19,10 @@
  *  @brief      Requests the posts of the specified type.
  *
  *  @param      postType    The type of the posts to get.  Cannot be nil.
- *  @param      blogID      The blog to get the posts from.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)getPostsOfType:(NSString *)postType
-               forBlogID:(NSNumber *)blogID
                success:(void (^)(NSArray *posts))success
                failure:(void (^)(NSError *error))failure;
 
@@ -34,13 +30,11 @@
  *  @brief      Requests the posts of the specified type using the specified options.
  *
  *  @param      postType    The type of the posts to get.  Cannot be nil.
- *  @param      blogID      The blog to get the posts from.  Cannot be nil.
  *  @param      options     The options to use for the request.  Can be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)getPostsOfType:(NSString *)postType
-             forBlogID:(NSNumber *)blogID
                options:(NSDictionary *)options
                success:(void (^)(NSArray *posts))success
                failure:(void (^)(NSError *error))failure;
@@ -49,12 +43,10 @@
  *  @brief      Creates a post remotely for the specified blog.
  *
  *  @param      post        The post to create remotely.  Cannot be nil.
- *  @param      blogID      The blog to create the post in.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)createPost:(RemotePost *)post
-         forBlogID:(NSNumber *)blogID
            success:(void (^)(RemotePost *post))success
            failure:(void (^)(NSError *error))failure;
 
@@ -62,12 +54,10 @@
  *  @brief      Updates a blog's post.
  *
  *  @param      post        The post to update.  Cannot be nil.
- *  @param      blogID      The blog that owns the post to update.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)updatePost:(RemotePost *)post
-         forBlogID:(NSNumber *)blogID
            success:(void (^)(RemotePost *post))success
            failure:(void (^)(NSError *error))failure;
 
@@ -75,12 +65,10 @@
  *  @brief      Deletes a post.
  *
  *  @param      post        The post to delete.  Cannot be nil.
- *  @param      blogID      The blog that owns the post to delete.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)deletePost:(RemotePost *)post
-         forBlogID:(NSNumber *)blogID
            success:(void (^)())success
            failure:(void (^)(NSError *error))failure;
 
@@ -88,12 +76,10 @@
  *  @brief      Trashes a post.
  *
  *  @param      post        The post to trash.  Cannot be nil.
- *  @param      blogID      The blog that owns the post to trash.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)trashPost:(RemotePost *)post
-        forBlogID:(NSNumber *)blogID
           success:(void (^)(RemotePost *))success
           failure:(void (^)(NSError *))failure;
 
@@ -101,12 +87,10 @@
  *  @brief      Restores a post.
  *
  *  @param      post        The post to restore.  Cannot be nil.
- *  @param      blogID      The blog that owns the post to restore.  Cannot be nil.
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)restorePost:(RemotePost *)post
-          forBlogID:(NSNumber *)blogID
             success:(void (^)(RemotePost *))success
             failure:(void (^)(NSError *error))failure;
 

--- a/WordPress/Classes/Networking/PostServiceRemoteREST.h
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "PostServiceRemote.h"
-#import "ServiceRemoteREST.h"
+#import "SiteServiceRemoteREST.h"
 
-@interface PostServiceRemoteREST : ServiceRemoteREST <PostServiceRemote>
+@interface PostServiceRemoteREST : SiteServiceRemoteREST <PostServiceRemote>
 
 @end

--- a/WordPress/Classes/Networking/PostServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.m
@@ -11,14 +11,12 @@ NSString * const PostRemoteStatusScheduled = @"future";
 @implementation PostServiceRemoteREST
 
 - (void)getPostWithID:(NSNumber *)postID
-            forBlogID:(NSNumber *)blogID
               success:(void (^)(RemotePost *post))success
               failure:(void (^)(NSError *))failure
 {
     NSParameterAssert(postID);
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
-    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@", blogID, postID];
+
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@", self.siteID, postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -38,23 +36,20 @@ NSString * const PostRemoteStatusScheduled = @"future";
 }
 
 - (void)getPostsOfType:(NSString *)postType
-             forBlogID:(NSNumber *)blogID
                success:(void (^)(NSArray *))success
                failure:(void (^)(NSError *))failure
 {
-    [self getPostsOfType:postType forBlogID:blogID options:nil success:success failure:failure];
+    [self getPostsOfType:postType options:nil success:success failure:failure];
 }
 
 - (void)getPostsOfType:(NSString *)postType
-             forBlogID:(NSNumber *)blogID
                options:(NSDictionary *)options
                success:(void (^)(NSArray *))success
                failure:(void (^)(NSError *))failure
 {
     NSParameterAssert([postType isKindOfClass:[NSString class]]);
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
-    NSString *path = [NSString stringWithFormat:@"sites/%@/posts", blogID];
+
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -83,14 +78,12 @@ NSString * const PostRemoteStatusScheduled = @"future";
 }
 
 - (void)createPost:(RemotePost *)post
-         forBlogID:(NSNumber *)blogID
            success:(void (^)(RemotePost *))success
            failure:(void (^)(NSError *))failure
 {
     NSParameterAssert([post isKindOfClass:[RemotePost class]]);
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
-    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/new?context=edit", blogID];
+
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/new?context=edit", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -111,14 +104,12 @@ NSString * const PostRemoteStatusScheduled = @"future";
 }
 
 - (void)updatePost:(RemotePost *)post
-         forBlogID:(NSNumber *)blogID
            success:(void (^)(RemotePost *))success
            failure:(void (^)(NSError *))failure
 {
     NSParameterAssert([post isKindOfClass:[RemotePost class]]);
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
-    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@?context=edit", blogID, post.postID];
+
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@?context=edit", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -139,14 +130,12 @@ NSString * const PostRemoteStatusScheduled = @"future";
 }
 
 - (void)deletePost:(RemotePost *)post
-         forBlogID:(NSNumber *)blogID
            success:(void (^)())success
            failure:(void (^)(NSError *))failure
 {
     NSParameterAssert([post isKindOfClass:[RemotePost class]]);
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
-    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", blogID, post.postID];
+
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -164,14 +153,12 @@ NSString * const PostRemoteStatusScheduled = @"future";
 }
 
 - (void)trashPost:(RemotePost *)post
-        forBlogID:(NSNumber *)blogID
           success:(void (^)(RemotePost *))success
           failure:(void (^)(NSError *))failure
 {
     NSParameterAssert([post isKindOfClass:[RemotePost class]]);
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
-    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", blogID, post.postID];
+
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
@@ -190,14 +177,12 @@ NSString * const PostRemoteStatusScheduled = @"future";
 }
 
 - (void)restorePost:(RemotePost *)post
-          forBlogID:(NSNumber *)blogID
             success:(void (^)(RemotePost *))success
             failure:(void (^)(NSError *))failure
 {
     NSParameterAssert([post isKindOfClass:[RemotePost class]]);
-    NSParameterAssert([blogID isKindOfClass:[NSNumber class]]);
-    
-    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/restore", blogID, post.postID];
+
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/restore", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     

--- a/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
@@ -16,7 +16,7 @@ const NSInteger HTTP404ErrorCode = 404;
               success:(void (^)(RemotePost *post))success
               failure:(void (^)(NSError *))failure
 {
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:postID];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:postID];
     [self.api callMethod:@"wp.getPost"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -54,7 +54,7 @@ const NSInteger HTTP404ErrorCode = 404;
         [mutableParameters addEntriesFromDictionary:options];
         extraParameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
     }
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:extraParameters];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
     [self.api callMethod:@"wp.getPosts"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -75,7 +75,7 @@ const NSInteger HTTP404ErrorCode = 404;
            failure:(void (^)(NSError *))failure
 {
     NSDictionary *extraParameters = [self parametersWithRemotePost:post];
-    NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:extraParameters];
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
     [self.api callMethod:@"metaWeblog.newPost"
               parameters:parameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -120,7 +120,7 @@ const NSInteger HTTP404ErrorCode = 404;
     }
 
     NSDictionary *extraParameters = [self parametersWithRemotePost:post];
-    NSMutableArray *parameters = [NSMutableArray arrayWithArray:[self getXMLRPCArgsForBlogWithID:blogID extra:extraParameters]];
+    NSMutableArray *parameters = [NSMutableArray arrayWithArray:[self XMLRPCArgumentsWithExtra:extraParameters]];
     [parameters replaceObjectAtIndex:0 withObject:post.postID];
     [self.api callMethod:@"metaWeblog.editPost"
               parameters:parameters
@@ -144,7 +144,7 @@ const NSInteger HTTP404ErrorCode = 404;
     NSParameterAssert([post.postID longLongValue] > 0);
     NSNumber *postID = post.postID;
     if ([postID longLongValue] > 0) {
-        NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:postID];
+        NSArray *parameters = [self XMLRPCArgumentsWithExtra:postID];
         [self.api callMethod:@"wp.deletePost"
                   parameters:parameters
                      success:^(AFHTTPRequestOperation *operation, id responseObject) {
@@ -163,7 +163,7 @@ const NSInteger HTTP404ErrorCode = 404;
     NSParameterAssert([post.postID longLongValue] > 0);
     NSNumber *postID = post.postID;
     if ([postID longLongValue] > 0) {
-        NSArray *parameters = [self getXMLRPCArgsForBlogWithID:blogID extra:postID];
+        NSArray *parameters = [self XMLRPCArgumentsWithExtra:postID];
 
         WPXMLRPCRequest *deletePostRequest = [self.api XMLRPCRequestWithMethod:@"wp.deletePost" parameters:parameters];
         WPXMLRPCRequestOperation *delOperation = [self.api XMLRPCRequestOperationWithRequest:deletePostRequest success:nil failure:nil];

--- a/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
@@ -12,7 +12,6 @@ const NSInteger HTTP404ErrorCode = 404;
 @implementation PostServiceRemoteXMLRPC
 
 - (void)getPostWithID:(NSNumber *)postID
-            forBlogID:(NSNumber *)blogID
               success:(void (^)(RemotePost *post))success
               failure:(void (^)(NSError *))failure
 {
@@ -31,14 +30,12 @@ const NSInteger HTTP404ErrorCode = 404;
 }
 
 - (void)getPostsOfType:(NSString *)postType
-               forBlogID:(NSNumber *)blogID
                success:(void (^)(NSArray *))success
                failure:(void (^)(NSError *))failure {
-    [self getPostsOfType:postType forBlogID:blogID options:nil success:success failure:failure];
+    [self getPostsOfType:postType options:nil success:success failure:failure];
 }
 
 - (void)getPostsOfType:(NSString *)postType
-             forBlogID:(NSNumber *)blogID
                options:(NSDictionary *)options
                success:(void (^)(NSArray *posts))success
                failure:(void (^)(NSError *error))failure {
@@ -70,7 +67,6 @@ const NSInteger HTTP404ErrorCode = 404;
 }
 
 - (void)createPost:(RemotePost *)post
-         forBlogID:(NSNumber *)blogID
            success:(void (^)(RemotePost *))success
            failure:(void (^)(NSError *))failure
 {
@@ -102,7 +98,6 @@ const NSInteger HTTP404ErrorCode = 404;
 }
 
 - (void)updatePost:(RemotePost *)post
-         forBlogID:(NSNumber *)blogID
            success:(void (^)(RemotePost *))success
            failure:(void (^)(NSError *))failure
 {
@@ -137,7 +132,6 @@ const NSInteger HTTP404ErrorCode = 404;
 }
 
 - (void)deletePost:(RemotePost *)post
-         forBlogID:(NSNumber *)blogID
            success:(void (^)())success
            failure:(void (^)(NSError *))failure
 {
@@ -156,7 +150,6 @@ const NSInteger HTTP404ErrorCode = 404;
 }
 
 - (void)trashPost:(RemotePost *)post
-        forBlogID:(NSNumber *)blogID
           success:(void (^)(RemotePost *))success
           failure:(void (^)(NSError *))failure
 {
@@ -196,11 +189,10 @@ const NSInteger HTTP404ErrorCode = 404;
 }
 
 - (void)restorePost:(RemotePost *)post
-          forBlogID:(NSNumber *)blogID
            success:(void (^)(RemotePost *))success
            failure:(void (^)(NSError *error))failure
 {
-    [self updatePost:post forBlogID:blogID success:success failure:failure];
+    [self updatePost:post success:success failure:failure];
 }
 
 #pragma mark - Private methods

--- a/WordPress/Classes/Networking/ServiceRemoteXMLRPC.h
+++ b/WordPress/Classes/Networking/ServiceRemoteXMLRPC.h
@@ -8,6 +8,7 @@
 
 @property (nonatomic, readonly) WPXMLRPCClient *api;
 
-- (NSArray *)getXMLRPCArgsForBlogWithID:(NSNumber *)blogID extra:(id)extra;
+- (NSArray *)defaultXMLRPCArguments;
+- (NSArray *)XMLRPCArgumentsWithExtra:(id)extra;
 
 @end

--- a/WordPress/Classes/Networking/ServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/ServiceRemoteXMLRPC.m
@@ -22,16 +22,12 @@
     return self;
 }
 
-- (NSArray *)getXMLRPCArgsForBlogWithID:(NSNumber *)blogID extra:(id)extra
-{
-    NSMutableArray *result = [NSMutableArray array];
-    NSString *password = self.password ?: [NSString string];
-    NSString *username = self.username ?: [NSString string];
-    
-    [result addObject:blogID];
-    [result addObject:username];
-    [result addObject:password];
-    
+- (NSArray *)defaultXMLRPCArguments {
+    return @[@0, self.username, self.password];
+}
+
+- (NSArray *)XMLRPCArgumentsWithExtra:(id)extra {
+    NSMutableArray *result = [[self defaultXMLRPCArguments] mutableCopy];
     if ([extra isKindOfClass:[NSArray class]]) {
         [result addObjectsFromArray:extra];
     } else if (extra != nil) {

--- a/WordPress/Classes/Networking/ServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/ServiceRemoteXMLRPC.m
@@ -22,6 +22,16 @@
     return self;
 }
 
+/**
+ Common XML-RPC arguments to most calls
+
+ Most XML-RPC calls will take blog ID, username, and password as their first arguments.
+ Blog ID is unused since the blog is inferred from the XML-RPC endpoint. We send a value of 0
+ because the documentation expects an int value, and we have to send something.
+
+ See https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-xmlrpc-server.php
+ for method documentation.
+ */
 - (NSArray *)defaultXMLRPCArguments {
     return @[@0, self.username, self.password];
 }

--- a/WordPress/Classes/Networking/SiteServiceRemoteREST.h
+++ b/WordPress/Classes/Networking/SiteServiceRemoteREST.h
@@ -1,0 +1,11 @@
+#import "ServiceRemoteREST.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SiteServiceRemoteREST : ServiceRemoteREST
+@property (nonatomic, readonly) NSNumber *siteID;
+- (instancetype)initWithApi:(WordPressComApi *)api __unavailable;
+- (instancetype)initWithApi:(WordPressComApi *)api siteID:(NSNumber *)siteID;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Networking/SiteServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/SiteServiceRemoteREST.m
@@ -1,0 +1,17 @@
+#import "SiteServiceRemoteREST.h"
+
+@interface SiteServiceRemoteREST ()
+@property (nonatomic, strong) NSNumber *siteID;
+@end
+
+@implementation SiteServiceRemoteREST
+
+- (instancetype)initWithApi:(WordPressComApi *)api siteID:(NSNumber *)siteID {
+    self = [super initWithApi:api];
+    if (self) {
+        _siteID = siteID;
+    }
+    return self;
+}
+
+@end

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -532,7 +532,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
         }
         
         blog.url = remoteBlog.url;
-        blog.blogID = remoteBlog.blogID;
+        blog.dotComID = remoteBlog.blogID;
         blog.isHostedAtWPcom = !remoteBlog.jetpack;
         blog.icon = remoteBlog.icon;
         blog.isAdmin = remoteBlog.isAdmin;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -188,7 +188,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
                 && !widgetIsConfigured
                 && defaultBlog != nil
                 && !defaultBlog.isDeleted) {
-                NSNumber *siteId = defaultBlog.blogID;
+                NSNumber *siteId = defaultBlog.dotComID;
                 NSString *blogName = defaultBlog.settings.name;
                 NSTimeZone *timeZone = [self timeZoneForBlog:defaultBlog];
                 NSString *oauth2Token = accountInContext.authToken;
@@ -216,10 +216,9 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
                    failure:(void (^)(NSError *error))failure
 {
     id<BlogServiceRemote> remote = [self remoteForBlog:blog];
-    [remote syncOptionsForBlogID:blog.blogID
-                       success:[self optionsHandlerWithBlogObjectID:blog.objectID
+    [remote syncOptionsWithSuccess:[self optionsHandlerWithBlogObjectID:blog.objectID
                                                   completionHandler:success]
-                       failure:failure];
+                           failure:failure];
 }
 
 - (void)syncSettingsForBlog:(Blog *)blog
@@ -236,7 +235,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
             return;
         }
         id<BlogServiceRemote> remote = [self remoteForBlog:blogInContext];
-        [remote syncSettingsForBlogID:blog.blogID success:^(RemoteBlogSettings *settings) {
+        [remote syncSettingsWithSuccess:^(RemoteBlogSettings *settings) {
             [self.managedObjectContext performBlock:^{
                 [self updateSettings:blogInContext.settings withRemoteSettings:settings];
                 [self.managedObjectContext save:nil];
@@ -258,7 +257,6 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
         Blog *blogInContext = (Blog *)[self.managedObjectContext objectWithID:blogID];
         id<BlogServiceRemote> remote = [self remoteForBlog:blogInContext];
         [remote updateBlogSettings:[self remoteSettingFromSettings:blogInContext.settings]
-                         forBlogID:blogInContext.blogID
                            success:^() {
                                [self.managedObjectContext performBlock:^{
                                    [self.managedObjectContext save:nil];
@@ -310,32 +308,29 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
                        failure:(void (^)(NSError *error))failure
 {
     id<BlogServiceRemote> remote = [self remoteForBlog:blog];
-    [remote syncPostFormatsForBlogID:blog.blogID
-                             success:[self postFormatsHandlerWithBlogObjectID:blog.objectID
+    [remote syncPostFormatsWithSuccess:[self postFormatsHandlerWithBlogObjectID:blog.objectID
                                                           completionHandler:success]
-                             failure:failure];
+                               failure:failure];
 }
 
 - (void)syncBlog:(Blog *)blog
 {
     NSManagedObjectID *blogObjectID = blog.objectID;
     id<BlogServiceRemote> remote = [self remoteForBlog:blog];
-    [remote syncOptionsForBlogID:blog.blogID success:[self optionsHandlerWithBlogObjectID:blogObjectID
+    [remote syncOptionsWithSuccess:[self optionsHandlerWithBlogObjectID:blogObjectID
                                                                completionHandler:nil]
-                       failure:^(NSError *error) { DDLogError(@"Failed syncing options for blog %@: %@", blog.url, error); }];
+                           failure:^(NSError *error) { DDLogError(@"Failed syncing options for blog %@: %@", blog.url, error); }];
 
-    [remote syncPostFormatsForBlogID:blog.blogID
-                           success:[self postFormatsHandlerWithBlogObjectID:blogObjectID
+    [remote syncPostFormatsWithSuccess:[self postFormatsHandlerWithBlogObjectID:blogObjectID
                                                           completionHandler:nil]
-                           failure:^(NSError *error) { DDLogError(@"Failed syncing post formats for blog %@: %@", blog.url, error); }];
+                               failure:^(NSError *error) { DDLogError(@"Failed syncing post formats for blog %@: %@", blog.url, error); }];
 
     PostCategoryService *categoryService = [[PostCategoryService alloc] initWithManagedObjectContext:self.managedObjectContext];
     [categoryService syncCategoriesForBlog:blog
                                    success:nil
                                    failure:^(NSError *error) { DDLogError(@"Failed syncing categories for blog %@: %@", blog.url, error); }];
 
-    [remote checkMultiAuthorForBlogID:blog.blogID
-                              success:^(BOOL isMultiAuthor) {
+    [remote checkMultiAuthorWithSuccess:^(BOOL isMultiAuthor) {
                                 [self updateMutliAuthor:isMultiAuthor forBlog:blogObjectID];
                               } failure:^(NSError *error) {
                                 DDLogError(@"Failed checking muti-author status for blog %@: %@", blog.url, error);
@@ -412,8 +407,8 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     NSArray *allBlogs = [self blogsWithPredicate:nil];
     
     for (Blog *blog in allBlogs) {
-        if (blog.blogID != nil) {
-            blogMap[blog.blogID] = blog;
+        if (blog.dotComID != nil) {
+            blogMap[blog.dotComID] = blog;
         }
     }
     
@@ -592,7 +587,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
 {
     id<BlogServiceRemote> remote;
     if (blog.restApi) {
-        remote = [[BlogServiceRemoteREST alloc] initWithApi:blog.restApi];
+        remote = [[BlogServiceRemoteREST alloc] initWithApi:blog.restApi siteID:blog.dotComID];
     } else {
         remote = [[BlogServiceRemoteXMLRPC alloc] initWithApi:blog.api username:blog.username password:blog.password];
     }

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -180,7 +180,6 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
     };
     
     [remote createMedia:remoteMedia
-              forBlogID:media.blog.blogID
                progress:progress
                 success:successBlock
                 failure:failureBlock];
@@ -193,7 +192,7 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
     id<MediaServiceRemote> remote = [self remoteForBlog:blog];
     NSManagedObjectID *blogID = blog.objectID;
     
-    [remote getMediaWithID:mediaID forBlogID:blog.blogID success:^(RemoteMedia *remoteMedia) {
+    [remote getMediaWithID:mediaID success:^(RemoteMedia *remoteMedia) {
        [self.managedObjectContext performBlock:^{
            Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:nil];
            if (!blog) {
@@ -256,8 +255,7 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
 {
     id<MediaServiceRemote> remote = [self remoteForBlog:blog];
     NSManagedObjectID *blogObjectID = [blog objectID];
-    [remote getMediaLibraryForBlogID:blog.blogID
-                           success:^(NSArray *media) {
+    [remote getMediaLibraryWithSuccess:^(NSArray *media) {
                                [self.managedObjectContext performBlock:^{
                                    Blog *blogInContext = (Blog *)[self.managedObjectContext objectWithID:blogObjectID];
                                    [self mergeMedia:media forBlog:blogInContext completionHandler:success];
@@ -359,8 +357,7 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
                             failure:(void (^)(NSError *error))failure
 {
     id<MediaServiceRemote> remote = [self remoteForBlog:blog];
-    [remote getMediaLibraryCountForBlogID:blog.blogID
-                           success:^(NSInteger count) {
+    [remote getMediaLibraryCountWithSuccess:^(NSInteger count) {
                                if (success) {
                                    success(count);
                                }
@@ -474,7 +471,7 @@ static NSString * const MediaDirectory = @"Media";
 {
     id <MediaServiceRemote> remote;
     if (blog.restApi) {
-        remote = [[MediaServiceRemoteREST alloc] initWithApi:blog.restApi];
+        remote = [[MediaServiceRemoteREST alloc] initWithApi:blog.restApi siteID:blog.dotComID];
     } else {
         WPXMLRPCClient *client = [WPXMLRPCClient clientWithXMLRPCEndpoint:[NSURL URLWithString:blog.xmlrpc]];
         remote = [[MediaServiceRemoteXMLRPC alloc] initWithApi:client username:blog.username password:blog.password];

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -8,7 +8,7 @@ struct PeopleService {
 
     init(blog: Blog) {
         remote = PeopleRemote(api: blog.restApi())
-        siteID = blog.dotComID() as Int
+        siteID = blog.dotComID as Int
     }
 
     func refreshTeam(completion: (Bool) -> Void) {

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -92,8 +92,7 @@
 {
     id<PostCategoryServiceRemote> remote = [self remoteForBlog:blog];
     NSManagedObjectID *blogID = blog.objectID;
-    [remote getCategoriesForBlogID:blog.blogID
-                           success:^(NSArray *categories) {
+    [remote getCategoriesWithSuccess:^(NSArray *categories) {
                                [self.managedObjectContext performBlock:^{
                                    Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:nil];
                                    if (!blog) {
@@ -121,7 +120,6 @@
 
     id<PostCategoryServiceRemote> remote = [self remoteForBlog:blog];
     [remote createCategory:remoteCategory
-                 forBlogID:blog.blogID
                    success:^(RemotePostCategory *receivedCategory) {
                        [self.managedObjectContext performBlock:^{
                            Blog *blog = [self blogWithObjectID:blogObjectID];
@@ -217,7 +215,7 @@
 
 - (id<PostCategoryServiceRemote>)remoteForBlog:(Blog *)blog {
     if (blog.restApi) {
-        return [[PostCategoryServiceRemoteREST alloc] initWithApi:blog.restApi];
+        return [[PostCategoryServiceRemoteREST alloc] initWithApi:blog.restApi siteID:blog.dotComID];
     } else {
         return [[PostCategoryServiceRemoteXMLRPC alloc] initWithApi:blog.api username:blog.username password:blog.password];
     }

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -78,7 +78,6 @@ const NSInteger PostServiceNumberToFetch = 40;
     id<PostServiceRemote> remote = [self remoteForBlog:blog];
     NSManagedObjectID *blogID = blog.objectID;
     [remote getPostWithID:postID
-                forBlogID:blog.blogID
                   success:^(RemotePost *remotePost){
                       [self.managedObjectContext performBlock:^{
                           Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:nil];
@@ -120,7 +119,6 @@ const NSInteger PostServiceNumberToFetch = 40;
     NSManagedObjectID *blogObjectID = blog.objectID;
     id<PostServiceRemote> remote = [self remoteForBlog:blog];
     [remote getPostsOfType:postType
-                 forBlogID:blog.blogID
                    success:^(NSArray *posts) {
                        [self.managedObjectContext performBlock:^{
                            Blog *blogInContext = (Blog *)[self.managedObjectContext existingObjectWithID:blogObjectID error:nil];
@@ -174,7 +172,6 @@ const NSInteger PostServiceNumberToFetch = 40;
     }
     NSManagedObjectID *blogID = blog.objectID;
     [remote getPostsOfType:postType
-                 forBlogID:blog.blogID
                    options:options
                    success:^(NSArray *posts) {
         [self.managedObjectContext performBlock:^{
@@ -238,7 +235,6 @@ const NSInteger PostServiceNumberToFetch = 40;
     options[@"number"] = @(PostServiceNumberToFetch);
     NSManagedObjectID *blogID = blog.objectID;
     [remote getPostsOfType:postType
-                 forBlogID:blog.blogID
                    options:options
                    success:^(NSArray *posts) {
                        BOOL hasMore = ([posts count] < PostServiceNumberToFetch) ? NO : YES;
@@ -326,7 +322,6 @@ const NSInteger PostServiceNumberToFetch = 40;
     options[@"number"] = @(postCount);
     NSManagedObjectID *blogID = blog.objectID;
     [remote getPostsOfType:postType
-                 forBlogID:blog.blogID
                    options:options
                    success:^(NSArray *posts) {
                        Blog *blogInContext = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:nil];
@@ -388,12 +383,10 @@ const NSInteger PostServiceNumberToFetch = 40;
 
     if ([post.postID longLongValue] > 0) {
         [remote updatePost:remotePost
-                 forBlogID:post.blog.blogID
                    success:successBlock
                    failure:failureBlock];
     } else {
         [remote createPost:remotePost
-                 forBlogID:post.blog.blogID
                    success:successBlock
                    failure:failureBlock];
     }
@@ -407,7 +400,7 @@ const NSInteger PostServiceNumberToFetch = 40;
     if ([postID longLongValue] > 0) {
         RemotePost *remotePost = [self remotePostWithPost:post];
         id<PostServiceRemote> remote = [self remoteForBlog:post.blog];
-        [remote deletePost:remotePost forBlogID:post.blog.blogID success:success failure:failure];
+        [remote deletePost:remotePost success:success failure:failure];
     }
     [self.managedObjectContext deleteObject:post];
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
@@ -461,7 +454,7 @@ const NSInteger PostServiceNumberToFetch = 40;
 
     RemotePost *remotePost = [self remotePostWithPost:post];
     id<PostServiceRemote> remote = [self remoteForBlog:post.blog];
-    [remote trashPost:remotePost forBlogID:post.blog.blogID success:successBlock failure:failureBlock];
+    [remote trashPost:remotePost success:successBlock failure:failureBlock];
 }
 
 - (void)restorePost:(AbstractPost *)post
@@ -519,7 +512,7 @@ const NSInteger PostServiceNumberToFetch = 40;
     }
 
     id<PostServiceRemote> remote = [self remoteForBlog:post.blog];
-    [remote restorePost:remotePost forBlogID:post.blog.blogID success:successBlock failure:failureBlock];
+    [remote restorePost:remotePost success:successBlock failure:failureBlock];
 }
 
 #pragma mark -
@@ -789,7 +782,7 @@ const NSInteger PostServiceNumberToFetch = 40;
 - (id<PostServiceRemote>)remoteForBlog:(Blog *)blog {
     id<PostServiceRemote> remote;
     if (blog.restApi) {
-        remote = [[PostServiceRemoteREST alloc] initWithApi:blog.restApi];
+        remote = [[PostServiceRemoteREST alloc] initWithApi:blog.restApi siteID:blog.dotComID];
     } else {
         remote = [[PostServiceRemoteXMLRPC alloc] initWithApi:blog.api username:blog.username password:blog.password];
     }

--- a/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
@@ -507,7 +507,7 @@ static UIEdgeInsets const CreateBlogCancelButtonPaddingPad  = {1.0, 13.0, 0.0, 0
                 blog = [blogService createBlogWithAccount:defaultAccount];
                 blog.xmlrpc = blogOptions[@"xmlrpc"];
             }
-            blog.blogID = [blogOptions numberForKey:@"blogid"];
+            blog.dotComID = [blogOptions numberForKey:@"blogid"];
             blog.url = blogOptions[@"url"];
             blog.settings.name = [blogOptions[@"blogname"] stringByDecodingXMLCharacters];
             defaultAccount.defaultBlog = blog;

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -105,7 +105,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
         return;
     }
     
-    self.suggestionsTableView = [[SuggestionsTableView alloc] initWithSiteID:self.comment.blog.blogID];
+    self.suggestionsTableView = [[SuggestionsTableView alloc] initWithSiteID:self.comment.blog.dotComID];
     self.suggestionsTableView.suggestionsDelegate = self;
     [self.suggestionsTableView setTranslatesAutoresizingMaskIntoConstraints:NO];
     [self.view addSubview:self.suggestionsTableView];
@@ -453,7 +453,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
     [commentService toggleLikeStatusForComment:self.comment
-                                        siteID:self.comment.blog.blogID
+                                        siteID:self.comment.blog.dotComID
                                        success:nil
                                        failure:^(NSError *error) {
                                            [weakSelf reloadData];
@@ -634,7 +634,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 {
     __typeof(self) __weak weakSelf = self;
     
-    EditReplyViewController *editViewController = [EditReplyViewController newReplyViewControllerForSiteID:self.comment.blog.blogID];
+    EditReplyViewController *editViewController = [EditReplyViewController newReplyViewControllerForSiteID:self.comment.blog.dotComID];
 
     editViewController.onCompletion = ^(BOOL hasNewContent, NSString *newContent) {
         [self dismissViewControllerAnimated:YES completion:^{
@@ -785,7 +785,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 
 - (BOOL)shouldAttachSuggestionsTableView
 {
-    BOOL shouldShowSuggestions = [[SuggestionService sharedInstance] shouldShowSuggestionsForSiteID:self.comment.blog.blogID];
+    BOOL shouldShowSuggestions = [[SuggestionService sharedInstance] shouldShowSuggestionsForSiteID:self.comment.blog.dotComID];
     return self.shouldAttachReplyTextView && shouldShowSuggestions;
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/EditReplyViewController.h
+++ b/WordPress/Classes/ViewRelated/Comments/EditReplyViewController.h
@@ -9,7 +9,7 @@
  on which the comment would be posted.  The siteID is used to retrieve @mention
  suggestions.  If no @mentions suggestions are desired, pass nil instead
  
- @param siteID Optional ID of the blog/site on which the user is commenting
+ @param siteID Optional WordPress.com ID of the blog/site on which the user is commenting
  @return An instance of EditReplyViewController
  */
 + (instancetype)newReplyViewControllerForSiteID:(NSNumber *)siteID;

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -868,7 +868,7 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
                 blog = [blogService createBlogWithAccount:defaultAccount];
                 blog.xmlrpc = blogOptions[@"xmlrpc"];
             }
-            blog.blogID = [blogOptions numberForKey:@"blogid"];
+            blog.dotComID = [blogOptions numberForKey:@"blogid"];
             blog.url = blogOptions[@"url"];
             blog.settings.name = [blogOptions[@"blogname"] stringByDecodingXMLCharacters];
             defaultAccount.defaultBlog = blog;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -989,7 +989,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     vc.selectedDate                = [NSDate date];
     vc.statsSection                = StatsSectionFollowers;
     vc.statsSubSection             = StatsSubSectionFollowersDotCom;
-    vc.statsService                = [[WPStatsService alloc] initWithSiteId:blog.blogID
+    vc.statsService                = [[WPStatsService alloc] initWithSiteId:blog.dotComID
                                                                siteTimeZone:[service timeZoneForBlog:blog]
                                                                 oauth2Token:blog.authToken
                                                  andCacheExpirationInterval:NotificationFiveMinutes];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -77,7 +77,7 @@ public class NotificationSettingsViewController : UIViewController
         // Find the Default Blog ID
         let service         = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
         let defaultAccount  = service.defaultWordPressComAccount()
-        let primaryBlogId   = defaultAccount?.defaultBlog?.blogID as? Int
+        let primaryBlogId   = defaultAccount?.defaultBlog?.dotComID as? Int
         
         // Proceed Grouping
         var blogSettings    = [NotificationSettings]()

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -4,7 +4,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
     public var blog: Blog?
     private lazy var resultsController: NSFetchedResultsController = {
         let request = NSFetchRequest(entityName: "Person")
-        request.predicate = NSPredicate(format: "siteID = %@", self.blog!.dotComID())
+        request.predicate = NSPredicate(format: "siteID = %@", self.blog!.dotComID)
         // FIXME(@koke, 2015-11-02): my user should be first
         request.sortDescriptors = [NSSortDescriptor(key: "displayName", ascending: true, selector: "localizedCaseInsensitiveCompare:")]
         let context = ContextManager.sharedInstance().mainContext

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -452,6 +452,7 @@
 		E125451812BF68F900D87A0A /* Page.m in Sources */ = {isa = PBXBuildFile; fileRef = E125451712BF68F900D87A0A /* Page.m */; };
 		E1266D2D1BBE8B9A00FCB6B6 /* Gravatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1266D2C1BBE8B9A00FCB6B6 /* Gravatar.swift */; };
 		E1266D2F1BBEC37B00FCB6B6 /* GravatarTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1266D2E1BBEC37B00FCB6B6 /* GravatarTest.swift */; };
+		E127A0F11C43B7CB00085129 /* SiteServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = E127A0F01C43B7CB00085129 /* SiteServiceRemoteREST.m */; };
 		E12E6E331C21BA170033C5D0 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12E6E321C21BA170033C5D0 /* FeatureFlag.swift */; };
 		E12E6E381C21E75F0033C5D0 /* FeatureFlagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12E6E371C21E75F0033C5D0 /* FeatureFlagTest.swift */; };
 		E131CB5216CACA6B004B0314 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E131CB5116CACA6B004B0314 /* CoreText.framework */; };
@@ -1441,6 +1442,8 @@
 		E125451712BF68F900D87A0A /* Page.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = Page.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		E1266D2C1BBE8B9A00FCB6B6 /* Gravatar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Gravatar.swift; sourceTree = "<group>"; };
 		E1266D2E1BBEC37B00FCB6B6 /* GravatarTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarTest.swift; sourceTree = "<group>"; };
+		E127A0EF1C43B7CB00085129 /* SiteServiceRemoteREST.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SiteServiceRemoteREST.h; sourceTree = "<group>"; };
+		E127A0F01C43B7CB00085129 /* SiteServiceRemoteREST.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SiteServiceRemoteREST.m; sourceTree = "<group>"; };
 		E12963A8174654B2002E7744 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E12E6E321C21BA170033C5D0 /* FeatureFlag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		E12E6E371C21E75F0033C5D0 /* FeatureFlagTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureFlagTest.swift; sourceTree = "<group>"; };
@@ -2485,6 +2488,8 @@
 				E1249B4019408C6F0035E895 /* Remote Objects */,
 				E1249B481940AE610035E895 /* ServiceRemoteREST.h */,
 				59E2AAE21B2096BF0051DC06 /* ServiceRemoteREST.m */,
+				E127A0EF1C43B7CB00085129 /* SiteServiceRemoteREST.h */,
+				E127A0F01C43B7CB00085129 /* SiteServiceRemoteREST.m */,
 				E1249B471940AE550035E895 /* ServiceRemoteXMLRPC.h */,
 				FF19340B1BB2F892006825B8 /* ServiceRemoteXMLRPC.m */,
 				FFC6ADDB1B56F3D2002F3C84 /* ThemeServiceRemote.h */,
@@ -4513,6 +4518,7 @@
 				B587798619B799EB00E57C5A /* Notification+Interface.swift in Sources */,
 				B57B92BD1B73B08100DFF00B /* SeparatorsView.swift in Sources */,
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,
+				E127A0F11C43B7CB00085129 /* SiteServiceRemoteREST.m in Sources */,
 				462F4E0A18369F0B0028D2F8 /* BlogDetailsViewController.m in Sources */,
 				B55F1AA81C10936600FD04D4 /* BlogSettings+Discussion.swift in Sources */,
 				74F313EF1A9B97A200AA8B45 /* WPTooltip.m in Sources */,

--- a/WordPress/WordPressTest/BlogJetpackTest.m
+++ b/WordPress/WordPressTest/BlogJetpackTest.m
@@ -170,10 +170,9 @@
     Blog *dotcomBlog = [blogService createBlogWithAccount:wpComAccount];
     dotcomBlog.xmlrpc = @"http://dotcom1.wordpress.com/xmlrpc.php";
     dotcomBlog.url = @"http://dotcom1.wordpress.com/";
-    dotcomBlog.blogID = @1;
+    dotcomBlog.dotComID = @1;
 
     Blog *jetpackLegacyBlog = [blogService createBlogWithAccount:nil];
-    jetpackLegacyBlog.blogID = @0;
     jetpackLegacyBlog.username = @"jetpack";
     jetpackLegacyBlog.xmlrpc = @"http://jetpack.example.com/xmlrpc.php";
     jetpackLegacyBlog.url = @"http://jetpack.example.com/";

--- a/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
@@ -32,23 +32,10 @@ static NSTimeInterval const TestExpectationTimeout = 5;
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
     
-    [service checkMultiAuthorForBlogID:[blog dotComID]
-                             success:^(BOOL isMultiAuthor) {}
-                             failure:^(NSError *error) {}];
-}
-
-
-- (void)testThatCheckMultiAuthorForBlogThrowsExceptionWithoutBlog
-{
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
-    BlogServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
-    XCTAssertThrows([service checkMultiAuthorForBlogID:nil
-                                             success:^(BOOL isMultiAuthor) {}
-                                             failure:^(NSError *error) {}]);
+    [service checkMultiAuthorWithSuccess:^(BOOL isMultiAuthor) {}
+                                 failure:^(NSError *error) {}];
 }
 
 
@@ -69,22 +56,10 @@ static NSTimeInterval const TestExpectationTimeout = 5;
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
     
-    [service syncOptionsForBlogID:[blog dotComID]
-                          success:^(NSDictionary *options) {}
-                          failure:^(NSError *error) {}];
-}
-
-- (void)testThatSyncOptionForBlogThrowsExceptionWithoutBlog
-{
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
-    BlogServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
-    XCTAssertThrows([service syncOptionsForBlogID:nil
-                                        success:^(NSDictionary *options) {}
-                                        failure:^(NSError *error) {}]);
+    [service syncOptionsWithSuccess:^(NSDictionary *options) {}
+                            failure:^(NSError *error) {}];
 }
 
 
@@ -105,22 +80,10 @@ static NSTimeInterval const TestExpectationTimeout = 5;
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
     
-    [service syncPostFormatsForBlogID:[blog dotComID]
-                              success:^(NSDictionary *options) {}
-                              failure:^(NSError *error) {}];
-}
-
-- (void)testThatSyncPostFormatsForBlogThrowsExceptionWithoutBlog
-{
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
-    BlogServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithApi:api]);
-    XCTAssertThrows([service syncPostFormatsForBlogID:nil
-                                            success:^(NSDictionary *options) {}
-                                            failure:^(NSError *error) {}]);
+    [service syncPostFormatsWithSuccess:^(NSDictionary *options) {}
+                                failure:^(NSError *error) {}];
 }
 
 
@@ -133,7 +96,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
     NSString *mockResponse          = @"rest-site-settings.json";
     
     WordPressComApi *api            = [WordPressComApi anonymousApi];
-    BlogServiceRemoteREST *service  = [[BlogServiceRemoteREST alloc] initWithApi:api];
+    BlogServiceRemoteREST *service  = [[BlogServiceRemoteREST alloc] initWithApi:api siteID:blogID];
     XCTAssertNotNil(service, @"Error while creating the new service");
     
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
@@ -146,7 +109,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"Site Settings"];
     
-    [service syncSettingsForBlogID:blogID success:^(RemoteBlogSettings *settings) {
+    [service syncSettingsWithSuccess:^(RemoteBlogSettings *settings) {
         // General
         XCTAssertEqualObjects(settings.name, @"My Epic Blog", @"");
         XCTAssertEqualObjects(settings.tagline, @"Definitely, the best blog out there", @"");

--- a/WordPress/WordPressTest/PostServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/PostServiceRemoteRESTTests.m
@@ -23,7 +23,8 @@
 - (PostServiceRemoteREST*)service
 {
     WordPressComApi *api = [[WordPressComApi alloc] initWithBaseURL:[NSURL URLWithString:@""]];
-    return [[PostServiceRemoteREST alloc] initWithApi:api];
+    NSNumber *siteID = @10;
+    return [[PostServiceRemoteREST alloc] initWithApi:api siteID:siteID];
 }
 
 #pragma mark - Getting posts by ID
@@ -45,35 +46,19 @@
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
     
     [service getPostWithID:postID
-                 forBlogID:[blog dotComID]
                    success:^(RemotePost *post) {}
                    failure:^(NSError *error) {}];
 }
 
 - (void)testThatGetPostWithIDThrowsExceptionWithoutPostID
 {
-    Blog *blog = OCMStrictClassMock([Blog class]);
-    OCMStub([blog dotComID]).andReturn(@10);
-    
     PostServiceRemoteREST *service = nil;
     
     XCTAssertNoThrow(service = [self service]);
     XCTAssertThrows([service getPostWithID:nil
-                                 forBlogID:[blog dotComID]
-                                   success:^(RemotePost *post) {}
-                                   failure:^(NSError *error) {}]);
-}
-
-- (void)testThatGetPostWithIDThrowsExceptionWithoutBlog
-{
-    PostServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [self service]);
-    XCTAssertThrows([service getPostWithID:@2
-                                 forBlogID:nil
                                    success:^(RemotePost *post) {}
                                    failure:^(NSError *error) {}]);
 }
@@ -103,23 +88,11 @@
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
     
     [service getPostsOfType:postType
-                  forBlogID:[blog dotComID]
                     success:^(NSArray *posts) {}
                     failure:^(NSError *error) {}];
-}
-
-- (void)testThatGetPostsOfTypeThrowsExceptionWithoutBlog
-{
-    PostServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [self service]);
-    XCTAssertThrows([service getPostsOfType:@"SomeType"
-                                  forBlogID:nil
-                                    success:^(NSArray *posts) {}
-                                    failure:^(NSError *error) {}]);
 }
 
 - (void)testThatGetPostsOfTypeWithOptionsWorks
@@ -150,25 +123,12 @@
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
     
     [service getPostsOfType:postType
-                  forBlogID:[blog dotComID]
                     options:options
                     success:^(NSArray *posts) {}
                     failure:^(NSError *error) {}];
-}
-
-- (void)testThatGetPostsOfTypeWithOptionsThrowsExceptionWithoutBlog
-{
-    PostServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [self service]);
-    XCTAssertThrows([service getPostsOfType:@"SomeType"
-                                  forBlogID:nil
-                                    options:@{}
-                                    success:^(NSArray *posts) {}
-                                    failure:^(NSError *error) {}]);
 }
 
 #pragma mark - Creating posts
@@ -196,37 +156,19 @@
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
     
     [service createPost:post
-              forBlogID:[blog dotComID]
                 success:^(RemotePost *posts) {}
                 failure:^(NSError *error) {}];
 }
 
 - (void)testThatCreatePostThrowsExceptionWithoutPost
 {
-    Blog *blog = OCMStrictClassMock([Blog class]);
-    OCMStub([blog dotComID]).andReturn(@10);
-    
     PostServiceRemoteREST *service = nil;
     
     XCTAssertNoThrow(service = [self service]);
     XCTAssertThrows([service createPost:nil
-                              forBlogID:[blog dotComID]
-                                success:^(RemotePost *posts) {}
-                                failure:^(NSError *error) {}]);
-}
-
-- (void)testThatCreatePostThrowsExceptionWithoutBlog
-{
-    RemotePost *post = OCMClassMock([RemotePost class]);
-    
-    PostServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [self service]);
-    XCTAssertThrows([service createPost:post
-                              forBlogID:nil
                                 success:^(RemotePost *posts) {}
                                 failure:^(NSError *error) {}]);
 }
@@ -257,37 +199,19 @@
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
     
     [service updatePost:post
-              forBlogID:[blog dotComID]
                 success:^(RemotePost *posts) {}
                 failure:^(NSError *error) {}];
 }
 
 - (void)testThatUpdatePostThrowsExceptionWithoutPost
 {
-    Blog *blog = OCMStrictClassMock([Blog class]);
-    OCMStub([blog dotComID]).andReturn(@10);
-    
     PostServiceRemoteREST *service = nil;
     
     XCTAssertNoThrow(service = [self service]);
     XCTAssertThrows([service updatePost:nil
-                              forBlogID:[blog dotComID]
-                                success:^(RemotePost *posts) {}
-                                failure:^(NSError *error) {}]);
-}
-
-- (void)testThatUpdatePostThrowsExceptionWithoutBlog
-{
-    RemotePost *post = OCMClassMock([RemotePost class]);
-    
-    PostServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [self service]);
-    XCTAssertThrows([service updatePost:post
-                              forBlogID:nil
                                 success:^(RemotePost *posts) {}
                                 failure:^(NSError *error) {}]);
 }
@@ -312,37 +236,19 @@
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
     
     [service deletePost:post
-              forBlogID:[blog dotComID]
                 success:^(RemotePost *posts) {}
                 failure:^(NSError *error) {}];
 }
 
 - (void)testThatDeletePostThrowsExceptionWithoutPost
 {
-    Blog *blog = OCMStrictClassMock([Blog class]);
-    OCMStub([blog dotComID]).andReturn(@10);
-    
     PostServiceRemoteREST *service = nil;
     
     XCTAssertNoThrow(service = [self service]);
     XCTAssertThrows([service deletePost:nil
-                              forBlogID:[blog dotComID]
-                                success:^(RemotePost *posts) {}
-                                failure:^(NSError *error) {}]);
-}
-
-- (void)testThatDeletePostThrowsExceptionWithoutBlog
-{
-    RemotePost *post = OCMClassMock([RemotePost class]);
-    
-    PostServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [self service]);
-    XCTAssertThrows([service deletePost:post
-                              forBlogID:nil
                                 success:^(RemotePost *posts) {}
                                 failure:^(NSError *error) {}]);
 }
@@ -367,37 +273,19 @@
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
     
     [service trashPost:post
-             forBlogID:[blog dotComID]
                success:^(RemotePost *posts) {}
                failure:^(NSError *error) {}];
 }
 
 - (void)testThatTashPostThrowsExceptionWithoutPost
 {
-    Blog *blog = OCMStrictClassMock([Blog class]);
-    OCMStub([blog dotComID]).andReturn(@10);
-    
     PostServiceRemoteREST *service = nil;
     
     XCTAssertNoThrow(service = [self service]);
     XCTAssertThrows([service trashPost:nil
-                             forBlogID:[blog dotComID]
-                               success:^(RemotePost *posts) {}
-                               failure:^(NSError *error) {}]);
-}
-
-- (void)testThatTrashPostThrowsExceptionWithoutBlog
-{
-    RemotePost *post = OCMClassMock([RemotePost class]);
-    
-    PostServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [self service]);
-    XCTAssertThrows([service trashPost:post
-                             forBlogID:nil
                                success:^(RemotePost *posts) {}
                                failure:^(NSError *error) {}]);
 }
@@ -422,37 +310,19 @@
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
     
     [service restorePost:post
-               forBlogID:[blog dotComID]
                  success:^(RemotePost *posts) {}
                  failure:^(NSError *error) {}];
 }
 
 - (void)testThatRestorePostThrowsExceptionWithoutPost
 {
-    Blog *blog = OCMStrictClassMock([Blog class]);
-    OCMStub([blog dotComID]).andReturn(@10);
-    
     PostServiceRemoteREST *service = nil;
     
     XCTAssertNoThrow(service = [self service]);
     XCTAssertThrows([service restorePost:nil
-                               forBlogID:[blog dotComID]
-                                 success:^(RemotePost *posts) {}
-                                 failure:^(NSError *error) {}]);
-}
-
-- (void)testThatRestorePostThrowsExceptionWithoutBlog
-{
-    RemotePost *post = OCMClassMock([RemotePost class]);
-    
-    PostServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [self service]);
-    XCTAssertThrows([service restorePost:post
-                               forBlogID:nil
                                  success:^(RemotePost *posts) {}
                                  failure:^(NSError *error) {}]);
 }


### PR DESCRIPTION
We haven't used blogID for a while for self hosted blogs, as it's pointless: most self hosted will have a blogID=1 if they're not multisite, and XML-RPC requires a blogID parameter on most calls but it's ignored.

So for a while now, we've just stored `0` as the blogID for self-hosted. For wp.com blogs, `blogID` had the actual site ID.

To avoid confusion, I'm deprecating `blogID`. From now on, only `dotComID` should be used.
`dotComID` has the wp.com ID of a WordPress.com or Jetpack site.

For XML-RPC, we're now explicitly sending `0` as the first (blogID) parameter when required.

On a future PR, I'll rename the core data `blogID` attribute to `dotComID`.

## Notes

I don't like this:

```[[BlogServiceRemoteREST alloc] initWithApi:blog.restApi siteID:blog.dotComID]```

Knowing the implementation, I know that if `restApi != nil` then `dotComID` should be set, but it's not enforced at compile time. I'm not sure if it can be.

I've removed a bunch of tests `test*ThrowsExceptionWithoutBlog` because they don't make sense anymore. The blog is provided when initialising the Remote class, and thanks to the new nullability annotations you'll get a warning if you try to pass a `nil` blogID.

I think it's pretty cool how `SiteServiceRemoteREST` disables the parent's `initWithApi:` initialiser by re-declaring it with `__unavailable`. Cool new trick :)

Fixes #4618 

Needs Review: @aerych 