### PR TITLE
Notifications: Swipe actions

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.h
+++ b/WordPress/Classes/Models/Notifications/Notification.h
@@ -182,11 +182,46 @@ typedef NS_ENUM(NSInteger, NoteBlockGroupType)
  */
 - (BOOL)isCommentApproved;
 
-- (void)setActionOverrideValue:(NSNumber *)obj forKey:(NSString *)key;
+/**
+ *	@brief      Allows us to set a local override for a remote value. This is used to fake the UI, while
+ *              there's a BG call going on.
+ *
+ *	@param		value       The local "Temporary" value.
+ *	@param		key         The key that should get a temporary 'Override' value
+ */
+- (void)setActionOverrideValue:(NSNumber *)value forKey:(NSString *)key;
+
+/**
+ *	@brief      Removes any local (temporary) value that might have been set by means of *setActionOverrideValue*.
+ *
+ *	@param		key         The key that should get its overrides removed.
+ */
 - (void)removeActionOverrideForKey:(NSString *)key;
+
+/**
+ *	@brief      Returns the Notification Block status for a given action. If there's any local override,
+ *              the (override) value will be returned.
+ *
+ *	@param		key         The key of the action to check.
+ *  @returns                The value for any given action
+ */
 - (NSNumber *)actionForKey:(NSString *)key;
 
+/**
+ *	@brief      Returns *true* if a given action is available
+ *
+ *	@param		key         The key of the action to check.
+ *  @returns                True if the action can be performed. False otherwise.
+ */
 - (BOOL)isActionEnabled:(NSString *)key;
+
+/**
+ *	@brief      Returns *true* if a given action is toggled on. (I.e.: Approval = On, means that the comment
+ *              is currently approved).
+ *
+ *	@param		key         The key of the action to check.
+ *  @returns                True if the action is currently "toggled on".
+ */
 - (BOOL)isActionOn:(NSString *)key;
 
 @end

--- a/WordPress/Classes/Models/Notifications/Notification.h
+++ b/WordPress/Classes/Models/Notifications/Notification.h
@@ -107,7 +107,6 @@ typedef NS_ENUM(NSInteger, NoteBlockGroupType)
 - (NotificationBlock *)snippetBlock;
 
 - (BOOL)isUnapprovedComment;
-- (void)didChangeOverrides;
 
 @end
 

--- a/WordPress/Classes/Models/Notifications/Notification.m
+++ b/WordPress/Classes/Models/Notifications/Notification.m
@@ -63,6 +63,16 @@ NSString const *NotePostIdKey           = @"post_id";
 NSString const *NoteReplyIdKey          = @"reply_comment";
 
 
+
+#pragma mark ====================================================================================
+#pragma mark Notification: Private Methods
+#pragma mark ====================================================================================
+
+@interface Notification (Internals)
+- (void)didChangeOverrides;
+@end
+
+
 #pragma mark ====================================================================================
 #pragma mark NotificationRange
 #pragma mark ====================================================================================
@@ -227,6 +237,7 @@ NSString const *NoteReplyIdKey          = @"reply_comment";
 @property (nonatomic, strong, readwrite) NSMutableDictionary    *actionsOverride;
 @property (nonatomic, assign, readwrite) NoteBlockType          type;
 @property (nonatomic, strong, readwrite) NSMutableDictionary    *dynamicAttributesCache;
+@property (nonatomic,   weak, readwrite) Notification           *parent;
 @end
 
 
@@ -318,6 +329,8 @@ NSString const *NoteReplyIdKey          = @"reply_comment";
     }
     
     _actionsOverride[key] = value;
+    
+    [self.parent didChangeOverrides];
 }
 
 - (void)removeActionOverrideForKey:(NSString *)key
@@ -378,6 +391,7 @@ NSString const *NoteReplyIdKey          = @"reply_comment";
         }
         
         NotificationBlock *block    = [[[self class] alloc] initWithDictionary:rawDict];
+        block.parent                = notification;
         
         //  Duck Typing code below:
         //  Infer block type based on... stuff. (Sorry)

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -24,6 +24,9 @@
 #import "MediaService.h"
 #import "MeHeaderView.h"
 
