### PR TITLE
Reader: Skip searching attachments for a candidate image to feature

### DIFF
--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -575,13 +575,6 @@ static const NSInteger MinutesToReadThreshold = 2;
         featuredImage = [self stringOrEmptyString:[featured_media stringForKey:@"uri"]];
     }
 
-    // If still no image specified, try attachments.
-    if ([featuredImage length] == 0) {
-        NSDictionary *attachments = [dict dictionaryForKey:PostRESTKeyAttachments];
-        NSString *imageToDisplay = [DisplayableImageHelper searchPostAttachmentsForImageToDisplay:attachments];
-        featuredImage = [self stringOrEmptyString:imageToDisplay];
-    }
-
     // If stilll no match, parse content
     if ([featuredImage length] == 0) {
         NSString *content = [dict stringForKey:PostRESTKeyContent];


### PR DESCRIPTION
Closes #4738 

For consistency with the web reader and the Android reader we won't consider images in the attachment's array as candidate featured images.  Related Android issue: https://github.com/wordpress-mobile/WordPress-Android/pull/3679 

Needs review: @kwonye 