### PR TITLE
Reorganizes post options in Settings.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -51,6 +51,8 @@ NS_ENUM(NSInteger, SiteSettingsWriting) {
 
 NS_ENUM(NSInteger, SiteSettingsDevice) {
     SiteSettingsDeviceGeotagging = 0,
+    SiteSettingsDeviceDefaultCategory,
+    SiteSettingsDeviceDefaultPostFormat,
     SiteSettingsDeviceCount,
 };
 
@@ -134,7 +136,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         [sections addObject:@(SiteSettingsSectionAccount)];
     }
     
-    if (self.blog.isAdmin || ![self.blog supports:BlogFeatureWPComRESTAPI]) {
+    if ([self.blog supports:BlogFeatureWPComRESTAPI] && self.blog.isAdmin) {
         [sections addObject:@(SiteSettingsSectionWriting)];
     }
     
@@ -205,18 +207,17 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             return SiteSettingsAccountCount;
         }
         case SiteSettingsSectionWriting: {
-            NSInteger rowsToHide = 0;
-            if (![self.blog supports:BlogFeatureWPComRESTAPI]) {
-                //  NOTE: Sergio Estevao (2015-09-23): Hides the related post for self-hosted sites not in jetpack
-                // because this options is not available for them.
-                rowsToHide += 1;
-            }
-            return SiteSettingsWritingCount - rowsToHide;
+            return SiteSettingsWritingCount;
         }
         case SiteSettingsSectionDiscussion: {
             return 1;
         }
         case SiteSettingsSectionDevice: {
+            if ([self.blog supports:BlogFeatureWPComRESTAPI]) {
+                // NOTE: Brent Coursey (2016-02-03): Only show geotagging cell for user of the REST API (REST).
+                // Any post default options are available in the Writing section for REST users.
+                return 1;
+            }
             return SiteSettingsDeviceCount;
         }
         case SiteSettingsSectionRemoveSite: {
@@ -348,18 +349,28 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     return _removeSiteCell;
 }
 