+#import "NotificationsViewController.h"
+#import "NotificationsViewController+Internal.h"
+
 #import "Notification.h"
 #import "Notification+Internals.h"
 #import "NSAttributedString+Util.h"

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.h
@@ -1,14 +1,9 @@
 #import <UIKit/UIKit.h>
+#import "Notifications+Definitions.h"
 
 
 
 @class Notification;
-
-typedef void (^NotificationDetailsDeletionCompletionBlock)(BOOL success);
-typedef void (^NotificationDetailsDeletionActionBlock)(NotificationDetailsDeletionCompletionBlock onCompletion);
-typedef void (^NotificationDetailsDeletionRequestBlock)(NotificationDetailsDeletionActionBlock onUndoTimeout);
-
-
 
 /**
  *  @class      NotificationDetailsViewController
@@ -28,7 +23,7 @@ typedef void (^NotificationDetailsDeletionRequestBlock)(NotificationDetailsDelet
  *              undo the destructive action, before it's effectively executed.
  */
 
-@property (nonatomic, copy) NotificationDetailsDeletionRequestBlock onDeletionRequestCallback;
+@property (nonatomic, copy) NotificationDeletionRequestBlock onDeletionRequestCallback;
 
 /**
  *	@brief		This method renders the details view, for any given notification/

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -1155,7 +1155,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     NSParameterAssert(self.onDeletionRequestCallback);
     
     // Spam Action
-    NotificationDetailsDeletionActionBlock spamAction = ^(NotificationDetailsDeletionCompletionBlock onCompletion) {
+    NotificationDeletionActionBlock spamAction = ^(NotificationDeletionCompletionBlock onCompletion) {
         NSParameterAssert(onCompletion);
         
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
@@ -1181,7 +1181,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     NSParameterAssert(self.onDeletionRequestCallback);
     
     // Trash Action
-    NotificationDetailsDeletionActionBlock deletionAction =  ^(NotificationDetailsDeletionCompletionBlock onCompletion) {
+    NotificationDeletionActionBlock deletionAction =  ^(NotificationDeletionCompletionBlock onCompletion) {
         NSParameterAssert(onCompletion);
         
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -1117,7 +1117,6 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 - (void)approveCommentWithBlock:(NotificationBlock *)block
 {
- 
     [WPAppAnalytics track:WPAnalyticsStatNotificationsCommentApproved withBlogID:block.metaSiteID];
     
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
@@ -1130,9 +1129,6 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     }];
 
     [block setActionOverrideValue:@(true) forKey:NoteActionApproveKey];
- 
-    // Hack: force NSFetchedResultsController to reload this notification
-    [self.note didChangeOverrides];
     [self.tableView reloadData];
 }
 
@@ -1150,9 +1146,6 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     }];
     
     [block setActionOverrideValue:@(false) forKey:NoteActionApproveKey];
-    
-    // Hack: force NSFetchedResultsController to reload this notification
-    [self.note didChangeOverrides];
     [self.tableView reloadData];
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
@@ -1,0 +1,26 @@
+#import "NotificationsViewController.h"
+
+
+@class ABXPromptView;
+@class WPTableViewHandler;
+@class WPNoResultsView;
+
+
+#pragma mark - Private Properties
+
+@interface NotificationsViewController ()
+
+@property (nonatomic, strong) IBOutlet UIView               *tableHeaderView;
+@property (nonatomic, strong) IBOutlet UISegmentedControl   *filtersSegmentedControl;
+@property (nonatomic, strong) IBOutlet ABXPromptView        *ratingsView;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint   *ratingsTopConstraint;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint   *ratingsHeightConstraint;
+@property (nonatomic, strong) WPTableViewHandler            *tableViewHandler;
+@property (nonatomic, strong) WPNoResultsView               *noResultsView;
+@property (nonatomic, strong) NSString                      *pushNotificationID;
+@property (nonatomic, strong) NSDate                        *pushNotificationDate;
+@property (nonatomic, strong) NSDate                        *lastReloadDate;
+@property (nonatomic, strong) NSMutableSet                  *notificationIdsMarkedForDeletion;
+@property (nonatomic, strong) NSMutableSet                  *notificationIdsBeingDeleted;
+
+@end

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+RowActions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+RowActions.swift
@@ -5,7 +5,11 @@ import WordPressShared
 extension NotificationsViewController
 {
     public override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-        return true
+        guard let note = tableViewHandler.resultsController.objectAtIndexPath(indexPath) as? Notification else {
+            return false
+        }
+        
+        return note.isComment
     }
     
     public override func tableView(tableView: UITableView, editingStyleForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCellEditingStyle {
@@ -16,30 +20,51 @@ extension NotificationsViewController
         guard let note = tableViewHandler.resultsController.objectAtIndexPath(indexPath) as? Notification,
                     group = note.blockGroupOfType(NoteBlockGroupType.Comment),
                     block = group.blockOfType(.Comment) else {
-            return []
+            return nil
         }
-
-        var actions = [UITableViewRowAction]()
         
-        if block.isActionEnabled(NoteActionTrashKey) {
+        // Helpers
+        let isTrashEnabled      = block.isActionEnabled(NoteActionTrashKey)
+        let isApproveEnabled    = block.isActionEnabled(NoteActionApproveKey)
+        let isApproveOn         = block.isActionOn(NoteActionApproveKey)
+        var actions             = [UITableViewRowAction]()
+        
+        // Comments: Trash
+        if isTrashEnabled {
             let title = NSLocalizedString("Trash", comment: "Trashes a comment")
-            let handler = { (action: UITableViewRowAction, path: NSIndexPath) -> Void in
-// TODO: Implement Me
-            }
             
-            let trash = UITableViewRowAction(style: .Destructive, title: title, handler: handler)
+            let trash = UITableViewRowAction(style: .Destructive, title: title, handler: { [weak self] action, path in
+                self?.trashCommentWithBlock(block)
+                self?.tableView.setEditing(false, animated: true)
+            })
+            
             trash.backgroundColor = WPStyleGuide.errorRed()
             actions.append(trash)
         }
         
-        if block.isActionEnabled(NoteActionApproveKey) {
-            let isApproveOn         = block.isActionOn(NoteActionApproveKey)
-            let handler             = isApproveOn ? approveComment : unapproveComment
-            let title               = isApproveOn ? NSLocalizedString("Unapprove", comment: "Unapproves a Comment") :
-                                                    NSLocalizedString("Approve",   comment: "Approves a Comment")
+        // Comments: Unapprove
+        if isApproveEnabled && isApproveOn {
+            let title = NSLocalizedString("Unapprove", comment: "Unapproves a Comment")
             
-            let trash               = UITableViewRowAction(style: .Normal, title: title, handler: handler)
-            trash.backgroundColor   = isApproveOn ? WPStyleGuide.grey() : WPStyleGuide.wordPressBlue()
+            let trash = UITableViewRowAction(style: .Normal, title: title, handler: { [weak self] action, path in
+                self?.unapproveCommentWithBlock(block)
+                self?.tableView.setEditing(false, animated: true)
+            })
+            
+            trash.backgroundColor = WPStyleGuide.grey()
+            actions.append(trash)
+        }
+
+        // Comments: Approve
+        if isApproveEnabled && !isApproveOn {
+            let title = NSLocalizedString("Approve", comment: "Approves a Comment")
+            
+            let trash = UITableViewRowAction(style: .Normal, title: title, handler: { [weak self] action, path in
+                self?.approveCommentWithBlock(block)
+                self?.tableView.setEditing(false, animated: true)
+            })
+            
+            trash.backgroundColor = WPStyleGuide.wordPressBlue()
             actions.append(trash)
         }
         
@@ -47,11 +72,37 @@ extension NotificationsViewController
     }
     
     
-    private func approveComment(action: UITableViewRowAction, path: NSIndexPath) {
+    private func trashCommentWithBlock(block: NotificationBlock) {
 // TODO: Implement Me
     }
     
-    private func unapproveComment(action: UITableViewRowAction, path: NSIndexPath) {
-// TODO: Implement Me
+    private func approveCommentWithBlock(block: NotificationBlock) {
+        let context = ContextManager.sharedInstance().mainContext
+        let service = CommentService(managedObjectContext: context)
+        
+        service.approveCommentWithID(block.metaCommentID, siteID: block.metaSiteID, success: {
+                DDLogSwift.logInfo("Successfully approved comment \(block.metaSiteID).\(block.metaCommentID)")
+            },
+            failure: { error in
+                DDLogSwift.logInfo("Error while trying to moderate comment: \(error)")
+                block.removeActionOverrideForKey(NoteActionApproveKey)
+            })
+        
+        block.setActionOverrideValue(true, forKey: NoteActionApproveKey)
+    }
+    
+    private func unapproveCommentWithBlock(block: NotificationBlock) {
+        let context = ContextManager.sharedInstance().mainContext
+        let service = CommentService(managedObjectContext: context)
+        
+        service.unapproveCommentWithID(block.metaCommentID, siteID: block.metaSiteID, success: {
+                DDLogSwift.logInfo("Successfully unapproved comment \(block.metaSiteID).\(block.metaCommentID)")
+            },
+            failure: { error in
+                DDLogSwift.logInfo("Error while trying to moderate comment: \(error)")
+                block.removeActionOverrideForKey(NoteActionApproveKey)
+            })
+        
+        block.setActionOverrideValue(false, forKey: NoteActionApproveKey)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+RowActions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+RowActions.swift
@@ -2,8 +2,14 @@ import Foundation
 import WordPressShared
 
 
+/// In this Extension, we'll enhance NotificationsViewController, so that it supports *Swipeable* rows.
+/// On the first iteration, we'll only support Comment Actions (matching the Push Interactive Notifications
+/// actionable items).
+///
 extension NotificationsViewController
 {
+    // MARK: - UITableViewDelegate Methods
+    
     public override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
         guard let note = tableViewHandler.resultsController.objectAtIndexPath(indexPath) as? Notification else {
             return false
@@ -72,10 +78,24 @@ extension NotificationsViewController
     }
     
     
+    
+    // MARK: - Private Helpers
+    
+    /// Trashes a comment referenced by a given NotificationBlock.
+    ///
+    /// - Parameters:
+    ///     - block: The Notification's Comment Block
+    ///
     private func trashCommentWithBlock(block: NotificationBlock) {
 // TODO: Implement Me
     }
     
+    
+    /// Approves a comment referenced by a given NotificationBlock.
+    ///
+    /// - Parameters:
+    ///     - block: The Notification's Comment Block
+    ///
     private func approveCommentWithBlock(block: NotificationBlock) {
         let context = ContextManager.sharedInstance().mainContext
         let service = CommentService(managedObjectContext: context)
@@ -91,6 +111,12 @@ extension NotificationsViewController
         block.setActionOverrideValue(true, forKey: NoteActionApproveKey)
     }
     
+    
+    /// Unapproves a comment referenced by a given NotificationBlock.
+    ///
+    /// - Parameters:
+    ///     - block: The Notification's Comment Block
+    ///
     private func unapproveCommentWithBlock(block: NotificationBlock) {
         let context = ContextManager.sharedInstance().mainContext
         let service = CommentService(managedObjectContext: context)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+RowActions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+RowActions.swift
@@ -1,0 +1,57 @@
+import Foundation
+import WordPressShared
+
+
+extension NotificationsViewController
+{
+    public override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        return true
+    }
+    
+    public override func tableView(tableView: UITableView, editingStyleForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCellEditingStyle {
+        return .Delete
+    }
+    
+    public override func tableView(tableView: UITableView, editActionsForRowAtIndexPath indexPath: NSIndexPath) -> [UITableViewRowAction]? {
+        guard let note = tableViewHandler.resultsController.objectAtIndexPath(indexPath) as? Notification,
+                    group = note.blockGroupOfType(NoteBlockGroupType.Comment),
+                    block = group.blockOfType(.Comment) else {
+            return []
+        }
+
+        var actions = [UITableViewRowAction]()
+        
+        if block.isActionEnabled(NoteActionTrashKey) {
+            let title = NSLocalizedString("Trash", comment: "Trashes a comment")
+            let handler = { (action: UITableViewRowAction, path: NSIndexPath) -> Void in
+// TODO: Implement Me
+            }
+            
+            let trash = UITableViewRowAction(style: .Destructive, title: title, handler: handler)
+            trash.backgroundColor = WPStyleGuide.errorRed()
+            actions.append(trash)
+        }
+        
+        if block.isActionEnabled(NoteActionApproveKey) {
+            let isApproveOn         = block.isActionOn(NoteActionApproveKey)
+            let handler             = isApproveOn ? approveComment : unapproveComment
+            let title               = isApproveOn ? NSLocalizedString("Unapprove", comment: "Unapproves a Comment") :
+                                                    NSLocalizedString("Approve",   comment: "Approves a Comment")
+            
+            let trash               = UITableViewRowAction(style: .Normal, title: title, handler: handler)
+            trash.backgroundColor   = isApproveOn ? WPStyleGuide.grey() : WPStyleGuide.wordPressBlue()
+            actions.append(trash)
+        }
+        
+        return actions
+    }
+    
+    
+    private func approveComment(action: UITableViewRowAction, path: NSIndexPath) {
+// TODO: Implement Me
+    }
+    
+    private func unapproveComment(action: UITableViewRowAction, path: NSIndexPath) {
+// TODO: Implement Me
+    }
+}

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.h
@@ -28,7 +28,6 @@
 
 - (void)showDetailsForNoteWithID:(NSString *)notificationID;
 
-
 /**
  *  @brief      Will display an Undelete button on top of a given notification.
  *  @details    On timeout, the destructive action (received via parameter) will be exeuted, and the notification

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.h
@@ -1,4 +1,5 @@
 #import <UIKit/UIKit.h>
+#import "Notifications+Definitions.h"
 
 
 
@@ -26,5 +27,17 @@
  */
 
 - (void)showDetailsForNoteWithID:(NSString *)notificationID;
