### PR TITLE
Reader: Fixes condtional so button is correctly enabled/disabled.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
+++ b/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
@@ -370,7 +370,7 @@ static const UIEdgeInsets ReplyAndLikeButtonEdgeInsets = {0.0f, 4.0f, 0.0f, -4.0
     [self.authorButton setTitle:[self.contentProvider authorForDisplay] forState:UIControlStateHighlighted];
     [self.authorButton setTitle:[self.contentProvider authorForDisplay] forState:UIControlStateDisabled];
 
-    if ([self.contentProvider respondsToSelector:@selector(authorURL)] && [self.contentProvider authorURL]) {
+    if ([self.contentProvider respondsToSelector:@selector(authorURL)]) {
         self.authorButton.enabled = ([[[self.contentProvider authorURL] absoluteString] length] > 0);
     }
 


### PR DESCRIPTION
Fixes #4878 
This fixes an improper conditional so that the author button is correctly enabled or disabled depending on if the comment author has a valid author URL.  This resolves the crash in #4878 which could be triggered if the button was enabled when the author URL was nil. 

To test: 
Repeat the steps described in #4878. 
Set a breakpoint in the editied conditional and confirm that the button is being correctly enabled/disabled. 

Needs review: @jleandroperez 

