### PR TITLE
Improve description of activity logs

### DIFF
--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
@@ -156,7 +156,7 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
 - (NSString *)titleForFooterInSection:(NSInteger)section
 {
     if (section == 0) {
-        return NSLocalizedString(@"Seven days worth of log files are kept on file.", @"");
+        return NSLocalizedString(@"Up to seven days worth of logs are saved.", @"Help text shown below the list of debug logs.");
     }
     return nil;
 }


### PR DESCRIPTION
That was an easy one.
The tricky question: should I search and replace in the strings file, so we reuse the existing translations? I'd guess many of them won't have this issue.

Fixes #1640
Needs Review: @aerych 