### PR TITLE
Comments Cell Cleanup

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -69,21 +69,9 @@ public class CommentsTableViewCell : WPTableViewCell
         assert(detailsLabel != nil)
         assert(timestampImageView != nil)
         assert(timestampLabel != nil)
-        assert(detailsLeadingConstraint != nil)
-        assert(detailsTrailingConstraint != nil)
         
         separatorsView.bottomVisible = true
         separatorsView.bottomInsets = separatorInsets
-    }
-    
-    public override func layoutSubviews() {
-        // Calculate the TextView's width, before hitting layoutSubviews!
-        var maxDetailsWidth = bounds.width
-        maxDetailsWidth     -= detailsLeadingConstraint.constant + detailsTrailingConstraint.constant
-        maxDetailsWidth     -= gravatarImageView.frame.maxX
-        detailsLabel.preferredMaxLayoutWidth = maxDetailsWidth
-        
-        super.layoutSubviews()
     }
     
     public override func setSelected(selected: Bool, animated: Bool) {
@@ -178,12 +166,10 @@ public class CommentsTableViewCell : WPTableViewCell
     private var gravatarURL : NSURL?
     
     // MARK: - IBOutlets
-    @IBOutlet private var layoutView                : UIView!
-    @IBOutlet private var separatorsView            : SeparatorsView!
-    @IBOutlet private var gravatarImageView         : CircularImageView!
-    @IBOutlet private var detailsLabel              : UILabel!
-    @IBOutlet private var timestampImageView        : UIImageView!
-    @IBOutlet private var timestampLabel            : UILabel!
-    @IBOutlet private var detailsLeadingConstraint  : NSLayoutConstraint!
-    @IBOutlet private var detailsTrailingConstraint : NSLayoutConstraint!
+    @IBOutlet private var layoutView            : UIView!
+    @IBOutlet private var separatorsView        : SeparatorsView!
+    @IBOutlet private var gravatarImageView     : CircularImageView!
+    @IBOutlet private var detailsLabel          : UILabel!
+    @IBOutlet private var timestampImageView    : UIImageView!
+    @IBOutlet private var timestampLabel        : UILabel!
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,6 +10,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="69.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AUn-YX-qnu" userLabel="Layout View">
@@ -27,7 +27,7 @@
                                     <constraint firstAttribute="width" constant="46" id="pBo-eH-W4J"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="240" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq">
                                 <rect key="frame" x="68" y="8" width="240" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -78,8 +78,6 @@
             <inset key="separatorInset" minX="12" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
                 <outlet property="detailsLabel" destination="Wrp-Wr-ZBq" id="Fos-Bf-RYL"/>
-                <outlet property="detailsLeadingConstraint" destination="IXJ-3i-CFq" id="1Th-ch-Nx7"/>
-                <outlet property="detailsTrailingConstraint" destination="WyT-D4-F81" id="gj6-SS-oua"/>
                 <outlet property="gravatarImageView" destination="0Gm-n3-CNm" id="GXM-xm-h6r"/>
                 <outlet property="layoutView" destination="AUn-YX-qnu" id="gcz-64-y5u"/>
                 <outlet property="separatorsView" destination="Kcl-X2-f1f" id="UCV-vD-QcQ"/>


### PR DESCRIPTION
#### Details:
In this PR we perform a minor cleanup over the CommentsTableViewCell height calculation code.

- Preferred Max Width is now automattic
- Layout subviews code is gone
- No need to implement `sizeThatFits`, since this cell already uses autolayout. We can use it's magic!

#### Testing:
1. Log into WPiOS
2. Open `My Sites` tab and access any of your blogs
3. Tap over `Comments`

As a result, the comment cells should show up onscreen, without any UI modifications (nor glitches!).

Needs Review: @aerych 
Thanks in advance sir!

Closes #4159
