### PR TITLE
WPAccount+AccountSettings: Updating defaultBlog Relationship

### DIFF
--- a/WordPress/Classes/Models/WPAccount+AccountSettings.swift
+++ b/WordPress/Classes/Models/WPAccount+AccountSettings.swift
@@ -5,6 +5,9 @@ extension WPAccount {
         switch change {
         case .DisplayName(let value):
             self.displayName = value
+        case .PrimarySite(let value):
+            let service = BlogService(managedObjectContext: managedObjectContext)
+            defaultBlog = service.blogByBlogId(value)
         default:
             break
         }


### PR DESCRIPTION
Fixes #4944

To test:
Easiest way to test this is by checking out `issue/2599-primary-site-order` branch, cherry-picking commit `acd8cd1` (the only commit in this PR) and...

1. Launch WPiOS
2. Open `Me` > `Account Settings`
3. Update the Primary Site
4. Verify that the (new) Primary Site shows up on top of the `My Sites` list

Needs review: @koke 