### PR TITLE
Site Management UI

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -35,6 +35,8 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     BlogFeatureSharing,
     /// Does the blog support people management
     BlogFeaturePeople,
+    /// Can the blog's site be changed or deleted?
+    BlogFeatureSiteManagement,
 };
 
 typedef NS_ENUM(NSInteger, SiteVisibility) {

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -436,6 +436,8 @@ NSString * const PostFormatStandard = @"standard";
             return [self supportsPushNotifications];
         case BlogFeatureThemeBrowsing:
             return [self isHostedAtWPcom] && [self isAdmin];
+        case BlogFeatureSiteManagement:
+            return [self supportsSiteManagementServices];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -1,0 +1,175 @@
+import UIKit
+import WordPressShared
+
+/// DeleteSiteViewController handles deletion of a user's site.
+///
+public class DeleteSiteViewController : UITableViewController
+{
+    // MARK: - Properties: must be set by creator
+    
+    /// The blog whose site we may delete
+    ///
+    var blog : Blog!
+
+    // MARK: - Properties
+    
+    /// Displayed and used as verification
+    ///
+    private var primaryDomain: String!
+    
+    /// Table content structure
+    ///
+    private struct Section
+    {
+        let header: WPTableViewSectionHeaderFooterView
+        let cell: UITableViewCell
+        let action: (() -> Void)?
+    }
+    private var sections = [Section]()
+    
+    // MARK: - Initializer
+
+    /// Preferred initializer for DeleteSiteViewController
+    ///
+    /// - Parameters:
+    ///     - blog: The Blog currently at the site
+    ///
+    public convenience init(blog: Blog) {
+        self.init(style: .Grouped)
+        self.blog = blog
+        self.primaryDomain = blog.displayURL
+    }
+    
+    // MARK: - View Lifecycle
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        
+        title = NSLocalizedString("Delete Site", comment: "Title of Delete Site settings page")
+        
+        WPStyleGuide.resetReadableMarginsForTableView(tableView)
+        WPStyleGuide.configureColorsForView(view, andTableView: tableView)
+       
+        createTableContent()
+    }
+    
+    private func createTableContent() {
+        sections.append(createDomainSection())
+        sections.append(createContentSection())
+        sections.append(createDeleteSection())
+
+        tableView.reloadData()
+    }
+
+    private func createDomainSection() -> Section {
+        let domainHeading = NSLocalizedString("Domain Removal", comment: "Heading for Domain Removal on Delete Site settings page")
+        
+        let domainDetail = NSLocalizedString("Be careful! Deleting your site will also remove your domain(s) listed below.", comment: "Detail for Domain Removal on Delete Site settings page")
+
+        let domainHeader = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil)
+        domainHeader.title = domainHeading
+
+        let domainCell = WPTableViewCellDefault(style: .Value1, reuseIdentifier: nil)
+        domainCell.textLabel?.text = primaryDomain
+        WPStyleGuide.configureTableViewCell(domainCell)
+        domainCell.selectionStyle = .None
+        domainCell.textLabel?.textColor = WPStyleGuide.grey()
+        
+        return Section(
+            header: domainHeader,
+            cell: domainCell,
+            action: nil)
+    }
+    
+    private func createContentSection() -> Section {
+        let contentHeading = NSLocalizedString("Keep Your Content", comment: "Heading for Keep Your Content on Delete Site settings page")
+        
+        let contentDetail = NSLocalizedString("If you are sure, please be sure to take the time and export your content now. It can not be recovered in the future.", comment: "Detail for Keep Your Content on Delete Site settings page")
+        
+        let contentTitle = NSLocalizedString("Export Content", comment: "Button to export content on Start Over settings page")
+
+        let contentHeader = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil)
+        contentHeader.title = contentHeading
+        
+        let contentCell = WPTableViewCellDefault(style: .Value1, reuseIdentifier: nil)
+        contentCell.textLabel?.text = contentTitle
+        WPStyleGuide.configureTableViewActionCell(contentCell)
+        contentCell.textLabel?.textAlignment = .Center
+
+        return Section(
+            header: contentHeader,
+            cell: contentCell,
+            action: nil)
+    }
+
+    private func createDeleteSection() -> Section {
+        let deleteHeading = NSLocalizedString("Are You Sure", comment: "Heading for Are You Sure on Delete Site settings page")
+        
+        let deleteDetail = NSLocalizedString("This action can not be undone. Deleting your site will remove all content, contributors, and domains from the site.", comment: "Detail for Are You Sureon Delete Site settings page")
+        
+        let deleteTitle = NSLocalizedString("Delete Site", comment: "Button to delete site on Start Over settings page")
+
+        let deleteHeader = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil)
+        deleteHeader.title = deleteHeading
+        
+        let deleteCell = WPTableViewCellDefault(style: .Value1, reuseIdentifier: nil)
+        deleteCell.textLabel?.text = deleteTitle
+        WPStyleGuide.configureTableViewDestructiveActionCell(deleteCell)
+
+        return Section(
+            header: deleteHeader,
+            cell: deleteCell,
+            action: nil)
+    }
+    
+    // MARK: Table View Data Source
+    
+    override public func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return sections.count
+    }
+    
+    override public func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard section < sections.count else {
+            return 0
+        }
+
+        return 1
+    }
+    
+    override public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        guard indexPath.section < sections.count else {
+            return UITableViewCell()
+        }
+        
+        return sections[indexPath.section].cell
+    }
+
+    // MARK: - Table View Delegate
+    
+    override public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        guard indexPath.section < sections.count else {
+            return
+        }
+        
+        sections[indexPath.section].action?()
+    }
+
+    override public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard section < sections.count else {
+            return nil
+        }
+        
+        return sections[section].header
+    }
+
+    override public func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        guard section < sections.count else {
+            return CGFloat.min
+        }
+        
+        let title = sections[section].header.title
+        let headerHeight = WPTableViewSectionHeaderFooterView.heightForHeader(title, width: tableView.frame.width)
+        
+        return headerHeight
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -88,7 +88,7 @@ public class DeleteSiteViewController : UITableViewController
         
         let contentDetail = NSLocalizedString("If you are sure, please be sure to take the time and export your content now. It can not be recovered in the future.", comment: "Detail for Keep Your Content on Delete Site settings page")
         
