### PR TITLE
Notifications: Fixing Empty State Overlap

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -897,7 +897,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 - (void)showNoResultsViewIfNeeded
 {
     // Remove If Needed
-    if (self.tableViewHandler.resultsController.fetchedObjects.count) {
+    if (!self.showsEmptyStateLegend) {
         [self.noResultsView removeFromSuperview];
         
         // Show filters if we have results

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -303,7 +303,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 
 - (void)showFiltersSegmentedControlIfApplicable
 {
-    if (!self.showsJetpackMessage && self.tableHeaderView.alpha == WPAlphaZero) {
+    if (self.tableHeaderView.alpha == WPAlphaZero && self.shouldDisplayFilters) {
         [UIView animateWithDuration:WPAnimationDurationDefault delay:0.0 options:UIViewAnimationCurveEaseIn animations:^{
             self.tableHeaderView.alpha = WPAlphaFull;
         } completion:nil];
@@ -312,10 +312,10 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 
 - (void)hideFiltersSegmentedControlIfApplicable
 {
-    if (self.showsJetpackMessage && self.tableHeaderView.alpha == WPAlphaFull) {
         [UIView animateWithDuration:WPAnimationDurationDefault delay:0.0 options:UIViewAnimationCurveEaseOut animations:^{
             self.tableHeaderView.alpha  = WPAlphaZero;
         } completion:nil];
+    if (self.tableHeaderView.alpha == WPAlphaFull && !self.shouldDisplayFilters) {
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -327,6 +327,11 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     notesBucket.notifyWhileIndexing = YES;
 }
 
+- (BOOL)shouldDisplayFilters
+{
+    return !self.showsJetpackMessage && !self.showsEmptyStateLegend;
+}
+
 
 #pragma mark - AppBotX Helpers
 
@@ -968,6 +973,11 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     BOOL showsJetpackMessage        = ![accountService defaultWordPressComAccount];
     
     return showsJetpackMessage;
+}
+
+- (BOOL)showsEmptyStateLegend
+{
+    return (self.tableViewHandler.resultsController.fetchedObjects.count == 0);
 }
 
 - (void)didTapNoResultsView:(WPNoResultsView *)noResultsView

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -312,10 +312,8 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 
 - (void)hideFiltersSegmentedControlIfApplicable
 {
-        [UIView animateWithDuration:WPAnimationDurationDefault delay:0.0 options:UIViewAnimationCurveEaseOut animations:^{
-            self.tableHeaderView.alpha  = WPAlphaZero;
-        } completion:nil];
     if (self.tableHeaderView.alpha == WPAlphaFull && !self.shouldDisplayFilters) {
+        self.tableHeaderView.alpha  = WPAlphaZero;
     }
 }
 


### PR DESCRIPTION
#### Details:
In this PR we'll fix an overlap between the Notification Filters and the Empty State Label, whenever the App ratings utility is displayed.

@kurzee may i bother you with a review?
Thanks in advance Brent!

Fixes #4536

#### Testing Steps:
1. Hack [this helper](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/Utility/Ratings/AppRatingUtility.m#L281) so that it always returns YES.
2. Log into an account that has no notifications (DM me, got a bunch of testing accounts!)
3. Tap over the Notifications tab

Notice that the Empty State legend won't be overlapping with the filters anymore. After receiving a new notification, the filters should show up automatically.
