### PR TITLE
Refactor Plan detail tests

### DIFF
--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -159,14 +159,18 @@ struct FeatureListItemRow : ImmuTableRow {
     
     let action: ImmuTableAction? = nil
     
-    let feature: PlanFeature
+    let title: String
+    let description: String?
+    let webOnly: Bool
     let available: Bool
     
     let checkmarkLeftPadding: CGFloat = 16.0
     let webOnlyFontSize: CGFloat = 13.0
     
     init(feature: PlanFeature, available: Bool) {
-        self.feature = feature
+        self.title = feature.title
+        self.description = feature.description
+        self.webOnly = feature.webOnly
         self.available = available
     }
     
@@ -184,7 +188,7 @@ struct FeatureListItemRow : ImmuTableRow {
     }
 
     var text: String? {
-        return feature.title
+        return title
     }
 
     var textColor: UIColor {
@@ -196,18 +200,15 @@ struct FeatureListItemRow : ImmuTableRow {
     }
 
     var detailText: String? {
-        switch (available, feature.webOnly) {
-        case (true, true):
-                return NSLocalizedString("WEB ONLY", comment: "Describes a feature of a WordPress.com plan that is only available to users via the web.")
-        case (true, false):
-            return feature.description
-        default:
-            return nil
+        if available && webOnly {
+            return NSLocalizedString("WEB ONLY", comment: "Describes a feature of a WordPress.com plan that is only available to users via the web.")
+        } else {
+            return description
         }
     }
 
     var detailTextFont: UIFont {
-        if available && feature.webOnly {
+        if available && webOnly {
             return WPFontManager.openSansRegularFontOfSize(webOnlyFontSize)
         } else {
             return WPStyleGuide.tableviewTextFont()
@@ -218,11 +219,11 @@ struct FeatureListItemRow : ImmuTableRow {
         guard let availableAccessibilityLabel = self.availableAccessibilityLabel else {
             return nil
         }
-        return String(format: "%@. %@", feature.title, availableAccessibilityLabel)
+        return String(format: "%@. %@", title, availableAccessibilityLabel)
     }
 
     var availableAccessibilityLabel: String? {
-        switch (availableIndicator, feature.webOnly) {
+        switch (availableIndicator, webOnly) {
         case (.Some(false), _):
             return NSLocalizedString("Not included", comment: "Spoken text. A feature is not included in the plan")
         case (.Some(true), true):
@@ -236,13 +237,14 @@ struct FeatureListItemRow : ImmuTableRow {
 
     // And indicator of a feature being available. It can be nil for features that have a description.
     var availableIndicator: Bool? {
-        switch (available, feature.description) {
+        switch (available, description) {
+        case (_, let description?) where !description.isEmpty:
+            // Never show an indicator if there's a description
+            return nil
         case (false, _):
             return false
-        case (true, nil), (true, .Some("")):
-            return true
         default:
-            return nil
+            return true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -78,14 +78,18 @@ class PlanDetailViewController: UIViewController {
         viewModel = ImmuTable(sections:
             [ ImmuTableSection(rows: PlanFeature.allFeatures.map { feature in
                 let available = plan.features.contains(feature)
-                
+
                 if available {
                     // If a feature is 'available', we have to find and use the feature instance
                     // from the _plan's_ list of features, as it will have the correct associated values
                     // for any enum case that has associated values.
                     let index = plan.features.indexOf(feature)
                     let planFeature = plan.features[index!]
-                    return FeatureListItemRow(feature: planFeature, available: available)
+                    if let description = planFeature.description {
+                        return TextRow(title: planFeature.title, value: description)
+                    } else {
+                        return FeatureListItemRow(feature: planFeature, available: available)
+                    }
                 }
                 
                 return FeatureListItemRow(feature: feature, available: available)
@@ -160,7 +164,6 @@ struct FeatureListItemRow : ImmuTableRow {
     let action: ImmuTableAction? = nil
     
     let title: String
-    let description: String?
     let webOnly: Bool
     let available: Bool
     
@@ -168,8 +171,9 @@ struct FeatureListItemRow : ImmuTableRow {
     let webOnlyFontSize: CGFloat = 13.0
     
     init(feature: PlanFeature, available: Bool) {
+        precondition(feature.description == nil, "Features with a description should use TextRow instead")
+
         self.title = feature.title
-        self.description = feature.description
         self.webOnly = feature.webOnly
         self.available = available
     }
@@ -203,7 +207,7 @@ struct FeatureListItemRow : ImmuTableRow {
         if available && webOnly {
             return NSLocalizedString("WEB ONLY", comment: "Describes a feature of a WordPress.com plan that is only available to users via the web.")
         } else {
-            return description
+            return nil
         }
     }
 
@@ -235,17 +239,8 @@ struct FeatureListItemRow : ImmuTableRow {
         }
     }
 
-    // And indicator of a feature being available. It can be nil for features that have a description.
     var availableIndicator: Bool? {
-        switch (available, description) {
-        case (_, let description?) where !description.isEmpty:
-            // Never show an indicator if there's a description
-            return nil
-        case (false, _):
-            return false
-        default:
-            return true
-        }
+        return available
     }
 
     var accessoryView: UIView? {

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -171,25 +171,47 @@ struct FeatureListItemRow : ImmuTableRow {
     }
     
     func configureCell(cell: UITableViewCell) {
+        cell.textLabel?.text = text
         cell.textLabel?.font = WPStyleGuide.tableviewTextFont()
-        
-        cell.textLabel?.textColor = available ? WPStyleGuide.darkGrey() : WPStyleGuide.grey()
-        cell.textLabel?.alpha = available ? 1.0 : 0.5
+        cell.textLabel?.textColor = textColor
+
+        cell.detailTextLabel?.text = detailText
+        cell.detailTextLabel?.font = detailTextFont
         cell.detailTextLabel?.textColor = WPStyleGuide.grey()
-        
-        cell.textLabel?.text = feature.title
-        
-        if available {
-            if feature.webOnly {
-                cell.detailTextLabel?.text = NSLocalizedString("WEB ONLY", comment: "Describes a feature of a WordPress.com plan that is only available to users via the web.")
-                cell.detailTextLabel?.font = WPFontManager.openSansRegularFontOfSize(webOnlyFontSize)
-            } else {
-                cell.detailTextLabel?.text = feature.description                
-                cell.detailTextLabel?.font = WPStyleGuide.tableviewTextFont()
-            }
-        }
+
         cell.accessoryView = accessoryView
         cell.accessibilityLabel = accessibilityLabel
+    }
+
+    var text: String? {
+        return feature.title
+    }
+
+    var textColor: UIColor {
+        if available {
+            return WPStyleGuide.darkGrey()
+        } else {
+            return WPStyleGuide.grey().colorWithAlphaComponent(0.5)
+        }
+    }
+
+    var detailText: String? {
+        switch (available, feature.webOnly) {
+        case (true, true):
+                return NSLocalizedString("WEB ONLY", comment: "Describes a feature of a WordPress.com plan that is only available to users via the web.")
+        case (true, false):
+            return feature.description
+        default:
+            return nil
+        }
+    }
+
+    var detailTextFont: UIFont {
+        if available && feature.webOnly {
+            return WPFontManager.openSansRegularFontOfSize(webOnlyFontSize)
+        } else {
+            return WPStyleGuide.tableviewTextFont()
+        }
     }
 
     var accessibilityLabel: String? {

--- a/WordPress/WordPressTest/PlanDetailViewControllerTest.swift
+++ b/WordPress/WordPressTest/PlanDetailViewControllerTest.swift
@@ -15,7 +15,7 @@ class PlanDetailViewControllerTest: XCTestCase {
         expect(row.availableIndicator).to(beTrue())
     }
     
-    func testFeatureListItemRowAvailableFeatureWebOnlyNoDetail() {
+    func testFeatureListItemRowAvailableFeatureWebOnly() {
         let feature = PlanFeature.CustomDomain
         let row = FeatureListItemRow(feature: feature, available: true)
         
@@ -24,7 +24,7 @@ class PlanDetailViewControllerTest: XCTestCase {
         expect(row.availableIndicator).to(beTrue())
     }
     
-    func testFeatureListItemRowUnavailableFeatureNoDetail() {
+    func testFeatureListItemRowUnavailableFeature() {
         let feature = PlanFeature.NoAds
         let row = FeatureListItemRow(feature: feature, available: false)
         

--- a/WordPress/WordPressTest/PlanDetailViewControllerTest.swift
+++ b/WordPress/WordPressTest/PlanDetailViewControllerTest.swift
@@ -15,15 +15,6 @@ class PlanDetailViewControllerTest: XCTestCase {
         expect(row.availableIndicator).to(beTrue())
     }
     
-    func testFeatureListItemRowAvailableFeatureWithDetail() {
-        let feature = PlanFeature.StorageSpace("10GB")
-        let row = FeatureListItemRow(feature: feature, available: true)
-
-        expect(row.text).notTo(beEmpty())
-        expect(row.detailText).to(contain("10GB"))
-        expect(row.availableIndicator).to(beNil())
-    }
-    
     func testFeatureListItemRowAvailableFeatureWebOnlyNoDetail() {
         let feature = PlanFeature.CustomDomain
         let row = FeatureListItemRow(feature: feature, available: true)
@@ -40,15 +31,6 @@ class PlanDetailViewControllerTest: XCTestCase {
         expect(row.text).notTo(beEmpty())
         expect(row.detailText).to(beNil())
         expect(row.availableIndicator).to(beFalse())
-    }
-    
-    func testFeatureListItemRowUnavailableFeatureWithDetail() {
-        let feature = PlanFeature.StorageSpace("10GB")
-        let row = FeatureListItemRow(feature: feature, available: false)
-        
-        expect(row.text).notTo(beEmpty())
-        expect(row.detailText).to(equal("10GB"))
-        expect(row.availableIndicator).to(beNil())
     }
     
     func testFeatureListItemRowUnavailableFeatureWebOnly() {

--- a/WordPress/WordPressTest/PlanDetailViewControllerTest.swift
+++ b/WordPress/WordPressTest/PlanDetailViewControllerTest.swift
@@ -2,21 +2,6 @@ import XCTest
 import Nimble
 @testable import WordPress
 
-public func containAnInstanceOf(expectedClass: AnyClass) -> NonNilMatcherFunc<Array<NSObject>> {
-    return NonNilMatcherFunc { actualExpression, failureMessage in
-        failureMessage.postfixMessage = "contain an instance of <\(expectedClass)>"
-        guard let actual = try actualExpression.evaluate() else { return false }
-        
-        for item in actual {
-            if item.isMemberOfClass(expectedClass) {
-                return true
-            }
-        }
-        
-        return false
-    }
-}
-
 class PlanDetailViewControllerTest: XCTestCase {
     
     // MARK: - FeatureListItemRow tests
@@ -25,74 +10,54 @@ class PlanDetailViewControllerTest: XCTestCase {
         let feature = PlanFeature.NoAds
         let row = FeatureListItemRow(feature: feature, available: true)
         
-        let cell = UITableViewCell(style: .Value1, reuseIdentifier: nil)
-        row.configureCell(cell)
-        
-        expect(cell.textLabel?.text).notTo(beEmpty())
-        expect(cell.detailTextLabel?.text).to(beNil())
-        // The accessory view should be an imageview (checkmark)
-        expect(cell.accessoryView?.subviews).to(containAnInstanceOf(UIImageView))
+        expect(row.text).notTo(beEmpty())
+        expect(row.detailText).to(beNil())
+        expect(row.availableIndicator).to(beTrue())
     }
     
     func testFeatureListItemRowAvailableFeatureWithDetail() {
         let feature = PlanFeature.StorageSpace("10GB")
         let row = FeatureListItemRow(feature: feature, available: true)
-        
-        let cell = UITableViewCell(style: .Value1, reuseIdentifier: nil)
-        row.configureCell(cell)
-        
-        expect(cell.textLabel?.text).notTo(beEmpty())
-        expect(cell.detailTextLabel?.text).to(contain("10GB"))
-        expect(cell.accessoryView).to(beNil())
+
+        expect(row.text).notTo(beEmpty())
+        expect(row.detailText).to(contain("10GB"))
+        expect(row.availableIndicator).to(beNil())
     }
     
     func testFeatureListItemRowAvailableFeatureWebOnlyNoDetail() {
         let feature = PlanFeature.CustomDomain
         let row = FeatureListItemRow(feature: feature, available: true)
         
-        let cell = UITableViewCell(style: .Value1, reuseIdentifier: nil)
-        row.configureCell(cell)
-        
-        expect(cell.textLabel?.text).notTo(beEmpty())
-        expect(cell.detailTextLabel?.text).to(contain("WEB ONLY"))
-        expect(cell.accessoryView?.subviews).to(containAnInstanceOf(UIImageView))
+        expect(row.text).notTo(beEmpty())
+        expect(row.detailText).to(contain("WEB ONLY"))
+        expect(row.availableIndicator).to(beTrue())
     }
     
     func testFeatureListItemRowUnavailableFeatureNoDetail() {
         let feature = PlanFeature.NoAds
         let row = FeatureListItemRow(feature: feature, available: false)
         
-        let cell = UITableViewCell(style: .Value1, reuseIdentifier: nil)
-        row.configureCell(cell)
-        
-        expect(cell.textLabel?.text).notTo(beEmpty())
-        expect(cell.detailTextLabel?.text).to(beNil())
-        expect(cell.accessoryView?.subviews).notTo(containAnInstanceOf(UIImageView))
+        expect(row.text).notTo(beEmpty())
+        expect(row.detailText).to(beNil())
+        expect(row.availableIndicator).to(beFalse())
     }
     
     func testFeatureListItemRowUnavailableFeatureWithDetail() {
         let feature = PlanFeature.StorageSpace("10GB")
         let row = FeatureListItemRow(feature: feature, available: false)
         
-        let cell = UITableViewCell(style: .Value1, reuseIdentifier: nil)
-        row.configureCell(cell)
-        
-        expect(cell.textLabel?.text).notTo(beEmpty())
-        expect(cell.detailTextLabel?.text).to(beNil())
-        // Don't show any detail text for unavailable items
-        expect(cell.accessoryView?.subviews).notTo(containAnInstanceOf(UIImageView))
+        expect(row.text).notTo(beEmpty())
+        expect(row.detailText).to(equal("10GB"))
+        expect(row.availableIndicator).to(beNil())
     }
     
     func testFeatureListItemRowUnavailableFeatureWebOnly() {
         let feature = PlanFeature.CustomDomain
         let row = FeatureListItemRow(feature: feature, available: false)
         
-        let cell = UITableViewCell(style: .Value1, reuseIdentifier: nil)
-        row.configureCell(cell)
-        
-        expect(cell.textLabel?.text).notTo(beEmpty())
+        expect(row.text).notTo(beEmpty())
         // Don't show any detail text for unavailable items
-        expect(cell.detailTextLabel?.text).to(beNil())
-        expect(cell.accessoryView?.subviews).notTo(containAnInstanceOf(UIImageView))
+        expect(row.detailText).to(beNil())
+        expect(row.availableIndicator).to(beFalse())
     }
 }


### PR DESCRIPTION
The main goal of this PR was to remove the UIKit dependency on the plan detail tests: instead of having to create a cell, configure it, and test it, we expose all the logic through accessors on `FeatureListItemRow` and test those.

While doing this, I had a couple test failures that I wasn't sure how to solve, because there were some states of `FeatureListItemRow` that just didn't make sense: what happens if a feature is not available and it has a description?

I think features with description are a special case, and now are being handled with a `TextRow`.

`FeatureListItemRow` is still initialized with a `PlanFeature` for convenience, but internally it stores `(title, webOnly, available)` so it's easier to reason about the possible combinations.

Fixes #4801 
Needs Review: @frosty 