### PR TITLE
Issue: Local posts hidden if created without a connection

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -551,6 +551,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     PostListFilter *filter = [self currentPostListFilter];
     if (filter.oldestPostDate && !self.isSearching) {
         // Filter posts by any posts newer than the filter's oldestPostDate.
+        // Also include any posts that don't have a date set, such as local posts created without a connection.
         NSPredicate *datePredicate = [NSPredicate predicateWithFormat:@"(date_created_gmt = NULL) OR (date_created_gmt >= %@)", filter.oldestPostDate];
         predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicate, datePredicate]];
     }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -551,7 +551,7 @@ const CGFloat DefaultHeightForFooterView = 44.0;
     PostListFilter *filter = [self currentPostListFilter];
     if (filter.oldestPostDate && !self.isSearching) {
         // Filter posts by any posts newer than the filter's oldestPostDate.
-        NSPredicate *datePredicate = [NSPredicate predicateWithFormat:@"date_created_gmt >= %@", filter.oldestPostDate];
+        NSPredicate *datePredicate = [NSPredicate predicateWithFormat:@"(date_created_gmt = NULL) OR (date_created_gmt >= %@)", filter.oldestPostDate];
         predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicate, datePredicate]];
     }
     


### PR DESCRIPTION
Previously posts where filtered out according to an oldest post date. This is to prevent old posts from showing up in a posts list and breaking the ordered paging.

Updating the predicate for filtering posts by an oldest date _and_ including posts that do not have a date. Posts that may not have a date are posts created without a connection or a bad connection. These posts should display at the top of the list, even after refreshing the post list.

To test:
1. Open up the "Blog Posts" posts list view.
2. Turn off Wifi or disable internet connection.
3. Create a new post and post it.
4. Post should display at top of the posts list as a "local post".
5. Enable internet connection.
6. Refresh list, post should either stay at top of list as a "local post" or should automatically post, depending on the timing.

Needs review: @diegoreymendez Good find!
