### PR TITLE
Refactor ImmuTablePresenter/Controller/VC

### DIFF
--- a/WordPress/Classes/ViewRelated/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/AccountSettingsViewController.swift
@@ -11,13 +11,10 @@ func AccountSettingsViewController(account account: WPAccount) -> ImmuTableViewC
 func AccountSettingsViewController(service service: AccountSettingsService) -> ImmuTableViewController {
     let controller = AccountSettingsController(service: service)
     let viewController = ImmuTableViewController(controller: controller)
-    assert(viewController.controller?.presenter != nil, "ImmuTableViewController should have set the presenter for AccountSettingsController")
     return viewController
 }
 
 private struct AccountSettingsController: SettingsController {
-    weak var presenter: ImmuTablePresenter? = nil
-
     let title = NSLocalizedString("Account Settings", comment: "Account Settings Title");
 
     var immuTableRows: [ImmuTableRow.Type] {
@@ -38,13 +35,7 @@ private struct AccountSettingsController: SettingsController {
     
     // MARK: - Model mapping
 
-    func mapViewModel(settings: AccountSettings?) -> ImmuTable {
-        precondition(presenter != nil, "presenter must be set before using")
-        guard let presenter = presenter else {
-            // This shouldn't happen. If there's no presenter we can't push the
-            // editText controllers.
-            return ImmuTable.Empty
-        }
+    func mapViewModel(settings: AccountSettings?, presenter: ImmuTablePresenter) -> ImmuTable {
         let username = TextRow(
             title: NSLocalizedString("Username", comment: "Account Settings Username label"),
             value: settings?.username ?? "")

--- a/WordPress/Classes/ViewRelated/Me/MyProfileViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MyProfileViewController.swift
@@ -10,7 +10,6 @@ func MyProfileViewController(account account: WPAccount) -> ImmuTableViewControl
 func MyProfileViewController(service service: AccountSettingsService) -> ImmuTableViewController {
     let controller = MyProfileController(service: service)
     let viewController = ImmuTableViewController(controller: controller)
-    assert(viewController.controller?.presenter != nil, "ImmuTableViewController should have set the presenter for MyProfileController")
     return viewController
 }
 
@@ -19,8 +18,6 @@ func MyProfileViewController(service service: AccountSettingsService) -> ImmuTab
 /// `MyProfileViewController` factory functions.
 private struct MyProfileController: SettingsController {
     // MARK: - ImmuTableController
-
-    weak var presenter: ImmuTablePresenter? = nil
 
     let title = NSLocalizedString("My Profile", comment: "My Profile view title")
 
@@ -38,13 +35,7 @@ private struct MyProfileController: SettingsController {
 
     // MARK: - Model mapping
 
-    func mapViewModel(settings: AccountSettings?) -> ImmuTable {
-        precondition(presenter != nil, "presenter must be set before using")
-        guard let presenter = presenter else {
-            // This shouldn't happen. If there's no presenter we can't push the
-            // editText controllers.
-            return ImmuTable.Empty
-        }
+    func mapViewModel(settings: AccountSettings?, presenter: ImmuTablePresenter) -> ImmuTable {
         let firstNameRow = EditableTextRow(
             title: NSLocalizedString("First Name", comment: "My Profile first name label"),
             value: settings?.firstName ?? "",

--- a/WordPress/Classes/ViewRelated/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/SettingsCommon.swift
@@ -2,8 +2,7 @@ import RxSwift
 
 protocol SettingsController: ImmuTableController {
     var service: AccountSettingsService { get }
-    var presenter: ImmuTablePresenter? { get }
-    func mapViewModel(settings: AccountSettings?) -> ImmuTable
+    func mapViewModel(settings: AccountSettings?, presenter: ImmuTablePresenter) -> ImmuTable
 }
 
 // MARK: - Shared implementation
@@ -16,20 +15,14 @@ extension SettingsController {
             SwitchRow.self]
     }
 
-    var immuTable: Observable<ImmuTable> {
-        precondition(presenter != nil, "presenter must be set before using")
-        return service.settings.map(mapViewModel)
+    func tableViewModelWithPresenter(presenter: ImmuTablePresenter) -> Observable<ImmuTable> {
+        return service.settings.map({ settings in
+            self.mapViewModel(settings, presenter: presenter)
+        })
     }
 
     var errorMessage: Observable<String?> {
-        precondition(presenter != nil, "presenter must be set before using")
-        guard let presenter = presenter else {
-            // This shouldn't happen, but if it does, disabling the error feels
-            // safer than having it running when the VC is not visible.
-            return Observable.just(nil)
-        }
         return service.refresh
-            .pausable(presenter.visible)
             // replace errors with .Failed status
             .catchErrorJustReturn(.Failed)
             // convert status to string


### PR DESCRIPTION
The main goal is to remove `visible` from `ImmuTablePresenter`, since it
doesn't really belong there. Presenter is a thing that can "present" view
controllers: usually a UIViewController, but implemented as a protocol so it's
testable.

But then I realized, the Controller doesn't really need a reference to
Presenter, or the parent View Controller. The only thing that needs that is
ImmuTable (for the callbacks), and we can pass the presenter when requesting
the table view model (renamed). This is similar to the previous solution, but
avoids the chicken-and-egg problem when initiailizing. And because of this, it
removes 4 assertions/preconditions that are now guaranteed at compile time.

The `visible` observable is still exposed on ImmuTableViewController, but
the VC is the one pausing the subscription to tableViewModel and errorMessage,
instead of relying on the controller. I like this slightly less semantically,
but it makes everything much simpler with initialization.

Needs Review: @frosty 