### PR TITLE
Use our custom add icon for the addSitebutton.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -79,7 +79,8 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
                                                                   action:nil];
     [self.navigationItem setBackBarButtonItem:backButton];
     
-    self.addSiteButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd
+    self.addSiteButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"icon-post-add"]
+                                                                                    style:UIBarButtonItemStylePlain
                                                                                    target:self
                                                                                    action:@selector(addSite)];
     UIBarButtonItem *searchButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"icon-post-search"]


### PR DESCRIPTION
The only icon that needed to be replaced on the My Sites screen is the Add icon, which is currently using the system standard add icon. This swaps it out in favor of the Add gridicon.