### PR TITLE
Caching stats w/ WPStatsServiceCache (Depends on WordPressCom-Stats-iOS PR #387)

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.h
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.h
@@ -5,7 +5,7 @@
 
 @interface StatsViewController : UIViewController
 
-@property (nonatomic, weak) Blog *blog;
-@property (nonatomic, copy) void (^dismissBlock)();
+@property (nullable, nonatomic, weak) Blog *blog;
+@property (nullable, nonatomic, copy) void (^dismissBlock)();
 
 @end

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -27,7 +27,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     static WPStatsServiceCache *cache = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        cache = [[WPStatsServiceCache alloc] init];
+        cache = [WPStatsServiceCache new];
     });
     return cache;
 }

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -83,6 +83,11 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     [self initStats];
 }
 
+- (nonnull WPStatsServiceCache *)statsServiceCache
+{
+    return [WPStatsServiceCache sharedCache];
+}
+
 - (void)setBlog:(Blog *)blog
 {
     _blog = blog;
@@ -243,12 +248,6 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     viewController.blog = blog;
 
     return viewController;
-}
-
-#pragma mark - Lazy Init
-- (nonnull WPStatsServiceCache *)statsServiceCache
-{
-    return [WPStatsServiceCache sharedCache];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -13,8 +13,26 @@
 #import "WordPress-Swift.h"
 #import "WPAppAnalytics.h"
 #import "WPWebViewController.h"
+#import <WordPressComStatsiOS/WPStatsServiceCache.h>
 
 static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
+
+@interface WPStatsServiceCache (Shared)
+@end
+
+@implementation WPStatsServiceCache (Shared)
+
++ (nonnull instancetype)sharedCache
+{
+    static WPStatsServiceCache *cache = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        cache = [[WPStatsServiceCache alloc] init];
+    });
+    return cache;
+}
+
+@end
 
 @interface StatsViewController () <WPStatsViewControllerDelegate>
 
@@ -22,6 +40,8 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 @property (nonatomic, strong) UINavigationController *statsNavVC;
 @property (nonatomic, strong) WPStatsViewController *statsVC;
 @property (nonatomic, weak) WPNoResultsView *noResultsView;
+
+@property (nonnull, nonatomic, strong) WPStatsServiceCache *statsServiceCache;
 
 @end
 
@@ -49,7 +69,8 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     self.statsNavVC = [[UIStoryboard storyboardWithName:@"SiteStats" bundle:bundle] instantiateInitialViewController];
     self.statsVC = self.statsNavVC.viewControllers.firstObject;
     self.statsVC.statsDelegate = self;
-    
+    self.statsVC.statsServiceCache = self.statsServiceCache;
+
     self.navigationItem.title = NSLocalizedString(@"Stats", @"Stats window title");
 
     // Being shown in a modal window
@@ -222,6 +243,12 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     viewController.blog = blog;
 
     return viewController;
+}
+
+#pragma mark - Lazy Init
+- (nonnull WPStatsServiceCache *)statsServiceCache
+{
+    return [WPStatsServiceCache sharedCache];
 }
 
 @end


### PR DESCRIPTION
### Depends on [WordPressCom-Stats-iOS PR #387](https://github.com/wordpress-mobile/WordPressCom-Stats-iOS/pull/387)

### Issue:
**The following is copy and pasted from PR #387**</br>
Every time `WPStatsViewController` was instantiated, it created two new instances of `WPStatsService` (one for `StatsTableViewController` and one for `InsightsTableViewController`) causing new stats data to be loaded every time `WPStatsViewController` is instantiated.

### What was done
- `StatsViewController` instantiates its child `WPStatsViewController` instance with a `WPStatsServiceCache` instance which [allows for these benefits](https://github.com/wordpress-mobile/WordPressCom-Stats-iOS/pull/387).