### PR TITLE
Disables Simperium verbose logs

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -29,7 +29,7 @@ target 'WordPress', :exclusive => true do
   pod 'EmailChecker', :podspec => 'https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec'
   pod 'MGImageUtilities', :git => 'git://github.com/wordpress-mobile/MGImageUtilities.git', :branch => 'gifsupport'
   pod 'NSObject-SafeExpectations', '0.0.2'
-  pod 'Simperium', '0.8.10'
+  pod 'Simperium', '0.8.12'
   pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
   pod 'WordPress-iOS-Shared', '0.5.1'
   pod 'WordPress-iOS-Editor', '1.1.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -140,17 +140,17 @@ PODS:
   - RxSwift (2.1.0)
   - RxTests (2.1.0):
     - RxSwift (~> 2.0)
-  - Simperium (0.8.10):
-    - Simperium/DiffMatchPach (= 0.8.10)
-    - Simperium/JRSwizzle (= 0.8.10)
-    - Simperium/SocketRocket (= 0.8.10)
-    - Simperium/SPReachability (= 0.8.10)
-    - Simperium/SSKeychain (= 0.8.10)
-  - Simperium/DiffMatchPach (0.8.10)
-  - Simperium/JRSwizzle (0.8.10)
-  - Simperium/SocketRocket (0.8.10)
-  - Simperium/SPReachability (0.8.10)
-  - Simperium/SSKeychain (0.8.10)
+  - Simperium (0.8.12):
+    - Simperium/DiffMatchPach (= 0.8.12)
+    - Simperium/JRSwizzle (= 0.8.12)
+    - Simperium/SocketRocket (= 0.8.12)
+    - Simperium/SPReachability (= 0.8.12)
+    - Simperium/SSKeychain (= 0.8.12)
+  - Simperium/DiffMatchPach (0.8.12)
+  - Simperium/JRSwizzle (0.8.12)
+  - Simperium/SocketRocket (0.8.12)
+  - Simperium/SPReachability (0.8.12)
+  - Simperium/SSKeychain (0.8.12)
   - Specta (1.0.5)
   - SVProgressHUD (1.1.3)
   - UIDeviceIdentifier (0.5.0)
@@ -213,7 +213,7 @@ DEPENDENCIES:
   - RxCocoa (~> 2.1.0)
   - RxSwift (~> 2.1.0)
   - RxTests (~> 2.1.0)
-  - Simperium (= 0.8.10)
+  - Simperium (= 0.8.12)
   - Specta (= 1.0.5)
   - SVProgressHUD (~> 1.1.3)
   - UIDeviceIdentifier (~> 0.1)
@@ -286,7 +286,7 @@ SPEC CHECKSUMS:
   RxCocoa: 79b5feb8378545336e756a0a33fcf5e95050b71c
   RxSwift: 110fb07f81c17c2c3b3254d168363057b1880d18
   RxTests: 94c67ffc37c36bd8c7aec90a84601a3db142be94
-  Simperium: f507d9b400c499048a98fe728a0b2b9956fd14c1
+  Simperium: 6622a66f72cb56632547f55215e884702f9b6339
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -739,10 +739,6 @@ int ddLogLevel                                                  = DDLogLevelInfo
     if (manager.didMigrationFail) {
         [self.simperium resetMetadata];
     }
-
-#ifdef DEBUG
-	self.simperium.verboseLoggingEnabled = false;
-#endif
 }
 
 - (void)loginSimperium

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -739,6 +739,8 @@ int ddLogLevel                                                  = DDLogLevelInfo
     if (manager.didMigrationFail) {
         [self.simperium resetMetadata];
     }
+    
+    self.simperium.verboseLoggingEnabled = NO;
 }
 
 - (void)loginSimperium


### PR DESCRIPTION
As per request, let's reduce the Simperium noise in WPiOS Logs, since the integration is already stable.

Needs Review: @SergioEstevao 
Thanks in advance sir!
