### PR TITLE
Disable My Profile and new Account Settings for 6.0

### DIFF
--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -9,6 +9,11 @@ enum FeatureFlag: Int {
     case Sharing
     /// My Sites > Site > Plans
     case Plans
+    /// Me > My Profile
+    case MyProfile
+    /// Me > Account Settings
+    /// Account Settings already existed prior to 6.0, and included application settings
+    case AccountSettings
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
         switch self {
@@ -17,6 +22,10 @@ enum FeatureFlag: Int {
         case .Sharing:
             return build(.Debug)
         case .Plans:
+            return build(.Debug)
+        case .MyProfile, .AccountSettings:
+            // Disabled until we figure out this:
+            // https://github.com/wordpress-mobile/WordPress-iOS/issues/4888
             return build(.Debug)
         }
     }

--- a/WordPress/Classes/ViewRelated/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/AccountSettingsViewController.swift
@@ -75,7 +75,7 @@ private struct AccountSettingsController: SettingsController {
             onChange: visualEditorChanged()
         )
 
-        if let service = service {
+        if Feature.enabled(.AccountSettings), let service = service {
             let username = TextRow(
                 title: NSLocalizedString("Username", comment: "Account Settings Username label"),
                 value: settings?.username ?? "")

--- a/WordPress/Classes/ViewRelated/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/MeViewController.swift
@@ -120,23 +120,42 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         let wordPressComAccount = NSLocalizedString("WordPress.com Account", comment: "WordPress.com sign-in/sign-out section header title")
 
         if loggedIn {
-            return ImmuTable(
-                sections: [
-                    ImmuTableSection(rows: [
-                        myProfile,
-                        accountSettings,
-                        notificationSettings
-                        ]),
-                    ImmuTableSection(rows: [
-                        helpAndSupport,
-                        about
-                        ]),
-                    ImmuTableSection(
-                        headerText: wordPressComAccount,
-                        rows: [
-                            logOut
-                        ])
-                ])
+            if Feature.enabled(.MyProfile) {
+                return ImmuTable(
+                    sections: [
+                        ImmuTableSection(rows: [
+                            myProfile,
+                            accountSettings,
+                            notificationSettings
+                            ]),
+                        ImmuTableSection(rows: [
+                            helpAndSupport,
+                            about
+                            ]),
+                        ImmuTableSection(
+                            headerText: wordPressComAccount,
+                            rows: [
+                                logOut
+                            ])
+                    ])
+            } else {
+                return ImmuTable(
+                    sections: [
+                        ImmuTableSection(rows: [
+                            accountSettings,
+                            notificationSettings
+                            ]),
+                        ImmuTableSection(rows: [
+                            helpAndSupport,
+                            about
+                            ]),
+                        ImmuTableSection(
+                            headerText: wordPressComAccount,
+                            rows: [
+                                logOut
+                            ])
+                    ])
+            }
         } else { // Logged out
             return ImmuTable(
                 sections: [


### PR DESCRIPTION
Since we still don't have  a clear solution for #4888, let's disable My Profile and the new fields in Account Settings in 6.0, and keep working on a solution for 6.1.

The easiest way to test is to change `build(.Debug)` to `false` in `FeatureFlag`. My Profile should be gone from Me, and Account Settings should only show the media size and visual editor options.

cc @diegoreymendez @sendhil @rachelmcr 
Needs Review: @jleandroperez 