### PR TITLE
Only show People on blogs that support REST

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -33,6 +33,8 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     BlogFeatureThemeBrowsing,
     /// Does the blog support sharing?
     BlogFeatureSharing,
+    /// Does the blog support people management
+    BlogFeaturePeople,
 };
 
 typedef NS_ENUM(NSInteger, SiteVisibility) {

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -420,6 +420,7 @@ NSString * const PostFormatStandard = @"standard";
              If the logic for this changes that needs to be updated as well
              */
             return [self accountIsDefaultAccount];
+        case BlogFeaturePeople:
         case BlogFeatureWPComRESTAPI:
             return [self restApi] != nil;
         case BlogFeatureSharing:

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -282,7 +282,7 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
                                                      }]];
     }
 
-    if ([Feature enabled:FeatureFlagPeople]) {
+    if ([Feature enabled:FeatureFlagPeople] && [self.blog supports:BlogFeaturePeople]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"People", @"Noun. Title. Links to the people management feature.")
                                                         image:[UIImage imageNamed:@"icon-menu-people"]
                                                      callback:^{


### PR DESCRIPTION
While trying to reproduce #4594 I ran into a different crash because I was testing with a self hosted without Jetpack, and `restApi` was `nil`. 

I believe this also fixes #4594 since I can't reproduce that crash on any site.

Needs Review: @aerych 