### PR TITLE
Reader: Lists should not be unfollowable from the menu.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -2,7 +2,7 @@ import Foundation
 import SVProgressHUD
 import WordPressComAnalytics
 
-public class ReaderHelpers {
+@objc public class ReaderHelpers : NSObject {
 
     public class func shareController(title:String?, summary:String?, tags:String?, link:String?) -> UIActivityViewController {
         var activityItems = [AnyObject]()

--- a/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
@@ -5,7 +5,7 @@
 #import "WPAccount.h"
 #import "WPStyleGuide.h"
 #import "WPTableViewHandler.h"
-#import "WordpRess-Swift.h"
+#import "WordPress-Swift.h"
 
 @interface SubscribedTopicsViewController ()<WPTableViewHandlerDelegate>
 
@@ -199,7 +199,8 @@
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (indexPath.section == 0) {
+    ReaderAbstractTopic *topic = [self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
+    if (![ReaderHelpers isTopicTag:topic]) {
         return NO;
     }
     return self.isEditing;


### PR DESCRIPTION
Closes #4743 

The reader has only partial support for lists.  You can view them if you're already subscribed, but you can not yet create them, follow them, or unfollow them from the app.  This functionality is intended to be implemented as a part of #4094.  For now, and for consistency with the post list behavior, lets remove the unfollow option from the menu for lists. 

To test:
- Be subscribed to a list. If you're not already subscribed, you can create one via the option in the web reader's sidebar. 
- In the app, open the reader's menu. 
- Tap the edit button. 
- Confirm that the "unfollow" button does not appear for the lists you're following, only for the tags you're following. 

Needs review: @kurzee would you do the honors? 