### PR TITLE
Fixing broken link to app store review

### DIFF
--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.h
@@ -119,4 +119,9 @@ typedef void (^AppRatingCompletionBlock)();
  */
 + (BOOL)hasUserEverDislikedApp;
 
+/**
+ *  The App Review URL that we send off to UIApplication to open up the app store review page.
+ */
++ (NSString *)appReviewUrl;
+
 @end

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
@@ -28,6 +28,7 @@ NSString *const AppRatingDislikedCurrentVersion = @"AppRatingDislikedCurrentVers
 NSString *const AppRatingLikedCurrentVersion = @"AppRatingLikedCurrentVersion";
 NSString *const AppRatingUserLikeCount = @"AppRatingUserLikeCount";
 NSString *const AppRatingUserDislikeCount = @"AppRatingUserDislikeCount";
+NSString *const AppRatingDefaultAppReviewUrl = @"http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=335703880&pageNumber=0&sortOrdering=2&type=Purple+Software&mt=8";
 
 NSString *const AppReviewPromptDisabledUrl = @"https://api.wordpress.org/iphoneapp/app-review-prompt-check/1.0/";
 
@@ -332,7 +333,7 @@ NSString *const AppReviewPromptDisabledUrl = @"https://api.wordpress.org/iphonea
 {
     AppRatingUtility *sharedInstance = [AppRatingUtility sharedInstance];
     if (sharedInstance.appReviewUrl.length == 0) {
-        return [NSString stringWithFormat:@"http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=%@&pageNumber=0&sortOrdering=2&type=Purple+Software&mt=8", WPiTunesAppId];
+        return AppRatingDefaultAppReviewUrl;
     } else {
         return sharedInstance.appReviewUrl;
     }

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
@@ -9,7 +9,7 @@
 @property (nonatomic, strong) NSMutableDictionary *sections;
 @property (nonatomic, strong) NSMutableDictionary *disabledSections;
 @property (nonatomic, assign) BOOL allPromptingDisabled;
-@property (nonatomic, strong) NSString *appReviewUrl;
+@property (nonatomic, copy) NSString *appReviewUrl;
 
 @end
 
@@ -37,7 +37,6 @@ NSString *const AppReviewPromptDisabledUrl = @"https://api.wordpress.org/iphonea
     if (self) {
         _sections = [NSMutableDictionary dictionary];
         _disabledSections = [NSMutableDictionary dictionary];
-        _appReviewUrl = [NSString stringWithFormat:@"http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=%@&pageNumber=0&sortOrdering=2&type=Purple+Software&mt=8", WPiTunesAppId];
     }
     return self;
 }
@@ -79,12 +78,10 @@ NSString *const AppReviewPromptDisabledUrl = @"https://api.wordpress.org/iphonea
             appRatingUtility.disabledSections[key] = @(disableSection);
         }];
         
