### PR TITLE
Hide close in Theme Customizer

### DIFF
--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -706,12 +706,7 @@ public protocol ThemePresenter: class
         suspendedSearch = searchName
         searchController.active = false
         presentingTheme = theme
-        let webViewController = ThemeWebViewController(url: url)
-
-        webViewController.authToken = blog.authToken
-        webViewController.username = blog.usernameForSite
-        webViewController.password = blog.password
-        webViewController.wpLoginURL = NSURL(string: blog.loginUrl())
+        let webViewController = ThemeWebViewController(theme: theme, url: url)
 
         webViewController.loadViewIfNeeded()
         webViewController.navigationItem.titleView = nil

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -706,8 +706,8 @@ public protocol ThemePresenter: class
         suspendedSearch = searchName
         searchController.active = false
         presentingTheme = theme
-        let webViewController = WPWebViewController(URL: NSURL(string: url))
-        
+        let webViewController = ThemeWebViewController(url: url)
+
         webViewController.authToken = blog.authToken
         webViewController.username = blog.usernameForSite
         webViewController.password = blog.password

--- a/WordPress/Classes/ViewRelated/Themes/ThemeWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeWebViewController.swift
@@ -18,6 +18,16 @@ public class ThemeWebViewController: WPWebViewController
             }
         }
     }
+    
+    // MARK: - Navigation constants
+
+    /// All Customize links must have "hide_close" set
+    ///
+    private struct Customize
+    {
+        static let path = "/wp-admin/customize.php"
+        static let hideClose = (name: "hide_close", value: "true")
+    }
 
     // MARK: - Initializer
     
@@ -34,6 +44,27 @@ public class ThemeWebViewController: WPWebViewController
             self.theme = theme
             self.url = NSURL(string: url)
         }
+    }
+
+    // MARK: - UIWebViewDelegate
+
+    override public func webView(webView: UIWebView, shouldStartLoadWithRequest request: NSURLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+        
+        if let url = request.URL, components = NSURLComponents(URL: url, resolvingAgainstBaseURL: false) {
+            
+            if components.path == Customize.path {
+                let hideCloseItem = NSURLQueryItem(name: Customize.hideClose.name, value: Customize.hideClose.value)
+                let queryItems = components.queryItems ?? []
+                if !queryItems.contains(hideCloseItem) {
+                    components.queryItems = queryItems + [hideCloseItem]
+                    self.url = components.URL
+                    
+                    return false
+                }
+            }
+        }
+
+        return super.webView(webView, shouldStartLoadWithRequest: request, navigationType: navigationType)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Themes/ThemeWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeWebViewController.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// ThemeWebViewController adds support for theme page navigation
+///
+public class ThemeWebViewController: WPWebViewController
+{
+    // MARK: - Initializer
+    
+    /// Preferred initializer for ThemeWebViewController
+    ///
+    /// - Parameters:
+    ///     - url: The URL to navigate to when presented
+    ///
+    public convenience init(url: String) {
+        self.init(nibName: "WPWebViewController", bundle: nil)
+        
+        self.url = NSURL(string: url)
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Themes/ThemeWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeWebViewController.swift
@@ -4,17 +4,36 @@ import Foundation
 ///
 public class ThemeWebViewController: WPWebViewController
 {
+    // MARK: - Properties: must be set by creator
+    
+    /// The Theme whose pages will be viewed
+    ///
+    public var theme: Theme? {
+        didSet {
+            if let blog = theme?.blog {
+                authToken = blog.authToken
+                username = blog.usernameForSite
+                password = blog.password
+                wpLoginURL = NSURL(string: blog.loginUrl())
+            }
+        }
+    }
+
     // MARK: - Initializer
     
     /// Preferred initializer for ThemeWebViewController
     ///
     /// - Parameters:
-    ///     - url: The URL to navigate to when presented
+    ///     - theme: The Theme whose pages will be viewed
+    ///     - url:   The URL to navigate to when presented
     ///
-    public convenience init(url: String) {
+    public convenience init(theme: Theme, url: String) {
         self.init(nibName: "WPWebViewController", bundle: nil)
         
-        self.url = NSURL(string: url)
+        defer {
+            self.theme = theme
+            self.url = NSURL(string: url)
+        }
     }
 
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -638,6 +638,7 @@
 		FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */; };
 		FA87F1AC1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA87F1AB1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift */; };
 		FA9E74481C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9E74471C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift */; };
+		FACB36F11C5C2BF800C6DF4E /* ThemeWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACB36F01C5C2BF800C6DF4E /* ThemeWebViewController.swift */; };
 		FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */; };
 		FAFB84061BBF3638000BBA8E /* get-multiple-themes-v1.2.json in Resources */ = {isa = PBXBuildFile; fileRef = FAFB84051BBF3638000BBA8E /* get-multiple-themes-v1.2.json */; };
 		FD21397F13128C5300099582 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FD21397E13128C5300099582 /* libiconv.dylib */; };
@@ -1739,6 +1740,7 @@
 		FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserHeaderView.swift; sourceTree = "<group>"; };
 		FA87F1AB1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceRemote.swift; sourceTree = "<group>"; };
 		FA9E74471C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceRemoteTests.swift; sourceTree = "<group>"; };
+		FACB36F01C5C2BF800C6DF4E /* ThemeWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeWebViewController.swift; sourceTree = "<group>"; };
 		FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartOverViewController.swift; sourceTree = "<group>"; };
 		FAFB84051BBF3638000BBA8E /* get-multiple-themes-v1.2.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "get-multiple-themes-v1.2.json"; sourceTree = "<group>"; };
 		FD0D42C11499F31700F5E115 /* WordPress 4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 4.xcdatamodel"; sourceTree = "<group>"; };
@@ -2401,6 +2403,7 @@
 				FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */,
 				596C035D1B84F21D00899EEB /* ThemeBrowserViewController.swift */,
 				598DD1701B97985700146967 /* ThemeBrowserCell.swift */,
+				FACB36F01C5C2BF800C6DF4E /* ThemeWebViewController.swift */,
 				FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */,
 			);
 			path = Themes;
@@ -4793,6 +4796,7 @@
 				E6DE44671B90D251000FA7EF /* ReaderHelpers.swift in Sources */,
 				5D42A3DF175E7452005CFF05 /* AbstractPost.m in Sources */,
 				BEBFE8721B2F50E0002C04EF /* WPSearchControllerConfigurator.m in Sources */,
+				FACB36F11C5C2BF800C6DF4E /* ThemeWebViewController.swift in Sources */,
 				5D42A3E0175E7452005CFF05 /* BasePost.m in Sources */,
 				5D000DE11AC0879600A7BAF9 /* PostCardActionBarItem.m in Sources */,
 				E1249B4319408C910035E895 /* RemoteComment.m in Sources */,


### PR DESCRIPTION
Closes #4679

Patches navigation to theme customization pages so that the close button is never visible to the user.

To test:
1. Open Sites > site > Themes browser
2. Tap 'Details' in the 'Current Theme' header
3. Scroll down to 'Customize' and tap.
4. Ensure that there is no 'X' in upper left as described in #4679.
5. Return to browser and tap 'Customize' for 'Current Theme' and 'Try & Customize' for non-current themes to ensure links with "hide_close" already set function as expected.

@kwonye: Please review functionality and conformance with Android behaviour.
Needs review: @kwonye 