-        let contentTitle = NSLocalizedString("Export Content", comment: "Button to export content on Start Over settings page")
+        let contentTitle = NSLocalizedString("Export Content", comment: "Button to export content on Delete Site settings page")
 
         let contentCell = WPTableViewCellDefault(style: .Value1, reuseIdentifier: nil)
         contentCell.textLabel?.text = contentTitle
@@ -98,15 +98,17 @@ public class DeleteSiteViewController : UITableViewController
         return Section(
             header: TableViewHeaderDetailView(title: contentHeading, detail: contentDetail),
             cell: contentCell,
-            action: nil)
+            action: { [unowned self] in
+                self.exportContent()
+            })
     }
 
     private func createDeleteSection() -> Section {
         let deleteHeading = NSLocalizedString("Are You Sure", comment: "Heading for Are You Sure on Delete Site settings page")
         
-        let deleteDetail = NSLocalizedString("This action can not be undone. Deleting your site will remove all content, contributors, and domains from the site.", comment: "Detail for Are You Sureon Delete Site settings page")
+        let deleteDetail = NSLocalizedString("This action can not be undone. Deleting your site will remove all content, contributors, and domains from the site.", comment: "Detail for Are You Sure on Delete Site settings page")
         
-        let deleteTitle = NSLocalizedString("Delete Site", comment: "Button to delete site on Start Over settings page")
+        let deleteTitle = NSLocalizedString("Delete Site", comment: "Button to delete site on Delete Site settings page")
 
         let deleteCell = WPTableViewCellDefault(style: .Value1, reuseIdentifier: nil)
         deleteCell.textLabel?.text = deleteTitle
@@ -174,6 +176,19 @@ public class DeleteSiteViewController : UITableViewController
 
     // MARK: - Actions
 
+    private func exportContent() {
+        tableView.deselectSelectedRowWithAnimation(true)
+        
+        let exportTitle = NSLocalizedString("Export Content", comment: "Title of alert when Export Content selected")
+        let exportMessage = NSLocalizedString("Currently exporting is only available through the web interface. Please go to WordPress.com in your browser to export content.", comment: "Message of alert when Export Content selected")
+        let alertController = UIAlertController(title: exportTitle, message: exportMessage, preferredStyle: .Alert)
+        
+        let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
+        alertController.addDefaultActionWithTitle(okTitle, handler: nil)
+        
+        presentViewController(alertController, animated: true, completion: nil)
+    }
+
     private func confirmDeleteSite() {
         tableView.deselectSelectedRowWithAnimation(true)
         
@@ -230,10 +245,10 @@ public class DeleteSiteViewController : UITableViewController
     }
     
     private func showError(error: NSError) {
-        let errorTitle = NSLocalizedString("Delete Site Error", comment:"Title of alert when site deletion fails")
+        let errorTitle = NSLocalizedString("Delete Site Error", comment: "Title of alert when site deletion fails")
         let alertController = UIAlertController(title: errorTitle, message: error.localizedDescription, preferredStyle: .Alert)
         
-        let okTitle = NSLocalizedString("OK", comment:"Alert dismissal title")
+        let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
         alertController.addDefaultActionWithTitle(okTitle, handler: nil)
         
         alertController.presentFromRootViewController()

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -21,7 +21,7 @@ public class DeleteSiteViewController : UITableViewController
     ///
     private struct Section
     {
-        let header: WPTableViewSectionHeaderFooterView
+        let header: TableViewHeaderDetailView
         let cell: UITableViewCell
         let action: (() -> Void)?
     }
@@ -66,9 +66,6 @@ public class DeleteSiteViewController : UITableViewController
         
         let domainDetail = NSLocalizedString("Be careful! Deleting your site will also remove your domain(s) listed below.", comment: "Detail for Domain Removal on Delete Site settings page")
 
-        let domainHeader = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil)
-        domainHeader.title = domainHeading
-
         let domainCell = WPTableViewCellDefault(style: .Value1, reuseIdentifier: nil)
         domainCell.textLabel?.text = primaryDomain
         WPStyleGuide.configureTableViewCell(domainCell)
@@ -76,7 +73,7 @@ public class DeleteSiteViewController : UITableViewController
         domainCell.textLabel?.textColor = WPStyleGuide.grey()
         
         return Section(
-            header: domainHeader,
+            header: TableViewHeaderDetailView(title: domainHeading, detail: domainDetail),
             cell: domainCell,
             action: nil)
     }
