### PR TITLE
Extract media settings to a separate class, add unit tests

### DIFF
--- a/WordPress/Classes/Extensions/Math.swift
+++ b/WordPress/Classes/Extensions/Math.swift
@@ -47,4 +47,8 @@ extension CGSize {
         let maxSize = CGSize(width: maxValue, height: maxValue)
         return clamp(min: minSize, max: maxSize)
     }
+
+    func clamp(min minValue: Int, max maxValue: Int) -> CGSize {
+        return clamp(min: CGFloat(minValue), max: CGFloat(maxValue))
+    }
 }

--- a/WordPress/Classes/Extensions/Math.swift
+++ b/WordPress/Classes/Extensions/Math.swift
@@ -19,7 +19,9 @@ extension Int {
         let half = divisor / 2
         return self + sign * (half - (abs(self) + half) % divisor)
     }
+}
 
+extension Comparable {
     /**
      Clamps self between a minimum and maximum value
      
@@ -28,7 +30,21 @@ extension Int {
         - max if self > max
         - otherwise it returns self
      */
-    func clamp(min minValue: Int, max maxValue: Int) -> Int {
+    func clamp(min minValue: Self, max maxValue: Self) -> Self {
         return Swift.min(Swift.max(self, minValue), maxValue)
+    }
+}
+
+extension CGSize {
+    func clamp(min minValue: CGSize, max maxValue: CGSize) -> CGSize {
+        let width = self.width.clamp(min: minValue.width, max: maxValue.width)
+        let height = self.height.clamp(min: minValue.height, max: maxValue.height)
+        return CGSize(width: width, height: height)
+    }
+
+    func clamp(min minValue: CGFloat, max maxValue: CGFloat) -> CGSize {
+        let minSize = CGSize(width: minValue, height: minValue)
+        let maxSize = CGSize(width: maxValue, height: maxValue)
+        return clamp(min: minSize, max: maxSize)
     }
 }

--- a/WordPress/Classes/Extensions/PHAsset+Exporters.swift
+++ b/WordPress/Classes/Extensions/PHAsset+Exporters.swift
@@ -10,8 +10,10 @@ extension PHAsset {
 
     /**
      Exports an asset to a file URL with the desired targetSize and removing geolocation if requested. 
-     The targetSize is the maximum resolution permited, the resultSize will normally be a lower value that maitains the aspect ratio of the asset
+     The targetSize is the maximum resolution permited, the resultSize will normally be a lower value that maitains the aspect ratio of the asset.
      
+     - Note: Images aren't scaled up, so if you pass a `maximumResolution` that's larger than the original image, it will not resize.
+
      - Parameters:
         - url: file url to where the asset should be exported, this must be writable location
         - targetUTI: the UTI format to use when exporting the asset

--- a/WordPress/Classes/Extensions/PHAsset+Exporters.swift
+++ b/WordPress/Classes/Extensions/PHAsset+Exporters.swift
@@ -15,7 +15,7 @@ extension PHAsset {
      - Parameters:
         - url: file url to where the asset should be exported, this must be writable location
         - targetUTI: the UTI format to use when exporting the asset
-        - maximumResolution:  the maximum pixel resolution that the asset can have after exporting. If CGSizeZero is provided the original size of image is returned.
+        - maximumResolution:  the maximum pixel resolution that the asset can have after exporting.
         - stripGeoLocation: if true any geographic location existent on the metadata of the asset will be stripped
         - successHandler:  a handler that will be invoked on success with the resulting resolution of the asset exported
         - errorHandler: a handler that will be invoked when some error occurs when generating the exported file for the asset
@@ -62,11 +62,11 @@ extension PHAsset {
         options.resizeMode = .Exact
         options.synchronous = false
         options.networkAccessAllowed = true
-        var requestedSize = maximumResolution
-        if (requestedSize == CGSize.zero) {
-            requestedSize = CGSize(width: pixelWidth, height: pixelHeight)
-        }
-        PHImageManager.defaultManager().requestImageForAsset(self, targetSize: requestedSize, contentMode: .AspectFit, options: options) { (image, info) -> Void in
+
+        let pixelSize = CGSize(width: pixelWidth, height: pixelHeight)
+        let requestedSize = maximumResolution.clamp(min: CGSizeZero, max: pixelSize)
+
+            PHImageManager.defaultManager().requestImageForAsset(self, targetSize: requestedSize, contentMode: .AspectFit, options: options) { (image, info) -> Void in
             guard let image = image else {
                 if let error = info?[PHImageErrorKey] as? NSError {
                     errorHandler(error: error)

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -3,18 +3,10 @@
 #import <Photos/Photos.h>
 #import "LocalCoreDataService.h"
 
-extern CGSize const MediaMaxImageSize;
-extern NSInteger const MediaMinImageSizeDimension;
-extern NSInteger const MediaMaxImageSizeDimension;
-
 @class Media;
 @class Blog;
 
 @interface MediaService : LocalCoreDataService
-
-+ (CGSize)maxImageSizeSetting;
-
-+ (void)setMaxImageSizeSetting:(CGSize)imageSize;
 
 /**
  Create a Media object using the asset as the source and making it a child of the post with postObjectId.

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -15,35 +15,7 @@
 #import "WPXMLRPCDecoder.h"
 #import "WordPressComApi.h"
 
-NSString * const SavedMaxImageSizeSetting = @"SavedMaxImageSizeSetting";
-CGSize const MediaMaxImageSize = {3000, 3000};
-NSInteger const MediaMinImageSizeDimension = 150;
-NSInteger const MediaMaxImageSizeDimension = 3000;
-
 @implementation MediaService
-
-+ (CGSize)maxImageSizeSetting
-{
-    NSString *savedSize = [[NSUserDefaults standardUserDefaults] stringForKey:SavedMaxImageSizeSetting];
-    CGSize maxSize = MediaMaxImageSize;
-    if (savedSize) {
-        maxSize = CGSizeFromString(savedSize);
-    }
-    return maxSize;
-}
-
-+ (void)setMaxImageSizeSetting:(CGSize)imageSize
-{
-    // Constraint to max width and height.
-    CGFloat width = imageSize.width;
-    CGFloat height = imageSize.height;
-    width = MAX(MIN(width, MediaMaxImageSizeDimension), MediaMinImageSizeDimension);
-    height = MAX(MIN(height, MediaMaxImageSizeDimension), MediaMinImageSizeDimension);
-
-    NSString *strSize = NSStringFromCGSize(CGSizeMake(width, height));
-    [[NSUserDefaults standardUserDefaults] setObject:strSize forKey:SavedMaxImageSizeSetting];
-    [NSUserDefaults resetStandardUserDefaults];
-}
 
 - (void)createMediaWithPHAsset:(PHAsset *)asset
              forPostObjectID:(NSManagedObjectID *)postObjectID
@@ -84,11 +56,8 @@ NSInteger const MediaMaxImageSizeDimension = 3000;
     
     BOOL geoLocationEnabled = post.blog.settings.geolocationEnabled;
     
-    CGSize maxImageSize = [MediaService maxImageSizeSetting];
-    if (maxImageSize.width == MediaMaxImageSize.width && maxImageSize.height == MediaMaxImageSize.height) {
-        maxImageSize = CGSizeZero;
-    }
-    
+    CGSize maxImageSize = [AppSettings imageSizeForUpload];
+
     NSURL *mediaURL = [self urlForMediaWithFilename:[asset originalFilename] andExtension:extension];
     NSURL *mediaThumbnailURL = [self urlForMediaWithFilename:[self pathForThumbnailOfFile:[mediaURL lastPathComponent]]
                                                 andExtension:[self extensionForUTI:[asset defaultThumbnailUTI]]];

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -56,7 +56,8 @@
     
     BOOL geoLocationEnabled = post.blog.settings.geolocationEnabled;
     
-    CGSize maxImageSize = [MediaSettings imageSizeForUpload];
+    NSInteger maxImageSize = [[MediaSettings new] imageSizeForUpload];
+    CGSize maximumResolution = CGSizeMake(maxImageSize, maxImageSize);
 
     NSURL *mediaURL = [self urlForMediaWithFilename:[asset originalFilename] andExtension:extension];
     NSURL *mediaThumbnailURL = [self urlForMediaWithFilename:[self pathForThumbnailOfFile:[mediaURL lastPathComponent]]
@@ -73,7 +74,7 @@
 
             [asset exportToURL:mediaURL
                      targetUTI:assetUTI
-             maximumResolution:maxImageSize
+             maximumResolution:maximumResolution
               stripGeoLocation:!geoLocationEnabled
                 successHandler:^(CGSize resultingSize)
                 {

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -56,7 +56,7 @@
     
     BOOL geoLocationEnabled = post.blog.settings.geolocationEnabled;
     
-    CGSize maxImageSize = [AppSettings imageSizeForUpload];
+    CGSize maxImageSize = [MediaSettings imageSizeForUpload];
 
     NSURL *mediaURL = [self urlForMediaWithFilename:[asset originalFilename] andExtension:extension];
     NSURL *mediaThumbnailURL = [self urlForMediaWithFilename:[self pathForThumbnailOfFile:[mediaURL lastPathComponent]]

--- a/WordPress/Classes/Services/MediaSettings.swift
+++ b/WordPress/Classes/Services/MediaSettings.swift
@@ -15,9 +15,13 @@ class MediaSettings: NSObject {
     private let storage: MediaSettingsStorage
 
     // MARK: - Initialization
-    init(storage: MediaSettingsStorage = DefaultsStorage()) {
+    init(storage: MediaSettingsStorage) {
         self.storage = storage
         super.init()
+    }
+
+    convenience override init() {
+        self.init(storage: DefaultsStorage())
     }
 
     // MARK: Public accessors

--- a/WordPress/Classes/Services/MediaSettings.swift
+++ b/WordPress/Classes/Services/MediaSettings.swift
@@ -1,41 +1,79 @@
 import Foundation
 
-class MediaSettings: NSObject {
-    private static let maxImageSizeKey = "SavedMaxImageSizeSetting"
-    
-    static let minImageDimension = 150
-    static let maxImageDimension = 3000
+protocol MediaSettingsStorage {
+    func valueForKey(key: String) -> AnyObject?
+    func setValue(value: AnyObject, forKey key: String)
+}
 
-    /// The absolute maximum size that the app can use as a setting. If
-    /// `maxImageSizeSetting` matches this value, images won't be resized.
-    private static var absoluteMaxImageSize: CGSize {
-        return CGSize(width: maxImageDimension, height: maxImageDimension)
+class MediaSettings: NSObject {
+    private let maxImageSizeKey = "SavedMaxImageSizeSetting"
+    
+    let minImageDimension = 150
+    let maxImageDimension = 3000
+
+    let storage: MediaSettingsStorage
+
+    init(storage: MediaSettingsStorage = DefaultsStorage()) {
+        self.storage = storage
+        super.init()
     }
 
-    /// The size that an image should be resized to before uploading.
-    static var maxImageSizeSetting: CGSize {
+    var allowedImageSizeRange: (Int, Int) {
+        return (minImageDimension, maxImageDimension)
+    }
+
+    /// The size that an image needs to be resized to before uploading.
+    /// - note: if the image doesn't need to be resized, it returns `Int.max`
+    var imageSizeForUpload: Int {
+        if maxImageSizeSetting >= maxImageDimension {
+            return Int.max
+        } else {
+            return maxImageSizeSetting
+        }
+    }
+
+    /// The stored value for the maximum size images can have before uploading.
+    /// If you set this to `maxImageDimension` or higher, it means images won't
+    /// be resized on upload.
+    ///
+    /// - important: don't access this propery directly to check what size to resize an image, use `imageSizeForUpload` instead.
+    var maxImageSizeSetting: Int {
         get {
-            if let savedSize = NSUserDefaults.standardUserDefaults().stringForKey(maxImageSizeKey) {
-                return CGSizeFromString(savedSize)
+            if let savedSize = storage.valueForKey(maxImageSizeKey) as? Int {
+                return savedSize
+            } else if let savedSize = storage.valueForKey(maxImageSizeKey) as? String {
+                let newSize = CGSizeFromString(savedSize).width
+                storage.setValue(newSize, forKey: maxImageSizeKey)
+                return Int(newSize)
             } else {
-                return absoluteMaxImageSize
+                return maxImageDimension
             }
         }
         set {
             let size = newValue.clamp(min: minImageDimension, max: maxImageDimension)
-            let sizeString = NSStringFromCGSize(size)
-            NSUserDefaults.standardUserDefaults().setObject(sizeString, forKey: maxImageSizeKey)
-            NSUserDefaults.resetStandardUserDefaults()
+            storage.setValue(size, forKey: maxImageSizeKey)
         }
     }
 
-    /// The size that an image needs to be resized to before uploading, or
-    /// CGSizeZero if it shouldn't be resized.
-    static var imageSizeForUpload: CGSize {
-        if maxImageSizeSetting == absoluteMaxImageSize {
-            return CGSizeZero
-        } else {
-            return maxImageSizeSetting
+    struct DefaultsStorage: MediaSettingsStorage {
+        func setValue(value: AnyObject, forKey key: String) {
+            NSUserDefaults.standardUserDefaults().setObject(value, forKey: key)
+            NSUserDefaults.resetStandardUserDefaults()
+        }
+        func valueForKey(key: String) -> AnyObject? {
+            return NSUserDefaults.standardUserDefaults().objectForKey(key)
+        }
+    }
+
+    class EphemeralStorage: MediaSettingsStorage {
+        private var memory = [String: AnyObject]()
+
+        func setValue(value: AnyObject, forKey key: String) {
+            memory[key] = value
+        }
+
+        func valueForKey(key: String) -> AnyObject? {
+            return memory[key]
         }
     }
 }

--- a/WordPress/Classes/Services/MediaSettings.swift
+++ b/WordPress/Classes/Services/MediaSettings.swift
@@ -29,7 +29,7 @@ class MediaSettings: NSObject {
     /// The minimum and maximum allowed sizes for `maxImageSizeSetting`.
     /// The UI to configure this setting should not allow values outside this limits.
     /// - seealso: maxImageSizeSetting
-    var allowedImageSizeRange: (Int, Int) {
+    var allowedImageSizeRange: (min: Int, max: Int) {
         return (minImageDimension, maxImageDimension)
     }
 

--- a/WordPress/Classes/Services/MediaSettings.swift
+++ b/WordPress/Classes/Services/MediaSettings.swift
@@ -1,16 +1,18 @@
 import Foundation
 
-class AppSettings: NSObject {
+class MediaSettings: NSObject {
     private static let maxImageSizeKey = "SavedMaxImageSizeSetting"
     
     static let minImageDimension = 150
     static let maxImageDimension = 3000
 
-    /// The absolute maximum size that the app can use as a setting. If `maxImageSizeSetting` matches this value, images won't be resized.
+    /// The absolute maximum size that the app can use as a setting. If
+    /// `maxImageSizeSetting` matches this value, images won't be resized.
     private static var absoluteMaxImageSize: CGSize {
         return CGSize(width: maxImageDimension, height: maxImageDimension)
     }
 
+    /// The size that an image should be resized to before uploading.
     static var maxImageSizeSetting: CGSize {
         get {
             if let savedSize = NSUserDefaults.standardUserDefaults().stringForKey(maxImageSizeKey) {
@@ -27,7 +29,8 @@ class AppSettings: NSObject {
         }
     }
 
-    /// The size that an image needs to be resized to before uploading, or CGSizeZero if it shouldn't be resized.
+    /// The size that an image needs to be resized to before uploading, or
+    /// CGSizeZero if it shouldn't be resized.
     static var imageSizeForUpload: CGSize {
         if maxImageSizeSetting == absoluteMaxImageSize {
             return CGSizeZero

--- a/WordPress/Classes/Services/MediaSettings.swift
+++ b/WordPress/Classes/Services/MediaSettings.swift
@@ -35,7 +35,7 @@ class MediaSettings: NSObject {
     /// The stored value for the maximum size images can have before uploading.
     /// If you set this to `maxImageDimension` or higher, it means images won't
     /// be resized on upload.
-    ///
+    /// If you set this to `minImageDimension` or lower, it will be set to `minImageDimension`.
     /// - important: don't access this propery directly to check what size to resize an image, use `imageSizeForUpload` instead.
     var maxImageSizeSetting: Int {
         get {

--- a/WordPress/Classes/Services/MediaSettings.swift
+++ b/WordPress/Classes/Services/MediaSettings.swift
@@ -6,18 +6,25 @@ protocol MediaSettingsStorage {
 }
 
 class MediaSettings: NSObject {
+    // MARK: - Constants
     private let maxImageSizeKey = "SavedMaxImageSizeSetting"
-    
-    let minImageDimension = 150
-    let maxImageDimension = 3000
+    private let minImageDimension = 150
+    private let maxImageDimension = 3000
 
-    let storage: MediaSettingsStorage
+    // MARK: - Internal variables
+    private let storage: MediaSettingsStorage
 
+    // MARK: - Initialization
     init(storage: MediaSettingsStorage = DefaultsStorage()) {
         self.storage = storage
         super.init()
     }
 
+    // MARK: Public accessors
+
+    /// The minimum and maximum allowed sizes for `maxImageSizeSetting`.
+    /// The UI to configure this setting should not allow values outside this limits.
+    /// - seealso: maxImageSizeSetting
     var allowedImageSizeRange: (Int, Int) {
         return (minImageDimension, maxImageDimension)
     }
@@ -54,6 +61,8 @@ class MediaSettings: NSObject {
             storage.setValue(size, forKey: maxImageSizeKey)
         }
     }
+
+    // MARK: - Storage implementations
 
     struct DefaultsStorage: MediaSettingsStorage {
         func setValue(value: AnyObject, forKey key: String) {

--- a/WordPress/Classes/System/AppSettings.swift
+++ b/WordPress/Classes/System/AppSettings.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+class AppSettings: NSObject {
+    private static let maxImageSizeKey = "SavedMaxImageSizeSetting"
+    
+    static let minImageDimension = 150
+    static let maxImageDimension = 3000
+
+    /// The absolute maximum size that the app can use as a setting. If `maxImageSizeSetting` matches this value, images won't be resized.
+    private static var absoluteMaxImageSize: CGSize {
+        return CGSize(width: maxImageDimension, height: maxImageDimension)
+    }
+
+    static var maxImageSizeSetting: CGSize {
+        get {
+            if let savedSize = NSUserDefaults.standardUserDefaults().stringForKey(maxImageSizeKey) {
+                return CGSizeFromString(savedSize)
+            } else {
+                return absoluteMaxImageSize
+            }
+        }
+        set {
+            let size = newValue.clamp(min: minImageDimension, max: maxImageDimension)
+            let sizeString = NSStringFromCGSize(size)
+            NSUserDefaults.standardUserDefaults().setObject(sizeString, forKey: maxImageSizeKey)
+            NSUserDefaults.resetStandardUserDefaults()
+        }
+    }
+
+    /// The size that an image needs to be resized to before uploading, or CGSizeZero if it shouldn't be resized.
+    static var imageSizeForUpload: CGSize {
+        if maxImageSizeSetting == absoluteMaxImageSize {
+            return CGSizeZero
+        } else {
+            return maxImageSizeSetting
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Cells/WPImmuTableCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/WPImmuTableCells.swift
@@ -265,7 +265,6 @@ struct MediaSizeRow: ImmuTableRow {
         cell.value = value
         cell.onChange = onChange
 
-        cell.minValue = MediaSettings.minImageDimension
-        cell.maxValue = MediaSettings.maxImageDimension
+        (cell.minValue, cell.maxValue) = MediaSettings().allowedImageSizeRange
     }
 }

--- a/WordPress/Classes/ViewRelated/Cells/WPImmuTableCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/WPImmuTableCells.swift
@@ -265,7 +265,7 @@ struct MediaSizeRow: ImmuTableRow {
         cell.value = value
         cell.onChange = onChange
 
-        cell.minValue = AppSettings.minImageDimension
-        cell.maxValue = AppSettings.maxImageDimension
+        cell.minValue = MediaSettings.minImageDimension
+        cell.maxValue = MediaSettings.maxImageDimension
     }
 }

--- a/WordPress/Classes/ViewRelated/Cells/WPImmuTableCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/WPImmuTableCells.swift
@@ -265,7 +265,7 @@ struct MediaSizeRow: ImmuTableRow {
         cell.value = value
         cell.onChange = onChange
 
-        cell.minValue = MediaMinImageSizeDimension
-        cell.maxValue = MediaMaxImageSizeDimension
+        cell.minValue = AppSettings.minImageDimension
+        cell.maxValue = AppSettings.maxImageDimension
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -52,7 +52,7 @@ private struct AccountSettingsController: SettingsController {
 
         let uploadSize = MediaSizeRow(
             title: NSLocalizedString("Max Image Upload Size", comment: "Title for the image size settings option."),
-            value: Int(MediaService.maxImageSizeSetting().width),
+            value: Int(AppSettings.maxImageSizeSetting.width),
             onChange: mediaSizeChanged())
 
         let visualEditor = SwitchRow(
@@ -93,7 +93,7 @@ private struct AccountSettingsController: SettingsController {
         return {
             value in
             let size = CGSize(width: value, height: value)
-            MediaService.setMaxImageSizeSetting(size)
+            AppSettings.maxImageSizeSetting = size
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -52,7 +52,7 @@ private struct AccountSettingsController: SettingsController {
 
         let uploadSize = MediaSizeRow(
             title: NSLocalizedString("Max Image Upload Size", comment: "Title for the image size settings option."),
-            value: Int(MediaSettings.maxImageSizeSetting.width),
+            value: Int(MediaSettings().maxImageSizeSetting),
             onChange: mediaSizeChanged())
 
         let visualEditor = SwitchRow(
@@ -92,8 +92,7 @@ private struct AccountSettingsController: SettingsController {
     func mediaSizeChanged() -> Int -> Void {
         return {
             value in
-            let size = CGSize(width: value, height: value)
-            MediaSettings.maxImageSizeSetting = size
+            MediaSettings().maxImageSizeSetting = value
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -52,7 +52,7 @@ private struct AccountSettingsController: SettingsController {
 
         let uploadSize = MediaSizeRow(
             title: NSLocalizedString("Max Image Upload Size", comment: "Title for the image size settings option."),
-            value: Int(AppSettings.maxImageSizeSetting.width),
+            value: Int(MediaSettings.maxImageSizeSetting.width),
             onChange: mediaSizeChanged())
 
         let visualEditor = SwitchRow(
@@ -93,7 +93,7 @@ private struct AccountSettingsController: SettingsController {
         return {
             value in
             let size = CGSize(width: value, height: value)
-            AppSettings.maxImageSizeSetting = size
+            MediaSettings.maxImageSizeSetting = size
         }
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -562,6 +562,7 @@
 		E1BEEC651C4E3978000B4FA0 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BEEC641C4E3978000B4FA0 /* PaddedLabel.swift */; };
 		E1C265C91BECFCDD00DC4C6B /* WPCrashlyticsLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = E1C265C81BECFCDD00DC4C6B /* WPCrashlyticsLogger.m */; };
 		E1C5457E1C6B962D001CEB0E /* MediaSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5457D1C6B962D001CEB0E /* MediaSettings.swift */; };
