### PR TITLE
Reader: Ensure object is a dictionary before continuing.

### DIFF
--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -273,6 +273,9 @@ static const NSInteger MinutesToReadThreshold = 2;
 
     NSArray *metadata = [dict arrayForKey:PostRESTKeyMetadata];
     for (NSDictionary *obj in metadata) {
+        if (![obj isKindOfClass:[NSDictionary class]]) {
+            continue;
+        }
         if ([[obj stringForKey:CrossPostMetaKey] isEqualToString:CrossPostMetaXPostPermalink] ||
             [[obj stringForKey:CrossPostMetaKey] isEqualToString:CrossPostMetaXCommentPermalink]) {
 


### PR DESCRIPTION
Addresses an odd crash seen while composing a remote reader post.  Sample stack trace:
```
 Fatal Exception: NSInvalidArgumentException
-[__NSCFBoolean stringForKey:]: unrecognized selector sent to instance 0x19fe800b0

Thread : Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x181c15900 __exceptionPreprocess
1  libobjc.A.dylib                0x181283f80 objc_exception_throw
2  CoreFoundation                 0x181c1c61c __methodDescriptionForSelector
3  CoreFoundation                 0x181c195b8 ___forwarding___
4  CoreFoundation                 0x181b1d68c _CF_forwarding_prep_0
5  WordPress                      0x100071aac -[ReaderPostServiceRemote crossPostMetaFromPostDictionary:] (ReaderPostServiceRemote.m:276)
6  WordPress                      0x1000716fc -[ReaderPostServiceRemote formatPostDictionary:] (ReaderPostServiceRemote.m:260)
7  WordPress                      0x1000701f4 __62-[ReaderPostServiceRemote fetchPost:fromSite:success:failure:]_block_invoke (ReaderPostServiceRemote.m:109)
8  libdispatch.dylib              0x181669630 _dispatch_call_block_and_release
9  libdispatch.dylib              0x1816695f0 _dispatch_client_callout
```

I'm not sure just how to reproduce the crash itself but a check to ensure the object is an `NSDictionary` as expected should prevent it. 

Needs review: @sendhil 
