### PR TITLE
CommentViewController: Disabling readable width

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -68,6 +68,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 
     self.tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
     self.tableView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.tableView.delegate = self;
     self.tableView.dataSource = self;


### PR DESCRIPTION
#### Steps:
1. Launch WPiOS on an iPad Device
2. Open `My Sites` > `(Any) Site`
3. Tap over Comments
4. Tap over any comment

As a result, the Comment Details should be onscreen. Note that the Header's right chevron accessor shouldn't have any (Weird) padding.

Needs Review: @aerych 
Thanks in advance sir!

Closes #4726

