### PR TITLE
Fixes Notifications Undelete Glitch

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
@@ -20,7 +20,7 @@
 @property (nonatomic, strong) NSString                      *pushNotificationID;
 @property (nonatomic, strong) NSDate                        *pushNotificationDate;
 @property (nonatomic, strong) NSDate                        *lastReloadDate;
-@property (nonatomic, strong) NSMutableSet                  *notificationIdsMarkedForDeletion;
+@property (nonatomic, strong) NSMutableDictionary           *notificationDeletionBlocks;
 @property (nonatomic, strong) NSMutableSet                  *notificationIdsBeingDeleted;
 
 @end

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -98,7 +98,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
         // Notifications that received a destructive action will allow the user to Undo this action.
         // Once the Timeout elapses, we'll move the NotificationID to the BeingDeleted collection,
         // so that it can be proactively filtered from the list.
-        self.notificationIdsMarkedForDeletion   = [NSMutableSet set];
+        self.notificationDeletionBlocks         = [NSMutableDictionary dictionary];
         self.notificationIdsBeingDeleted        = [NSMutableSet set];
     }
     
@@ -592,7 +592,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 - (void)showUndeleteForNoteWithID:(NSManagedObjectID *)noteObjectID onTimeout:(NotificationDeletionActionBlock)onTimeout
 {
     // Mark this note as Pending Deletion and Reload
-    [self.notificationIdsMarkedForDeletion addObject:noteObjectID];
+    self.notificationDeletionBlocks[noteObjectID] = [onTimeout copy];
     [self reloadRowForNotificationWithID:noteObjectID];
     
     // Dispatch the Action block
@@ -602,7 +602,8 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 - (void)performDeletionActionForNoteWithID:(NSManagedObjectID *)noteObjectID
 {
     // Was the Deletion Cancelled?
-    if ([self isNoteMarkedForDeletion:noteObjectID] == false) {
+    NotificationDeletionActionBlock deletionBlock = self.notificationDeletionBlocks[noteObjectID];
+    if (!deletionBlock) {
         return;
     }
     
@@ -613,7 +614,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     // Hit the Deletion Block
     deletionBlock(^(BOOL success) {
         // Cleanup
-        [self.notificationIdsMarkedForDeletion removeObject:noteObjectID];
+        [self.notificationDeletionBlocks removeObjectForKey:noteObjectID];
         [self.notificationIdsBeingDeleted removeObject:noteObjectID];
         
         // Error: let's unhide the row
@@ -623,16 +624,17 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     });
 }
 
-- (void)cancelDeletionForNotificationWithID:(NSManagedObjectID *)noteObjectID
 - (void)cancelDeletionForNoteWithID:(NSManagedObjectID *)noteObjectID
 {
-    [self.notificationIdsMarkedForDeletion removeObject:noteObjectID];
+    [self.notificationDeletionBlocks removeObjectForKey:noteObjectID];
     [self reloadRowForNotificationWithID:noteObjectID];
+    
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(performDeletionActionForNoteWithID:) object:noteObjectID];
 }
 
 - (BOOL)isNoteMarkedForDeletion:(NSManagedObjectID *)noteObjectID
 {
-    return [self.notificationIdsMarkedForDeletion containsObject:noteObjectID];
+    return [self.notificationDeletionBlocks objectForKey:noteObjectID] != nil;
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -596,13 +596,10 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     [self reloadRowForNotificationWithID:noteObjectID];
     
     // Dispatch the Action block
-    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(NotificationsUndoTimeout * NSEC_PER_SEC));
-    dispatch_after(timeout, dispatch_get_main_queue(), ^{
-        [self performDeletionActionForNotificationWithID:noteObjectID deletionBlock:onTimeout];
-    });
+    [self performSelector:@selector(performDeletionActionForNoteWithID:) withObject:noteObjectID afterDelay:NotificationsUndoTimeout];
 }
 
-- (void)performDeletionActionForNotificationWithID:(NSManagedObjectID *)noteObjectID deletionBlock:(NotificationDeletionActionBlock)deletionBlock
+- (void)performDeletionActionForNoteWithID:(NSManagedObjectID *)noteObjectID
 {
     // Was the Deletion Cancelled?
     if ([self isNoteMarkedForDeletion:noteObjectID] == false) {
@@ -627,6 +624,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 }
 
 - (void)cancelDeletionForNotificationWithID:(NSManagedObjectID *)noteObjectID
+- (void)cancelDeletionForNoteWithID:(NSManagedObjectID *)noteObjectID
 {
     [self.notificationIdsMarkedForDeletion removeObject:noteObjectID];
     [self reloadRowForNotificationWithID:noteObjectID];
@@ -844,7 +842,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     cell.showsBottomSeparator       = !isLastRow && !isMarkedForDeletion;
     cell.selectionStyle             = isMarkedForDeletion ? UITableViewCellSelectionStyleNone : UITableViewCellSelectionStyleGray;
     cell.onUndelete                 = ^{
-        [weakSelf cancelDeletionForNotificationWithID:note.objectID];
+        [weakSelf cancelDeletionForNoteWithID:note.objectID];
     };
 
     [cell downloadIconWithURL:note.iconURL];


### PR DESCRIPTION
Fixes #4859

To test:
1. Receive a Comment-Y Notification
2. Launch WPiOS and open the Notifications tab
3. Open the Notification details
4. Tap over the `Trash` button
5. Within 4 seconds, tap *Undo*, open the Notification Details, and tap `Trash` again

Verify that the notification gets effectively nuked *4 seconds* after tapping the Trash button. This was caused by a *GCD* dispatch_after call, not being cancelled (because there is no mechanism to do so!).

Needs review: @astralbodies 
Thanks in advance Aaron!
