### PR TITLE
Fetch product prices from StoreKit

### DIFF
--- a/WordPress/Classes/Extensions/WPNoResultsView+Model.swift
+++ b/WordPress/Classes/Extensions/WPNoResultsView+Model.swift
@@ -1,0 +1,25 @@
+import Foundation
+import WordPressShared
+
+extension WPNoResultsView {
+    struct Model {
+        let title: String
+        let message: String?
+        let accessoryView: UIView?
+        let buttonTitle: String?
+
+        init(title: String, message: String? = nil, accessoryView: UIView? = nil, buttonTitle: String? = nil) {
+            self.title = title
+            self.message = message
+            self.accessoryView = accessoryView
+            self.buttonTitle = buttonTitle
+        }
+    }
+
+    func bindViewModel(viewModel: Model) {
+        titleText = viewModel.title
+        messageText = viewModel.message
+        accessoryView = viewModel.accessoryView
+        buttonTitle = viewModel.buttonTitle
+    }
+}

--- a/WordPress/Classes/Models/Plan.swift
+++ b/WordPress/Classes/Models/Plan.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 typealias Plan = PlanEnum
-    
+
 /// Represents a WordPress.com free or paid plan.
 /// - seealso: [WordPress.com Store](https://store.wordpress.com/plans/)
 @objc
@@ -19,6 +19,18 @@ enum PlanEnum: Int {
             return "premium"
         case .Business:
             return "business"
+        }
+    }
+
+    /// The StoreKit product identifier, or nil for free plans
+    var productIdentifier: String? {
+        switch self {
+        case .Free:
+            return nil
+        case .Premium:
+            return "com.wordpress.test.premium.subscription.1year"
+        case .Business:
+            return "com.wordpress.test.business.subscription.1year"
         }
     }
     

