### PR TITLE
Fixes an issue with how local changes were handled.

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -358,6 +358,10 @@
 
 - (BOOL)hasLocalChanges
 {
+    if([super hasLocalChanges]) {
+        return YES;
+    }
+    
     if (![self isRevision]) {
         return NO;
     }

--- a/WordPress/Classes/Models/BasePost.h
+++ b/WordPress/Classes/Models/BasePost.h
@@ -84,6 +84,21 @@ extern NSString * const PostStatusDeleted;
  */
 - (BOOL)isScheduled;
 
+/**
+ *  Whether there was any attempt ever to upload this post, either successful or failed.
+ *
+ *  @returns    YES if there ever was an attempt to upload this post, NO otherwise.
+ */
+- (BOOL)hasNeverAttemptedToUpload;
+
+/**
+ *  Whether the post has local changes or not.  Local changes are all changes that are have not been
+ *  published to the server yet.
+ *
+ *  @returns    YES if the post has local changes, NO otherwise.
+ */
+- (BOOL)hasLocalChanges;
+
 // Does the post exist on the blog?
 - (BOOL)hasRemote;
 // Deletes post locally

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -78,6 +78,16 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
              PostStatusPublish];
 }
 
+- (BOOL)hasNeverAttemptedToUpload
+{
+    return self.remoteStatus == AbstractPostRemoteStatusLocal;
+}
+
+- (BOOL)hasLocalChanges
+{
+    return self.remoteStatus == AbstractPostRemoteStatusLocal || self.remoteStatus == AbstractPostRemoteStatusFailed;
+}
+
 - (BOOL)hasRemote
 {
     return ((self.postID != nil) && ([self.postID longLongValue] > 0));

--- a/WordPress/Classes/Models/Post.m
+++ b/WordPress/Classes/Models/Post.m
@@ -149,10 +149,6 @@
 
 - (BOOL)hasLocalChanges
 {
-    if (![self isRevision]) {
-        return NO;
-    }
-    
     if ([super hasLocalChanges]) {
         return YES;
     }

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -801,13 +801,6 @@ EditImageDetailsViewControllerDelegate
     [self presentViewController:picker animated:animated completion:nil];
 }
 
-#pragma mark - Data Model: Post
-
-- (BOOL)isPostLocal
-{
-    return self.post.remoteStatus == AbstractPostRemoteStatusLocal;
-}
-
 #pragma mark - Editing
 
 - (void)cancelEditing
@@ -845,21 +838,22 @@ EditImageDetailsViewControllerDelegate
         [self actionSheetDiscardButtonPressed];
     }];
     
-	if (![self.post.original.status isEqualToString:PostStatusDraft] && ![self isPostLocal]) {
-    } else if ([self isPostLocal]) {
-        // The post is a local draft or an autosaved draft: Discard or Save
-        [alertController addActionWithTitle:NSLocalizedString(@"Save Draft", @"Button shown if there are unsaved changes and the author is trying to move away from the post.")
-                                      style:UIAlertActionStyleDefault
-                                    handler:^(UIAlertAction * action) {
-            [self actionSheetSaveDraftButtonPressed];
-        }];
-    } else {
-        // The post was already a draft
-        [alertController addActionWithTitle:NSLocalizedString(@"Update Draft", @"Button shown if there are unsaved changes and the author is trying to move away from an already published/saved post.")
-                                      style:UIAlertActionStyleDefault
-                                    handler:^(UIAlertAction * action) {
-            [self actionSheetSaveDraftButtonPressed];
-        }];
+    if ([self.post hasLocalChanges]) {
+        if (![self.post hasRemote]) {
+            // The post is a local draft or an autosaved draft: Discard or Save
+            [alertController addActionWithTitle:NSLocalizedString(@"Save Draft", @"Button shown if there are unsaved changes and the author is trying to move away from the post.")
+                                          style:UIAlertActionStyleDefault
+                                        handler:^(UIAlertAction * action) {
+                [self actionSheetSaveDraftButtonPressed];
+            }];
+        } else if ([self.post.status isEqualToString:PostStatusDraft]) {
+            // The post was already a draft
+            [alertController addActionWithTitle:NSLocalizedString(@"Update Draft", @"Button shown if there are unsaved changes and the author is trying to move away from an already published/saved post.")
+                                          style:UIAlertActionStyleDefault
+                                        handler:^(UIAlertAction * action) {
+                [self actionSheetSaveDraftButtonPressed];
+            }];
+        }
     }
     
     alertController.popoverPresentationController.barButtonItem = self.currentCancelButton;
@@ -983,7 +977,7 @@ EditImageDetailsViewControllerDelegate
 - (NSString *)editorTitle
 {
     NSString *title = @"";
-    if ([self isPostLocal]) {
+    if ([self.post hasNeverAttemptedToUpload]) {
         title = NSLocalizedString(@"New Post", @"Post Editor screen title.");
     } else {
         if ([self.post.postTitle length]) {
@@ -1493,7 +1487,7 @@ EditImageDetailsViewControllerDelegate
 
 - (void)didSaveNewPost
 {
-    if ([self isPostLocal]) {
+    if ([self.post hasLocalChanges]) {
         [[WPTabBarController sharedInstance] switchTabToPostsListForPost:self.post];
     }
 }


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/393

To test:
1. Launch WPiOS
2. Start writing a new post.
3. Disconnect from your wifi
4. Try to "Post" the post.
5. It should be saved locally.
6. Reconnect to the internet
7. Open the post
8. Tap the back button.

Expected behaviour: a "Save as Draft" option should be available.

Also: play with creating posts, closing them, saving, etc... and make sure the action sheet buttons are always correct.

Needs review: @SergioEstevao 