+		E1C545801C6C79BB001CEB0E /* MediaSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5457F1C6C79BB001CEB0E /* MediaSettingsTests.swift */; };
 		E1C9AA511C10419200732665 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA501C10419200732665 /* Math.swift */; };
 		E1C9AA561C10427100732665 /* MathTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA551C10427100732665 /* MathTest.swift */; };
 		E1D04D7E19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D04D7D19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m */; };
@@ -1655,6 +1656,7 @@
 		E1C265C71BECFCDD00DC4C6B /* WPCrashlyticsLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPCrashlyticsLogger.h; sourceTree = "<group>"; };
 		E1C265C81BECFCDD00DC4C6B /* WPCrashlyticsLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPCrashlyticsLogger.m; sourceTree = "<group>"; };
 		E1C5457D1C6B962D001CEB0E /* MediaSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaSettings.swift; sourceTree = "<group>"; };
+		E1C5457F1C6C79BB001CEB0E /* MediaSettingsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaSettingsTests.swift; sourceTree = "<group>"; };
 		E1C807471696F72E00E545A6 /* WordPress 9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 9.xcdatamodel"; sourceTree = "<group>"; };
 		E1C9AA501C10419200732665 /* Math.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Math.swift; sourceTree = "<group>"; };
 		E1C9AA551C10427100732665 /* MathTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MathTest.swift; sourceTree = "<group>"; };
@@ -3234,6 +3236,7 @@
 				930FD0A519882742000CC81D /* BlogServiceTest.m */,
 				FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */,
 				59A9AB391B4C3ECD00A433DC /* LocalCoreDataServiceTests.m */,