--- a/WordPress/Classes/Models/Product.swift
+++ b/WordPress/Classes/Models/Product.swift
@@ -26,7 +26,7 @@ class MockProduct: NSObject, Product {
     let localizedDescription: String
     let localizedTitle: String
     let price: NSDecimalNumber
-    let priceLocale: NSLocale
+    var priceLocale: NSLocale
     let productIdentifier: String
 
     init(localizedDescription: String, localizedTitle: String, price: NSDecimalNumber, priceLocale: NSLocale, productIdentifier: String) {

--- a/WordPress/Classes/Models/Product.swift
+++ b/WordPress/Classes/Models/Product.swift
@@ -13,7 +13,6 @@ protocol Product {
     
     var productIdentifier: String { get }
 }
-typealias Products = [Product]
 
 extension SKProduct: Product {}
 

--- a/WordPress/Classes/Models/Product.swift
+++ b/WordPress/Classes/Models/Product.swift
@@ -1,0 +1,40 @@
+import Foundation
+import StoreKit
+
+@objc
+protocol Product {
+    var localizedDescription: String { get }
+    
+    var localizedTitle: String { get }
+    
+    var price: NSDecimalNumber { get }
+    
+    var priceLocale: NSLocale { get }
+    
+    var productIdentifier: String { get }
+}
+typealias Products = [Product]
+
+extension SKProduct: Product {}
+
+extension SKProduct {
+    public override var description: String {
+        return "<SKProduct: \(productIdentifier), title: \(localizedTitle)>"
+    }
+}
+
+class MockProduct: NSObject, Product {
+    let localizedDescription: String
+    let localizedTitle: String
+    let price: NSDecimalNumber
+    let priceLocale: NSLocale
+    let productIdentifier: String
+
+    init(localizedDescription: String, localizedTitle: String, price: NSDecimalNumber, priceLocale: NSLocale, productIdentifier: String) {
+        self.localizedDescription = localizedDescription
+        self.localizedTitle = localizedTitle
+        self.price = price
+        self.priceLocale = priceLocale
+        self.productIdentifier = productIdentifier
+    }
+}

--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct PlanService {
+    let store: StoreFacade
+
+    init(storeFacade: StoreFacade = StoreKitFacade()) {
+        self.store = storeFacade
+    }
+
+    func plansForBlog(siteID: Int, success: [Plan] -> Void, failure: ErrorType -> Void) {
+        // Hardcoded for now. Use success/failure in case we retrieve plans from the API instead.
+        success([.Free, .Premium, .Business])
+    }
+
+    func plansWithPricesForBlog(siteID: Int, success: [(Plan, String)] -> Void, failure: ErrorType -> Void) {
+        plansForBlog(siteID,
+            success: { plans in
+                return self.store.getPricesForPlans(plans,
+                    success: { prices in
+                        success(Array(zip(plans, prices)))
+                    }, failure: failure)
+            }, failure: failure)
+    }
+}

--- a/WordPress/Classes/Services/StoreFacade.swift
+++ b/WordPress/Classes/Services/StoreFacade.swift
@@ -1,0 +1,160 @@
+import Foundation
+import StoreKit
+
+enum ProductRequestError: ErrorType {
+    /// One of the requested product identifiers wasn't included in the response.
+    case MissingProduct
+
+    /// A product price couldn't be formatted into a String using the returned locale.
+    case InvalidProductPrice
+}
+
+protocol StoreFacade {
+    func getProductsWithIdentifiers(identifiers: Set<String>, success: Products -> Void, failure: ErrorType -> Void)
+}
+
+extension StoreFacade {
+    /// Requests prices for the given plans.
+    ///
+    /// On success, it calls the `success` function with an array of prices. If
+    /// one of the plans didn't have a product identifier, it's treated as a
+    /// "free" plan and the returned price will be an empty string.
+    func getPricesForPlans(plans: [Plan], success: [String] -> Void, failure: ErrorType -> Void) {
+        let identifiers = Set(plans.flatMap({ $0.productIdentifier }))
+        getProductsWithIdentifiers(
+            identifiers,
+            success: { products in
+                do {
+                    let prices = try plans.map({ plan -> String in
+                        return try priceForPlan(plan, products: products)
+                    })
+                    success(prices)
+                } catch let error {
+                    failure(error)
+                }
+            },
+            failure: failure
+        )
+    }
+}
+
+class StoreKitFacade: StoreFacade {
+    func getProductsWithIdentifiers(identifiers: Set<String>, success: Products -> Void, failure: ErrorType -> Void) {
+        let request = SKProductsRequest(productIdentifiers: identifiers)
+        let delegate = ProductRequestDelegate(onSuccess: success, onError: failure)
+        request.delegate = delegate
+
+        request.start()
+    }
+}
+
+/// Mock Store Facade to use while developing.
+///
+/// If you want to simulate a successful products request, use `MockStoreFacade.succeeding(after:)`.
+///
+/// If you want to simulate a failure, use `MockStoreFacade.failing(after:)`.
+///
+/// Both constructors support an optional `delay` parameter that defaults to 1 second.
+struct MockStoreFacade: StoreFacade {
+    /// Response delay in seconds
+    let delay: Double
+    let succeeds: Bool
+
+    static func succeeding(after delay: Double = 1.0) -> MockStoreFacade {
+        return MockStoreFacade(delay: delay, succeeds: true)
+    }
+
+    static func failing(after delay: Double = 1.0) -> MockStoreFacade {
+        return MockStoreFacade(delay: delay, succeeds: false)
+    }
+
+    let products = [
+        MockProduct(
+            localizedDescription: "1 year of WordPress.com Premium",
+            localizedTitle: "WordPress.com Premium 1 year",
+            price: NSDecimalNumber(float: 99.88),
+            priceLocale: NSLocale(localeIdentifier: "en-US"),
+            productIdentifier: "com.wordpress.test.premium.1year"
+        ),
+        MockProduct(
+            localizedDescription: "1 year of WordPress.com Business",
+            localizedTitle: "WordPress.com Business 1 year",
+            price: NSDecimalNumber(float: 299.88),
+            priceLocale: NSLocale(localeIdentifier: "en-US"),
+            productIdentifier: "com.wordpress.test.business.1year"
+        )
+    ]
+
+    func getProductsWithIdentifiers(identifiers: Set<String>, success: Products -> Void, failure: ErrorType -> Void) {
+        let products = identifiers.map({ identifier in
+            return self.products.filter({ $0.productIdentifier == identifier }).first
+        })
+        if !products.filter({ $0 == nil }).isEmpty {
+            failure(ProductRequestError.MissingProduct)
+        } else {
+            let products = products.flatMap({ $0 })
+
+            dispatch_after(
+                dispatch_time(DISPATCH_TIME_NOW, Int64(delay * Double(NSEC_PER_SEC))),
+                dispatch_get_main_queue()) {
+                    if (self.succeeds) {
+                        success(products)
+                    } else {
+                        failure(ProductRequestError.MissingProduct)
+                    }
+            }
+        }
+    }
+}
+
+private class ProductRequestDelegate: NSObject, SKProductsRequestDelegate {
+    typealias Success = Products -> Void
+    typealias Failure = ErrorType -> Void
+    
+    let onSuccess: Success
+    let onError: Failure
+    // Keeps a strong reference to self until the request finishes
+    var retainedDelegate: ProductRequestDelegate? = nil
+
+    init(onSuccess: Success, onError: Failure) {
+        self.onSuccess = onSuccess
+        self.onError = onError
+        super.init()
+        retainedDelegate = self
+    }
+    
+    @objc func productsRequest(request: SKProductsRequest, didReceiveResponse response: SKProductsResponse) {
+        if !response.invalidProductIdentifiers.isEmpty {
+            DDLogSwift.logWarn("Invalid product identifiers: \(response.invalidProductIdentifiers)")
+        }
+        onSuccess(response.products)
+    }
+    
+    @objc func request(request: SKRequest, didFailWithError error: NSError) {
+        onError(error)
+    }
+
+    @objc func requestDidFinish(request: SKRequest) {
+        retainedDelegate = nil
+    }
+}
+
+private func priceForProduct(identifier: String, products: Products) throws -> String {
+    guard let product = products.filter({ $0.productIdentifier == identifier }).first else {
+        throw ProductRequestError.MissingProduct
+    }
+    let formatter = NSNumberFormatter()
+    formatter.numberStyle = .CurrencyStyle
+    formatter.locale = product.priceLocale
+    guard let price = formatter.stringFromNumber(product.price) else {
+        throw ProductRequestError.InvalidProductPrice
+    }
+    return price
+}
+
+private func priceForPlan(plan: Plan, products: Products) throws -> String {
+    guard let identifier = plan.productIdentifier else {
+        return ""
+    }
+    return try priceForProduct(identifier, products: products)
+}

--- a/WordPress/Classes/Services/StoreFacade.swift
+++ b/WordPress/Classes/Services/StoreFacade.swift
@@ -10,7 +10,7 @@ enum ProductRequestError: ErrorType {
 }
 
 protocol StoreFacade {
-    func getProductsWithIdentifiers(identifiers: Set<String>, success: Products -> Void, failure: ErrorType -> Void)
+    func getProductsWithIdentifiers(identifiers: Set<String>, success: [Product] -> Void, failure: ErrorType -> Void)
 }
 
 extension StoreFacade {
@@ -39,7 +39,7 @@ extension StoreFacade {
 }
 
 class StoreKitFacade: StoreFacade {
-    func getProductsWithIdentifiers(identifiers: Set<String>, success: Products -> Void, failure: ErrorType -> Void) {
+    func getProductsWithIdentifiers(identifiers: Set<String>, success: [Product] -> Void, failure: ErrorType -> Void) {
         let request = SKProductsRequest(productIdentifiers: identifiers)
         let delegate = ProductRequestDelegate(onSuccess: success, onError: failure)
         request.delegate = delegate
@@ -85,7 +85,7 @@ struct MockStoreFacade: StoreFacade {
         )
     ]
 
-    func getProductsWithIdentifiers(identifiers: Set<String>, success: Products -> Void, failure: ErrorType -> Void) {
+    func getProductsWithIdentifiers(identifiers: Set<String>, success: [Product] -> Void, failure: ErrorType -> Void) {
         let products = identifiers.map({ identifier in
             return self.products.filter({ $0.productIdentifier == identifier }).first
         })
@@ -108,7 +108,7 @@ struct MockStoreFacade: StoreFacade {
 }
 
 private class ProductRequestDelegate: NSObject, SKProductsRequestDelegate {
-    typealias Success = Products -> Void
+    typealias Success = [Product] -> Void
     typealias Failure = ErrorType -> Void
     
     let onSuccess: Success
@@ -139,7 +139,7 @@ private class ProductRequestDelegate: NSObject, SKProductsRequestDelegate {
     }
 }
 
-private func priceForProduct(identifier: String, products: Products) throws -> String {
+private func priceForProduct(identifier: String, products: [Product]) throws -> String {
     guard let product = products.filter({ $0.productIdentifier == identifier }).first else {
         throw ProductRequestError.MissingProduct
     }
@@ -152,7 +152,7 @@ private func priceForProduct(identifier: String, products: Products) throws -> S
     return price
 }
 
-private func priceForPlan(plan: Plan, products: Products) throws -> String {
+private func priceForPlan(plan: Plan, products: [Product]) throws -> String {
     guard let identifier = plan.productIdentifier else {
         return ""
     }

--- a/WordPress/Classes/Services/StoreFacade.swift
+++ b/WordPress/Classes/Services/StoreFacade.swift
@@ -74,14 +74,14 @@ struct MockStoreFacade: StoreFacade {
             localizedTitle: "WordPress.com Premium 1 year",
             price: NSDecimalNumber(float: 99.88),
             priceLocale: NSLocale(localeIdentifier: "en-US"),
-            productIdentifier: "com.wordpress.test.premium.1year"
+            productIdentifier: "com.wordpress.test.premium.subscription.1year"
         ),
         MockProduct(
             localizedDescription: "1 year of WordPress.com Business",
             localizedTitle: "WordPress.com Business 1 year",
             price: NSDecimalNumber(float: 299.88),
             priceLocale: NSLocale(localeIdentifier: "en-US"),
-            productIdentifier: "com.wordpress.test.business.1year"
+            productIdentifier: "com.wordpress.test.business.subscription.1year"
         )
     ]
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -12,7 +12,7 @@ struct PlanListRow: ImmuTableRow {
     let icon: UIImage
 
     let action: ImmuTableAction?
-    
+
     func configureCell(cell: UITableViewCell) {
         WPStyleGuide.configureTableViewSmallSubtitleCell(cell)
         cell.imageView?.image = icon
@@ -69,35 +69,50 @@ struct PlanListRow: ImmuTableRow {
     }
 }
 
-struct PlanListViewModel {
-    let activePlan: Plan?
+enum PlanListViewModel {
+    case Loading
+    case Ready(activePlan: Plan, plans:[(Plan, String)])
+    case Error(String)
 
-    func tableViewModelWithPresenter(presenter: ImmuTablePresenter) -> ImmuTable {
-        let rowForPlan = rowGenerator(presenter)
-        return ImmuTable(sections: [
-            ImmuTableSection(
-                headerText: NSLocalizedString("WordPress.com Plans", comment: "Title for the Plans list header"),
-                rows: [
-                    rowForPlan(.Free),
-                    rowForPlan(.Premium),
-                    rowForPlan(.Business)
-                ])
-            ])
+    var noResultsViewModel: WPNoResultsView.Model? {
+        switch self {
+        case .Loading:
+            return WPNoResultsView.Model(
+                title: NSLocalizedString("Loading Plans...", comment: "Text displayed while loading plans details")
+            )
+        case .Ready(_):
+            return nil
+        case .Error(_):
+            return WPNoResultsView.Model(
+                title: NSLocalizedString("Oops", comment: ""),
+                message: NSLocalizedString("There was an error loading plans", comment: ""),
+                buttonTitle: NSLocalizedString("Contact support", comment: "")
+            )
+        }
     }
 
-    private func rowGenerator(presenter: ImmuTablePresenter) -> Plan -> PlanListRow {
-        return { [unowned presenter] plan in
-            let active = (self.activePlan == plan)
-            let icon = active ? plan.activeImage : plan.image
-
-            return PlanListRow(
-                title: plan.title,
-                active: active,
-                price: self.priceForPlan(plan),
-                description: plan.description,
-                icon: icon,
-                action: presenter.present(self.controllerForPlanDetails(plan))
-            )
+    func tableViewModelWithPresenter(presenter: ImmuTablePresenter) -> ImmuTable {
+        switch self {
+        case .Loading, .Error(_):
+            return ImmuTable.Empty
+        case .Ready(let activePlan, let plans):
+            let rows: [ImmuTableRow] = plans.map({ (plan, price) in
+                let active = (activePlan == plan)
+                let icon = active ? plan.activeImage : plan.image
+                return PlanListRow(
+                    title: plan.title,
+                    active: active,
+                    price: price,
+                    description: plan.description,
+                    icon: icon,
+                    action: presenter.present(self.controllerForPlanDetails(plan))
+                )
+            })
+            return ImmuTable(sections: [
+                ImmuTableSection(
+                    headerText: NSLocalizedString("WordPress.com Plans", comment: "Title for the Plans list header"),
+                    rows: rows)
+                ])
         }
     }
 
@@ -109,26 +124,40 @@ struct PlanListViewModel {
             return navigationVC
         }
     }
-
-    // TODO: Prices should always come from StoreKit
-    // @koke 2016-02-02
-    private func priceForPlan(plan: Plan) -> String {
-        switch plan {
-        case .Free:
-            return ""
-        case .Premium:
-            return "$99.99"
-        case .Business:
-            return "$299.99"
-        }
-    }
 }
 
-final class PlanListViewController: UITableViewController, ImmuTablePresenter {
+final class PlanListViewController: UITableViewController, ImmuTablePresenter, WPNoResultsViewDelegate {
     private lazy var handler: ImmuTableViewHandler = {
         return ImmuTableViewHandler(takeOver: self)
     }()
-    private let viewModel: PlanListViewModel
+    private var viewModel: PlanListViewModel = .Loading {
+        didSet {
+            handler.viewModel = viewModel.tableViewModelWithPresenter(self)
+            updateNoResults()
+        }
+    }
+
+    private let noResultsView = WPNoResultsView()
+
+    func updateNoResults() {
+            if let noResultsViewModel = viewModel.noResultsViewModel {
+                showNoResults(noResultsViewModel)
+            } else {
+                hideNoResults()
+            }
+    }
+    func showNoResults(viewModel: WPNoResultsView.Model) {
+        noResultsView.bindViewModel(viewModel)
+        if noResultsView.isDescendantOfView(tableView) {
+            noResultsView.centerInSuperview()
+        } else {
+            tableView.addSubviewWithFadeAnimation(noResultsView)
+        }
+    }
+
+    func hideNoResults() {
+        noResultsView.removeFromSuperview()
+    }
 
     static let restorationIdentifier = "PlanList"
 
@@ -136,17 +165,17 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
         self.init(activePlan: blog.plan)
     }
 
-    convenience init(activePlan: Plan?) {
-        let viewModel = PlanListViewModel(activePlan: activePlan)
-        self.init(viewModel: viewModel)
-    }
-
-    private init(viewModel: PlanListViewModel) {
-        self.viewModel = viewModel
+    // FIXME: inject active plan for now, get it from Blog ID later
+    // See https://github.com/wordpress-mobile/WordPress-iOS/issues/4818
+    // @koke 2016-02-29
+    let activePlan: Plan?
+    init(activePlan: Plan?) {
+        self.activePlan = activePlan
         super.init(style: .Grouped)
         title = NSLocalizedString("Plans", comment: "Title for the plan selector")
         restorationIdentifier = PlanListViewController.restorationIdentifier
         restorationClass = PlanListViewController.self
+        noResultsView.delegate = self
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -159,54 +188,52 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
         ImmuTable.registerRows([PlanListRow.self], tableView: tableView)
         handler.viewModel = viewModel.tableViewModelWithPresenter(self)
-    }
-}
-
-extension PlanListViewModel: Equatable {}
-func ==(lhs: PlanListViewModel, rhs: PlanListViewModel) -> Bool {
-    return lhs.activePlan == rhs.activePlan
-}
-
-/*
- Since PlanListViewModel is a struct, it can't conform to NSCoding.
- We're just using the same naming for convenience.
- */
-extension PlanListViewModel/*: NSCoding */ {
-    struct EncodingKey {
-        static let activePlan = "activePlan"
-
-    }
-    func encodeWithCoder(aCoder: NSCoder) {
-        if let plan = activePlan {
-            aCoder.encodeInteger(plan.rawValue, forKey: EncodingKey.activePlan)
-        }
+        updateNoResults()
     }
 
-    init(coder aDecoder: NSCoder) {
-        let planID: Int? = {
-            guard aDecoder.containsValueForKey(EncodingKey.activePlan) else {
-                return nil
-            }
-            return aDecoder.decodeIntegerForKey(EncodingKey.activePlan)
-        }()
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
 
-        let plan = planID.flatMap({ Plan(rawValue: $0) })
-        self.init(activePlan: plan)
+        let service = PlanService(storeFacade: StoreKitFacade())
+        service.plansWithPricesForBlog(0, success: { plansWithPrices in
+            // FIXME: this will crash if there's no active plan
+            // See https://github.com/wordpress-mobile/WordPress-iOS/issues/4818
+            // @koke 2016-02-29
+            self.viewModel = .Ready(activePlan: self.activePlan!, plans: plansWithPrices)
+            }, failure: { error in
+                self.viewModel = .Error(String(error))
+        })
+    }
+
+    func didTapNoResultsView(noResultsView: WPNoResultsView!) {
+        SupportViewController.showFromTabBar()
     }
 }
 
 extension PlanListViewController: UIViewControllerRestoration {
+    struct EncodingKey {
+        static let activePlan = "activePlan"
+    }
     static func viewControllerWithRestorationIdentifierPath(identifierComponents: [AnyObject], coder: NSCoder) -> UIViewController? {
         guard let identifier = identifierComponents.last as? String where identifier == PlanListViewController.restorationIdentifier else {
             return nil
         }
 
-        let viewModel = PlanListViewModel(coder: coder)
-        return PlanListViewController(viewModel: viewModel)
+        let planID: Int? = {
+            guard coder.containsValueForKey(EncodingKey.activePlan) else {
+                return nil
+            }
+            return coder.decodeIntegerForKey(EncodingKey.activePlan)
+        }()
+
+        let plan = planID.flatMap({ Plan(rawValue: $0) })
+        return PlanListViewController(activePlan: plan)
     }
 
     override func encodeRestorableStateWithCoder(coder: NSCoder) {
         super.encodeRestorableStateWithCoder(coder)
-        viewModel.encodeWithCoder(coder)
+        if let activePlan = self.activePlan {
+            coder.encodeInteger(activePlan.rawValue, forKey: EncodingKey.activePlan)
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -126,7 +126,7 @@ enum PlanListViewModel {
     }
 }
 
-final class PlanListViewController: UITableViewController, ImmuTablePresenter, WPNoResultsViewDelegate {
+final class PlanListViewController: UITableViewController, ImmuTablePresenter {
     private lazy var handler: ImmuTableViewHandler = {
         return ImmuTableViewHandler(takeOver: self)
     }()
@@ -204,11 +204,17 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter, W
                 self.viewModel = .Error(String(error))
         })
     }
+}
 
+// MARK: - WPNoResultsViewDelegate
+
+extension PlanListViewController: WPNoResultsViewDelegate {
     func didTapNoResultsView(noResultsView: WPNoResultsView!) {
         SupportViewController.showFromTabBar()
     }
 }
+
+// MARK: - UIViewControllerRestoration
 
 extension PlanListViewController: UIViewControllerRestoration {
     struct EncodingKey {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -498,6 +498,8 @@
 		E1418A101C59307A003214B7 /* PlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1418A0F1C59307A003214B7 /* PlanTests.swift */; };
 		E14200781C117A2E00B3B115 /* ManagedAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14200771C117A2E00B3B115 /* ManagedAccountSettings.swift */; };
 		E142007A1C117A3B00B3B115 /* ManagedAccountSettings+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14200791C117A3B00B3B115 /* ManagedAccountSettings+CoreDataProperties.swift */; };
+		E148362F1C6DF7D8005ACF53 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = E148362E1C6DF7D8005ACF53 /* Product.swift */; };
+		E14836311C6DF942005ACF53 /* StoreFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14836301C6DF942005ACF53 /* StoreFacade.swift */; };
 		E14977181C0DC0770057CD60 /* MediaSizeSliderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14977171C0DC0770057CD60 /* MediaSizeSliderCell.swift */; };
 		E149771A1C0DCB6F0057CD60 /* MediaSizeSliderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E14977191C0DCB6F0057CD60 /* MediaSizeSliderCell.xib */; };
 		E149D64E19349E69006A843D /* AccountServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = E149D64619349E69006A843D /* AccountServiceRemoteREST.m */; };
@@ -506,6 +508,7 @@
 		E14B13C31C4E7675009DD68F /* Reachability+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14B13C21C4E7675009DD68F /* Reachability+Rx.swift */; };
 		E14B40FD1C58B806005046F6 /* AccountSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14B40FC1C58B806005046F6 /* AccountSettingsViewController.swift */; };
 		E14B40FF1C58B93F005046F6 /* SettingsCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14B40FE1C58B93F005046F6 /* SettingsCommon.swift */; };
+		E14B74111C7B16FD00C26E21 /* WPNoResultsView+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14B74101C7B16FD00C26E21 /* WPNoResultsView+Model.swift */; };
 		E1556CF2193F6FE900FC52EA /* CommentService.m in Sources */ = {isa = PBXBuildFile; fileRef = E1556CF1193F6FE900FC52EA /* CommentService.m */; };
 		E15618FD16DB8677006532C4 /* UIKitTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = E15618FC16DB8677006532C4 /* UIKitTestHelper.m */; };
 		E15618FF16DBA983006532C4 /* xmlrpc-response-newpost.xml in Resources */ = {isa = PBXBuildFile; fileRef = E15618FE16DBA983006532C4 /* xmlrpc-response-newpost.xml */; };
@@ -542,6 +545,7 @@
 		E183ECB216B2179B00C2EB11 /* Twitter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC24E5F21577DFF400A6D5B5 /* Twitter.framework */; };
 		E1845F591BFF75D200B69421 /* AccountSettingsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1845F581BFF75D200B69421 /* AccountSettingsRemote.swift */; };
 		E18EE95119349EC300B0A40C /* ReaderTopicServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = E18EE95019349EC300B0A40C /* ReaderTopicServiceRemote.m */; };
