### PR TITLE
Refactor ImmuTablePresenter/Controller/VC

### DIFF
--- a/WordPress/Classes/Utility/ImmuTableViewController.swift
+++ b/WordPress/Classes/Utility/ImmuTableViewController.swift
@@ -5,8 +5,8 @@ import WordPressShared
 typealias ImmuTableRowControllerGenerator = ImmuTableRow -> UIViewController
 
 protocol ImmuTablePresenter: class {
-    var visible: Observable<Bool> { get }
     func push(controllerGenerator: ImmuTableRowControllerGenerator) -> ImmuTableAction
+    func present(controllerGenerator: ImmuTableRowControllerGenerator) -> ImmuTableAction
 }
 
 extension ImmuTablePresenter where Self: UIViewController {
@@ -17,14 +17,21 @@ extension ImmuTablePresenter where Self: UIViewController {
             self.navigationController?.pushViewController(controller, animated: true)
         }
     }
+
+    func present(controllerGenerator: ImmuTableRowControllerGenerator) -> ImmuTableAction {
+        return {
+            [unowned self] in
+            let controller = controllerGenerator($0)
+            self.presentViewController(controller, animated: true, completion: nil)
+        }
+    }
 }
 
 protocol ImmuTableController {
-    var presenter: ImmuTablePresenter? { get set }
     var title: String { get }
     var immuTableRows: [ImmuTableRow.Type] { get }
-    var immuTable: Observable<ImmuTable> { get }
     var errorMessage: Observable<String?> { get }
+    func tableViewModelWithPresenter(presenter: ImmuTablePresenter) -> Observable<ImmuTable>
 }
 
 /// Generic view controller to present ImmuTable-based tables
@@ -41,32 +48,31 @@ final class ImmuTableViewController: UITableViewController, ImmuTablePresenter {
 
     private var errorAnimator: ErrorAnimator!
 
-    let controller: ImmuTableController?
+    let controller: ImmuTableController
 
     private let bag = DisposeBag()
 
     // MARK: - Table View Controller
 
-    init(controller: ImmuTableController? = nil) {
+    init(controller: ImmuTableController) {
         self.controller = controller
         super.init(style: .Grouped)
-        self.controller?.presenter = self
-        if let controller = self.controller {
-            title = controller.title
-            registerRows(controller.immuTableRows)
-            controller.immuTable
-                .observeOn(MainScheduler.instance)
-                .subscribeNext({ [weak self] in
-                    self?.handler.viewModel = $0
-                    })
-                .addDisposableTo(bag)
-            controller.errorMessage
-                .observeOn(MainScheduler.instance)
-                .subscribeNext({ [weak self] in
-                    self?.errorMessage = $0
-                    })
-                .addDisposableTo(bag)
-        }
+        title = controller.title
+        registerRows(controller.immuTableRows)
+        controller.tableViewModelWithPresenter(self)
+            .pausable(visible)
+            .observeOn(MainScheduler.instance)
+            .subscribeNext({ [weak self] in
+                self?.handler.viewModel = $0
+                })
+            .addDisposableTo(bag)
+        controller.errorMessage
+            .pausable(visible)
+            .observeOn(MainScheduler.instance)
+            .subscribeNext({ [weak self] in
+                self?.errorMessage = $0
+                })
+            .addDisposableTo(bag)
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
The main goal is to remove `visible` from `ImmuTablePresenter`, since it
doesn't really belong there. Presenter is a thing that can "present" view
controllers: usually a UIViewController, but implemented as a protocol so it's
testable.

But then I realized, the Controller doesn't really need a reference to
Presenter, or the parent View Controller. The only thing that needs that is
ImmuTable (for the callbacks), and we can pass the presenter when requesting
the table view model (renamed). This is similar to the previous solution, but
avoids the chicken-and-egg problem when initiailizing. And because of this, it
removes 4 assertions/preconditions that are now guaranteed at compile time.

The `visible` observable is still exposed on ImmuTableViewController, but
the VC is the one pausing the subscription to tableViewModel and errorMessage,
instead of relying on the controller. I like this slightly less semantically,
but it makes everything much simpler with initialization.

Needs Review: @frosty 