### PR TITLE
Cancelling editing no longer modifies the post list filtering.

### DIFF
--- a/WordPress/Classes/Utility/Sharing/WordPressActivity.m
+++ b/WordPress/Classes/Utility/Sharing/WordPressActivity.m
@@ -63,7 +63,7 @@
 	
 	if ([WPPostViewController isNewEditorEnabled]) {
 		WPPostViewController * editPostViewController = [[WPPostViewController alloc] initWithTitle:self.title andContent:content andTags:self.tags andImage:nil];
-		editPostViewController.onClose = ^(WPPostViewController *viewController){
+		editPostViewController.onClose = ^(WPPostViewController *viewController, BOOL changesSaved){
 			[weakSelf activityDidFinish:YES];
 		};
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.m
@@ -431,9 +431,11 @@ static const CGFloat PostListHeightForFooterView = 34.0;
     
     __weak __typeof(self) weakSelf = self;
     
-    postViewController.onClose = ^void(WPPostViewController *viewController) {
+    postViewController.onClose = ^void(WPPostViewController *viewController, BOOL changesSaved) {
         
-        [weakSelf setFilterWithPostStatus:viewController.post.status];
+        if (changesSaved) {
+            [weakSelf setFilterWithPostStatus:viewController.post.status];
+        }
         
         [viewController.presentingViewController dismissViewControllerAnimated:YES completion:nil];
     };
@@ -483,9 +485,11 @@ static const CGFloat PostListHeightForFooterView = 34.0;
         
         __weak __typeof(self) weakSelf = self;
         
-        postViewController.onClose = ^void(WPPostViewController* viewController) {
+        postViewController.onClose = ^void(WPPostViewController* viewController, BOOL changesSaved) {
             
-            [weakSelf setFilterWithPostStatus:viewController.post.status];
+            if (changesSaved) {
+                [weakSelf setFilterWithPostStatus:viewController.post.status];
+            }
             
             [viewController.navigationController popViewControllerAnimated:YES];
         };

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
@@ -29,7 +29,7 @@ extern NSString* const kWPEditorConfigURLParamEnabled;
 /*
  EditPostViewController instance will execute the onClose callback, if provided, whenever the UI is dismissed.
  */
-typedef void (^EditPostCompletionHandler)(WPPostViewController* viewController);
+typedef void (^EditPostCompletionHandler)(WPPostViewController* viewController, BOOL saved);
 @property (nonatomic, copy, readwrite) EditPostCompletionHandler onClose;
 
 #pragma mark - Properties: Post

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -309,7 +309,7 @@ EditImageDetailsViewControllerDelegate
     [super viewDidAppear:animated];
     
     if (self.failedStateRestorationMode) {
-        [self dismissEditView];
+        [self dismissEditView:NO];
     } else {
         [self refreshNavigationBarButtons:NO];
         [self.navigationController.navigationBar addSubview:self.mediaProgressView];
@@ -933,7 +933,7 @@ EditImageDetailsViewControllerDelegate
     if (self.isEditing) {
         [self cancelEditing];
     } else {
-        [self dismissEditView];
+        [self dismissEditView:NO];
     }
 }
 
@@ -1384,18 +1384,19 @@ EditImageDetailsViewControllerDelegate
     [self discardChanges];
     
     if (!self.post || self.isOpenedDirectlyForEditing) {
-        [self dismissEditView];
+        [self dismissEditView:NO];
     } else {
         [self refreshUIForCurrentPost];
     }
 }
 
 - (void)dismissEditViewAnimated:(BOOL)animated
+                   changesSaved:(BOOL)changesSaved
 {
     [WPAppAnalytics track:WPAnalyticsStatEditorClosed withBlog:self.post.blog];
     
     if (self.onClose) {
-        self.onClose(self);
+        self.onClose(self, changesSaved);
         self.onClose = nil;
     } else if (self.presentingViewController) {
         [self.presentingViewController dismissViewControllerAnimated:animated completion:nil];
@@ -1404,9 +1405,9 @@ EditImageDetailsViewControllerDelegate
     }
 }
 
-- (void)dismissEditView
+- (void)dismissEditView:(BOOL)changesSaved
 {
-    [self dismissEditViewAnimated:YES];
+    [self dismissEditViewAnimated:YES changesSaved:changesSaved];
 }
 
 - (void)saveAction
@@ -1435,7 +1436,7 @@ EditImageDetailsViewControllerDelegate
     }
     [self stopEditing];
     [self savePost];
-    [self dismissEditView];
+    [self dismissEditView:YES];
 }
 
 /**
@@ -2100,7 +2101,7 @@ EditImageDetailsViewControllerDelegate
 - (void)mediaPickerControllerDidCancel:(WPMediaPickerViewController *)picker
 {
     if (self.isOpenedDirectlyForPhotoPost) {
-        [self dismissEditViewAnimated:NO];
+        [self dismissEditViewAnimated:NO changesSaved:NO];
     } else {
         [self dismissViewControllerAnimated:YES completion:nil];
     }


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/785

**Test 1:**
1. Go to the list of posts for any blog.
2. Set the filtering to "Published"
3. Create a new post but instead of saving, discard it.
4. The filtering should still be set to "Published".

**Test 2:**
1. Go to the list of posts for any blog.
2. Set the filtering to "Published"
3. Create a new post, and save it as draft.
4. The filtering should be changed to "Draft" and the new post should be on screen.

Needs review: @SergioEstevao 