@@ -88,16 +85,13 @@ public class DeleteSiteViewController : UITableViewController
         
         let contentTitle = NSLocalizedString("Export Content", comment: "Button to export content on Start Over settings page")
 
-        let contentHeader = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil)
-        contentHeader.title = contentHeading
-        
         let contentCell = WPTableViewCellDefault(style: .Value1, reuseIdentifier: nil)
         contentCell.textLabel?.text = contentTitle
         WPStyleGuide.configureTableViewActionCell(contentCell)
         contentCell.textLabel?.textAlignment = .Center
 
         return Section(
-            header: contentHeader,
+            header: TableViewHeaderDetailView(title: contentHeading, detail: contentDetail),
             cell: contentCell,
             action: nil)
     }
@@ -109,15 +103,12 @@ public class DeleteSiteViewController : UITableViewController
         
         let deleteTitle = NSLocalizedString("Delete Site", comment: "Button to delete site on Start Over settings page")
 
-        let deleteHeader = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil)
-        deleteHeader.title = deleteHeading
-        
         let deleteCell = WPTableViewCellDefault(style: .Value1, reuseIdentifier: nil)
         deleteCell.textLabel?.text = deleteTitle
         WPStyleGuide.configureTableViewDestructiveActionCell(deleteCell)
 
         return Section(
-            header: deleteHeader,
+            header: TableViewHeaderDetailView(title: deleteHeading, detail: deleteDetail),
             cell: deleteCell,
             action: nil)
     }
@@ -167,8 +158,9 @@ public class DeleteSiteViewController : UITableViewController
             return CGFloat.min
         }
         
