### PR TITLE
Use safe expectations when parsing Media objects.

### DIFF
--- a/WordPress/Classes/Networking/MediaServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteREST.m
@@ -194,8 +194,8 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 {
     RemoteMedia * remoteMedia=[[RemoteMedia alloc] init];
     remoteMedia.mediaID =  [jsonMedia numberForKey:@"ID"];
-    remoteMedia.url = [NSURL URLWithString:jsonMedia[@"URL"]];
-    remoteMedia.guid = [NSURL URLWithString:jsonMedia[@"guid"]];
+    remoteMedia.url = [NSURL URLWithString:[jsonMedia stringForKey:@"URL"]];
+    remoteMedia.guid = [NSURL URLWithString:[jsonMedia stringForKey:@"guid"]];
     remoteMedia.date = [NSDate dateWithWordPressComJSONString:jsonMedia[@"date"]];
     remoteMedia.postID = [jsonMedia numberForKey:@"post_ID"];
     remoteMedia.file = [jsonMedia stringForKey:@"file"];


### PR DESCRIPTION
Fix crash on Media parsing detected on Crashlytics.

https://fabric.io/automattic/ios/apps/org.wordpress/issues/56508180f5d3a7f76bc18d84/sessions/a998377dcb0945068d93a03719309a4f

Needs Review: @frosty 