### PR TITLE
Theme Search Layout

### DIFF
--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -242,7 +242,9 @@ public protocol ThemePresenter: class
     public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
         
-        collectionView?.collectionViewLayout.invalidateLayout()
+        coordinator.animateAlongsideTransition({ [weak self] context in
+            self?.collectionView?.collectionViewLayout.invalidateLayout()
+        }, completion: nil)
     }
 
     public override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
Closes #4639 

Resuming a search on web controller dismissal now adapts properly to changed bounds and size class of view whilst the browser was hidden.

To test: 
1. Open Sites > site > Themes browser
2. Activate Search and enter a search string.
3. Tap a result to display its preview.
4. Rotate device 90°.
5. Dismiss preview and ensure reveal smoothly animates back to a browser with grid cell size adapted to content width.

@kurzee: Could you check everything you reported in #4639 is fixed please?
Needs review: @kurzee 