### PR TITLE
Share Extension Metrics

### DIFF
--- a/WordPress/Classes/Services/ShareExtensionService.swift
+++ b/WordPress/Classes/Services/ShareExtensionService.swift
@@ -10,9 +10,9 @@ public class ShareExtensionService: NSObject
     ///
     class func configureShareExtensionToken(oauth2Token: String) {
         do {
-            try SFHFKeychainUtils.storeUsername(WPShareExtensionTokenKeychainUsername,
+            try SFHFKeychainUtils.storeUsername(WPShareExtensionKeychainTokenKey,
                 andPassword: oauth2Token,
-                forServiceName: WPShareExtensionTokenKeychainServiceName,
+                forServiceName: WPShareExtensionKeychainServiceName,
                 accessGroup: WPAppKeychainAccessGroup,
                 updateExisting: true)
         } catch {
@@ -20,6 +20,23 @@ public class ShareExtensionService: NSObject
         }
     }
 
+    /// Sets the Username that should be used by the Share Extension to hit the Dotcom Backend.
+    ///
+    /// -   Parameters:
+    ///     - oauth2Token: WordPress.com OAuth Token
+    ///
+    class func configureShareExtensionUsername(username: String) {
+        do {
+            try SFHFKeychainUtils.storeUsername(WPShareExtensionKeychainUsernameKey,
+                andPassword: username,
+                forServiceName: WPShareExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup,
+                updateExisting: true)
+        } catch {
+            print("Error while saving Share Extension OAuth bearer token: \(error)")
+        }
+    }
+    
     /// Sets the Primary Site that should be pre-selected in the Share Extension.
     ///
     /// -   Parameters:
@@ -40,11 +57,19 @@ public class ShareExtensionService: NSObject
     ///
     class func removeShareExtensionConfiguration() {
         do {
-            try SFHFKeychainUtils.deleteItemForUsername(WPShareExtensionTokenKeychainUsername,
-                andServiceName: WPShareExtensionTokenKeychainServiceName,
+            try SFHFKeychainUtils.deleteItemForUsername(WPShareExtensionKeychainTokenKey,
+                andServiceName: WPShareExtensionKeychainServiceName,
                 accessGroup: WPAppKeychainAccessGroup)
         } catch {
             print("Error while removing Share Extension OAuth2 bearer token: \(error)")
+        }
+
+        do {
+            try SFHFKeychainUtils.deleteItemForUsername(WPShareExtensionKeychainUsernameKey,
+                andServiceName: WPShareExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup)
+        } catch {
+            print("Error while removing Share Extension Username: \(error)")
         }
         
         if let userDefaults = NSUserDefaults(suiteName: WPAppDefaultsGroupName) {
@@ -59,8 +84,22 @@ public class ShareExtensionService: NSObject
     /// - Returns: The OAuth Token, if any.
     ///
     class func retrieveShareExtensionToken() -> String? {
-        guard let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPShareExtensionTokenKeychainUsername,
-            andServiceName: WPShareExtensionTokenKeychainServiceName, accessGroup: WPAppKeychainAccessGroup) else
+        guard let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPShareExtensionKeychainTokenKey,
+            andServiceName: WPShareExtensionKeychainServiceName, accessGroup: WPAppKeychainAccessGroup) else
+        {
+            return nil
+        }
+        
+        return oauth2Token
+    }
+    
+    /// Retrieves the WordPress.com Username, meant for Extension usage.
+    ///
+    /// - Returns: The Username, if any.
+    ///
+    class func retrieveShareExtensionUsername() -> String? {
+        guard let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPShareExtensionKeychainUsernameKey,
+            andServiceName: WPShareExtensionKeychainServiceName, accessGroup: WPAppKeychainAccessGroup) else
         {
             return nil
         }

--- a/WordPress/Classes/Services/TodayExtensionService.m
+++ b/WordPress/Classes/Services/TodayExtensionService.m
@@ -26,9 +26,9 @@
     [sharedDefaults synchronize];
     
     NSError *error;
-    [SFHFKeychainUtils storeUsername:WPStatsTodayWidgetTokenKeychainUsername
+    [SFHFKeychainUtils storeUsername:WPStatsTodayWidgetKeychainTokenKey
                          andPassword:oauth2Token
-                      forServiceName:WPStatsTodayWidgetTokenKeychainServiceName
+                      forServiceName:WPStatsTodayWidgetKeychainServiceName
                          accessGroup:WPAppKeychainAccessGroup
                       updateExisting:YES
                                error:&error];
@@ -49,8 +49,8 @@
     [sharedDefaults removeObjectForKey:WPStatsTodayWidgetUserDefaultsSiteNameKey];
     [sharedDefaults synchronize];
     
-    [SFHFKeychainUtils deleteItemForUsername:WPStatsTodayWidgetTokenKeychainUsername
-                              andServiceName:WPStatsTodayWidgetTokenKeychainServiceName
+    [SFHFKeychainUtils deleteItemForUsername:WPStatsTodayWidgetKeychainTokenKey
+                              andServiceName:WPStatsTodayWidgetKeychainServiceName
                                  accessGroup:WPAppKeychainAccessGroup
                                        error:nil];
 }
@@ -68,8 +68,8 @@
 {
     NSUserDefaults *sharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:WPAppDefaultsGroupName];
     NSString *siteId = [sharedDefaults stringForKey:WPStatsTodayWidgetUserDefaultsSiteIdKey];
-    NSString *oauth2Token = [SFHFKeychainUtils getPasswordForUsername:WPStatsTodayWidgetTokenKeychainUsername
-                                                       andServiceName:WPStatsTodayWidgetTokenKeychainServiceName
+    NSString *oauth2Token = [SFHFKeychainUtils getPasswordForUsername:WPStatsTodayWidgetKeychainTokenKey
+                                                       andServiceName:WPStatsTodayWidgetKeychainServiceName
                                                           accessGroup:WPAppKeychainAccessGroup
                                                                 error:nil];
     

--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -35,15 +35,16 @@ extern NSString *const WPAppKeychainAccessGroup;
 
 /// Share Extension Constants
 ///
-extern NSString *const WPShareExtensionTokenKeychainUsername;
-extern NSString *const WPShareExtensionTokenKeychainServiceName;
+extern NSString *const WPShareExtensionKeychainUsernameKey;
+extern NSString *const WPShareExtensionKeychainTokenKey;
+extern NSString *const WPShareExtensionKeychainServiceName;
 extern NSString *const WPShareExtensionUserDefaultsPrimarySiteName;
 extern NSString *const WPShareExtensionUserDefaultsPrimarySiteID;
 
 /// Today Widget Constants
 ///
-extern NSString *const WPStatsTodayWidgetTokenKeychainUsername;
-extern NSString *const WPStatsTodayWidgetTokenKeychainServiceName;
+extern NSString *const WPStatsTodayWidgetKeychainTokenKey;
+extern NSString *const WPStatsTodayWidgetKeychainServiceName;
 extern NSString *const WPStatsTodayWidgetUserDefaultsSiteIdKey;
 extern NSString *const WPStatsTodayWidgetUserDefaultsSiteNameKey;
 extern NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey;

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -40,15 +40,16 @@ NSString *const WPAppKeychainAccessGroup                            = @"3TMU3BH3
 
 /// Share Extension Constants
 ///
-NSString *const WPShareExtensionTokenKeychainUsername               = @"OAuth2Token";
-NSString *const WPShareExtensionTokenKeychainServiceName            = @"ShareExtension";
+NSString *const WPShareExtensionKeychainUsernameKey                 = @"Username";
+NSString *const WPShareExtensionKeychainTokenKey                    = @"OAuth2Token";
+NSString *const WPShareExtensionKeychainServiceName                 = @"ShareExtension";
 NSString *const WPShareExtensionUserDefaultsPrimarySiteName         = @"WPShareUserDefaultsPrimarySiteName";
 NSString *const WPShareExtensionUserDefaultsPrimarySiteID           = @"WPShareUserDefaultsPrimarySiteID";
 
 /// Today Widget Constants
 ///
-NSString *const WPStatsTodayWidgetTokenKeychainUsername             = @"OAuth2Token";
-NSString *const WPStatsTodayWidgetTokenKeychainServiceName          = @"TodayWidget";
+NSString *const WPStatsTodayWidgetKeychainTokenKey                  = @"OAuth2Token";
+NSString *const WPStatsTodayWidgetKeychainServiceName               = @"TodayWidget";
 NSString *const WPStatsTodayWidgetUserDefaultsSiteIdKey             = @"WordPressTodayWidgetSiteId";
 NSString *const WPStatsTodayWidgetUserDefaultsSiteNameKey           = @"WordPressTodayWidgetSiteName";
 NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey       = @"WordPressTodayWidgetTimeZone";

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -996,6 +996,7 @@ int ddLogLevel = DDLogLevelInfo;
     WPAccount *account              = [accountService defaultWordPressComAccount];
     
     [ShareExtensionService configureShareExtensionToken:account.authToken];
+    [ShareExtensionService configureShareExtensionUsername:account.username];
 }
 
 - (void)removeShareExtensionConfiguration

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -7,11 +7,11 @@
 #import "BlogService.h"
 #import "SFHFKeychainUtils.h"
 #import "TodayExtensionService.h"
-#import <WordPressComStatsiOS/WPStatsViewController.h>
 #import <WordPressShared/WPNoResultsView.h>
 #import "WordPress-Swift.h"
 #import "WPAppAnalytics.h"
 #import "WPWebViewController.h"
+@import WordPressComStatsiOS;
 
 static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 

--- a/WordPress/Tracks+ShareExtension.swift
+++ b/WordPress/Tracks+ShareExtension.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+
+/// This extension implements helper tracking methods, meant for Share Extension Usage.
+///
+extension Tracks
+{
+    // MARK: - Public Methods
+    public func trackExtensionLaunched(wpcomAvailable: Bool) {
+        let properties = ["is_configured_dotcom" : wpcomAvailable]
+        trackExtensionEvent(.Launched, properties: properties)
+    }
+    
+    public func trackExtensionPosted(status: String) {
+        let properties = ["post_status" : status]
+        trackExtensionEvent(.Posted, properties: properties)
+    }
+    
+    public func trackExtensionCancelled() {
+        trackExtensionEvent(.Canceled)
+    }
+    
+    
+    // MARK: - Private Helpers
+    private func trackExtensionEvent(event: ExtensionEvents, properties: [String: AnyObject]? = nil) {
+        track(event.rawValue, properties: properties)
+    }
+    
+
+    // MARK: - Private Enums
+    private enum ExtensionEvents : String {
+        case Launched   = "wpios_share_extension_launched"
+        case Posted     = "wpios_share_extension_posted"
+        case Canceled   = "wpios_share_extension_canceled"
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -483,7 +483,6 @@
 		C56636E91868D0CE00226AAB /* StatsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C56636E71868D0CE00226AAB /* StatsViewController.m */; };
 		C58349C51806F95100B64089 /* IOS7CorrectedTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = C58349C41806F95100B64089 /* IOS7CorrectedTextView.m */; };
 		CEBD3EAB0FF1BA3B00C1396E /* Blog.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBD3EAA0FF1BA3B00C1396E /* Blog.m */; };
-		DFC0CE914560303A6567D882 /* Pods_WordPressShare.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 221474ED60F5079096014F42 /* Pods_WordPressShare.framework */; };
 		E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */; };
 		E10A2E9B134E8AD3007643F9 /* PostAnnotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 833AF25A114575A50016DE8F /* PostAnnotation.m */; };
 		E10B3652158F2D3F00419A93 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E10B3651158F2D3F00419A93 /* QuartzCore.framework */; };
