### PR TITLE
Improve accessibility of comment actions

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -43,6 +43,9 @@ import WordPressShared.WPStyleGuide
         set {
             btnLike.selected = newValue
             btnLike.accessibilityLabel = likeAccesibilityLabel
+            btnLike.accessibilityHint = likeAccessibilityHint
+            // Force button trait to avoid automatic "Selected" trait
+            btnLike.accessibilityTraits = UIAccessibilityTraitButton
         }
         get {
             return btnLike.selected
@@ -52,6 +55,9 @@ import WordPressShared.WPStyleGuide
         set {
             btnApprove.selected = newValue
             btnApprove.accessibilityLabel = approveAccesibilityLabel
+            btnApprove.accessibilityHint = approveAccesibilityHint
+            // Force button trait to avoid automatic "Selected" trait
+            btnApprove.accessibilityTraits = UIAccessibilityTraitButton
         }
         get {
             return btnApprove.selected
@@ -68,12 +74,6 @@ import WordPressShared.WPStyleGuide
         
         let textNormalColor         = WPStyleGuide.Notifications.blockActionDisabledColor
         let textSelectedColor       = WPStyleGuide.Notifications.blockActionEnabledColor
-        
-        let likeNormalTitle         = NSLocalizedString("Like",     comment: "Like a comment")
-        let likeSelectedTitle       = NSLocalizedString("Liked",    comment: "A comment has been liked")
-
-        let approveNormalTitle      = NSLocalizedString("Approve",  comment: "Approve a comment")
-        let approveSelectedTitle    = NSLocalizedString("Approved", comment: "Unapprove a comment")
 
         let replyTitle              = NSLocalizedString("Reply",    comment: "Verb, reply to a comment")
         let spamTitle               = NSLocalizedString("Spam",     comment: "Verb, spam a comment")
@@ -148,17 +148,35 @@ import WordPressShared.WPStyleGuide
     }
     
     private var approveAccesibilityLabel : String {
-        return isApproveOn ? NSLocalizedString("Unapprove", comment: "Unapproves a comment") : NSLocalizedString("Approve", comment: "Approve a comment")
+        return isApproveOn ? approveSelectedTitle : approveNormalTitle
     }
-    
+
+    private var approveAccesibilityHint : String {
+        return isApproveOn ? approveSelectedHint : approveNormalHint
+    }
+
     private var likeAccesibilityLabel : String {
-        return isLikeOn ? NSLocalizedString("Unlike", comment: "Unlikes a comment") : NSLocalizedString("Like", comment: "Like a comment")
+        return isLikeOn ? likeSelectedTitle : likeNormalTitle
+    }
+
+    private var likeAccessibilityHint : String {
+        return isLikeOn ? likeSelectedHint : likeNormalHint
     }
     
     
     // MARK: - Private Constants
     private let buttonSpacing           = CGFloat(20)
     private let buttonSpacingCompact    = CGFloat(10)
+
+    private let likeNormalTitle         = NSLocalizedString("Like",     comment: "Like a comment")
+    private let likeSelectedTitle       = NSLocalizedString("Liked",    comment: "A comment has been liked")
+    private let likeNormalHint          = NSLocalizedString("Likes the comment",     comment: "Likes a comment. Spoken Hint.")
+    private let likeSelectedHint        = NSLocalizedString("Unlikes the comment",   comment: "Unlikes a comment. Spoken Hint.")
+    
+    private let approveNormalTitle      = NSLocalizedString("Approve",  comment: "Approve a comment")
+    private let approveSelectedTitle    = NSLocalizedString("Approved", comment: "Unapprove a comment")
+    private let approveNormalHint       = NSLocalizedString("Approves the comment",  comment: "Approves a comment. Spoken Hint.")
+    private let approveSelectedHint     = NSLocalizedString("Disapproves the comment", comment: "Unapproves a comment. Spoken Hint.")
     
     // MARK: - IBOutlets
     @IBOutlet private var actionsView   : UIStackView!


### PR DESCRIPTION
Continuing the work on #4926
Fixes #4894

To test:
1. Log into your WP.com account
2. Tap over Notifications
3. Open a Comment-Y Notification
4. Enable iOS VoiceOver
5. Verify that `Like` / `Approve` buttons change their accessibility labels, as needed.

Like button should say:
- When liked: _Liked, Button,... Unlikes the comment_
- When not liked: _Like, Button,... Likes the comment_

Approve button should say:
- When approved: _Approved, Button,... Disapproves the comment_
- Wehn not approved: _Approve, Button,... Approves the comment_

I chose "Disapproves" over "Unapproved" as VoiceOver was pronouncing that weird, and it's also a bit more accurate.

Needs review: @jleandroperez 