### PR TITLE
Updating Helpshift to 5.3.0.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,7 @@ target 'WordPress', :exclusive => true do
   pod 'CocoaLumberjack', '~> 2.2.0'
   pod 'google-plus-ios-sdk', '~>1.5'
   pod 'HockeySDK', '~>3.8.0'
-  pod 'Helpshift', '~>4.10.0'
+  pod 'Helpshift', '~> 5.3.0-support'
   pod 'Lookback', '1.1.4', :configurations => ['Release-Internal', 'Release-Alpha']
   pod 'MRProgress', '~>0.7.0'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -67,7 +67,7 @@ PODS:
   - FormatterKit/UnitOfInformationFormatter (1.8.0)
   - FormatterKit/URLRequestFormatter (1.8.0)
   - google-plus-ios-sdk (1.7.1)
-  - Helpshift (4.10.2)
+  - Helpshift (5.3.0-supportXcode6)
   - HockeySDK (3.8.5):
     - HockeySDK/AllFeaturesLib (= 3.8.5)
   - HockeySDK/AllFeaturesLib (3.8.5)
@@ -191,7 +191,7 @@ DEPENDENCIES:
   - Expecta (= 0.3.2)
   - FormatterKit (~> 1.8.0)
   - google-plus-ios-sdk (~> 1.5)
-  - Helpshift (~> 4.10.0)
+  - Helpshift (~> 5.3.0-support)
   - HockeySDK (~> 3.8.0)
   - KIF/IdentifierTests (~> 3.1)
   - Lookback (= 1.1.4)
@@ -263,7 +263,7 @@ SPEC CHECKSUMS:
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
   google-plus-ios-sdk: 47adbe03ea904bdb7aa1c0eca282a23c4686e1bc
-  Helpshift: 9c84a5e4ffd881c7e7eb395c2afc8d6a46eb2187
+  Helpshift: af8567ca7991c6d2c1aa76e10ee6e6893409c0a1
   HockeySDK: dd11a2b9da3372fd025643bee5bc10c8c613d169
   KIF: 0a82046d06f3648799cac522d2d0f7934214caac
   Lookback: 9ab9027ff246d2dc5ce34be483f70e4a6718280b


### PR DESCRIPTION
This introduces a bunch of deprecation warnings we'll need to address(https://developers.helpshift.com/ios/upgrade-4x/#api-changes) but as we have them currently suppressed we can defer dealing with it given this is a hot fix.

Note - in develop Helpshift doesn't appear by default and in order to get it to appear you'll have to modify this line - https://github.com/wordpress-mobile/WordPress-iOS/blob/1445e067b2f62984940f260a9f8dbfed81b73e83/WordPress/Classes/Utility/HelpshiftUtils.m#L74.

cc @kwonye 