+
+
+/**
+ *  @brief      Will display an Undelete button on top of a given notification.
+ *  @details    On timeout, the destructive action (received via parameter) will be exeuted, and the notification
+ *              will (supposedly) get deleted.
+ *
+ *  @param      noteObjectID        The Core Data ObjectID associated to a given notification.
+ *  @param      onTimeout           A "destructive" closure, to be executed after a given timeout.
+ */
+
+- (void)showUndeleteForNoteWithID:(NSManagedObjectID *)noteObjectID onTimeout:(NotificationDeletionActionBlock)onTimeout;
 
 @end

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -1,4 +1,4 @@
-#import "NotificationsViewController.h"
+#import "NotificationsViewController+Internal.h"
 
 #import <Simperium/Simperium.h>
 #import "WordPressAppDelegate.h"
@@ -34,6 +34,14 @@
 #import "WordPress-Swift.h"
 
 
+@interface NotificationsViewController (Protocols) <SPBucketDelegate,
+                                                    WPNoResultsViewDelegate,
+                                                    WPTableViewHandlerDelegate,
+                                                    ABXPromptViewDelegate,
+                                                    ABXFeedbackViewControllerDelegate>
+
+@end
+
 
 #pragma mark ====================================================================================
 #pragma mark Constants
@@ -55,27 +63,6 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     NotificationFilterFollow,
     NotificationFilterLike
 };
