### PR TITLE
Safety checks for 3D Touch shortcuts

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -48,7 +48,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     [defaults synchronize];
     
     WP3DTouchShortcutCreator *shortcutCreator = [WP3DTouchShortcutCreator new];
-    [shortcutCreator createShortcuts:YES];
+    [shortcutCreator createShortcutsIf3DTouchAvailable:YES];
 }
 
 - (Blog *)lastUsedOrFirstBlog

--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -80,7 +80,7 @@
     }
 
     WP3DTouchShortcutCreator *shortcutCreator = [WP3DTouchShortcutCreator new];
-    [shortcutCreator createShortcuts:YES];
+    [shortcutCreator createShortcutsIf3DTouchAvailable:YES];
     
     [WPAnalytics track:WPAnalyticsStatAddedSelfHostedSite];
     [WPAnalytics track:WPAnalyticsStatSignedIn withProperties:@{ @"dotcom_user" : @(NO) }];

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -26,11 +26,13 @@ public class WP3DTouchShortcutCreator: NSObject
         blogService = BlogService(managedObjectContext: mainContext)
     }
     
-    public func createShortcuts(loggedIn: Bool) {
-        if loggedIn {
-            createLoggedInShortcuts()
-        } else {
-            createLoggedOutShortcuts()
+    public func createShortcutsIf3DTouchAvailable(loggedIn: Bool) {
+        if is3DTouchAvailable() {
+            if loggedIn {
+                createLoggedInShortcuts()
+            } else {
+                createLoggedOutShortcuts()
+            }
         }
     }
     
@@ -97,6 +99,12 @@ public class WP3DTouchShortcutCreator: NSObject
     
     private func createLoggedOutShortcuts() {
         application.shortcutItems = loggedOutShortcutArray()
+    }
+    
+    private func is3DTouchAvailable() -> Bool {
+        let window = UIApplication.sharedApplication().keyWindow
+        
+        return window?.traitCollection.forceTouchCapability == .Available
     }
     
     private func hasWordPressComAccount() -> Bool {

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -49,7 +49,7 @@ public class WP3DTouchShortcutCreator: NSObject
     public func loggedInShortcutArray() -> [UIApplicationShortcutItem] {
         var defaultBlogName: String?
         if blogService.blogCountForAllAccounts() > 1 {
-            defaultBlogName = blogService.lastUsedOrFirstBlog().settings.name
+            defaultBlogName = blogService.lastUsedOrFirstBlog()?.settings?.name
         }
         
         let notificationsShortcut = UIMutableApplicationShortcutItem(type: WP3DTouchShortcutHandler.ShortcutIdentifier.Notifications.type,

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -27,12 +27,14 @@ public class WP3DTouchShortcutCreator: NSObject
     }
     
     public func createShortcutsIf3DTouchAvailable(loggedIn: Bool) {
-        if is3DTouchAvailable() {
-            if loggedIn {
-                createLoggedInShortcuts()
-            } else {
-                createLoggedOutShortcuts()
-            }
+        if !is3DTouchAvailable() {
+            return
+        }
+        
+        if loggedIn {
+            createLoggedInShortcuts()
+        } else {
+            createLoggedOutShortcuts()
         }
     }
     

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -38,7 +38,7 @@ public class WP3DTouchShortcutCreator: NSObject
         }
     }
     
-    public func loggedOutShortcutArray() -> [UIApplicationShortcutItem] {
+    private func loggedOutShortcutArray() -> [UIApplicationShortcutItem] {
         let logInShortcut = UIMutableApplicationShortcutItem(type: WP3DTouchShortcutHandler.ShortcutIdentifier.LogIn.type,
                                                    localizedTitle: NSLocalizedString("Log In", comment: "Log In 3D Touch Shortcut"),
                                                 localizedSubtitle: nil,
@@ -48,7 +48,7 @@ public class WP3DTouchShortcutCreator: NSObject
         return [logInShortcut]
     }
     
-    public func loggedInShortcutArray() -> [UIApplicationShortcutItem] {
+    private func loggedInShortcutArray() -> [UIApplicationShortcutItem] {
         var defaultBlogName: String?
         if blogService.blogCountForAllAccounts() > 1 {
             defaultBlogName = blogService.lastUsedOrFirstBlog()?.settings?.name

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -640,7 +640,7 @@ int ddLogLevel                                                  = DDLogLevelInfo
 - (void)create3DTouchShortcutItems
 {
     WP3DTouchShortcutCreator *shortcutCreator = [WP3DTouchShortcutCreator new];
-    [shortcutCreator createShortcuts:[self isLoggedIn]];
+    [shortcutCreator createShortcutsIf3DTouchAvailable:[self isLoggedIn]];
 }
 
 #pragma mark - Analytics

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -160,7 +160,7 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
 - (void)update3DTouchForLogIn
 {
     WP3DTouchShortcutCreator *shortcutCreator = [WP3DTouchShortcutCreator new];
-    [shortcutCreator createShortcuts:self.cancellable];
+    [shortcutCreator createShortcutsIf3DTouchAvailable:self.cancellable];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/WordPress/WordPressTest/System/3DTouch/WP3DTouchShortcutCreatorTests.swift
+++ b/WordPress/WordPressTest/System/3DTouch/WP3DTouchShortcutCreatorTests.swift
@@ -1,12 +1,14 @@
 import XCTest
 import WordPress
 
-class WP3DTouchShortcutCreatorTests: XCTestCase {
+class WP3DTouchShortcutCreatorTests: XCTestCase
+{
     var testShortcutCreator: WP3DTouchShortcutCreator!
     
     override func setUp() {
         super.setUp()
         testShortcutCreator = WP3DTouchShortcutCreator()
+        UIApplication.sharedApplication().shortcutItems = nil
     }
     
     override func tearDown() {
@@ -14,8 +16,8 @@ class WP3DTouchShortcutCreatorTests: XCTestCase {
         super.tearDown()
     }
     
-    func testCreateShortcutLoggedOutCreatesLoggedOutShortcuts() {
+    func testCreateShortcutLoggedOutDoesNotCreatesLoggedOutShortcutsWith3DTouchNotAvailable() {
         testShortcutCreator.createShortcutsIf3DTouchAvailable(false)
-        XCTAssertEqual(UIApplication.sharedApplication().shortcutItems!, testShortcutCreator.loggedOutShortcutArray())
+        XCTAssertEqual(UIApplication.sharedApplication().shortcutItems!.capacity, 0)
     }
 }

--- a/WordPress/WordPressTest/System/3DTouch/WP3DTouchShortcutCreatorTests.swift
+++ b/WordPress/WordPressTest/System/3DTouch/WP3DTouchShortcutCreatorTests.swift
@@ -15,7 +15,7 @@ class WP3DTouchShortcutCreatorTests: XCTestCase {
     }
     
     func testCreateShortcutLoggedOutCreatesLoggedOutShortcuts() {
-        testShortcutCreator.createShortcuts(false)
+        testShortcutCreator.createShortcutsIf3DTouchAvailable(false)
         XCTAssertEqual(UIApplication.sharedApplication().shortcutItems!, testShortcutCreator.loggedOutShortcutArray())
     }
 }


### PR DESCRIPTION
3D Touch creator now checks for the availability of 3D Touch before attempting to make shortcuts. Also handles possible cases where there is no blog or the settings cannot be found.

Needs review: @aerych