### PR TITLE
Issue/4756 Reorganizes appearance of geotagging and post defaults.

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -6,6 +6,7 @@
 #import "WPError.h"
 #import "Comment.h"
 #import "Post.h"
+#import "PostCategory.h"
 #import "Page.h"
 #import "Media.h"
 #import "PostCategoryService.h"
@@ -802,8 +803,8 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     settings.privacy = remoteSettings.privacy ?: settings.privacy;
     
     // Writing
-    settings.defaultCategoryID = remoteSettings.defaultCategoryID ?: settings.defaultCategoryID;
-    settings.defaultPostFormat = remoteSettings.defaultPostFormat ?: settings.defaultPostFormat;
+    settings.defaultCategoryID = remoteSettings.defaultCategoryID ?: @(PostCategoryUncategorized);
+    settings.defaultPostFormat = remoteSettings.defaultPostFormat;
 
     // Discussion
     settings.commentsAllowed = [remoteSettings.commentsAllowed boolValue];

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -42,16 +42,16 @@ NS_ENUM(NSInteger, SiteSettingsAccount) {
     SiteSettingsAccountCount,
 };
 
-NS_ENUM(NSInteger, SiteSettingsDevice) {
-    SiteSettingsDeviceGeotagging = 0,
-    SiteSettingsDeviceCount
-};
-
 NS_ENUM(NSInteger, SiteSettingsWriting) {
     SiteSettingsWritingDefaultCategory= 0,
     SiteSettingsWritingDefaultPostFormat,
     SiteSettingsWritingRelatedPosts,
     SiteSettingsWritingCount,
+};
+
+NS_ENUM(NSInteger, SiteSettingsDevice) {
+    SiteSettingsDeviceGeotagging = 0,
+    SiteSettingsDeviceCount
 };
 
 NS_ENUM(NSInteger, SiteSettingsAdvanced) {
@@ -63,9 +63,9 @@ NS_ENUM(NSInteger, SiteSettingsAdvanced) {
 NS_ENUM(NSInteger, SiteSettingsSection) {
     SiteSettingsSectionGeneral = 0,
     SiteSettingsSectionAccount,
-    SiteSettingsSectionDevice,
     SiteSettingsSectionWriting,
     SiteSettingsSectionDiscussion,
+    SiteSettingsSectionDevice,
     SiteSettingsSectionRemoveSite,
     SiteSettingsSectionAdvanced,
 };
@@ -83,12 +83,13 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 @property (nonatomic, strong) SettingTableViewCell *usernameTextCell;
 @property (nonatomic, strong) SettingTableViewCell *passwordTextCell;
 #pragma mark - Writing Section
-@property (nonatomic, strong) SwitchTableViewCell *geotaggingCell;
 @property (nonatomic, strong) SettingTableViewCell *defaultCategoryCell;
 @property (nonatomic, strong) SettingTableViewCell *defaultPostFormatCell;
 @property (nonatomic, strong) SettingTableViewCell *relatedPostsCell;
-#pragma mark - Discussion
+#pragma mark - Discussion Section
 @property (nonatomic, strong) SettingTableViewCell *discussionSettingsCell;
+#pragma mark - Device Section
+@property (nonatomic, strong) SwitchTableViewCell *geotaggingCell;
 #pragma mark - Removal Section
 @property (nonatomic, strong) UITableViewCell *removeSiteCell;
 #pragma mark - Advanced Section
@@ -133,8 +134,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         [sections addObject:@(SiteSettingsSectionAccount)];
     }
     
-    [sections addObject:@(SiteSettingsSectionDevice)];
-    
     if ([self.blog supports:BlogFeatureWPComRESTAPI] && self.blog.isAdmin) {
         // only REST API connections and admins can change Writing options
         [sections addObject:@(SiteSettingsSectionWriting)];
@@ -143,6 +142,8 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     if ([self.blog supports:BlogFeatureWPComRESTAPI]) {
         [sections addObject:@(SiteSettingsSectionDiscussion)];
     }
+    
+    [sections addObject:@(SiteSettingsSectionDevice)];
     
     if ([self.blog supports:BlogFeatureRemovable]) {
         [sections addObject:@(SiteSettingsSectionRemoveSite)];
@@ -204,14 +205,14 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         case SiteSettingsSectionAccount: {
             return SiteSettingsAccountCount;
         }
-        case SiteSettingsSectionDevice: {
-            return SiteSettingsDeviceCount;
-        }
         case SiteSettingsSectionWriting: {
             return SiteSettingsWritingCount;
         }
         case SiteSettingsSectionDiscussion: {
             return 1;
+        }
+        case SiteSettingsSectionDevice: {
+            return SiteSettingsDeviceCount;
         }
         case SiteSettingsSectionRemoveSite: {
             return 1;
@@ -487,14 +488,14 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         case SiteSettingsSectionAccount: {
             return [self tableView:tableView cellForAccountSettingsInRow:indexPath.row];
         }
-        case SiteSettingsSectionDevice: {
-            return self.geotaggingCell;
-        }
         case SiteSettingsSectionWriting: {
             return [self tableView:tableView cellForWritingSettingsAtRow:indexPath.row];
         }
         case SiteSettingsSectionDiscussion: {
             return self.discussionSettingsCell;
+        }
+        case SiteSettingsSectionDevice: {
+            return self.geotaggingCell;
         }
         case SiteSettingsSectionRemoveSite: {
             return self.removeSiteCell;


### PR DESCRIPTION
As discussed in https://github.com/wordpress-mobile/WordPress-iOS/pull/4757, the best approach for resolving our feature confusion with default post options is to disable toggling the options for non-admin or XML-RPC users in Site Settings.

This PR changes the Site Settings to only show the default post options for admin REST API users. This also moves the Geotagging option within a new section titled "This Device", which is available for all users.

This brings parity with the Calypso web handling of default post options, in which the options are only available sites connected as admin users.

The only concern I could see with this change is potential confusion with any users who might have already changed their default post options in-app as non-admin REST or XML-RPC users. An upcoming update including this change would disallow them from changing their default options again, in-app. The only way for the user to update their previously made changes in-app would be to re-connect their site or account, restoring the site defaults.

REST Testing:
1. Open Site Settings for a site connected via the REST-API and as an admin user.
2. Observe the available default category, post format and related posts options.
3. Observe the available Geotagging option under "This Device".

REST Testing:
1. Open Site Settings for a site connected via the REST-API and as a non-admin user.
2. Observe no availability for the default category, post format and related posts options.
3. Observe the available Geotagging option under "This Device".

XML-RPC Testing:
1. Open Site Settings for a site connected via the XML-RPC.
2. Observe no availability for the default category, post format and related posts options.
3. Observe the available Geotagging option under "This Device".

@aerych please review. Also, @mattmiklic please review the text changes.