### PR TITLE
Plans: Display user's current plan

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -12,6 +12,7 @@ data model as well as any custom migrations.
 - `Blog` added new relationship called `menus`. Persisting associated Menus for a site.
 - `Blog` added new relationship called `menuLocations`. Persists associated MenuLocations available for a site.
 - `Blog` added new relationship called `tags`. Persisting associated PostTags for a site.
+- `Blog` added new integer64 attribute `planID` to store a blog's current plan's product ID.
 
 ## WordPress 44 (@aerych 2016-01-11)
 

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -85,6 +85,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (nonatomic, assign, readwrite) BOOL isHostedAtWPcom;
 @property (nonatomic, strong, readwrite) NSString *icon;
 @property (nonatomic, assign, readwrite) SiteVisibility siteVisibility;
+@property (nonatomic, strong, readwrite) NSNumber *planID;
 
 /**
  *  @details    Maps to a BlogSettings instance, which contains a collection of the available preferences, 

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -63,7 +63,7 @@ NSString * const PostFormatStandard = @"standard";
 @dynamic icon;
 @dynamic username;
 @dynamic settings;
-
+@dynamic planID;
 
 @synthesize api = _api;
 @synthesize isSyncingPosts;

--- a/WordPress/Classes/Models/Plan.swift
+++ b/WordPress/Classes/Models/Plan.swift
@@ -1,12 +1,27 @@
 import Foundation
 
+typealias Plan = PlanEnum
+    
 /// Represents a WordPress.com free or paid plan.
 /// - seealso: [WordPress.com Store](https://store.wordpress.com/plans/)
-enum Plan: String {
-    case Free = "free"
-    case Premium = "premium"
-    case Business = "business"
-
+@objc
+enum PlanEnum: Int {
+    // Product IDs of the various plans (https://public-api.wordpress.com/rest/v1/plans/)
+    case Free = 1
+    case Premium = 1003
+    case Business = 1008
+    
+    var slug: String {
+        switch self {
+        case .Free:
+            return "free"
+        case .Premium:
+            return "premium"
+        case .Business:
+            return "business"
+        }
+    }
+    
     /// The localized name of the plan (e.g. "Business").
     var title: String {
         switch self {
@@ -44,16 +59,33 @@ enum Plan: String {
     }
 }
 
+// We currently need to access the title of a plan in BlogDetailsViewController, which is
+// written in Objective-C. This small wrapper lets us do that.
+@objc(Plan)
+class PlanObjc: NSObject {
+    @nonobjc
+    private let plan: Plan
+    
+    init(plan: Plan) {
+        self.plan = plan
+        super.init()
+    }
+    
+    var title: String {
+        return plan.title
+    }
+}
+
 // Icons
 extension Plan {
     /// The name of the image that represents the plan when it's not the current plan
     var imageName: String {
-        return "plan-\(rawValue)"
+        return "plan-\(slug)"
     }
 
     /// The name of the image that represents the plan when it's the current plan
     var activeImageName: String {
-        return "plan-\(rawValue)-active"
+        return "plan-\(slug)-active"
     }
 
     /// An image that represents the plan when it's not the current plan

--- a/WordPress/Classes/Models/Plan.swift
+++ b/WordPress/Classes/Models/Plan.swift
@@ -65,8 +65,16 @@ enum PlanEnum: Int {
 class PlanObjc: NSObject {
     @nonobjc
     private let plan: Plan
-    
-    init(plan: Plan) {
+
+    init?(planID: Int) {
+        guard let plan = Plan(rawValue: planID) else {
+            // We need to initialize this to something before we can fail
+            // Should be fixed in Swift 2.2
+            self.plan = .Free
+            super.init()
+            return nil
+        }
+
         self.plan = plan
         super.init()
     }

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -151,6 +151,7 @@ static NSString * const UserDictionaryAvatarURLKey = @"avatar_URL";
     blog.icon = [jsonBlog stringForKeyPath:@"icon.img"];
     blog.isAdmin = [[jsonBlog numberForKeyPath:@"capabilities.manage_options"] boolValue];
     blog.visible = [[jsonBlog numberForKey:@"visible"] boolValue];
+    blog.planID = [jsonBlog numberForKeyPath:@"plan.product_id"];
     return blog;
 }
 

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
@@ -39,6 +39,11 @@
 @property (nonatomic, copy) NSString *icon;
 
 /**
+ *  @details Product ID of the site's current plan, if it has one.
+ */
+@property (nonatomic, copy) NSNumber *planID;
+
+/**
  *  @details Indicates whether it's a jetpack site, or not.
  */
 @property (nonatomic, assign) BOOL jetpack;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -537,6 +537,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
         blog.icon = remoteBlog.icon;
         blog.isAdmin = remoteBlog.isAdmin;
         blog.visible = remoteBlog.visible;