+- (void)configureDefaultCategoryCell
+{
+    PostCategoryService *postCategoryService = [[PostCategoryService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
+    PostCategory *postCategory = [postCategoryService findWithBlogObjectID:self.blog.objectID andCategoryID:self.blog.settings.defaultCategoryID];
+    [self.defaultCategoryCell setTextValue:[postCategory categoryName]];
+}
+
+- (void)configureDefaultPostFormatCell
+{
+    [self.defaultPostFormatCell setTextValue:self.blog.defaultPostFormatText];
+}
+
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForWritingSettingsAtRow:(NSInteger)row
 {
     switch (row) {
         case (SiteSettingsWritingDefaultCategory):{
-            PostCategoryService *postCategoryService = [[PostCategoryService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
-            PostCategory *postCategory = [postCategoryService findWithBlogObjectID:self.blog.objectID andCategoryID:self.blog.settings.defaultCategoryID];
-            [self.defaultCategoryCell setTextValue:[postCategory categoryName]];
+            [self configureDefaultCategoryCell];
             return self.defaultCategoryCell;
         }
         break;
         case (SiteSettingsWritingDefaultPostFormat):{
-            [self.defaultPostFormatCell setTextValue:self.blog.defaultPostFormatText];
+            [self configureDefaultPostFormatCell];
             return self.defaultPostFormatCell;
         }
         case (SiteSettingsWritingRelatedPosts):{
@@ -367,6 +378,28 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         }
         break;
 
+    }
+    return nil;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForDeviceSettingsAtRow:(NSInteger)row
+{
+    switch (row) {
+        case (SiteSettingsDeviceGeotagging):{
+            return self.geotaggingCell;
+        }
+            break;
+        case (SiteSettingsDeviceDefaultCategory):{
+            [self configureDefaultCategoryCell];
+            return self.defaultCategoryCell;
+        }
+            break;
+        case (SiteSettingsDeviceDefaultPostFormat):{
+            [self configureDefaultPostFormatCell];
+            return self.defaultPostFormatCell;
+        }
+            break;
+            
     }
     return nil;
 }
@@ -500,7 +533,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             return self.discussionSettingsCell;
         }
         case SiteSettingsSectionDevice: {
-            return self.geotaggingCell;
+            return [self tableView:tableView cellForDeviceSettingsAtRow:indexPath.row];
         }
         case SiteSettingsSectionRemoveSite: {
             return self.removeSiteCell;
@@ -670,6 +703,22 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     }
 }
 
+- (void)showDefaultCategorySelector
+{
+    PostCategoryService *postCategoryService = [[PostCategoryService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
+    NSNumber *defaultCategoryID = self.blog.settings.defaultCategoryID ?: @(PostCategoryUncategorized);
+    PostCategory *postCategory = [postCategoryService findWithBlogObjectID:self.blog.objectID andCategoryID:defaultCategoryID];
+    NSArray *currentSelection = @[];
+    if (postCategory){
+        currentSelection = @[postCategory];
+    }
+    PostCategoriesViewController *postCategoriesViewController = [[PostCategoriesViewController alloc] initWithBlog:self.blog
+                                                                                                   currentSelection:currentSelection
+                                                                                                      selectionMode:CategoriesSelectionModeBlogDefault];
+    postCategoriesViewController.delegate = self;
+    [self.navigationController pushViewController:postCategoriesViewController animated:YES];
+}
+
 - (void)showPostFormatSelector
 {
     NSArray *titles = self.blog.sortedPostFormatNames;
@@ -717,18 +766,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 {
     switch (row) {
         case SiteSettingsWritingDefaultCategory:{
-            PostCategoryService *postCategoryService = [[PostCategoryService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
-            NSNumber *defaultCategoryID = self.blog.settings.defaultCategoryID ?: @(PostCategoryUncategorized);
-            PostCategory *postCategory = [postCategoryService findWithBlogObjectID:self.blog.objectID andCategoryID:defaultCategoryID];
-            NSArray *currentSelection = @[];
-            if (postCategory){
-                currentSelection = @[postCategory];
-            }
-            PostCategoriesViewController *postCategoriesViewController = [[PostCategoriesViewController alloc] initWithBlog:self.blog
-                                                                                                           currentSelection:currentSelection
-                                                                                                              selectionMode:CategoriesSelectionModeBlogDefault];
-            postCategoriesViewController.delegate = self;
-            [self.navigationController pushViewController:postCategoriesViewController animated:YES];
+            [self showDefaultCategorySelector];
         }
         break;
         case SiteSettingsWritingDefaultPostFormat:{
@@ -739,7 +777,20 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             [self showRelatedPostsSettings];
         }
         break;
+    }
+}
 
+- (void)tableView:(UITableView *)tableView didSelectInDeviceSectionRow:(NSInteger)row
+{
+    switch (row) {
+        case SiteSettingsDeviceDefaultCategory:{
+            [self showDefaultCategorySelector];
+        }
+        break;
+        case SiteSettingsDeviceDefaultPostFormat:{
+            [self showPostFormatSelector];
+        }
+        break;
     }
 }
 
@@ -786,6 +837,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         } break;
         case SiteSettingsSectionDiscussion: {
             [self showDiscussionSettingsForBlog:self.blog];
+        } break;
+        case SiteSettingsSectionDevice: {
+            [self tableView:tableView didSelectInDeviceSectionRow:indexPath.row];
         } break;
         case SiteSettingsSectionRemoveSite:{
             [tableView deselectSelectedRowWithAnimation:YES];

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -134,7 +134,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         [sections addObject:@(SiteSettingsSectionAccount)];
     }
     
-    if (self.blog.isAdmin) {
+    if (self.blog.isAdmin || ![self.blog supports:BlogFeatureWPComRESTAPI]) {
         [sections addObject:@(SiteSettingsSectionWriting)];
     }
     
@@ -696,7 +696,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         if ([status isKindOfClass:[NSString class]]) {
             if (weakSelf.blog.settings.defaultPostFormat != status) {
                 weakSelf.blog.settings.defaultPostFormat = status;
-                [weakSelf saveSettings];
+                if ([weakSelf savingWritingDefaultsIsAvailable]) {
+                    [weakSelf saveSettings];
+                }
             }
         }
     };
@@ -943,6 +945,11 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     }];
 }
 
+- (BOOL)savingWritingDefaultsIsAvailable
+{
+    return [self.blog supports:BlogFeatureWPComRESTAPI] && self.blog.isAdmin;
+}
+
 - (IBAction)cancel:(id)sender
 {
     if (self.isCancellable) {
@@ -1013,7 +1020,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 {
     self.blog.settings.defaultCategoryID = category.categoryID;
     self.defaultCategoryCell.detailTextLabel.text = category.categoryName;
-    [self saveSettings];
+    if ([self savingWritingDefaultsIsAvailable]) {
+        [self saveSettings];
+    }
 }
 
 @end


### PR DESCRIPTION
Resolves the conversation and issues raised in https://github.com/wordpress-mobile/WordPress-iOS/issues/4756, https://github.com/wordpress-mobile/WordPress-iOS/pull/4757 and https://github.com/wordpress-mobile/WordPress-iOS/pull/4766.

After much thought and conversation with @aerych. The best approach moving forward allows for both admin and non-admin users of XML-RPC sites to toggle default post options under a new section in settings titled "This Device".

This PR also moves "Geotagging" under "This Device" for all users, XML-RPC and REST.

REST users only have default post options available if they are admins of the connected site and under the section "Writing". Non-admins will instead default to what the admin has selected for the site. (This is in parity with Calypso on the web)

REST Testing:
1. Open Site Settings for a site connected via the REST-API and as an admin user.
2. Observe the available default category, post format and related posts options under "Writing".
3. Observe the available Geotagging option under "This Device".
4. Selecting any of the available options updates both in-app and on the site.

REST Testing:
1. Open Site Settings for a site connected via the REST-API and as a non-admin user.
2. Observe no available "Writing" section.
3. Observe the available Geotagging option under "This Device".

XML-RPC Testing:
1. Open Site Settings for a site connected via the XML-RPC as admin or non-admin user.
2. Observe the availability for the default category, post format options under "This Device".
3. Observe the available Geotagging option under "This Device" as well.

@aerych please review and @mattmiklic on the text review, one more time. 😃Thanks so much for your input guys.