### PR TITLE
Safari username/password autofill for login

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -48,7 +48,7 @@ target 'WordPress', :exclusive => true do
   pod 'WordPress-iOS-Editor', '1.1.2'
   pod 'WordPress-iOS-Shared', '0.5.1'
   pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
-  pod 'WordPressCom-Analytics-iOS', '0.1.3'
+  pod 'WordPressCom-Analytics-iOS', '0.1.4'
   pod 'WordPressCom-Stats-iOS/UI', '0.6.2'
   pod 'wpxmlrpc', '~> 0.8'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -169,7 +169,7 @@ PODS:
   - WordPressApi (0.3.6):
     - AFNetworking (~> 2.6.0)
     - wpxmlrpc (~> 0.7)
-  - WordPressCom-Analytics-iOS (0.1.3)
+  - WordPressCom-Analytics-iOS (0.1.4)
   - WordPressCom-Stats-iOS/Services (0.6.2):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (~> 2.2.0)
@@ -226,7 +226,7 @@ DEPENDENCIES:
   - WordPress-iOS-Editor (= 1.1.2)
   - WordPress-iOS-Shared (= 0.5.1)
   - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
-  - WordPressCom-Analytics-iOS (= 0.1.3)
+  - WordPressCom-Analytics-iOS (= 0.1.4)
   - WordPressCom-Stats-iOS/Services (= 0.6.2)
   - WordPressCom-Stats-iOS/UI (= 0.6.2)
   - WPMediaPicker (~> 0.8.2)
@@ -300,7 +300,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Editor: 20b958fb699f2df8848da0e22a36ae21803b09d2
   WordPress-iOS-Shared: ced218039d88c91572f3205882832f7a05c61f97
   WordPressApi: 39ca2b950a95fd0bf7ae5c86c92a272fb350187b
-  WordPressCom-Analytics-iOS: 55c52378f752ad8a8bbbd8bd75db0eb4b5a93d34
+  WordPressCom-Analytics-iOS: 1d4cf0426fdc91393ea1ba65daf19133e440ff6a
   WordPressCom-Stats-iOS: f1e9e7c3f214cdf347db3e6a239f77004c08f8be
   WPMediaPicker: 29d9b97e11c872f62fc36a268a4c23b18ed53525
   wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -538,6 +538,12 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         case WPAnalyticsStatReaderTagUnfollowed:
             eventName = @"reader_reader_tag_unfollowed";
             break;
+        case WPAnalyticsStatSafariCredentialsLoginFilled:
+            eventName = @"safari_credentials_login_filled";
+            break;
+        case WPAnalyticsStatSafariCredentialsLoginUpdated:
+            eventName = @"safari_credentials_login_updated";
+            break;
         case WPAnalyticsStatSelectedInstallJetpack:
             eventName = @"stats_install_jetpack_selected";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -846,6 +846,12 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatTwoFactorCodeRequested:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Two Factor - Requested Verification Code"];
             break;
+        case WPAnalyticsStatSafariCredentialsLoginFilled:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Safari Credentials - Login Filled"];
+            break;
+        case WPAnalyticsStatSafariCredentialsLoginUpdated:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Safari Credentials - Login Updated"];
+            break;
         case WPAnalyticsStatShortcutLogIn:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"3D Touch Shortcut - Log In"];
             break;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -67,6 +67,11 @@
 // Measurements
 @property (nonatomic, assign) CGFloat                   keyboardOffset;
 
+// SharedCredentials
+@property (nonatomic, assign) BOOL shouldAvoidRequestingSharedCredentials;
+@property (nonatomic, assign) NSUInteger autofilledUsernameCredentialHash;
+@property (nonatomic, assign) NSUInteger autofilledPasswordCredentialHash;
+
 @end
 
 
