### PR TITLE
PostService and AbstractPostListViewController Refactor

### DIFF
--- a/WordPress/Classes/Networking/PostServiceRemote.h
+++ b/WordPress/Classes/Networking/PostServiceRemote.h
@@ -23,7 +23,7 @@
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)getPostsOfType:(NSString *)postType
-               success:(void (^)(NSArray *posts))success
+               success:(void (^)(NSArray <RemotePost *> *remotePosts))success
                failure:(void (^)(NSError *error))failure;
 
 /**
@@ -36,7 +36,7 @@
  */
 - (void)getPostsOfType:(NSString *)postType
                options:(NSDictionary *)options
-               success:(void (^)(NSArray *posts))success
+               success:(void (^)(NSArray <RemotePost *> *remotePosts))success
                failure:(void (^)(NSError *error))failure;
 
 /**

--- a/WordPress/Classes/Networking/PostServiceRemote.h
+++ b/WordPress/Classes/Networking/PostServiceRemote.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import "PostServiceRemoteOptions.h"
 
 @class RemotePost;
 
@@ -93,5 +94,12 @@
 - (void)restorePost:(RemotePost *)post
             success:(void (^)(RemotePost *))success
             failure:(void (^)(NSError *error))failure;
+
+/**
+ *  @brief      Returns a dictionary set with option parameters of the PostServiceRemoteOptions protocol.
+ *
+ *  @param      options  The object with set remote options.  Cannot be nil.
+ */
+- (NSDictionary *)dictionaryWithRemoteOptions:(id <PostServiceRemoteOptions>)options;
 
 @end

--- a/WordPress/Classes/Networking/PostServiceRemoteOptions.h
+++ b/WordPress/Classes/Networking/PostServiceRemoteOptions.h
@@ -1,0 +1,76 @@
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, PostServiceResultsOrder) {
+    /**
+     (default) Request results in descending order. For dates, that means newest to oldest.
+     */
+    PostServiceResultsOrderDescending = 0,
+    /**
+     Request results in ascending order. For dates, that means oldest to newest.
+     */
+    PostServiceResultsOrderAscending
+};
+
+typedef NS_ENUM(NSUInteger, PostServiceResultsOrdering) {
+    /**
+     (default) Order the results by the created time of each post.
+     */
+    PostServiceResultsOrderingByDate = 0,
+    /**
+     Order the results by the modified time of each post.
+     */
+    PostServiceResultsOrderingByModified,
+    /**
+     Order the results lexicographically by the title of each post.
+     */
+    PostServiceResultsOrderingByTitle,
+    /**
+     Order the results by the number of comments for each pot.
+     */
+    PostServiceResultsOrderingByCommentCount,
+    /**
+     Order the results by the postID of each post.
+     */
+    PostServiceResultsOrderingByPostID
+};
+
+@protocol PostServiceRemoteOptions <NSObject>
+
+/**
+ List of PostStatuses for which to query
+ */
+- (NSArray <NSString *> *)statuses;
+
+/**
+ The number of posts to return. Limit: 100.
+ */
+- (NSNumber *)number;
+
+/**
+ 0-indexed offset for paging requests.
+ */
+- (NSNumber *)offset;
+
+/**
+ The order direction of the results.
+ */
+- (PostServiceResultsOrder)order;
+
+/**
+ The ordering value used when ordering results.
+ */
+- (PostServiceResultsOrdering)orderBy;
+
+/**
+ Specify posts only by the given authorID.
+ @attention Not supported in XML-RPC.
+ */
+- (NSNumber *)authorID;
+
+/**
+ A search query used when requesting posts.
+ @attention Not supported in XML-RPC.
+ */
+- (NSString *)search;
+
+@end

--- a/WordPress/Classes/Networking/PostServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.m
@@ -8,6 +8,22 @@
 NSString * const PostRemoteStatusPublish = @"publish";
 NSString * const PostRemoteStatusScheduled = @"future";
 
+static NSString * const RemoteOptionKeyNumber = @"number";
+static NSString * const RemoteOptionKeyOffset = @"offset";
+static NSString * const RemoteOptionKeyOrder = @"order";
+static NSString * const RemoteOptionKeyOrderBy = @"order_by";
+static NSString * const RemoteOptionKeyStatus = @"status";
+static NSString * const RemoteOptionKeySearch = @"search";
+static NSString * const RemoteOptionKeyAuthor = @"author";
+
+static NSString * const RemoteOptionValueOrderAscending = @"ASC";
+static NSString * const RemoteOptionValueOrderDescending = @"DESC";
+static NSString * const RemoteOptionValueOrderByDate = @"date";
+static NSString * const RemoteOptionValueOrderByModified = @"modified";
+static NSString * const RemoteOptionValueOrderByTitle = @"title";
+static NSString * const RemoteOptionValueOrderByCommentCount = @"comment_count";
+static NSString * const RemoteOptionValueOrderByPostID = @"ID";
+
 @implementation PostServiceRemoteREST
 
 - (void)getPostWithID:(NSNumber *)postID
@@ -200,6 +216,69 @@ NSString * const PostRemoteStatusScheduled = @"future";
            }];
 }
 
+- (NSDictionary *)dictionaryWithRemoteOptions:(id <PostServiceRemoteOptions>)options
+{
+    NSMutableDictionary *remoteParams = [NSMutableDictionary dictionary];
+    if (options.number) {
+        [remoteParams setObject:options.number forKey:RemoteOptionKeyNumber];
+    }
+    if (options.offset) {
+        [remoteParams setObject:options.offset forKey:RemoteOptionKeyOffset];
+    }
+    
+    NSString *statusesStr = nil;
+    if (options.statuses.count) {
+        statusesStr = [options.statuses componentsJoinedByString:@","];
+    }
+    if (options.order) {
+        NSString *orderStr = nil;
+        switch (options.order) {
+            case PostServiceResultsOrderDescending:
+                orderStr = RemoteOptionValueOrderDescending;
+                break;
+            case PostServiceResultsOrderAscending:
+                orderStr = RemoteOptionValueOrderAscending;
+                break;
+        }
+        [remoteParams setObject:orderStr forKey:RemoteOptionKeyOrder];
+    }
+    
+    NSString *orderByStr = nil;
+    if (options.orderBy) {
+        switch (options.orderBy) {
+            case PostServiceResultsOrderingByDate:
+                orderByStr = RemoteOptionValueOrderByDate;
+                break;
+            case PostServiceResultsOrderingByModified:
+                orderByStr = RemoteOptionValueOrderByModified;
+                break;
+            case PostServiceResultsOrderingByTitle:
+                orderByStr = RemoteOptionValueOrderByTitle;
+                break;
+            case PostServiceResultsOrderingByCommentCount:
+                orderByStr = RemoteOptionValueOrderByCommentCount;
+                break;
+            case PostServiceResultsOrderingByPostID:
+                orderByStr = RemoteOptionValueOrderByPostID;
+                break;
+        }
+    }
+    
+    if (statusesStr.length) {
+        [remoteParams setObject:statusesStr forKey:RemoteOptionKeyStatus];
+    }
+    if (orderByStr.length) {
+        [remoteParams setObject:orderByStr forKey:RemoteOptionKeyOrderBy];
+    }
+    if (options.authorID) {
+        [remoteParams setObject:options.authorID forKey:RemoteOptionKeyAuthor];
+    }
+    if (options.search.length > 0) {
+        [remoteParams setObject:options.search forKey:RemoteOptionKeySearch];
+    }
+    
+    return remoteParams.count ? [NSDictionary dictionaryWithDictionary:remoteParams] : nil;
+}
 
 #pragma mark - Private methods
 

