### PR TITLE
Sharing: Removes sharing feature flag.

### DIFF
--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -5,16 +5,12 @@ enum FeatureFlag: Int {
     /// My Sites > Site > People
     /// Development on hold while we focus on Me
     case People
-    /// My Sites > Site > Sharing
-    case Sharing
     /// My Sites > Site > Plans
     case Plans
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
         switch self {
         case .People:
-            return build(.Debug)
-        case .Sharing:
             return build(.Debug)
         case .Plans:
             return build(.Debug)

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -316,7 +316,7 @@ NSInteger const BlogDetailAccountHideViewAdminDay = 7;
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
 
-    if ([Feature enabled:FeatureFlagSharing] && [self.blog supports:BlogFeatureSharing]) {
+    if ([self.blog supports:BlogFeatureSharing]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Sharing", @"Noun. Title. Links to a blog's sharing options.")
                                                         image:[UIImage imageNamed:@"icon-menu-sharing"]
                                                      callback:^{


### PR DESCRIPTION
Refs #4907 
This pr removes the sharing feature flag, and enables the feature in non-debug builds. 

Needs review: @alexcurylo 

