### PR TITLE
SettingsPickerViewController: Preventing flicker on selection

### DIFF
--- a/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
@@ -187,7 +187,9 @@ public class SettingsPickerViewController : UITableViewController
         pickerSelectedValue = newValue
         
         // Refresh the 'Current Value' row
-        tableView.reloadRowsAtIndexPaths([pickerIndexPath], withRowAnimation: .None)
+        if let cell = tableView.cellForRowAtIndexPath(selectedValueIndexPath) as? WPTableViewCell {
+            configureTextCell(cell)
+        }
         
         // Hit the Callback
         onChange?(enabled: switchOn, newValue: pickerSelectedValue)
@@ -221,7 +223,7 @@ public class SettingsPickerViewController : UITableViewController
         return switchVisible ? 1 : 0
     }
     
-    private var pickerIndexPath : NSIndexPath {
+    private var selectedValueIndexPath : NSIndexPath {
         return NSIndexPath(forRow: 0, inSection: pickerSection)
     }
     


### PR DESCRIPTION
#### Steps:
1. Launch WPiOS and open `My Sites` tab
2. Open any WordPress.com site
3. Tap over the `Settings` row
4. Scroll all the way down, and tap over `Discussion`
5. Tap over `Close Commenting`
6. Rotate the device into landscape mode
7. Make sure the Days Picker is onscreen
8 .Select any of the picker's rows

As a result, once the user lifts the finger the screen should *not* flicker, and the row right above the picker should show the new selected value.

Closes #4695 

Needs Review: @SergioEstevao  
Thanks in advance Sergio!

P.s.: Props to @astralbodies for spotting the bug on this one. Thanks Aaron!