### PR TITLE
Issue/4954 3d touch crash no blogs

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -50,7 +50,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     [defaults synchronize];
     
     WP3DTouchShortcutCreator *shortcutCreator = [WP3DTouchShortcutCreator new];
-    [shortcutCreator createShortcuts:YES];
+    [shortcutCreator createShortcutsIf3DTouchAvailable:YES];
 }
 
 - (Blog *)lastUsedOrFirstBlog

--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -80,7 +80,7 @@
     }
 
     WP3DTouchShortcutCreator *shortcutCreator = [WP3DTouchShortcutCreator new];
-    [shortcutCreator createShortcuts:YES];
+    [shortcutCreator createShortcutsIf3DTouchAvailable:YES];
     
     [WPAnalytics track:WPAnalyticsStatAddedSelfHostedSite];
     [WPAnalytics track:WPAnalyticsStatSignedIn withProperties:@{ @"dotcom_user" : @(NO) }];

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -28,7 +28,11 @@ public class WP3DTouchShortcutCreator: NSObject
     
     public func createShortcuts(loggedIn: Bool) {
         if loggedIn {
-            createLoggedInShortcuts()
+            if hasBlog() {
+                createLoggedInShortcuts()
+            } else {
+                clearShortcuts()
+            }
         } else {
             createLoggedOutShortcuts()
         }
@@ -95,6 +99,10 @@ public class WP3DTouchShortcutCreator: NSObject
         application.shortcutItems = visibleShortcutArray
     }
     
+    private func clearShortcuts() {
+        application.shortcutItems = nil
+    }
+    
     private func createLoggedOutShortcuts() {
         application.shortcutItems = loggedOutShortcutArray()
     }
@@ -111,5 +119,9 @@ public class WP3DTouchShortcutCreator: NSObject
         }
         
         return hasWordPressComAccount() && currentBlog.supports(BlogFeature.Stats)
+    }
+    
+    private func hasBlog() -> Bool {
+        return blogService.blogCountForAllAccounts() > 0
     }
 }

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -26,7 +26,11 @@ public class WP3DTouchShortcutCreator: NSObject
         blogService = BlogService(managedObjectContext: mainContext)
     }
     
-    public func createShortcuts(loggedIn: Bool) {
+    public func createShortcutsIf3DTouchAvailable(loggedIn: Bool) {
+        if !is3DTouchAvailable() {
+            return
+        }
+        
         if loggedIn {
             if hasBlog() {
                 createLoggedInShortcuts()
@@ -38,7 +42,7 @@ public class WP3DTouchShortcutCreator: NSObject
         }
     }
     
-    public func loggedOutShortcutArray() -> [UIApplicationShortcutItem] {
+    private func loggedOutShortcutArray() -> [UIApplicationShortcutItem] {
         let logInShortcut = UIMutableApplicationShortcutItem(type: WP3DTouchShortcutHandler.ShortcutIdentifier.LogIn.type,
                                                    localizedTitle: NSLocalizedString("Sign In", comment: "Sign In 3D Touch Shortcut"),
                                                 localizedSubtitle: nil,
@@ -48,10 +52,10 @@ public class WP3DTouchShortcutCreator: NSObject
         return [logInShortcut]
     }
     
-    public func loggedInShortcutArray() -> [UIApplicationShortcutItem] {
+    private func loggedInShortcutArray() -> [UIApplicationShortcutItem] {
         var defaultBlogName: String?
         if blogService.blogCountForAllAccounts() > 1 {
-            defaultBlogName = blogService.lastUsedOrFirstBlog()?.settings.name
+            defaultBlogName = blogService.lastUsedOrFirstBlog()?.settings?.name
         }
         
         let notificationsShortcut = UIMutableApplicationShortcutItem(type: WP3DTouchShortcutHandler.ShortcutIdentifier.Notifications.type,
@@ -105,6 +109,12 @@ public class WP3DTouchShortcutCreator: NSObject
     
     private func createLoggedOutShortcuts() {
         application.shortcutItems = loggedOutShortcutArray()
+    }
+    
+    private func is3DTouchAvailable() -> Bool {
+        let window = UIApplication.sharedApplication().keyWindow
+        
+        return window?.traitCollection.forceTouchCapability == .Available
     }
     
     private func hasWordPressComAccount() -> Bool {

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -620,7 +620,7 @@ int ddLogLevel                                                  = DDLogLevelInfo
 - (void)create3DTouchShortcutItems
 {
     WP3DTouchShortcutCreator *shortcutCreator = [WP3DTouchShortcutCreator new];
-    [shortcutCreator createShortcuts:[self isLoggedIn]];
+    [shortcutCreator createShortcutsIf3DTouchAvailable:[self isLoggedIn]];
 }
 
 #pragma mark - Analytics

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -177,7 +177,7 @@ static NSString * const LoginSharedWebCredentialFQDN = @"wordpress.com";
 - (void)update3DTouchForLogIn
 {
     WP3DTouchShortcutCreator *shortcutCreator = [WP3DTouchShortcutCreator new];
-    [shortcutCreator createShortcuts:self.cancellable];
+    [shortcutCreator createShortcutsIf3DTouchAvailable:self.cancellable];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/WordPress/WordPressTest/System/3DTouch/WP3DTouchShortcutCreatorTests.swift
+++ b/WordPress/WordPressTest/System/3DTouch/WP3DTouchShortcutCreatorTests.swift
@@ -1,12 +1,14 @@
 import XCTest
 import WordPress
 
-class WP3DTouchShortcutCreatorTests: XCTestCase {
+class WP3DTouchShortcutCreatorTests: XCTestCase
+{
     var testShortcutCreator: WP3DTouchShortcutCreator!
     
     override func setUp() {
         super.setUp()
         testShortcutCreator = WP3DTouchShortcutCreator()
+        UIApplication.sharedApplication().shortcutItems = nil
     }
     
     override func tearDown() {
@@ -14,8 +16,8 @@ class WP3DTouchShortcutCreatorTests: XCTestCase {
         super.tearDown()
     }
     
-    func testCreateShortcutLoggedOutCreatesLoggedOutShortcuts() {
-        testShortcutCreator.createShortcuts(false)
-        XCTAssertEqual(UIApplication.sharedApplication().shortcutItems!, testShortcutCreator.loggedOutShortcutArray())
+    func testCreateShortcutLoggedOutDoesNotCreatesLoggedOutShortcutsWith3DTouchNotAvailable() {
+        testShortcutCreator.createShortcutsIf3DTouchAvailable(false)
+        XCTAssertEqual(UIApplication.sharedApplication().shortcutItems!.capacity, 0)
     }
 }


### PR DESCRIPTION
Fixes #4954 

To test:
1. Sign in with an account that has no blogs
2. Verify when 3D touching it does not crash and there are no shortcut icons

cc @koke. I'm going to have @diegoreymendez review it as he can actually test it.

Needs review: @diegoreymendez 