--- a/WordPress/Classes/Networking/PostServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.m
@@ -36,7 +36,7 @@ NSString * const PostRemoteStatusScheduled = @"future";
 }
 
 - (void)getPostsOfType:(NSString *)postType
-               success:(void (^)(NSArray *))success
+               success:(void (^)(NSArray <RemotePost *> *remotePosts))success
                failure:(void (^)(NSError *))failure
 {
     [self getPostsOfType:postType options:nil success:success failure:failure];
@@ -44,7 +44,7 @@ NSString * const PostRemoteStatusScheduled = @"future";
 
 - (void)getPostsOfType:(NSString *)postType
                options:(NSDictionary *)options
-               success:(void (^)(NSArray *))success
+               success:(void (^)(NSArray <RemotePost *> *remotePosts))success
                failure:(void (^)(NSError *))failure
 {
     NSParameterAssert([postType isKindOfClass:[NSString class]]);

--- a/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
@@ -9,6 +9,20 @@
 
 const NSInteger HTTP404ErrorCode = 404;
 
+static NSString * const RemoteOptionKeyNumber = @"number";
+static NSString * const RemoteOptionKeyOffset = @"offset";
+static NSString * const RemoteOptionKeyOrder = @"order";
+static NSString * const RemoteOptionKeyOrderBy = @"orderby";
+static NSString * const RemoteOptionKeyStatus = @"post_status";
+
+static NSString * const RemoteOptionValueOrderAscending = @"ASC";
+static NSString * const RemoteOptionValueOrderDescending = @"DESC";
+static NSString * const RemoteOptionValueOrderByDate = @"date";
+static NSString * const RemoteOptionValueOrderByModified = @"modified";
+static NSString * const RemoteOptionValueOrderByTitle = @"title";
+static NSString * const RemoteOptionValueOrderByCommentCount = @"comment_count";
+static NSString * const RemoteOptionValueOrderByPostID = @"ID";
+
 @implementation PostServiceRemoteXMLRPC
 
 - (void)getPostWithID:(NSNumber *)postID
@@ -193,6 +207,64 @@ const NSInteger HTTP404ErrorCode = 404;
            failure:(void (^)(NSError *error))failure
 {
     [self updatePost:post success:success failure:failure];
+}
+
+- (NSDictionary *)dictionaryWithRemoteOptions:(id <PostServiceRemoteOptions>)options
+{
+    NSMutableDictionary *remoteParams = [NSMutableDictionary dictionary];
+    if (options.number) {
+        [remoteParams setObject:options.number forKey:RemoteOptionKeyNumber];
+    }
+    if (options.offset) {
+        [remoteParams setObject:options.offset forKey:RemoteOptionKeyOffset];
+    }
+    
+    NSString *statusesStr = nil;
+    if (options.statuses.count) {
+        statusesStr = [options.statuses componentsJoinedByString:@","];
+    }
+    if (options.order) {
+        NSString *orderStr = nil;
+        switch (options.order) {
+            case PostServiceResultsOrderDescending:
+                orderStr = RemoteOptionValueOrderDescending;
+                break;
+            case PostServiceResultsOrderAscending:
+                orderStr = RemoteOptionValueOrderAscending;
+                break;
+        }
+        [remoteParams setObject:orderStr forKey:RemoteOptionKeyOrder];
+    }
+    
+    NSString *orderByStr = nil;
+    if (options.orderBy) {
+        switch (options.orderBy) {
+            case PostServiceResultsOrderingByDate:
+                orderByStr = RemoteOptionValueOrderByDate;
+                break;
+            case PostServiceResultsOrderingByModified:
+                orderByStr = RemoteOptionValueOrderByModified;
+                break;
+            case PostServiceResultsOrderingByTitle:
+                orderByStr = RemoteOptionValueOrderByTitle;
+                break;
+            case PostServiceResultsOrderingByCommentCount:
+                orderByStr = RemoteOptionValueOrderByCommentCount;
+                break;
+            case PostServiceResultsOrderingByPostID:
+                orderByStr = RemoteOptionValueOrderByPostID;
+                break;
+        }
+    }
+    
+    if (statusesStr.length) {
+        [remoteParams setObject:statusesStr forKey:RemoteOptionKeyStatus];
+    }
+    if (orderByStr.length) {
+        [remoteParams setObject:orderByStr forKey:RemoteOptionKeyOrderBy];
+    }
+    
+    return remoteParams.count ? [NSDictionary dictionaryWithDictionary:remoteParams] : nil;
 }
 
 #pragma mark - Private methods

--- a/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
@@ -30,14 +30,14 @@ const NSInteger HTTP404ErrorCode = 404;
 }
 
 - (void)getPostsOfType:(NSString *)postType
-               success:(void (^)(NSArray *))success
+               success:(void (^)(NSArray <RemotePost *> *remotePosts))success
                failure:(void (^)(NSError *))failure {
     [self getPostsOfType:postType options:nil success:success failure:failure];
 }
 
 - (void)getPostsOfType:(NSString *)postType
                options:(NSDictionary *)options
-               success:(void (^)(NSArray *posts))success
+               success:(void (^)(NSArray <RemotePost *> *remotePosts))success
                failure:(void (^)(NSError *error))failure {
     NSArray *statuses = @[PostStatusDraft, PostStatusPending, PostStatusPrivate, PostStatusPublish, PostStatusScheduled, PostStatusTrash];
     NSString *postStatus = [statuses componentsJoinedByString:@","];
@@ -197,7 +197,7 @@ const NSInteger HTTP404ErrorCode = 404;
 
 #pragma mark - Private methods
 
-- (NSArray *)remotePostsFromXMLRPCArray:(NSArray *)xmlrpcArray {
+- (NSArray <RemotePost *> *)remotePostsFromXMLRPCArray:(NSArray *)xmlrpcArray {
     return [xmlrpcArray wp_map:^id(NSDictionary *xmlrpcPost) {
         return [self remotePostFromXMLRPCDictionary:xmlrpcPost];
     }];

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -1,11 +1,17 @@
 #import <Foundation/Foundation.h>
 #import "LocalCoreDataService.h"
+#import "PostServiceOptions.h"
 
 @class Blog, Post, Page, AbstractPost;
 
 extern NSString * const PostServiceTypePost;
 extern NSString * const PostServiceTypePage;
 extern NSString * const PostServiceTypeAny;
+
+extern const NSUInteger PostServiceDefaultNumberToSync;
+
+typedef void(^PostServiceSyncSuccess)(NSArray *posts);
+typedef void(^PostServiceSyncFailure)(NSError *error);
 
 @interface PostService : LocalCoreDataService
 
@@ -43,102 +49,26 @@ extern NSString * const PostServiceTypeAny;
  */
 - (void)syncPostsOfType:(NSString *)postType
                 forBlog:(Blog *)blog
-                success:(void (^)())success
-                failure:(void (^)(NSError *error))failure;
+                success:(PostServiceSyncSuccess)success
+                failure:(PostServiceSyncFailure)failure;
 
 /**
- Sync additional posts from the specified blog
- Please note that success and/or failure are called in the context of the
- NSManagedObjectContext supplied when the PostService was initialized, and may not
- run on the main thread.
-
- @param postType The type (post or page) of post to sync
- @param blog The blog that has the posts.
- @param success A success block
- @param failure A failure block
- */
-- (void)loadMorePostsOfType:(NSString *)postType
-                    forBlog:(Blog *)blog
-                    success:(void (^)())success
-                    failure:(void (^)(NSError *error))failure;
-
-/**
- Sync an initial batch of posts of the specific status types from the specified blog
- Please note that success and/or failure are called in the context of the
- NSManagedObjectContext supplied when the PostService was initialized, and may not
- run on the main thread.
-
- @param postType The type (post or page) of post to sync
- @param postStatus An array of post status strings.
- @param blog The blog that has the posts.
- @param success A success block
- @param failure A failure block
- */
-- (void)syncPostsOfType:(NSString *)postType
-           withStatuses:(NSArray *)postStatus
-                forBlog:(Blog *)blog
-                success:(void (^)(BOOL hasMore))success
-                failure:(void (^)(NSError *))failure;
-
-/**
- Sync additional posts of the specific status types from the specified blog
- Please note that success and/or failure are called in the context of the
- NSManagedObjectContext supplied when the PostService was initialized, and may not
- run on the main thread.
-
- @param postType The type (post or page) of post to sync
- @param postStatus An array of post status strings.
- @param blog The blog that has the posts.
- @param success A success block
- @param failure A failure block
- */
-
-- (void)loadMorePostsOfType:(NSString *)postType
-               withStatuses:(NSArray *)postStatus
-                    forBlog:(Blog *)blog
-                    success:(void (^)(BOOL hasMore))success
-                    failure:(void (^)(NSError *))failure;
-
-/**
- Sync an initial batch of posts of the specific status types from the specified blog
- Please note that success and/or failure are called in the context of the
- NSManagedObjectContext supplied when the PostService was initialized, and may not
- run on the main thread.
-
- @param postType The type (post or page) of post to sync
- @param postStatus An array of post status strings.
- @param authorID The user ID of a specific author, or nil if everyone's posts should be synced.
- @param blog The blog that has the posts.
- @param success A success block
- @param failure A failure block
- */
-- (void)syncPostsOfType:(NSString *)postType
-           withStatuses:(NSArray *)postStatus
-               byAuthor:(NSNumber *)authorID
-                forBlog:(Blog *)blog
-                success:(void (^)(BOOL hasMore))success
-                failure:(void (^)(NSError *))failure;
-
-/**
- Sync additional posts of the specific status types from the specified blog
+ Sync a batch of posts with the specified options from the specified blog.
  Please note that success and/or failure are called in the context of the
  NSManagedObjectContext supplied when the PostService was initialized, and may not
  run on the main thread.
  
  @param postType The type (post or page) of post to sync
- @param postStatus An array of post status strings.
- @param authorID The user ID of a specific author, or nil if everyone's posts should be synced.
+ @param options Sync options for specific request parameters.
  @param blog The blog that has the posts.
  @param success A success block
  @param failure A failure block
  */
-
-- (void)loadMorePostsOfType:(NSString *)postType
-               withStatuses:(NSArray *)postStatus
-                   byAuthor:(NSNumber *)authorID
-                    forBlog:(Blog *)blog
-                    success:(void (^)(BOOL hasMore))success
-                    failure:(void (^)(NSError *))failure;
+- (void)syncPostsOfType:(NSString *)postType
+            withOptions:(PostServiceSyncOptions *)options
+                forBlog:(Blog *)blog
+                success:(PostServiceSyncSuccess)success
+                failure:(PostServiceSyncFailure)failure;
 
 /**
  Syncs local changes on a post back to the server.
@@ -147,7 +77,6 @@ extern NSString * const PostServiceTypeAny;
  @param success A success block
  @param failure A failure block
  */
-
 - (void)uploadPost:(AbstractPost *)post
            success:(void (^)())success
            failure:(void (^)(NSError *error))failure;

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -19,24 +19,6 @@ NSString * const PostServiceTypePage = @"page";
 NSString * const PostServiceTypeAny = @"any";
 NSString * const PostServiceErrorDomain = @"PostServiceErrorDomain";
 
-static NSString * const RemoteOptionKeyNumber = @"number";
-static NSString * const RemoteOptionKeyOffset = @"offset";
-static NSString * const RemoteOptionKeyOrder = @"order";
-static NSString * const RemoteOptionKeyOrderByREST = @"order_by";
-static NSString * const RemoteOptionKeyOrderByXMLRPC = @"orderby";
-static NSString * const RemoteOptionKeyStatusREST = @"status";
-static NSString * const RemoteOptionKeyStatusXMLRPC = @"post_status";
-static NSString * const RemoteOptionKeySearchREST = @"search";
-static NSString * const RemoteOptionKeyAuthorREST = @"author";
-
-static NSString * const RemoteOptionValueOrderAscending = @"ASC";
-static NSString * const RemoteOptionValueOrderDescending = @"DESC";
-static NSString * const RemoteOptionValueOrderByDate = @"date";
-static NSString * const RemoteOptionValueOrderByModified = @"modified";
-static NSString * const RemoteOptionValueOrderByTitle = @"title";
-static NSString * const RemoteOptionValueOrderByCommentCount = @"comment_count";
-static NSString * const RemoteOptionValueOrderByPostID = @"ID";
-
 const NSUInteger PostServiceDefaultNumberToSync = 40;
 
 @implementation PostService
@@ -434,81 +416,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
 - (NSDictionary *)remoteSyncParametersDictionaryForRemote:(nonnull id <PostServiceRemote>)remote
                                               withOptions:(nonnull PostServiceSyncOptions *)options
 {
-    NSMutableDictionary *remoteParams = [NSMutableDictionary dictionary];
-    // setup default parameters support by both REST and XMLRPC
-    if (options.number) {
-        [remoteParams setObject:options.number forKey:RemoteOptionKeyNumber];
-    } else {
-        [remoteParams setObject:@(PostServiceDefaultNumberToSync) forKey:RemoteOptionKeyNumber];
-    }
-    if (options.offset) {
-        [remoteParams setObject:options.offset forKey:RemoteOptionKeyOffset];
-    }
-    
-    NSString *statusesStr = nil;
-    if (options.statuses.count) {
-        statusesStr = [options.statuses componentsJoinedByString:@","];
-    }
-    if (options.order) {
-        NSString *orderStr = nil;
-        switch (options.order) {
-            case PostServiceResultsOrderDescending:
-                orderStr = RemoteOptionValueOrderDescending;
-                break;
-            case PostServiceResultsOrderAscending:
-                orderStr = RemoteOptionValueOrderAscending;
-                break;
-        }
-        [remoteParams setObject:orderStr forKey:RemoteOptionKeyOrder];
-    }
-    
-    NSString *orderByStr = nil;
-    if (options.orderBy) {
-        switch (options.orderBy) {
-            case PostServiceResultsOrderingByDate:
-                orderByStr = RemoteOptionValueOrderByDate;
-                break;
-            case PostServiceResultsOrderingByModified:
-                orderByStr = RemoteOptionValueOrderByModified;
-                break;
-            case PostServiceResultsOrderingByTitle:
-                orderByStr = RemoteOptionValueOrderByTitle;
-                break;
-            case PostServiceResultsOrderingByCommentCount:
-                orderByStr = RemoteOptionValueOrderByCommentCount;
-                break;
-            case PostServiceResultsOrderingByPostID:
-                orderByStr = RemoteOptionValueOrderByPostID;
-                break;
-        }
-    }
-    
-    // setup parameters unique to either REST or XML-RPC
-    if ([remote isKindOfClass:[PostServiceRemoteREST class]]) {
-        // setup REST unique params
-        if (statusesStr.length) {
-            [remoteParams setObject:statusesStr forKey:RemoteOptionKeyStatusREST];
-        }
-        if (orderByStr.length) {
-            [remoteParams setObject:orderByStr forKey:RemoteOptionKeyOrderByREST];
-        }
-        if (options.authorID) {
-            [remoteParams setObject:options.authorID forKey:RemoteOptionKeyAuthorREST];
-        }
-        if (options.search.length > 0) {
-            [remoteParams setObject:options.search forKey:RemoteOptionKeySearchREST];
-        }
-    } else if ([remote isKindOfClass:[PostServiceRemoteXMLRPC class]]) {
-        // setup XML-RPC unique params
-        if (statusesStr.length) {
-            [remoteParams setObject:statusesStr forKey:RemoteOptionKeyStatusXMLRPC];
-        }
-        if (orderByStr.length) {
-            [remoteParams setObject:orderByStr forKey:RemoteOptionKeyOrderByXMLRPC];
-        }
-    }
-    
-    return remoteParams.count ? [NSDictionary dictionaryWithDictionary:remoteParams] : nil;
+    return [remote dictionaryWithRemoteOptions:options];
 }
 
 - (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost {

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -134,7 +134,6 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     id<PostServiceRemote> remote = [self remoteForBlog:blog];
 
     NSDictionary *remoteOptions = options ? [self remoteSyncParametersDictionaryForRemote:remote withOptions:options] : nil;
-    NSLog(@"remote otions: %@", remoteOptions);
     [remote getPostsOfType:postType
                    options:remoteOptions
                    success:^(NSArray <RemotePost *> *remotePosts) {

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -146,7 +146,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
                            }
                            [self mergePosts:remotePosts
                                      ofType:postType
-                                    forBlog:blog
+                                    forBlog:blogInContext
                           completionHandler:^(NSArray<AbstractPost *> *posts) {
                               if (success) {
                                   success(posts);

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -19,6 +19,24 @@ NSString * const PostServiceTypePage = @"page";
 NSString * const PostServiceTypeAny = @"any";
 NSString * const PostServiceErrorDomain = @"PostServiceErrorDomain";
 
+static NSString * const RemoteOptionKeyNumber = @"number";
+static NSString * const RemoteOptionKeyOffset = @"offset";
+static NSString * const RemoteOptionKeyOrder = @"order";
+static NSString * const RemoteOptionKeyOrderByREST = @"order_by";
+static NSString * const RemoteOptionKeyOrderByXMLRPC = @"orderby";
+static NSString * const RemoteOptionKeyStatusREST = @"status";
+static NSString * const RemoteOptionKeyStatusXMLRPC = @"post_status";
+static NSString * const RemoteOptionKeySearchREST = @"search";
+static NSString * const RemoteOptionKeyAuthorREST = @"author";
+
+static NSString * const RemoteOptionValueOrderAscending = @"ASC";
+static NSString * const RemoteOptionValueOrderDescending = @"DESC";
+static NSString * const RemoteOptionValueOrderByDate = @"date";
+static NSString * const RemoteOptionValueOrderByModified = @"modified";
+static NSString * const RemoteOptionValueOrderByTitle = @"title";
+static NSString * const RemoteOptionValueOrderByCommentCount = @"comment_count";
+static NSString * const RemoteOptionValueOrderByPostID = @"ID";
+
 const NSUInteger PostServiceDefaultNumberToSync = 40;
 
 @implementation PostService
@@ -395,13 +413,14 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     NSMutableDictionary *remoteParams = [NSMutableDictionary dictionary];
     // setup default parameters support by both REST and XMLRPC
     if (options.number) {
-        [remoteParams setObject:options.number forKey:@"number"];
+        [remoteParams setObject:options.number forKey:RemoteOptionKeyNumber];
     } else {
-        [remoteParams setObject:@(PostServiceDefaultNumberToSync) forKey:@"number"];
+        [remoteParams setObject:@(PostServiceDefaultNumberToSync) forKey:RemoteOptionKeyNumber];
     }
     if (options.offset) {
-        [remoteParams setObject:options.offset forKey:@"offset"];
+        [remoteParams setObject:options.offset forKey:RemoteOptionKeyOffset];
     }
+    
     NSString *statusesStr = nil;
     if (options.statuses.count) {
         statusesStr = [options.statuses componentsJoinedByString:@","];
@@ -410,55 +429,58 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         NSString *orderStr = nil;
         switch (options.order) {
             case PostServiceResultsOrderDescending:
-                orderStr = @"DESC";
+                orderStr = RemoteOptionValueOrderDescending;
                 break;
             case PostServiceResultsOrderAscending:
-                orderStr = @"ASC";
+                orderStr = RemoteOptionValueOrderAscending;
                 break;
         }
-        [remoteParams setObject:orderStr forKey:@"order"];
+        [remoteParams setObject:orderStr forKey:RemoteOptionKeyOrder];
     }
+    
     NSString *orderByStr = nil;
     if (options.orderBy) {
         switch (options.orderBy) {
             case PostServiceResultsOrderingByDate:
-                orderByStr = @"date";
+                orderByStr = RemoteOptionValueOrderByDate;
                 break;
             case PostServiceResultsOrderingByModified:
-                orderByStr = @"modified";
+                orderByStr = RemoteOptionValueOrderByModified;
                 break;
             case PostServiceResultsOrderingByTitle:
-                orderByStr = @"title";
+                orderByStr = RemoteOptionValueOrderByTitle;
                 break;
             case PostServiceResultsOrderingByCommentCount:
-                orderByStr = @"comment_count";
+                orderByStr = RemoteOptionValueOrderByCommentCount;
                 break;
             case PostServiceResultsOrderingByPostID:
-                orderByStr = @"ID";
+                orderByStr = RemoteOptionValueOrderByPostID;
                 break;
         }
     }
+    
+    // setup parameters unique to either REST or XML-RPC
     if ([remote isKindOfClass:[PostServiceRemoteREST class]]) {
         // setup REST unique params
         if (statusesStr.length) {
-            [remoteParams setObject:statusesStr forKey:@"status"];
+            [remoteParams setObject:statusesStr forKey:RemoteOptionKeyStatusREST];
         }
         if (orderByStr.length) {
-            [remoteParams setObject:orderByStr forKey:@"order_by"];
+            [remoteParams setObject:orderByStr forKey:RemoteOptionKeyOrderByREST];
         }
         if (options.authorID) {
-            [remoteParams setObject:options.authorID forKey:@"author"];
+            [remoteParams setObject:options.authorID forKey:RemoteOptionKeyAuthorREST];
         }
         if (options.search.length > 0) {
-            [remoteParams setObject:options.search forKey:@"search"];
+            [remoteParams setObject:options.search forKey:RemoteOptionKeySearchREST];
         }
     } else if ([remote isKindOfClass:[PostServiceRemoteXMLRPC class]]) {
         // setup XML-RPC unique params
         if (statusesStr.length) {
-            [remoteParams setObject:statusesStr forKey:@"post_status"];
+            [remoteParams setObject:statusesStr forKey:RemoteOptionKeyStatusXMLRPC];
         }
         if (orderByStr.length) {
-            [remoteParams setObject:orderByStr forKey:@"orderby"];
+            [remoteParams setObject:orderByStr forKey:RemoteOptionKeyOrderByXMLRPC];
         }
     }
     

--- a/WordPress/Classes/Services/PostServiceOptions.h
+++ b/WordPress/Classes/Services/PostServiceOptions.h
@@ -1,38 +1,4 @@
-#import <Foundation/Foundation.h>
-
-typedef NS_ENUM(NSUInteger, PostServiceResultsOrder) {
-    /**
-     (default) Request results in descending order. For dates, that means newest to oldest.
-     */
-    PostServiceResultsOrderDescending = 0,
-    /**
-     Request results in ascending order. For dates, that means oldest to newest.
-     */
-    PostServiceResultsOrderAscending
-};
-
-typedef NS_ENUM(NSUInteger, PostServiceResultsOrdering) {
-    /**
-     (default) Order the results by the created time of each post.
-     */
-    PostServiceResultsOrderingByDate = 0,
-    /**
-     Order the results by the modified time of each post.
-     */
-    PostServiceResultsOrderingByModified,
-    /**
-     Order the results lexicographically by the title of each post.
-     */
-    PostServiceResultsOrderingByTitle,
-    /**
-     Order the results by the number of comments for each pot.
-     */
-    PostServiceResultsOrderingByCommentCount,
-    /**
-     Order the results by the postID of each post.
-     */
-    PostServiceResultsOrderingByPostID
-};
+#import "PostServiceRemoteOptions.h"
 
 /**
  @class PostServiceSyncOptions
@@ -41,48 +7,22 @@ typedef NS_ENUM(NSUInteger, PostServiceResultsOrdering) {
  WP.com/REST Jetpack: https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/
  XML-RPC: https://codex.wordpress.org/XML-RPC_WordPress_API/Posts
  */
-@interface PostServiceSyncOptions : NSObject
+@interface PostServiceSyncOptions : NSObject <PostServiceRemoteOptions>
 
 /**
  When set to true previously synced AbstractPosts matching statuses and authorID will be purged while updating.
  */
 @property (nonatomic, assign) BOOL purgesLocalSync;
 
-/**
- List of PostStatuses for which to query
+/*
+ Properties fulfilling PostServiceRemoteOptions protocol.
  */
 @property (nonatomic, strong) NSArray <NSString *> *statuses;
-
-/**
- The number of posts to return. Limit: 100.
- */
 @property (nonatomic, strong) NSNumber *number;
-
-/**
- 0-indexed offset for paging requests.
- */
 @property (nonatomic, strong) NSNumber *offset;
-
-/**
- The order direction of the results.
- */
 @property (nonatomic, assign) PostServiceResultsOrder order;
-
-/**
- The ordering value used when ordering results.
- */
 @property (nonatomic, assign) PostServiceResultsOrdering orderBy;
-
-/**
- Specify posts only by the given authorID.
- @attention Not supported in XML-RPC.
- */
 @property (nonatomic, strong) NSNumber *authorID;
-
-/**
- A search query used when requesting posts.
- @attention Not supported in XML-RPC.
- */
 @property (nonatomic, copy) NSString *search;
 
 @end

--- a/WordPress/Classes/Services/PostServiceOptions.h
+++ b/WordPress/Classes/Services/PostServiceOptions.h
@@ -36,14 +36,22 @@ typedef NS_ENUM(NSUInteger, PostServiceResultsOrdering) {
 
 /**
  @class PostServiceSyncOptions
- @brief A object for passing parameters to the API when requesting specific filtering of posts.
- See each remote API for specifics regarding default values and limits.
+ @brief An object of options and paramters for specific filtering and syncing of posts.
+ See each remote API parameters for specifics regarding default values and limits.
  WP.com/REST Jetpack: https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/
  XML-RPC: https://codex.wordpress.org/XML-RPC_WordPress_API/Posts
  */
 @interface PostServiceSyncOptions : NSObject
 
-@property (nonatomic, strong) NSArray *statuses;
+/**
+ When set to true previously synced AbstractPosts matching statuses and authorID will be purged while updating.
+ */
+@property (nonatomic, assign) BOOL purgesLocalSync;
+
+/**
+ List of PostStatuses for which to query
+ */
+@property (nonatomic, strong) NSArray <NSString *> *statuses;
 
 /**
  The number of posts to return. Limit: 100.

--- a/WordPress/Classes/Services/PostServiceOptions.h
+++ b/WordPress/Classes/Services/PostServiceOptions.h
@@ -1,0 +1,80 @@
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, PostServiceResultsOrder) {
+    /**
+     (default) Request results in descending order. For dates, that means newest to oldest.
+     */
+    PostServiceResultsOrderDescending = 0,
+    /**
+     Request results in ascending order. For dates, that means oldest to newest.
+     */
+    PostServiceResultsOrderAscending
+};
+
+typedef NS_ENUM(NSUInteger, PostServiceResultsOrdering) {
+    /**
+     (default) Order the results by the created time of each post.
+     */
+    PostServiceResultsOrderingByDate = 0,
+    /**
+     Order the results by the modified time of each post.
+     */
+    PostServiceResultsOrderingByModified,
+    /**
+     Order the results lexicographically by the title of each post.
+     */
+    PostServiceResultsOrderingByTitle,
+    /**
+     Order the results by the number of comments for each pot.
+     */
+    PostServiceResultsOrderingByCommentCount,
+    /**
+     Order the results by the postID of each post.
+     */
+    PostServiceResultsOrderingByPostID
+};
+
+/**
+ @class PostServiceSyncOptions
+ @brief A object for passing parameters to the API when requesting specific filtering of posts.
+ See each remote API for specifics regarding default values and limits.
+ WP.com/REST Jetpack: https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/
+ XML-RPC: https://codex.wordpress.org/XML-RPC_WordPress_API/Posts
+ */
+@interface PostServiceSyncOptions : NSObject
+
+@property (nonatomic, strong) NSArray *statuses;
+
+/**
+ The max number of posts to return.
+ */
+@property (nonatomic, strong) NSNumber *number;
+
+/**
+ 0-indexed offset for paging requests.
+ */
+@property (nonatomic, strong) NSNumber *offset;
+
+/**
+ The order direction of the results.
+ */
+@property (nonatomic, assign) PostServiceResultsOrder order;
+
+/**
+ The ordering value used when ordering results.
+ */
+@property (nonatomic, assign) PostServiceResultsOrdering orderBy;
+
+/**
+ Specify posts only by the given authorID.
+ @attention Not supported in XML-RPC.
+ */
+@property (nonatomic, strong) NSNumber *authorID;
+
+/**
+ A search query used when requesting posts.
+ @attention Not supported in XML-RPC.
+ */
+@property (nonatomic, copy) NSString *search;
+
+@end

--- a/WordPress/Classes/Services/PostServiceOptions.h
+++ b/WordPress/Classes/Services/PostServiceOptions.h
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSUInteger, PostServiceResultsOrdering) {
 @property (nonatomic, strong) NSArray *statuses;
 
 /**
- The max number of posts to return.
+ The number of posts to return. Limit: 100.
  */
 @property (nonatomic, strong) NSNumber *number;
 

--- a/WordPress/Classes/Services/PostServiceOptions.m
+++ b/WordPress/Classes/Services/PostServiceOptions.m
@@ -1,0 +1,5 @@
+#import "PostServiceOptions.h"
+
+@implementation PostServiceSyncOptions
+
+@end

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -402,6 +402,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     options.statuses = filter.statuses;
     options.authorID = author;
     options.number = @([self numberOfPostsPerSync]);
+    options.purgesLocalSync = YES;
     
     [postService syncPostsOfType:[self postTypeToSync]
                      withOptions:options

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -372,8 +372,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     }
     filter.hasMore = posts.count >= options.number.unsignedIntegerValue;
     
-    [self updateAndPerformFetchRequest];
-    [self.tableView reloadData];
+    [self updateAndPerformFetchRequestRefreshingCachedRowHeights];
 }
 
 - (NSUInteger)numberOfPostsPerSync
@@ -582,11 +581,6 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 
 - (void)updateAndPerformFetchRequestRefreshingCachedRowHeights
 {
-    // Reset the tableView contentOffset to the top before we make any dataSource changes.
-    CGPoint tableOffset = self.tableView.contentOffset;
-    tableOffset.y = -self.tableView.contentInset.top;
-    self.tableView.contentOffset = tableOffset;
-    
     [self updateAndPerformFetchRequest];
 
     CGFloat width = CGRectGetWidth(self.tableView.bounds);
@@ -594,6 +588,14 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 
     [self.tableView reloadData];
     [self configureNoResultsView];
+}
+
+- (void)resetTableViewContentOffset
+{
+    // Reset the tableView contentOffset to the top before we make any dataSource changes.
+    CGPoint tableOffset = self.tableView.contentOffset;
+    tableOffset.y = -self.tableView.contentInset.top;
+    self.tableView.contentOffset = tableOffset;
 }
 
 - (NSPredicate *)predicateForFetchRequest
@@ -866,6 +868,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 
     [self.recentlyTrashedPostObjectIDs removeAllObjects];
     [self updateFilterTitle];
+    [self resetTableViewContentOffset];
     [self updateAndPerformFetchRequestRefreshingCachedRowHeights];
 }
 
@@ -952,11 +955,13 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     }];
 
     self.searchController.searchBar.text = nil;
+    [self resetTableViewContentOffset];
     [self updateAndPerformFetchRequestRefreshingCachedRowHeights];
 }
 
 - (void)updateSearchResultsForSearchController:(WPSearchController *)searchController
 {
+    [self resetTableViewContentOffset];
     [self updateAndPerformFetchRequestRefreshingCachedRowHeights];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -563,6 +563,11 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 
 - (void)updateAndPerformFetchRequestRefreshingCachedRowHeights
 {
+    // Reset the tableView contentOffset to the top before we make any dataSource changes.
+    CGPoint tableOffset = self.tableView.contentOffset;
+    tableOffset.y = -self.tableView.contentInset.top;
+    self.tableView.contentOffset = tableOffset;
+    
     [self updateAndPerformFetchRequest];
 
     CGFloat width = CGRectGetWidth(self.tableView.bounds);

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -361,7 +361,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 - (void)updateFilter:(PostListFilter *)filter withSyncedPosts:(NSArray <AbstractPost *> *)posts syncOptions:(PostServiceSyncOptions *)options
 {
     AbstractPost *oldestPost = [posts lastObject];
-    NSDate *oldestPostDate = oldestPost.date_created_gmt;
+    NSDate *oldestPostDate = oldestPost.dateCreated;
     if (filter.oldestPostDate) {
         // If we already set an oldestPostDate on the filter, see if this sync has an older post date.
         if ([filter.oldestPostDate compare:oldestPostDate] == NSOrderedDescending) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -361,15 +361,8 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 - (void)updateFilter:(PostListFilter *)filter withSyncedPosts:(NSArray <AbstractPost *> *)posts syncOptions:(PostServiceSyncOptions *)options
 {
     AbstractPost *oldestPost = [posts lastObject];
-    NSDate *oldestPostDate = oldestPost.dateCreated;
-    if (filter.oldestPostDate) {
-        // If we already set an oldestPostDate on the filter, see if this sync has an older post date.
-        if ([filter.oldestPostDate compare:oldestPostDate] == NSOrderedDescending) {
-            filter.oldestPostDate = oldestPostDate;
-        }
-    } else {
-        filter.oldestPostDate = oldestPostDate;
-    }
+    // Reset the filter to only show the latest sync point.
+    filter.oldestPostDate = oldestPost.dateCreated;
     filter.hasMore = posts.count >= options.number.unsignedIntegerValue;
     
     [self updateAndPerformFetchRequestRefreshingCachedRowHeights];

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -363,8 +363,6 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     AbstractPost *oldestPost = [posts lastObject];
     filter.oldestPostDate = oldestPost.date_created_gmt;
     filter.hasMore = posts.count >= options.number.unsignedIntegerValue;
-    filter.fetchLimit = options.offset.unsignedIntegerValue + posts.count;
-
     [self updateAndPerformFetchRequest];
     [self.tableView reloadData];
 }
@@ -525,7 +523,6 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     fetchRequest.predicate = [self predicateForFetchRequest];
     fetchRequest.sortDescriptors = [self sortDescriptorsForFetchRequest];
     fetchRequest.fetchBatchSize = PostsFetchRequestBatchSize;
-    fetchRequest.fetchLimit = [self numberOfPostsPerSync];
     return fetchRequest;
 }
 
@@ -550,9 +547,11 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     [fetchRequest setSortDescriptors:sortDescriptors];
     
     PostListFilter *filter = [self currentPostListFilter];
-    if (filter.fetchLimit) {
-        fetchRequest.fetchLimit = filter.fetchLimit;
+    if (filter.oldestPostDate) {
+        // If filtering by the oldestPostDate the fetchLimit should be disabled.
+        fetchRequest.fetchLimit = 0;
     } else {
+        // If not filtering by the oldestPostDate, set the fetchLimit to the default number of posts.
         fetchRequest.fetchLimit = [self numberOfPostsPerSync];
     }
     

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
@@ -67,6 +67,7 @@ extern const CGSize PreferredFiltersPopoverContentSize;
 - (void)deletePost:(AbstractPost *)apost;
 - (void)restorePost:(AbstractPost *)apost;
 - (void)updateAndPerformFetchRequestRefreshingCachedRowHeights;
+- (void)resetTableViewContentOffset;
 - (BOOL)isSearching;
 - (NSString *)currentSearchTerm;
 - (NSDictionary *)propertiesForAnalytics;

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewControllerSubclass.h
@@ -50,7 +50,7 @@ extern const CGSize PreferredFiltersPopoverContentSize;
 @property (nonatomic, weak) IBOutlet NSLayoutConstraint *authorsFilterViewHeightConstraint;
 @property (nonatomic, weak) IBOutlet NSLayoutConstraint *searchWrapperViewHeightConstraint;
 @property (nonatomic, strong) WPSearchController *searchController; // Stand-in for UISearchController
-@property (nonatomic, strong) NSArray *postListFilters;
+@property (nonatomic, strong) NSMutableDictionary <NSString *, NSArray *> *allPostListFilters;
 @property (nonatomic, strong) NSMutableArray *recentlyTrashedPostObjectIDs; // IDs of trashed posts. Cleared on refresh or when filter changes.
 
 - (NSString *)postTypeToSync;

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.h
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.h
@@ -10,12 +10,13 @@ typedef NS_ENUM(NSUInteger, PostListStatusFilter) {
 @interface PostListFilter : NSObject
 
 @property (nonatomic, assign) BOOL hasMore;
+@property (nonatomic, assign) NSUInteger fetchLimit;
+@property (nonatomic, strong) NSDate *oldestPostDate;
 @property (nonatomic, assign) PostListStatusFilter filterType;
 @property (nonatomic, strong) NSString *title;
 @property (nonatomic, strong) NSArray *statuses;
-@property (nonatomic, strong) NSPredicate *predicateForFetchRequest;
-@property (nonatomic, assign) NSUInteger fetchLimit;
 
 + (NSArray *)newPostListFilters;
+- (NSPredicate *)predicateForFetchRequest;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.h
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.h
@@ -14,6 +14,7 @@ typedef NS_ENUM(NSUInteger, PostListStatusFilter) {
 @property (nonatomic, strong) NSString *title;
 @property (nonatomic, strong) NSArray *statuses;
 @property (nonatomic, strong) NSPredicate *predicateForFetchRequest;
+@property (nonatomic, assign) NSUInteger fetchLimit;
 
 + (NSArray *)newPostListFilters;
 

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.h
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.h
@@ -14,8 +14,8 @@ typedef NS_ENUM(NSUInteger, PostListStatusFilter) {
 @property (nonatomic, assign) PostListStatusFilter filterType;
 @property (nonatomic, strong) NSString *title;
 @property (nonatomic, strong) NSArray *statuses;
+@property (nonatomic, strong) NSPredicate *predicateForFetchRequest;
 
 + (NSArray *)newPostListFilters;
-- (NSPredicate *)predicateForFetchRequest;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.h
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.h
@@ -10,7 +10,6 @@ typedef NS_ENUM(NSUInteger, PostListStatusFilter) {
 @interface PostListFilter : NSObject
 
 @property (nonatomic, assign) BOOL hasMore;
-@property (nonatomic, assign) NSUInteger fetchLimit;
 @property (nonatomic, strong) NSDate *oldestPostDate;
 @property (nonatomic, assign) PostListStatusFilter filterType;
 @property (nonatomic, strong) NSString *title;

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.m
@@ -3,8 +3,6 @@
 
 @interface PostListFilter ()
 
-@property (nonatomic, strong) NSPredicate *basePredicateForFetchRequest;
-
 @end
 
 @implementation PostListFilter
@@ -25,7 +23,7 @@
     filter.title = NSLocalizedString(@"Published", @"Title of the published filter. This filter shows a list of posts that the user has published.");
     filter.statuses = @[PostStatusPublish, PostStatusPrivate];
     filter.filterType = PostListStatusFilterPublished;
-    filter.basePredicateForFetchRequest = [NSPredicate predicateWithFormat:@"status IN %@", filter.statuses];
+    filter.predicateForFetchRequest = [NSPredicate predicateWithFormat:@"status IN %@", filter.statuses];
     return filter;
 }
 
@@ -37,7 +35,7 @@
     filter.filterType = PostListStatusFilterDraft;
     // Exclude known status values. This allows for pending and custom post status to be treated as draft.
     NSArray *excludeStatuses = @[PostStatusPublish, PostStatusPrivate, PostStatusScheduled, PostStatusTrash];
-    filter.basePredicateForFetchRequest = [NSPredicate predicateWithFormat:@"NOT status IN %@", excludeStatuses];
+    filter.predicateForFetchRequest = [NSPredicate predicateWithFormat:@"NOT status IN %@", excludeStatuses];
     return filter;
 }
 
@@ -47,7 +45,7 @@
     filter.title = NSLocalizedString(@"Scheduled", @"Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date.");
     filter.statuses = @[PostStatusScheduled];
     filter.filterType = PostListStatusFilterScheduled;
-    filter.basePredicateForFetchRequest = [NSPredicate predicateWithFormat:@"status = %@", PostStatusScheduled];
+    filter.predicateForFetchRequest = [NSPredicate predicateWithFormat:@"status = %@", PostStatusScheduled];
     return filter;
 }
 
@@ -57,7 +55,7 @@
     filter.title = NSLocalizedString(@"Trashed", @"Title of the trashed filter. This filter shows posts that have been moved to the trash bin.");
     filter.statuses = @[PostStatusTrash];
     filter.filterType = PostListStatusFilterTrashed;
-    filter.basePredicateForFetchRequest = [NSPredicate predicateWithFormat:@"status = %@", PostStatusTrash];
+    filter.predicateForFetchRequest = [NSPredicate predicateWithFormat:@"status = %@", PostStatusTrash];
     return filter;
 }
 
@@ -68,11 +66,6 @@
         self.hasMore = YES;
     }
     return self;
-}
-
-- (NSPredicate *)predicateForFetchRequest
-{
-    return self.basePredicateForFetchRequest;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.m
@@ -72,11 +72,6 @@
 
 - (NSPredicate *)predicateForFetchRequest
 {
-    if (self.oldestPostDate) {
-        NSPredicate *datePredicate = [NSPredicate predicateWithFormat:@"date_created_gmt >= %@", self.oldestPostDate];
-        return [NSCompoundPredicate andPredicateWithSubpredicates:@[self.basePredicateForFetchRequest, datePredicate]];
-    }
-    
     return self.basePredicateForFetchRequest;
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -33,7 +33,7 @@ static const CGFloat PostListHeightForFooterView = 34.0;
 
 @property (nonatomic, strong) PostCardTableViewCell *textCellForLayout;
 @property (nonatomic, strong) PostCardTableViewCell *imageCellForLayout;
-@property (nonatomic, weak) IBOutlet UISegmentedControl *authorsFilter;
+@property (nonatomic, weak) IBOutlet UISegmentedControl *authorFilterSegmentedControl;
 
 @end
 
@@ -236,20 +236,20 @@ static const CGFloat PostListHeightForFooterView = 34.0;
 {
     NSString *onlyMe = NSLocalizedString(@"Only Me", @"Label for the post author filter. This fliter shows posts only authored by the current user.");
     NSString *everyone = NSLocalizedString(@"Everyone", @"Label for the post author filter. This filter shows posts for all users on the blog.");
-    [WPStyleGuide applyPostAuthorFilterStyle:self.authorsFilter];
-    [self.authorsFilter setTitle:onlyMe forSegmentAtIndex:0];
-    [self.authorsFilter setTitle:everyone forSegmentAtIndex:1];
+    [WPStyleGuide applyPostAuthorFilterStyle:self.authorFilterSegmentedControl];
+    [self.authorFilterSegmentedControl setTitle:onlyMe forSegmentAtIndex:0];
+    [self.authorFilterSegmentedControl setTitle:everyone forSegmentAtIndex:1];
     self.authorsFilterView.backgroundColor = [WPStyleGuide lightGrey];
 
     if (![self canFilterByAuthor]) {
         self.authorsFilterViewHeightConstraint.constant = 0.0;
-        self.authorsFilter.hidden = YES;
+        self.authorFilterSegmentedControl.hidden = YES;
     }
 
     if ([self currentPostAuthorFilter] == PostAuthorFilterMine) {
-        self.authorsFilter.selectedSegmentIndex = 0;
+        self.authorFilterSegmentedControl.selectedSegmentIndex = 0;
     } else {
-        self.authorsFilter.selectedSegmentIndex = 1;
+        self.authorFilterSegmentedControl.selectedSegmentIndex = 1;
     }
 }
 
@@ -271,7 +271,7 @@ static const CGFloat PostListHeightForFooterView = 34.0;
 
 - (IBAction)handleAuthorFilterChanged:(id)sender
 {
-    if (self.authorsFilter.selectedSegmentIndex == PostAuthorFilterMine) {
+    if (self.authorFilterSegmentedControl.selectedSegmentIndex == PostAuthorFilterMine) {
         [self setCurrentPostAuthorFilter:PostAuthorFilterMine];
     } else {
         [self setCurrentPostAuthorFilter:PostAuthorFilterEveryone];

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -553,6 +553,7 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     [NSUserDefaults resetStandardUserDefaults];
 
     [self.recentlyTrashedPostObjectIDs removeAllObjects];
+    [self resetTableViewContentOffset];
     [self updateAndPerformFetchRequestRefreshingCachedRowHeights];
     [self syncItemsWithUserInteraction:NO];
 }

--- a/WordPress/Classes/ViewRelated/Post/Posts.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Posts.storyboard
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <scenes>
         <!--Posts-->
@@ -14,7 +13,7 @@
                         <viewControllerLayoutGuide type="bottom" id="AIH-s0-RTt"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Zhd-4n-wcm">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="536"/>
+                        <rect key="frame" x="0.0" y="64" width="600" height="536"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kl8-s3-Dv4">
@@ -87,7 +86,7 @@
                     <nil key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="addButton" destination="9Az-zB-Hwe" id="r4s-oX-gyT"/>
-                        <outlet property="authorsFilter" destination="2zZ-72-iKA" id="Ycd-OB-A7L"/>
+                        <outlet property="authorFilterSegmentedControl" destination="2zZ-72-iKA" id="A6u-P2-Z7M"/>
                         <outlet property="authorsFilterView" destination="9at-tM-m4A" id="Iue-Ql-B4V"/>
                         <outlet property="authorsFilterViewHeightConstraint" destination="KUd-OB-pfW" id="qbe-pV-Ymo"/>
                         <outlet property="filterButton" destination="qr8-Nf-Mwl" id="u7d-J1-vsa"/>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		082AB9D61C4EEA72000CA523 /* RemotePostTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9D51C4EEA72000CA523 /* RemotePostTag.m */; };
 		082AB9D91C4EEEF4000CA523 /* PostTagService.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9D81C4EEEF4000CA523 /* PostTagService.m */; };
 		082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9DC1C4F035E000CA523 /* PostTag.m */; };
+		08472A201C727E020040769D /* PostServiceOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 08472A1F1C727E020040769D /* PostServiceOptions.m */; };
 		08A6FD9C1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A6FD9B1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m */; };
 		08CC677E1C49B65A00153AD7 /* MenuItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC67791C49B65A00153AD7 /* MenuItem.m */; };
 		08CC677F1C49B65A00153AD7 /* Menu.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC677A1C49B65A00153AD7 /* Menu.m */; };
@@ -791,6 +792,8 @@
 		082AB9D81C4EEEF4000CA523 /* PostTagService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostTagService.m; sourceTree = "<group>"; };
 		082AB9DB1C4F035E000CA523 /* PostTag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostTag.h; sourceTree = "<group>"; };
 		082AB9DC1C4F035E000CA523 /* PostTag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostTag.m; sourceTree = "<group>"; };
+		08472A1E1C7273FA0040769D /* PostServiceOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PostServiceOptions.h; sourceTree = "<group>"; };
+		08472A1F1C727E020040769D /* PostServiceOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostServiceOptions.m; sourceTree = "<group>"; };
 		08A6FD9A1C5960AB00AC33E4 /* RemoteTaxonomyPaging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteTaxonomyPaging.h; path = "Remote Objects/RemoteTaxonomyPaging.h"; sourceTree = "<group>"; };
 		08A6FD9B1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteTaxonomyPaging.m; path = "Remote Objects/RemoteTaxonomyPaging.m"; sourceTree = "<group>"; };
 		08CC67771C49B52E00153AD7 /* WordPress 45.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 45.xcdatamodel"; sourceTree = "<group>"; };
@@ -3018,6 +3021,8 @@
 				93FA59DC18D88C1C001446BC /* PostCategoryService.m */,
 				082AB9D71C4EEEF4000CA523 /* PostTagService.h */,
 				082AB9D81C4EEEF4000CA523 /* PostTagService.m */,
+				08472A1E1C7273FA0040769D /* PostServiceOptions.h */,
+				08472A1F1C727E020040769D /* PostServiceOptions.m */,
 				E1A6DBE319DC7D230071AC1E /* PostService.h */,
 				E1A6DBE419DC7D230071AC1E /* PostService.m */,
 				B535209C1AF7EB9F00B33BA8 /* PushAuthenticationService.swift */,
@@ -4863,6 +4868,7 @@
 				E1249B4B1940AECC0035E895 /* CommentServiceRemoteREST.m in Sources */,
 				E1266D2D1BBE8B9A00FCB6B6 /* Gravatar.swift in Sources */,
 				E240859C183D82AE002EB0EF /* WPAnimatedBox.m in Sources */,
+				08472A201C727E020040769D /* PostServiceOptions.m in Sources */,
 				852416CF1A12EBDD0030700C /* AppRatingUtility.m in Sources */,
 				B5CC05F91962186D00975CAC /* Meta.m in Sources */,
 				E6431DE51C4E892900FD8D90 /* SharingConnectionsViewController.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -803,6 +803,7 @@
 		08CC677B1C49B65A00153AD7 /* Menu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Menu.h; sourceTree = "<group>"; };
 		08CC677C1C49B65A00153AD7 /* MenuLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuLocation.h; sourceTree = "<group>"; };
 		08CC677D1C49B65A00153AD7 /* MenuLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuLocation.m; sourceTree = "<group>"; };
+		08F37EC61C7554EF0095BE8B /* PostServiceRemoteOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostServiceRemoteOptions.h; sourceTree = "<group>"; };
 		0B2A5E7CD1F8E32549F3DC7E /* Pods-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release.xcconfig"; sourceTree = "<group>"; };
 		0CE0577B6AC0CF064C42E6EA /* Pods-WordPress.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release-internal.xcconfig"; sourceTree = "<group>"; };
 		0CF877DC71756EFA3346E26F /* Pods-WordPressTodayWidget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTodayWidget.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTodayWidget/Pods-WordPressTodayWidget.debug.xcconfig"; sourceTree = "<group>"; };
@@ -2659,6 +2660,7 @@
 				E1DF5DFA19E7CFAE004E70D5 /* TaxonomyServiceRemoteREST.m */,
 				E1DF5DFB19E7CFAE004E70D5 /* TaxonomyServiceRemoteXMLRPC.h */,
 				E1DF5DFC19E7CFAE004E70D5 /* TaxonomyServiceRemoteXMLRPC.m */,
+				08F37EC61C7554EF0095BE8B /* PostServiceRemoteOptions.h */,
 				E1A6DBDC19DC7D140071AC1E /* PostServiceRemote.h */,
 				E1A6DBDD19DC7D140071AC1E /* PostServiceRemoteREST.h */,
 				E1A6DBDE19DC7D140071AC1E /* PostServiceRemoteREST.m */,

--- a/WordPress/WordPressTest/PostServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/PostServiceRemoteRESTTests.m
@@ -89,9 +89,9 @@
              failure:[OCMArg isNotNil]]);
     
     XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithApi:api siteID:blog.dotComID]);
