### PR TITLE
Switch to Xcode 7.2.1 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.1
+osx_image: xcode7.2
 language: objective-c
 xcode_workspace: WordPress.xcworkspace
 xcode_scheme: WordPress


### PR DESCRIPTION
Travis has been erroring a lot lately with simulator timeouts. I've read that just upgrading to 7.2 might fix it, so let's try.

Needs Review: @SergioEstevao 