@@ -2034,7 +2033,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DFC0CE914560303A6567D882 /* Pods_WordPressShare.framework in Frameworks */,
 				59A1C9CD58F3446A1EC73064 /* Pods_WordPressShareExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -461,6 +461,7 @@
 		B5EFB1C91B333C5A007608A3 /* NotificationsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EFB1C81B333C5A007608A3 /* NotificationsServiceTests.swift */; };
 		B5EFB1D11B33630C007608A3 /* notifications-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = B5EFB1D01B33630C007608A3 /* notifications-settings.json */; };
 		B5F995A01B59708C00AB0B3E /* NotificationSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5F9959F1B59708C00AB0B3E /* NotificationSettingsViewController.xib */; };
+		B5FA22831C99F6180016CA7C /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
 		B5FD4543199D0F2800286FBB /* NotificationDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FD4540199D0F2800286FBB /* NotificationDetailsViewController.m */; };
 		B5FD4544199D0F2800286FBB /* NotificationsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FD4542199D0F2800286FBB /* NotificationsViewController.m */; };
 		BE1071FC1BC75E7400906AFF /* WPStyleGuide+Blog.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1071FB1BC75E7400906AFF /* WPStyleGuide+Blog.swift */; };
@@ -1542,6 +1543,7 @@
 		B5EFB1C81B333C5A007608A3 /* NotificationsServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationsServiceTests.swift; sourceTree = "<group>"; };
 		B5EFB1D01B33630C007608A3 /* notifications-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-settings.json"; sourceTree = "<group>"; };
 		B5F9959F1B59708C00AB0B3E /* NotificationSettingsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NotificationSettingsViewController.xib; sourceTree = "<group>"; };
+		B5FA22821C99F6180016CA7C /* Tracks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Tracks.swift; path = WordPressShareExtension/Tracks.swift; sourceTree = SOURCE_ROOT; };
 		B5FD4520199D0C9A00286FBB /* WordPress-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "WordPress-Bridging-Header.h"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		B5FD453F199D0F2800286FBB /* NotificationDetailsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationDetailsViewController.h; sourceTree = "<group>"; };
 		B5FD4540199D0F2800286FBB /* NotificationDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = NotificationDetailsViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -3043,14 +3045,14 @@
 		932225A81C7CE50300443B02 /* WordPressShareExtension */ = {
 			isa = PBXGroup;
 			children = (
+				B5FA22851C99F63B0016CA7C /* Extensions */,
+				B5FA22841C99F6340016CA7C /* Tracks */,
 				B5BEA5661C7CEB4400C8035B /* Supporting Files */,
 				B50248C51C96FFE800AFBDED /* MainInterface.storyboard */,
 				B50248B81C96FFB000AFBDED /* WordPressShare-Bridging-Header.h */,
 				B50248B01C96FF8400AFBDED /* PostStatusPickerViewController.swift */,
 				B50248B11C96FF8400AFBDED /* ShareViewController.swift */,
 				B50248B21C96FF8400AFBDED /* SitePickerViewController.swift */,
-				B50248B31C96FF8400AFBDED /* UIImageView+Extensions.swift */,
-				B50248AE1C96FF6200AFBDED /* WPStyleGuide+Share.swift */,
 			);
 			name = WordPressShareExtension;
 			path = WordPressShare;
@@ -3507,6 +3509,23 @@
 				85D239AC1AE5A5FC0074768D /* WordPressXMLRPCAPIFacade.m */,
 			);
 			name = Facades;
