### PR TITLE
Rename ImmuTableActionType to ImmuTableAction

### DIFF
--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -12,7 +12,7 @@
      struct DestructiveButtonRow: ImmuTableRow {
          static let cell = ImmuTableCell.Class(UITableViewCell.self)
          let title: String
-         let action: ImmuTableActionType?
+         let action: ImmuTableAction?
 
          func configureCell(cell: UITableViewCell) {
              cell.textLabel?.text = title
@@ -137,7 +137,7 @@ public protocol ImmuTableRow {
          }
 
      */
-    var action: ImmuTableActionType? { get }
+    var action: ImmuTableAction? { get }
 
     /// This method is called when an associated cell needs to be configured.
     /// - precondition: You can assume that the passed cell is of the type defined
@@ -297,7 +297,7 @@ public class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewD
 // MARK: - Type aliases
 
 
-public typealias ImmuTableActionType = (ImmuTableRow) -> Void
+public typealias ImmuTableAction = (ImmuTableRow) -> Void
 
 
 // MARK: - Internal testing helpers

--- a/WordPress/Classes/ViewRelated/Cells/WPImmuTableCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/WPImmuTableCells.swift
@@ -90,9 +90,9 @@ struct NavigationItemRow : ImmuTableRow {
 
     let title: String
     let icon: UIImage?
-    let action: ImmuTableActionType?
+    let action: ImmuTableAction?
 
-    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, action: ImmuTableActionType) {
+    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, action: ImmuTableAction) {
         self.title = title
         self.icon = icon
         self.action = action
@@ -112,10 +112,10 @@ struct BadgeNavigationItemRow: ImmuTableRow {
 
     let title: String
     let icon: UIImage?
-    let action: ImmuTableActionType?
+    let action: ImmuTableAction?
     let badgeCount: Int
 
-    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, action: ImmuTableActionType) {
+    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, action: ImmuTableAction) {
         self.title = title
         self.icon = icon
         self.badgeCount = badgeCount
@@ -139,7 +139,7 @@ struct EditableTextRow : ImmuTableRow {
 
     let title: String
     let value: String
-    let action: ImmuTableActionType?
+    let action: ImmuTableAction?
 
     func configureCell(cell: UITableViewCell) {
         cell.textLabel?.text = title
@@ -155,7 +155,7 @@ struct TextRow : ImmuTableRow {
 
     let title: String
     let value: String
-    let action: ImmuTableActionType? = nil
+    let action: ImmuTableAction? = nil
 
     func configureCell(cell: UITableViewCell) {
         cell.textLabel?.text = title
@@ -170,7 +170,7 @@ struct LinkRow : ImmuTableRow {
     static let cell = ImmuTableCell.Class(WPTableViewCellValue1)
 
     let title: String
-    let action: ImmuTableActionType?
+    let action: ImmuTableAction?
 
     func configureCell(cell: UITableViewCell) {
         cell.textLabel?.text = title
@@ -184,7 +184,7 @@ struct LinkWithValueRow : ImmuTableRow {
 
     let title: String
     let value: String
-    let action: ImmuTableActionType?
+    let action: ImmuTableAction?
 
     func configureCell(cell: UITableViewCell) {
         cell.textLabel?.text = title
@@ -198,7 +198,7 @@ struct ButtonRow: ImmuTableRow {
     static let cell = ImmuTableCell.Class(WPTableViewCellDefault)
 
     let title: String
-    let action: ImmuTableActionType?
+    let action: ImmuTableAction?
 
     func configureCell(cell: UITableViewCell) {
         cell.textLabel?.text = title
@@ -212,7 +212,7 @@ struct DestructiveButtonRow: ImmuTableRow {
     static let cell = ImmuTableCell.Class(WPTableViewCellDefault)
 
     let title: String
-    let action: ImmuTableActionType?
+    let action: ImmuTableAction?
 
     func configureCell(cell: UITableViewCell) {
         cell.textLabel?.text = title
@@ -226,7 +226,7 @@ struct SwitchRow: ImmuTableRow {
 
     let title: String
     let value: Bool
-    let action: ImmuTableActionType? = nil
+    let action: ImmuTableAction? = nil
     let onChange: Bool -> Void
 
     func configureCell(cell: UITableViewCell) {
@@ -252,7 +252,7 @@ struct MediaSizeRow: ImmuTableRow {
     let value: Int
     let onChange: Int -> Void
 
-    let action: ImmuTableActionType? = nil
+    let action: ImmuTableAction? = nil
 
     func configureCell(cell: UITableViewCell) {
         let cell = cell as! CellType

--- a/WordPress/Classes/ViewRelated/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/MeViewController.swift
@@ -175,7 +175,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
     // MARK: - Actions
 
-    func pushMyProfile() -> ImmuTableActionType {
+    func pushMyProfile() -> ImmuTableAction {
         return { [unowned self] row in
             WPAppAnalytics.track(.OpenedMyProfile)
             let controller = MyProfileViewController()
@@ -184,7 +184,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         }
     }
 
-    func pushAccountSettings() -> ImmuTableActionType {
+    func pushAccountSettings() -> ImmuTableAction {
         return { [unowned self] row in
             WPAppAnalytics.track(.OpenedAccountSettings)
             let controller = SettingsViewController()
@@ -192,28 +192,28 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         }
     }
 
-    func pushNotificationSettings() -> ImmuTableActionType {
+    func pushNotificationSettings() -> ImmuTableAction {
         return { [unowned self] row in
             let controller = NotificationSettingsViewController()
             self.navigationController?.pushViewController(controller, animated: true)
         }
     }
 
-    func pushHelp() -> ImmuTableActionType {
+    func pushHelp() -> ImmuTableAction {
         return { [unowned self] row in
             let controller = SupportViewController()
             self.navigationController?.pushViewController(controller, animated: true)
         }
     }
 
-    func pushAbout() -> ImmuTableActionType {
+    func pushAbout() -> ImmuTableAction {
         return { [unowned self] row in
             let controller = AboutViewController()
             self.navigationController?.pushViewController(controller, animated: true)
         }
     }
 
-    func presentLogin() -> ImmuTableActionType {
+    func presentLogin() -> ImmuTableAction {
         return { [unowned self] row in
             let controller = LoginViewController()
             controller.onlyDotComAllowed = true
@@ -227,7 +227,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         }
     }
 
-    func confirmLogout() -> ImmuTableActionType {
+    func confirmLogout() -> ImmuTableAction {
         return { [unowned self] row in
             let format = NSLocalizedString("Disconnecting your account will remove all of @%@’s WordPress.com data from this device.", comment: "Label for disconnecting WordPress.com account. The %@ is a placeholder for the user's screen name.")
             let title = String(format: format, self.defaultAccount()!.username)

--- a/WordPress/WordPressTest/ImmuTableTest.swift
+++ b/WordPress/WordPressTest/ImmuTableTest.swift
@@ -34,7 +34,7 @@ class ImmuTableTestViewCellWithNib: UITableViewCell {}
 struct BasicImmuTableRow: ImmuTableRow {
     static let cell = ImmuTableCell.Class(UITableViewCell)
     let title: String
-    var action: ImmuTableActionType? = nil
+    var action: ImmuTableAction? = nil
     func configureCell(cell: UITableViewCell) {
     }
 }
@@ -43,7 +43,7 @@ struct ImageImmuTableRow: ImmuTableRow {
     static let cell = ImmuTableCell.Class(UITableViewCell)
     let title: String
     let image: UIImage
-    var action: ImmuTableActionType? = nil
+    var action: ImmuTableAction? = nil
     func configureCell(cell: UITableViewCell) {
     }
 }
@@ -51,7 +51,7 @@ struct ImageImmuTableRow: ImmuTableRow {
 struct TestImmuTableRow: ImmuTableRow {
     static let cell = ImmuTableCell.Class(TestTableViewCell)
     let title: String
-    var action: ImmuTableActionType? = nil
+    var action: ImmuTableAction? = nil
     func configureCell(cell: UITableViewCell) {
     }
 }
@@ -62,7 +62,7 @@ struct TestWithNibImmuTableRow: ImmuTableRow {
         let nib = UINib(nibName: "ImmuTableTestViewCellWithNib", bundle: NSBundle(forClass: ImmuTableTestViewCellWithNib.self))
         return ImmuTableCell.Nib(nib, CellType.self)
     }()
-    var action: ImmuTableActionType? = nil
+    var action: ImmuTableAction? = nil
     func configureCell(cell: UITableViewCell) {
     }
 }


### PR DESCRIPTION
It just looks better and there's no point in having the `Type` suffix

Needs Review: @jleandroperez 