-        let title = sections[section].header.title
-        let headerHeight = WPTableViewSectionHeaderFooterView.heightForHeader(title, width: tableView.frame.width)
+        let headerView = sections[section].header
+        headerView.layoutWidth = tableView.frame.width
+        let headerHeight = headerView.intrinsicContentSize().height
         
         return headerHeight
     }

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
@@ -1,0 +1,122 @@
+import UIKit
+import WordPressShared
+
+ /// StartOverViewController allows user to trigger help session to remove site content.
+ ///
+public class StartOverViewController: UITableViewController
+{
+    // MARK: - Properties: must be set by creator
+    
+    /// The blog whose content we want to remove
+    ///
+    var blog : Blog!
+    
+    // MARK: - Properties: table content
+    
+    let headerView: TableViewHeaderDetailView = {
+        let header = NSLocalizedString("Let Us Help", comment: "Heading for instructions on Start Over settings page")
+        let detail = NSLocalizedString("If you want a site but don't want any of the posts and pages you have now, our support team can delete your posts, pages, media, and comments for you.\n\nThis will keep your site and URL active, but give you a fresh start on your content creation. Just contact us to have your current content cleared out.", comment: "Detail for instructions on Start Over settings page")
+        
+       return TableViewHeaderDetailView(title: header, detail: detail)
+    }()
+
+    let contactCell: UITableViewCell = {
+        let contactTitle = NSLocalizedString("Contact Support", comment: "Button to contact support on Start Over settings page")
+
+        let actionCell = WPTableViewCellDefault(style: .Value1, reuseIdentifier: nil)
+        actionCell.textLabel?.text = contactTitle
+        WPStyleGuide.configureTableViewActionCell(actionCell)
+        actionCell.textLabel?.textAlignment = .Center
+        
+        return actionCell
+    }()
+
+    // MARK: - Initializer
+    
+    /// Preferred initializer for DeleteSiteViewController
+    ///
+    /// - Parameters:
+    ///     - blog: The Blog currently at the site
+    ///
+    convenience init(blog: Blog) {
+        self.init(style: .Grouped)
+        self.blog = blog
+    }
+    
+    // MARK: - View Lifecycle
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        
+        title = NSLocalizedString("Start Over", comment: "Title of Start Over settings page")
+        
+        WPStyleGuide.resetReadableMarginsForTableView(tableView)
+        WPStyleGuide.configureColorsForView(view, andTableView: tableView)
+    }
+    
+    // MARK: Table View Data Source
+    
+    override public func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    override public func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    override public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        return contactCell
+    }
+
+    // MARK: - Table View Delegate
+    
+    override public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        contactSupport()
+    }
+
+    override public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        return headerView
+    }
+
+    override public func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        headerView.layoutWidth = tableView.frame.width
+        let height = headerView.intrinsicContentSize().height
+        
+        return height
+    }
+
+    // MARK: - Actions
+
+    private func contactSupport() {
+        tableView.deselectSelectedRowWithAnimation(true)
+
+        if HelpshiftUtils.isHelpshiftEnabled() {
+            setupHelpshift(blog.account)
+            
+            let metadata = helpshiftMetadata(blog)
+            Helpshift.sharedInstance().showConversation(self, withOptions: metadata)
+        } else {
+            if let contact = NSURL(string: "https://support.wordpress.com/contact/") {
+                UIApplication.sharedApplication().openURL(contact)
+            }
+        }
+    }
+
+    private func setupHelpshift(account: WPAccount) {
+        let user = account.userID.stringValue
+        Helpshift.setUserIdentifier(user)
+        
+        let name = account.username
+        let email = account.email
+        Helpshift.setName(name, andEmail: email)
+    }
+    
+    private func helpshiftMetadata(blog: Blog) -> [NSObject: AnyObject] {
+        let options: [String: String] = [
+            "Source": "Start Over",
+            "Blog": blog.logDescription(),
+            ]
+
+        return [HSCustomMetadataKey: options]
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/TableViewHeaderDetailView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/TableViewHeaderDetailView.swift
@@ -1,0 +1,184 @@
+import UIKit
+import WordPressShared
+
+/// TableViewHeaderDetailView displays a title and detail using autolayout.
+///
+public class TableViewHeaderDetailView : UITableViewHeaderFooterView
+{
+    /// Title is displayed in standard section header style
+    ///
+    public var title: String = "" {
+        didSet {
+            if title != oldValue {
+                titleLabel.text = title.uppercaseStringWithLocale(NSLocale.currentLocale())
+                setNeedsLayout()
+            }
+        }
+    }
+    
+    /// Detail is displayed in standard section footer style
+    ///
+    public var detail: String = "" {
+        didSet {
+            if detail != oldValue {
+                detailLabel.text = detail
+                setNeedsLayout()
+            }
+        }
+    }
+    
+    /// layoutWidth may be set from heightForHeaderInSection then intrinsicSize queried for height
+    ///
+    public var layoutWidth: CGFloat = 0 {
+        didSet {
+            layoutWidth = Style.layoutWidthFitting(layoutWidth)
+            if layoutWidth != oldValue {
+                let labelWidth = max(layoutWidth - stackView.layoutMargins.left - stackView.layoutMargins.right, 0)
+                titleLabel.preferredMaxLayoutWidth = labelWidth
+                detailLabel.preferredMaxLayoutWidth = labelWidth
+                
+                stackWidthConstraint?.constant = layoutWidth
+                setNeedsUpdateConstraints()
+            }
+        }
+    }
+    
+    // MARK: - Private Aliases
+    
+    private typealias Style = WPStyleGuide.TableViewHeaderDetailView
+
+    // MARK: - Private Properties
+
+    private let titleLabel: UILabel = {
+        let titleLabel = UILabel()
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.numberOfLines = 0
+        titleLabel.lineBreakMode = .ByWordWrapping
+        titleLabel.font = Style.titleFont
+        titleLabel.textColor = Style.titleColor
+        
+        return titleLabel
+    }()
+    
+    private let detailLabel: UILabel = {
+        let detailLabel = UILabel()
+        detailLabel.translatesAutoresizingMaskIntoConstraints = false
+        detailLabel.numberOfLines = 0
+        detailLabel.lineBreakMode = .ByWordWrapping
+        detailLabel.font = Style.detailFont
+        detailLabel.textColor = Style.detailColor
+        
+        return detailLabel
+    }()
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .Vertical
+        stackView.alignment = .Fill
+        stackView.distribution = .Fill
+        stackView.spacing = Style.headerDetailSpacing
+        stackView.layoutMargins = Style.layoutMargins
+        stackView.layoutMarginsRelativeArrangement = true
+        
+        return stackView
+    }()
+    
+    private var stackWidthConstraint: NSLayoutConstraint?
+
+    // MARK: - Initializers
+    
+    /// Convenience initializer for TableViewHeaderDetailView
+    ///
+    /// - Parameters:
+    ///     - title: String displayed in standard section header style
+    ///     - detail: String displayed in standard section footer style
+    ///
+    convenience public init(title: String?, detail: String?) {
+        self.init(reuseIdentifier: nil)
+        defer {
+            self.title = title ?? ""
+            self.detail = detail ?? ""
+        }
+    }
+    
+    override public init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        stackSubviews()
+    }
+    
+    required public init?(coder aDecoder: NSCoder){
+        super.init(coder: aDecoder)
+        stackSubviews()
+    }
+    
+    private func stackSubviews() {
+        contentView.addSubview(stackView)
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(detailLabel)
+        
+        stackView.centerXAnchor.constraintEqualToAnchor(contentView.centerXAnchor).active = true
+        stackWidthConstraint = stackView.widthAnchor.constraintEqualToConstant(UIScreen.mainScreen().bounds.width)
+        stackWidthConstraint?.active = true
+    }
+    
+    // MARK: - View Lifecycle
+
+    override public func layoutSubviews() {
+        super.layoutSubviews()
+        
+        layoutWidth = frame.size.width
+    }
+    
+    override public func intrinsicContentSize() -> CGSize {
+        guard layoutWidth > 0 else {
+            return CGSize.zero
+        }
+        
+        let titleSize = titleLabel.intrinsicContentSize()
+        let detailSize = detailLabel.intrinsicContentSize()
+        let height = stackView.layoutMargins.top + titleSize.height + stackView.spacing + detailSize.height + stackView.layoutMargins.bottom
+        
+        return CGSize(width: layoutWidth, height: height)
+    }
+    
+    override public func prepareForReuse() {
+        super.prepareForReuse()
+        
+        title = ""
+        detail = ""
+    }
+}
+
+/// WPStyleGuide extension with styles and methods specific to TableViewHeaderDetailView.
+///
+extension WPStyleGuide
+{
+    public struct TableViewHeaderDetailView
+    {
+        // MARK: - Text Styles
+
+        public static let titleFont = WPStyleGuide.tableviewSectionHeaderFont()
+        public static let titleColor = WPStyleGuide.greyDarken20()
+
+        public static let detailFont = WPStyleGuide.tableviewSectionHeaderFont()
+        public static let detailColor = WPStyleGuide.greyDarken10()
+
+        // MARK: - Metrics
+
+        public static func layoutWidthFitting(width: CGFloat) -> CGFloat {
+            var result = max(width, sideMargin * 2)
+            if UIDevice.isPad() {
+                result = min(result, WPTableViewFixedWidth)
+            }
+            return result
+        }
+
+        public static let topMargin: CGFloat = 21
+        public static let bottomMargin: CGFloat = 8
+        public static let sideMargin: CGFloat = 16
+        public static let layoutMargins = UIEdgeInsets(top: topMargin, left: sideMargin, bottom: bottomMargin, right: sideMargin)
+        
+        public static let headerDetailSpacing: CGFloat = 8
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -51,7 +51,8 @@ NS_ENUM(NSInteger, SiteSettingsWriting) {
 };
 
 NS_ENUM(NSInteger, SiteSettingsAdvanced) {
-    SiteSettingsAdvancedDeleteSite = 0,
+    SiteSettingsAdvancedStartOver = 0,
+    SiteSettingsAdvancedDeleteSite,
     SiteSettingsAdvancedCount,
 };
 
@@ -86,6 +87,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 #pragma mark - Removal Section
 @property (nonatomic, strong) UITableViewCell *removeSiteCell;
 #pragma mark - Advanced Section
+@property (nonatomic, strong) SettingTableViewCell *startOverCell;
 @property (nonatomic, strong) SettingTableViewCell *deleteSiteCell;
 
 @property (nonatomic, strong) Blog *blog;
@@ -437,6 +439,18 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     return [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"NoCell"];
 }
 
+- (SettingTableViewCell *)startOverCell
+{
+    if (_startOverCell) {
+        return _startOverCell;
+    }
+    
+    _startOverCell = [[SettingTableViewCell alloc] initWithLabel:NSLocalizedString(@"Start Over", @"Label for selecting the Start Over Settings item")
+                                                        editable:YES
+                                                 reuseIdentifier:nil];
+    return _startOverCell;
+}
+
 - (SettingTableViewCell *)deleteSiteCell
 {
     if (_deleteSiteCell) {
@@ -452,6 +466,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForAdvancedSettingsAtRow:(NSInteger)row
 {
     switch (row) {
+        case SiteSettingsAdvancedStartOver: {
+            return self.startOverCell;
+        } break;
         case SiteSettingsAdvancedDeleteSite: {
             return self.deleteSiteCell;
         } break;
@@ -723,6 +740,14 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     }
 }
 
+- (void)showStartOverForBlog:(Blog *)blog
+{
+    NSParameterAssert([blog supportsSiteManagementServices]);
+
+    StartOverViewController *viewController = [[StartOverViewController alloc] initWithBlog:blog];
+    [self.navigationController pushViewController:viewController animated:YES];
+}
+
 - (void)showDeleteSiteForBlog:(Blog *)blog
 {
     NSParameterAssert([blog supportsSiteManagementServices]);
@@ -734,6 +759,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 - (void)tableView:(UITableView *)tableView didSelectInAdvancedSectionRow:(NSInteger)row
 {
     switch (row) {
+        case SiteSettingsAdvancedStartOver: {
+            [self showStartOverForBlog:self.blog];
+        } break;
         case SiteSettingsAdvancedDeleteSite: {
             [self showDeleteSiteForBlog:self.blog];
         } break;

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -727,7 +727,8 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 {
     NSParameterAssert([blog supportsSiteManagementServices]);
     
-    //TODO: Show Delete Site controller
+    DeleteSiteViewController *viewController = [[DeleteSiteViewController alloc] initWithBlog:blog];
+    [self.navigationController pushViewController:viewController animated:YES];
 }
 
 - (void)tableView:(UITableView *)tableView didSelectInAdvancedSectionRow:(NSInteger)row

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -50,12 +50,18 @@ NS_ENUM(NSInteger, SiteSettingsWriting) {
     SiteSettingsWritingCount,
 };
 
+NS_ENUM(NSInteger, SiteSettingsAdvanced) {
+    SiteSettingsAdvancedDeleteSite = 0,
+    SiteSettingsAdvancedCount,
+};
+
 NS_ENUM(NSInteger, SiteSettingsSection) {
     SiteSettingsSectionGeneral = 0,
     SiteSettingsSectionAccount,
     SiteSettingsSectionWriting,
     SiteSettingsSectionDiscussion,
     SiteSettingsSectionRemoveSite,
+    SiteSettingsSectionAdvanced,
 };
 
 
@@ -79,6 +85,8 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 @property (nonatomic, strong) SettingTableViewCell *discussionSettingsCell;
 #pragma mark - Removal Section
 @property (nonatomic, strong) UITableViewCell *removeSiteCell;
+#pragma mark - Advanced Section
+@property (nonatomic, strong) SettingTableViewCell *deleteSiteCell;
 
 @property (nonatomic, strong) Blog *blog;
 @property (nonatomic, strong) NSString *url;
@@ -126,6 +134,10 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     
     if ([self.blog supports:BlogFeatureRemovable]) {
         [sections addObject:@(SiteSettingsSectionRemoveSite)];
+    }
+
+    if ([self.blog supports:BlogFeatureSiteManagement]) {
+        [sections addObject:@(SiteSettingsSectionAdvanced)];
     }
 
     self.tableSections = sections;
@@ -198,6 +210,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         }
         case SiteSettingsSectionRemoveSite: {
             return 1;
+        }
+        case SiteSettingsSectionAdvanced: {
+            return SiteSettingsAdvancedCount;
         }
     }
     return 0;
@@ -422,6 +437,29 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     return [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"NoCell"];
 }
 
+- (SettingTableViewCell *)deleteSiteCell
+{
+    if (_deleteSiteCell) {
+        return _deleteSiteCell;
+    }
+    
+    _deleteSiteCell = [[SettingTableViewCell alloc] initWithLabel:NSLocalizedString(@"Delete Site", @"Label for selecting the Delete Site Settings item")
+                                                         editable:YES
+                                                  reuseIdentifier:nil];
+    return _deleteSiteCell;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForAdvancedSettingsAtRow:(NSInteger)row
+{
+    switch (row) {
+        case SiteSettingsAdvancedDeleteSite: {
+            return self.deleteSiteCell;
+        } break;
+    }
+
+    NSAssert(false, @"Missing Advanced section cell");
+    return [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"NoCell"];
+}
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
@@ -441,6 +479,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         }
         case SiteSettingsSectionRemoveSite: {
             return self.removeSiteCell;
+        }
+        case SiteSettingsSectionAdvanced: {
+            return [self tableView:tableView cellForAdvancedSettingsAtRow:indexPath.row];
         }
     }
 
@@ -487,6 +528,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             break;
         case SiteSettingsSectionWriting:
             headingTitle = NSLocalizedString(@"Writing", @"Title for the writing section in site settings screen");
+            break;
+        case SiteSettingsSectionAdvanced:
+            headingTitle = NSLocalizedString(@"Advanced", @"Title for the advanced section in site settings screen");
             break;
     }
     return headingTitle;
@@ -679,6 +723,22 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     }
 }
 