+			sourceTree = "<group>";
+		};
+		B5FA22841C99F6340016CA7C /* Tracks */ = {
+			isa = PBXGroup;
+			children = (
+				B5FA22821C99F6180016CA7C /* Tracks.swift */,
+			);
+			name = Tracks;
+			sourceTree = "<group>";
+		};
+		B5FA22851C99F63B0016CA7C /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				B50248B31C96FF8400AFBDED /* UIImageView+Extensions.swift */,
+				B50248AE1C96FF6200AFBDED /* WPStyleGuide+Share.swift */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 		B5FD4523199D0F1100286FBB /* Views */ = {
@@ -5369,6 +5388,7 @@
 				B50248B51C96FF8400AFBDED /* ShareViewController.swift in Sources */,
 				B5BEA5601C7CE6D700C8035B /* SFHFKeychainUtils.m in Sources */,
 				B51DAF001C7E2332007F474C /* NSString+Helpers.swift in Sources */,
+				B5FA22831C99F6180016CA7C /* Tracks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 		B50248C71C96FFE800AFBDED /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B50248C51C96FFE800AFBDED /* MainInterface.storyboard */; };
 		B50421E71B680839008EEA82 /* NoteUndoOverlayView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B50421E61B680839008EEA82 /* NoteUndoOverlayView.xib */; };
 		B50421E91B68170F008EEA82 /* NoteUndoOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50421E81B68170F008EEA82 /* NoteUndoOverlayView.swift */; };
