### PR TITLE
Reader: Extracts child context creation to ContextManager

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -47,6 +47,18 @@
 - (NSManagedObjectContext *const)newDerivedContext;
 
 /**
+ For usage as a snapshot of the main context. This is useful when operations 
+ should happen on the main queue (fetches) but not immedately reflect changes to
+ the main context.
+
+ Make sure to save using saveContext:
+
+ @return a new MOC with NSMainQueueConcurrencyType,
+ with the parent context as the main context
+ */
+- (NSManagedObjectContext *const)newMainContextChildContext;
+
+/**
  Save a derived context created with `newDerivedContext` via this convenience method
  
  @param a derived NSManagedObjectContext constructed with `newDerivedContext` above

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -41,12 +41,12 @@ static ContextManager *_override;
 
 - (NSManagedObjectContext *const)newDerivedContext
 {
-    NSManagedObjectContext *derived = [[NSManagedObjectContext alloc]
-                                       initWithConcurrencyType:NSPrivateQueueConcurrencyType];
-    derived.parentContext = self.mainContext;
-    derived.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
+    return [self newChildContextWithConcurrencyType:NSPrivateQueueConcurrencyType];
+}
 
-    return derived;
+- (NSManagedObjectContext *const)newMainContextChildContext
+{
+    return [self newChildContextWithConcurrencyType:NSMainQueueConcurrencyType];
 }
 
 - (NSManagedObjectContext *const)mainContext
@@ -58,6 +58,17 @@ static ContextManager *_override;
 
     return _mainContext;
 }
+
+- (NSManagedObjectContext *const)newChildContextWithConcurrencyType:(NSManagedObjectContextConcurrencyType)concurrencyType
+{
+    NSManagedObjectContext *childContext = [[NSManagedObjectContext alloc]
+                                            initWithConcurrencyType:concurrencyType];
+    childContext.parentContext = self.mainContext;
+    childContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
+
+    return childContext;
+}
+
 
 #pragma mark - Context Saving and Merging
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1074,10 +1074,9 @@ import WordPressComAnalytics
             return context
         }
 
-        let mainContext = ContextManager.sharedInstance().mainContext
-        displayContext = NSManagedObjectContext(concurrencyType: .MainQueueConcurrencyType)
-        displayContext!.parentContext = mainContext
+        displayContext = ContextManager.sharedInstance().newMainContextChildContext()
 
+        let mainContext = ContextManager.sharedInstance().mainContext
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "handleContextDidSaveNotification:", name: NSManagedObjectContextDidSaveNotification, object: mainContext)
 
         return displayContext!


### PR DESCRIPTION
Closes #4263 
Moves the child context creation out of `ReaderStreamViewController` and into a new method in `ContextManager`.

Needs review: @astralbodies  