### PR TITLE
Don't hide the back buton when saving password

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -706,7 +706,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     siteTitleViewController.title = NSLocalizedString(@"Password", @"Title for screen that shows self hosted password editor.");
     siteTitleViewController.onValueChanged = ^(id value) {
         if (![value isEqualToString:self.blog.password]) {
-            [self.navigationItem setHidesBackButton:YES animated:YES];
             self.password = value;
             [self validateLoginCredentials];
         }
@@ -980,7 +979,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         }
         BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:strongSelf.blog.managedObjectContext];
         [blogService updatePassword:strongSelf.password forBlog:strongSelf.blog];
-        [strongSelf.navigationItem setHidesBackButton:NO animated:NO];
     } failure:^(NSError *error){
         [SVProgressHUD dismiss];
         [weakSelf loginValidationFailedWithError:error];
@@ -990,7 +988,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 
 - (void)loginValidationFailedWithError:(NSError *)error
 {
-    [self.navigationItem setHidesBackButton:NO animated:NO];
     self.password = self.blog.password;    
     if (error) {
         NSString *message;


### PR DESCRIPTION
Hiding the button has a weird side effect where it would hide after pushing a
new view controller, and you'd be stuck.

Since the modal "Authenticating..." is shown while validating the credentials,
and you can't tap Back anyway, there's no need to hide the button.

Fixes #4885 
Needs Review: @SergioEstevao 