+- (void)showDeleteSiteForBlog:(Blog *)blog
+{
+    NSParameterAssert([blog supportsSiteManagementServices]);
+    
+    //TODO: Show Delete Site controller
+}
+
+- (void)tableView:(UITableView *)tableView didSelectInAdvancedSectionRow:(NSInteger)row
+{
+    switch (row) {
+        case SiteSettingsAdvancedDeleteSite: {
+            [self showDeleteSiteForBlog:self.blog];
+        } break;
+    }
+}
+
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     NSInteger settingsSection = [self.tableSections[indexPath.section] intValue];
@@ -698,6 +758,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         case SiteSettingsSectionRemoveSite:{
             [tableView deselectSelectedRowWithAnimation:YES];
             [self showRemoveSiteForBlog:self.blog];
+        } break;
+        case SiteSettingsSectionAdvanced:{
+            [self tableView:tableView didSelectInAdvancedSectionRow:indexPath.row];
         } break;
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -634,6 +634,7 @@
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
 		FA5C740C1C596E69000B528C /* DeleteSiteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5C740A1C596E69000B528C /* DeleteSiteViewController.swift */; };
+		FA5C740F1C599BA7000B528C /* TableViewHeaderDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */; };
 		FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */; };
 		FA87F1AC1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA87F1AB1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift */; };
 		FA9E74481C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9E74471C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift */; };