-        if (responseDictionary[@"app-review-url"] != nil) {
-            NSString *appReviewUrl = responseDictionary[@"app-review-url"];
-            if (appReviewUrl.length > 0) {
-                AppRatingUtility *sharedInstance = [self sharedInstance];
-                sharedInstance.appReviewUrl = appReviewUrl;
-            }
+        NSString *appReviewUrl = [responseDictionary stringForKey:@"app-review-url"];
+        if (appReviewUrl.length > 0) {
+            AppRatingUtility *sharedInstance = [self sharedInstance];
+            sharedInstance.appReviewUrl = appReviewUrl;
         }
         
         if (success) {
@@ -334,7 +331,11 @@ NSString *const AppReviewPromptDisabledUrl = @"https://api.wordpress.org/iphonea
 + (NSString *)appReviewUrl
 {
     AppRatingUtility *sharedInstance = [AppRatingUtility sharedInstance];
-    return sharedInstance.appReviewUrl;
+    if (sharedInstance.appReviewUrl.length == 0) {
+        return [NSString stringWithFormat:@"http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=%@&pageNumber=0&sortOrdering=2&type=Purple+Software&mt=8", WPiTunesAppId];
+    } else {
+        return sharedInstance.appReviewUrl;
+    }
 }
 
 @end

--- a/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
+++ b/WordPress/Classes/Utility/Ratings/AppRatingUtility.m
@@ -1,12 +1,15 @@
 
 #import "AppRatingUtility.h"
 
+#import "Constants.h"
+
 @interface AppRatingUtility ()
 
 @property (nonatomic, assign) NSUInteger systemWideSignificantEventCountRequiredForPrompt;
 @property (nonatomic, strong) NSMutableDictionary *sections;
 @property (nonatomic, strong) NSMutableDictionary *disabledSections;
 @property (nonatomic, assign) BOOL allPromptingDisabled;
+@property (nonatomic, strong) NSString *appReviewUrl;
 
 @end
 
@@ -34,6 +37,7 @@ NSString *const AppReviewPromptDisabledUrl = @"https://api.wordpress.org/iphonea
     if (self) {
         _sections = [NSMutableDictionary dictionary];
         _disabledSections = [NSMutableDictionary dictionary];
+        _appReviewUrl = [NSString stringWithFormat:@"http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=%@&pageNumber=0&sortOrdering=2&type=Purple+Software&mt=8", WPiTunesAppId];
     }
     return self;
 }
@@ -74,6 +78,14 @@ NSString *const AppReviewPromptDisabledUrl = @"https://api.wordpress.org/iphonea
             BOOL disableSection = [responseDictionary[disabledKey] boolValue];
             appRatingUtility.disabledSections[key] = @(disableSection);
         }];
+        
+        if (responseDictionary[@"app-review-url"] != nil) {
+            NSString *appReviewUrl = responseDictionary[@"app-review-url"];
+            if (appReviewUrl.length > 0) {
+                AppRatingUtility *sharedInstance = [self sharedInstance];
+                sharedInstance.appReviewUrl = appReviewUrl;
+            }
+        }
         
         if (success) {
             success();
@@ -317,6 +329,12 @@ NSString *const AppReviewPromptDisabledUrl = @"https://api.wordpress.org/iphonea
 + (void)assertValidSection:(NSString *)section
 {
     NSAssert([[AppRatingUtility sharedInstance].sections.allKeys containsObject:section], @"Invalid section");
+}
+
++ (NSString *)appReviewUrl
+{
+    AppRatingUtility *sharedInstance = [AppRatingUtility sharedInstance];
+    return sharedInstance.appReviewUrl;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -988,8 +988,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 - (void)appbotPromptForReview
 {
     [WPAnalytics track:WPAnalyticsStatAppReviewsRatedApp];
-    NSString *appReviewUrl = [NSString stringWithFormat:@"http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=%@&pageNumber=0&sortOrdering=2&type=Purple+Software&mt=8", WPiTunesAppId];
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:appReviewUrl]];
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[AppRatingUtility appReviewUrl]]];
     [AppRatingUtility ratedCurrentVersion];
     [self hideRatingView];
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -988,7 +988,8 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 - (void)appbotPromptForReview
 {
     [WPAnalytics track:WPAnalyticsStatAppReviewsRatedApp];
-    [ABXAppStore openAppStoreReviewForApp:WPiTunesAppId];
+    NSString *appReviewUrl = [NSString stringWithFormat:@"http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=%@&pageNumber=0&sortOrdering=2&type=Purple+Software&mt=8", WPiTunesAppId];
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:appReviewUrl]];
     [AppRatingUtility ratedCurrentVersion];
     [self hideRatingView];
 }


### PR DESCRIPTION
Our App Ratings prompt is currently broken. I don't know what happened but I think recently Apple changed things and the link that we used to use to pull up the App Review page from within the app no longer works. This PR updates the link to work correctly.

**To Test**

1. Start with a clean version of WPiOS
2. Login
3. Go to the Notifications Page
4. Open 5 notifications
5. Once the prompt appears tap "I Like It" -> "Leave a Review". At this point the App Store review page should display.

Needs Review:@astralbodies