-
-
-#pragma mark ====================================================================================
-#pragma mark Private Properties
-#pragma mark ====================================================================================
-
-@interface NotificationsViewController () <SPBucketDelegate, WPTableViewHandlerDelegate, ABXPromptViewDelegate,
-                                            ABXFeedbackViewControllerDelegate, WPNoResultsViewDelegate>
-@property (nonatomic, strong) IBOutlet UIView               *tableHeaderView;
-@property (nonatomic, strong) IBOutlet UISegmentedControl   *filtersSegmentedControl;
-@property (nonatomic, strong) IBOutlet ABXPromptView        *ratingsView;
-@property (nonatomic, strong) IBOutlet NSLayoutConstraint   *ratingsTopConstraint;
-@property (nonatomic, strong) IBOutlet NSLayoutConstraint   *ratingsHeightConstraint;
-@property (nonatomic, strong) WPTableViewHandler            *tableViewHandler;
-@property (nonatomic, strong) WPNoResultsView               *noResultsView;
-@property (nonatomic, strong) NSString                      *pushNotificationID;
-@property (nonatomic, strong) NSDate                        *pushNotificationDate;
-@property (nonatomic, strong) NSDate                        *lastReloadDate;
-@property (nonatomic, strong) NSMutableSet                  *notificationIdsMarkedForDeletion;
-@property (nonatomic, strong) NSMutableSet                  *notificationIdsBeingDeleted;
-@end
 
 
 #pragma mark ====================================================================================

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -586,7 +586,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 
 #pragma mark - Undelete Mechanism
 