+		E1926C091C779868009F3C2C /* PlanListViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B2FF581C637AE200F6BDEA /* PlanListViewControllerTest.swift */; };
 		E19A10CA1B010AA0006192B0 /* WPURLRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E19A10C91B010AA0006192B0 /* WPURLRequestTest.m */; };
 		E19DF741141F7BDD000002F3 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E19DF740141F7BDD000002F3 /* libz.dylib */; };
 		E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A03EE117422DCE0085D192 /* BlogToAccount.m */; };
@@ -560,7 +564,6 @@
 		E1AC282D18282423004D394C /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		E1B23B081BFB3B370006559B /* MyProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B23B071BFB3B370006559B /* MyProfileViewController.swift */; };
 		E1B289DB19F7AF7000DB0707 /* RemoteBlog.m in Sources */ = {isa = PBXBuildFile; fileRef = E1B289DA19F7AF7000DB0707 /* RemoteBlog.m */; };
-		E1B2FF591C637AE200F6BDEA /* PlanListViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B2FF581C637AE200F6BDEA /* PlanListViewControllerTest.swift */; };
 		E1B62A7B13AA61A100A6FCA4 /* WPWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E1B62A7A13AA61A100A6FCA4 /* WPWebViewController.m */; };
 		E1B912811BB00EFD003C25B9 /* People.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E1B912801BB00EFD003C25B9 /* People.storyboard */; };
 		E1B912831BB01047003C25B9 /* PeopleRoleBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B912821BB01047003C25B9 /* PeopleRoleBadgeView.swift */; };
