### PR TITLE
Reader: Adds guard against nil and logs nil as an error.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1177,7 +1177,12 @@ import WordPressComAnalytics
 
     public func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         tableView.deselectRowAtIndexPath(indexPath, animated: false)
-        let posts = tableViewHandler.resultsController.fetchedObjects as! [ReaderPost]
+
+        guard let posts = tableViewHandler.resultsController.fetchedObjects as? [ReaderPost] else {
+            DDLogSwift.logError("[ReaderStreamViewController tableView:didSelectRowAtIndexPath:] fetchedObjects was nil.")
+            return
+        }
+
         var post = posts[indexPath.row]
 
         if post.isKindOfClass(ReaderGapMarker) {


### PR DESCRIPTION
Fixes #4956 (maybe) 

This is a best guess as a patch for #4956 based on the offending line number.  If nothing else its probably a better practice to use `guard` here than the previous explicit unwrapping of the optional.  It *shouldn't* have ever been nil but I'm not sure how else to account for the crash. 

Needs review: @kurzee 

