### PR TITLE
Blog Details: Quick refactor making it easier to change table content.

### DIFF
--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -36,7 +36,3 @@ extern NSString *const WPOnePasswordWordPressTitle;
 extern NSString *const WPOnePasswordWordPressComURL;
 extern NSInteger const WPOnePasswordGeneratedMinLength;
 extern NSInteger const WPOnePasswordGeneratedMaxLength;
-
-#ifdef DEBUG
-#define WP_PEOPLE_ENABLED
-#endif

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -184,10 +184,9 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
 #pragma mark - Data Model setup
 
 
-- (NSArray *)configureTableViewData
+- (void)configureTableViewData
 {
     NSMutableArray *marr = [NSMutableArray array];
-
     [marr addObject:[self generalSectionViewModel]];
     [marr addObject:[self publishTypeSectionViewModel]];
     if ([self.blog supports:BlogFeatureThemeBrowsing]) {
@@ -195,7 +194,8 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
     }
     [marr addObject:[self configurationSectionViewModel]];
 
-    return marr;
+    // Assign non mutable copy.
+    self.tableSections = [NSArray arrayWithArray:marr];
 }
 
 - (BlogDetailsSection *)generalSectionViewModel

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -205,19 +205,19 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"View Site", @"Action title. Opens the user's site in an in-app browser")
                                                     image:[UIImage imageNamed:@"icon-menu-viewsite"]
                                                  callback:^{
-                                                     [weakSelf showViewSiteForBlog];
+                                                     [weakSelf showViewSite];
                                                  }]];
 
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"WP Admin", @"Action title. Noun. Opens the user's WordPress Admin in an external browser.")
                                                     image:[UIImage imageNamed:@"icon-menu-viewadmin"]
                                                  callback:^{
-                                                     [weakSelf showViewAdminForBlog];
+                                                     [weakSelf showViewAdmin];
                                                  }]];
 
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
                                                     image:[UIImage imageNamed:@"icon-menu-stats"]
                                                  callback:^{
-                                                     [weakSelf showStatsForBlog];
+                                                     [weakSelf showStats];
                                                  }]];
 
     return [[BlogDetailsSection alloc] initWithTitle:nil andRows:rows];
@@ -230,19 +230,19 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Blog Posts", @"Noun. Title. Links to the blog's Posts screen.")
                                                     image:[UIImage imageNamed:@"icon-menu-posts"]
                                                  callback:^{
-                                                     [weakSelf showPostListForBlog];
+                                                     [weakSelf showPostList];
                                                  }]];
 
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Pages", @"Noun. Title. Links to the blog's Pages screen.")
                                                     image:[UIImage imageNamed:@"icon-menu-pages"]
                                                  callback:^{
-                                                     [weakSelf showPageListForBlog];
+                                                     [weakSelf showPageList];
                                                  }]];
 
     BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Comments", @"Noun. Title. Links to the blog's Comments screen.")
                                                           image:[UIImage imageNamed:@"icon-menu-comments"]
                                                        callback:^{
-                                                           [weakSelf showCommentsForBlog];
+                                                           [weakSelf showComments];
                                                        }];
     NSUInteger numberOfPendingComments = [self.blog numberOfPendingComments];
     if (numberOfPendingComments > 0) {
@@ -261,7 +261,7 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Themes", @"Themes option in the blog details")
                                                     image:[UIImage imageNamed:@"icon-menu-theme"]
                                                  callback:^{
-                                                     [weakSelf showThemesForBlog];
+                                                     [weakSelf showThemes];
                                                  }]];
 
     NSString *title =NSLocalizedString(@"Personalize", @"Section title for the personalize table section in the blog details screen.");
@@ -273,17 +273,18 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
 
-#ifdef WP_PEOPLE_ENABLED
-    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"People", @"Noun. Title. Links to the people management feature.")
-                                                    image:[UIImage imageNamed:@"icon-menu-people"]
-                                                 callback:^{
-                                                     [weakSelf showPeopleForBlog];
-                                                 }]];
-#endif
+    if ([Feature enabled:FeatureFlagPeople]) {
+        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"People", @"Noun. Title. Links to the people management feature.")
+                                                        image:[UIImage imageNamed:@"icon-menu-people"]
+                                                     callback:^{
+                                                         [weakSelf showPeople];
+                                                     }]];
+    }
+
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Settings", @"Noun. Title. Links to the blog's Settings screen.")
                                                     image:[UIImage imageNamed:@"icon-menu-settings"]
                                                  callback:^{
-                                                     [weakSelf showSettingsForBlog];
+                                                     [weakSelf showSettings];
                                                  }]];
 
     NSString *title = NSLocalizedString(@"Configure", @"Section title for the configure table section in the blog details screen");