+		B504F5F51C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */; };
 		B5066D031BEBFAA900355819 /* RemoteBlogSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5066D021BEBFAA900355819 /* RemoteBlogSettings.swift */; };
 		B50EED791C0E5B2400D278CA /* SettingsPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50EED781C0E5B2400D278CA /* SettingsPickerViewController.swift */; };
 		B51535D41BBB16AA0029B84B /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B51535D31BBB16AA0029B84B /* Launch Screen.storyboard */; };
@@ -1408,6 +1409,7 @@
 		B50248C61C96FFE800AFBDED /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = MainInterface.storyboard; sourceTree = "<group>"; };
 		B50421E61B680839008EEA82 /* NoteUndoOverlayView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NoteUndoOverlayView.xib; sourceTree = "<group>"; };
 		B50421E81B68170F008EEA82 /* NoteUndoOverlayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoteUndoOverlayView.swift; sourceTree = "<group>"; };
+		B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tracks+ShareExtension.swift"; sourceTree = SOURCE_ROOT; };
 		B5066D021BEBFAA900355819 /* RemoteBlogSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RemoteBlogSettings.swift; path = "Remote Objects/RemoteBlogSettings.swift"; sourceTree = "<group>"; };
 		B50EED781C0E5B2400D278CA /* SettingsPickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsPickerViewController.swift; sourceTree = "<group>"; };
 		B51535D31BBB16AA0029B84B /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
@@ -3518,6 +3520,7 @@
 			isa = PBXGroup;
 			children = (
 				B5FA22821C99F6180016CA7C /* Tracks.swift */,
+				B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */,
 			);
 			name = Tracks;
 			sourceTree = "<group>";
@@ -5391,6 +5394,7 @@
 				B5BEA55F1C7CE6D100C8035B /* Constants.m in Sources */,
 				B50248B51C96FF8400AFBDED /* ShareViewController.swift in Sources */,
 				B5BEA5601C7CE6D700C8035B /* SFHFKeychainUtils.m in Sources */,