+				E1C5457F1C6C79BB001CEB0E /* MediaSettingsTests.swift */,
 				B5EFB1C81B333C5A007608A3 /* NotificationsServiceTests.swift */,
 				5DE8A0401912D95B00B2FF59 /* ReaderPostServiceTest.m */,
 				E66969C71B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift */,
@@ -5045,6 +5048,7 @@
 				BEA0E4851BD83565000AEE81 /* WP3DTouchShortcutCreatorTests.swift in Sources */,
 				85F8E19B1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift in Sources */,
 				E13BF2CA1C522A1300275BE9 /* AccountSettingsRemoteTests.swift in Sources */,
+				E1C545801C6C79BB001CEB0E /* MediaSettingsTests.swift in Sources */,
 				59FBD5621B5684F300734466 /* ThemeServiceTests.m in Sources */,
 				85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */,
 				931D270019EDAE8600114F17 /* CoreDataMigrationTests.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -561,6 +561,7 @@
 		E1BEEC631C4E35A8000B4FA0 /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BEEC621C4E35A8000B4FA0 /* Animator.swift */; };
 		E1BEEC651C4E3978000B4FA0 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BEEC641C4E3978000B4FA0 /* PaddedLabel.swift */; };
 		E1C265C91BECFCDD00DC4C6B /* WPCrashlyticsLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = E1C265C81BECFCDD00DC4C6B /* WPCrashlyticsLogger.m */; };