@@ -419,7 +420,7 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
 
 #pragma mark - Private methods
 
-- (void)showCommentsForBlog
+- (void)showComments
 {
     [WPAppAnalytics track:WPAnalyticsStatOpenedComments withBlog:self.blog];
     CommentsViewController *controller = [[CommentsViewController alloc] initWithStyle:UITableViewStyleGrouped];
@@ -427,21 +428,21 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)showPostListForBlog
+- (void)showPostList
 {
     [WPAppAnalytics track:WPAnalyticsStatOpenedPosts withBlog:self.blog];
     PostListViewController *controller = [PostListViewController controllerWithBlog:self.blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)showPageListForBlog
+- (void)showPageList
 {
     [WPAppAnalytics track:WPAnalyticsStatOpenedPages withBlog:self.blog];
     PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)showPeopleForBlog
+- (void)showPeople
 {
     // TODO(@koke, 2015-11-02): add analytics
     PeopleViewController *controller = [[UIStoryboard storyboardWithName:@"People" bundle:nil] instantiateInitialViewController];
@@ -449,14 +450,14 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)showSettingsForBlog
+- (void)showSettings
 {
     [WPAppAnalytics track:WPAnalyticsStatOpenedSiteSettings withBlog:self.blog];
     SiteSettingsViewController *controller = [[SiteSettingsViewController alloc] initWithBlog:self.blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)showStatsForBlog
+- (void)showStats
 {
     [WPAppAnalytics track:WPAnalyticsStatStatsAccessed withBlog:self.blog];
     StatsViewController *statsView = [StatsViewController new];
@@ -464,7 +465,7 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
     [self.navigationController pushViewController:statsView animated:YES];
 }
 
-- (void)showThemesForBlog
+- (void)showThemes
 {
     [WPAppAnalytics track:WPAnalyticsStatThemesAccessedThemeBrowser withBlog:self.blog];
     ThemeBrowserViewController *viewController = [ThemeBrowserViewController browserWithBlog:self.blog];
@@ -472,7 +473,7 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
                                          animated:YES];
 }
 
-- (void)showViewSiteForBlog
+- (void)showViewSite
 {
     [WPAppAnalytics track:WPAnalyticsStatOpenedViewSite withBlog:self.blog];
     NSURL *targetURL = [NSURL URLWithString:self.blog.homeURL];
@@ -486,7 +487,7 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
     [self presentViewController:navController animated:YES completion:nil];
 }
 
-- (void)showViewAdminForBlog
+- (void)showViewAdmin
 {
     if (![ReachabilityUtils isInternetReachable]) {
         [ReachabilityUtils showAlertNoInternetConnection];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1,44 +1,70 @@
 #import "BlogDetailsViewController.h"
-#import "SiteSettingsViewController.h"
-#import "CommentsViewController.h"
-#import "StatsViewController.h"
-#import "WPWebViewController.h"
-#import "WPTableViewCell.h"
-#import "ContextManager.h"
+
 #import "AccountService.h"
 #import "BlogService.h"
-#import "WPTableViewSectionHeaderFooterView.h"
 #import "BlogDetailHeaderView.h"
-#import "ReachabilityUtils.h"
-#import "WPAccount.h"
+#import "CommentsViewController.h"
+#import "ContextManager.h"
 #import "PostListViewController.h"
 #import "PageListViewController.h"
-#import "WPGUIConstants.h"
-#import "Wordpress-Swift.h"
+#import "ReachabilityUtils.h"
+#import "SiteSettingsViewController.h"
+#import "StatsViewController.h"
+#import "WPAccount.h"
 #import "WPAppAnalytics.h"
+#import "WPGUIConstants.h"
+#import "WPStyleGuide+ReadableMargins.h"
+#import "WPTableViewCell.h"
+#import "WPTableViewSectionHeaderFooterView.h"
+#import "WPWebViewController.h"
+#import "Wordpress-Swift.h"
 
-const NSInteger BlogDetailsRowViewSite = 0;
-const NSInteger BlogDetailsRowViewAdmin = 1;
-const NSInteger BlogDetailsRowStats = 2;
-const NSInteger BlogDetailsRowBlogPosts = 0;
-const NSInteger BlogDetailsRowPages = 1;
-const NSInteger BlogDetailsRowComments = 2;
-#ifdef WP_PEOPLE_ENABLED
-const NSInteger BlogDetailsRowPeople = 0;
-const NSInteger BlogDetailsRowEditSite = 1;
-#else
-const NSInteger BlogDetailsRowPeople = -1;
-const NSInteger BlogDetailsRowEditSite = 0;
-#endif
-const NSInteger BlogDetailsRowThemes = 0;
 
-typedef NS_ENUM(NSInteger, TableSectionContentType) {
-    TableViewSectionGeneralType = 0,
-    TableViewSectionPublishType,
-    TableViewSectionAppearance,
-    TableViewSectionConfigurationType,
-    TableViewSectionCount
-};
+#pragma mark - Helper Classes for Blog Details view model.
+
+@interface BlogDetailsRow : NSObject
+
+@property (nonatomic, strong) NSString *title;
+@property (nonatomic, strong) UIImage *image;
+@property (nonatomic, strong) NSString *detail;
+@property (nonatomic, copy) void (^callback)();
+
+@end
+
+@implementation BlogDetailsRow
+
+- (instancetype)initWithTitle:(NSString * __nonnull)title image:(UIImage * __nonnull)image callback:(void(^)())callback
+{
+    self = [super init];
+    if (self) {
+        _title = title;
+        _image = image;
+        _callback = callback;
+    }
+    return self;
+}
+
+@end
+
+@interface BlogDetailsSection : NSObject
+
+@property (nonatomic, strong) NSString *title;
+@property (nonatomic, strong) NSArray *rows;
+
+@end
+
+@implementation BlogDetailsSection
+- (instancetype)initWithTitle:(NSString *)title andRows:(NSArray *)rows
+{
+    self = [super init];
+    if (self) {
+        _title = title;
+        _rows = rows;
+    }
+    return self;
+}
+@end
+
 
 static NSString *const BlogDetailsCellIdentifier = @"BlogDetailsCell";
 NSString * const WPBlogDetailsRestorationID = @"WPBlogDetailsID";
@@ -46,14 +72,7 @@ NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
 NSInteger const BlogDetailHeaderViewHorizontalMarginiPhone = 15;
 NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
 
-NSInteger const BlogDetailsRowCountForSectionGeneralType = 3;
-NSInteger const BlogDetailsRowCountForSectionPublishType = 3;
-NSInteger const BlogDetailsRowCountForSectionAppearance = 1;
-#ifdef WP_PEOPLE_ENABLED
-NSInteger const BlogDetailsRowCountForSectionConfigurationType = 2;
-#else
-NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
-#endif
+#pragma mark -
 
 @interface BlogDetailsViewController () <UIActionSheetDelegate, UIAlertViewDelegate>
 
@@ -64,7 +83,6 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 @end
 
 @implementation BlogDetailsViewController
-@synthesize blog = _blog;
 
 + (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
 {
@@ -91,6 +109,9 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     return viewController;
 }
 
+
+#pragma mark = Lifecycle Methods
+
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -116,16 +137,6 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 {
     [super viewDidLoad];
 
-    self.tableSections = @[@(TableViewSectionGeneralType),
-                           @(TableViewSectionPublishType)
-                          ];
-    
-    if ([self.blog supports:BlogFeatureThemeBrowsing]) {
-        self.tableSections = [self.tableSections arrayByAddingObject:@(TableViewSectionAppearance)];
-    }
-
-    self.tableSections = [self.tableSections arrayByAddingObject:@(TableViewSectionConfigurationType)];
-
     [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:BlogDetailsCellIdentifier];
@@ -148,20 +159,154 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     [self.headerView setBlog:_blog];
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+
+    [self.headerView setBlog:self.blog];
+    [self updateHeaderViewConstraintsForTraitCollection:self.traitCollection];
+
+    // Configure and reload table data when appearing to ensure pending comment count is updated
+    [self configureTableViewData];
+    [self.tableView reloadData];
+}
+
+- (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
+{
+    [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
+
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        [self updateHeaderViewConstraintsForTraitCollection:newCollection];
+    } completion:nil];
+}
+
+
+#pragma mark - Data Model setup
+
+
+- (NSArray *)configureTableViewData
+{
+    NSMutableArray *marr = [NSMutableArray array];
+
+    [marr addObject:[self generalSectionViewModel]];
+    [marr addObject:[self publishTypeSectionViewModel]];
+    if ([self.blog supports:BlogFeatureThemeBrowsing]) {
+        [marr addObject:[self appearanceSectionViewModel]];
+    }
+    [marr addObject:[self configurationSectionViewModel]];
+
+    return marr;
+}
+
+- (BlogDetailsSection *)generalSectionViewModel
+{
+    __weak __typeof(self) weakSelf = self;
+    NSMutableArray *rows = [NSMutableArray array];
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"View Site", @"Action title. Opens the user's site in an in-app browser")
+                                                    image:[UIImage imageNamed:@"icon-menu-viewsite"]
+                                                 callback:^{
+                                                     [weakSelf showViewSiteForBlog];
+                                                 }]];
+
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"WP Admin", @"Action title. Noun. Opens the user's WordPress Admin in an external browser.")
+                                                    image:[UIImage imageNamed:@"icon-menu-viewadmin"]
+                                                 callback:^{
+                                                     [weakSelf showViewAdminForBlog];
+                                                 }]];
+
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
+                                                    image:[UIImage imageNamed:@"icon-menu-stats"]
+                                                 callback:^{
+                                                     [weakSelf showStatsForBlog];
+                                                 }]];
+
+    return [[BlogDetailsSection alloc] initWithTitle:nil andRows:rows];
+}
+
+- (BlogDetailsSection *)publishTypeSectionViewModel
+{
+    __weak __typeof(self) weakSelf = self;
+    NSMutableArray *rows = [NSMutableArray array];
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Blog Posts", @"Noun. Title. Links to the blog's Posts screen.")
+                                                    image:[UIImage imageNamed:@"icon-menu-posts"]
+                                                 callback:^{
+                                                     [weakSelf showPostListForBlog];
+                                                 }]];
+
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Pages", @"Noun. Title. Links to the blog's Pages screen.")
+                                                    image:[UIImage imageNamed:@"icon-menu-pages"]
+                                                 callback:^{
+                                                     [weakSelf showPageListForBlog];
+                                                 }]];
+
+    BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Comments", @"Noun. Title. Links to the blog's Comments screen.")
+                                                          image:[UIImage imageNamed:@"icon-menu-comments"]
+                                                       callback:^{
+                                                           [weakSelf showCommentsForBlog];
+                                                       }];
+    NSUInteger numberOfPendingComments = [self.blog numberOfPendingComments];
+    if (numberOfPendingComments > 0) {
+        row.detail = [NSString stringWithFormat:@"%d", numberOfPendingComments];
+    }
+    [rows addObject:row];
+
+    NSString *title = NSLocalizedString(@"Publish", @"Section title for the publish table section in the blog details screen");
+    return [[BlogDetailsSection alloc] initWithTitle:title andRows:rows];
+}
+
+- (BlogDetailsSection *)appearanceSectionViewModel
+{
+    __weak __typeof(self) weakSelf = self;
+    NSMutableArray *rows = [NSMutableArray array];
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Themes", @"Themes option in the blog details")
+                                                    image:[UIImage imageNamed:@"icon-menu-theme"]
+                                                 callback:^{
+                                                     [weakSelf showThemesForBlog];
+                                                 }]];
+
+    NSString *title =NSLocalizedString(@"Personalize", @"Section title for the personalize table section in the blog details screen.");
+    return [[BlogDetailsSection alloc] initWithTitle:title andRows:rows];
+}
+
+- (BlogDetailsSection *)configurationSectionViewModel
+{
+    __weak __typeof(self) weakSelf = self;
+    NSMutableArray *rows = [NSMutableArray array];
+
+#ifdef WP_PEOPLE_ENABLED
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"People", @"Noun. Title. Links to the people management feature.")
+                                                    image:[UIImage imageNamed:@"icon-menu-people"]
+                                                 callback:^{
+                                                     [weakSelf showPeopleForBlog];
+                                                 }]];
+#endif
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Settings", @"Noun. Title. Links to the blog's Settings screen.")
+                                                    image:[UIImage imageNamed:@"icon-menu-settings"]
+                                                 callback:^{
+                                                     [weakSelf showSettingsForBlog];
+                                                 }]];
+
+    NSString *title = NSLocalizedString(@"Configure", @"Section title for the configure table section in the blog details screen");
+    return [[BlogDetailsSection alloc] initWithTitle:title andRows:rows];
+}
+
+
+#pragma mark - Configuration
+
 - (void)configureBlogDetailHeader
 {
     // Wrapper view
     UIView *headerWrapper = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, CGRectGetWidth(self.view.bounds), BlogDetailHeaderViewBlavatarSize + BlogDetailHeaderViewVerticalMargin * 2)];
     self.tableView.tableHeaderView = headerWrapper;
