### PR TITLE
Refreshing Discussion Settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -10,7 +10,7 @@ public class DiscussionSettingsViewController : UITableViewController
     // MARK: - Initializers / Deinitializers
     public convenience init(blog: Blog) {
         self.init(style: .Grouped)
-        self.settings = blog.settings
+        self.blog = blog
     }
 
     deinit {
@@ -586,7 +586,12 @@ public class DiscussionSettingsViewController : UITableViewController
     
 
     // MARK: - Private Properties
-    private var settings : BlogSettings!
+    private var blog : Blog!
+    
+    // MARK: - Computed Properties
+    private var settings : BlogSettings {
+        return blog.settings
+    }
     
     // MARK: - Typealiases
     private typealias CommentsSorting           = BlogSettings.CommentsSorting

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -67,9 +67,9 @@ public class DiscussionSettingsViewController : UITableViewController
     // MARK: - Persistance!
     private func refreshSettings() {
         let service = BlogService(managedObjectContext: settings.managedObjectContext)
-        service.syncSettingsForBlog(settings.blog,
-            success: {
-                self.tableView.reloadData()
+        service.syncSettingsForBlog(blog,
+            success: { [weak self] in
+                self?.tableView.reloadData()
                 DDLogSwift.logInfo("Reloaded Settings")
             },
             failure: { (error: NSError!) in

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -31,6 +31,7 @@ public class DiscussionSettingsViewController : UITableViewController
         super.viewWillAppear(animated)
         tableView.reloadSelectedRow()
         tableView.deselectSelectedRowWithAnimation(true)
+        refreshSettings()
     }
     
     public override func viewWillDisappear(animated: Bool) {
@@ -55,8 +56,6 @@ public class DiscussionSettingsViewController : UITableViewController
     }
 
     private func setupNotificationListeners() {
-        assert(settings != nil)
-        
         let notificationCenter = NSNotificationCenter.defaultCenter()
         notificationCenter.addObserver(self, selector: "handleContextDidChange:",
             name: NSManagedObjectContextObjectsDidChangeNotification,
@@ -66,6 +65,18 @@ public class DiscussionSettingsViewController : UITableViewController
     
 
     // MARK: - Persistance!
+    private func refreshSettings() {
+        let service = BlogService(managedObjectContext: settings.managedObjectContext)
+        service.syncSettingsForBlog(settings.blog,
+            success: {
+                self.tableView.reloadData()
+                DDLogSwift.logInfo("Reloaded Settings")
+            },
+            failure: { (error: NSError!) in
+                DDLogSwift.logError("Error while sync'ing blog settings: \(error)")
+            })
+    }
+    
     private func saveSettingsIfNeeded() {
         if !settings.hasChanges {
             return


### PR DESCRIPTION
#### Steps:
1. Make sure that "Comment author must fill out name and e-mail" is checked.
2. Open the site settings in the mobile app.
3. Open the site settings in calypso.
4. Go back one level in the mobile app, without changing anything.
5. Uncheck "Comment author must fill out name and e-mail" in Calypso and save the settings.
6. Open the site settings in the mobile app again.

As a result, "Comment author must fill (...)" should reflect the last Calypso-saved state.

Closes #4615

Needs Review: @aerych  
Thanks in advance Eric!