+		E1C5457E1C6B962D001CEB0E /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5457D1C6B962D001CEB0E /* AppSettings.swift */; };
 		E1C9AA511C10419200732665 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA501C10419200732665 /* Math.swift */; };
 		E1C9AA561C10427100732665 /* MathTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA551C10427100732665 /* MathTest.swift */; };
 		E1D04D7E19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D04D7D19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m */; };
@@ -1653,6 +1654,7 @@
 		E1BEEC641C4E3978000B4FA0 /* PaddedLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaddedLabel.swift; sourceTree = "<group>"; };
 		E1C265C71BECFCDD00DC4C6B /* WPCrashlyticsLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPCrashlyticsLogger.h; sourceTree = "<group>"; };
 		E1C265C81BECFCDD00DC4C6B /* WPCrashlyticsLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPCrashlyticsLogger.m; sourceTree = "<group>"; };
+		E1C5457D1C6B962D001CEB0E /* AppSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		E1C807471696F72E00E545A6 /* WordPress 9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 9.xcdatamodel"; sourceTree = "<group>"; };
 		E1C9AA501C10419200732665 /* Math.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Math.swift; sourceTree = "<group>"; };
 		E1C9AA551C10427100732665 /* MathTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MathTest.swift; sourceTree = "<group>"; };
@@ -2837,6 +2839,7 @@
 				1D3623250D0F684500981E51 /* WordPressAppDelegate.m */,
 				591A428D1A6DC6F2003807A6 /* WPGUIConstants.h */,
 				591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */,