-- (void)showUndeleteForNotificationWithID:(NSManagedObjectID *)noteObjectID onTimeout:(NotificationDetailsDeletionActionBlock)onTimeout
+- (void)showUndeleteForNoteWithID:(NSManagedObjectID *)noteObjectID onTimeout:(NotificationDeletionActionBlock)onTimeout
 {
     // Mark this note as Pending Deletion and Reload
     [self.notificationIdsMarkedForDeletion addObject:noteObjectID];
@@ -599,7 +599,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     });
 }
 
-- (void)performDeletionActionForNotificationWithID:(NSManagedObjectID *)noteObjectID deletionBlock:(NotificationDetailsDeletionActionBlock)deletionBlock
+- (void)performDeletionActionForNotificationWithID:(NSManagedObjectID *)noteObjectID deletionBlock:(NotificationDeletionActionBlock)deletionBlock
 {
     // Was the Deletion Cancelled?
     if ([self isNoteMarkedForDeletion:noteObjectID] == false) {
@@ -761,8 +761,8 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     if([segue.identifier isEqualToString:detailsSegueID]) {
         NotificationDetailsViewController *detailsViewController = segue.destinationViewController;
         [detailsViewController setupWithNotification:note];
-        detailsViewController.onDeletionRequestCallback = ^(NotificationDetailsDeletionActionBlock onUndoTimeout){
-            [weakSelf showUndeleteForNotificationWithID:note.objectID onTimeout:onUndoTimeout];
+        detailsViewController.onDeletionRequestCallback = ^(NotificationDeletionActionBlock onUndoTimeout){
+            [weakSelf showUndeleteForNoteWithID:note.objectID onTimeout:onUndoTimeout];
         };
         
     } else if([segue.identifier isEqualToString:readerSegueID]) {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -34,14 +34,6 @@
 #import "WordPress-Swift.h"
 
 
-@interface NotificationsViewController (Protocols) <SPBucketDelegate,
-                                                    WPNoResultsViewDelegate,
-                                                    WPTableViewHandlerDelegate,
-                                                    ABXPromptViewDelegate,
-                                                    ABXFeedbackViewControllerDelegate>
-
-@end
-
 
 #pragma mark ====================================================================================
 #pragma mark Constants
@@ -63,6 +55,20 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     NotificationFilterFollow,
     NotificationFilterLike
 };
+
+
+#pragma mark ====================================================================================
+#pragma mark Protocols
+#pragma mark ====================================================================================
+
+@interface NotificationsViewController (Protocols) <SPBucketDelegate,
+                                                    WPNoResultsViewDelegate,
+                                                    WPTableViewHandlerDelegate,
+                                                    ABXPromptViewDelegate,
+                                                    ABXFeedbackViewControllerDelegate>
+
+@end
+
 
 
 #pragma mark ====================================================================================

--- a/WordPress/Classes/ViewRelated/Notifications/Helpers/Notifications+Definitions.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Helpers/Notifications+Definitions.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+
+
+/// Shared Heper Definitions:
+/// Used by both NotificationsViewController and NotificationDetailsViewController.
+///
+
+typedef void (^NotificationDeletionCompletionBlock)(BOOL success);
+typedef void (^NotificationDeletionActionBlock)(NotificationDeletionCompletionBlock onCompletion);
+typedef void (^NotificationDeletionRequestBlock)(NotificationDeletionActionBlock onUndoTimeout);

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -397,6 +397,7 @@
 		B587798719B799EB00E57C5A /* NotificationBlock+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = B587798519B799EB00E57C5A /* NotificationBlock+Interface.swift */; };
 		B5899ADE1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5899ADD1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift */; };
 		B5899AE41B422D990075A3D6 /* NotificationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5899AE31B422D990075A3D6 /* NotificationSettings.swift */; };
