### PR TITLE
Support for shared Safari web credentials on login

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -34,7 +34,7 @@ target 'WordPress', :exclusive => true do
   pod 'WordPress-iOS-Shared', '0.5.1'
   pod 'WordPress-iOS-Editor', '1.1.2'
   pod 'WordPressCom-Stats-iOS/UI', '0.6.2'
-  pod 'WordPressCom-Analytics-iOS', '0.1.3'
+  pod 'WordPressCom-Analytics-iOS', '0.1.4'
   pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
   pod 'WPMediaPicker', '~> 0.8.1'
   pod 'ReactiveCocoa', '~> 2.4.7'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -166,7 +166,7 @@ PODS:
   - WordPressApi (0.3.6):
     - AFNetworking (~> 2.6.0)
     - wpxmlrpc (~> 0.7)
-  - WordPressCom-Analytics-iOS (0.1.3)
+  - WordPressCom-Analytics-iOS (0.1.4)
   - WordPressCom-Stats-iOS/Services (0.6.2):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (~> 2.2.0)
@@ -222,7 +222,7 @@ DEPENDENCIES:
   - WordPress-iOS-Editor (= 1.1.2)
   - WordPress-iOS-Shared (= 0.5.1)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
-  - WordPressCom-Analytics-iOS (= 0.1.3)
+  - WordPressCom-Analytics-iOS (= 0.1.4)
   - WordPressCom-Stats-iOS/Services (= 0.6.2)
   - WordPressCom-Stats-iOS/UI (= 0.6.2)
   - WPMediaPicker (~> 0.8.1)
@@ -294,7 +294,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Editor: 20b958fb699f2df8848da0e22a36ae21803b09d2
   WordPress-iOS-Shared: ced218039d88c91572f3205882832f7a05c61f97
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
-  WordPressCom-Analytics-iOS: 55c52378f752ad8a8bbbd8bd75db0eb4b5a93d34
+  WordPressCom-Analytics-iOS: 1d4cf0426fdc91393ea1ba65daf19133e440ff6a
   WordPressCom-Stats-iOS: f1e9e7c3f214cdf347db3e6a239f77004c08f8be
   WPMediaPicker: 49547df8644892215b357cb94fa08dae5ebde469
   wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -541,6 +541,9 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         case WPAnalyticsStatSafariCredentialsLoginFilled:
             eventName = @"safari_credentials_login_filled";
             break;
+        case WPAnalyticsStatSafariCredentialsLoginUpdated:
+            eventName = @"safari_credentials_login_updated";
+            break;
         case WPAnalyticsStatSelectedInstallJetpack:
             eventName = @"stats_install_jetpack_selected";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -538,6 +538,9 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         case WPAnalyticsStatReaderTagUnfollowed:
             eventName = @"reader_reader_tag_unfollowed";
             break;
+        case WPAnalyticsStatSafariCredentialsLoginFilled:
+            eventName = @"safari_credentials_login_filled";
+            break;
         case WPAnalyticsStatSelectedInstallJetpack:
             eventName = @"stats_install_jetpack_selected";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -846,6 +846,9 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatTwoFactorCodeRequested:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Two Factor - Requested Verification Code"];
             break;
+        case WPAnalyticsStatSafariCredentialsLoginFilled:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Safari Credentials - Login Filled"];
+            break;
         case WPAnalyticsStatShortcutLogIn:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"3D Touch Shortcut - Log In"];
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -849,6 +849,9 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatSafariCredentialsLoginFilled:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Safari Credentials - Login Filled"];
             break;