+        blog.planID = remoteBlog.planID;
         
         // Update 'Top Level' Settings
         BlogSettings *settings = blog.settings;

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -140,7 +140,7 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
 
     [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
-    [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:BlogDetailsCellIdentifier];
+    [self.tableView registerClass:[WPTableViewCellValue1 class] forCellReuseIdentifier:BlogDetailsCellIdentifier];
 
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
@@ -222,11 +222,16 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
                                                  }]];
 
     if ([Feature enabled:FeatureFlagPlans] && [self.blog supports:BlogFeaturePlans]) {
-        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Plans", @"Action title. Noun. Links to a blog's Plans screen.")
-                                                        image:[UIImage imageNamed:@"icon-menu-plans"]
-                                                     callback:^{
-                                                         [weakSelf showPlans];
-                                                     }]];
+        BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Plans", @"Action title. Noun. Links to a blog's Plans screen.")
+                                                              image:[UIImage imageNamed:@"icon-menu-plans"]
+                                                           callback:^{
+                                                               [weakSelf showPlans];
+                                                           }];
+
+        Plan *plan = [[Plan alloc] initWithPlan:[self.blog.planID integerValue]];
+        row.detail = plan.title;
+
+        [rows addObject:row];
     }
     
     return [[BlogDetailsSection alloc] initWithTitle:nil andRows:rows];
@@ -255,7 +260,8 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
                                                        }];
     NSUInteger numberOfPendingComments = [self.blog numberOfPendingComments];
     if (numberOfPendingComments > 0) {
-        row.detail = [NSString stringWithFormat:@"%d", numberOfPendingComments];
+        // TODO (@frosty 2015-02-01) Needs review for correct functionality and whether we still desire this functionality.
+        // row.detail = [NSString stringWithFormat:@"%d", numberOfPendingComments];
     }
     [rows addObject:row];
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -228,7 +228,7 @@ NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
                                                                [weakSelf showPlans];
                                                            }];
 
-        Plan *plan = [[Plan alloc] initWithPlan:[self.blog.planID integerValue]];
+        Plan *plan = [[Plan alloc] initWithPlanID:[self.blog.planID integerValue]];
         row.detail = plan.title;
 
         [rows addObject:row];

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 45.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 45.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15C50" minimumToolsVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15D21" minimumToolsVersion="Automatic">
     <entity name="AbstractPost" representedClassName="AbstractPost" isAbstract="YES" parentEntity="BasePost">
         <attribute name="metaIsLocal" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="metaPublishImmediately" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>
@@ -113,6 +113,7 @@
         <attribute name="options" optional="YES" attributeType="Transformable">
             <userInfo/>
         </attribute>
+        <attribute name="planID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <attribute name="postFormats" optional="YES" attributeType="Transformable">
             <userInfo/>
         </attribute>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 45.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 45.xcdatamodel/contents
@@ -113,7 +113,7 @@
         <attribute name="options" optional="YES" attributeType="Transformable">
             <userInfo/>
         </attribute>
-        <attribute name="planID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="planID" optional="YES" attributeType="Integer 64" syncable="YES"/>
         <attribute name="postFormats" optional="YES" attributeType="Transformable">
             <userInfo/>
         </attribute>


### PR DESCRIPTION
Displays a blog's current Plan on its row in `BlogDetailViewController`.

![plandisplay](https://cloud.githubusercontent.com/assets/4780/12732819/45423bee-c92f-11e5-97a6-cb6051e9443b.png)

**Note:** To display the detail value on the row, I had to change `BlogDetailViewController` to register the `Value1` cell type instead of the standard `WPTableViewCell`. This had the side effect of displaying the number of pending comments on the Comments row, which appears to have not been working since  219812a1 when it was changed _from_ `Value1`. I've disabled the line that adds the number of comments to the cell, and I'm opening another issue to flag it for review / removal.

### To Test

* Select various blogs with different types of plan from the blog list and ensure you can see their correct plan in the blog detail screen. 
* Jetpack sites should currently display no value.

Part of #4744

Needs Review: @koke 