### PR TITLE
Taxonomy paging and search for Categories and Tags.

### DIFF
--- a/WordPress/Classes/Networking/Remote Objects/RemoteTaxonomyPaging.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteTaxonomyPaging.h
@@ -16,37 +16,37 @@ typedef NS_ENUM(NSUInteger, RemoteTaxonomyPagingResultsOrdering) {
 
 
 /**
- *  @class RemoteTaxonomyPaging
- *  @brief A paging object for passing parameters to the API when requesting paged lists of taxonomies.
- *         See each remote API for specifics regarding default values and limits.
- *         WP.com/REST Jetpack: https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/categories/
- *         XML-RPC: https://codex.wordpress.org/XML-RPC_WordPress_API/Taxonomies
+   @class RemoteTaxonomyPaging
+   @brief A paging object for passing parameters to the API when requesting paged lists of taxonomies.
+          See each remote API for specifics regarding default values and limits.
+          WP.com/REST Jetpack: https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/categories/
+          XML-RPC: https://codex.wordpress.org/XML-RPC_WordPress_API/Taxonomies
  */
 @interface RemoteTaxonomyPaging : NSObject
 
-/* 
- * @details The max number of taxonomies to return.
+/**
+ @brief The max number of taxonomies to return.
  */
 @property (nonatomic, strong) NSNumber *number;
 
-/* 
- * @details 0-indexed offset for paging.
+/**
+  @brief 0-indexed offset for paging.
  */
 @property (nonatomic, strong) NSNumber *offset;
 
-/* 	
- * @details Return the Nth 1-indexed page of tags. Takes precedence over the offset parameter.
- * @warning Not supported in XML-RPC.
+/**
+  @brief Return the Nth 1-indexed page of tags. Takes precedence over the offset parameter.
+  @attention Not supported in XML-RPC.
  */
 @property (nonatomic, strong) NSNumber *page;
 
-/* 
- * @details Return the taxonomies in ascending or descending order. Defaults YES via the API.
+/**
+  @brief Return the taxonomies in ascending or descending order. Defaults YES via the API.
  */
 @property (nonatomic, assign) RemoteTaxonomyPagingResultsOrder order;
 
-/* 
- * @details Return the taxonomies ordering by name or associated count.
+/**
+  @brief Return the taxonomies ordering by name or associated count.
  */
 @property (nonatomic, assign) RemoteTaxonomyPagingResultsOrdering orderBy;
 

--- a/WordPress/Classes/Networking/Remote Objects/RemoteTaxonomyPaging.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteTaxonomyPaging.h
@@ -1,0 +1,53 @@
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, RemoteTaxonomyPagingResultsOrder) {
+    RemoteTaxonomyPagingOrderAscending = 0,
+    RemoteTaxonomyPagingOrderDescending
+};
+
+typedef NS_ENUM(NSUInteger, RemoteTaxonomyPagingResultsOrdering) {
+    /* Order the results by the name of the taxonomy.
+     */
+    RemoteTaxonomyPagingResultsOrderingByName = 0,
+    /* Order the results by the number of posts associated with the taxonomy.
+     */
+    RemoteTaxonomyPagingResultsOrderingByCount
+};
+
+
+/**
+ *  @class RemoteTaxonomyPaging
+ *  @brief A paging object for passing parameters to the API when requesting paged lists of taxonomies.
+ *         See each remote API for specifics regarding default values and limits.
+ *         WP.com/REST Jetpack: https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/categories/
+ *         XML-RPC: https://codex.wordpress.org/XML-RPC_WordPress_API/Taxonomies
+ */
+@interface RemoteTaxonomyPaging : NSObject
+
+/* 
+ * @details The max number of taxonomies to return.
+ */
+@property (nonatomic, strong) NSNumber *number;
+
+/* 
+ * @details 0-indexed offset for paging.
+ */
+@property (nonatomic, strong) NSNumber *offset;
+
+/* 	
+ * @details Return the Nth 1-indexed page of tags. Takes precedence over the offset parameter.
+ * @warning Not supported in XML-RPC.
+ */
+@property (nonatomic, strong) NSNumber *page;
+
+/* 
+ * @details Return the taxonomies in ascending or descending order. Defaults YES via the API.
+ */
+@property (nonatomic, assign) RemoteTaxonomyPagingResultsOrder order;
+
+/* 
+ * @details Return the taxonomies ordering by name or associated count.
+ */
+@property (nonatomic, assign) RemoteTaxonomyPagingResultsOrdering orderBy;
+
+@end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteTaxonomyPaging.m
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteTaxonomyPaging.m
@@ -1,0 +1,5 @@
+#import "RemoteTaxonomyPaging.h"
+
+@implementation RemoteTaxonomyPaging
+
+@end

--- a/WordPress/Classes/Networking/TaxonomyServiceRemote.h
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemote.h
@@ -26,6 +26,12 @@
                           paging:(RemoteTaxonomyPaging *)paging
                          failure:(void (^)(NSError *error))failure;
 
+/* Fetch a list of categories whose names or slugs match the provided search query. Case-insensitive.
+ */
+- (void)searchCategoriesWithName:(NSString *)nameQuery
+                         success:(void (^)(NSArray <RemotePostCategory *> *categories))success
+                         failure:(void (^)(NSError *error))failure;
+
 /* Fetch a list of tags associated with the site.
  * Note: Requests no paging parameters via the API defaulting the response.
  */
@@ -37,5 +43,11 @@
 - (void)getTagsWithSuccess:(void (^)(NSArray <RemotePostTag *> *tags))success
                     paging:(RemoteTaxonomyPaging *)paging
                    failure:(void (^)(NSError *error))failure;
+
+/* Fetch a list of tags whose names or slugs match the provided search query. Case-insensitive.
+ */
+- (void)searchTagsWithName:(NSString *)nameQuery
+                 success:(void (^)(NSArray <RemotePostTag *> *tags))success
+                 failure:(void (^)(NSError *error))failure;
 
 @end

--- a/WordPress/Classes/Networking/TaxonomyServiceRemote.h
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemote.h
@@ -2,9 +2,9 @@
 
 @class RemotePostCategory;
 @class RemotePostTag;
+@class RemoteTaxonomyPaging;
 
-/*
- Interface for requesting taxonomy such as tags and categories on a site.
+/* Interface for requesting taxonomy such as tags and categories on a site.
  */
 @protocol TaxonomyServiceRemote <NSObject>
 
@@ -15,13 +15,27 @@
                failure:(void (^)(NSError *error))failure;
 
 /* Fetch a list of categories associated with the site.
+ * Note: Requests no paging parameters via the API defaulting the response.
  */
 - (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *categories))success
                          failure:(void (^)(NSError *error))failure;
 
+/* Fetch a list of categories associated with the site with paging.
+ */
+- (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *categories))success
+                          paging:(RemoteTaxonomyPaging *)paging
+                         failure:(void (^)(NSError *error))failure;
+
 /* Fetch a list of tags associated with the site.
+ * Note: Requests no paging parameters via the API defaulting the response.
  */
 - (void)getTagsWithSuccess:(void (^)(NSArray <RemotePostTag *> *tags))success
+                   failure:(void (^)(NSError *error))failure;
+
+/* Fetch a list of tags associated with the site with paging.
+ */
+- (void)getTagsWithSuccess:(void (^)(NSArray <RemotePostTag *> *tags))success
+                    paging:(RemoteTaxonomyPaging *)paging
                    failure:(void (^)(NSError *error))failure;
 
 @end

--- a/WordPress/Classes/Networking/TaxonomyServiceRemote.h
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemote.h
@@ -22,9 +22,9 @@
 
 /* Fetch a list of categories associated with the site with paging.
  */