+				E1C5457D1C6B962D001CEB0E /* AppSettings.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -4775,6 +4778,7 @@
 				E10B5ACF1C4518E100F6A390 /* AccountService+Rx.swift in Sources */,
 				93FA59DD18D88C1C001446BC /* PostCategoryService.m in Sources */,
 				E1BEEC631C4E35A8000B4FA0 /* Animator.swift in Sources */,
+				E1C5457E1C6B962D001CEB0E /* AppSettings.swift in Sources */,
 				5DCC4CD819A50CC0003E548C /* ReaderSite.m in Sources */,
 				93C4864F181043D700A24725 /* ActivityLogDetailViewController.m in Sources */,
 				859F761D18F2159800EF8D5D /* WPAnalyticsTrackerMixpanelInstructionsForStat.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -561,7 +561,7 @@
 		E1BEEC631C4E35A8000B4FA0 /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BEEC621C4E35A8000B4FA0 /* Animator.swift */; };
 		E1BEEC651C4E3978000B4FA0 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BEEC641C4E3978000B4FA0 /* PaddedLabel.swift */; };
 		E1C265C91BECFCDD00DC4C6B /* WPCrashlyticsLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = E1C265C81BECFCDD00DC4C6B /* WPCrashlyticsLogger.m */; };
-		E1C5457E1C6B962D001CEB0E /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5457D1C6B962D001CEB0E /* AppSettings.swift */; };
+		E1C5457E1C6B962D001CEB0E /* MediaSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5457D1C6B962D001CEB0E /* MediaSettings.swift */; };
 		E1C9AA511C10419200732665 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA501C10419200732665 /* Math.swift */; };
 		E1C9AA561C10427100732665 /* MathTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA551C10427100732665 /* MathTest.swift */; };
 		E1D04D7E19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D04D7D19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m */; };
