### PR TITLE
Media: Use jpg instead of jpeg for uploaded image extension

### DIFF
--- a/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
@@ -119,7 +119,11 @@
     NSString *path = media.localURL;
     NSString *type = media.mimeType;
     NSString *filename = media.file;
-    
+    // Even though jpeg is a valid extension, use jpg instead for the widest possible
+    // support.  Some third-party image related plugins prefer the .jpg extension.
+    // See https://github.com/wordpress-mobile/WordPress-iOS/issues/4663
+    filename = [filename stringByReplacingOccurrencesOfString:@".jpeg" withString:@".jpg"];
+
     NSDictionary *data = @{
                            @"name": filename,
                            @"type": type,


### PR DESCRIPTION
Closes #4663. 

Arguably the plugins in question should support the jpeg extension since its valid, but drawing that line in the sand doesn't help our users.  The extensions are interchangeable and anecdotal experience suggests jpg is more common, as does a bit of [googling](http://stackoverflow.com/questions/23424399/jpg-vs-jpeg-image-formats/23424447#23424447). Making this change is a nice gesture if nothing else. 

@SergioEstevao, thoughts on this? 

Needs review: @SergioEstevao 