+        case WPAnalyticsStatSafariCredentialsLoginUpdated:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Safari Credentials - Login Updated"];
+            break;
         case WPAnalyticsStatShortcutLogIn:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"3D Touch Shortcut - Log In"];
             break;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -308,7 +308,11 @@ static NSString * const LoginSharedWebCredentialFQDN = @"wordpress.com";
     SecAddSharedWebCredential(fqdnStr, usernameStr, passwordStr, ^(CFErrorRef  _Nullable error) {
         if (error) {
             DDLogError(@"Error occurred updating shared web credential: %@", error);
+            return;
         }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [WPAnalytics track:WPAnalyticsStatSafariCredentialsLoginUpdated];
+        })
     });
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -272,6 +272,8 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
         // Update the fields for display
         [weakSelf setUsernameTextValue:username];
         [weakSelf setPasswordTextValue:password];
+        
+        [WPAnalytics track:WPAnalyticsStatSafariCredentialsLoginFilled];
     }];
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -312,7 +312,7 @@ static NSString * const LoginSharedWebCredentialFQDN = @"wordpress.com";
         }
         dispatch_async(dispatch_get_main_queue(), ^{
             [WPAnalytics track:WPAnalyticsStatSafariCredentialsLoginUpdated];
-        })
+        });
     });
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
@@ -220,6 +220,8 @@ typedef void (^OverlayViewCallback)(WPWalkthroughOverlayView *);
 - (void)setFocusToMultifactorText;
 
 - (void)autoFillLoginWithSharedWebCredentialsIfAvailable;
+- (void)updateAutoFillLoginCredentialsIfNeeded:(NSString *)username password:(NSString *)password;
+
 - (void)displayErrorMessageForInvalidOrMissingFields;
 - (void)displayReservedNameErrorMessage;
 - (void)reloadInterfaceWithAnimation:(BOOL)animated;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
@@ -103,6 +103,7 @@
  */
 @property (nonatomic, assign) BOOL shouldReauthenticateDefaultAccount;
 
+
 /**
  *  The title of the sign in button
  */
@@ -218,6 +219,7 @@ typedef void (^OverlayViewCallback)(WPWalkthroughOverlayView *);
 - (void)setFocusToSiteUrlText;
 - (void)setFocusToMultifactorText;
 