@@ -1654,7 +1654,7 @@
 		E1BEEC641C4E3978000B4FA0 /* PaddedLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaddedLabel.swift; sourceTree = "<group>"; };
 		E1C265C71BECFCDD00DC4C6B /* WPCrashlyticsLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPCrashlyticsLogger.h; sourceTree = "<group>"; };
 		E1C265C81BECFCDD00DC4C6B /* WPCrashlyticsLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPCrashlyticsLogger.m; sourceTree = "<group>"; };
-		E1C5457D1C6B962D001CEB0E /* AppSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		E1C5457D1C6B962D001CEB0E /* MediaSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaSettings.swift; sourceTree = "<group>"; };
 		E1C807471696F72E00E545A6 /* WordPress 9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 9.xcdatamodel"; sourceTree = "<group>"; };
 		E1C9AA501C10419200732665 /* Math.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Math.swift; sourceTree = "<group>"; };
 		E1C9AA551C10427100732665 /* MathTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MathTest.swift; sourceTree = "<group>"; };
@@ -2839,7 +2839,6 @@
 				1D3623250D0F684500981E51 /* WordPressAppDelegate.m */,
 				591A428D1A6DC6F2003807A6 /* WPGUIConstants.h */,
 				591A428E1A6DC6F2003807A6 /* WPGUIConstants.m */,
