### PR TITLE
Adds Plan Comparison view

### DIFF
--- a/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
@@ -1,0 +1,126 @@
+import UIKit
+import WordPressShared
+
+class PlanComparisonViewController: UIViewController {
+    private let embedIdentifier = "PageViewControllerEmbedSegue"
+    
+    var pageViewController: UIPageViewController!
+    
+    @IBOutlet weak var pageControl: UIPageControl!
+    @IBOutlet weak var divider: UIView!
+    
+    var currentPlan: Plan = .Free {
+        didSet {
+            title = currentPlan.title
+            
+            updatePageControl()
+        }
+    }
+    
+    private let allPlans = [Plan.Free, Plan.Premium, Plan.Business]
+    
+    lazy private var cancelXButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(image: UIImage(named: "gridicons-cross"), style: .Plain, target: self, action: "closeTapped")
+        button.accessibilityLabel = NSLocalizedString("Close", comment: "Dismiss the current view")
+        
+        return button
+    }()
+    
+    class func controllerWithInitialPlan(plan: Plan) -> PlanComparisonViewController {
+        let storyboard = UIStoryboard(name: "Plans", bundle: NSBundle.mainBundle())
+        let controller = storyboard.instantiateViewControllerWithIdentifier(NSStringFromClass(self)) as! PlanComparisonViewController
+        
+        controller.currentPlan = plan
+        
+        return controller
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = WPStyleGuide.greyLighten30()
+        divider.backgroundColor = WPStyleGuide.greyLighten20()
+        pageControl.currentPageIndicatorTintColor = WPStyleGuide.grey()
+        pageControl.pageIndicatorTintColor = WPStyleGuide.grey().colorWithAlphaComponent(0.5)
+        
+        navigationItem.leftBarButtonItem = cancelXButton
+        
+        updatePageControl()
+    }
+    
+    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
+        super.prepareForSegue(segue, sender: sender)
+        
+        if let pageViewController = segue.destinationViewController as? UIPageViewController where segue.identifier == embedIdentifier {
+            self.pageViewController = pageViewController
+            
+            configurePageViewController()
+        }
+    }
+    
+    // MARK: - IBActions
+    
+    @IBAction private func closeTapped() {
+        dismissViewControllerAnimated(true, completion: nil)
+    }
+
+    // MARK: - PageViewController
+    private func configurePageViewController() {
+        pageViewController.dataSource = self
+        pageViewController.delegate = self
+        
+        if let index = allPlans.indexOf(currentPlan),
+            let initialViewController = viewControllerAtIndex(index) {
+                
+            pageViewController.setViewControllers([initialViewController], direction: .Forward, animated: false, completion: nil)
+        }
+    }
+    
+    private func viewControllerAtIndex(index: Int) -> UIViewController? {
+        guard index >= 0 && index < allPlans.count  else {
+            return nil
+        }
+        
+        let plan = allPlans[index]
+        return PlanDetailViewController.controllerWithPlan(plan)
+    }
+    
+    private func indexOfViewController(viewController: PlanDetailViewController) -> Int {
+        let plan = viewController.plan
+        return allPlans.indexOf(plan)!
+    }
+    
+    private func updatePageControl() {
+        if let index = allPlans.indexOf(currentPlan) {
+            pageControl?.currentPage = index
+        }
+    }
+}
+
+extension PlanComparisonViewController: UIPageViewControllerDataSource, UIPageViewControllerDelegate {
+    func pageViewController(pageViewController: UIPageViewController, viewControllerBeforeViewController viewController: UIViewController) -> UIViewController? {
+        guard let index = allPlans.indexOf(currentPlan) else { return nil }
+        
+        let previousIndex = index - 1
+        return viewControllerAtIndex(previousIndex)
+    }
+    
+    func pageViewController(pageViewController: UIPageViewController, viewControllerAfterViewController viewController: UIViewController) -> UIViewController? {
+        guard let index = allPlans.indexOf(currentPlan) else { return nil }
+        
+        let nextIndex = index + 1
+        return viewControllerAtIndex(nextIndex)
+    }
+    
+    func pageViewController(pageViewController: UIPageViewController, willTransitionToViewControllers pendingViewControllers: [UIViewController]) {
+        if let controller = pendingViewControllers.first as? PlanDetailViewController {
+            currentPlan = allPlans[indexOfViewController(controller)]
+        }
+    }
+    
+    func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+        if let controller = pageViewController.viewControllers?.first as? PlanDetailViewController {
+            currentPlan = allPlans[indexOfViewController(controller)]
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
@@ -172,7 +172,7 @@ extension PlanComparisonViewController: UIScrollViewDelegate {
         let currentPage = Int(floor(centerX / pageWidth))
 
         // Keep it within bounds
-        return max(min(currentPage, allPlans.count - 1), 0)
+        return currentPage.clamp(min: 0, max: allPlans.count - 1)
     }
 
     /// @return True if there was valid page to scroll to, false if we've reached the beginning / end

--- a/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
@@ -149,6 +149,7 @@ extension PlanComparisonViewController: UIPageViewControllerDataSource, UIPageVi
     func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         if let controller = pageViewController.viewControllers?.first as? PlanDetailViewController {
             currentPlan = allPlans[indexOfViewController(controller)]
+            UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, currentPlan.title)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
@@ -140,12 +140,6 @@ extension PlanComparisonViewController: UIPageViewControllerDataSource, UIPageVi
         return viewControllerAtIndex(index + 1)
     }
     
-    func pageViewController(pageViewController: UIPageViewController, willTransitionToViewControllers pendingViewControllers: [UIViewController]) {
-        if let controller = pendingViewControllers.first as? PlanDetailViewController {
-            currentPlan = allPlans[indexOfViewController(controller)]
-        }
-    }
-    
     func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
         if let controller = pageViewController.viewControllers?.first as? PlanDetailViewController {
             currentPlan = allPlans[indexOfViewController(controller)]
@@ -172,6 +166,6 @@ extension PlanComparisonViewController: UIPageViewControllerDataSource, UIPageVi
         }
         
         pageViewController.setViewControllers([previousViewController], direction: .Reverse, animated: true, completion: nil)
-        completion?(success: false)
+        completion?(success: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
@@ -4,22 +4,26 @@ import WordPressShared
 class PlanComparisonViewController: UIViewController {
     private let embedIdentifier = "PageViewControllerEmbedSegue"
     
-    var pageViewController: UIPageViewController!
-    
     @IBOutlet weak var pageControl: UIPageControl!
     @IBOutlet weak var divider: UIView!
+    @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet weak var planStackView: UIStackView!
     
     var currentPlan: Plan = .Free {
         didSet {
-            title = currentPlan.title
-            
-            updatePageControl()
+            if currentPlan != oldValue {
+                updateForCurrentPlan()
+            }
         }
     }
-    
-    private var currentIndex: Int? {
-        return allPlans.indexOf(currentPlan)
+
+    private var currentIndex: Int {
+        return allPlans.indexOf(currentPlan) ?? 0
     }
+    
+    private lazy var viewControllers: [PlanDetailViewController] = {
+        return self.allPlans.map { PlanDetailViewController.controllerWithPlan($0) }
+    }()
     
     private let allPlans = [Plan.Free, Plan.Premium, Plan.Business]
     
@@ -49,17 +53,44 @@ class PlanComparisonViewController: UIViewController {
         
         navigationItem.leftBarButtonItem = cancelXButton
         
-        updatePageControl()
+        initializePlanDetailViewControllers()
+        updateForCurrentPlan()
     }
     
-    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        super.prepareForSegue(segue, sender: sender)
-        
-        if let pageViewController = segue.destinationViewController as? UIPageViewController where segue.identifier == embedIdentifier {
-            self.pageViewController = pageViewController
+    override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
+
+        // If the view is changing size (e.g. on rotation, or multitasking), scroll to the correct page boundary based on the new size
+        coordinator.animateAlongsideTransition({ context in
+            self.scrollView.setContentOffset(CGPoint(x: CGFloat(self.currentIndex) * size.width, y: 0), animated: true)
+        }, completion: nil)
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        scrollToPage(currentIndex, animated: false)
+    }
+
+    func initializePlanDetailViewControllers() {
+        for controller in viewControllers {
+            addChildViewController(controller)
             
-            configurePageViewController()
+            controller.view.translatesAutoresizingMaskIntoConstraints = false
+            planStackView.addArrangedSubview(controller.view)
+            
+            controller.view.widthAnchor.constraintEqualToAnchor(view.widthAnchor, multiplier: 1.0).active = true
+            controller.view.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
+            controller.view.bottomAnchor.constraintEqualToAnchor(divider.topAnchor).active = true
+            
+            controller.didMoveToParentViewController(self)
         }
+    }
+    
+    func updateForCurrentPlan() {
+        title = currentPlan.title
+        
+        updatePageControl()
     }
     
     // MARK: - IBActions
@@ -69,103 +100,60 @@ class PlanComparisonViewController: UIViewController {
     }
     
     @IBAction func pageControlChanged() {
-        guard let index = currentIndex else { return }
-        
-        if pageControl.currentPage > index {
-            scrollToNextPage() { success in
-                if success {
-                    self.currentPlan = self.allPlans[index + 1]
-                }
-            }
-        } else if pageControl.currentPage < index {
-            scrollToPreviousPage() { success in
-                if success {
-                    self.currentPlan = self.allPlans[index - 1]
-                }
-            }
-        }
-    }
-
-    // MARK: - PageViewController
-    private func configurePageViewController() {
-        pageViewController.dataSource = self
-        pageViewController.delegate = self
-        
-        if let index = currentIndex,
-            let initialViewController = viewControllerAtIndex(index) {
-                
-            pageViewController.setViewControllers([initialViewController], direction: .Forward, animated: false, completion: nil)
-        }
-    }
-    
-    private func viewControllerAtIndex(index: Int) -> UIViewController? {
-        guard index >= 0 && index < allPlans.count  else {
-            return nil
+        guard !scrollView.dragging else {
+            // If the user is currently dragging, reset the change and ignore it
+            pageControl.currentPage = currentIndex
+            return
         }
         
-        let plan = allPlans[index]
-        return PlanDetailViewController.controllerWithPlan(plan)
-    }
-    
-    private func indexOfViewController(viewController: PlanDetailViewController) -> Int {
-        let plan = viewController.plan
-        return allPlans.indexOf(plan)!
+        // Stop the user interacting whilst we animate a scroll
+        scrollView.userInteractionEnabled = false
+        
+        var targetPage = currentIndex
+        if pageControl.currentPage > currentIndex {
+            targetPage += 1
+        } else if pageControl.currentPage < currentIndex {
+            targetPage -= 1
+        }
+        
+        if allPlans.indices.contains(targetPage) {
+            scrollToPage(targetPage, animated: true)
+            currentPlan = allPlans[targetPage]
+        }
     }
     
     private func updatePageControl() {
-        if let index = currentIndex {
-            pageControl?.currentPage = index
-        }
+        pageControl?.currentPage = currentIndex
     }
 }
 
-extension PlanComparisonViewController: UIPageViewControllerDataSource, UIPageViewControllerDelegate {
-    func pageViewController(pageViewController: UIPageViewController, viewControllerBeforeViewController viewController: UIViewController) -> UIViewController? {
-        return previousViewController()
-    }
-    
-    func pageViewController(pageViewController: UIPageViewController, viewControllerAfterViewController viewController: UIViewController) -> UIViewController? {
-        return nextViewController()
-    }
-    
-    private func previousViewController() -> UIViewController? {
-        guard let index = currentIndex else { return nil }
-        
-        return viewControllerAtIndex(index - 1)
-    }
-    
-    private func nextViewController() -> UIViewController? {
-        guard let index = currentIndex else { return nil }
-        
-        return viewControllerAtIndex(index + 1)
-    }
-    
-    func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
-        if let controller = pageViewController.viewControllers?.first as? PlanDetailViewController {
-            currentPlan = allPlans[indexOfViewController(controller)]
-            UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, currentPlan.title)
+extension PlanComparisonViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(scrollView: UIScrollView) {
+        // Ignore programmatic scrolling
+        if scrollView.dragging {
+            currentPlan = allPlans[currentScrollViewPage()]
         }
     }
+    
+    func scrollViewDidEndScrollingAnimation(scrollView: UIScrollView) {
+        scrollView.userInteractionEnabled = true
+        
+        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, currentPlan.title)
+    }
+    
+    private func currentScrollViewPage() -> Int {
+        // Calculate which plan's VC is at the center of the view
+        let pageWidth = scrollView.bounds.width
+        let centerX = scrollView.contentOffset.x + (pageWidth / 2)
+        let currentPage = Int(floor(centerX / pageWidth))
 
-    /// `success` is if the scrolling action was successful (i.e. there was a page to scroll to)
-    private func scrollToNextPage(completion: ((success: Bool) -> ())? = nil) {
-        guard let nextViewController = nextViewController() else {
-            completion?(success: false)
-            return
-        }
-        
-        pageViewController.setViewControllers([nextViewController], direction: .Forward, animated: true, completion: nil)
-        completion?(success: true)
+        // Keep it within bounds
+        return max(min(currentPage, allPlans.count - 1), 0)
     }
     
-    /// `success` is true if the scrolling action was successful (i.e. there was a page to scroll to)
-    private func scrollToPreviousPage(completion: ((success: Bool) -> ())? = nil) {
-        guard let previousViewController = previousViewController() else {
-            completion?(success: false)
-            return
-        }
+    private func scrollToPage(page: Int, animated: Bool) {
+        let pageWidth = view.bounds.width
         
-        pageViewController.setViewControllers([previousViewController], direction: .Reverse, animated: true, completion: nil)
-        completion?(success: true)
+        scrollView.setContentOffset(CGPoint(x: CGFloat(page) * pageWidth, y: 0), animated: animated)
     }
 }

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -19,13 +19,6 @@ class PlanDetailViewController: UIViewController {
     @IBOutlet weak var planPriceLabel: UILabel!
     @IBOutlet weak var purchaseButton: UIButton!
     
-    lazy private var cancelXButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(image: UIImage(named: "gridicons-cross"), style: .Plain, target: self, action: "closeTapped")
-        button.accessibilityLabel = NSLocalizedString("Close", comment: "Dismiss the current view")
-        
-        return button
-    }()
-    
     class func controllerWithPlan(plan: Plan) -> PlanDetailViewController {
         let storyboard = UIStoryboard(name: "Plans", bundle: NSBundle.mainBundle())
         let controller = storyboard.instantiateViewControllerWithIdentifier(NSStringFromClass(self)) as! PlanDetailViewController
@@ -43,7 +36,6 @@ class PlanDetailViewController: UIViewController {
         super.viewDidLoad()
         
         title = plan.title
-        navigationItem.leftBarButtonItem = cancelXButton
         
         configureAppearance()
         configureImmuTable()
@@ -116,10 +108,6 @@ class PlanDetailViewController: UIViewController {
     }
     
     //MARK: - IBActions
-    
-    @IBAction private func closeTapped() {
-        dismissViewControllerAnimated(true, completion: nil)
-    }
     
     @IBAction private func purchaseTapped() {
     }

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -103,7 +103,7 @@ struct PlanListViewModel {
 
     func controllerForPlanDetails(plan: Plan) -> ImmuTableRowControllerGenerator {
         return { row in
-            let planVC = PlanDetailViewController.controllerWithPlan(plan)
+            let planVC = PlanComparisonViewController.controllerWithInitialPlan(plan)
             let navigationVC = UINavigationController(rootViewController: planVC)
             navigationVC.modalPresentationStyle = .FormSheet
             return navigationVC

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -17,6 +17,80 @@
         </mutableArray>
     </customFonts>
     <scenes>
+        <!--Plan Comparison View Controller-->
+        <scene sceneID="CYw-U0-oI7">
+            <objects>
+                <viewController storyboardIdentifier="WordPress.PlanComparisonViewController" id="s5h-iz-0HE" customClass="PlanComparisonViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="lq2-Q7-GhV"/>
+                        <viewControllerLayoutGuide type="bottom" id="Ygn-aZ-YVi"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="DDG-cG-6UG">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ZY0-qL-r53">
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                                <subviews>
+                                    <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DDA-ao-02X">
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="540"/>
+                                        <connections>
+                                            <segue destination="wPO-UE-j7U" kind="embed" identifier="PageViewControllerEmbedSegue" id="VoH-AU-fv7"/>
+                                        </connections>
+                                    </containerView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f0d-zt-grM">
+                                        <rect key="frame" x="0.0" y="540" width="600" height="1"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="Ar8-74-nXx"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8En-Ia-Wlh">
+                                        <rect key="frame" x="0.0" y="541" width="600" height="59"/>
+                                        <subviews>
+                                            <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="HLT-dO-RyH">
+                                                <rect key="frame" x="281" y="11" width="39" height="37"/>
+                                                <color key="pageIndicatorTintColor" red="0.72326811719999995" green="0.869224102" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                <color key="currentPageIndicatorTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                            </pageControl>
+                                        </subviews>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="59" id="9sq-hY-CdS"/>
+                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="HLT-dO-RyH" secondAttribute="trailing" constant="20" id="C8c-68-OYE"/>
+                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="centerX" secondItem="8En-Ia-Wlh" secondAttribute="centerX" id="adF-OC-swL"/>
+                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="8En-Ia-Wlh" secondAttribute="leading" constant="20" id="gMX-M1-Fko"/>
+                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="centerY" secondItem="8En-Ia-Wlh" secondAttribute="centerY" id="v9R-u6-tJo"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="ZY0-qL-r53" firstAttribute="top" secondItem="DDG-cG-6UG" secondAttribute="top" id="9aF-PV-qII"/>
+                            <constraint firstItem="Ygn-aZ-YVi" firstAttribute="top" secondItem="ZY0-qL-r53" secondAttribute="bottom" id="FF2-u9-9d4"/>
+                            <constraint firstAttribute="trailing" secondItem="ZY0-qL-r53" secondAttribute="trailing" id="eQp-nW-JVq"/>
+                            <constraint firstItem="ZY0-qL-r53" firstAttribute="leading" secondItem="DDG-cG-6UG" secondAttribute="leading" id="eUm-og-PEa"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="divider" destination="f0d-zt-grM" id="at9-Wz-9lj"/>
+                        <outlet property="pageControl" destination="HLT-dO-RyH" id="lQJ-N9-WAz"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="SjQ-fQ-CVI" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="853" y="-327"/>
+        </scene>
+        <!--Page View Controller-->
+        <scene sceneID="PlE-hJ-uWS">
+            <objects>
+                <pageViewController autoresizesArchivedViewToFullSize="NO" transitionStyle="scroll" navigationOrientation="horizontal" spineLocation="none" id="wPO-UE-j7U" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="FxE-Ed-OqA" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1531" y="-327"/>
+        </scene>
         <!--Plan Detail View Controller-->
         <scene sceneID="9Cj-IU-3xt">
             <objects>

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -49,7 +49,7 @@
                                         <rect key="frame" x="0.0" y="541" width="600" height="59"/>
                                         <subviews>
                                             <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="HLT-dO-RyH">
-                                                <rect key="frame" x="281" y="11" width="39" height="37"/>
+                                                <rect key="frame" x="8" y="8" width="584" height="43"/>
                                                 <color key="pageIndicatorTintColor" red="0.72326811719999995" green="0.869224102" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <color key="currentPageIndicatorTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <connections>
@@ -59,14 +59,20 @@
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
+                                            <constraint firstAttribute="bottomMargin" secondItem="HLT-dO-RyH" secondAttribute="bottom" id="81N-Sg-1d8"/>
                                             <constraint firstAttribute="height" constant="59" id="9sq-hY-CdS"/>
-                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="HLT-dO-RyH" secondAttribute="trailing" constant="20" id="C8c-68-OYE"/>
-                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="centerX" secondItem="8En-Ia-Wlh" secondAttribute="centerX" id="adF-OC-swL"/>
-                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="8En-Ia-Wlh" secondAttribute="leading" constant="20" id="gMX-M1-Fko"/>
-                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="centerY" secondItem="8En-Ia-Wlh" secondAttribute="centerY" id="v9R-u6-tJo"/>
+                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="trailing" secondItem="8En-Ia-Wlh" secondAttribute="trailingMargin" id="OiO-eD-sc9"/>
+                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="leading" secondItem="8En-Ia-Wlh" secondAttribute="leadingMargin" id="dei-oZ-v5R"/>
+                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="top" secondItem="8En-Ia-Wlh" secondAttribute="topMargin" id="mHh-yT-0WZ"/>
                                         </constraints>
                                     </view>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="8En-Ia-Wlh" secondAttribute="bottom" id="1ES-Qt-Inb"/>
+                                    <constraint firstAttribute="trailing" secondItem="8En-Ia-Wlh" secondAttribute="trailing" id="JEQ-Xp-Co1"/>
+                                    <constraint firstItem="8En-Ia-Wlh" firstAttribute="top" secondItem="f0d-zt-grM" secondAttribute="bottom" id="WGN-iv-Hcv"/>
+                                    <constraint firstItem="8En-Ia-Wlh" firstAttribute="leading" secondItem="ZY0-qL-r53" secondAttribute="leading" id="oZE-0i-nLg"/>
+                                </constraints>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -52,6 +52,9 @@
                                                 <rect key="frame" x="281" y="11" width="39" height="37"/>
                                                 <color key="pageIndicatorTintColor" red="0.72326811719999995" green="0.869224102" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <color key="currentPageIndicatorTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                <connections>
+                                                    <action selector="pageControlChanged" destination="s5h-iz-0HE" eventType="valueChanged" id="I3s-63-M21"/>
+                                                </connections>
                                             </pageControl>
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -32,12 +32,24 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ZY0-qL-r53">
                                 <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <subviews>
-                                    <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DDA-ao-02X">
+                                    <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ftR-lg-UD4">
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="540"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Ba2-eJ-6aE">
+                                                <rect key="frame" x="0.0" y="0.0" width="600" height="540"/>
+                                            </stackView>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="Ba2-eJ-6aE" firstAttribute="leading" secondItem="ftR-lg-UD4" secondAttribute="leading" id="2Zx-zX-Oqk"/>
+                                            <constraint firstAttribute="bottom" secondItem="Ba2-eJ-6aE" secondAttribute="bottom" id="ciG-Fi-9vX"/>
+                                            <constraint firstItem="Ba2-eJ-6aE" firstAttribute="top" secondItem="ftR-lg-UD4" secondAttribute="top" id="jxy-j0-dHk"/>
+                                            <constraint firstAttribute="trailing" secondItem="Ba2-eJ-6aE" secondAttribute="trailing" id="mMa-Dr-hN7"/>
+                                            <constraint firstItem="Ba2-eJ-6aE" firstAttribute="height" secondItem="ftR-lg-UD4" secondAttribute="height" placeholder="YES" id="mek-QN-aIi" userLabel="Placeholder content height"/>
+                                        </constraints>
                                         <connections>
-                                            <segue destination="wPO-UE-j7U" kind="embed" identifier="PageViewControllerEmbedSegue" id="VoH-AU-fv7"/>
+                                            <outlet property="delegate" destination="s5h-iz-0HE" id="JhT-Ps-vCX"/>
                                         </connections>
-                                    </containerView>
+                                    </scrollView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f0d-zt-grM">
                                         <rect key="frame" x="0.0" y="540" width="600" height="1"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -67,18 +79,13 @@
                                         </constraints>
                                     </view>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="8En-Ia-Wlh" secondAttribute="bottom" id="1ES-Qt-Inb"/>
-                                    <constraint firstAttribute="trailing" secondItem="8En-Ia-Wlh" secondAttribute="trailing" id="JEQ-Xp-Co1"/>
-                                    <constraint firstItem="8En-Ia-Wlh" firstAttribute="top" secondItem="f0d-zt-grM" secondAttribute="bottom" id="WGN-iv-Hcv"/>
-                                    <constraint firstItem="8En-Ia-Wlh" firstAttribute="leading" secondItem="ZY0-qL-r53" secondAttribute="leading" id="oZE-0i-nLg"/>
-                                </constraints>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="ZY0-qL-r53" firstAttribute="top" secondItem="DDG-cG-6UG" secondAttribute="top" id="9aF-PV-qII"/>
                             <constraint firstItem="Ygn-aZ-YVi" firstAttribute="top" secondItem="ZY0-qL-r53" secondAttribute="bottom" id="FF2-u9-9d4"/>
+                            <constraint firstItem="Ba2-eJ-6aE" firstAttribute="width" secondItem="DDG-cG-6UG" secondAttribute="width" placeholder="YES" id="HyI-ca-bSZ" userLabel="Placeholder content width"/>
                             <constraint firstAttribute="trailing" secondItem="ZY0-qL-r53" secondAttribute="trailing" id="eQp-nW-JVq"/>
                             <constraint firstItem="ZY0-qL-r53" firstAttribute="leading" secondItem="DDG-cG-6UG" secondAttribute="leading" id="eUm-og-PEa"/>
                         </constraints>
@@ -86,19 +93,13 @@
                     <connections>
                         <outlet property="divider" destination="f0d-zt-grM" id="at9-Wz-9lj"/>
                         <outlet property="pageControl" destination="HLT-dO-RyH" id="lQJ-N9-WAz"/>
+                        <outlet property="planStackView" destination="Ba2-eJ-6aE" id="LYo-0W-yKg"/>
+                        <outlet property="scrollView" destination="ftR-lg-UD4" id="wfO-df-2xS"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="SjQ-fQ-CVI" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="853" y="-327"/>
-        </scene>
-        <!--Page View Controller-->
-        <scene sceneID="PlE-hJ-uWS">
-            <objects>
-                <pageViewController autoresizesArchivedViewToFullSize="NO" transitionStyle="scroll" navigationOrientation="horizontal" spineLocation="none" id="wPO-UE-j7U" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="FxE-Ed-OqA" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1531" y="-327"/>
         </scene>
         <!--Plan Detail View Controller-->
         <scene sceneID="9Cj-IU-3xt">

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		176579F71C63A40F0000978E /* PurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176579F61C63A40F0000978E /* PurchaseButton.swift */; };
 		17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */; };
 		17C1BA0E1C68D63C0017F38C /* PlanDetailViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C1BA0D1C68D63C0017F38C /* PlanDetailViewControllerTest.swift */; };
+		17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */; };
 		1D3623260D0F684500981E51 /* WordPressAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* WordPressAppDelegate.m */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
@@ -791,6 +792,7 @@
 		176579F61C63A40F0000978E /* PurchaseButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseButton.swift; sourceTree = "<group>"; };
 		17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogSiteVisibilityHelperTest.m; sourceTree = "<group>"; };
 		17C1BA0D1C68D63C0017F38C /* PlanDetailViewControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanDetailViewControllerTest.swift; sourceTree = "<group>"; };
+		17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanComparisonViewController.swift; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D3623240D0F684500981E51 /* WordPressAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressAppDelegate.h; sourceTree = "<group>"; };
 		1D3623250D0F684500981E51 /* WordPressAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = WordPressAppDelegate.m; sourceTree = "<group>"; usesTabs = 0; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -3679,6 +3681,7 @@
 				1724DDC71C60F1200099D273 /* PlanDetailViewController.swift */,
 				1724DDCB1C6121D00099D273 /* Plans.storyboard */,
 				176579F61C63A40F0000978E /* PurchaseButton.swift */,
+				17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */,
 			);
 			path = Plans;
 			sourceTree = "<group>";
@@ -4612,6 +4615,7 @@
 				5DED0E141B42E3E400431FCD /* RemoteSourcePostAttribution.m in Sources */,
 				5DFA7EC71AF814E40072023B /* PageListTableViewCell.m in Sources */,
 				5D62BAD718AA88210044E5F7 /* PageSettingsViewController.m in Sources */,
+				17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */,
 				B57273601B66CCEF000D1C4F /* AlertInternalView.swift in Sources */,
 				7059CD210F332B6500A0660B /* WPCategoryTree.m in Sources */,
 				B5E167F419C08D18009535AA /* NSCalendar+Helpers.swift in Sources */,


### PR DESCRIPTION
Implements #4799, adding a comparison view for plans.

### Known issues
- No state restoration – we'll revisit that after this has been merged.
- The current active plan isn't highlighted, as that requires quite a visual change from the current plan detail screens. Will raise a separate issue to track that.

Needs review: @koke 