-    
+
     // Blog detail header view
     self.headerView = [[BlogDetailHeaderView alloc] initWithFrame:CGRectMake(0.0, 0.0, CGRectGetWidth(self.view.bounds), BlogDetailHeaderViewBlavatarSize)];
     self.headerView.translatesAutoresizingMaskIntoConstraints = NO;
     [headerWrapper addSubview:self.headerView];
-    
+
     NSDictionary *views = NSDictionaryOfVariableBindings(_headerView);
     NSDictionary *metrics = @{@"verticalMargin": @(BlogDetailHeaderViewVerticalMargin)};
-    
+
     // Constrain the headerView vertically
     [headerWrapper addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(verticalMargin)-[_headerView]-(verticalMargin)-|"
                                                                           options:0
@@ -172,27 +317,27 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 - (void)updateHeaderViewConstraintsForTraitCollection:(UITraitCollection *)traitCollection
 {
     UIView *headerWrapper = self.tableView.tableHeaderView;
-    
+
     // We only remove the constraints we've added, not the view's autoresizing constraints
     [headerWrapper removeConstraints:self.headerViewHorizontalConstraints];
-    
+
     if (traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact || traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
         NSDictionary *views = NSDictionaryOfVariableBindings(_headerView);
         NSDictionary *metrics = @{@"horizontalMargin": @(BlogDetailHeaderViewHorizontalMarginiPhone)};
-        
+
         self.headerViewHorizontalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"|-(horizontalMargin)-[_headerView]-(horizontalMargin)-|"
                                                                                        options:0
                                                                                        metrics:metrics
                                                                                          views:views];
     } else {
         NSMutableArray *constraints = [NSMutableArray new];
-        
+
         CGFloat headerWidth = WPTableViewFixedWidth;
         [constraints addObject:[self.headerView.widthAnchor constraintEqualToConstant:headerWidth]];
-         
+
         // Center the headerView inside the wrapper
         [constraints addObject:[self.headerView.centerXAnchor constraintEqualToAnchor:headerWrapper.centerXAnchor]];
-         
+
         self.headerViewHorizontalConstraints = [constraints copy];
     }
 
@@ -200,29 +345,6 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     [headerWrapper layoutIfNeeded];
 }
 