@@ -580,6 +583,7 @@
 		E1D086E2194214C600F0CC19 /* NSDate+WordPressJSON.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D086E1194214C600F0CC19 /* NSDate+WordPressJSON.m */; };
 		E1D0D81616D3B86800E33F4C /* SafariActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D0D81516D3B86800E33F4C /* SafariActivity.m */; };
 		E1D458691309589C00BF0235 /* Coordinate.m in Sources */ = {isa = PBXBuildFile; fileRef = E14932B5130427B300154804 /* Coordinate.m */; };
+		E1D7FF381C74EB0E00E7E5E5 /* PlanService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1D7FF371C74EB0E00E7E5E5 /* PlanService.swift */; };
 		E1D86E691B2B414300DD2192 /* WordPress-32-33.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E1D86E681B2B414300DD2192 /* WordPress-32-33.xcmappingmodel */; };
 		E1D91456134A853D0089019C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E1D91454134A853D0089019C /* Localizable.strings */; };
 		E1D95EB817A28F5E00A3E9F3 /* WPActivityDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D95EB717A28F5E00A3E9F3 /* WPActivityDefaults.m */; };
@@ -1587,6 +1591,8 @@
 		E14200791C117A3B00B3B115 /* ManagedAccountSettings+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ManagedAccountSettings+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		E1457202135EC85700C7BAD2 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E1472EF915344A2A00D08657 /* WordPress 5.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 5.xcdatamodel"; sourceTree = "<group>"; };
+		E148362E1C6DF7D8005ACF53 /* Product.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
+		E14836301C6DF942005ACF53 /* StoreFacade.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreFacade.swift; sourceTree = "<group>"; };
 		E14932B4130427B300154804 /* Coordinate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Coordinate.h; sourceTree = "<group>"; };
 		E14932B5130427B300154804 /* Coordinate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Coordinate.m; sourceTree = "<group>"; };
 		E14977171C0DC0770057CD60 /* MediaSizeSliderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaSizeSliderCell.swift; sourceTree = "<group>"; };
@@ -1601,6 +1607,7 @@
 		E14B13C21C4E7675009DD68F /* Reachability+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Reachability+Rx.swift"; sourceTree = "<group>"; };
 		E14B40FC1C58B806005046F6 /* AccountSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsViewController.swift; sourceTree = "<group>"; };
 		E14B40FE1C58B93F005046F6 /* SettingsCommon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsCommon.swift; sourceTree = "<group>"; };
+		E14B74101C7B16FD00C26E21 /* WPNoResultsView+Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPNoResultsView+Model.swift"; sourceTree = "<group>"; };
 		E14D65C717E09663007E3EA4 /* Social.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Social.framework; path = System/Library/Frameworks/Social.framework; sourceTree = SDKROOT; };
 		E150520B16CAC5C400D3DDDC /* BlogJetpackTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogJetpackTest.m; sourceTree = "<group>"; };
 		E150520D16CAC75A00D3DDDC /* CoreDataTestHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreDataTestHelper.h; sourceTree = "<group>"; };
@@ -1705,6 +1712,7 @@
 		E1D086E1194214C600F0CC19 /* NSDate+WordPressJSON.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+WordPressJSON.m"; sourceTree = "<group>"; };
 		E1D0D81416D3B86800E33F4C /* SafariActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SafariActivity.h; sourceTree = "<group>"; };
 		E1D0D81516D3B86800E33F4C /* SafariActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SafariActivity.m; sourceTree = "<group>"; };
+		E1D7FF371C74EB0E00E7E5E5 /* PlanService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanService.swift; sourceTree = "<group>"; };
 		E1D86E671B2B406600DD2192 /* WordPress 33.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 33.xcdatamodel"; sourceTree = "<group>"; };
 		E1D86E681B2B414300DD2192 /* WordPress-32-33.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-32-33.xcmappingmodel"; sourceTree = "<group>"; };
 		E1D91455134A853D0089019C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -2218,6 +2226,7 @@
 				E125451712BF68F900D87A0A /* Page.m */,
 				E166FA1C1BB0658600374B5B /* Person.swift */,
 				E1418A0D1C592F8C003214B7 /* Plan.swift */,