@@ -97,6 +102,8 @@ static UIEdgeInsets const LoginHelpButtonPaddingPad             = {1.0, 0.0, 0.0
 
 static UIOffset const LoginOnePasswordPadding                   = {9.0, 0.0f};
 static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
+
+static NSString * const LoginSharedWebCredentialFQDN = @"wordpress.com";
 
 - (void)dealloc
 {
@@ -176,6 +183,13 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
     [HelpshiftUtils refreshUnreadNotificationCount];
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    
+    [self autoFillLoginWithSharedWebCredentialsIfAvailable];
+}
+
 - (void)viewWillLayoutSubviews
 {
     [super viewWillLayoutSubviews];
@@ -238,6 +252,112 @@ static NSInteger const LoginVerificationCodeNumberOfLines       = 3;
         [overlayView dismiss];
     };
     return overlayView;
+}
+
+#pragma mark - AutoFill Authentication
+
+- (void)autoFillLoginWithSharedWebCredentialsIfAvailable
+{
+    __weak __typeof(self)weakSelf = self;
+    [self requestSharedWebCredentials:^(NSString *username, NSString *password) {
+        
+        if (!username.length || !password.length) {
+            return;
+        }
+        if (!weakSelf.viewModel.userIsDotCom) {
+            // If the user has swtiched away from dotcom sign-in, swith back before autofilling
+            [weakSelf.viewModel toggleSignInFormAction];
+        }
+        
+        // Update the model
+        weakSelf.viewModel.username = username;
+        weakSelf.viewModel.password = password;
+        // Update the fields for display
+        [weakSelf setUsernameTextValue:username];
+        [weakSelf setPasswordTextValue:password];
+        
+        weakSelf.autofilledUsernameCredentialHash = [username hash];
+        weakSelf.autofilledPasswordCredentialHash = [password hash];
+        
+        [WPAnalytics track:WPAnalyticsStatSafariCredentialsLoginFilled];
+    }];
+}
+
+- (void)updateAutoFillLoginCredentialsIfNeeded:(NSString *)username password:(NSString *)password
+{
+    // Don't try and update credentials for self-hosted.
+    if (!self.viewModel.userIsDotCom) {
+        return;
+    }
+    
+    // If the user changed screen names, don't try and update/create a new shared web credential.
+    // We'll let Safari handle creating newly saved usernames/passwords.
+    if (self.autofilledUsernameCredentialHash != [username hash]) {
+        return;
+    }
+    
+    // If the user didn't change the password from previousl filled password no update is needed.
+    if (self.autofilledPasswordCredentialHash == [password hash]) {
+        return;
+    }
+    
+    // Update the shared credential
+    CFStringRef fqdnStr = (__bridge CFStringRef)LoginSharedWebCredentialFQDN;
+    CFStringRef usernameStr = (__bridge CFStringRef)username;
+    CFStringRef passwordStr = (__bridge CFStringRef)password;
+    SecAddSharedWebCredential(fqdnStr, usernameStr, passwordStr, ^(CFErrorRef  _Nullable error) {
+        if (error) {
+            DDLogError(@"Error occurred updating shared web credential: %@", error);
+            return;
+        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [WPAnalytics track:WPAnalyticsStatSafariCredentialsLoginUpdated];
+        });
+    });
+}
+
+- (void)requestSharedWebCredentials:(void(^)(NSString *username, NSString *password))completion
+{
+    if (self.shouldAvoidRequestingSharedCredentials) {
+        return;
+    }
+    
+    // Disable repeat calls for shared credentials.
+    self.shouldAvoidRequestingSharedCredentials = YES;
+    CFStringRef fqdnStr = (__bridge CFStringRef)LoginSharedWebCredentialFQDN;
+    SecRequestSharedWebCredential(fqdnStr, NULL, ^(CFArrayRef credentials, CFErrorRef error) {
+        
+        if (error != NULL) {
+            DDLogError(@"Error occurred while requesting shared web credentials: %@", error);
+            if (completion) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    completion(nil, nil);
+                });
+            }
+            return;
+        }
+        
+        // Check if any credential values are available
+        if (CFArrayGetCount(credentials) > 0) {
+            
+            // There will only ever be one credential dictionary since the selection is automatically handled
+            CFDictionaryRef credentialDict =CFArrayGetValueAtIndex(credentials, 0);
+            CFStringRef userNameStr = CFDictionaryGetValue(credentialDict, kSecAttrAccount);
+            CFStringRef passwordStr = CFDictionaryGetValue(credentialDict, kSecSharedPassword);
+            if (userNameStr == NULL || passwordStr == NULL) {
+                // No complete shared credentials found, or credentials were saved as NULL values
+                return;
+            }
+            
+            NSString *userName = (__bridge NSString *)userNameStr;
+            NSString *password = (__bridge NSString *)passwordStr;
+            if (completion) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    completion(userName, password);
+                });
+            }
+        }
+    });
 }
 
 #pragma mark - 1Password Related

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -328,7 +328,7 @@ static NSString * const LoginSharedWebCredentialFQDN = @"wordpress.com";
     SecRequestSharedWebCredential(fqdnStr, NULL, ^(CFArrayRef credentials, CFErrorRef error) {
         
         if (error != NULL) {
-            DDLogError(@"Error occurred while requesting shared web credentials: %@", error);
+            DDLogError(@"Completed requesting shared web credentials with: %@", error);
             if (completion) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     completion(nil, nil);

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.h
@@ -103,6 +103,7 @@
  */
 @property (nonatomic, assign) BOOL shouldReauthenticateDefaultAccount;
 
+
 /**
  *  The title of the sign in button
  */
@@ -217,6 +218,9 @@ typedef void (^OverlayViewCallback)(WPWalkthroughOverlayView *);
 - (void)setPasswordTextReturnKeyType:(UIReturnKeyType)returnKeyType;
 - (void)setFocusToSiteUrlText;
 - (void)setFocusToMultifactorText;
+
+- (void)autoFillLoginWithSharedWebCredentialsIfAvailable;
+- (void)updateAutoFillLoginCredentialsIfNeeded:(NSString *)username password:(NSString *)password;
 
 - (void)displayErrorMessageForInvalidOrMissingFields;
 - (void)displayReservedNameErrorMessage;

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -491,6 +491,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
 - (void)finishedLoginWithUsername:(NSString *)username authToken:(NSString *)authToken requiredMultifactorCode:(BOOL)requiredMultifactorCode
 {
     [self dismissLoginMessage];
+    [self.presenter updateAutoFillLoginCredentialsIfNeeded:username password:self.password];
     
     if (self.shouldReauthenticateDefaultAccount) {
         [self.accountServiceFacade removeLegacyAccount:username];

--- a/WordPress/WordPress-Alpha.entitlements
+++ b/WordPress/WordPress-Alpha.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:wordpress.com</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.wordpress.alpha</string>

--- a/WordPress/WordPress-Internal.entitlements
+++ b/WordPress/WordPress-Internal.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:wordpress.com</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.wordpress.internal</string>

--- a/WordPress/WordPress.entitlements
+++ b/WordPress/WordPress.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:wordpress.com</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.org.wordpress</string>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4185,6 +4185,9 @@
 							com.apple.Keychain = {
 								enabled = 1;
 							};
+							com.apple.SafariKeychain = {
+								enabled = 1;
+							};
 						};
 					};
 					8511CFB51C607A7000B7CEED = {


### PR DESCRIPTION
Adds support for iOS associated domains to pull in Safari saved passwords. Using the shared web credential functions, any saved passwords that were entered via the FQDN of wordpress.com will prompt for autofill on login within the app.

Any subdomains of wordpress.com, mapped domains, or self-hosted sites will not work as they cannot be an "associated domain" without inclusion in the app bundle.

Also including support for updating a Safari saved password if the user autofills an out-of-date password and inputs the correct updated password text upon successful login.

**Testing:**

1. On a device, enable saved passwords and names in Safari settings.
2. Log in at http://wordpress.com/wp-login.php
3. When prompted, save password.
4. Open app and log out if needed.
5. Upon viewing the log in view, a prompt for using the saved password should present and autofill if accepted.

**Testing:**

1. Change the password for a wp.com account that is currently saved via Safari on a device.
2. Do not update the password in Safari.
3. Open WPiOS on the device and autofill the account with the account of the changed password.
4. Attempting to login will prompt an incorrect password message.
5. Update the password field with the correct password.
6. Upon login, a prompt should appear to update the shared Safari password.
7. The password should now updated and available for autofill.

Needs review: @aerych 