### PR TITLE
Fixing Extension Setup via Jetpack Login

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -173,44 +173,6 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
             }
             
             [self mergeBlogs:blogs withAccount:accountInContext completion:success];
-            
-            // Update the Widget Configuration
-            NSManagedObjectID *defaultBlogObjectID = accountInContext.defaultBlog.objectID;
-            if (!defaultBlogObjectID) {
-                DDLogError(@"Error: The Default Blog objectID could not be loaded");
-                return;
-            }
-            
-            Blog *defaultBlog = (Blog *)[self.managedObjectContext existingObjectWithID:defaultBlogObjectID
-                                                                                  error:nil];
-            TodayExtensionService *service = [TodayExtensionService new];
-            BOOL widgetIsConfigured = [service widgetIsConfigured];
-            
-            if (WIDGETS_EXIST
-                && !widgetIsConfigured
-                && defaultBlog != nil
-                && !defaultBlog.isDeleted) {
-                NSNumber *siteId = defaultBlog.dotComID;
-                NSString *blogName = defaultBlog.settings.name;
-                NSTimeZone *timeZone = [self timeZoneForBlog:defaultBlog];
-                NSString *oauth2Token = accountInContext.authToken;
-                
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    TodayExtensionService *service = [TodayExtensionService new];
-                    [service configureTodayWidgetWithSiteID:siteId
-                                                   blogName:blogName
-                                               siteTimeZone:timeZone
-                                             andOAuth2Token:oauth2Token];
-                });
-            }
-            
-            // Configure the Share Extension
-            if (defaultBlog != nil && !defaultBlog.isDeleted) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [ShareExtensionService configureShareExtensionDefaultSiteID:defaultBlog.dotComID.integerValue
-                                                                defaultSiteName:defaultBlog.settings.name];
-                });
-            }
 
         }];
     } failure:^(NSError *error) {

--- a/WordPress/Classes/Services/JetpackService.m
+++ b/WordPress/Classes/Services/JetpackService.m
@@ -65,12 +65,18 @@
                                      BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:self.managedObjectContext];
                                      [self associateBlogIDs:blogIDs withJetpackAccount:account];
                                      if ([[accountService defaultWordPressComAccount] isEqual:account]) {
+                                         // Note I:
+                                         // Sync the blogs first, so that Update User Details doesn't fail setting the
+                                         // primary blog.
+                                         //
+                                         // Note II:
                                          // We want this to show the user's gravatar in the Me tab
                                          // It should only matter for the default account, but feel free to take it
                                          // out of the `if` if it's needed for something else
-                                         [accountService updateUserDetailsForAccount:account success:nil failure:nil];
-
-                                         [blogService syncBlogsForAccount:account success:nil failure:nil];
+                                         //
+                                         [blogService syncBlogsForAccount:account success:^{
+                                             [accountService updateUserDetailsForAccount:account success:nil failure:nil];
+                                         } failure:nil];
                                      }
                                      if (success) {
                                          success(account);

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -480,7 +480,6 @@
 		C56636E91868D0CE00226AAB /* StatsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C56636E71868D0CE00226AAB /* StatsViewController.m */; };
 		C58349C51806F95100B64089 /* IOS7CorrectedTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = C58349C41806F95100B64089 /* IOS7CorrectedTextView.m */; };
 		CEBD3EAB0FF1BA3B00C1396E /* Blog.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBD3EAA0FF1BA3B00C1396E /* Blog.m */; };
-		DFC0CE914560303A6567D882 /* Pods_WordPressShare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 221474ED60F5079096014F42 /* Pods_WordPressShare.framework */; };
 		E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */; };
 		E10A2E9B134E8AD3007643F9 /* PostAnnotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 833AF25A114575A50016DE8F /* PostAnnotation.m */; };
 		E10B3652158F2D3F00419A93 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E10B3651158F2D3F00419A93 /* QuartzCore.framework */; };
@@ -2028,7 +2027,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DFC0CE914560303A6567D882 /* Pods_WordPressShare.framework in Frameworks */,
 				59A1C9CD58F3446A1EC73064 /* Pods_WordPressShareExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressShareExtension.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressShareExtension.xcscheme
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "932225A61C7CE50300443B02"
+               BuildableName = "WordPressShareExtension.appex"
+               BlueprintName = "WordPressShareExtension"
+               ReferencedContainer = "container:WordPress.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+               BuildableName = "WordPress.app"
+               BlueprintName = "WordPress"
+               ReferencedContainer = "container:WordPress.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "932225A61C7CE50300443B02"
+            BuildableName = "WordPressShareExtension.appex"
+            BlueprintName = "WordPressShareExtension"
+            ReferencedContainer = "container:WordPress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+            BuildableName = "WordPress.app"
+            BlueprintName = "WordPress"
+            ReferencedContainer = "container:WordPress.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+            BuildableName = "WordPress.app"
+            BlueprintName = "WordPress"
+            ReferencedContainer = "container:WordPress.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
#### Steps:
1. From a fresh install, sign into a self hosted blog.
2. Open safari and confirm that the share extension prompts you to connect a wpcom acct.
3. Back in the app, navigate to the blog detail screen and tap Stats.
4. Sign into the wpcom account connected to Jetpack.
5. Return to the blog list and confirm any other wpcom blogs owned by the account appear in the list.
6. Return to Safari and try the share extension again.
7. The Today Extension should show the "Primary Blog" pre-selected

Fixes #4955
Needs Review: @astralbodies 