+				E148362E1C6DF7D8005ACF53 /* Product.swift */,
 				838C672C1210C3C300B09CA3 /* Post.h */,
 				838C672D1210C3C300B09CA3 /* Post.m */,
 				833AF259114575A50016DE8F /* PostAnnotation.h */,
@@ -3032,6 +3041,7 @@
 				E1C5457D1C6B962D001CEB0E /* MediaSettings.swift */,
 				B5EFB1C11B31B98E007608A3 /* NotificationsService.swift */,
 				93FA59DB18D88C1C001446BC /* PostCategoryService.h */,
+				E1D7FF371C74EB0E00E7E5E5 /* PlanService.swift */,
 				93FA59DC18D88C1C001446BC /* PostCategoryService.m */,
 				082AB9D71C4EEEF4000CA523 /* PostTagService.h */,
 				082AB9D81C4EEEF4000CA523 /* PostTagService.m */,
@@ -3284,6 +3294,7 @@
 				E131F5341C2930FC00D2D975 /* String+Helpers.swift */,
 				E116D4401C50D5F400DC5593 /* Rx.swift */,
 				E678FC141C76241000F55F55 /* WPStyleGuide+ApplicationStyles.swift */,
+				E14B74101C7B16FD00C26E21 /* WPNoResultsView+Model.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3382,6 +3393,7 @@
 				85D239A61AE5A5FC0074768D /* LoginFacade.m */,
 				85D239A71AE5A5FC0074768D /* OnePasswordFacade.h */,
 				85D239A81AE5A5FC0074768D /* OnePasswordFacade.m */,
