### PR TITLE
BlogSettings: Maintain default languageID when syncing to blog withou…

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -830,7 +830,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     settings.name = remoteSettings.name;
     settings.tagline = remoteSettings.tagline;
     settings.privacy = remoteSettings.privacy ?: settings.privacy;
-    settings.languageID = remoteSettings.languageID;
+    settings.languageID = remoteSettings.languageID ?: settings.languageID;
     
     // Writing
     settings.defaultCategoryID = remoteSettings.defaultCategoryID ?: settings.defaultCategoryID;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -238,10 +238,11 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
         [remote syncSettingsWithSuccess:^(RemoteBlogSettings *settings) {
             [self.managedObjectContext performBlock:^{
                 [self updateSettings:blogInContext.settings withRemoteSettings:settings];
-                [self.managedObjectContext save:nil];
-                if (success) {
-                    success();
-                }
+                [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
+                    if (success) {
+                        success();
+                    }
+                }];
             }];
         }
         failure:failure];
@@ -259,10 +260,11 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
         [remote updateBlogSettings:[self remoteSettingFromSettings:blogInContext.settings]
                            success:^() {
                                [self.managedObjectContext performBlock:^{
-                                   [self.managedObjectContext save:nil];
-                                   if (success) {
-                                       success();
-                                   }
+                                   [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
+                                       if (success) {
+                                           success();
+                                       }
+                                   }];
                                }];
                            }
                            failure:failure];


### PR DESCRIPTION
Closes #4880 

Ensures that the required field `BlogSettings.languageID` is not overwritten by nil when syncing blog settings via XMLRPC.

To test:
1. Add an XMLRPC-using blog to the app.
2. Visit the Settings screen to trigger a BlogSettings merge with remote settings from remoteBlogSettingFromXMLRPCDictionary().
3. Back out to trigger a Core Data save that does not fail validation as noted in #4880.

Needs review: @jleandroperez