### PR TITLE
Newly created posts can now switch the parent VC's filter to be shown.

### DIFF
--- a/WordPress/Classes/Utility/Sharing/WordPressActivity.m
+++ b/WordPress/Classes/Utility/Sharing/WordPressActivity.m
@@ -63,7 +63,7 @@
 	
 	if ([WPPostViewController isNewEditorEnabled]) {
 		WPPostViewController * editPostViewController = [[WPPostViewController alloc] initWithTitle:self.title andContent:content andTags:self.tags andImage:nil];
-		editPostViewController.onClose = ^(){
+		editPostViewController.onClose = ^(WPPostViewController *viewController){
 			[weakSelf activityDidFinish:YES];
 		};
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.h
@@ -4,6 +4,8 @@
 
 @interface AbstractPostListViewController : UIViewController
 
-@property (nonatomic, strong) Blog *blog;
+@property (nonatomic, strong) Blog* __nullable blog;
+
+- (void)setFilterWithPostStatus:(NSString* __nonnull)status;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.h
@@ -6,6 +6,11 @@
 
 @property (nonatomic, strong) Blog* __nullable blog;
 
+/**
+ *  Sets the filtering of this VC to show the posts with the specified status.
+ *
+ *  @param      status      The status of the type of post we want to show.
+ */
 - (void)setFilterWithPostStatus:(NSString* __nonnull)status;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -747,6 +747,28 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     return [self.postListFilters objectAtIndex:[self indexForFilterWithType:PostListStatusFilterDraft]];
 }
 
+
+- (NSUInteger)indexOfFilterThatDisplaysPostsWithStatus:(NSString *)postStatus
+{
+    __block NSUInteger index = 0;
+    __block BOOL found = NO;
+    
+    [self.postListFilters enumerateObjectsUsingBlock:^(PostListFilter* _Nonnull filter, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([filter.statuses containsObject:postStatus]) {
+            index = idx;
+            found = YES;
+            *stop = YES;
+        }
+    }];
+    
+    if (!found) {
+        // The draft filter is the catch all by convention.
+        index = [self indexForFilterWithType:PostListStatusFilterDraft];
+    }
+    
+    return index;
+}
+
 - (NSInteger)indexForFilterWithType:(PostListStatusFilter)filterType
 {
     NSInteger index = [self.postListFilters indexOfObjectPassingTest:^BOOL(id obj, NSUInteger idx, BOOL *stop) {
@@ -839,6 +861,14 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     controller.modalPresentationStyle = UIModalPresentationPageSheet;
     controller.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     [self presentViewController:controller animated:YES completion:nil];
+}
+
+
+- (void)setFilterWithPostStatus:(NSString* __nonnull)status
+{
+    NSUInteger index = [self indexOfFilterThatDisplaysPostsWithStatus:status];
+    
+    [self setCurrentFilterIndex:index];
 }
 
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -817,13 +817,9 @@ const CGFloat DefaultHeightForFooterView = 44.0;
 
 - (PostListFilter *)filterThatDisplaysPostsWithStatus:(NSString *)postStatus
 {
-    for (PostListFilter *filter in self.availablePostListFilters) {
-        if ([filter.statuses containsObject:postStatus]) {
-            return filter;
-        }
-    }
-    // The draft filter is the catch all by convention.
-    return [self.availablePostListFilters objectAtIndex:[self indexForFilterWithType:PostListStatusFilterDraft]];
+    NSUInteger index = [self indexOfFilterThatDisplaysPostsWithStatus:postStatus];
+    
+    return self.availablePostListFilters[index];
 }
 
 
@@ -832,7 +828,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     __block NSUInteger index = 0;
     __block BOOL found = NO;
     
-    [self.postListFilters enumerateObjectsUsingBlock:^(PostListFilter* _Nonnull filter, NSUInteger idx, BOOL * _Nonnull stop) {
+    [self.availablePostListFilters enumerateObjectsUsingBlock:^(PostListFilter* _Nonnull filter, NSUInteger idx, BOOL* _Nonnull stop) {
         if ([filter.statuses containsObject:postStatus]) {
             index = idx;
             found = YES;

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -418,8 +418,6 @@ static const CGFloat PostListHeightForFooterView = 34.0;
 
 - (void)createPost
 {
-    UINavigationController *navController;
-
     if ([WPPostViewController isNewEditorEnabled]) {
         [self createPostInNewEditor];
     } else {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -483,7 +483,12 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     if ([WPPostViewController isNewEditorEnabled]) {
         WPPostViewController *postViewController = [[WPPostViewController alloc] initWithPost:apost mode:mode];
         
+        __weak __typeof(self) weakSelf = self;
+        
         postViewController.onClose = ^void(WPPostViewController* viewController) {
+            
+            [weakSelf setFilterWithPostStatus:viewController.post.status];
+            
             [viewController.navigationController popViewControllerAnimated:YES];
         };
         

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
@@ -29,7 +29,7 @@ extern NSString* const kWPEditorConfigURLParamEnabled;
 /*
  EditPostViewController instance will execute the onClose callback, if provided, whenever the UI is dismissed.
  */
-typedef void (^EditPostCompletionHandler)(void);
+typedef void (^EditPostCompletionHandler)(WPPostViewController* viewController);
 @property (nonatomic, copy, readwrite) EditPostCompletionHandler onClose;
 
 #pragma mark - Properties: Post

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1395,7 +1395,7 @@ EditImageDetailsViewControllerDelegate
     [WPAppAnalytics track:WPAnalyticsStatEditorClosed withBlog:self.post.blog];
     
     if (self.onClose) {
-        self.onClose();
+        self.onClose(self);
         self.onClose = nil;
     } else if (self.presentingViewController) {
         [self.presentingViewController dismissViewControllerAnimated:animated completion:nil];


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/769).

Basically when a post is created or edited in the new editor, and saved, the parent list makes sure that the post is visible by changing the filtering as necessary (ie: published, draft, pending, etc).

**Test 1:**
1. Launch the app
2. Open the list of posts for a blog
3. Set the filtering to "Published"
4. Create a new post
5. Set it to save as "Draft" in the optinons
6. Save the draft
7. The parent VC's filtering should be changed to "Drafts".

Variations of this test can be performed by changing the status.

**Test 2:**
1. Launch the app
2. Open the list of posts for a blog
3. Set the filtering to "Published"
4. Edit an existing post
5. Change it to "Draft" in the optinons
6. Save the draft
7. The parent VC's filtering should be changed to "Drafts".

Variations of this test can be performed by changing the status.

/cc @SergioEstevao for review.