### PR TITLE
Fix Media Removal

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1655,7 +1655,7 @@ EditImageDetailsViewControllerDelegate
 - (void)dismissAssociatedAlertControllerIfVisible:(NSString *)uniqueMediaId {
     // let's see if we where displaying an action sheet for this image
     if (self.currentAlertController && [uniqueMediaId isEqualToString:self.selectedMediaID]){
-        [self dismissViewControllerAnimated:YES completion:nil];
+        [self.currentAlertController dismissViewControllerAnimated:YES completion:nil];
         self.currentAlertController = nil;
     }
 }


### PR DESCRIPTION
How to test:

 - Open the app and create a new post
 - Disconnect the network connection
 - Insert a image
 - You should get a failed media upload
 - Tap on the image and select the option Remove
 - Check if the editor is not dismissed.

Needs Review @frosty 