-    
+
     [service getPostsOfType:postType
-                    success:^(NSArray *posts) {}
+                    success:^(NSArray<RemotePost *> *remotePosts) {}
                     failure:^(NSError *error) {}];
 }
 
@@ -127,7 +127,7 @@
     
     [service getPostsOfType:postType
                     options:options
-                    success:^(NSArray *posts) {}
+                    success:^(NSArray<RemotePost *> *remotePosts) {}
                     failure:^(NSError *error) {}];
 }
 


### PR DESCRIPTION
Originally, the `PostService` implementation did a couple things in which it managed paging of posts itself. In some sense, this just about attempted to manage its own state by paging requests based on whatever oldest post happened to be in CoreData, and also with purging any posts that weren't a part of a sync or paging request.

The above was an issue while implementing a new endpoint within `PostService` for searching posts. Searching posts created an issue because resulting posts would break the assumed paging of `PostService` implementation.

The primary refactor of this PR is within `PostService` and separating the use of sync and paging parameters instead on users of `PostService` via a new object parameter class `PostServiceOptions`. 

The secondary refactor is within `AbstractPostListViewController` and its supporting files, due to how intertwined the previous `PostService` sync, paging, and purge implementation were. `AbstractPostListViewController` now handles paging on its own and filters posts according to the sync results. Particularly, posts that are older than the `oldestPostDate` are filtered out of the `NSFetchRequest` to ensure posts arbitrarily loaded into CoreData are not displayed in a paged list (search results).

Additional refactoring includes method naming cleanup, use of generics and a bit of code-cleanup for clarity of what's going on.

**Testing:**
1. Open "Blog Posts", posts should load normally and in order from newest to oldest.
2. Scroll down the bottom of the list, older posts should load in order.
3. Continuing scrolling to load old posts until a desirable depth is reached.
4. Select either "Everyone" or "Only" in the segmented control above.
5. Posts should behave as expected as in steps 1, 2, 3.
6. Switch back to the previous segmented control option, the post list should be at the top and paging should continue where you left off for either segment control option.
7. Select a post to view it, go back, post list should maintain scroll position except for significant updates of ordering (unlikely).
8. Create a new post and post it, post should show up at the top of the list.
9. Select different post filters from the drop down, posts should display, page and order as expected.
10. Go back to the Site menu and select "Pages". Everything should work as expected 😎.

Please review @aerych 💥💥💥💥💥