### PR TITLE
Fix crash on Account Settings for self hosted

### DIFF
--- a/WordPress/Classes/ViewRelated/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/AccountSettingsViewController.swift
@@ -3,12 +3,14 @@ import UIKit
 import RxSwift
 import WordPressComAnalytics
 
-func AccountSettingsViewController(account account: WPAccount) -> ImmuTableViewController {
-    let service = AccountSettingsService(userID: account.userID.integerValue, api: account.restApi)
+func AccountSettingsViewController(account account: WPAccount?) -> ImmuTableViewController {
+    let service = account.map({ account in
+        return AccountSettingsService(userID: account.userID.integerValue, api: account.restApi)
+    })
     return AccountSettingsViewController(service: service)
 }
 
-func AccountSettingsViewController(service service: AccountSettingsService) -> ImmuTableViewController {
+func AccountSettingsViewController(service service: AccountSettingsService?) -> ImmuTableViewController {
     let controller = AccountSettingsController(service: service)
     let viewController = ImmuTableViewController(controller: controller)
     return viewController
@@ -27,66 +29,109 @@ private struct AccountSettingsController: SettingsController {
 
     // MARK: - Initialization
 
-    let service: AccountSettingsService
+    let service: AccountSettingsService?
 
-    init(service: AccountSettingsService) {
+    init(service: AccountSettingsService?) {
         self.service = service
     }
-    
+
+    // MARK: - ImmuTableViewController
+
+    func tableViewModelWithPresenter(presenter: ImmuTablePresenter) -> Observable<ImmuTable> {
+        if let service = self.service {
+            return service.settings.map({ settings in
+                self.mapViewModel(settings, service: service, presenter: presenter)
+            })
+        } else {
+            return Observable.just(self.mapViewModel(nil, service: nil, presenter: presenter))
+        }
+    }
+
+    var errorMessage: Observable<String?> {
+        if let service = self.service {
+            return service.refresh
+                // replace errors with .Failed status
+                .catchErrorJustReturn(.Failed)
+                // convert status to string
+                .map({ $0.errorMessage })
+        } else {
+            return Observable.just(nil)
+        }
+    }
+
     // MARK: - Model mapping
 
-    func mapViewModel(settings: AccountSettings?, presenter: ImmuTablePresenter) -> ImmuTable {
-        let username = TextRow(
-            title: NSLocalizedString("Username", comment: "Account Settings Username label"),
-            value: settings?.username ?? "")
-
-        let email = TextRow(
-            title: NSLocalizedString("Email", comment: "Account Settings Email label"),
-            value: settings?.email ?? "")
-
-        let webAddress = EditableTextRow(
-            title: NSLocalizedString("Web Address", comment: "Account Settings Web Address label"),
-            value: settings?.webAddress ?? "",
-            action: presenter.push(editWebAddress())
-        )
-
+    func mapViewModel(settings: AccountSettings?, service: AccountSettingsService?, presenter: ImmuTablePresenter) -> ImmuTable {
+        let mediaHeader = NSLocalizedString("Media", comment: "Title label for the media settings section in the app settings")
         let uploadSize = MediaSizeRow(
             title: NSLocalizedString("Max Image Upload Size", comment: "Title for the image size settings option."),
             value: Int(MediaService.maxImageSizeSetting().width),
             onChange: mediaSizeChanged())
 
+        let editorHeader = NSLocalizedString("Editor", comment: "Title label for the editor settings section in the app settings")
         let visualEditor = SwitchRow(
             title: NSLocalizedString("Visual Editor", comment: "Option to enable the visual editor"),
             value: WPPostViewController.isNewEditorEnabled(),
             onChange: visualEditorChanged()
         )
 
-        return ImmuTable(sections: [
-            ImmuTableSection(
-                rows: [
-                    username,
-                    email,
-                    webAddress
-                ]),
-            ImmuTableSection(
-                headerText: NSLocalizedString("Media", comment: "Title label for the media settings section in the app settings"),
-                rows: [
-                    uploadSize
-                ],
-                footerText: nil),
-            ImmuTableSection(
-                headerText: NSLocalizedString("Editor", comment: "Title label for the editor settings section in the app settings"),
-                rows: [
-                    visualEditor
-                ],
-                footerText: nil)
-            ])
+        if let service = service {
+            let username = TextRow(
+                title: NSLocalizedString("Username", comment: "Account Settings Username label"),
+                value: settings?.username ?? "")
+            
+            let email = TextRow(
+                title: NSLocalizedString("Email", comment: "Account Settings Email label"),
+                value: settings?.email ?? "")
+            
+            let webAddress = EditableTextRow(
+                title: NSLocalizedString("Web Address", comment: "Account Settings Web Address label"),
+                value: settings?.webAddress ?? "",
+                action: presenter.push(editWebAddress(service))
+            )
+            
+            return ImmuTable(sections: [
+                ImmuTableSection(
+                    rows: [
+                        username,
+                        email,
+                        webAddress
+                    ]),
+                ImmuTableSection(
+                    headerText: mediaHeader,
+                    rows: [
+                        uploadSize
+                    ],
+                    footerText: nil),
+                ImmuTableSection(
+                    headerText: editorHeader,
+                    rows: [
+                        visualEditor
+                    ],
+                    footerText: nil)
+                ])
+        } else {
+            return ImmuTable(sections: [
+                ImmuTableSection(
+                    headerText: mediaHeader,
+                    rows: [
+                        uploadSize
+                    ],
+                    footerText: nil),
+                ImmuTableSection(
+                    headerText: editorHeader,
+                    rows: [
+                        visualEditor
+                    ],
+                    footerText: nil)
+                ])
+        }
     }
 
     // MARK: - Actions
 
-    func editWebAddress() -> ImmuTableRowControllerGenerator {
-        return editText(AccountSettingsChange.WebAddress, hint: NSLocalizedString("Shown publicly when you comment on blogs.", comment: "Help text when editing web address"))
+    func editWebAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
+        return editText(AccountSettingsChange.WebAddress, hint: NSLocalizedString("Shown publicly when you comment on blogs.", comment: "Help text when editing web address"), service: service)
     }
 
     func mediaSizeChanged() -> Int -> Void {

--- a/WordPress/Classes/ViewRelated/Me/MyProfileViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MyProfileViewController.swift
@@ -32,29 +32,45 @@ private struct MyProfileController: SettingsController {
     init(service: AccountSettingsService) {
         self.service = service
     }
-
+    
+    // MARK: - ImmuTableViewController
+    
+    func tableViewModelWithPresenter(presenter: ImmuTablePresenter) -> Observable<ImmuTable> {
+        return service.settings.map({ settings in
+            self.mapViewModel(settings, presenter: presenter)
+        })
+    }
+    
+    var errorMessage: Observable<String?> {
+        return service.refresh
+            // replace errors with .Failed status
+            .catchErrorJustReturn(.Failed)
+            // convert status to string
+            .map({ $0.errorMessage })
+    }
+    
     // MARK: - Model mapping
 
     func mapViewModel(settings: AccountSettings?, presenter: ImmuTablePresenter) -> ImmuTable {
         let firstNameRow = EditableTextRow(
             title: NSLocalizedString("First Name", comment: "My Profile first name label"),
             value: settings?.firstName ?? "",
-            action: presenter.push(editText(AccountSettingsChange.FirstName)))
+            action: presenter.push(editText(AccountSettingsChange.FirstName, service: service)))
 
         let lastNameRow = EditableTextRow(
             title: NSLocalizedString("Last Name", comment: "My Profile last name label"),
             value: settings?.lastName ?? "",
-            action: presenter.push(editText(AccountSettingsChange.LastName)))
+            action: presenter.push(editText(AccountSettingsChange.LastName, service: service)))
 
         let displayNameRow = EditableTextRow(
             title: NSLocalizedString("Display Name", comment: "My Profile display name label"),
             value: settings?.displayName ?? "",
-            action: presenter.push(editText(AccountSettingsChange.DisplayName)))
+            action: presenter.push(editText(AccountSettingsChange.DisplayName, service: service)))
 
         let aboutMeRow = EditableTextRow(
             title: NSLocalizedString("About Me", comment: "My Profile 'About me' label"),
             value: settings?.aboutMe ?? "",
-            action: presenter.push(editText(AccountSettingsChange.AboutMe)))
+            action: presenter.push(editText(AccountSettingsChange.AboutMe, service: service)))
 
         return ImmuTable(sections: [
             ImmuTableSection(rows: [

--- a/WordPress/Classes/ViewRelated/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/MeViewController.swift
@@ -175,14 +175,8 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
     func pushAccountSettings() -> ImmuTableAction {
         return { [unowned self] row in
-            guard let account = self.defaultAccount() else {
-                let error = "Tried to push Account Settings without a default account. This shouldn't happen"
-                assertionFailure(error)
-                DDLogSwift.logError(error)
-                return
-            }
             WPAppAnalytics.track(.OpenedAccountSettings)
-            let controller = AccountSettingsViewController(account: account)
+            let controller = AccountSettingsViewController(account: self.defaultAccount())
             self.navigationController?.pushViewController(controller, animated: true)
         }
     }

--- a/WordPress/Classes/ViewRelated/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/SettingsCommon.swift
@@ -1,45 +1,17 @@
 import RxSwift
 
-protocol SettingsController: ImmuTableController {
-    var service: AccountSettingsService { get }
-    func mapViewModel(settings: AccountSettings?, presenter: ImmuTablePresenter) -> ImmuTable
-}
-
-// MARK: - Shared implementation
-extension SettingsController {
-    var immutableRows: [ImmuTableRow.Type] {
-        return [
-            TextRow.self,
-            EditableTextRow.self,
-            MediaSizeRow.self,
-            SwitchRow.self]
-    }
-
-    func tableViewModelWithPresenter(presenter: ImmuTablePresenter) -> Observable<ImmuTable> {
-        return service.settings.map({ settings in
-            self.mapViewModel(settings, presenter: presenter)
-        })
-    }
-
-    var errorMessage: Observable<String?> {
-        return service.refresh
-            // replace errors with .Failed status
-            .catchErrorJustReturn(.Failed)
-            // convert status to string
-            .map({ $0.errorMessage })
-    }
-}
+protocol SettingsController: ImmuTableController {}
 
 // MARK: - Actions
 extension SettingsController {
-    func editText(changeType: (AccountSettingsChangeWithString), hint: String? = nil) -> ImmuTableRowControllerGenerator {
+    func editText(changeType: (AccountSettingsChangeWithString), hint: String? = nil, service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
         return { row in
             let row = row as! EditableTextRow
-            return self.controllerForEditableText(row, changeType: changeType, hint: hint)
+            return self.controllerForEditableText(row, changeType: changeType, hint: hint, service: service)
         }
     }
 
-    func controllerForEditableText(row: EditableTextRow, changeType: (AccountSettingsChangeWithString), hint: String? = nil, isPassword: Bool = false) -> SettingsTextViewController {
+    func controllerForEditableText(row: EditableTextRow, changeType: (AccountSettingsChangeWithString), hint: String? = nil, isPassword: Bool = false, service: AccountSettingsService) -> SettingsTextViewController {
         let title = row.title
         let value = row.value
 
@@ -54,7 +26,7 @@ extension SettingsController {
             value in
 
             let change = changeType(value)
-            self.service.saveChange(change)
+            service.saveChange(change)
             DDLogSwift.logDebug("\(title) changed: \(value)")
         }
 


### PR DESCRIPTION
I've removed most of the shared logic in SettingsCommon and only left the
ImmuTable action helpers there. My Profile doesn't make sense without a
service, while Account Settings still can display the app settings witout one.

The table view model and error logic is still similar for both, but not the
same, so each controller implements its own variant.

I also now pass the service to the action helpers explicitly to avoid having to
deal with optionals: the rows with actions that require a service won't be
displayed if there's no service.

Fixes #4842 
Cc: @astralbodies 
Needs Review: @jleandroperez 