+				E14836301C6DF942005ACF53 /* StoreFacade.swift */,
 				85D239A91AE5A5FC0074768D /* WordPressComOAuthClientFacade.h */,
 				85D239AA1AE5A5FC0074768D /* WordPressComOAuthClientFacade.m */,
 				85D239AB1AE5A5FC0074768D /* WordPressXMLRPCAPIFacade.h */,
@@ -4678,6 +4690,7 @@
 				5D577D33189127BE00B964C3 /* PostGeolocationViewController.m in Sources */,
 				FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */,
 				1D3623260D0F684500981E51 /* WordPressAppDelegate.m in Sources */,
+				E1D7FF381C74EB0E00E7E5E5 /* PlanService.swift in Sources */,
 				5D7DEA2919D488DD0032EE77 /* WPStyleGuide+ReaderComments.swift in Sources */,
 				E1D86E691B2B414300DD2192 /* WordPress-32-33.xcmappingmodel in Sources */,
 				5DB3BA0818D11D8D00F3F3E9 /* PublishDatePickerView.m in Sources */,
@@ -4787,6 +4800,7 @@
 				93C486501810442200A24725 /* SupportViewController.m in Sources */,
 				B5509A9319CA38B3006D2E49 /* EditReplyViewController.m in Sources */,
 				E6D2E1651B8AAD7E0000ED14 /* ReaderSiteStreamHeader.swift in Sources */,
+				E14B74111C7B16FD00C26E21 /* WPNoResultsView+Model.swift in Sources */,
 				E1A6DBE119DC7D140071AC1E /* PostServiceRemoteREST.m in Sources */,
 				E166FA1B1BB0656B00374B5B /* PeopleCellViewModel.swift in Sources */,
 				83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */,
@@ -4985,6 +4999,7 @@
 				5DB93EEC19B6190700EC88EB /* CommentContentView.m in Sources */,
 				E14977181C0DC0770057CD60 /* MediaSizeSliderCell.swift in Sources */,
 				85D239BB1AE5A6620074768D /* LoginFields.m in Sources */,
