### PR TITLE
Notification Settings: Site Title is now a TableView Header

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -47,18 +47,7 @@ public class NotificationSettingDetailsViewController : UITableViewController
     
     // MARK: - Setup Helpers
     private func setupTitle() {
-        switch settings!.channel {
-        case .WordPressCom:
-            title = NSLocalizedString("WordPress.com Updates", comment: "WordPress.com Notification Settings Title")
-        case .Other:
-            let title = NSLocalizedString("Other Sites", comment: "Other Sites Notification Settings Title")
-            let subtitle = stream?.kind.description()
-            navigationItem.titleView = NavigationTitleView(title: title, subtitle: subtitle)
-        default:
-            let title = settings?.blog?.settings?.name
-            let subtitle = stream?.kind.description()
-            navigationItem.titleView = NavigationTitleView(title: title, subtitle: subtitle)
-        }
+        title = stream?.kind.description()
     }
     
     private func setupNotifications() {
@@ -162,6 +151,24 @@ public class NotificationSettingDetailsViewController : UITableViewController
         }
         
         return cell!
+    }
+
+    public override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        guard section == firstSectionIndex else {
+            return 0
+        }
+        
+        return WPTableViewSectionHeaderFooterView.heightForHeader(siteName, width: view.bounds.width)
+    }
+    
+    public override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard section == firstSectionIndex else {
+            return nil
+        }
+        
+        let headerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
+        headerView.title    = siteName
+        return headerView
     }
     
     public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
@@ -294,12 +301,27 @@ public class NotificationSettingDetailsViewController : UITableViewController
         }
     }
     
+
+    // MARK: - Computed Properties
+    private var siteName : String {
+        switch settings!.channel {
+        case .WordPressCom:
+            return NSLocalizedString("WordPress.com Updates", comment: "WordPress.com Notification Settings Title")
+        case .Other:
+            return NSLocalizedString("Other Sites", comment: "Other Sites Notification Settings Title")
+        default:
+            return settings?.blog?.settings?.name ?? NSLocalizedString("Unnamed Site", comment: "Displayed when a site has no name")
+        }
+    }
+
+    // MARK: - Private Constants
+    private let firstSectionIndex = 0
     
     // MARK: - Private Properties
-    private var settings        : NotificationSettings?
-    private var stream          : NotificationSettings.Stream?
+    private var settings : NotificationSettings?
+    private var stream : NotificationSettings.Stream?
     
     // MARK: - Helpers
-    private var sections        = [Section]()
-    private var newValues       = [String: Bool]()
+    private var sections = [Section]()
+    private var newValues = [String: Bool]()
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -118,8 +118,8 @@ public class NotificationSettingDetailsViewController : UITableViewController
         
         for row in rows {
             let unwrappedKey    = row.key ?? String()
-            let details         = settings.localizedDetails(unwrappedKey)
-            let section         = Section(rows: [row], footerText: details)
+            let footerText      = settings.localizedDetails(unwrappedKey)
+            let section         = Section(rows: [row], footerText: footerText)
             sections.append(section)
         }
         
@@ -165,21 +165,21 @@ public class NotificationSettingDetailsViewController : UITableViewController
     }
     
     public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        if let footerText = sections[section].footerText {
-            return WPTableViewSectionHeaderFooterView.heightForFooter(footerText, width: view.bounds.width)
+        guard let footerText = sections[section].footerText else {
+            return CGFloat.min
         }
 
-        return CGFloat.min
+        return WPTableViewSectionHeaderFooterView.heightForFooter(footerText, width: view.bounds.width)
     }
     
     public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        if let footerText = sections[section].footerText {
-            let footerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-            footerView.title    = footerText
-            return footerView
+        guard let footerText = sections[section].footerText else {
+            return nil
         }
-
-        return nil
+        
+        let footerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
+        footerView.title    = footerText
+        return footerView
     }
     
     


### PR DESCRIPTION
#### Details:
In this PR we'll update the style of the Notification Settings's NavBar Title.

@frosty may i bother you with a review?
Thanks in advance sir!

Closes #4390

#### Steps:
1. Log into WPiOS
2. Open the `Me` tab, and tap over `Notification Settings`
3. Open any of your sites
4. Tap over any (all) of the available Notification Streams

Verify that the site title (in the actual stream settings view, also known as "the last one") displays the Site Title as the tableView header of the first section.

--

#### New Style:

![simulator screen shot jan 15 2016 11 50 53](https://cloud.githubusercontent.com/assets/1195260/12355859/43478786-bb7e-11e5-8e6d-e80605179768.png)

--

#### Old Style:

![simulator screen shot jan 15 2016 11 52 04](https://cloud.githubusercontent.com/assets/1195260/12355891/6cb8bd2e-bb7e-11e5-92eb-1f72647e902b.png)