+		B58FD8CE1C7256DF00E5F6A4 /* NotificationsViewController+RowActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58FD8CD1C7256DF00E5F6A4 /* NotificationsViewController+RowActions.swift */; };
 		B59D994F1C0790CC0003D795 /* SettingsListEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59D994E1C0790CC0003D795 /* SettingsListEditorViewController.swift */; };
 		B5A6BB8C1BF4DF38002F6A96 /* rest-site-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = B5A6BB8B1BF4DF38002F6A96 /* rest-site-settings.json */; };
 		B5A6CEA619FA800E009F07DE /* AccountToAccount20to21.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A6CEA519FA800E009F07DE /* AccountToAccount20to21.swift */; };
@@ -1421,6 +1422,7 @@
 		B587798519B799EB00E57C5A /* NotificationBlock+Interface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NotificationBlock+Interface.swift"; sourceTree = "<group>"; };
 		B5899ADD1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationSettingDetailsViewController.swift; sourceTree = "<group>"; };
 		B5899AE31B422D990075A3D6 /* NotificationSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationSettings.swift; sourceTree = "<group>"; };
+		B58FD8CD1C7256DF00E5F6A4 /* NotificationsViewController+RowActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NotificationsViewController+RowActions.swift"; sourceTree = "<group>"; };
 		B58FD8CF1C7258C000E5F6A4 /* NotificationsViewController+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NotificationsViewController+Internal.h"; sourceTree = "<group>"; };
 		B59D994E1C0790CC0003D795 /* SettingsListEditorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsListEditorViewController.swift; sourceTree = "<group>"; };
 		B5A6BB8B1BF4DF38002F6A96 /* rest-site-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "rest-site-settings.json"; sourceTree = "<group>"; };
@@ -3394,6 +3396,7 @@
 				B5FD4541199D0F2800286FBB /* NotificationsViewController.h */,
 				B58FD8CF1C7258C000E5F6A4 /* NotificationsViewController+Internal.h */,
 				B5FD4542199D0F2800286FBB /* NotificationsViewController.m */,
