### PR TITLE
Site Settings: Language service layer

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -11,6 +11,7 @@ data model as well as any custom migrations.
 - `BlogSettings` added bool `sharingCommentLikesEnabled`. Whether comments display a like button.
 - `BlogSettings` added bool `sharingDisabledLikes`.  Whether posts display a like button. 
 - `BlogSettings` added bool `sharingDisabledReblogs`. Whether posts display a reblog button. 
+- `BlogSettings` added integer `languageID`. Stores the Blog's Language ID.
 - Added `SharingButton` entity. Represents a buton for sharing content to a third-party service.
 - `Blog` added new relationship `sharingButtons`. An unordered set of `ShareButton`s for the blog.
 

--- a/WordPress/Classes/Models/BlogSettings.swift
+++ b/WordPress/Classes/Models/BlogSettings.swift
@@ -7,9 +7,8 @@ public class BlogSettings : NSManagedObject
 {
     // MARK: - Relationships
     
-    /**
-    *  @details Maps to the related Blog.
-    */
+    /// Maps to the related Blog.
+    ///
     @NSManaged var blog : Blog?
     
 

--- a/WordPress/Classes/Models/BlogSettings.swift
+++ b/WordPress/Classes/Models/BlogSettings.swift
@@ -1,10 +1,8 @@
 import Foundation
 
 
-/**
- *  @class           BlogSettings
- *  @brief           This class encapsulates all of the settings available for a Blog entity
- */
+/// This class encapsulates all of the settings available for a Blog entity
+///
 public class BlogSettings : NSManagedObject
 {
     // MARK: - Relationships
@@ -18,157 +16,129 @@ public class BlogSettings : NSManagedObject
     
     // MARK: - General
     
-    /**
-    *  @details Represents the Blog Name.
-    */
+    /// Represents the Blog Name.
+    ///
     @NSManaged var name : String?
     
-    /**
-     *  @details Stores the Blog's Tagline setting.
-     */
+    /// Stores the Blog's Tagline setting.
+    ///
     @NSManaged var tagline : String?
     
-    /**
-     *  @details Stores the Blog's Privacy Preferences Settings
-     */
+    /// Stores the Blog's Privacy Preferences Settings
+    ///
     @NSManaged var privacy : NSNumber?
 
     
     
-    // MARK: - Writing
-    /**
-    *  @details Contains the Default Category ID. Used when creating new posts.
-    */
     
+    // MARK: - Writing
+
+    /// Contains the Default Category ID. Used when creating new posts.
+    ///
     @NSManaged var defaultCategoryID : NSNumber?
     
-    /**
-    *  @details Contains the Default Post Format. Used when creating new posts.
-    */
+    /// Contains the Default Post Format. Used when creating new posts.
+    ///
     @NSManaged var defaultPostFormat : String?
     
     
     
     // MARK: - Discussion
     
-    /**
-    *  @details Represents whether comments are allowed, or not.
-    */
+    /// Represents whether comments are allowed, or not.
+    ///
     @NSManaged var commentsAllowed : Bool
     
-    /**
-     *  @details Contains a list of words, space separated, that would cause a comment to be automatically
-     *           blacklisted.
-     */
+    /// Contains a list of words, space separated, that would cause a comment to be automatically blacklisted.
+    ///
     @NSManaged var commentsBlacklistKeys : Set<String>?
     
-    /**
-     *  @details If true, comments will be automatically closed after the number of days, specified
-     *           by `commentsCloseAutomaticallyAfterDays`.
-     */
+    /// If true, comments will be automatically closed after the number of days, specified by `commentsCloseAutomaticallyAfterDays`.
+    ///
     @NSManaged var commentsCloseAutomatically : Bool
     
-    /**
-     *  @details Represents the number of days comments will be enabled, granted that the
-     *           `commentsCloseAutomatically` property is set to true.
-     */
+    /// Represents the number of days comments will be enabled, granted that the `commentsCloseAutomatically` 
+    /// property is set to true.
+    ///
     @NSManaged var commentsCloseAutomaticallyAfterDays : NSNumber?
     
-    /**
-     *  @details When enabled, comments from known users will be whitelisted.
-     */
+    /// When enabled, comments from known users will be whitelisted.
+    ///
     @NSManaged var commentsFromKnownUsersWhitelisted : Bool
     
-    /**
-     *  @details Indicates the maximum number of links allowed per comment. When a new comment exceeds this
-     *           number, it'll be held in queue for moderation.
-     */
+    /// Indicates the maximum number of links allowed per comment. When a new comment exceeds this number, 
+    /// it'll be held in queue for moderation.
+    ///
     @NSManaged var commentsMaximumLinks : NSNumber?
     
-    /**
-     *  @details Contains a list of words, space separated, that cause a comment to require moderation.
-     */
+    /// Contains a list of words, space separated, that cause a comment to require moderation.
+    ///
     @NSManaged var commentsModerationKeys : Set<String>?
     
-    /**
-     *  @details If true, comment pagination will be enabled.
-     */
+    /// If true, comment pagination will be enabled.
+    ///
     @NSManaged var commentsPagingEnabled : Bool
     
-    /**
-     *  @details Specifies the number of comments per page. This will be used only if the property
-     *           `commentsPagingEnabled` is set to true.
-     */
+    /// Specifies the number of comments per page. This will be used only if the property `commentsPagingEnabled` 
+    /// is set to true.
+    ///
     @NSManaged var commentsPageSize : NSNumber?
     
-    /**
-     *  @details When enabled, new comments will require Manual Moderation, before showing up.
-     */
+    /// When enabled, new comments will require Manual Moderation, before showing up.
+    ///
     @NSManaged var commentsRequireManualModeration : Bool
     
-    /**
-     *  @details If set to true, commenters will be required to enter their name and email.
-     */
+    /// If set to true, commenters will be required to enter their name and email.
+    ///
     @NSManaged var commentsRequireNameAndEmail : Bool
     
-    /**
-     *  @details Specifies whether commenters should be registered or not.
-     */
+    /// Specifies whether commenters should be registered or not.
+    ///
     @NSManaged var commentsRequireRegistration : Bool
     
-    /**
-     *  @details Indicates the sorting order of the comments. Ascending / Descending, based on the date.
-     */
+    /// Indicates the sorting order of the comments. Ascending / Descending, based on the date.
+    ///
     @NSManaged var commentsSortOrder : NSNumber?
     
-    /**
-     *  @details Indicates the number of levels allowed per comment.
-     */
+    /// Indicates the number of levels allowed per comment.
+    ///
     @NSManaged var commentsThreadingDepth : NSNumber?
     
-    /**
-     *  @details When enabled, comment threading will be supported.
-     */
+    /// When enabled, comment threading will be supported.
+    ///
     @NSManaged var commentsThreadingEnabled : Bool
 
-    /**
-     *  @details *LOCAL* flag (non stored remotely) indicating whether post geolocation is enabled or not.
-     *           This can be overriden on a per-post basis.
-     */
+    /// *LOCAL* flag (non stored remotely) indicating whether post geolocation is enabled or not.
+    /// This can be overriden on a per-post basis.
+    ///
     @NSManaged var geolocationEnabled : Bool
     
-    /**
-     *  @details If set to true, 3rd party sites will be allowed to post pingbacks.
-     */
+    /// If set to true, 3rd party sites will be allowed to post pingbacks.
+    ///
     @NSManaged var pingbackInboundEnabled : Bool
     
-    /**
-     *  @details When Outbound Pingbacks are enabled, 3rd party sites that get linked will be notified.
-     */
+    /// When Outbound Pingbacks are enabled, 3rd party sites that get linked will be notified.
+    ///
     @NSManaged var pingbackOutboundEnabled : Bool
 
     
     
     // MARK: - Related Posts
     
-    /**
-    *  @details When set to true, Related Posts will be allowed.
-    */
+    /// When set to true, Related Posts will be allowed.
+    ///
     @NSManaged var relatedPostsAllowed : Bool
     
-    /**
-    *  @details When set to true, Related Posts will be enabled.
-     */
+    /// When set to true, Related Posts will be enabled.
+    ///
     @NSManaged var relatedPostsEnabled : Bool
     
-    /**
-     *  @details Indicates whether related posts should show a headline.
-     */
+    /// Indicates whether related posts should show a headline.
+    ///
     @NSManaged var relatedPostsShowHeadline : Bool
     
-    /**
-     *  @details Indicates whether related posts should show thumbnails.
-     */
+    /// Indicates whether related posts should show thumbnails.
+    ///
     @NSManaged var relatedPostsShowThumbnails : Bool
 
 

--- a/WordPress/Classes/Models/BlogSettings.swift
+++ b/WordPress/Classes/Models/BlogSettings.swift
@@ -27,7 +27,10 @@ public class BlogSettings : NSManagedObject
     /// Stores the Blog's Privacy Preferences Settings
     ///
     @NSManaged var privacy : NSNumber?
-
+    
+    /// Stores the Blog's Language ID Setting
+    ///
+    @NSManaged var languageID : NSNumber
     
     
     

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -8,6 +8,7 @@
 static NSString * const RemoteBlogNameKey                                   = @"name";
 static NSString * const RemoteBlogTaglineKey                                = @"description";
 static NSString * const RemoteBlogPrivacyKey                                = @"blog_public";
+static NSString * const RemoteBlogLanguageKey                               = @"lang_id";
 
 static NSString * const RemoteBlogSettingsKey                               = @"settings";
 static NSString * const RemoteBlogDefaultCategoryKey                        = @"default_category";
@@ -227,6 +228,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     settings.name = [json stringForKey:RemoteBlogNameKey];
     settings.tagline = [json stringForKey:RemoteBlogTaglineKey];
     settings.privacy = [rawSettings numberForKey:RemoteBlogPrivacyKey];
+    settings.languageID = [rawSettings numberForKey:RemoteBlogLanguageKey];
     
     // Writing
     settings.defaultCategoryID = [rawSettings numberForKey:RemoteBlogDefaultCategoryKey] ?: @(RemoteBlogUncategorizedCategory);
@@ -284,7 +286,8 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     [parameters setValueIfNotNil:settings.name forKey:RemoteBlogNameForUpdateKey];
     [parameters setValueIfNotNil:settings.tagline forKey:RemoteBlogTaglineForUpdateKey];
     [parameters setValueIfNotNil:settings.privacy forKey:RemoteBlogPrivacyKey];
-
+    [parameters setValueIfNotNil:settings.languageID forKey:RemoteBlogLanguageKey];
+    
     [parameters setValueIfNotNil:settings.defaultCategoryID forKey:RemoteBlogDefaultCategoryKey];
     [parameters setValueIfNotNil:settings.defaultPostFormat forKey:RemoteBlogDefaultPostFormatKey];
     

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlogSettings.swift
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlogSettings.swift
@@ -1,158 +1,129 @@
 import Foundation
 
 
-/**
- *  @class           RemoteBlogSettings
- *  @brief           This class encapsulates all of the *remote* settings available for a Blog entity
- */
+/// This class encapsulates all of the *remote* settings available for a Blog entity
+///
 public class RemoteBlogSettings : NSObject
 {
     // MARK: - General
     
-    /**
-    *  @details Represents the Blog Name.
-    */
+    /// Represents the Blog Name.
+    ///
     var name : String?
     
-    /**
-     *  @details Stores the Blog's Tagline setting.
-     */
+    /// Stores the Blog's Tagline setting.
+    ///
     var tagline : String?
     
-    /**
-     *  @details Stores the Blog's Privacy Preferences Settings
-     */
+    /// Stores the Blog's Privacy Preferences Settings
+    ///
     var privacy : NSNumber?
     
     
     
     // MARK: - Writing
-    /**
-    *  @details Contains the Default Category ID. Used when creating new posts.
-    */
     
+    /// Contains the Default Category ID. Used when creating new posts.
+    ///
     var defaultCategoryID : NSNumber?
     
-    /**
-     *  @details Contains the Default Post Format. Used when creating new posts.
-     */
+    /// Contains the Default Post Format. Used when creating new posts.
+    ///
     var defaultPostFormat : String?
     
     
     
     // MARK: - Discussion
     
-    /**
-    *  @details Represents whether comments are allowed, or not.
-    */
+    /// Represents whether comments are allowed, or not.
+    ///
     var commentsAllowed : NSNumber?
 
-    /**
-     *  @details Contains a list of words that would automatically blacklist a comment.
-     */
+    /// Contains a list of words that would automatically blacklist a comment.
+    ///
     var commentsBlacklistKeys : String?
     
-    /**
-     *  @details If true, comments will be automatically closed after the number of days, specified
-     *           by `commentsCloseAutomaticallyAfterDays`.
-     */
+    /// If true, comments will be automatically closed after the number of days, specified by `commentsCloseAutomaticallyAfterDays`.
+    ///
     var commentsCloseAutomatically : NSNumber?
     
-    /**
-     *  @details Represents the number of days comments will be enabled, granted that the
-     *           `commentsCloseAutomatically` property is set to true.
-     */
+    /// Represents the number of days comments will be enabled, granted that the `commentsCloseAutomatically` 
+    /// property is set to true.
+    ///
     var commentsCloseAutomaticallyAfterDays : NSNumber?
 
-    /**
-     *  @details When enabled, comments from known users will be whitelisted.
-     */
+    /// When enabled, comments from known users will be whitelisted.
+    ///
     var commentsFromKnownUsersWhitelisted : NSNumber?
     
-    /**
-     *  @details Indicates the maximum number of links allowed per comment. When a new comment exceeds this
-     *           number, it'll be held in queue for moderation.
-     */
+    /// Indicates the maximum number of links allowed per comment. When a new comment exceeds this number, 
+    /// it'll be held in queue for moderation.
+    ///
     var commentsMaximumLinks : NSNumber?
     
-    /**
-     *  @details Contains a list of words that cause a comment to require moderation.
-     */
+    /// Contains a list of words that cause a comment to require moderation.
+    ///
     var commentsModerationKeys : String?
-    
-    /**
-     *  @details If true, comment pagination will be enabled.
-     */
+
+    /// If true, comment pagination will be enabled.
+    ///
     var commentsPagingEnabled : NSNumber?
     
-    /**
-     *  @details Specifies the number of comments per page. This will be used only if the property
-     *           `commentsPagingEnabled` is set to true.
-     */
+    /// Specifies the number of comments per page. This will be used only if the property `commentsPagingEnabled` 
+    /// is set to true.
+    ///
     var commentsPageSize : NSNumber?
     
-    /**
-     *  @details When enabled, new comments will require Manual Moderation, before showing up.
-     */
+    /// When enabled, new comments will require Manual Moderation, before showing up.
+    ///
     var commentsRequireManualModeration : NSNumber?
     
-    /**
-     *  @details If set to true, commenters will be required to enter their name and email.
-     */
+    /// If set to true, commenters will be required to enter their name and email.
+    ///
     var commentsRequireNameAndEmail : NSNumber?
     
-    /**
-     *  @details Specifies whether commenters should be registered or not.
-     */
+    /// Specifies whether commenters should be registered or not.
+    ///
     var commentsRequireRegistration : NSNumber?
     
-    /**
-     *  @details Indicates the sorting order of the comments. Ascending / Descending, based on the date.
-     */
+    /// Indicates the sorting order of the comments. Ascending / Descending, based on the date.
+    ///
     var commentsSortOrder : String?
     
-    /**
-     *  @details Indicates the number of levels allowed per comment.
-     */
+    /// Indicates the number of levels allowed per comment.
+    ///
     var commentsThreadingDepth : NSNumber?
     
-    /**
-     *  @details When enabled, comment threading will be supported.
-     */
+    /// When enabled, comment threading will be supported.
+    ///
     var commentsThreadingEnabled : NSNumber?
     
-    /**
-     *  @details If set to true, 3rd party sites will be allowed to post pingbacks.
-     */
+    /// If set to true, 3rd party sites will be allowed to post pingbacks.
+    ///
     var pingbackInboundEnabled : NSNumber?
     
-    /**
-     *  @details When Outbound Pingbacks are enabled, 3rd party sites that get linked will be notified.
-     */
+    /// When Outbound Pingbacks are enabled, 3rd party sites that get linked will be notified.
+    ///
     var pingbackOutboundEnabled : NSNumber?
     
     
     
     // MARK: - Related Posts
     
-    /**
-    *  @details When set to true, Related Posts will be allowed.
-    */
+    /// When set to true, Related Posts will be allowed.
+    ///
     var relatedPostsAllowed : NSNumber?
     
-    /**
-     *  @details When set to true, Related Posts will be enabled.
-     */
+    /// When set to true, Related Posts will be enabled.
+    ///
     var relatedPostsEnabled : NSNumber?
     
-    /**
-     *  @details Indicates whether related posts should show a headline.
-     */
+    /// Indicates whether related posts should show a headline.
+    ///
     var relatedPostsShowHeadline : NSNumber?
     
-    /**
-     *  @details Indicates whether related posts should show thumbnails.
-     */
+    /// Indicates whether related posts should show thumbnails.
+    ///
     var relatedPostsShowThumbnails : NSNumber?
     
 
@@ -186,10 +157,8 @@ public class RemoteBlogSettings : NSObject
     
     // MARK: - Helpers
     
-    /**
-    *  @details Computed property, meant to help conversion from Remote / String-Based values, into their
-    *           Integer counterparts
-    */
+    /// Computed property, meant to help conversion from Remote / String-Based values, into their Integer counterparts
+    ///
     var commentsSortOrderAscending : Bool {
         set {
             commentsSortOrder = newValue ? RemoteBlogSettings.AscendingStringValue :  RemoteBlogSettings.DescendingStringValue

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlogSettings.swift
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlogSettings.swift
@@ -19,6 +19,9 @@ public class RemoteBlogSettings : NSObject
     ///
     var privacy : NSNumber?
     
+    /// Stores the Blog's Language ID Setting
+    ///
+    var languageID : NSNumber?
     
     
     // MARK: - Writing

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -830,6 +830,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     settings.name = remoteSettings.name;
     settings.tagline = remoteSettings.tagline;
     settings.privacy = remoteSettings.privacy ?: settings.privacy;
+    settings.languageID = remoteSettings.languageID;
     
     // Writing
     settings.defaultCategoryID = remoteSettings.defaultCategoryID ?: settings.defaultCategoryID;
@@ -888,6 +889,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     remoteSettings.name = settings.name;
     remoteSettings.tagline = settings.tagline;
     remoteSettings.privacy = settings.privacy;
+    remoteSettings.languageID = settings.languageID;
     
     // Writing
     remoteSettings.defaultCategoryID = settings.defaultCategoryID;

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 46.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 46.xcdatamodel/contents
@@ -174,6 +174,7 @@
         <attribute name="geolocationEnabled" attributeType="Boolean" defaultValueString="NO">
             <userInfo/>
         </attribute>
+        <attribute name="languageID" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="pingbackInboundEnabled" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="pingbackOutboundEnabled" optional="YES" attributeType="Boolean" syncable="YES"/>
@@ -600,7 +601,7 @@
         <element name="AccountSettings" positionX="18" positionY="153" width="128" height="195"/>
         <element name="BasePost" positionX="0" positionY="0" width="128" height="300"/>
         <element name="Blog" positionX="0" positionY="0" width="128" height="585"/>
-        <element name="BlogSettings" positionX="18" positionY="153" width="128" height="555"/>
+        <element name="BlogSettings" positionX="18" positionY="153" width="128" height="570"/>
         <element name="Category" positionX="0" positionY="0" width="128" height="120"/>
         <element name="Comment" positionX="0" positionY="0" width="128" height="343"/>
         <element name="Media" positionX="0" positionY="0" width="128" height="375"/>
@@ -624,8 +625,8 @@
         <element name="ReaderSite" positionX="9" positionY="153" width="128" height="163"/>
         <element name="ReaderSiteTopic" positionX="36" positionY="180" width="128" height="195"/>
         <element name="ReaderTagTopic" positionX="27" positionY="171" width="128" height="90"/>
+        <element name="SharingButton" positionX="27" positionY="153" width="128" height="165"/>
         <element name="SourcePostAttribution" positionX="9" positionY="153" width="128" height="225"/>
         <element name="Theme" positionX="9" positionY="153" width="128" height="330"/>
-        <element name="SharingButton" positionX="27" positionY="153" width="128" height="165"/>
     </elements>
 </model>

--- a/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
@@ -113,7 +113,8 @@ static NSTimeInterval const TestExpectationTimeout = 5;
         // General
         XCTAssertEqualObjects(settings.name, @"My Epic Blog", @"");
         XCTAssertEqualObjects(settings.tagline, @"Definitely, the best blog out there", @"");
-        XCTAssertEqualObjects(settings.privacy, @(1), @"");
+        XCTAssertEqualObjects(settings.privacy, @(1), @"Invalid Privacy Value");
+        XCTAssertEqualObjects(settings.languageID, @(31337), @"Invalid Language ID");
         
         // Writing
         XCTAssertEqualObjects(settings.defaultCategoryID, @(8), @"");

--- a/WordPress/WordPressTest/Test Data/rest-site-settings.json
+++ b/WordPress/WordPressTest/Test Data/rest-site-settings.json
@@ -54,7 +54,7 @@
         "comment_max_links"                     : 42,
         "moderation_keys"                       : "moderation keys",
         "blacklist_keys"                        : "some evil keywords",
-        "lang_id"                               : false,
+        "lang_id"                               : 31337,
         "wga"                                   : false,
         "disabled_likes"                        : false,
         "disabled_reblogs"                      : false,


### PR DESCRIPTION
#### Details:
In this PR we'll add a new field, `languageID`, to the `BlogSettings` entity. Changes in the Service Layer + Persistance layer are included right here.

Please, verify that the Unit Tests pass, and check the Data Model 46 changes. I'm reusing Mark 46 since it's not been sent, yet, to our beta testers.

Needs Review: @aerych 
Thanks in advance sir!

Reference: #3558