### PR TITLE
Media: Use jpg instead of jpeg for uploaded image extension

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -141,7 +141,12 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
 {
     id<MediaServiceRemote> remote = [self remoteForBlog:media.blog];
     RemoteMedia *remoteMedia = [self remoteMediaFromMedia:media];
-    
+
+    // Even though jpeg is a valid extension, use jpg instead for the widest possible
+    // support.  Some third-party image related plugins prefer the .jpg extension.
+    // See https://github.com/wordpress-mobile/WordPress-iOS/issues/4663
+    remoteMedia.file = [remoteMedia.file stringByReplacingOccurrencesOfString:@".jpeg" withString:@".jpg"];
+
     media.remoteStatus = MediaRemoteStatusPushing;
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
     NSManagedObjectID *mediaObjectID = media.objectID;

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -148,7 +148,7 @@
  completionBlock:(WPMediaAddedBlock)completionBlock
 {
     [self addAssetWithChangeRequest:^PHAssetChangeRequest *{
-        NSString *fileName = [NSString stringWithFormat:@"%@_%@", [[NSProcessInfo processInfo] globallyUniqueString], @".jpeg"];
+        NSString *fileName = [NSString stringWithFormat:@"%@_%@", [[NSProcessInfo processInfo] globallyUniqueString], @".jpg"];
         NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
         NSError *error;
         if ([image writeToURL:fileURL type:(__bridge NSString *)kUTTypeJPEG compressionQuality:0.9 metadata:metadata error:&error]){


### PR DESCRIPTION
Closes #4663.

This is a replacement for #4681.  Props @koke for the suggestion

Needs review: @koke 