+				E14836311C6DF942005ACF53 /* StoreFacade.swift in Sources */,
 				E61084C11B9B47BA008050C5 /* ReaderSiteTopic.swift in Sources */,
 				5DAE40AD19EC70930011A0AE /* ReaderPostHeaderView.m in Sources */,
 				74BB6F1A19AE7B9400FB7829 /* WPLegacyEditPageViewController.m in Sources */,
@@ -5074,6 +5089,7 @@
 				E14B13C31C4E7675009DD68F /* Reachability+Rx.swift in Sources */,
 				B587797C19B799D800E57C5A /* NSParagraphStyle+Helpers.swift in Sources */,
 				5D6C4B121B604190005E3C43 /* RichTextView.swift in Sources */,
+				E148362F1C6DF7D8005ACF53 /* Product.swift in Sources */,
 				082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */,
 				5D119DA3176FBE040073D83A /* UIImageView+AFNetworkingExtra.m in Sources */,
 				5DF59C0B1770AE3A00171208 /* UILabel+SuggestSize.m in Sources */,
@@ -5162,6 +5178,7 @@
 				93B853231B4416A30064FE72 /* WPAnalyticsTrackerAutomatticTracksTests.m in Sources */,
 				E66969CA1B9E0C4F00EC9C00 /* ReaderTopicServiceRemoteTests.m in Sources */,
 				5DFA7EBC1AF7B8D30072023B /* NSDateStringFormattingTest.m in Sources */,
+				E1926C091C779868009F3C2C /* PlanListViewControllerTest.swift in Sources */,
 				E157D5E01C690A6C00F04FB9 /* ImmuTableTestUtils.swift in Sources */,
 				E1C9AA561C10427100732665 /* MathTest.swift in Sources */,
 				93A379EC19FFBF7900415023 /* KeychainTest.m in Sources */,
@@ -5176,7 +5193,6 @@
 				5D2BEB4919758102005425F7 /* PhotonImageURLHelperTest.m in Sources */,
 				5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */,
 				85D239C01AE5A7020074768D /* LoginFacadeTests.m in Sources */,
-				E1B2FF591C637AE200F6BDEA /* PlanListViewControllerTest.swift in Sources */,
 				5DA988061AEEA594002AFB12 /* DisplayableImageHelperTest.m in Sources */,
 				B566EC751B83867800278395 /* NSMutableAttributedStringTest.swift in Sources */,
 				E6B9B8AF1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -473,6 +473,7 @@
 		E1249B4319408C910035E895 /* RemoteComment.m in Sources */ = {isa = PBXBuildFile; fileRef = E1249B4219408C910035E895 /* RemoteComment.m */; };
 		E1249B4619408D0F0035E895 /* CommentServiceRemoteXMLRPC.m in Sources */ = {isa = PBXBuildFile; fileRef = E1249B4519408D0F0035E895 /* CommentServiceRemoteXMLRPC.m */; };
 		E1249B4B1940AECC0035E895 /* CommentServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = E1249B4A1940AECC0035E895 /* CommentServiceRemoteREST.m */; };
+		E124CE721C86D27100F7BA99 /* StoreFacadeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E124CE711C86D27100F7BA99 /* StoreFacadeTests.swift */; };
 		E125443C12BF5A7200D87A0A /* WordPress.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = E125443B12BF5A7200D87A0A /* WordPress.xcdatamodeld */; };
 		E125445612BF5B3900D87A0A /* PostCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = E125445512BF5B3900D87A0A /* PostCategory.m */; };
 		E125451812BF68F900D87A0A /* Page.m in Sources */ = {isa = PBXBuildFile; fileRef = E125451712BF68F900D87A0A /* Page.m */; };
@@ -1554,6 +1555,7 @@
 		E1249B481940AE610035E895 /* ServiceRemoteREST.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceRemoteREST.h; sourceTree = "<group>"; };
 		E1249B491940AECC0035E895 /* CommentServiceRemoteREST.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommentServiceRemoteREST.h; sourceTree = "<group>"; };
 		E1249B4A1940AECC0035E895 /* CommentServiceRemoteREST.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CommentServiceRemoteREST.m; sourceTree = "<group>"; };
+		E124CE711C86D27100F7BA99 /* StoreFacadeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreFacadeTests.swift; sourceTree = "<group>"; };
 		E125443D12BF5A7200D87A0A /* WordPress 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 2.xcdatamodel"; sourceTree = "<group>"; };
 		E125445412BF5B3900D87A0A /* PostCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostCategory.h; sourceTree = "<group>"; };
 		E125445512BF5B3900D87A0A /* PostCategory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostCategory.m; sourceTree = "<group>"; };
@@ -3331,6 +3333,7 @@
 				E66969C71B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift */,
 				59FBD5611B5684F300734466 /* ThemeServiceTests.m */,
 				E12BE5EF1C524FC9000FD5CA /* AccountSettingsServiceTests.swift */,
+				E124CE711C86D27100F7BA99 /* StoreFacadeTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -5220,6 +5223,7 @@
 				852416D21A12ED690030700C /* AppRatingUtilityTests.m in Sources */,
 				598F86AB1B67BD7600550C9C /* ThemeServiceRemoteTests.m in Sources */,
 				E15618FD16DB8677006532C4 /* UIKitTestHelper.m in Sources */,
+				E124CE721C86D27100F7BA99 /* StoreFacadeTests.swift in Sources */,
 				B5744A1E1C3D8FA700A3B8DC /* InteractiveNotificationsHandlerTests.m in Sources */,
 				B5EFB1C91B333C5A007608A3 /* NotificationsServiceTests.swift in Sources */,
 				B5AEEC721ACACF2F008BF2A4 /* NotificationTests.m in Sources */,