@@ -1733,6 +1734,7 @@
 		FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementService.swift; sourceTree = "<group>"; };
 		FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceTests.swift; sourceTree = "<group>"; };
 		FA5C740A1C596E69000B528C /* DeleteSiteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteSiteViewController.swift; sourceTree = "<group>"; };
+		FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewHeaderDetailView.swift; sourceTree = "<group>"; };
 		FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserHeaderView.swift; sourceTree = "<group>"; };
 		FA87F1AB1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceRemote.swift; sourceTree = "<group>"; };
 		FA9E74471C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceRemoteTests.swift; sourceTree = "<group>"; };
@@ -3820,6 +3822,7 @@
 			isa = PBXGroup;
 			children = (
 				FA5C740A1C596E69000B528C /* DeleteSiteViewController.swift */,
+				FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */,
 			);
 			path = SiteManagement;
 			sourceTree = "<group>";
@@ -4680,6 +4683,7 @@
 				B532D4E9199D4357006E4DF6 /* NoteBlockCommentTableViewCell.swift in Sources */,
 				B5E06E311A9CD31D00128985 /* WPURLRequest.m in Sources */,
 				E1A0FAE7162F11CF0063B098 /* UIDevice+Helpers.m in Sources */,
+				FA5C740F1C599BA7000B528C /* TableViewHeaderDetailView.swift in Sources */,
 				5D44EB351986D695008B7175 /* ReaderSiteServiceRemote.m in Sources */,
 				5DB4683B18A2E718004A89A9 /* LocationService.m in Sources */,
 				E1D04D7E19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -638,6 +638,7 @@
 		FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */; };
 		FA87F1AC1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA87F1AB1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift */; };
 		FA9E74481C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9E74471C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift */; };
