### PR TITLE
CommentsTableViewCell: Forcing layout on details refresh

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -91,6 +91,7 @@ public class CommentsTableViewCell : WPTableViewCell
     // MARK: - Private Helpers
     private func refreshDetailsLabel() {
         detailsLabel.attributedText = attributedDetailsText(approved)
+        layoutIfNeeded()
     }
     
     private func refreshTimestampLabel() {


### PR DESCRIPTION
#### Steps:
1. Launch WPiOS
2. Open `My Sites` > `(Any site)` > `Comments`
3. Tap over any comment
4. Toggle the Approval / Unapproval state
5. Hit back

As a result, the comment cell might end up rendering the Comment Details beyond the visible area ([Sample Video Here](https://cloudup.com/c4X1irKRDdt)).

In this PR we're forcing a layout pass, whenever the Cell's Details Text is updated.

Needs Review: @aerych (Last PR of the week, promise Eric!)

Thank you sir!
