### PR TITLE
Prompt for autofill credentials when returning to the app from background.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -130,6 +130,16 @@ static NSString * const LoginSharedWebCredentialFQDN = @"wordpress.com";
     [self.navigationController setNavigationBarHidden:YES animated:NO];
     self.view.backgroundColor = [WPStyleGuide wordPressBlue];
     
+    NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
+    [defaultCenter addObserver:self
+                      selector:@selector(applicationWillEnterForegroundNotification:)
+                          name:UIApplicationWillEnterForegroundNotification
+                        object:nil];
+    [defaultCenter addObserver:self
+                      selector:@selector(applicationDidBecomeActiveNotification:)
+                          name:UIApplicationDidBecomeActiveNotification
+                        object:nil];
+    
     // Initialize Interface
     [self addMainView];
     [self addControls];
@@ -1201,6 +1211,21 @@ static NSString * const LoginSharedWebCredentialFQDN = @"wordpress.com";
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
     return UIStatusBarStyleLightContent;
+}
+
+#pragma mark - Notifications
+
+- (void)applicationWillEnterForegroundNotification:(NSNotification *)notification
+{
+    // If the user hasn't filled in a username and password, toggle the prompt for autofill when called on didBecomeActive.
+    if (self.usernameText.text.length == 0 && self.passwordText.text.length == 0) {
+        self.shouldAvoidRequestingSharedCredentials = NO;
+    }
+}
+
+- (void)applicationDidBecomeActiveNotification:(NSNotification *)notification
+{
+    [self autoFillLoginWithSharedWebCredentialsIfAvailable];
 }
 
 @end


### PR DESCRIPTION
Adding support for prompting Safari AutoFill credentials when a user on the LoginView backgrounds the app and returns to the app/LoginView.

This resolves a case in which a user may have saved a password into Safari while the app is backgrounded, or if the user hit the "Not Now" button and then returned to the app expecting the prompt.

To test:
1. Open the app, sign out if needed.
2. Hit the "Not Now" button on the prompt.
3. Background the app, return to the app.
4. Notice prompt for autofilling credentials.

Needs review: @aerych 