### PR TITLE
Issue/4184: Increases Undo button padding

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
@@ -10,14 +10,14 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" tableViewCell="AgI-Sn-JeL" id="QqJ-JC-nik">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qtC-jW-wnY">
                         <rect key="frame" x="6" y="0.0" width="308" height="42"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Page moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au3-8f-nAh">
-                                <rect key="frame" x="13" y="0.0" width="137.5" height="42"/>
+                                <rect key="frame" x="13" y="0.0" width="138" height="42"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
@@ -29,7 +29,7 @@
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <inset key="contentEdgeInsets" minX="3" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="3" maxY="0.0"/>
+                                <inset key="imageEdgeInsets" minX="-3" minY="0.0" maxX="3" maxY="0.0"/>
                                 <state key="normal" title="Undo" image="icon-post-undo">
                                     <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                     <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,13 +10,14 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" tableViewCell="AgI-Sn-JeL" id="QqJ-JC-nik">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qtC-jW-wnY">
                         <rect key="frame" x="6" y="0.0" width="308" height="42"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Page moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au3-8f-nAh">
-                                <rect key="frame" x="13" y="0.0" width="139" height="42"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Page moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au3-8f-nAh">
+                                <rect key="frame" x="13" y="0.0" width="137.5" height="42"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
@@ -42,6 +42,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="dPd-xc-GkE" firstAttribute="top" secondItem="qtC-jW-wnY" secondAttribute="top" id="3BZ-ED-4O8"/>
+                            <constraint firstItem="dPd-xc-GkE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="au3-8f-nAh" secondAttribute="trailing" constant="3" id="4yA-13-Cxl"/>
                             <constraint firstAttribute="bottom" secondItem="au3-8f-nAh" secondAttribute="bottom" id="BAj-O1-1jz"/>
                             <constraint firstAttribute="trailing" secondItem="dPd-xc-GkE" secondAttribute="trailing" constant="14" id="TF1-Iy-WTJ">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,6 +10,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="65"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" tableViewCell="cm8-te-h9Y" id="n47-YY-a6J">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="64.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gcy-ef-aVi">
@@ -23,8 +23,8 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XWn-76-OyW">
                                 <rect key="frame" x="6" y="10" width="308" height="44"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Post moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tDg-aX-r9a">
-                                        <rect key="frame" x="13" y="0.0" width="135" height="44"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Post moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tDg-aX-r9a">
+                                        <rect key="frame" x="13" y="0.0" width="133.5" height="44"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
@@ -57,6 +57,7 @@
                                     <constraint firstAttribute="bottom" secondItem="tDg-aX-r9a" secondAttribute="bottom" id="NVR-Tx-ea4"/>
                                     <constraint firstItem="tDg-aX-r9a" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" id="ay6-0i-iUF"/>
                                     <constraint firstAttribute="bottom" secondItem="5bW-zk-smP" secondAttribute="bottom" id="fd1-Xw-yJ2"/>
+                                    <constraint firstItem="5bW-zk-smP" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tDg-aX-r9a" secondAttribute="trailing" constant="3" id="iiX-Ba-qGN"/>
                                     <constraint firstItem="5bW-zk-smP" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" id="lZy-0i-LeW"/>
                                     <constraint firstAttribute="width" constant="600" id="zH8-kM-TvE"/>
                                 </constraints>

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
@@ -10,7 +10,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="65"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" tableViewCell="cm8-te-h9Y" id="n47-YY-a6J">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="64.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gcy-ef-aVi">
@@ -24,7 +24,7 @@
                                 <rect key="frame" x="6" y="10" width="308" height="44"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Post moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tDg-aX-r9a">
-                                        <rect key="frame" x="13" y="0.0" width="133.5" height="44"/>
+                                        <rect key="frame" x="13" y="0.0" width="134" height="44"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                         <nil key="highlightedColor"/>
@@ -36,7 +36,7 @@
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <inset key="contentEdgeInsets" minX="3" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="3" maxY="0.0"/>
+                                        <inset key="imageEdgeInsets" minX="-3" minY="0.0" maxX="3" maxY="0.0"/>
                                         <state key="normal" title="Undo" image="icon-post-undo">
                                             <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                             <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -94,8 +94,6 @@
     button.titleLabel.font = [WPStyleGuide subtitleFont];
     [button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
     [button setTitleColor:[WPStyleGuide darkBlue] forState:UIControlStateHighlighted];
-    
-    [self applyHorizontalSpacing:3.0 toButton:button];
 }
 
 #pragma mark - Attributed String Attributes