+		FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */; };
 		FAFB84061BBF3638000BBA8E /* get-multiple-themes-v1.2.json in Resources */ = {isa = PBXBuildFile; fileRef = FAFB84051BBF3638000BBA8E /* get-multiple-themes-v1.2.json */; };
 		FD21397F13128C5300099582 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FD21397E13128C5300099582 /* libiconv.dylib */; };
 		FD3D6D2C1349F5D30061136A /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD3D6D2B1349F5D30061136A /* ImageIO.framework */; };
@@ -1738,6 +1739,7 @@
 		FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserHeaderView.swift; sourceTree = "<group>"; };
 		FA87F1AB1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceRemote.swift; sourceTree = "<group>"; };
 		FA9E74471C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceRemoteTests.swift; sourceTree = "<group>"; };
+		FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartOverViewController.swift; sourceTree = "<group>"; };
 		FAFB84051BBF3638000BBA8E /* get-multiple-themes-v1.2.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "get-multiple-themes-v1.2.json"; sourceTree = "<group>"; };
 		FD0D42C11499F31700F5E115 /* WordPress 4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 4.xcdatamodel"; sourceTree = "<group>"; };
 		FD21397E13128C5300099582 /* libiconv.dylib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
@@ -3822,6 +3824,7 @@
 			isa = PBXGroup;
 			children = (
 				FA5C740A1C596E69000B528C /* DeleteSiteViewController.swift */,
