### PR TITLE
Issue/4756 Allow use of Settings Writing defaults for XML-RPC and non-admin users

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -701,7 +701,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         if ([status isKindOfClass:[NSString class]]) {
             if (weakSelf.blog.settings.defaultPostFormat != status) {
                 weakSelf.blog.settings.defaultPostFormat = status;
-                [weakSelf saveSettings];
+                if ([weakSelf blogSupportsSavingWritingDefaults]) {
+                    [weakSelf saveSettings];
+                }
             }
         }
     };
@@ -831,6 +833,10 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     [[ContextManager sharedInstance] saveContext:self.blog.managedObjectContext];
 }
 
+- (BOOL)blogSupportsSavingWritingDefaults
+{
+    return [self.blog supports:BlogFeatureWPComRESTAPI];
+}
 
 #pragma mark - Authentication methods
 
@@ -1018,7 +1024,10 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 {
     self.blog.settings.defaultCategoryID = category.categoryID;
     self.defaultCategoryCell.detailTextLabel.text = category.categoryName;
-    [self saveSettings];
+    
+    if ([self blogSupportsSavingWritingDefaults]) {
+        [self saveSettings];
+    }
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -544,8 +544,14 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             headingTitle = NSLocalizedString(@"Account", @"Title for the account section in site settings screen");
             break;
         case SiteSettingsSectionWriting:
-            headingTitle = NSLocalizedString(@"Writing", @"Title for the writing section in site settings screen");
+        {
+            if ([self.blog supports:BlogFeatureWPComRESTAPI]) {
+                headingTitle = NSLocalizedString(@"Writing", @"Title for the writing section in site settings screen");
+            } else {
+                headingTitle = NSLocalizedString(@"Writing (App Defaults)", @"Title for the writing section in site settings screen when the settings are saved only within the app.");
+            }
             break;
+        }
         case SiteSettingsSectionAdvanced:
             headingTitle = NSLocalizedString(@"Advanced", @"Title for the advanced section in site settings screen");
             break;

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -197,8 +197,8 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         case SiteSettingsSectionWriting: {
             if ([self.blog supports:BlogFeatureWPComRESTAPI]) {
                 if (!self.blog.isAdmin) {
-                    // If we're not admin, we just want to show the geotagging cell
-                    return 1;
+                    // NOTE: Brent Coursey (2016-02-01): Hides the related post for non-admin users as they cannot change this option.
+                    return SiteSettingsWritingCount - 1;
                 }
                 return SiteSettingsWritingCount;
             } else {
@@ -835,7 +835,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 
 - (BOOL)blogSupportsSavingWritingDefaults
 {
-    return [self.blog supports:BlogFeatureWPComRESTAPI];
+    return [self.blog supports:BlogFeatureWPComRESTAPI] && self.blog.isAdmin;
 }
 
 #pragma mark - Authentication methods

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -195,17 +195,17 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             return SiteSettingsAccountCount;
         }
         case SiteSettingsSectionWriting: {
-            if (!self.blog.isAdmin) {
-                // If we're not admin, we just want to show the geotagging cell
-                return 1;
-            }
-            NSInteger rowsToHide = 0;
-            if (![self.blog supports:BlogFeatureWPComRESTAPI]) {
+            if ([self.blog supports:BlogFeatureWPComRESTAPI]) {
+                if (!self.blog.isAdmin) {
+                    // If we're not admin, we just want to show the geotagging cell
+                    return 1;
+                }
+                return SiteSettingsWritingCount;
+            } else {
                 //  NOTE: Sergio Estevao (2015-09-23): Hides the related post for self-hosted sites not in jetpack
                 // because this options is not available for them.
-                rowsToHide += 1;
+                return SiteSettingsWritingCount - 1;
             }
-            return SiteSettingsWritingCount - rowsToHide;
         }
         case SiteSettingsSectionDiscussion: {
             return 1;

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -545,7 +545,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             break;
         case SiteSettingsSectionWriting:
         {
-            if ([self.blog supports:BlogFeatureWPComRESTAPI]) {
+            if ([self blogSupportsSavingWritingDefaults]) {
                 headingTitle = NSLocalizedString(@"Writing", @"Title for the writing section in site settings screen");
             } else {
                 headingTitle = NSLocalizedString(@"Writing (App Defaults)", @"Title for the writing section in site settings screen when the settings are saved only within the app.");


### PR DESCRIPTION
As seen in https://github.com/wordpress-mobile/WordPress-iOS/issues/4756, this allows XML-RPC and non-admin users to change their writing defaults for use within the app without syncing to the site.

This also adds a bit of text to the section label for "Writing" for users who are only updating these settings locally. Currently this is "Writing (App Defaults)", let me know of any feedback on the wording.

I'm not 100% sure this is the best solution for what's going on here. Should we instead disable these fields altogether for any users who can't sync these options to this site?

**XML-RPC Testing**

1. Open Site Settings for an XML-RPC site as an admin user.
2. Writing options for Default Post Category and Default Post Format should be available.
3. The section label for writing should note that these are for use within the app only.
4. Selecting a new category or post format should update the setting within the app without error.
5. Posting via the editor should use these selected defaults.

**REST Testing**

1. Open Settings for a REST site as an admin user.
2. Writing options for Default Post Category, Default Post Format and Related Posts should be available.
3. Changing any of these settings should update the app's defaults and the site's.

**REST Testing**

1. Open Settings for a REST site as a non-admin user. 
2. Writing options for Default Post Category and Default Post Format should be available.
3. Selecting a new category or post format should update the setting within the app without error.
4. Posting via the editor should use these selected defaults.

@aerych Please review, also @SergioEstevao may have some thoughts?