+- (void)autoFillLoginWithSharedWebCredentialsIfAvailable;
 - (void)displayErrorMessageForInvalidOrMissingFields;
 - (void)displayReservedNameErrorMessage;
 - (void)reloadInterfaceWithAnimation:(BOOL)animated;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -491,6 +491,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
 - (void)finishedLoginWithUsername:(NSString *)username authToken:(NSString *)authToken requiredMultifactorCode:(BOOL)requiredMultifactorCode
 {
     [self dismissLoginMessage];
+    [self.presenter updateAutoFillLoginCredentialsIfNeeded:username password:self.password];
     
     if (self.shouldReauthenticateDefaultAccount) {
         [self.accountServiceFacade removeLegacyAccount:username];

--- a/WordPress/WordPress-Alpha.entitlements
+++ b/WordPress/WordPress-Alpha.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:wordpress.com</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.wordpress.alpha</string>

--- a/WordPress/WordPress-Internal.entitlements
+++ b/WordPress/WordPress-Internal.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:wordpress.com</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.wordpress.internal</string>

--- a/WordPress/WordPress.entitlements
+++ b/WordPress/WordPress.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:wordpress.com</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.wordpress</string>

--- a/WordPress/WordPress.entitlements
+++ b/WordPress/WordPress.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>webcredentials:wordpress.com</string>
-	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.wordpress</string>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4178,6 +4178,9 @@
 							com.apple.Keychain = {
 								enabled = 1;
 							};
+							com.apple.SafariKeychain = {
+								enabled = 1;
+							};
 						};
 					};
 					8511CFB51C607A7000B7CEED = {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4178,9 +4178,6 @@
 							com.apple.Keychain = {
 								enabled = 1;
 							};
-							com.apple.SafariKeychain = {
-								enabled = 1;
-							};
 						};
 					};
 					8511CFB51C607A7000B7CEED = {
@@ -5372,7 +5369,6 @@
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = WordPress.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = YES;
@@ -5416,7 +5412,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "be2385da-4206-4bf3-b7b3-8598943c8b87";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -5436,8 +5432,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = WordPress.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc. (PZYM8XX95Q)";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = YES;
@@ -5477,7 +5472,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "e2604f41-a7ef-448b-8fd9-5c48031085b8";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5521,8 +5516,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = WordPress.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc. (PZYM8XX95Q)";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = YES;
@@ -5563,7 +5557,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "427a9a94-c260-463e-9245-2643f8e1b2c6";
 				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
@@ -5823,8 +5817,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = "WordPress-Alpha.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = YES;
@@ -5867,7 +5860,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D ALPHA_BUILD -D INTERNAL_BUILD";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.alpha;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "f277d7c2-eff6-46cd-aaa3-6784e2b4dcfc";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6091,8 +6084,7 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = "WordPress-Internal.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = YES;
@@ -6134,7 +6126,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D INTERNAL_BUILD";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.internal;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE = "036de270-0b4a-4a46-aa03-342d07937bba";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4178,6 +4178,9 @@
 							com.apple.Keychain = {
 								enabled = 1;
 							};
+							com.apple.SafariKeychain = {
+								enabled = 1;
+							};
 						};
 					};
 					8511CFB51C607A7000B7CEED = {
@@ -5369,6 +5372,7 @@
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = WordPress.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = YES;
@@ -5412,7 +5416,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "be2385da-4206-4bf3-b7b3-8598943c8b87";
+				PROVISIONING_PROFILE = "";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -5432,7 +5436,8 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = WordPress.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc. (PZYM8XX95Q)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = YES;
@@ -5472,7 +5477,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "e2604f41-a7ef-448b-8fd9-5c48031085b8";
+				PROVISIONING_PROFILE = "";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -5516,7 +5521,8 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = WordPress.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc. (PZYM8XX95Q)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = YES;
@@ -5557,7 +5563,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "427a9a94-c260-463e-9245-2643f8e1b2c6";
+				PROVISIONING_PROFILE = "";
 				STRIP_INSTALLED_PRODUCT = NO;
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
@@ -5817,7 +5823,8 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = "WordPress-Alpha.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = YES;
@@ -5860,7 +5867,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D ALPHA_BUILD -D INTERNAL_BUILD";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.alpha;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "f277d7c2-eff6-46cd-aaa3-6784e2b4dcfc";
+				PROVISIONING_PROFILE = "";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6084,7 +6091,8 @@
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
 				CODE_SIGN_ENTITLEMENTS = "WordPress-Internal.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = YES;
@@ -6126,7 +6134,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D INTERNAL_BUILD";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.internal;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "036de270-0b4a-4a46-aa03-342d07937bba";
+				PROVISIONING_PROFILE = "";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
Adds support for iOS associated domains to pull in Safari saved passwords via the shared web credential functions. This will work for saved passwords that were entered on a FQDN of `wordpress.com` but not on any subdomains of `wordpress.com` or self-hosted sites.

Also includes support for updating a Safari saved password if the user autofills an out-of-date password and inputs the correct updated password text upon login.

**Testing:**

1. On a device, enable saved passwords and names in Safari settings.
2. Log in at http://wordpress.com/wp-login.php
3. When prompted, save password.
4. Open app and log out if needed.
5. Upon viewing the log in view, a prompt for using the saved password should present and autofill if accepted.

**Testing:**

1. Change the password for a wp.com account that is currently saved via Safari on a device.
2. Do not update the password in Safari.
3. Open WPiOS on the device and autofill the account with the account of the changed password.
4. Attempting to login will prompt an incorrect password message.
5. Update the password field with the correct password.
6. Upon login, a prompt should appear to update the shared Safari password.
7. The password should now updated and available for autofill.

_Do not merge_

NOTE: Waiting on the merge of stats: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS/pull/50 for building pass.