### PR TITLE
Issue/4814 helpshift deprecated fix

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -21,7 +21,7 @@ target 'WordPress', :exclusive => true do
   pod 'Mixpanel', '2.8.2'
   pod 'CocoaLumberjack', '~> 2.2.0'
   pod 'HockeySDK', '~>3.8.0'
-  pod 'Helpshift', '~>4.15.0'
+  pod 'Helpshift', '~> 5.3.0-support'
   pod 'Lookback', '1.1.4', :configurations => ['Release-Internal', 'Release-Alpha']
   pod 'MRProgress', '~>0.7.0'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -66,7 +66,7 @@ PODS:
   - FormatterKit/TimeIntervalFormatter (1.8.0)
   - FormatterKit/UnitOfInformationFormatter (1.8.0)
   - FormatterKit/URLRequestFormatter (1.8.0)
-  - Helpshift (4.15.0)
+  - Helpshift (5.3.0-supportXcode6)
   - HockeySDK (3.8.5):
     - HockeySDK/AllFeaturesLib (= 3.8.5)
   - HockeySDK/AllFeaturesLib (3.8.5)
@@ -194,7 +194,7 @@ DEPENDENCIES:
   - EmailChecker (from `https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec`)
   - Expecta (= 0.3.2)
   - FormatterKit (~> 1.8.0)
-  - Helpshift (~> 4.15.0)
+  - Helpshift (~> 5.3.0-support)
   - HockeySDK (~> 3.8.0)
   - KIF/IdentifierTests (~> 3.1)
   - Lookback (= 1.1.4)
@@ -268,7 +268,7 @@ SPEC CHECKSUMS:
   EmailChecker: 78dd8dfa9d004826c8b5889be6c380b72b837d44
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
-  Helpshift: 8bbba1dad877dd7fb7f18915949e5816f6471e3b
+  Helpshift: af8567ca7991c6d2c1aa76e10ee6e6893409c0a1
   HockeySDK: dd11a2b9da3372fd025643bee5bc10c8c613d169
   KIF: 0a82046d06f3648799cac522d2d0f7934214caac
   Lookback: 9ab9027ff246d2dc5ce34be483f70e4a6718280b

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -1,4 +1,5 @@
-#import <Helpshift/Helpshift.h>
+#import <Helpshift/HelpshiftCore.h>
+#import <Helpshift/HelpshiftSupport.h>
 #import <Mixpanel/Mixpanel.h>
 #import "SFHFKeychainUtils.h"
 #import <UIDeviceIdentifier/UIDeviceHardware.h>

--- a/WordPress/Classes/Utility/HelpshiftUtils.m
+++ b/WordPress/Classes/Utility/HelpshiftUtils.m
@@ -1,7 +1,8 @@
 #import "HelpShiftUtils.h"
 #import <Mixpanel/MPTweakInline.h>
 #import "WordPressComApiCredentials.h"
-#import <Helpshift/Helpshift.h>
+#import <Helpshift/HelpshiftCore.h>
+#import <Helpshift/HelpshiftSupport.h>
 
 NSString *const UserDefaultsHelpshiftEnabled = @"wp_helpshift_enabled";
 NSString *const UserDefaultsHelpshiftWasUsed = @"wp_helpshift_used";