-- (void)viewWillAppear:(BOOL)animated
-{
-    [super viewWillAppear:animated];
-    
-    [self.headerView setBlog:self.blog];
-    [self updateHeaderViewConstraintsForTraitCollection:self.traitCollection];
-
-    [self.tableView reloadData];
-}
-
-- (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
-{
-    [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
-    
-    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-        [self updateHeaderViewConstraintsForTraitCollection:newCollection];
-    } completion:nil];
-}
-
-- (void)setBlog:(Blog *)blog
-{
-    _blog = blog;
-}
 
 #pragma mark - Table view data source
 
@@ -233,88 +355,17 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    NSInteger realSection = [self.tableSections[section] integerValue];
-    switch (realSection) {
-        case TableViewSectionGeneralType:
-            return BlogDetailsRowCountForSectionGeneralType;
-            break;
-        case TableViewSectionPublishType:
-            return BlogDetailsRowCountForSectionPublishType;
-            break;
-        case TableViewSectionAppearance:
-            return BlogDetailsRowCountForSectionAppearance;
-            break;
-        case TableViewSectionConfigurationType:
-            return BlogDetailsRowCountForSectionConfigurationType;
-            break;
-    }
-
-    return 0;
+    BlogDetailsSection *detailSection = [self.tableSections objectAtIndex:section];
+    return [detailSection.rows count];
 }
 
 - (void)configureCell:(UITableViewCell *)cell atIndexPath:(NSIndexPath *)indexPath
 {
-    NSInteger section = [self.tableSections[indexPath.section] integerValue];
-    switch (section) {
-        case TableViewSectionGeneralType:
-            switch (indexPath.row) {
-                case BlogDetailsRowViewSite:
-                    cell.textLabel.text = NSLocalizedString(@"View Site", nil);
-                    cell.imageView.image = [UIImage imageNamed:@"icon-menu-viewsite"];
-                    break;
-                case BlogDetailsRowViewAdmin:
-                    cell.textLabel.text = NSLocalizedString(@"WP Admin", nil);
-                    cell.imageView.image = [UIImage imageNamed:@"icon-menu-viewadmin"];
-                    break;
-                case BlogDetailsRowStats:
-                    cell.textLabel.text = NSLocalizedString(@"Stats", nil);
-                    cell.imageView.image = [UIImage imageNamed:@"icon-menu-stats"];
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case TableViewSectionPublishType:
-            switch (indexPath.row) {
-                case BlogDetailsRowBlogPosts:
-                    cell.textLabel.text = NSLocalizedString(@"Blog Posts", nil);
-                    cell.imageView.image = [UIImage imageNamed:@"icon-menu-posts"];
-                    break;
-                case BlogDetailsRowPages:
-                    cell.textLabel.text = NSLocalizedString(@"Pages", nil);
-                    cell.imageView.image = [UIImage imageNamed:@"icon-menu-pages"];
-                    break;
-                case BlogDetailsRowComments:
-                    cell.textLabel.text = NSLocalizedString(@"Comments", nil);
-                    cell.imageView.image = [UIImage imageNamed:@"icon-menu-comments"];
-                    NSUInteger numberOfPendingComments = [self.blog numberOfPendingComments];
-                    if (numberOfPendingComments > 0) {
-                        cell.detailTextLabel.text = [NSString stringWithFormat:@"%d", numberOfPendingComments];
-                    }
-                    break;
-                default:
-                    break;
-            }
-            break;
-        case TableViewSectionAppearance:
-            cell.textLabel.text = NSLocalizedString(@"Themes", @"Themes option in the blog details");
-            cell.imageView.image = [UIImage imageNamed:@"icon-menu-theme"];
-            break;
-        case TableViewSectionConfigurationType:
-            switch (indexPath.row) {
-                case BlogDetailsRowPeople:
-                    cell.textLabel.text = NSLocalizedString(@"People", nil);
-                    cell.imageView.image = [UIImage imageNamed:@"icon-menu-people"];
-                    break;
-                case BlogDetailsRowEditSite:
-                    cell.textLabel.text = NSLocalizedString(@"Settings", nil);
-                    cell.imageView.image = [UIImage imageNamed:@"icon-menu-settings"];
-                    break;
-
-                default:
-                    break;
-            }
-    }
+    BlogDetailsSection *section = [self.tableSections objectAtIndex:indexPath.section];
+    BlogDetailsRow *row = [section.rows objectAtIndex:indexPath.row];
+    cell.textLabel.text = row.title;
+    cell.detailTextLabel.text = row.detail;
+    cell.imageView.image = row.image;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -331,65 +382,10 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
-    
-    NSInteger section = [self.tableSections[indexPath.section] integerValue];
-    switch (section) {
-        case TableViewSectionGeneralType:
-            switch (indexPath.row) {
-                case BlogDetailsRowViewSite:
-                    [self showViewSiteForBlog:self.blog];
-                    break;
-                case BlogDetailsRowViewAdmin:
-                    [self showViewAdminForBlog:self.blog];
-                    break;
-                case BlogDetailsRowStats:
-                    [self showStatsForBlog:self.blog];
-                    break;
-                default:
-                    NSAssert(NO, @"Row Handling not implemented");
-                    break;
-            }
-            break;
-        case TableViewSectionPublishType:
-            switch (indexPath.row) {
-                case BlogDetailsRowBlogPosts:
-                    [self showPostListForBlog:self.blog];
-                    break;
-                case BlogDetailsRowPages:
-                    [self showPageListForBlog:self.blog];
-                    break;
-                case BlogDetailsRowComments:
-                    [self showCommentsForBlog:self.blog];
-                    break;
-                default:
-                    NSAssert(NO, @"Row Handling not implemented");
-                    break;
-            }
-            break;
-        case TableViewSectionAppearance:
-            switch (indexPath.row) {
-                case BlogDetailsRowThemes:
-                    [self showThemesForBlog:self.blog];
-                    break;
-                default:
-                    NSAssert(NO, @"Row Handling not implemented");
-                    break;
-            }
-            break;
-        case TableViewSectionConfigurationType:
-            switch (indexPath.row) {
-                case BlogDetailsRowPeople:
-                    [self showPeopleForBlog:self.blog];
-                    break;
-                case BlogDetailsRowEditSite:
-                    [self showSettingsForBlog:self.blog];
-                    break;
-                default:
-                    NSAssert(NO, @"Row Handling not implemented");
-                    break;
-            }
-            break;
-    }
+
+    BlogDetailsSection *section = [self.tableSections objectAtIndex:indexPath.section];
+    BlogDetailsRow *row = [section.rows objectAtIndex:indexPath.row];
+    row.callback();
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -409,7 +405,7 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     if (title.length == 0) {
         return nil;
     }
-    
+
     WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
     header.title = title;
     return header;
@@ -417,106 +413,89 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
-    NSString *headingTitle = nil;
-    NSInteger realSection = [self.tableSections[section] integerValue];
-    switch (realSection) {
-        case TableViewSectionGeneralType:
-            // no header here
-        break;
-        case TableViewSectionPublishType:
-            headingTitle = NSLocalizedString(@"Publish", @"Section title for the publish table section in the blog details screen");
-        break;
-        case TableViewSectionAppearance:
-            headingTitle = NSLocalizedString(@"Personalize",
-                                             @"Section title for the personalize table section in the" \
-                                             " blog details screen.");
-        break;
-        case TableViewSectionConfigurationType:
-            headingTitle = NSLocalizedString(@"Configure", @"Section title for the configure table section in the blog details screen");
-        break;
-    }
-    return headingTitle;
+    BlogDetailsSection *detailSection = [self.tableSections objectAtIndex:section];
+    return detailSection.title;
 }
 
 #pragma mark - Private methods
 
-- (void)showCommentsForBlog:(Blog *)blog
+- (void)showCommentsForBlog
 {
-    [WPAppAnalytics track:WPAnalyticsStatOpenedComments withBlog:blog];
+    [WPAppAnalytics track:WPAnalyticsStatOpenedComments withBlog:self.blog];
     CommentsViewController *controller = [[CommentsViewController alloc] initWithStyle:UITableViewStyleGrouped];
-    controller.blog = blog;
+    controller.blog = self.blog;
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)showPostListForBlog:(Blog *)blog
+- (void)showPostListForBlog
 {
-    [WPAppAnalytics track:WPAnalyticsStatOpenedPosts withBlog:blog];
-    PostListViewController *controller = [PostListViewController controllerWithBlog:blog];
+    [WPAppAnalytics track:WPAnalyticsStatOpenedPosts withBlog:self.blog];
+    PostListViewController *controller = [PostListViewController controllerWithBlog:self.blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)showPageListForBlog:(Blog *)blog
+- (void)showPageListForBlog
 {
-    [WPAppAnalytics track:WPAnalyticsStatOpenedPages withBlog:blog];
-    PageListViewController *controller = [PageListViewController controllerWithBlog:blog];
+    [WPAppAnalytics track:WPAnalyticsStatOpenedPages withBlog:self.blog];
+    PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)showPeopleForBlog:(Blog *)blog
+- (void)showPeopleForBlog
 {
     // TODO(@koke, 2015-11-02): add analytics
     PeopleViewController *controller = [[UIStoryboard storyboardWithName:@"People" bundle:nil] instantiateInitialViewController];
-    controller.blog = blog;
+    controller.blog = self.blog;
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)showSettingsForBlog:(Blog *)blog
+- (void)showSettingsForBlog
 {
-    [WPAppAnalytics track:WPAnalyticsStatOpenedSiteSettings withBlog:blog];
-    SiteSettingsViewController *controller = [[SiteSettingsViewController alloc] initWithBlog:blog];
+    [WPAppAnalytics track:WPAnalyticsStatOpenedSiteSettings withBlog:self.blog];
+    SiteSettingsViewController *controller = [[SiteSettingsViewController alloc] initWithBlog:self.blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
 
-- (void)showStatsForBlog:(Blog *)blog
+- (void)showStatsForBlog
 {
-    [WPAppAnalytics track:WPAnalyticsStatStatsAccessed withBlog:blog];
+    [WPAppAnalytics track:WPAnalyticsStatStatsAccessed withBlog:self.blog];
     StatsViewController *statsView = [StatsViewController new];
-    statsView.blog = blog;
+    statsView.blog = self.blog;
     [self.navigationController pushViewController:statsView animated:YES];
 }
 
-- (void)showThemesForBlog:(Blog *)blog
+- (void)showThemesForBlog
 {
-    [WPAppAnalytics track:WPAnalyticsStatThemesAccessedThemeBrowser withBlog:blog];
-    ThemeBrowserViewController *viewController = [ThemeBrowserViewController browserWithBlog:blog];
+    [WPAppAnalytics track:WPAnalyticsStatThemesAccessedThemeBrowser withBlog:self.blog];
+    ThemeBrowserViewController *viewController = [ThemeBrowserViewController browserWithBlog:self.blog];
     [self.navigationController pushViewController:viewController
                                          animated:YES];
 }
 
-- (void)showViewSiteForBlog:(Blog *)blog
+- (void)showViewSiteForBlog
 {
-    [WPAppAnalytics track:WPAnalyticsStatOpenedViewSite withBlog:blog];
-    NSURL *targetURL = [NSURL URLWithString:blog.homeURL];
+    [WPAppAnalytics track:WPAnalyticsStatOpenedViewSite withBlog:self.blog];
+    NSURL *targetURL = [NSURL URLWithString:self.blog.homeURL];
     WPWebViewController *webViewController = [WPWebViewController webViewControllerWithURL:targetURL];
-    webViewController.authToken = blog.authToken;
-    webViewController.username = blog.usernameForSite;
-    webViewController.password = blog.password;
-    webViewController.wpLoginURL = [NSURL URLWithString:blog.loginUrl];
-    
+    webViewController.authToken = self.blog.authToken;
+    webViewController.username = self.blog.usernameForSite;
+    webViewController.password = self.blog.password;
+    webViewController.wpLoginURL = [NSURL URLWithString:self.blog.loginUrl];
+
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];
 }
 
-- (void)showViewAdminForBlog:(Blog *)blog
+- (void)showViewAdminForBlog
 {
     if (![ReachabilityUtils isInternetReachable]) {
         [ReachabilityUtils showAlertNoInternetConnection];
         return;
     }
 
-    [WPAppAnalytics track:WPAnalyticsStatOpenedViewAdmin withBlog:blog];
-    
-    NSString *dashboardUrl = [blog.xmlrpc stringByReplacingOccurrencesOfString:@"xmlrpc.php" withString:@"wp-admin/"];
+    [WPAppAnalytics track:WPAnalyticsStatOpenedViewAdmin withBlog:self.blog];
+
+    NSString *dashboardUrl = [self.blog.xmlrpc stringByReplacingOccurrencesOfString:@"xmlrpc.php" withString:@"wp-admin/"];
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:dashboardUrl]];
 }
 
@@ -529,7 +508,7 @@ NSInteger const BlogDetailsRowCountForSectionConfigurationType = 1;
     if ([deletedObjects containsObject:self.blog]) {
         [self.navigationController popToRootViewControllerAnimated:NO];
     }
-    
+
     NSSet *updatedObjects = note.userInfo[NSUpdatedObjectsKey];
     if ([updatedObjects containsObject:self.blog]) {
         self.navigationItem.title = self.blog.settings.name;


### PR DESCRIPTION
The forthcoming sharing feature will be enabled/disabled via a feature flag and accessible from the Blog Details screen.
This change makes it a bit easier (and saner) to present cells conditionally, and avoids some complicated `const` wrangling.
The approach is similar to what was done in ImmuTable and should be considered as a stopgap/stepping stone til `ImmuTable` is usable in ObjC classes, or when `BlogDetailsViewController` is refactored to Swift.

To test: 
Test each cell and confirm that the correct content is opened.  Do this for a wpcom and self-hosted site. Note that the People feature is currently crashing for self-hosted sites but is only available in dev builds. 

Needs review: @koke 