### PR TITLE
Move the awful layout code into the right lifecycle method

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
@@ -75,7 +75,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 
 - (instancetype)initWithBlog:(Blog *)blog
 {
-    self = [super initWithNibName:nil bundle:nil];
+    self = [self init];
     if (self) {
         _blog = blog;
         _showFullScreen = YES;

--- a/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
@@ -75,7 +75,7 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 
 - (instancetype)initWithBlog:(Blog *)blog
 {
-    self = [super init];
+    self = [super initWithNibName:nil bundle:nil];
     if (self) {
         _blog = blog;
         _showFullScreen = YES;
@@ -95,6 +95,8 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration
 {
+    [super willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
+    
     [self layoutControls];
 }
 
@@ -104,9 +106,23 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
+
     [self.navigationController setNavigationBarHidden:self.showFullScreen animated:animated];
+}
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+
     [self reloadInterface];
     [self updateForm];
+}
+
+
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+
     [self checkForJetpack];
 }
 
@@ -128,13 +144,6 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
     [self addControls];
     [self addGesturesRecognizer];
     [self addSkipButtonIfNeeded];
-}
-
-// This resolves a crash due to JetpackSettingsViewController previously using a .xib.
-// Source: http://stackoverflow.com/questions/17708292/not-key-value-coding-compliant-error-from-deleted-xib
-- (void)loadView
-{
-    [super loadView];
 }
 
 - (void)addControls


### PR DESCRIPTION
Fixes #4665 

Corrects a problem with layout being called at the wrong point in the view controller lifecycle. This fixes a glitch with the UI jumping upwards after a remote request has completed.

The ultimate solution is to replace the UI with something with autolayout and not all manual layout code. This would resolve #1914 as well.

**Testing:**
1. Start with a fresh app install.
2. Add self-hosted site that does not have Jetpack installed.
3. Attempt to view settings.
4. View (you should install Jetpack notice) should not jump after a couple seconds.

Also -
1. Start with a fresh app install.
2. Add self-hosted site that has Jetpack installed (and connected).
3. Attempt to view settings.
4. View (log into your Jetpack) should not jump after a couple seconds.

Needs Review: @aerych 