### PR TITLE
Remove WPAccount isWPComAccount

### DIFF
--- a/WordPress/Classes/Models/WPAccount.h
+++ b/WordPress/Classes/Models/WPAccount.h
@@ -53,15 +53,4 @@
 - (void)addJetpackBlogs:(NSSet *)values;
 - (void)removeJetpackBlogs:(NSSet *)values;
 
-#pragma mark - WordPress.com support methods
-
-/**
- *  @brief      Call this method to know if the account is a WordPress.com account.
- *  @details    This is the same as checking if restApi != nil, but it conveys its own meaning
- *              in a cleaner way to the reader.
- *
- *  @returns    YES if this account is a WordPress.com account, NO otherwise.
- */
-- (BOOL)isWPComAccount;
-
 @end

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -125,11 +125,4 @@
     return _restApi;
 }
 
-#pragma mark - WordPress.com support methods
-
-- (BOOL)isWPComAccount
-{
-    return self.restApi != nil;
-}
-
 @end

--- a/WordPress/Classes/Services/ThemeService.h
+++ b/WordPress/Classes/Services/ThemeService.h
@@ -14,16 +14,6 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
 #pragma mark - Themes availability
 
 /**
- *  @brief      Call this method to know if a certain account supports theme services.
- *  @details    Right now only WordPress.com accounts support theme services.
- *
- *  @param      account     The account to query for theme services support.  Cannot be nil.
- *
- *  @returns    YES if the account supports theme services, NO otherwise.
- */
-- (BOOL)accountSupportsThemeServices:(WPAccount *)account;
-
-/**
  *  @brief      Call this method to know if a certain blog supports theme services.
  *  @details    Right now only WordPress.com blogs support theme services.
  *

--- a/WordPress/Classes/Services/ThemeService.m
+++ b/WordPress/Classes/Services/ThemeService.m
@@ -17,13 +17,6 @@ const NSInteger ThemeOrderTrailing = 9999;
 
 #pragma mark - Themes availability
 
-- (BOOL)accountSupportsThemeServices:(WPAccount *)account
-{
-    NSParameterAssert([account isKindOfClass:[WPAccount class]]);
-    
-    return [account isWPComAccount];
-}
-
 - (BOOL)blogSupportsThemeServices:(Blog *)blog
 {
     NSParameterAssert([blog isKindOfClass:[Blog class]]);
@@ -193,9 +186,7 @@ const NSInteger ThemeOrderTrailing = 9999;
                     failure:(ThemeServiceFailureBlock)failure
 {
     NSParameterAssert([themeId isKindOfClass:[NSString class]]);
-    NSAssert([self accountSupportsThemeServices:account],
-             @"Do not call this method on unsupported accounts, check with blogSupportsThemeServices first.");
-    
+
     ThemeServiceRemote *remote = [[ThemeServiceRemote alloc] initWithApi:account.restApi];
     
     NSOperation *operation = [remote getThemeId:themeId
@@ -219,9 +210,7 @@ const NSInteger ThemeOrderTrailing = 9999;
                              failure:(ThemeServiceFailureBlock)failure
 {
     NSParameterAssert([account isKindOfClass:[WPAccount class]]);
-    NSAssert([self accountSupportsThemeServices:account],
-             @"Do not call this method on unsupported accounts, check with blogSupportsThemeServices first.");
-    
+
     ThemeServiceRemote *remote = [[ThemeServiceRemote alloc] initWithApi:account.restApi];
     
     NSOperation *operation = [remote getThemesPage:page

--- a/WordPress/WordPressTest/ThemeServiceTests.m
+++ b/WordPress/WordPressTest/ThemeServiceTests.m
@@ -37,34 +37,6 @@
 
 #pragma mark - Themes availability
 
-- (void)testThatWordPressAccountSupportsThemeServices
-{
-    WPAccount *account = OCMStrictClassMock([WPAccount class]);
-    OCMStub([account isWPComAccount]).andReturn(YES);
-    
-    NSManagedObjectContext *context = OCMStrictClassMock([NSManagedObjectContext class]);
-    
-    ThemeService *service = [[ThemeService alloc] initWithManagedObjectContext:context];
-    BOOL result = NO;
-    
-    XCTAssertNoThrow(result = [service accountSupportsThemeServices:account]);
-    XCTAssertTrue(result);
-}
-
-- (void)testThatSelfHostedAccountDoesNotSupportThemeServices
-{
-    WPAccount *account = OCMStrictClassMock([WPAccount class]);
-    OCMStub([account isWPComAccount]).andReturn(NO);
-    
-    NSManagedObjectContext *context = OCMStrictClassMock([NSManagedObjectContext class]);
-    
-    ThemeService *service = [[ThemeService alloc] initWithManagedObjectContext:context];
-    BOOL result = NO;
-    
-    XCTAssertNoThrow(result = [service accountSupportsThemeServices:account]);
-    XCTAssertTrue(!result);
-}
-
 - (void)testThatWordPressBlogSupportsThemeServices
 {
     WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
@@ -176,7 +148,6 @@
     NSString *themeId = @"SomeTheme";
     NSString *url = [NSString stringWithFormat:@"v1.1/themes/%@", themeId];
     
-    OCMStub([account isWPComAccount]).andReturn(YES);
     OCMStub([account restApi]).andReturn(api);
     
     OCMStub([api GET:[OCMArg isEqual:url]
@@ -198,7 +169,6 @@
     WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
     ThemeService *service = nil;
     
-    OCMStub([account isWPComAccount]).andReturn(YES);
     OCMStub([account restApi]).andReturn(api);
     
     XCTAssertNoThrow(service = [[ThemeService alloc] initWithManagedObjectContext:context]);
@@ -229,7 +199,6 @@
     ThemeService *service = nil;
     NSString *url = @"v1.2/themes";
     
-    OCMStub([account isWPComAccount]).andReturn(YES);
     OCMStub([account restApi]).andReturn(api);
     
     OCMStub([api GET:[OCMArg isEqual:url]


### PR DESCRIPTION
Every account is now a WordPress.com account, so that method doesn't make sense
anymore.

Needs Review: @diegoreymendez 