-				E1C5457D1C6B962D001CEB0E /* AppSettings.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -2964,6 +2963,7 @@
 				E1F8E1221B0B411E0073E628 /* JetpackService.m */,
 				5DA3EE141925090A00294E0B /* MediaService.h */,
 				5DA3EE151925090A00294E0B /* MediaService.m */,
+				E1C5457D1C6B962D001CEB0E /* MediaSettings.swift */,
 				B5EFB1C11B31B98E007608A3 /* NotificationsService.swift */,
 				93FA59DB18D88C1C001446BC /* PostCategoryService.h */,
 				93FA59DC18D88C1C001446BC /* PostCategoryService.m */,
@@ -4778,7 +4778,7 @@
 				E10B5ACF1C4518E100F6A390 /* AccountService+Rx.swift in Sources */,
 				93FA59DD18D88C1C001446BC /* PostCategoryService.m in Sources */,
 				E1BEEC631C4E35A8000B4FA0 /* Animator.swift in Sources */,
-				E1C5457E1C6B962D001CEB0E /* AppSettings.swift in Sources */,
+				E1C5457E1C6B962D001CEB0E /* MediaSettings.swift in Sources */,
 				5DCC4CD819A50CC0003E548C /* ReaderSite.m in Sources */,
 				93C4864F181043D700A24725 /* ActivityLogDetailViewController.m in Sources */,
 				859F761D18F2159800EF8D5D /* WPAnalyticsTrackerMixpanelInstructionsForStat.m in Sources */,

--- a/WordPress/WordPressTest/Extensions/MathTest.swift
+++ b/WordPress/WordPressTest/Extensions/MathTest.swift
@@ -30,4 +30,33 @@ class MathTest: XCTestCase {
         expect(30.clamp(min: 10, max: 20)).to(equal(20))
     }
 
+    func testClampCGSizeWithSize() {
+        let maxSize = CGSize(width: 4000, height: 3000)
+        let minSize = CGSize(width: 400, height: 300)
+
+        do {
+            let clamped = CGSize(width: 3000, height: 4000).clamp(min: minSize, max: maxSize)
+            let expected = CGSize(width: 3000, height: 3000)
+            expect(clamped).to(equal(expected))
+        }
+
+        do {
+            let clamped = CGSize(width: 6000, height: 4000).clamp(min: minSize, max: maxSize)
+            let expected = CGSize(width: 4000, height: 3000)
+            expect(clamped).to(equal(expected))
+        }
+
+        do {
+            let clamped = CGSize(width: 100, height: 400).clamp(min: minSize, max: maxSize)
+            let expected = CGSize(width: 400, height: 400)
+            expect(clamped).to(equal(expected))
+        }
+
+        do {
+            let clamped = CGSize(width: 100, height: 100).clamp(min: minSize, max: maxSize)
+            let expected = CGSize(width: 400, height: 300)
+            expect(clamped).to(equal(expected))
+        }
+    }
+
 }

