### PR TITLE
My Sites: Decodes entities in title and tagline when syncing via XMLRPC

### DIFF
--- a/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.m
@@ -166,8 +166,8 @@
 {
     RemoteBlogSettings *remoteSettings = [RemoteBlogSettings new];
     
-    remoteSettings.name = [json stringForKeyPath:@"blog_title.value"];
-    remoteSettings.tagline = [json stringForKeyPath:@"blog_tagline.value"];
+    remoteSettings.name = [[json stringForKeyPath:@"blog_title.value"] stringByDecodingXMLCharacters];
+    remoteSettings.tagline = [[json stringForKeyPath:@"blog_tagline.value"] stringByDecodingXMLCharacters];
     if (json[@"blog_public"]) {
         remoteSettings.privacy = [json numberForKeyPath:@"blog_public.value"];
     }


### PR DESCRIPTION
Closes #4472 

Decodes entities in the title and tagline

Needs Review: @koke 

Before:
![simulator screen shot jan 25 2016 5 13 40 pm](https://cloud.githubusercontent.com/assets/1435271/12567845/38cd27d2-c387-11e5-8c66-88de3698183c.png)

After:
![simulator screen shot jan 25 2016 5 13 01 pm](https://cloud.githubusercontent.com/assets/1435271/12567849/3d9b35b0-c387-11e5-9e5e-db0c0ee59363.png)
