### PR TITLE
BlogServiceRemoteXMLRPC: Adds nil failsafe(s)

### DIFF
--- a/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.m
@@ -1,4 +1,5 @@
 #import "BlogServiceRemoteXMLRPC.h"
+#import "NSMutableDictionary+Helpers.h"
 #import <WordPressApi/WordPressApi.h>
 #import "WordPress-Swift.h"
 
@@ -64,10 +65,9 @@
                    success:(SuccessHandler)success
                    failure:(void (^)(NSError *error))failure
 {
-    NSDictionary *rawParameters = @{
-        @"blog_title"   : remoteBlogSettings.name,
-        @"blog_tagline" : remoteBlogSettings.tagline
-    };
+    NSMutableDictionary *rawParameters = [NSMutableDictionary dictionary];    
+    [rawParameters setValueIfNotNil:remoteBlogSettings.name forKey:@"blog_title"];
+    [rawParameters setValueIfNotNil:remoteBlogSettings.tagline forKey:@"blog_tagline"];
     
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:rawParameters];
     


### PR DESCRIPTION
Fixes #4887

To test:
- Check out `release/5.8`. If you find a build error you might need to replace an AFNetworking header import with `@import AFNetworking;` in `WPWebView.m`
- Run the app, fresh install
- Add a self hosted blog
- Go to wp-admin on a browser and change your password
- Check out this fix's branch
- Run the app
- Go to site settings
- Change the site title

As a result, the app shouldn't break anymore.

Needs review: @koke 
Thanks in advance!