-- (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *categories))success
-                          paging:(RemoteTaxonomyPaging *)paging
-                         failure:(void (^)(NSError *error))failure;
+- (void)getCategoriesWithPaging:(RemoteTaxonomyPaging *)paging
+                        success:(void (^)(NSArray <RemotePostCategory *> *categories))success
+                        failure:(void (^)(NSError *error))failure;
 
 /* Fetch a list of categories whose names or slugs match the provided search query. Case-insensitive.
  */
@@ -40,9 +40,9 @@
 
 /* Fetch a list of tags associated with the site with paging.
  */
-- (void)getTagsWithSuccess:(void (^)(NSArray <RemotePostTag *> *tags))success
-                    paging:(RemoteTaxonomyPaging *)paging
-                   failure:(void (^)(NSError *error))failure;
+- (void)getTagsWithPaging:(RemoteTaxonomyPaging *)paging
+                  success:(void (^)(NSArray <RemotePostTag *> *tags))success
+                  failure:(void (^)(NSError *error))failure;
 
 /* Fetch a list of tags whose names or slugs match the provided search query. Case-insensitive.
  */

--- a/WordPress/Classes/Networking/TaxonomyServiceRemote.h
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemote.h
@@ -8,16 +8,16 @@
  */
 @protocol TaxonomyServiceRemote <NSObject>
 
-/* Fetch a list of categories associated with the site.
- */
-- (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *categories))success
-                         failure:(void (^)(NSError *error))failure;
-
 /* Create a new category with the site.
  */
 - (void)createCategory:(RemotePostCategory *)category
                success:(void (^)(RemotePostCategory *category))success
                failure:(void (^)(NSError *error))failure;
+
+/* Fetch a list of categories associated with the site.
+ */
+- (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *categories))success
+                         failure:(void (^)(NSError *error))failure;
 
 /* Fetch a list of tags associated with the site.
  */

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
@@ -36,14 +36,14 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 - (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *))success
                          failure:(void (^)(NSError *))failure
 {
-    [self getCategoriesWithSuccess:success
-                      paging:nil
-                     failure:failure];
+    [self getCategoriesWithPaging:nil
+                          success:success
+                          failure:failure];
 }
 
