### PR TITLE
Improve accessibility of plan details.

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/WPImmuTableCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/WPImmuTableCells.swift
@@ -15,6 +15,7 @@ class WPReusableTableViewCell: WPTableViewCell {
         accessoryType = .None
         accessoryView = nil
         selectionStyle = .Default
+        accessibilityLabel = nil
     }
 }
 


### PR DESCRIPTION
Before, VoiceOver would read all the features without saying if they were
included in the plan or not.

With this change, it will add either "Included", "Included in web version", or
"Not included" after reading the feature name. For features with a description
(support and storage), it will still read the name and description.

It adds some refactoring so the accessoryView and spoken text follow the same
logic.

Demo: https://www.youtube.com/watch?v=CjiDAyew4WE

Fixes #4800 
Needs Review: @frosty 