### PR TITLE
DiscussionSettingsViewController: Updates insertion and edition titles

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -349,8 +349,8 @@ public class DiscussionSettingsViewController : UITableViewController
         let moderationKeys                      = settings.commentsModerationKeys
         let settingsViewController              = SettingsListEditorViewController(collection: moderationKeys)
         settingsViewController.title            = NSLocalizedString("Hold for Moderation", comment: "Moderation Keys Title")
-        settingsViewController.insertTitle      = NSLocalizedString("New Moderation Key", comment: "Moderation Keyword Insertion Title")
-        settingsViewController.editTitle        = NSLocalizedString("Edit Moderation Key", comment: "Moderation Keyword Edition Title")
+        settingsViewController.insertTitle      = NSLocalizedString("New Moderation Word", comment: "Moderation Keyword Insertion Title")
+        settingsViewController.editTitle        = NSLocalizedString("Edit Moderation Word", comment: "Moderation Keyword Edition Title")
         settingsViewController.footerText       = NSLocalizedString("When a comment contains any of these words in its content, name, URL, e-mail or IP, it will be held in the moderation queue. You can enter partial words, so \"press\" will match \"WordPress\".",
                                                                     comment: "Text rendered at the bottom of the Discussion Moderation Keys editor")
         settingsViewController.onChange         = { [weak self] (updated: Set<String>) in

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -364,8 +364,8 @@ public class DiscussionSettingsViewController : UITableViewController
         let blacklistKeys                       = settings.commentsBlacklistKeys
         let settingsViewController              = SettingsListEditorViewController(collection: blacklistKeys)
         settingsViewController.title            = NSLocalizedString("Blacklist", comment: "Blacklist Title")
-        settingsViewController.insertTitle      = NSLocalizedString("New Blacklist Key", comment: "Blacklist Keyword Insertion Title")
-        settingsViewController.editTitle        = NSLocalizedString("Edit Blacklist Key", comment: "Blacklist Keyword Edition Title")
+        settingsViewController.insertTitle      = NSLocalizedString("New Blacklist Word", comment: "Blacklist Keyword Insertion Title")
+        settingsViewController.editTitle        = NSLocalizedString("Edit Blacklist Word", comment: "Blacklist Keyword Edition Title")
         settingsViewController.footerText       = NSLocalizedString("When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam. You can enter partial words, so \"press\" will match \"WordPress\".",
                                                                     comment: "Text rendered at the bottom of the Discussion Blacklist Keys editor")
         settingsViewController.onChange         = { [weak self] (updated: Set<String>) in


### PR DESCRIPTION
#### Scenario:
1. Launch WordPress
2. Open `My Sites` tab
3. Open any WordPress.com site
4. Tap over the `Settings` row
5. Tap over `Discussion` row
6. Tap over `Blacklist`

Try adding / editing a keyword. Note that the navigation title should read `New Blacklist Word` / `Edit Blacklist Word`.

Needs Review: @koke 
Thanks in advance!
