### PR TITLE
Issue/4647: Add Site button now shows correctly on initial launch

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -41,6 +41,7 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *searchWrapperViewHeightConstraint;
 @property (nonatomic, weak) UIAlertController *addSiteAlertController;
 @property (nonatomic, strong) UIBarButtonItem *addSiteButton;
+@property (nonatomic, strong) UIBarButtonItem *searchButton;
 
 @property (nonatomic) NSDate *firstHide;
 @property (nonatomic) NSInteger hideCount;
@@ -82,11 +83,15 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
     self.addSiteButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd
                                                                                    target:self
                                                                                    action:@selector(addSite)];
-    UIBarButtonItem *searchButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"icon-post-search"]
-                                                                     style:UIBarButtonItemStylePlain
-                                                                    target:self
-                                                                    action:@selector(toggleSearch)];
-    [self.navigationItem setRightBarButtonItems:@[self.addSiteButton, searchButton]];
+    
+    self.searchButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"icon-post-search"]
+                                                         style:UIBarButtonItemStylePlain
+                                                        target:self
+                                                        action:@selector(toggleSearch)];
+
+    self.navigationItem.rightBarButtonItems = @[ self.addSiteButton, self.searchButton ];
+
+    self.navigationItem.title = NSLocalizedString(@"My Sites", @"");
 }
 
 - (NSString *)modelIdentifierForElementAtIndexPath:(NSIndexPath *)indexPath inView:(UIView *)view
@@ -232,7 +237,10 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     if ([blogService blogCountForAllAccounts] <= 1) {
-        self.navigationItem.rightBarButtonItem = nil;
+        // Hide the search button if there's only one blog
+        self.navigationItem.rightBarButtonItems = @[ self.addSiteButton ];
+    } else {
+        self.navigationItem.rightBarButtonItems = @[ self.addSiteButton, self.searchButton ];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -89,7 +89,7 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
                                                         target:self
                                                         action:@selector(toggleSearch)];
 
-    self.navigationItem.rightBarButtonItems = @[ self.addSiteButton, self.searchButton ];
+    [self updateSearchButton];
 
     self.navigationItem.title = NSLocalizedString(@"My Sites", @"");
 }


### PR DESCRIPTION
Fixes #4647. On first launch, BlogListViewController's add search (+) button would be hidden, and never re-appear until you relaunched the app.

This was due to the updateSearchButton method nilling out rightBarButtonItems when it initially detected a blog count of zero (before the user has logged in). Despite the method being called on viewWillAppear:, it would never re-add the button on subsequent calls when more than one blog is present.

I think there was also another bug in this code – I'm presuming that the updateSearchButton method should've been hiding the search button, not the add site button. I've updated it to do so, and also to add the button back in if there are > 1 blogs.

Needs review: @kwonye