### PR TITLE
Posts without content can no longer be saved.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -821,7 +821,7 @@ EditImageDetailsViewControllerDelegate
     [self.editorView saveSelection];
     [self.editorView.focusedField blur];
 	
-    if ([self.post hasLocalChanges]) {
+    if ([self.post canSave] && [self.post hasUnsavedChanges]) {
         [self showPostHasChangesAlert];
     } else {
         [self stopEditing];


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/751).

**How to test:**
- Open a post, can be either a new one, or an existing one.
- Delete the title and content, make sure they're empty.
- Change the post's publication date or anything else in the post's settings screen.
- Exit the editor without saving.
- The editor should roll the changes back, and the post should be gone if it was a new one.