### PR TITLE
Ensures blogs are synced to the device before dismissing the login UI

### DIFF
--- a/WordPress/WordPressTest/LoginViewModelTests.m
+++ b/WordPress/WordPressTest/LoginViewModelTests.m
@@ -1611,20 +1611,21 @@ describe(@"LoginFacadeDelegate methods", ^{
                     [mockViewModelPresenter verify];
                 });
                 
-                it(@"should indicate dismiss the login view", ^{
-                    [[mockViewModelPresenter expect] dismissLoginView];
-                    
-                    [viewModel finishedLoginWithUsername:username authToken:authToken requiredMultifactorCode:requiredMultifactorCode];
-                    
-                    [mockViewModelPresenter verify];
-                });
-                
                 it(@"should update the user details for the newly created account", ^{
                     [[mockAccountServiceFacade expect] updateUserDetailsForAccount:OCMOCK_ANY success:OCMOCK_ANY failure:OCMOCK_ANY];
                     
                     [viewModel finishedLoginWithUsername:username authToken:authToken requiredMultifactorCode:requiredMultifactorCode];
                     
                     [mockAccountServiceFacade verify];
+
+                    it(@"should indicate dismiss the login view", ^{
+                        [[mockViewModelPresenter expect] dismissLoginView];
+                        
+                        [viewModel finishedLoginWithUsername:username authToken:authToken requiredMultifactorCode:requiredMultifactorCode];
+                        
+                        [mockViewModelPresenter verify];
+                    });
+                    
                 });
             });
             


### PR DESCRIPTION
Fixes #4287 

Waits to dismiss the login UI until all of the sync operations have completed. This fixes an issue with BlogListController firing off too early in the login process. The default blog hadn't been stored yet which made setting the Today Extension stats site up impossible.

**Testing:**
1. Fresh install
2. Log in with a WordPress.com account.
3. Verify Today Widget is configured.

Needs Review: @jleandroperez, @sendhil 