### PR TITLE
Nukes WIDGETS_EXIST Macro

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -186,8 +186,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
             TodayExtensionService *service = [TodayExtensionService new];
             BOOL widgetIsConfigured = [service widgetIsConfigured];
             
-            if (WIDGETS_EXIST
-                && !widgetIsConfigured
+            if (!widgetIsConfigured
                 && defaultBlog != nil
                 && !defaultBlog.isDeleted) {
                 NSNumber *siteId = defaultBlog.dotComID;

--- a/WordPress/Classes/Services/TodayExtensionService.m
+++ b/WordPress/Classes/Services/TodayExtensionService.m
@@ -12,10 +12,6 @@
     NSParameterAssert(timeZone != nil);
     NSParameterAssert(oauth2Token.length > 0);
     
-    if (!WIDGETS_EXIST) {
-        return;
-    }
-    
     [[NCWidgetController widgetController] setHasContent:YES forWidgetWithBundleIdentifier:@"org.wordpress.WordPressTodayWidget"];
     
     // Save the token and site ID to shared user defaults for use in the today widget
@@ -39,10 +35,6 @@
 
 - (void)removeTodayWidgetConfiguration
 {
-    if (!WIDGETS_EXIST) {
-        return;
-    }
-    
     NSUserDefaults *sharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:WPAppGroupName];
     [sharedDefaults removeObjectForKey:WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey];
     [sharedDefaults removeObjectForKey:WPStatsTodayWidgetUserDefaultsSiteIdKey];
@@ -57,10 +49,6 @@
 
 - (void)hideTodayWidgetIfNotConfigured
 {
-    if (!WIDGETS_EXIST) {
-        return;
-    }
-    
     [[NCWidgetController widgetController] setHasContent:YES forWidgetWithBundleIdentifier:@"org.wordpress.WordPressTodayWidget"];
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -69,7 +69,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 - (void)addStatsViewControllerToView
 {
-    if (self.presentingViewController == nil && WIDGETS_EXIST) {
+    if (self.presentingViewController == nil) {
         UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Today", @"") style:UIBarButtonItemStylePlain target:self action:@selector(makeSiteTodayWidgetSite:)];
         self.navigationItem.rightBarButtonItem = settingsButton;
     }

--- a/WordPress/WordPress_Prefix.pch
+++ b/WordPress/WordPress_Prefix.pch
@@ -35,10 +35,6 @@
 #define IS_RETINA ([[UIScreen mainScreen] respondsToSelector:@selector(scale)] && [[UIScreen mainScreen] scale] == 2)
 #endif
 
-#ifndef WIDGETS_EXIST
-#define WIDGETS_EXIST (NSClassFromString(@"NCWidgetController") != nil)
-#endif
-
 #ifndef WPCOM_SCHEME
 #warning WPCOM_SCHEME is not defined for this target configuration! Defaulting to "wordpress".
 #define WPCOM_SCHEME @"wordpress"


### PR DESCRIPTION
This PR is a minor cleanup. `NCWidgetController` is available for iOS +8 devices, and since our deployment target has been +9 for a while, already... it's time to clean the house.

Needs Review: @astralbodies 
Thanks!
