### PR TITLE
Suppress 'Activate' button in Theme preview

### DIFF
--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -589,7 +589,7 @@ public protocol ThemePresenter: class
 
     public func presentPreviewForTheme(theme: Theme?) {
         WPAppAnalytics.track(.ThemesPreviewedSite, withBlog: self.blog)
-        presentUrlForTheme(theme, url: theme?.customizeUrl())
+        presentUrlForTheme(theme, url: theme?.customizeUrl(), activeButton: false)
     }
     
     public func presentDetailsForTheme(theme: Theme?) {


### PR DESCRIPTION
Closes #4711

Suppresses navigation bar 'Activate' button for inactive as well as active theme Customizer invocations.

To test: 
Bring up Theme browser. Select 'Try & Customize' for an inactive theme. Observe that the Customizer's 'Save & Activate' button is visible and the navigation bar 'Activate' button is not.

Needs review: @sendhil 