@@ -200,21 +198,6 @@
     button.titleLabel.font = [WPFontManager openSansSemiBoldFontOfSize:fontSize];
     [button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
     [button setTitleColor:[WPStyleGuide darkBlue] forState:UIControlStateHighlighted];
-
-    [self applyHorizontalSpacing:3.0 toButton:button];
-}
-
-#pragma mark - Helpers
-
-+ (void)applyHorizontalSpacing:(CGFloat)spacing toButton:(UIButton *)button
-{
-    // Insets required to create specified spacing between image and text with no truncation
-    // as per http://stackoverflow.com/a/25559946
-    CGFloat insetAmount = spacing / 2.0;
-    
-    button.imageEdgeInsets = UIEdgeInsetsMake(0.0, -insetAmount, 0.0, insetAmount);
-    button.titleEdgeInsets = UIEdgeInsetsMake(0.0, insetAmount, 0.0, -insetAmount);
-    button.contentEdgeInsets = UIEdgeInsetsMake(0.0, insetAmount, 0.0, insetAmount);
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -94,9 +94,9 @@
     button.titleLabel.font = [WPStyleGuide subtitleFont];
     [button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
     [button setTitleColor:[WPStyleGuide darkBlue] forState:UIControlStateHighlighted];
-    button.imageEdgeInsets = UIEdgeInsetsMake(0.0, 0.0, 0.0, 3.0);
+    
+    [self applyHorizontalSpacing:3.0 toButton:button];
 }
-
 
 #pragma mark - Attributed String Attributes
 
@@ -200,7 +200,21 @@
     button.titleLabel.font = [WPFontManager openSansSemiBoldFontOfSize:fontSize];
     [button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
     [button setTitleColor:[WPStyleGuide darkBlue] forState:UIControlStateHighlighted];
-    button.imageEdgeInsets = UIEdgeInsetsMake(0.0, 0.0, 0.0, 3.0);
+
+    [self applyHorizontalSpacing:3.0 toButton:button];
+}
+
+#pragma mark - Helpers
+
++ (void)applyHorizontalSpacing:(CGFloat)spacing toButton:(UIButton *)button
+{
+    // Insets required to create specified spacing between image and text with no truncation
+    // as per http://stackoverflow.com/a/25559946
+    CGFloat insetAmount = spacing / 2.0;
+    
+    button.imageEdgeInsets = UIEdgeInsetsMake(0.0, -insetAmount, 0.0, insetAmount);
+    button.titleEdgeInsets = UIEdgeInsetsMake(0.0, insetAmount, 0.0, -insetAmount);
+    button.contentEdgeInsets = UIEdgeInsetsMake(0.0, insetAmount, 0.0, insetAmount);
 }
 
 @end


### PR DESCRIPTION
Fixes #4184. Increases horizontal padding inside Undo button for deleting posts and pages (`RestorePostTableViewCell` and `RestorePageTableViewCell`). I also noticed that with long localizations (e.g. Dutch) the button and the info text in the cell would overlap, so I've added some extra constraints to handle this.

Before:

![simulator screen shot 12 jan 2016 17 43 52](https://cloud.githubusercontent.com/assets/4780/12271868/3f594a68-b955-11e5-89ba-5106c391a296.png)

After:

![simulator screen shot 12 jan 2016 17 43 09](https://cloud.githubusercontent.com/assets/4780/12271871/45cc660a-b955-11e5-99e8-79a9d6070e57.png)

### To Test

1. Launch the app in a language other than English (original issue was raised against Spanish).
2. Delete a page, and observe the spacing between the undo arrow and the label of the undo button.
3. Repeat for deleting a post.

Also verify with languages with long translations (Dutch is one that I used) to ensure that text does not overlap as per screenshots above.

Needs review: @koke