-- (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *categories))success
-                          paging:(RemoteTaxonomyPaging *)paging
-                         failure:(void (^)(NSError *error))failure
+- (void)getCategoriesWithPaging:(RemoteTaxonomyPaging *)paging
+                        success:(void (^)(NSArray <RemotePostCategory *> *categories))success
+                        failure:(void (^)(NSError *error))failure
 {
     [self getTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
                    parameters:[self parametersForPaging:paging]
@@ -73,14 +73,14 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 - (void)getTagsWithSuccess:(void (^)(NSArray <RemotePostTag *> *tags))success
                    failure:(void (^)(NSError *error))failure
 {
-    [self getTagsWithSuccess:success
-                      paging:nil
-                     failure:failure];
+    [self getTagsWithPaging:nil
+                    success:success
+                    failure:failure];
 }
 
-- (void)getTagsWithSuccess:(void (^)(NSArray<RemotePostTag *> *))success
-                    paging:(RemoteTaxonomyPaging *)paging
-                   failure:(void (^)(NSError *))failure
+- (void)getTagsWithPaging:(RemoteTaxonomyPaging *)paging
+                  success:(void (^)(NSArray <RemotePostTag *> *tags))success
+                  failure:(void (^)(NSError *error))failure
 {
     [self getTaxonomyWithType:TaxonomyServiceRemoteRESTTagTypeIdentifier
                    parameters:[self parametersForPaging:paging]

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
@@ -54,6 +54,20 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
                       } failure:failure];
 }
 
+- (void)searchCategoriesWithName:(NSString *)nameQuery
+                   success:(void (^)(NSArray <RemotePostCategory *> *tags))success
+                   failure:(void (^)(NSError *error))failure
+{
+    NSParameterAssert(nameQuery.length > 0);
+    [self getTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
+                   parameters:@{@"search": nameQuery}
+                      success:^(id responseObject) {
+                          if (success) {
+                              success([self remoteCategoriesWithJSONArray:[responseObject arrayForKey:@"categories"]]);
+                          }
+                      } failure:failure];
+}
+
 #pragma mark - tags
 
 - (void)getTagsWithSuccess:(void (^)(NSArray <RemotePostTag *> *tags))success
@@ -70,6 +84,20 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 {
     [self getTaxonomyWithType:TaxonomyServiceRemoteRESTTagTypeIdentifier
                    parameters:[self parametersForPaging:paging]
+                      success:^(id responseObject) {
+                          if (success) {
+                              success([self remoteTagsWithJSONArray:[responseObject arrayForKey:@"tags"]]);
+                          }
+                      } failure:failure];
+}
+
+- (void)searchTagsWithName:(NSString *)nameQuery
+                   success:(void (^)(NSArray <RemotePostTag *> *tags))success
+                   failure:(void (^)(NSError *error))failure
+{
+    NSParameterAssert(nameQuery.length > 0);
+    [self getTaxonomyWithType:TaxonomyServiceRemoteRESTTagTypeIdentifier
+                   parameters:@{@"search": nameQuery}
                       success:^(id responseObject) {
                           if (success) {
                               success([self remoteTagsWithJSONArray:[responseObject arrayForKey:@"tags"]]);

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
@@ -4,8 +4,19 @@
 #import "RemotePostTag.h"
 #import "RemoteTaxonomyPaging.h"
 
-static NSString * const TaxonomyServiceRemoteRESTCategoryTypeIdentifier = @"categories";
-static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
+static NSString * const TaxonomyRESTCategoryIdentifier = @"categories";
+static NSString * const TaxonomyRESTTagIdentifier = @"tags";
+
+static NSString * const TaxonomyRESTIDParameter = @"ID";
+static NSString * const TaxonomyRESTNameParameter = @"name";
+static NSString * const TaxonomyRESTSlugParameter = @"slug";
+static NSString * const TaxonomyRESTParentParameter = @"parent";
+static NSString * const TaxonomyRESTSearchParameter = @"search";
+static NSString * const TaxonomyRESTOrderParameter = @"order";
+static NSString * const TaxonomyRESTOrderByParameter = @"order_by";
+static NSString * const TaxonomyRESTNumberParameter = @"number";
+static NSString * const TaxonomyRESTOffsetParameter = @"offset";
+static NSString * const TaxonomyRESTPageParameter = @"page";
 
 @implementation TaxonomyServiceRemoteREST
 
@@ -18,12 +29,12 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
     NSParameterAssert(category.name.length > 0);
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-    parameters[@"name"] = category.name;
+    parameters[TaxonomyRESTNameParameter] = category.name;
     if (category.parentID) {
-        parameters[@"parent"] = category.parentID;
+        parameters[TaxonomyRESTParentParameter] = category.parentID;
     }
     
-    [self createTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
+    [self createTaxonomyWithType:TaxonomyRESTCategoryIdentifier
                       parameters:parameters
                          success:^(NSDictionary *taxonomyDictionary) {
                              RemotePostCategory *receivedCategory = [self remoteCategoryWithJSONDictionary:taxonomyDictionary];
@@ -45,11 +56,11 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
                         success:(void (^)(NSArray <RemotePostCategory *> *categories))success
                         failure:(void (^)(NSError *error))failure
 {
-    [self getTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
+    [self getTaxonomyWithType:TaxonomyRESTCategoryIdentifier
                    parameters:[self parametersForPaging:paging]
                       success:^(NSDictionary *responseObject) {
                           if (success) {
-                              success([self remoteCategoriesWithJSONArray:[responseObject arrayForKey:@"categories"]]);
+                              success([self remoteCategoriesWithJSONArray:[responseObject arrayForKey:TaxonomyRESTCategoryIdentifier]]);
                           }
                       } failure:failure];
 }
@@ -59,11 +70,11 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
                    failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(nameQuery.length > 0);
-    [self getTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
-                   parameters:@{@"search": nameQuery}
+    [self getTaxonomyWithType:TaxonomyRESTCategoryIdentifier
+                   parameters:@{TaxonomyRESTSearchParameter: nameQuery}
                       success:^(NSDictionary *responseObject) {
                           if (success) {
-                              success([self remoteCategoriesWithJSONArray:[responseObject arrayForKey:@"categories"]]);
+                              success([self remoteCategoriesWithJSONArray:[responseObject arrayForKey:TaxonomyRESTCategoryIdentifier]]);
                           }
                       } failure:failure];
 }
@@ -82,11 +93,11 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
                   success:(void (^)(NSArray <RemotePostTag *> *tags))success
                   failure:(void (^)(NSError *error))failure
 {
-    [self getTaxonomyWithType:TaxonomyServiceRemoteRESTTagTypeIdentifier
+    [self getTaxonomyWithType:TaxonomyRESTTagIdentifier
                    parameters:[self parametersForPaging:paging]
                       success:^(NSDictionary *responseObject) {
                           if (success) {
-                              success([self remoteTagsWithJSONArray:[responseObject arrayForKey:@"tags"]]);
+                              success([self remoteTagsWithJSONArray:[responseObject arrayForKey:TaxonomyRESTTagIdentifier]]);
                           }
                       } failure:failure];
 }
@@ -96,11 +107,11 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
                    failure:(void (^)(NSError *error))failure
 {
     NSParameterAssert(nameQuery.length > 0);
-    [self getTaxonomyWithType:TaxonomyServiceRemoteRESTTagTypeIdentifier
-                   parameters:@{@"search": nameQuery}
+    [self getTaxonomyWithType:TaxonomyRESTTagIdentifier
+                   parameters:@{TaxonomyRESTSearchParameter: nameQuery}
                       success:^(NSDictionary *responseObject) {
                           if (success) {
-                              success([self remoteTagsWithJSONArray:[responseObject arrayForKey:@"tags"]]);
+                              success([self remoteTagsWithJSONArray:[responseObject arrayForKey:TaxonomyRESTTagIdentifier]]);
                           }
                       } failure:failure];
 }
@@ -174,9 +185,9 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
     }
     
     RemotePostCategory *category = [RemotePostCategory new];
-    category.categoryID = [jsonCategory numberForKey:@"ID"];
-    category.name = [jsonCategory stringForKey:@"name"];
-    category.parentID = [jsonCategory numberForKey:@"parent"];
+    category.categoryID = [jsonCategory numberForKey:TaxonomyRESTIDParameter];
+    category.name = [jsonCategory stringForKey:TaxonomyRESTNameParameter];
+    category.parentID = [jsonCategory numberForKey:TaxonomyRESTParentParameter];
     return category;
 }
 
@@ -194,9 +205,9 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
     }
     
     RemotePostTag *tag = [RemotePostTag new];
-    tag.tagID = [jsonTag numberForKey:@"ID"];
-    tag.name = [jsonTag stringForKey:@"name"];
-    tag.slug = [jsonTag stringForKey:@"slug"];
+    tag.tagID = [jsonTag numberForKey:TaxonomyRESTIDParameter];
+    tag.name = [jsonTag stringForKey:TaxonomyRESTNameParameter];
+    tag.slug = [jsonTag stringForKey:TaxonomyRESTSlugParameter];
     return tag;
 }
 
@@ -209,27 +220,27 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
     
     if (paging.number) {
-        [dictionary setObject:paging.number forKey:@"number"];
+        [dictionary setObject:paging.number forKey:TaxonomyRESTNumberParameter];
     }
     
     if (paging.offset) {
-        [dictionary setObject:paging.offset forKey:@"offset"];
+        [dictionary setObject:paging.offset forKey:TaxonomyRESTOffsetParameter];
     }
     
     if (paging.page) {
-        [dictionary setObject:paging.page forKey:@"page"];
+        [dictionary setObject:paging.page forKey:TaxonomyRESTPageParameter];
     }
     
     if (paging.order == RemoteTaxonomyPagingOrderAscending) {
-        [dictionary setObject:@"ASC" forKey:@"order"];
+        [dictionary setObject:@"ASC" forKey:TaxonomyRESTOrderParameter];
     } else if (paging.order == RemoteTaxonomyPagingOrderDescending) {
-        [dictionary setObject:@"DESC" forKey:@"order"];
+        [dictionary setObject:@"DESC" forKey:TaxonomyRESTOrderParameter];
     }
     
     if (paging.orderBy == RemoteTaxonomyPagingResultsOrderingByName) {
-        [dictionary setObject:@"name" forKey:@"order_by"];
+        [dictionary setObject:@"name" forKey:TaxonomyRESTOrderByParameter];
     } else if (paging.orderBy == RemoteTaxonomyPagingResultsOrderingByCount) {
-        [dictionary setObject:@"count" forKey:@"order_by"];
+        [dictionary setObject:@"count" forKey:TaxonomyRESTOrderByParameter];
     }
     
     return dictionary.count ? dictionary : nil;

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
@@ -25,8 +25,8 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
     
     [self createTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
                       parameters:parameters
-                         success:^(id responseObject) {
-                             RemotePostCategory *receivedCategory = [self remoteCategoryWithJSONDictionary:responseObject];
+                         success:^(NSDictionary *taxonomyDictionary) {
+                             RemotePostCategory *receivedCategory = [self remoteCategoryWithJSONDictionary:taxonomyDictionary];
                              if (success) {
                                  success(receivedCategory);
                              }
@@ -47,7 +47,7 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 {
     [self getTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
                    parameters:[self parametersForPaging:paging]
-                      success:^(id responseObject) {
+                      success:^(NSDictionary *responseObject) {
                           if (success) {
                               success([self remoteCategoriesWithJSONArray:[responseObject arrayForKey:@"categories"]]);
                           }
@@ -61,7 +61,7 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
     NSParameterAssert(nameQuery.length > 0);
     [self getTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
                    parameters:@{@"search": nameQuery}
-                      success:^(id responseObject) {
+                      success:^(NSDictionary *responseObject) {
                           if (success) {
                               success([self remoteCategoriesWithJSONArray:[responseObject arrayForKey:@"categories"]]);
                           }
@@ -84,7 +84,7 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 {
     [self getTaxonomyWithType:TaxonomyServiceRemoteRESTTagTypeIdentifier
                    parameters:[self parametersForPaging:paging]
-                      success:^(id responseObject) {
+                      success:^(NSDictionary *responseObject) {
                           if (success) {
                               success([self remoteTagsWithJSONArray:[responseObject arrayForKey:@"tags"]]);
                           }
@@ -98,7 +98,7 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
     NSParameterAssert(nameQuery.length > 0);
     [self getTaxonomyWithType:TaxonomyServiceRemoteRESTTagTypeIdentifier
                    parameters:@{@"search": nameQuery}
-                      success:^(id responseObject) {
+                      success:^(NSDictionary *responseObject) {
                           if (success) {
                               success([self remoteTagsWithJSONArray:[responseObject arrayForKey:@"tags"]]);
                           }
@@ -109,7 +109,7 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 
 - (void)createTaxonomyWithType:(NSString *)typeIdentifier
                     parameters:(NSDictionary *)parameters
-                       success:(void (^)(id responseObject))success
+                       success:(void (^)(NSDictionary *taxonomyDictionary))success
                        failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/%@/new?context=edit", self.siteID, typeIdentifier];
@@ -118,6 +118,10 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
     [self.api POST:requestUrl
         parameters:parameters
            success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+               NSAssert([responseObject isKindOfClass:[NSDictionary class]], @"responseObject should be a dictionary");
+               if (![responseObject isKindOfClass:[NSDictionary class]]) {
+                   responseObject = nil;
+               }
                if (success) {
                    success(responseObject);
                }
@@ -130,7 +134,7 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 
 - (void)getTaxonomyWithType:(NSString *)typeIdentifier
                  parameters:(id)parameters
-                    success:(void (^)(id responseObject))success
+                    success:(void (^)(NSDictionary *responseObject))success
                     failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/%@?context=edit", self.siteID, typeIdentifier];
@@ -140,6 +144,10 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
     [self.api GET:requestUrl
        parameters:parameters
           success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+              NSAssert([responseObject isKindOfClass:[NSDictionary class]], @"responseObject should be a dictionary");
+              if (![responseObject isKindOfClass:[NSDictionary class]]) {
+                  responseObject = nil;
+              }
               if (success) {
                   success(responseObject);
               }
@@ -161,6 +169,10 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 
 - (RemotePostCategory *)remoteCategoryWithJSONDictionary:(NSDictionary *)jsonCategory
 {
+    if (!jsonCategory) {
+        return nil;
+    }
+    
     RemotePostCategory *category = [RemotePostCategory new];
     category.categoryID = [jsonCategory numberForKey:@"ID"];
     category.name = [jsonCategory stringForKey:@"name"];
@@ -177,6 +189,10 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 
 - (RemotePostTag *)remoteTagWithJSONDictionary:(NSDictionary *)jsonTag
 {
+    if (!jsonTag) {
+        return nil;
+    }
+    
     RemotePostTag *tag = [RemotePostTag new];
     tag.tagID = [jsonTag numberForKey:@"ID"];
     tag.name = [jsonTag stringForKey:@"name"];

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
@@ -10,18 +10,6 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 
 #pragma mark - categories
 
-- (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *))success
-                         failure:(void (^)(NSError *))failure
-{
-    [self getTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
-                   parameters:nil
-                      success:^(id responseObject) {
-                          if (success) {
-                              success([self remoteCategoriesWithJSONArray:[responseObject arrayForKey:@"categories"]]);
-                          }
-                      } failure:failure];
-}
-
 - (void)createCategory:(RemotePostCategory *)category
                success:(void (^)(RemotePostCategory *))success
                failure:(void (^)(NSError *))failure
@@ -35,13 +23,25 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
     }
     
     [self createTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
-                            parameters:parameters
-                               success:^(id responseObject) {
-                                   RemotePostCategory *receivedCategory = [self remoteCategoryWithJSONDictionary:responseObject];
-                                   if (success) {
-                                       success(receivedCategory);
-                                   }
-                                } failure:failure];
+                      parameters:parameters
+                         success:^(id responseObject) {
+                             RemotePostCategory *receivedCategory = [self remoteCategoryWithJSONDictionary:responseObject];
+                             if (success) {
+                                 success(receivedCategory);
+                             }
+                         } failure:failure];
+}
+
+- (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *))success
+                         failure:(void (^)(NSError *))failure
+{
+    [self getTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
+                   parameters:nil
+                      success:^(id responseObject) {
+                          if (success) {
+                              success([self remoteCategoriesWithJSONArray:[responseObject arrayForKey:@"categories"]]);
+                          }
+                      } failure:failure];
 }
 
 #pragma mark - tags
@@ -59,6 +59,27 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 }
 
 #pragma mark - default methods
+
+- (void)createTaxonomyWithType:(NSString *)typeIdentifier
+                    parameters:(NSDictionary *)parameters
+                       success:(void (^)(id responseObject))success
+                       failure:(void (^)(NSError *error))failure
+{
+    NSString *path = [NSString stringWithFormat:@"sites/%@/%@/new?context=edit", self.siteID, typeIdentifier];
+    NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteRESTApiVersion_1_1];
+    
+    [self.api POST:requestUrl
+        parameters:parameters
+           success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+               if (success) {
+                   success(responseObject);
+               }
+           } failure:^(AFHTTPRequestOperation * _Nullable operation, NSError * _Nonnull error) {
+               if (failure) {
+                   failure(error);
+               }
+           }];
+}
 
 - (void)getTaxonomyWithType:(NSString *)typeIdentifier
                  parameters:(id)parameters
@@ -80,27 +101,6 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
                   failure(error);
               }
           }];
-}
-
-- (void)createTaxonomyWithType:(NSString *)typeIdentifier
-            parameters:(NSDictionary *)parameters
-               success:(void (^)(id responseObject))success
-               failure:(void (^)(NSError *error))failure
-{
-    NSString *path = [NSString stringWithFormat:@"sites/%@/%@/new?context=edit", self.siteID, typeIdentifier];
-    NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteRESTApiVersion_1_1];
-    
-    [self.api POST:requestUrl
-        parameters:parameters
-           success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
-               if (success) {
-                   success(responseObject);
-               }
-           } failure:^(AFHTTPRequestOperation * _Nullable operation, NSError * _Nonnull error) {
-               if (failure) {
-                   failure(error);
-               }
-           }];
 }
 
 #pragma mark - helpers

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
@@ -2,6 +2,7 @@
 #import "WordPressComApi.h"
 #import "RemotePostCategory.h"
 #import "RemotePostTag.h"
+#import "RemoteTaxonomyPaging.h"
 
 static NSString * const TaxonomyServiceRemoteRESTCategoryTypeIdentifier = @"categories";
 static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
@@ -35,8 +36,17 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 - (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *))success
                          failure:(void (^)(NSError *))failure
 {
+    [self getCategoriesWithSuccess:success
+                      paging:nil
+                     failure:failure];
+}
+
+- (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *categories))success
+                          paging:(RemoteTaxonomyPaging *)paging
+                         failure:(void (^)(NSError *error))failure
+{
     [self getTaxonomyWithType:TaxonomyServiceRemoteRESTCategoryTypeIdentifier
-                   parameters:nil
+                   parameters:[self parametersForPaging:paging]
                       success:^(id responseObject) {
                           if (success) {
                               success([self remoteCategoriesWithJSONArray:[responseObject arrayForKey:@"categories"]]);
@@ -49,8 +59,17 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
 - (void)getTagsWithSuccess:(void (^)(NSArray <RemotePostTag *> *tags))success
                    failure:(void (^)(NSError *error))failure
 {
+    [self getTagsWithSuccess:success
+                      paging:nil
+                     failure:failure];
+}
+
+- (void)getTagsWithSuccess:(void (^)(NSArray<RemotePostTag *> *))success
+                    paging:(RemoteTaxonomyPaging *)paging
+                   failure:(void (^)(NSError *))failure
+{
     [self getTaxonomyWithType:TaxonomyServiceRemoteRESTTagTypeIdentifier
-                   parameters:nil
+                   parameters:[self parametersForPaging:paging]
                       success:^(id responseObject) {
                           if (success) {
                               success([self remoteTagsWithJSONArray:[responseObject arrayForKey:@"tags"]]);
@@ -135,6 +154,41 @@ static NSString * const TaxonomyServiceRemoteRESTTagTypeIdentifier = @"tags";
     tag.name = [jsonTag stringForKey:@"name"];
     tag.slug = [jsonTag stringForKey:@"slug"];
     return tag;
+}
+
+- (NSDictionary *)parametersForPaging:(RemoteTaxonomyPaging *)paging
+{
+    if (!paging) {
+        return nil;
+    }
+    
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    
+    if (paging.number) {
+        [dictionary setObject:paging.number forKey:@"number"];
+    }
+    
+    if (paging.offset) {
+        [dictionary setObject:paging.offset forKey:@"offset"];
+    }
+    
+    if (paging.page) {
+        [dictionary setObject:paging.page forKey:@"page"];
+    }
+    
+    if (paging.order == RemoteTaxonomyPagingOrderAscending) {
+        [dictionary setObject:@"ASC" forKey:@"order"];
+    } else if (paging.order == RemoteTaxonomyPagingOrderDescending) {
+        [dictionary setObject:@"DESC" forKey:@"order"];
+    }
+    
+    if (paging.orderBy == RemoteTaxonomyPagingResultsOrderingByName) {
+        [dictionary setObject:@"name" forKey:@"order_by"];
+    } else if (paging.orderBy == RemoteTaxonomyPagingResultsOrderingByCount) {
+        [dictionary setObject:@"count" forKey:@"order_by"];
+    }
+    
+    return dictionary.count ? dictionary : nil;
 }
 
 @end

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
@@ -57,6 +57,20 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
                         } failure:failure];
 }
 
+- (void)searchCategoriesWithName:(NSString *)nameQuery
+                         success:(void (^)(NSArray<RemotePostCategory *> *))success
+                         failure:(void (^)(NSError *))failure
+{
+    NSDictionary *searchParameters = @{@"search": nameQuery};
+    [self getTaxonomiesWithType:TaxonomyServiceRemoteXMLRPCCategoryTypeIdentifier
+                     parameters:searchParameters
+                        success:^(NSArray *responseArray) {
+                            if (success) {
+                                success([self remoteCategoriesFromXMLRPCArray:responseArray]);
+                            }
+                        } failure:failure];
+}
+
 #pragma mark - tags
 
 - (void)getTagsWithSuccess:(void (^)(NSArray<RemotePostTag *> *))success
@@ -73,6 +87,20 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
 {
     [self getTaxonomiesWithType:TaxonomyServiceRemoteXMLRPCTagTypeIdentifier
                      parameters:[self parametersForPaging:paging]
+                        success:^(NSArray *responseArray) {
+                            if (success) {
+                                success([self remoteTagsFromXMLRPCArray:responseArray]);
+                            }
+                        } failure:failure];
+}
+
+- (void)searchTagsWithName:(NSString *)nameQuery
+                         success:(void (^)(NSArray<RemotePostTag *> *))success
+                         failure:(void (^)(NSError *))failure
+{
+    NSDictionary *searchParameters = @{@"search": nameQuery};
+    [self getTaxonomiesWithType:TaxonomyServiceRemoteXMLRPCTagTypeIdentifier
+                     parameters:searchParameters
                         success:^(NSArray *responseArray) {
                             if (success) {
                                 success([self remoteTagsFromXMLRPCArray:responseArray]);

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
@@ -39,14 +39,14 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
 - (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *))success
                          failure:(void (^)(NSError *))failure
 {
-    [self getCategoriesWithSuccess:success
-                            paging:nil
-                           failure:failure];
+    [self getCategoriesWithPaging:nil
+                          success:success
+                          failure:failure];
 }
 
-- (void)getCategoriesWithSuccess:(void (^)(NSArray<RemotePostCategory *> *))success
-                          paging:(RemoteTaxonomyPaging *)paging
-                         failure:(void (^)(NSError *))failure
+- (void)getCategoriesWithPaging:(RemoteTaxonomyPaging *)paging
+                        success:(void (^)(NSArray <RemotePostCategory *> *categories))success
+                        failure:(void (^)(NSError *error))failure
 {
     [self getTaxonomiesWithType:TaxonomyServiceRemoteXMLRPCCategoryTypeIdentifier
                      parameters:[self parametersForPaging:paging]
@@ -76,14 +76,14 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
 - (void)getTagsWithSuccess:(void (^)(NSArray<RemotePostTag *> *))success
                    failure:(void (^)(NSError *))failure
 {
-    [self getTagsWithSuccess:success
-                      paging:nil
-                     failure:failure];
+    [self getTagsWithPaging:nil
+                    success:success
+                    failure:failure];
 }
 
-- (void)getTagsWithSuccess:(void (^)(NSArray<RemotePostTag *> *))success
-                    paging:(RemoteTaxonomyPaging *)paging
-                   failure:(void (^)(NSError *))failure
+- (void)getTagsWithPaging:(RemoteTaxonomyPaging *)paging
+                  success:(void (^)(NSArray <RemotePostTag *> *tags))success
+                  failure:(void (^)(NSError *error))failure
 {
     [self getTaxonomiesWithType:TaxonomyServiceRemoteXMLRPCTagTypeIdentifier
                      parameters:[self parametersForPaging:paging]

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
@@ -5,8 +5,19 @@
 #import <WordPressShared/NSString+Util.h>
 #import <WordPressApi/WordPressApi.h>
 
-static NSString * const TaxonomyServiceRemoteXMLRPCCategoryTypeIdentifier = @"category";
-static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_tag";
+static NSString * const TaxonomyXMLRPCCategoryIdentifier = @"category";
+static NSString * const TaxonomyXMLRPCTagIdentifier = @"post_tag";
+
+static NSString * const TaxonomyXMLRPCIDParameter = @"term_id";
+static NSString * const TaxonomyXMLRPCSlugParameter = @"slug";
+static NSString * const TaxonomyXMLRPCNameParameter = @"name";
+static NSString * const TaxonomyXMLRPCParentParameter = @"parent";
+static NSString * const TaxonomyXMLRPCSearchParameter = @"search";
+static NSString * const TaxonomyXMLRPCOrderParameter = @"order";
+static NSString * const TaxonomyXMLRPCOrderByParameter = @"order_by";
+static NSString * const TaxonomyXMLRPCNumberParameter = @"number";
+static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
+
 
 @implementation TaxonomyServiceRemoteXMLRPC
 
@@ -16,13 +27,13 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
                success:(void (^)(RemotePostCategory *))success
                failure:(void (^)(NSError *))failure
 {
-    NSMutableDictionary *extraParameters = [NSMutableDictionary dictionaryWithCapacity:2];
-    [extraParameters setObject:category.name ?: [NSNull null] forKey:@"name"];
+    NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
+    [extraParameters setObject:category.name ?: [NSNull null] forKey:TaxonomyXMLRPCNameParameter];
     if ([category.parentID integerValue] > 0) {
-        [extraParameters setObject:category.parentID forKey:@"parent"];
+        [extraParameters setObject:category.parentID forKey:TaxonomyXMLRPCParentParameter];
     }
     
-    [self createTaxonomyWithType:TaxonomyServiceRemoteXMLRPCCategoryTypeIdentifier
+    [self createTaxonomyWithType:TaxonomyXMLRPCCategoryIdentifier
                       parameters:extraParameters
                          success:^(NSString *responseString) {
                              
@@ -48,7 +59,7 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
                         success:(void (^)(NSArray <RemotePostCategory *> *categories))success
                         failure:(void (^)(NSError *error))failure
 {
-    [self getTaxonomiesWithType:TaxonomyServiceRemoteXMLRPCCategoryTypeIdentifier
+    [self getTaxonomiesWithType:TaxonomyXMLRPCCategoryIdentifier
                      parameters:[self parametersForPaging:paging]
                         success:^(NSArray *responseArray) {
                             if (success) {
@@ -61,8 +72,8 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
                          success:(void (^)(NSArray<RemotePostCategory *> *))success
                          failure:(void (^)(NSError *))failure
 {
-    NSDictionary *searchParameters = @{@"search": nameQuery};
-    [self getTaxonomiesWithType:TaxonomyServiceRemoteXMLRPCCategoryTypeIdentifier
+    NSDictionary *searchParameters = @{TaxonomyXMLRPCSearchParameter: nameQuery};
+    [self getTaxonomiesWithType:TaxonomyXMLRPCCategoryIdentifier
                      parameters:searchParameters
                         success:^(NSArray *responseArray) {
                             if (success) {
@@ -85,7 +96,7 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
                   success:(void (^)(NSArray <RemotePostTag *> *tags))success
                   failure:(void (^)(NSError *error))failure
 {
-    [self getTaxonomiesWithType:TaxonomyServiceRemoteXMLRPCTagTypeIdentifier
+    [self getTaxonomiesWithType:TaxonomyXMLRPCTagIdentifier
                      parameters:[self parametersForPaging:paging]
                         success:^(NSArray *responseArray) {
                             if (success) {
@@ -98,8 +109,8 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
                          success:(void (^)(NSArray<RemotePostTag *> *))success
                          failure:(void (^)(NSError *))failure
 {
-    NSDictionary *searchParameters = @{@"search": nameQuery};
-    [self getTaxonomiesWithType:TaxonomyServiceRemoteXMLRPCTagTypeIdentifier
+    NSDictionary *searchParameters = @{TaxonomyXMLRPCSearchParameter: nameQuery};
+    [self getTaxonomiesWithType:TaxonomyXMLRPCTagIdentifier
                      parameters:searchParameters
                         success:^(NSArray *responseArray) {
                             if (success) {
@@ -193,9 +204,9 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
     }
     
     RemotePostCategory *category = [RemotePostCategory new];
-    category.categoryID = [xmlrpcDictionary numberForKey:@"term_id"];
-    category.name = [xmlrpcDictionary stringForKey:@"name"];
-    category.parentID = [xmlrpcDictionary numberForKey:@"parent"];
+    category.categoryID = [xmlrpcDictionary numberForKey:TaxonomyXMLRPCIDParameter];
+    category.name = [xmlrpcDictionary stringForKey:TaxonomyXMLRPCNameParameter];
+    category.parentID = [xmlrpcDictionary numberForKey:TaxonomyXMLRPCParentParameter];
     return category;
 }
 
@@ -213,9 +224,9 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
     }
     
     RemotePostTag *tag = [RemotePostTag new];
-    tag.tagID = [xmlrpcDictionary numberForKey:@"term_id"];
-    tag.name = [xmlrpcDictionary stringForKey:@"name"];
-    tag.slug = [xmlrpcDictionary stringForKey:@"slug"];
+    tag.tagID = [xmlrpcDictionary numberForKey:TaxonomyXMLRPCIDParameter];
+    tag.name = [xmlrpcDictionary stringForKey:TaxonomyXMLRPCNumberParameter];
+    tag.slug = [xmlrpcDictionary stringForKey:TaxonomyXMLRPCSlugParameter];
     return tag;
 }
 
@@ -228,23 +239,23 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
     NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
     
     if (paging.number) {
-        [dictionary setObject:paging.number forKey:@"number"];
+        [dictionary setObject:paging.number forKey:TaxonomyXMLRPCNumberParameter];
     }
     
     if (paging.offset) {
-        [dictionary setObject:paging.offset forKey:@"offset"];
+        [dictionary setObject:paging.offset forKey:TaxonomyXMLRPCOffsetParameter];
     }
     
     if (paging.order == RemoteTaxonomyPagingOrderAscending) {
-        [dictionary setObject:@"ASC" forKey:@"order"];
+        [dictionary setObject:@"ASC" forKey:TaxonomyXMLRPCOrderParameter];
     } else if (paging.order == RemoteTaxonomyPagingOrderDescending) {
-        [dictionary setObject:@"DESC" forKey:@"order"];
+        [dictionary setObject:@"DESC" forKey:TaxonomyXMLRPCOrderParameter];
     }
     
     if (paging.orderBy == RemoteTaxonomyPagingResultsOrderingByName) {
-        [dictionary setObject:@"name" forKey:@"order_by"];
+        [dictionary setObject:@"name" forKey:TaxonomyXMLRPCOrderByParameter];
     } else if (paging.orderBy == RemoteTaxonomyPagingResultsOrderingByCount) {
-        [dictionary setObject:@"count" forKey:@"order_by"];
+        [dictionary setObject:@"count" forKey:TaxonomyXMLRPCOrderByParameter];
     }
     
     return dictionary.count ? dictionary : nil;

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
@@ -16,10 +16,12 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
                success:(void (^)(RemotePostCategory *))success
                failure:(void (^)(NSError *))failure
 {
-    NSDictionary *extraParameters = @{
-                                      @"name" : category.name ?: [NSNull null],
-                                      @"parent_id" : category.parentID ?: @0,
-                                      };
+    NSMutableDictionary *extraParameters = [NSMutableDictionary dictionaryWithCapacity:2];
+    [extraParameters setObject:category.name ?: [NSNull null] forKey:@"name"];
+    if ([category.parentID integerValue] > 0) {
+        [extraParameters setObject:category.parentID forKey:@"parent"];
+    }
+    
     [self createTaxonomyWithType:TaxonomyServiceRemoteXMLRPCCategoryTypeIdentifier
                       parameters:extraParameters
                          success:^(NSString *responseString) {

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
@@ -164,6 +164,9 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
               parameters:xmlrpcParameters
                  success:^(AFHTTPRequestOperation *operation, id responseObject) {
                      NSAssert([responseObject isKindOfClass:[NSArray class]], @"Response should be an array.");
+                     if (![responseObject isKindOfClass:[NSArray class]]) {
+                         responseObject = nil;
+                     }
                      if (success) {
                          success(responseObject);
                      }
@@ -185,6 +188,10 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
 
 - (RemotePostCategory *)remoteCategoryFromXMLRPCDictionary:(NSDictionary *)xmlrpcDictionary
 {
+    if (!xmlrpcDictionary) {
+        return nil;
+    }
+    
     RemotePostCategory *category = [RemotePostCategory new];
     category.categoryID = [xmlrpcDictionary numberForKey:@"term_id"];
     category.name = [xmlrpcDictionary stringForKey:@"name"];
@@ -201,6 +208,10 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
 
 - (RemotePostTag *)remoteTagFromXMLRPCDictionary:(NSDictionary *)xmlrpcDictionary
 {
+    if (!xmlrpcDictionary) {
+        return nil;
+    }
+    
     RemotePostTag *tag = [RemotePostTag new];
     tag.tagID = [xmlrpcDictionary numberForKey:@"term_id"];
     tag.name = [xmlrpcDictionary stringForKey:@"name"];

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
@@ -11,18 +11,6 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
 
 #pragma mark - categories
 
-- (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *))success
-                         failure:(void (^)(NSError *))failure
-{
-    [self getTaxonomiesWithType:TaxonomyServiceRemoteXMLRPCCategoryTypeIdentifier
-                     parameters:nil
-                        success:^(NSArray *responseArray) {
-                            if (success) {
-                                success([self remoteCategoriesFromXMLRPCArray:responseArray]);
-                            }
-                        } failure:failure];
-}
-
 - (void)createCategory:(RemotePostCategory *)category
                success:(void (^)(RemotePostCategory *))success
                failure:(void (^)(NSError *))failure
@@ -45,6 +33,18 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
                          } failure:failure];
 }
 
+- (void)getCategoriesWithSuccess:(void (^)(NSArray <RemotePostCategory *> *))success
+                         failure:(void (^)(NSError *))failure
+{
+    [self getTaxonomiesWithType:TaxonomyServiceRemoteXMLRPCCategoryTypeIdentifier
+                     parameters:nil
+                        success:^(NSArray *responseArray) {
+                            if (success) {
+                                success([self remoteCategoriesFromXMLRPCArray:responseArray]);
+                            }
+                        } failure:failure];
+}
+
 #pragma mark - tags
 
 - (void)getTagsWithSuccess:(void (^)(NSArray<RemotePostTag *> *))success
@@ -60,31 +60,6 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
 }
 
 #pragma mark - default methods
-
-- (void)getTaxonomiesWithType:(NSString *)typeIdentifier
-                 parameters:(NSDictionary *)parameters
-                    success:(void (^)(NSArray *responseArray))success
-                      failure:(void (^)(NSError *error))failure
-{
-    NSArray *xmlrpcParameters = nil;
-    if (parameters.count) {
-        xmlrpcParameters = [self XMLRPCArgumentsWithExtra:@[typeIdentifier, parameters]];
-    }else {
-        xmlrpcParameters = [self XMLRPCArgumentsWithExtra:typeIdentifier];
-    }
-    [self.api callMethod:@"wp.getTerms"
-              parameters:xmlrpcParameters
-                 success:^(AFHTTPRequestOperation *operation, id responseObject) {
-                     NSAssert([responseObject isKindOfClass:[NSArray class]], @"Response should be an array.");
-                     if (success) {
-                         success(responseObject);
-                     }
-                 } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-                     if (failure) {
-                         failure(error);
-                     }
-                 }];
-}
 
 - (void)createTaxonomyWithType:(NSString *)typeIdentifier
                     parameters:(NSDictionary *)parameters
@@ -118,6 +93,31 @@ static NSString * const TaxonomyServiceRemoteXMLRPCTagTypeIdentifier = @"post_ta
                          success(responseObject);
                      }
                      
+                 } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                     if (failure) {
+                         failure(error);
+                     }
+                 }];
+}
+
+- (void)getTaxonomiesWithType:(NSString *)typeIdentifier
+                 parameters:(NSDictionary *)parameters
+                    success:(void (^)(NSArray *responseArray))success
+                      failure:(void (^)(NSError *error))failure
+{
+    NSArray *xmlrpcParameters = nil;
+    if (parameters.count) {
+        xmlrpcParameters = [self XMLRPCArgumentsWithExtra:@[typeIdentifier, parameters]];
+    }else {
+        xmlrpcParameters = [self XMLRPCArgumentsWithExtra:typeIdentifier];
+    }
+    [self.api callMethod:@"wp.getTerms"
+              parameters:xmlrpcParameters
+                 success:^(AFHTTPRequestOperation *operation, id responseObject) {
+                     NSAssert([responseObject isKindOfClass:[NSArray class]], @"Response should be an array.");
+                     if (success) {
+                         success(responseObject);
+                     }
                  } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
                      if (failure) {
                          failure(error);

--- a/WordPress/Classes/Services/PostCategoryService.h
+++ b/WordPress/Classes/Services/PostCategoryService.h
@@ -19,13 +19,4 @@
                forBlogObjectID:(NSManagedObjectID *)blogObjectID
                        success:(void (^)(PostCategory *category))success
                        failure:(void (^)(NSError *error))failure;
-
-
-/* Search categories for blog matching a name or slug of the query. Case-insensitive search.
- */
-- (void)searchCategoriesWithName:(NSString *)nameQuery
-                      blog:(Blog *)blog
-                   success:(void (^)(NSArray <PostCategory *> *categories))success
-                   failure:(void (^)(NSError *error))failure;
-
 @end

--- a/WordPress/Classes/Services/PostCategoryService.h
+++ b/WordPress/Classes/Services/PostCategoryService.h
@@ -21,4 +21,11 @@
                        failure:(void (^)(NSError *error))failure;
 
 
+/* Search categories for blog matching a name or slug of the query. Case-insensitive search.
+ */
+- (void)searchCategoriesWithName:(NSString *)nameQuery
+                      blog:(Blog *)blog
+                   success:(void (^)(NSArray <PostCategory *> *categories))success
+                   failure:(void (^)(NSError *error))failure;
+
 @end

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -155,29 +155,6 @@
                    } failure:failure];
 }
 
-- (void)searchCategoriesWithName:(NSString *)nameQuery
-                            blog:(Blog *)blog
-                         success:(void (^)(NSArray <PostCategory *> *categories))success
-                         failure:(void (^)(NSError *error))failure
-{
-    id<TaxonomyServiceRemote> remote = [self remoteForBlog:blog];
-    NSManagedObjectID *blogID = blog.objectID;
-    [remote searchCategoriesWithName:nameQuery
-                             success:^(NSArray<RemotePostCategory *> *categories) {
-                                 Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:nil];
-                                 if (!blog) {
-                                     return;
-                                 }
-                                 [self mergeCategories:categories
-                                               forBlog:blog
-                                     completionHandler:^(NSArray <PostCategory *> *postCategories) {
-                                         if (success) {
-                                             success(postCategories);
-                                         }
-                                     }];
-                             } failure:failure];
-}
-
 - (void)mergeCategories:(NSArray <RemotePostCategory *> *)remoteCategories forBlog:(Blog *)blog completionHandler:(void (^)(NSArray <PostCategory *> *categories))completion
 {
     NSSet *remoteSet = [NSSet setWithArray:[remoteCategories valueForKey:@"categoryID"]];

--- a/WordPress/Classes/Services/PostTagService.h
+++ b/WordPress/Classes/Services/PostTagService.h
@@ -4,7 +4,7 @@
 
 @interface PostTagService : LocalCoreDataService
 
-/* Fetches the associated tags for blog and replaces all currently persisted PostTag entities for blog.tags
+/* Fetches the associated tags for blog and merges all currently persisted PostTag entities for blog.tags
  */
 - (void)syncTagsForBlog:(Blog *)blog
                       success:(void (^)())success

--- a/WordPress/Classes/Services/PostTagService.h
+++ b/WordPress/Classes/Services/PostTagService.h
@@ -16,4 +16,12 @@
 - (void)loadMoreTagsForBlog:(Blog *)blog
                     success:(void (^)(NSArray <PostTag *> *tags))success
                     failure:(void (^)(NSError *error))failure;
+
+/* Search tags for blog matching a name or slug of the query. Case-insensitive search.
+ */
+- (void)searchTagsWithName:(NSString *)nameQuery
+                      blog:(Blog *)blog
+                   success:(void (^)(NSArray <PostTag *> *tags))success
+                   failure:(void (^)(NSError *error))failure;
+
 @end

--- a/WordPress/Classes/Services/PostTagService.h
+++ b/WordPress/Classes/Services/PostTagService.h
@@ -1,13 +1,19 @@
 #import "LocalCoreDataService.h"
 
 @class Blog;
+@class PostTag;
 
 @interface PostTagService : LocalCoreDataService
 
-/* Fetches the associated tags for blog and merges all currently persisted PostTag entities for blog.tags
+/* Sync an initial batch of tags for blog via default remote parameters and responses.
  */
 - (void)syncTagsForBlog:(Blog *)blog
-                      success:(void (^)())success
-                      failure:(void (^)(NSError *error))failure;
+                success:(void (^)())success
+                failure:(void (^)(NSError *error))failure;
 
+/* Sync additional tags for blog via paging maintained within an instance of PostTagService.
+ */
+- (void)loadMoreTagsForBlog:(Blog *)blog
+                    success:(void (^)(NSArray <PostTag *> *tags))success
+                    failure:(void (^)(NSError *error))failure;
 @end

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -24,9 +24,10 @@
     NSManagedObjectID *blogID = blog.objectID;
     [remote getTagsWithSuccess:^(NSArray <RemotePostTag *> *remoteTags) {
         [self.managedObjectContext performBlock:^{
-            
-            Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:nil];
+            NSError *error;
+            Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:&error];
             if (!blog) {
+                DDLogError(@"Error when retrieving Blog by blogID: %@", error);
                 return;
             }
             
@@ -57,8 +58,10 @@
     NSManagedObjectID *blogID = blog.objectID;
     [remote getTagsWithPaging:paging
                       success:^(NSArray<RemotePostTag *> *remoteTags) {
-                          Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:nil];
+                          NSError *error;
+                          Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:&error];
                           if (!blog) {
+                              DDLogError(@"Error when retrieving Blog by blogID: %@", error);
                               return;
                           }
                           
@@ -84,9 +87,10 @@
     NSManagedObjectID *blogID = blog.objectID;
     [remote searchTagsWithName:nameQuery
                        success:^(NSArray<RemotePostTag *> *remoteTags) {
-                           
-                           Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:nil];
+                           NSError *error;
+                           Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:&error];
                            if (!blog) {
+                               DDLogError(@"Error when retrieving Blog by blogID: %@", error);
                                return;
                            }
                            

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -55,24 +55,23 @@
     
     id<TaxonomyServiceRemote> remote = [self remoteForBlog:blog];
     NSManagedObjectID *blogID = blog.objectID;
-    [remote getTagsWithSuccess:^(NSArray<RemotePostTag *> *remoteTags) {
-    
-        Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:nil];
-        if (!blog) {
-            return;
-        }
-        
-        // increment the offset by the number of tags being requested for the next paging request
-        self.remotePaging.offset = @(self.remotePaging.offset.integerValue + self.remotePaging.number.integerValue);
-        
-        NSArray *tags = [self mergeTagsWithRemoteTags:remoteTags blog:blog];
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-        
-        if (success) {
-            success(tags);
-        }
-        
-    } paging:paging failure:failure];
+    [remote getTagsWithPaging:paging
+                      success:^(NSArray<RemotePostTag *> *remoteTags) {
+                          Blog *blog = (Blog *)[self.managedObjectContext existingObjectWithID:blogID error:nil];
+                          if (!blog) {
+                              return;
+                          }
+                          
+                          // increment the offset by the number of tags being requested for the next paging request
+                          self.remotePaging.offset = @(self.remotePaging.offset.integerValue + self.remotePaging.number.integerValue);
+                          
+                          NSArray *tags = [self mergeTagsWithRemoteTags:remoteTags blog:blog];
+                          [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+                          
+                          if (success) {
+                              success(tags);
+                          }
+                      } failure:failure];
 }
 
 - (void)searchTagsWithName:(NSString *)nameQuery

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		082AB9D61C4EEA72000CA523 /* RemotePostTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9D51C4EEA72000CA523 /* RemotePostTag.m */; };
 		082AB9D91C4EEEF4000CA523 /* PostTagService.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9D81C4EEEF4000CA523 /* PostTagService.m */; };
 		082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9DC1C4F035E000CA523 /* PostTag.m */; };
+		08A6FD9C1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A6FD9B1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m */; };
 		08CC677E1C49B65A00153AD7 /* MenuItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC67791C49B65A00153AD7 /* MenuItem.m */; };
 		08CC677F1C49B65A00153AD7 /* Menu.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC677A1C49B65A00153AD7 /* Menu.m */; };
 		08CC67801C49B65A00153AD7 /* MenuLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC677D1C49B65A00153AD7 /* MenuLocation.m */; };
@@ -745,6 +746,8 @@
 		082AB9D81C4EEEF4000CA523 /* PostTagService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostTagService.m; sourceTree = "<group>"; };
 		082AB9DB1C4F035E000CA523 /* PostTag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostTag.h; sourceTree = "<group>"; };
 		082AB9DC1C4F035E000CA523 /* PostTag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostTag.m; sourceTree = "<group>"; };
+		08A6FD9A1C5960AB00AC33E4 /* RemoteTaxonomyPaging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteTaxonomyPaging.h; path = "Remote Objects/RemoteTaxonomyPaging.h"; sourceTree = "<group>"; };
+		08A6FD9B1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteTaxonomyPaging.m; path = "Remote Objects/RemoteTaxonomyPaging.m"; sourceTree = "<group>"; };
 		08CC67771C49B52E00153AD7 /* WordPress 45.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 45.xcdatamodel"; sourceTree = "<group>"; };
 		08CC67781C49B65A00153AD7 /* MenuItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItem.h; sourceTree = "<group>"; };
 		08CC67791C49B65A00153AD7 /* MenuItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItem.m; sourceTree = "<group>"; };
@@ -3547,6 +3550,8 @@
 				E1A6DBD719DC7D080071AC1E /* RemotePostCategory.m */,
 				082AB9D41C4EEA72000CA523 /* RemotePostTag.h */,
 				082AB9D51C4EEA72000CA523 /* RemotePostTag.m */,
+				08A6FD9A1C5960AB00AC33E4 /* RemoteTaxonomyPaging.h */,
+				08A6FD9B1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m */,
 				E1A6DBD819DC7D080071AC1E /* RemotePost.h */,
 				E1A6DBD919DC7D080071AC1E /* RemotePost.m */,
 				E6374DC41C44550700F24720 /* RemotePublicizeConnection.swift */,
@@ -4532,6 +4537,7 @@
 				B57273601B66CCEF000D1C4F /* AlertInternalView.swift in Sources */,
 				7059CD210F332B6500A0660B /* WPCategoryTree.m in Sources */,
 				B5E167F419C08D18009535AA /* NSCalendar+Helpers.swift in Sources */,
+				08A6FD9C1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m in Sources */,
 				BE1071FC1BC75E7400906AFF /* WPStyleGuide+Blog.swift in Sources */,
 				E149D64E19349E69006A843D /* AccountServiceRemoteREST.m in Sources */,
 				5D9282F91B54697D00066CED /* RemoteReaderSiteInfo.m in Sources */,


### PR DESCRIPTION
This is required implementation for work on Menus management and also for the upcoming work on Categories and Tags management. There is more work to be done between categories and tags across the whole app, but will await a larger refactor with many more dependencies observed.

1. Refactors `TaxonomyServiceRemote` for paging and searching taxonomy results via REST and XML-RPC.
2. Refactors `PostTagService` for supporting search and paging via remotes.
3. This also resolves an issue seen in XML-RPC connections in which a category created via the app with a parent category was not setting the parent correctly according to the XML-RPC.

**Note on `PostCategoryService`**: I did not include the methods on `PostCategoryService` for supporting paging or search. Upon testing I noticed it will require additional refactoring that will have to pay careful attention to current dependencies of `PostCategoryService` and how it merges the `PostCategory` entities.

**Testing should be done with both REST and XML-RPC sites.**

1. Open "Settings" for a site.
2. The "Default Category" should be presented correctly.
3. Selecting the "Default Category" cell should present a site's categories.
4. Hitting the + button should create a new category for the site.
5. Creating a new category with a parent should work correctly, particularly on XML-RPC (broken previously)
6. Create a new post for a site.
7. When the post is posted, the default category should have been automatically assigned.
8. Create a post with a different category, the post should have the correct category.

Additional testing for the `PostTagService` will come with upcoming Menus PRs, since there are no current users of the `PostTagService` within the project.

Please review @aerych.