--- a/WordPress/Classes/Utility/HelpshiftUtils.m
+++ b/WordPress/Classes/Utility/HelpshiftUtils.m
@@ -32,6 +32,7 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
 
 + (void)setup
 {
+    [HelpshiftCore initializeWithProvider:[HelpshiftSupport sharedInstance]];
     [[HelpshiftSupport sharedInstance] setDelegate:[HelpshiftUtils sharedInstance]];
     [HelpshiftCore installForApiKey:[WordPressComApiCredentials helpshiftAPIKey] domainName:[WordPressComApiCredentials helpshiftDomainName] appID:[WordPressComApiCredentials helpshiftAppId]];
 

--- a/WordPress/Classes/Utility/HelpshiftUtils.m
+++ b/WordPress/Classes/Utility/HelpshiftUtils.m
@@ -10,7 +10,7 @@ NSString *const HelpshiftUnreadCountUpdatedNotification = @"HelpshiftUnreadCount
 // This delay is required to give some time to Mixpanel to update the remote variable
 CGFloat const HelpshiftFlagCheckDelay = 10.0;
 
-@interface HelpshiftUtils () <HelpshiftDelegate>
+@interface HelpshiftUtils () <HelpshiftSupportDelegate>
 
 @property (nonatomic, assign) NSInteger unreadNotificationCount;
 
@@ -32,8 +32,8 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
 
 + (void)setup
 {
-    [[Helpshift sharedInstance] setDelegate:[HelpshiftUtils sharedInstance]];
-    [Helpshift installForApiKey:[WordPressComApiCredentials helpshiftAPIKey] domainName:[WordPressComApiCredentials helpshiftDomainName] appID:[WordPressComApiCredentials helpshiftAppId]];
+    [[HelpshiftSupport sharedInstance] setDelegate:[HelpshiftUtils sharedInstance]];
+    [HelpshiftCore installForApiKey:[WordPressComApiCredentials helpshiftAPIKey] domainName:[WordPressComApiCredentials helpshiftDomainName] appID:[WordPressComApiCredentials helpshiftAppId]];
 
     // We want to make sure Mixpanel updates the remote variable before we check for the flag
     [[HelpshiftUtils sharedInstance] performSelector:@selector(checkIfHelpshiftShouldBeEnabled)
@@ -84,12 +84,12 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
 
 + (void)refreshUnreadNotificationCount
 {
-    [[Helpshift sharedInstance] getNotificationCountFromRemote:YES];
+    [HelpshiftSupport getNotificationCountFromRemote:YES];
 }
 
-#pragma mark - Helpshift Delegate
+#pragma mark - HelpshiftSupport Delegate
 
-- (void)didReceiveInAppNotificationWithMessageCount:(NSInteger)count;
+- (void)didReceiveInAppNotificationWithMessageCount:(NSInteger)count
 {
     if (count > 0) {
         [WPAnalytics track:WPAnalyticsStatSupportReceivedResponseFromSupport];

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -115,7 +115,7 @@ final public class PushNotificationsManager : NSObject
     func registerDeviceToken(tokenData: NSData) {
         // We want to register Helpshift regardless so that way if a user isn't logged in
         // they can still get push notifications that we replied to their support ticket.
-        Helpshift.sharedInstance()?.registerDeviceToken(tokenData)
+        HelpshiftCore.registerDeviceToken(tokenData)
         Mixpanel.sharedInstance()?.people?.addPushDeviceToken(tokenData)
 
         // Don't bother registering for WordPress anything if the user isn't logged in
@@ -257,7 +257,7 @@ final public class PushNotificationsManager : NSObject
         let rootViewController = sharedApplication.keyWindow?.rootViewController
         let payload = userInfo as [NSObject : AnyObject]
         
-        Helpshift.sharedInstance()?.handleRemoteNotification(payload, withController: rootViewController)
+        HelpshiftCore.handleRemoteNotification(payload, withController: rootViewController)
         WPAnalytics.track(.SupportReceivedResponseFromSupport)
         
         completionHandler?(.NewData)

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
@@ -94,7 +94,7 @@ public class StartOverViewController: UITableViewController
             setupHelpshift(blog.account)
             
             let metadata = helpshiftMetadata(blog)
-            Helpshift.sharedInstance().showConversation(self, withOptions: metadata)
+            HelpshiftSupport.showConversation(self, withOptions: metadata)
         } else {
             if let contact = NSURL(string: "https://support.wordpress.com/contact/") {
                 UIApplication.sharedApplication().openURL(contact)
@@ -104,11 +104,11 @@ public class StartOverViewController: UITableViewController
 
     private func setupHelpshift(account: WPAccount) {
         let user = account.userID.stringValue
-        Helpshift.setUserIdentifier(user)
+        HelpshiftSupport.setUserIdentifier(user)
         
         let name = account.username
         let email = account.email
-        Helpshift.setName(name, andEmail: email)
+        HelpshiftCore.setName(name, andEmail: email)
     }
     
     private func helpshiftMetadata(blog: Blog) -> [NSObject: AnyObject] {
@@ -117,6 +117,6 @@ public class StartOverViewController: UITableViewController
             "Blog": blog.logDescription(),
             ]
 
-        return [HSCustomMetadataKey: options]
+        return [HelpshiftSupportCustomMetadataKey: options]
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -1054,7 +1054,7 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
     NSDictionary *metaData = @{@"Source": @"Failed login",
                                @"Username": self.viewModel.username,
                                @"SiteURL": self.viewModel.siteUrl};
-    
+
     [HelpshiftSupport showConversation:self withOptions:@{HelpshiftSupportCustomMetadataKey: metaData}];
     [WPAnalytics track:WPAnalyticsStatSupportOpenedHelpshiftScreen];
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -1,5 +1,5 @@
 #import <WPXMLRPC/WPXMLRPC.h>
-#import <Helpshift/Helpshift.h>
+#import <Helpshift/HelpshiftSupport.h>
 #import <WordPressShared/WPFontManager.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -1054,8 +1054,8 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
     NSDictionary *metaData = @{@"Source": @"Failed login",
                                @"Username": self.viewModel.username,
                                @"SiteURL": self.viewModel.siteUrl};
-
-    [[Helpshift sharedInstance] showConversation:self withOptions:@{HSCustomMetadataKey: metaData}];
+    
+    [HelpshiftSupport showConversation:self withOptions:@{HelpshiftSupportCustomMetadataKey: metaData}];
     [WPAnalytics track:WPAnalyticsStatSupportOpenedHelpshiftScreen];
 }
 

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -234,7 +234,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionFeedbackRows)
                                 NSString *emailAddress = ([responseObject valueForKey:@"email"]) ? [responseObject objectForKey:@"email"] : nil;
                                 NSString *userID = ([responseObject valueForKey:@"ID"]) ? [[responseObject objectForKey:@"ID"] stringValue] : nil;
 
-                                [Helpshift setUserIdentifier:userID];
+                                [HelpshiftSupport setUserIdentifier:userID];
                                 [self displayHelpshiftWindowOfType:helpshiftType withUsername:displayName andEmail:emailAddress andMetadata:metaData];
                             } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
                                 [self hideLoadingSpinner];
@@ -250,12 +250,12 @@ typedef NS_ENUM(NSInteger, SettingsSectionFeedbackRows)
                             andEmail:(NSString*)email
                          andMetadata:(NSDictionary*)metaData
 {
-    [Helpshift setName:username andEmail:email];
+    [HelpshiftCore setName:username andEmail:email];
 
     if (helpshiftType == kHelpshiftWindowTypeFAQs) {
-        [[Helpshift sharedInstance] showFAQs:self withOptions:@{HSCustomMetadataKey: metaData}];
+        [HelpshiftSupport showFAQs:self withOptions:@{HelpshiftSupportCustomMetadataKey: metaData}];
     } else if (helpshiftType == kHelpshiftWindowTypeConversation) {
-        [[Helpshift sharedInstance] showConversation:self withOptions:@{HSCustomMetadataKey: metaData}];
+        [HelpshiftSupport showConversation:self withOptions:@{HelpshiftSupportCustomMetadataKey: metaData}];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -5,7 +5,7 @@
 #import "WordPressAppDelegate.h"
 #import <CocoaLumberjack/DDFileLogger.h>
 #import "WPTableViewSectionHeaderFooterView.h"
-#import <Helpshift/Helpshift.h>
+#import <Helpshift/HelpshiftSupport.h>
 #import "WPAnalytics.h"
 #import <WordPressShared/WPStyleGuide.h>
 #import "ContextManager.h"


### PR DESCRIPTION
Fixes #4814

Cherry picked the helpshift update commit, so there should be no merge conflicts when merging 5.9.1 back in.

Needs review: @sendhil 