### PR TITLE
Update media picker to version 0.8.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -36,7 +36,7 @@ target 'WordPress', :exclusive => true do
   pod 'WordPressCom-Stats-iOS/UI', '0.6.1'
   pod 'WordPressCom-Analytics-iOS', '0.1.3'
   pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
-  pod 'WPMediaPicker', '~> 0.8.0'
+  pod 'WPMediaPicker', '~> 0.8.1'
   pod 'ReactiveCocoa', '~> 2.4.7'
   pod 'FormatterKit', '~> 1.8.0'
   pod 'RxSwift', '~> 2.1.0'

--- a/Podfile
+++ b/Podfile
@@ -36,7 +36,7 @@ target 'WordPress', :exclusive => true do
   pod 'WordPressCom-Stats-iOS/UI', '0.6.1'
   pod 'WordPressCom-Analytics-iOS', '0.1.3'
   pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
-  pod 'WPMediaPicker', '~> 0.7.3'
+  pod 'WPMediaPicker', '~> 0.8.0'
   pod 'ReactiveCocoa', '~> 2.4.7'
   pod 'FormatterKit', '~> 1.8.0'
   pod 'RxSwift', '~> 2.1.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -178,7 +178,7 @@ PODS:
     - WordPress-iOS-Shared (~> 0.5.1)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
     - WordPressCom-Stats-iOS/Services
-  - WPMediaPicker (0.7.3)
+  - WPMediaPicker (0.8.0)
   - wpxmlrpc (0.8.1)
 
 DEPENDENCIES:
@@ -222,7 +222,7 @@ DEPENDENCIES:
   - WordPressCom-Analytics-iOS (= 0.1.3)
   - WordPressCom-Stats-iOS/Services (= 0.6.1)
   - WordPressCom-Stats-iOS/UI (= 0.6.1)
-  - WPMediaPicker (~> 0.7.3)
+  - WPMediaPicker (~> 0.8.0)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -292,7 +292,7 @@ SPEC CHECKSUMS:
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
   WordPressCom-Analytics-iOS: 55c52378f752ad8a8bbbd8bd75db0eb4b5a93d34
   WordPressCom-Stats-iOS: 1eff7faca675ed77819d2fa49528f91bea9fdbcc
-  WPMediaPicker: 6bbce465f5a5c071267ae28bdf31d0fd6e109721
+  WPMediaPicker: cc2e022caf5cfd1f3c517c794aa5e3a81e065b05
   wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0
 
 COCOAPODS: 0.39.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -178,7 +178,7 @@ PODS:
     - WordPress-iOS-Shared (~> 0.5.1)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
     - WordPressCom-Stats-iOS/Services
-  - WPMediaPicker (0.8.0)
+  - WPMediaPicker (0.8.1)
   - wpxmlrpc (0.8.1)
 
 DEPENDENCIES:
@@ -222,7 +222,7 @@ DEPENDENCIES:
   - WordPressCom-Analytics-iOS (= 0.1.3)
   - WordPressCom-Stats-iOS/Services (= 0.6.1)
   - WordPressCom-Stats-iOS/UI (= 0.6.1)
-  - WPMediaPicker (~> 0.8.0)
+  - WPMediaPicker (~> 0.8.1)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -292,7 +292,7 @@ SPEC CHECKSUMS:
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
   WordPressCom-Analytics-iOS: 55c52378f752ad8a8bbbd8bd75db0eb4b5a93d34
   WordPressCom-Stats-iOS: 1eff7faca675ed77819d2fa49528f91bea9fdbcc
-  WPMediaPicker: cc2e022caf5cfd1f3c517c794aa5e3a81e065b05
+  WPMediaPicker: 49547df8644892215b357cb94fa08dae5ebde469
   wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
Update media picker to version 0.8.0:

This version of the media picker fixes the following issues:

- remove all deprecated classes that used the AssetLibrary
- remove all user of alert view and popover controllers classes
- update the rotation to be platform independent with no more checks for iPad

Needs Review: @astralbodies 