--- a/WordPress/WordPressTest/MediaSettingsTests.swift
+++ b/WordPress/WordPressTest/MediaSettingsTests.swift
@@ -17,7 +17,7 @@ class MediaSettingsTests: XCTestCase {
     func testDefaultMaxImageSize() {
         let settings = MediaSettings(storage: MediaSettings.EphemeralStorage())
         let maxImageSize = settings.maxImageSizeSetting
-        expect(maxImageSize).to(equal(settings.maxImageDimension))
+        expect(maxImageSize).to(equal(settings.allowedImageSizeRange.max))
     }
 
     func testMaxImageSizeMigratesCGSizeToInt() {
@@ -34,18 +34,18 @@ class MediaSettingsTests: XCTestCase {
 
     func testMaxImageSizeClampsValues() {
         let settings = MediaSettings(storage: MediaSettings.EphemeralStorage())
-        let lowValue = settings.minImageDimension - 1
-        let highValue = settings.maxImageDimension + 1
+        let lowValue = settings.allowedImageSizeRange.min - 1
+        let highValue = settings.allowedImageSizeRange.max + 1
 
         settings.maxImageSizeSetting = lowValue
-        expect(settings.maxImageSizeSetting).to(equal(settings.minImageDimension))
+        expect(settings.maxImageSizeSetting).to(equal(settings.allowedImageSizeRange.min))
         settings.maxImageSizeSetting = highValue
-        expect(settings.maxImageSizeSetting).to(equal(settings.maxImageDimension))
+        expect(settings.maxImageSizeSetting).to(equal(settings.allowedImageSizeRange.max))
     }
 
     func testImageSizeForUploadReturnsIntMax() {
         let settings = MediaSettings(storage: MediaSettings.EphemeralStorage())
-        let highValue = settings.maxImageDimension + 1
+        let highValue = settings.allowedImageSizeRange.max + 1
 
         settings.maxImageSizeSetting = highValue
         expect(settings.imageSizeForUpload).to(equal(Int.max))

--- a/WordPress/WordPressTest/MediaSettingsTests.swift
+++ b/WordPress/WordPressTest/MediaSettingsTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import Nimble
+@testable import WordPress
+
+class MediaSettingsTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testDefaultMaxImageSize() {
+        let settings = MediaSettings(storage: MediaSettings.EphemeralStorage())
+        let maxImageSize = settings.maxImageSizeSetting
+        expect(maxImageSize).to(equal(settings.maxImageDimension))
+    }
+
+    func testMaxImageSizeMigratesCGSizeToInt() {
+        let dimension = 1200
+        let size = CGSize(width: dimension, height: dimension)
+        let storage = MediaSettings.EphemeralStorage()
+        storage.setValue(NSStringFromCGSize(size), forKey: "SavedMaxImageSizeSetting")
+
+        let settings = MediaSettings(storage: storage)
+        expect(settings.maxImageSizeSetting).to(equal(dimension))
+        let storedValue = storage.valueForKey("SavedMaxImageSizeSetting") as? Int
+        expect(storedValue).to(equal(dimension))
+    }
+
+    func testMaxImageSizeClampsValues() {
+        let settings = MediaSettings(storage: MediaSettings.EphemeralStorage())
+        let lowValue = settings.minImageDimension - 1
+        let highValue = settings.maxImageDimension + 1
+
+        settings.maxImageSizeSetting = lowValue
+        expect(settings.maxImageSizeSetting).to(equal(settings.minImageDimension))
+        settings.maxImageSizeSetting = highValue
+        expect(settings.maxImageSizeSetting).to(equal(settings.maxImageDimension))
+    }
+
+    func testImageSizeForUploadReturnsIntMax() {
+        let settings = MediaSettings(storage: MediaSettings.EphemeralStorage())
+        let highValue = settings.maxImageDimension + 1
+
+        settings.maxImageSizeSetting = highValue
+        expect(settings.imageSizeForUpload).to(equal(Int.max))
+
+    }
+
+}


### PR DESCRIPTION
Removes the max image size setting logic from `MediaService` and moves it to a new class.

I also cleaned it up a bit, and now we just deal with a single `Int` value instead of a `CGSize`.

Also modified the logic for "Original" resize: instead of having `0` or `CGSizeZero` as a mark for "Original", I use `Int.max` now. Then the code to check that is more generic and just checks if the desired target size is bigger than the image size, an uses the original size in that case.

Refs #4797 
cc @astralbodies 
Needs Review: @SergioEstevao 