+				B58FD8CD1C7256DF00E5F6A4 /* NotificationsViewController+RowActions.swift */,
 				B5FD453F199D0F2800286FBB /* NotificationDetailsViewController.h */,
 				B5FD4540199D0F2800286FBB /* NotificationDetailsViewController.m */,
 				B522C4F71B3DA79B00E47B59 /* NotificationSettingsViewController.swift */,
@@ -4810,6 +4813,7 @@
 				E6374DC01C444D8B00F24720 /* PublicizeConnection.swift in Sources */,
 				5D17F0BE1A1D4C5F0087CCB8 /* PrivateSiteURLProtocol.m in Sources */,
 				E14B40FF1C58B93F005046F6 /* SettingsCommon.swift in Sources */,
+				B58FD8CE1C7256DF00E5F6A4 /* NotificationsViewController+RowActions.swift in Sources */,
 				937D9A0F19F83812007B9D5F /* WordPress-22-23.xcmappingmodel in Sources */,
 				5D1D04761B7A50B100CDE646 /* ReaderStreamViewController.swift in Sources */,
 				B587798619B799EB00E57C5A /* Notification+Interface.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1340,6 +1340,7 @@
 		B5066D021BEBFAA900355819 /* RemoteBlogSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RemoteBlogSettings.swift; path = "Remote Objects/RemoteBlogSettings.swift"; sourceTree = "<group>"; };
 		B50EED781C0E5B2400D278CA /* SettingsPickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsPickerViewController.swift; sourceTree = "<group>"; };
 		B51535D31BBB16AA0029B84B /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		B5227E8E1C7375B400F04020 /* Notifications+Definitions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Notifications+Definitions.h"; sourceTree = "<group>"; };
 		B522C4F71B3DA79B00E47B59 /* NotificationSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationSettingsViewController.swift; sourceTree = "<group>"; };
 		B526DC271B1E47FC002A8C5F /* WPStyleGuide+WebView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPStyleGuide+WebView.h"; sourceTree = "<group>"; };
 		B526DC281B1E47FC002A8C5F /* WPStyleGuide+WebView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WPStyleGuide+WebView.m"; sourceTree = "<group>"; };
@@ -3113,6 +3114,14 @@
 			path = Blog;
 			sourceTree = "<group>";
 		};
+		B5227E8D1C73759000F04020 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				B5227E8E1C7375B400F04020 /* Notifications+Definitions.h */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		B526DC241B1E473B002A8C5F /* WebViewController */ = {
 			isa = PBXGroup;
 			children = (
@@ -3616,6 +3625,7 @@
 		CC1D800D1656D8B2002A542F /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
+				B5227E8D1C73759000F04020 /* Helpers */,
 				B5B56D2F19AFB68800B4E29B /* Style */,
 				B54E1DEC1A0A7BAA00807537 /* ReplyTextView */,
 				B5E23BD919AD0CED000D6879 /* Tools */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1421,6 +1421,7 @@
 		B587798519B799EB00E57C5A /* NotificationBlock+Interface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NotificationBlock+Interface.swift"; sourceTree = "<group>"; };
 		B5899ADD1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationSettingDetailsViewController.swift; sourceTree = "<group>"; };
 		B5899AE31B422D990075A3D6 /* NotificationSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationSettings.swift; sourceTree = "<group>"; };
+		B58FD8CF1C7258C000E5F6A4 /* NotificationsViewController+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NotificationsViewController+Internal.h"; sourceTree = "<group>"; };
 		B59D994E1C0790CC0003D795 /* SettingsListEditorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsListEditorViewController.swift; sourceTree = "<group>"; };
 		B5A6BB8B1BF4DF38002F6A96 /* rest-site-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "rest-site-settings.json"; sourceTree = "<group>"; };
 		B5A6CEA519FA800E009F07DE /* AccountToAccount20to21.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AccountToAccount20to21.swift; path = "20-21/AccountToAccount20to21.swift"; sourceTree = "<group>"; };
@@ -3391,6 +3392,7 @@
 			isa = PBXGroup;
 			children = (
 				B5FD4541199D0F2800286FBB /* NotificationsViewController.h */,
+				B58FD8CF1C7258C000E5F6A4 /* NotificationsViewController+Internal.h */,
 				B5FD4542199D0F2800286FBB /* NotificationsViewController.m */,
 				B5FD453F199D0F2800286FBB /* NotificationDetailsViewController.h */,
 				B5FD4540199D0F2800286FBB /* NotificationDetailsViewController.m */,


### PR DESCRIPTION
#### Description:
In this PR we'll enhance the Notifications List, so that the user may swipe over any comment cell, and Approve / Unapprove / Trash any comments, right there.

#### Details:
The new set of UITableViewDelegate methods have been implemented in a Swift category. Main reason is: we'll gradually migrate the Notifications Stack over to Swift.

Note: I've noticed we've got code that looks alike in several spots (NotificationsViewController / NotificationDetailsViewController). Looks like a great candidate for `The Fourth Layer`, will dig into that!.

Needs Review: @astralbodies 
Thanks in advance Aaron!

Closes #4825

--

#### Scenario: Approve / Unapprove Comments
1. Receive a Comment-Y Notification
2. Launch the app and open the Notifications tab
3. Swipe over the cell
4. Tap over Approve / Unapprove

Verify that the web properly reflects the new state.

#### Scenario: Trash
1. Receive a Comment-Y Notification
2. Launch the app and open the Notifications tab
3. Swipe over the cell
4. Tap over Trash
5. Verify that an Undelete legend is displayed

After a timeout (4 secs) the Undelete button should become invisible, and the comment should get effectively nuked.
