### PR TITLE
WPAvatarSourceTest: Don't use a shared WPAvatarSource

### DIFF
--- a/WordPress/WordPressTest/WPAvatarSourceTest.m
+++ b/WordPress/WordPressTest/WPAvatarSourceTest.m
@@ -17,7 +17,7 @@
 {
     [super setUp];
 
-    _source = [WPAvatarSource sharedSource];
+    _source = [WPAvatarSource new];
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
         return [[request.URL host] isEqualToString:@"gravatar.com"];
     } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {


### PR DESCRIPTION
`testGravatarCaches` was failing intermittently, and seemingly only when run in combination with other tests.
This could be due to multiple tests using the same shared instance of `WPAvatarSource`.
This PR changes the tests to create a new instance each time. 

I had more success recreating the issue by running with a clean simulator instance.

Needs review: @astralbodies 