+				FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */,
 				FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */,
 			);
 			path = SiteManagement;
@@ -4572,6 +4575,7 @@
 				E6D2E1671B8AAD8C0000ED14 /* ReaderTagStreamHeader.swift in Sources */,
 				85D239B61AE5A6170074768D /* ReachabilityFacade.m in Sources */,
 				B5899ADE1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift in Sources */,
+				FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */,
 				B57B99D519A2C20200506504 /* NoteTableHeaderView.swift in Sources */,
 				83418AAA11C9FA6E00ACF00C /* Comment.m in Sources */,
 				E125443C12BF5A7200D87A0A /* WordPress.xcdatamodeld in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -633,6 +633,7 @@
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
+		FA5C740C1C596E69000B528C /* DeleteSiteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5C740A1C596E69000B528C /* DeleteSiteViewController.swift */; };
 		FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */; };
 		FA87F1AC1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA87F1AB1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift */; };
 		FA9E74481C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9E74471C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift */; };
@@ -1731,6 +1732,7 @@
 		FA2D12891BCED0AD006F2A15 /* WordPress 40.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 40.xcdatamodel"; sourceTree = "<group>"; };
 		FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementService.swift; sourceTree = "<group>"; };
 		FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceTests.swift; sourceTree = "<group>"; };
+		FA5C740A1C596E69000B528C /* DeleteSiteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteSiteViewController.swift; sourceTree = "<group>"; };
 		FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserHeaderView.swift; sourceTree = "<group>"; };
 		FA87F1AB1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceRemote.swift; sourceTree = "<group>"; };
 		FA9E74471C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceRemoteTests.swift; sourceTree = "<group>"; };
@@ -2964,6 +2966,7 @@
 			children = (
 				BE8A267F1BEC1A3500C1D3D3 /* CreateNewBlog */,
 				E6431DDE1C4E890B00FD8D90 /* Sharing */,
+				FA5C74091C596E69000B528C /* SiteManagement */,
 				BE6AB7FB1BC62E0B00D980FC /* Style */,
 				31C9F82C1A2368A2008BB945 /* BlogDetailHeaderView.h */,
 				31C9F82D1A2368A2008BB945 /* BlogDetailHeaderView.m */,
@@ -3813,6 +3816,14 @@
 			path = Pages;
 			sourceTree = "<group>";
 		};
+		FA5C74091C596E69000B528C /* SiteManagement */ = {
+			isa = PBXGroup;
+			children = (
+				FA5C740A1C596E69000B528C /* DeleteSiteViewController.swift */,
+			);
+			path = SiteManagement;
+			sourceTree = "<group>";
+		};
 		FFF96F8319EBE7FB00DFC821 /* UITests */ = {
 			isa = PBXGroup;
 			children = (
@@ -4537,6 +4548,7 @@
 				B5E167F419C08D18009535AA /* NSCalendar+Helpers.swift in Sources */,
 				BE1071FC1BC75E7400906AFF /* WPStyleGuide+Blog.swift in Sources */,
 				E149D64E19349E69006A843D /* AccountServiceRemoteREST.m in Sources */,
+				FA5C740C1C596E69000B528C /* DeleteSiteViewController.swift in Sources */,
 				5D9282F91B54697D00066CED /* RemoteReaderSiteInfo.m in Sources */,
 				E6D2E16C1B8B423B0000ED14 /* ReaderStreamHeader.swift in Sources */,
 				5DF6571B1AE6ACAC00AAA8D7 /* DisplayableImageHelper.m in Sources */,


### PR DESCRIPTION
Adds the UI for our first pass at WordPress.com site management features as listed in #4570.

To Test:
- Check that Blog > Settings now has an 'Advanced' section with 'Start Over' and 'Delete Site' items for WordPress.com blogs that user has admin access to
- Check that section is not there for non-WordPress.com blogs or non-administered blogs
- Check that Start Over controller opens a Helpshift session if enabled, and goes to browser support otherwise (similar to behaviour of Me > Support)
- Check that Delete Site controller correctly displays blog's primary domain and requires exact match to enable deletion 
- Verify that a deleted site is in fact deleted

Please Review: @kurzee