+				B504F5F51C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift in Sources */,
 				B51DAF001C7E2332007F474C /* NSString+Helpers.swift in Sources */,
 				B5FA22831C99F6180016CA7C /* Tracks.swift in Sources */,
 			);

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -10,7 +10,6 @@ class ShareViewController: SLComposeServiceViewController {
     private var selectedSiteID: Int?
     private var selectedSiteName: String?
     private var postStatus = "publish"
-    private var configuration: NSURLSessionConfiguration!
     private var tracks: Tracks!
     
     
@@ -27,12 +26,8 @@ class ShareViewController: SLComposeServiceViewController {
         selectedSiteID = defaultSite?.siteID
         selectedSiteName = defaultSite?.siteName
 
-        // Session Configuration
-        configuration = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier(WPAppGroupName)
-        configuration.sharedContainerIdentifier = WPAppGroupName
-
         // Tracker
-        tracks = Tracks(configuration: configuration)
+        tracks = Tracks(appGroupName: WPAppGroupName)
         tracks.wpcomUsername = username
     }
     
@@ -67,7 +62,11 @@ class ShareViewController: SLComposeServiceViewController {
         RequestRouter.bearerToken = oauth2Token! as String
 
         loadWebsiteUrl { (url: NSURL?) in
-            let service = PostService(configuration: self.configuration)
+            let identifier = WPAppGroupName + "." + NSUUID().UUIDString
+            let configuration = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier(identifier)
+            configuration.sharedContainerIdentifier = WPAppGroupName
+            
+            let service = PostService(configuration: configuration)
             let (subject, body) = self.splitContentTextIntoSubjectAndBody(self.contentWithSourceURL(url))
             service.createPost(siteID: self.selectedSiteID!, status:self.postStatus, title: subject, body: body) { (post, error) in
                 print("Post \(post) Error \(error)")

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -4,15 +4,18 @@ import WordPressComKit
 
 
 class ShareViewController: SLComposeServiceViewController {
+    private var wpcomUsername: String?
     private var oauth2Token: NSString?
     private var selectedSiteID: Int?
     private var selectedSiteName: String?
     private var postStatus = "publish"
     
     override func viewDidLoad() {
+        let username = ShareExtensionService.retrieveShareExtensionUsername()
         let authToken = ShareExtensionService.retrieveShareExtensionToken()
         let defaultSite = ShareExtensionService.retrieveShareExtensionPrimarySite()
         
+        wpcomUsername = username
         oauth2Token = authToken
         selectedSiteID = defaultSite?.siteID
         selectedSiteName = defaultSite?.siteName
@@ -22,6 +25,10 @@ class ShareViewController: SLComposeServiceViewController {
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
         dismissIfNeeded()
+        
+        
+        let tracks = Tracks(groupName: WPAppDefaultsGroupName, wpcomUsername: wpcomUsername)
+        tracks.track("wpios_share_extension_launched")
     }
     
     // MARK: - Private Helpers

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -4,12 +4,15 @@ import WordPressComKit
 
 
 class ShareViewController: SLComposeServiceViewController {
+    // MARK: - Private Properties
     private var wpcomUsername: String?
     private var oauth2Token: NSString?
     private var selectedSiteID: Int?
     private var selectedSiteName: String?
     private var postStatus = "publish"
-    private let tracks = Tracks(groupName: WPAppGroupName)
+    private var configuration: NSURLSessionConfiguration!
+    private var tracks: Tracks!
+    
     
     // MARK: - UIViewController Methods
     override func viewDidLoad() {
@@ -23,8 +26,13 @@ class ShareViewController: SLComposeServiceViewController {
         oauth2Token = token
         selectedSiteID = defaultSite?.siteID
         selectedSiteName = defaultSite?.siteName
-        
+
+        // Session Configuration
+        configuration = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier(WPAppGroupName)
+        configuration.sharedContainerIdentifier = WPAppGroupName
+
         // Tracker
+        tracks = Tracks(configuration: configuration)
         tracks.wpcomUsername = username
     }
     
@@ -59,9 +67,7 @@ class ShareViewController: SLComposeServiceViewController {
         RequestRouter.bearerToken = oauth2Token! as String
 
         loadWebsiteUrl { (url: NSURL?) in
-            let configuration = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier(WPAppGroupName)
-            configuration.sharedContainerIdentifier = WPAppGroupName
-            let service = PostService(configuration: configuration)
+            let service = PostService(configuration: self.configuration)
             let (subject, body) = self.splitContentTextIntoSubjectAndBody(self.contentWithSourceURL(url))
             service.createPost(siteID: self.selectedSiteID!, status:self.postStatus, title: subject, body: body) { (post, error) in
                 print("Post \(post) Error \(error)")

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -29,6 +29,7 @@ public class Tracks
     // MARK: - Private Helpers
     private func payloadWithEventName(eventName: String) -> [String: AnyObject] {
         let timestamp   = NSDate().timeIntervalSince1970 * 1000
+        let userID      = NSUUID().UUIDString
         let device      = UIDevice.currentDevice()
         let bundle      = NSBundle.mainBundle()
         let appName     = bundle.objectForInfoDictionaryKey("CFBundleName") as? String
@@ -38,9 +39,8 @@ public class Tracks
         return [
             "_en"                                   : eventName,
             "_ts"                                   : timestamp,
-            "_ui"                                   : "UserID",
-            "_ul"                                   : "Username",
-            "_ut"                                   : "wpcom:user_id",
+            "_ui"                                   : userID,
+            "_ut"                                   : "anon",
             "_via_ua"                               : Tracks.userAgent,
             "_rt"                                   : timestamp,
             "device_info_app_name"                  : appName       ?? "WordPress",

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+
+public class Tracks
+{
+    // MARK: - Properties
+    private let groupName           : String
+    
+    // MARK: - Constants
+    private static let version      = "1.0"
+    private static let userAgent    = "Nosara Extensions Client for iOS Mark " + version
+    
+    // MARK: - Initializers
+    init(groupName: String) {
+        self.groupName = groupName
+    }
+    
+    
+    // MARK: - Public Methods
+    public func track(eventName: String) {
+        let payload  = payloadWithEventName(eventName)
+        let uploader = Uploader(groupName: groupName)
+
+        uploader.send(payload)
+    }
+    
+    
+    
+    // MARK: - Private Helpers
+    private func payloadWithEventName(eventName: String) -> [String: AnyObject] {
+        let timestamp   = NSDate().timeIntervalSince1970 * 1000
+        let device      = UIDevice.currentDevice()
+        let bundle      = NSBundle.mainBundle()
+        let appName     = bundle.objectForInfoDictionaryKey("CFBundleName") as? String
+        let appVersion  = bundle.objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
+        let appCode     = bundle.objectForInfoDictionaryKey("CFBundleVersion") as? String
+        
+        return [
+            "_en"                                   : eventName,
+            "_ts"                                   : timestamp,
+            "_ui"                                   : "UserID",
+            "_ul"                                   : "Username",
+            "_ut"                                   : "wpcom:user_id",
+            "_via_ua"                               : Tracks.userAgent,
+            "_rt"                                   : timestamp,
+            "device_info_app_name"                  : appName       ?? "WordPress",
+            "device_info_app_version"               : appVersion    ?? "Unknown",
+            "device_info_app_version_code"          : appCode       ?? "Unknown",
+            "device_info_os"                        : device.systemName,
+            "device_info_os_version"                : device.systemVersion
+        ] as [String: AnyObject]
+    }
+    
+    
+    
+    /// Private Internal Helper:
+    /// Encapsulates all of the Backend Tracks Interaction, and deals with NSURLSession's API.
+    ///
+    private class Uploader: NSObject, NSURLSessionDelegate
+    {
+        // MARK: - Properties
+        private let groupName : String
+        
+        // MARK: - Constants
+        private let tracksURL   = "https://public-api.wordpress.com/rest/v1.1/tracks/record"
+        private let httpMethod  = "POST"
+        private let headers     = [ "Content-Type"  : "application/json",
+                                    "Accept"        : "application/json",
+                                    "User-Agent"    : "WPiOS App Extension"]
+        
+        // MARK: - Initializers
+        init(groupName: String) {
+            self.groupName = groupName
+        }
+        
+        
+        
+        // MARK: - Public Methods
+        func send(event: [String: AnyObject]) {
+            // Build the targetURL
+            let targetURL = NSURL(string: tracksURL)!
+            
+            // Payload
+            let dataToSend = [ "events" : [event], "commonProps" : [] ]
+            let requestBody = try? NSJSONSerialization.dataWithJSONObject(dataToSend, options: .PrettyPrinted)
+            
+            // Request
+            let request = NSMutableURLRequest(URL: targetURL)
+            request.HTTPMethod = httpMethod
+            request.HTTPBody = requestBody
+            
+            for (field, value) in headers {
+                request.setValue(value, forHTTPHeaderField: field)
+            }
+            
+            // Task!
+            let sc = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier(groupName)
+            sc.sharedContainerIdentifier = groupName
+
+            let session = NSURLSession(configuration: sc, delegate: self, delegateQueue: NSOperationQueue.mainQueue())
+            let task = session.downloadTaskWithRequest(request)
+            task.resume()
+        }
+        
+        
+        
+        // MARK: - NSURLSessionDelegate
+        @objc func URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError error: NSError?) {
+            print("<> Tracker.didCompleteWithError: \(error)")
+        }
+        
+        @objc func URLSession(session: NSURLSession, didBecomeInvalidWithError error: NSError?) {
+            print("<> Tracker.didBecomeInvalidWithError: \(error)")
+        }
+        
+        @objc func URLSessionDidFinishEventsForBackgroundURLSession(session: NSURLSession) {
+            print("<> Tracker.URLSessionDidFinishEventsForBackgroundURLSession")
+        }
+    }
+}

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -5,14 +5,16 @@ public class Tracks
 {
     // MARK: - Properties
     private let groupName           : String
+    private let wpcomUsername       : String?
     
     // MARK: - Constants
     private static let version      = "1.0"
     private static let userAgent    = "Nosara Extensions Client for iOS Mark " + version
     
     // MARK: - Initializers
-    init(groupName: String) {
+    init(groupName: String, wpcomUsername: String?) {
         self.groupName = groupName
+        self.wpcomUsername = wpcomUsername
     }
     
     
@@ -36,19 +38,27 @@ public class Tracks
         let appVersion  = bundle.objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
         let appCode     = bundle.objectForInfoDictionaryKey("CFBundleVersion") as? String
         
-        return [
-            "_en"                                   : eventName,
-            "_ts"                                   : timestamp,
-            "_ui"                                   : userID,
-            "_ut"                                   : "anon",
-            "_via_ua"                               : Tracks.userAgent,
-            "_rt"                                   : timestamp,
-            "device_info_app_name"                  : appName       ?? "WordPress",
-            "device_info_app_version"               : appVersion    ?? "Unknown",
-            "device_info_app_version_code"          : appCode       ?? "Unknown",
-            "device_info_os"                        : device.systemName,
-            "device_info_os_version"                : device.systemVersion
+        var payload = [
+            "_en"                           : eventName,
+            "_ts"                           : timestamp,
+            "_via_ua"                       : Tracks.userAgent,
+            "_rt"                           : timestamp,
+            "device_info_app_name"          : appName       ?? "WordPress",
+            "device_info_app_version"       : appVersion    ?? "Unknown",
+            "device_info_app_version_code"  : appCode       ?? "Unknown",
+            "device_info_os"                : device.systemName,
+            "device_info_os_version"        : device.systemVersion
         ] as [String: AnyObject]
+        
+        if let username = wpcomUsername {
+            payload["_ul"] = username
+            payload["_ut"] = "wpcom:user_id"
+        } else {
+            payload["_ui"] = userID
+            payload["_ut"] = "anon"
+        }
+        
+        return payload
     }
     
     

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -3,18 +3,19 @@ import Foundation
 
 public class Tracks
 {
-    // MARK: - Properties
+    // MARK: - Public Properties
+    public var wpcomUsername        : String?
+    
+    // MARK: - Private Properties
     private let groupName           : String
-    private let wpcomUsername       : String?
     
     // MARK: - Constants
     private static let version      = "1.0"
     private static let userAgent    = "Nosara Extensions Client for iOS Mark " + version
     
     // MARK: - Initializers
-    init(groupName: String, wpcomUsername: String?) {
+    init(groupName: String) {
         self.groupName = groupName
-        self.wpcomUsername = wpcomUsername
     }
     
     

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -7,22 +7,22 @@ public class Tracks
     public var wpcomUsername        : String?
     
     // MARK: - Private Properties
-    private let groupName           : String
+    private let configuration       : NSURLSessionConfiguration
     
     // MARK: - Constants
     private static let version      = "1.0"
     private static let userAgent    = "Nosara Extensions Client for iOS Mark " + version
     
     // MARK: - Initializers
-    init(groupName: String) {
-        self.groupName = groupName
+    init(configuration: NSURLSessionConfiguration) {
+        self.configuration = configuration
     }
     
     
     // MARK: - Public Methods
     public func track(eventName: String, properties: [String: AnyObject]? = nil) {
         let payload  = payloadWithEventName(eventName, properties: properties)
-        let uploader = Uploader(groupName: groupName)
+        let uploader = Uploader(configuration: configuration)
 
         uploader.send(payload)
     }
@@ -79,7 +79,7 @@ public class Tracks
     private class Uploader: NSObject, NSURLSessionDelegate
     {
         // MARK: - Properties
-        private let groupName : String
+        private let configuration : NSURLSessionConfiguration
         
         // MARK: - Constants
         private let tracksURL   = "https://public-api.wordpress.com/rest/v1.1/tracks/record"
@@ -89,8 +89,8 @@ public class Tracks
                                     "User-Agent"    : "WPiOS App Extension"]
         
         // MARK: - Initializers
-        init(groupName: String) {
-            self.groupName = groupName
+        init(configuration: NSURLSessionConfiguration) {
+            self.configuration = configuration
         }
         
         
@@ -114,10 +114,8 @@ public class Tracks
             }
             
             // Task!
-            let sc = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier(groupName)
-            sc.sharedContainerIdentifier = groupName
-
-            let session = NSURLSession(configuration: sc, delegate: self, delegateQueue: NSOperationQueue.mainQueue())
+            let delegateQueue = NSOperationQueue.mainQueue()
+            let session = NSURLSession(configuration: configuration, delegate: self, delegateQueue: delegateQueue)
             let task = session.downloadTaskWithRequest(request)
             task.resume()
         }

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -19,8 +19,8 @@ public class Tracks
     
     
     // MARK: - Public Methods
-    public func track(eventName: String) {
-        let payload  = payloadWithEventName(eventName)
+    public func track(eventName: String, properties: [String: AnyObject]? = nil) {
+        let payload  = payloadWithEventName(eventName, properties: properties)
         let uploader = Uploader(groupName: groupName)
 
         uploader.send(payload)
@@ -29,7 +29,7 @@ public class Tracks
     
     
     // MARK: - Private Helpers
-    private func payloadWithEventName(eventName: String) -> [String: AnyObject] {
+    private func payloadWithEventName(eventName: String, properties: [String: AnyObject]?) -> [String: AnyObject] {
         let timestamp   = NSDate().timeIntervalSince1970 * 1000
         let userID      = NSUUID().UUIDString
         let device      = UIDevice.currentDevice()
@@ -38,6 +38,7 @@ public class Tracks
         let appVersion  = bundle.objectForInfoDictionaryKey("CFBundleShortVersionString") as? String
         let appCode     = bundle.objectForInfoDictionaryKey("CFBundleVersion") as? String
         
+        // Main Payload
         var payload = [
             "_en"                           : eventName,
             "_ts"                           : timestamp,
@@ -50,12 +51,20 @@ public class Tracks
             "device_info_os_version"        : device.systemVersion
         ] as [String: AnyObject]
         
+        // Username
         if let username = wpcomUsername {
             payload["_ul"] = username
             payload["_ut"] = "wpcom:user_id"
         } else {
             payload["_ui"] = userID
             payload["_ut"] = "anon"
+        }
+        
+        // Inject the custom properties
+        if let theProperties = properties {
+            for (key, value) in theProperties {
+                payload[key] = value
+            }
         }
         
         return payload

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -127,7 +127,7 @@ class TodayViewController: UIViewController {
     }
 
     func fetchOAuthBearerToken() -> String? {
-        let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPStatsTodayWidgetTokenKeychainUsername, andServiceName: WPStatsTodayWidgetTokenKeychainServiceName, accessGroup: WPAppKeychainAccessGroup)
+        let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPStatsTodayWidgetKeychainTokenKey, andServiceName: WPStatsTodayWidgetKeychainServiceName, accessGroup: WPAppKeychainAccessGroup)
         
         return oauth2Token as String?
     }


### PR DESCRIPTION
#### Description:
In this PR we're implementing a small tool, meant for Extensions Usage, which hits the Tracks Backend.
This tool can be hooked to a background NSURLSessionConfiguration in background mode, which allows us to "complete tracker-OP's even after the extension has been killed"™.

Testing scenarios outlined below.

--


#### Scenario A: Uninitialized Extension Launch
1. Fresh install the app, and **don't sign into your account**
2. Switch to Safari
3. Launch the WPiOS Share Extension

As a result, after a couple minutes, the event `wpios_share_extension_launched` should show up, with the payload `is_configured_dotcom = false`.

#### Scenario B: Initialized Extension Launch
1. Fresh install the app, and sign into your account
2. Switch to Safari
3. Launch the WPiOS Share Extension

As a result, after a couple minutes, the event `wpios_share_extension_launched` should show up, with the payload `is_configured_dotcom = false`.

#### Scenario C: Posting Content
1. Fresh install the app, and sign into your account
2. Switch to Safari
3. Launch the WPiOS Share Extension
4. Post some content

As a result, the event `wpios_share_extension_posted` should show up, with the right `post_status` as payload.

#### Scenario D: Cancelling
1. Fresh install the app, and sign into your account
2. Switch to Safari
3. Launch the WPiOS Share Extension
4. Hit the cancel button

As a result, the event `wpios_share_extension_canceled` should be tracked.

--

Closes #4957

Needs review: @astralbodies 
Thanks Aaron!!