--- a/WordPress/WordPressTest/PlanListViewControllerTest.swift
+++ b/WordPress/WordPressTest/PlanListViewControllerTest.swift
@@ -28,18 +28,8 @@ class PlanListViewControllerTest: XCTestCase {
 
     // MARK: - PlanListViewModel tests
 
-    func testPlanListViewModel() {
-        let model = PlanListViewModel(activePlan: .Free)
-        let presenter = MockImmuTablePresenter()
-        let tableViewModel = model.tableViewModelWithPresenter(presenter)
-        expect(model.activePlan).to(equal(Plan.Free))
-        expect(tableViewModel.sections.count).to(equal(1))
-        let section = tableViewModel.sections[0]
-        expect(section.rows.count).to(equal(3))
-    }
-
     func testPlanImageWhenActivePlanSet() {
-        let model = PlanListViewModel(activePlan: .Premium)
+        let model = PlanListViewModel.Ready(activePlan: .Premium, plans: plansWithPrices)
         let presenter = MockImmuTablePresenter()
         let tableViewModel = model.tableViewModelWithPresenter(presenter)
         let freeRow = tableViewModel.planRowAtIndex(0)
@@ -51,69 +41,11 @@ class PlanListViewControllerTest: XCTestCase {
         expect(businessRow.icon).to(equal(Plan.Business.image))
     }
 
-    func testPlanImageWhenActivePlanNotSet() {
-        let model = PlanListViewModel(activePlan: nil)
-        let presenter = MockImmuTablePresenter()
-        let tableViewModel = model.tableViewModelWithPresenter(presenter)
-        let freeRow = tableViewModel.planRowAtIndex(0)
-        let premiumRow = tableViewModel.planRowAtIndex(1)
-        let businessRow = tableViewModel.planRowAtIndex(2)
-
-        expect(freeRow.icon).to(equal(Plan.Free.image))
-        expect(premiumRow.icon).to(equal(Plan.Premium.image))
-        expect(businessRow.icon).to(equal(Plan.Business.image))
-    }
-
-    func testPlanViewModelEquatable() {
-        let freeModel = PlanListViewModel(activePlan: .Free)
-        let secondFreeModel = PlanListViewModel(activePlan: .Free)
-        let premiumModel = PlanListViewModel(activePlan: .Premium)
-        let businessModel = PlanListViewModel(activePlan: .Business)
-        let nilModel = PlanListViewModel(activePlan: nil)
-
-        expect(freeModel).to(equal(secondFreeModel))
-
-        // Let's test all the combinations, for science!
-        expect(freeModel).toNot(equal(premiumModel))
-        expect(freeModel).toNot(equal(businessModel))
-        expect(freeModel).toNot(equal(nilModel))
-        expect(premiumModel).toNot(equal(freeModel))
-        expect(premiumModel).toNot(equal(businessModel))
-        expect(premiumModel).toNot(equal(nilModel))
-        expect(businessModel).toNot(equal(freeModel))
-        expect(businessModel).toNot(equal(premiumModel))
-        expect(businessModel).toNot(equal(nilModel))
-        expect(nilModel).toNot(equal(freeModel))
-        expect(nilModel).toNot(equal(premiumModel))
-        expect(nilModel).toNot(equal(businessModel))
-    }
-
-    func testPlanViewModelEncodingWithActivePlanSet() {
-        let model = PlanListViewModel(activePlan: .Business)
-        let data = NSMutableData()
-        let coder = NSKeyedArchiver(forWritingWithMutableData: data)
-        model.encodeWithCoder(coder)
-        coder.finishEncoding()
-
-        let decoder = NSKeyedUnarchiver(forReadingWithData: data)
-        let decodedModel = PlanListViewModel(coder: decoder)
-        expect(decodedModel).to(equal(model))
-    }
-
-    func testPlanViewModelEncodingWithActivePlanNotSet() {
-        let model = PlanListViewModel(activePlan: nil)
-        let data = NSMutableData()
-        let coder = NSKeyedArchiver(forWritingWithMutableData: data)
-        model.encodeWithCoder(coder)
-        coder.finishEncoding()
-
-        let decoder = NSKeyedUnarchiver(forReadingWithData: data)
-        let decodedModel = PlanListViewModel(coder: decoder)
-        expect(decodedModel).to(equal(model))
-    }
-
-    let testImage = Plan.Free.image
-
+    let plansWithPrices: [(Plan, String)] = [
+        (.Free, ""),
+        (.Premium, "$99.99"),
+        (.Business, "$299.99")
+    ]
 }
 
 extension ImmuTable {

--- a/WordPress/WordPressTest/StoreFacadeTests.swift
+++ b/WordPress/WordPressTest/StoreFacadeTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+import Nimble
+@testable import WordPress
+
+class StoreFacadeTests: XCTestCase {
+    func testGetPricesForPlans() {
+        let store = MockStoreFacade.succeeding(after: 0)
+        store.getPricesForPlans([.Free, .Premium, .Business],
+            success: { prices in
+                expect(prices.count).to(equal(3))
+                expect(prices[0] as String).to(equal(""))
+                expect(prices[1] as String).to(equal("$99.88"))
+                expect(prices[2] as String).to(equal("$299.88"))
+            }, failure: { _ in
+                XCTFail()
+        })
+    }
+
+    func testGetPricesLocalization() {
+        let store = MockStoreFacade.succeeding(after: 0)
+        store.products[0].priceLocale = NSLocale(localeIdentifier: "es-ES")
+        store.products[1].priceLocale = NSLocale(localeIdentifier: "es-ES")
+        store.getPricesForPlans(
+            [.Free, .Premium, .Business],
+            success: { prices in
+                expect(prices.count).to(equal(3))
+                expect(prices[0] as String).to(equal(""))
+                expect(prices[1] as String).to(equal("99,88 €"))
+                expect(prices[2] as String).to(equal("299,88 €"))
+            },
+            failure: { error in
+                XCTFail()
+            }
+        )
+    }
+}


### PR DESCRIPTION
Includes a mock store facade for quick testing of the UI.

Some notes:
- Available plans are still hardcoded, but it's designed so they can be loaded from the API in a future version.
- (Test) product identifiers are hardcoded.
- I'm not happy about how `ProductRequestDelegate` retains itself until the request completes but I couldn't think of a better solution.
- The UI for loading/error is pretty basic. I didn't wanted to clutter this PR with all the animation code, but it's ready for a future PR.

See #4746
Needs Review: @frosty 