### PR TITLE
NotificationTests: Explicitly cleaning up ContextManager Override

### DIFF
--- a/WordPress/WordPressTest/NotificationTests.m
+++ b/WordPress/WordPressTest/NotificationTests.m
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import "ContextManager-Internals.h"
 #import "TestContextManager.h"
 #import "Notification.h"
 
@@ -19,7 +20,10 @@
 - (void)tearDown
 {
     [super tearDown];
-    self.contextManager = nil;
+    
+    // Note: We'll force TestContextManager override reset, since, for (unknown reasons) the TestContextManager
+    // might be retained more than expected, and it may break other core data based tests.
+    [ContextManager overrideSharedInstance:nil];
 }
 
 - (void)testBadgeNotificationHasBadgeFlagSetToTrue


### PR DESCRIPTION
In this PR we'll explicitly cleanup the ContextManager Override. The Override is, apparently, getting retained more than expected, which might have weird side effects.

P.s.: Same kind of bug / fix already applied to `ContextManagerTests`.

May i bother you with a quick review / test @koke?
Fixes #4848