### PR TITLE
Improves self hosted login errors

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,7 +47,7 @@ target 'WordPress', :exclusive => true do
   pod 'WPMediaPicker', '~> 0.9.0'
   pod 'WordPress-iOS-Editor', '1.1.5'
   pod 'WordPress-iOS-Shared', '0.5.3'
-  pod 'WordPressApi', :git => "https://github.com/wordpress-mobile/WordPress-API-iOS.git"
+  pod 'WordPressApi', '~>0.4'
   pod 'WordPressCom-Analytics-iOS', '0.1.4'
   pod 'WordPressCom-Stats-iOS/UI', '0.6.3'
   pod 'wpxmlrpc', '~> 0.8'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -166,9 +166,9 @@ PODS:
   - WordPress-iOS-Shared (0.5.3):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (~> 2.2.0)
-  - WordPressApi (0.3.6):
+  - WordPressApi (0.4.0):
     - AFNetworking (~> 2.6.0)
-    - wpxmlrpc (~> 0.7)
+    - wpxmlrpc (~> 0.8)
   - WordPressCom-Analytics-iOS (0.1.4)
   - WordPressCom-Stats-iOS/Services (0.6.3):
     - AFNetworking (~> 2.6.0)
@@ -184,7 +184,7 @@ PODS:
     - WordPressCom-Analytics-iOS (~> 0.1.0)
     - WordPressCom-Stats-iOS/Services
   - WPMediaPicker (0.9.0)
-  - wpxmlrpc (0.8.1)
+  - wpxmlrpc (0.8.2)
 
 DEPENDENCIES:
   - 1PasswordExtension (= 1.6.4)
@@ -225,7 +225,7 @@ DEPENDENCIES:
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
   - WordPress-iOS-Editor (= 1.1.5)
   - WordPress-iOS-Shared (= 0.5.3)
-  - WordPressApi (from `https://github.com/wordpress-mobile/WordPress-API-iOS.git`)
+  - WordPressApi (~> 0.4)
   - WordPressCom-Analytics-iOS (= 0.1.4)
   - WordPressCom-Stats-iOS/Services (= 0.6.3)
   - WordPressCom-Stats-iOS/UI (= 0.6.3)
@@ -244,8 +244,6 @@ EXTERNAL SOURCES:
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPressApi:
-    :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -257,9 +255,6 @@ CHECKOUT OPTIONS:
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPressApi:
-    :commit: e89ef2bf8820d785c3fe9713ebeeb83f8a3f0429
-    :git: https://github.com/wordpress-mobile/WordPress-API-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 9f471645d378283cb88c6d4bf502e4381a42c0ad
@@ -299,10 +294,10 @@ SPEC CHECKSUMS:
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
   WordPress-iOS-Editor: 81649efb004edc8286d3af98225d8ec2a24452ae
   WordPress-iOS-Shared: 43f55f24f0685e431167084071b7914d7c7134a8
-  WordPressApi: 78e75bd45467f8bb0f7dad41cd7c3b0a1a9d3d4c
+  WordPressApi: 483767025bcdab26429b51bfe5171f17d3d30466
   WordPressCom-Analytics-iOS: 1d4cf0426fdc91393ea1ba65daf19133e440ff6a
   WordPressCom-Stats-iOS: 75dbdf4765c09b90a8fe00375dc96a93e64feffa
   WPMediaPicker: 2c399b1cbd4d8a7fcd312eb93107a349d26fb23f
-  wpxmlrpc: bd391dab54e9bdceb5d1de23d161ecf1ba80f0e0
+  wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
 COCOAPODS: 0.39.0

--- a/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
@@ -101,7 +101,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
                          }
                      } else if (failure) {
                          NSDictionary *userInfo = @{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Invalid value returned for new post: %@", responseObject]};
-                         NSError *error = [NSError errorWithDomain:@"org.wordpress.iphone" code:0 userInfo:userInfo];
+                         NSError *error = [NSError errorWithDomain:WordPressAppErrorDomain code:0 userInfo:userInfo];
                          failure(error);
                      }
                  } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
@@ -120,7 +120,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     if ([post.postID integerValue] <= 0) {
         if (failure) {
             NSDictionary *userInfo = @{NSLocalizedDescriptionKey: @"Can't edit a post if it's not in the server"};
-            NSError *error = [NSError errorWithDomain:@"org.wordpress.iphone" code:0 userInfo:userInfo];
+            NSError *error = [NSError errorWithDomain:WordPressAppErrorDomain code:0 userInfo:userInfo];
             dispatch_async(dispatch_get_main_queue(), ^{
                 failure(error);
             });

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -4,6 +4,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString *const WordPressMinimumVersion;
+
 @class WPAccount;
 
 @interface BlogService : LocalCoreDataService

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -30,7 +30,7 @@ NSString *const LastUsedBlogURLDefaultsKey = @"LastUsedBlogURLDefaultsKey";
 NSString *const EditPostViewControllerLastUsedBlogURLOldKey = @"EditPostViewControllerLastUsedBlogURL";
 NSString *const WPComGetFeatures = @"wpcom.getFeatures";
 NSString *const VideopressEnabled = @"videopress_enabled";
-NSString *const MinimumVersion = @"3.6";
+NSString *const WordPressMinimumVersion = @"4.0";
 NSString *const HttpsPrefix = @"https://";
 CGFloat const OneHourInSeconds = 60.0 * 60.0;
 
@@ -791,14 +791,14 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
             blog.options = [NSDictionary dictionaryWithDictionary:options];
 
             CGFloat version = [[blog version] floatValue];
-            if (version < [MinimumVersion floatValue]) {
+            if (version < [WordPressMinimumVersion floatValue]) {
                 if (blog.lastUpdateWarning == nil
-                    || [blog.lastUpdateWarning floatValue] < [MinimumVersion floatValue])
+                    || [blog.lastUpdateWarning floatValue] < [WordPressMinimumVersion floatValue])
                 {
                     // TODO :: Remove UI call from service layer
                     [WPError showAlertWithTitle:NSLocalizedString(@"WordPress version too old", @"")
-                                        message:[NSString stringWithFormat:NSLocalizedString(@"The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@", @""), [blog hostname], [blog version], MinimumVersion]];
-                    blog.lastUpdateWarning = MinimumVersion;
+                                        message:[NSString stringWithFormat:NSLocalizedString(@"The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@", @""), [blog hostname], [blog version], WordPressMinimumVersion]];
+                    blog.lastUpdateWarning = WordPressMinimumVersion;
                 }
             }
 

--- a/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
@@ -28,11 +28,6 @@
         return error;
     } else if ([error.domain isEqual:WPXMLRPCErrorDomain] && error.code == WPXMLRPCInvalidInputError) {
         return error;
-    } else if ([error.domain isEqual:AFURLRequestSerializationErrorDomain] || [error.domain isEqual:AFURLResponseSerializationErrorDomain]) {
-        NSString *str = [NSString stringWithFormat:NSLocalizedString(@"There was a server error communicating with your site:\n%@\nTap 'Need Help?' to view the FAQ.", nil), [error localizedDescription]];
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: str};
-        NSError *err = [NSError errorWithDomain:WordPressAppErrorDomain code:NSURLErrorBadServerResponse userInfo:userInfo];
-        return err;
     } else {
         NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to find a WordPress site at that URL. Tap 'Need Help?' to view the FAQ.", nil)};
         NSError *err = [NSError errorWithDomain:WordPressAppErrorDomain code:NSURLErrorBadURL userInfo:userInfo];

--- a/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
@@ -29,7 +29,10 @@
     } else if ([error.domain isEqual:WPXMLRPCErrorDomain] && error.code == WPXMLRPCInvalidInputError) {
         return error;
     } else {
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to find a WordPress site at that URL. Tap 'Need Help?' to view the FAQ.", nil)};
+        NSDictionary *userInfo = @{
+                                   NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to find a WordPress site at that URL. Tap 'Need Help?' to view the FAQ.", nil),
+                                   NSLocalizedFailureReasonErrorKey: error.localizedDescription
+                                   };
         NSError *err = [NSError errorWithDomain:WordPressAppErrorDomain code:NSURLErrorBadURL userInfo:userInfo];
         return err;
     }

--- a/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
@@ -24,7 +24,7 @@
 - (NSError *)errorForGuessXMLRPCApiFailure:(NSError *)error
 {
     if ([error.domain isEqual:NSURLErrorDomain] && error.code == NSURLErrorUserCancelledAuthentication) {
-        return nil;
+        return error;
     } else if ([error.domain isEqual:WPXMLRPCErrorDomain] && error.code == WPXMLRPCInvalidInputError) {
         return error;
     } else if ([error.domain isEqual:AFURLRequestSerializationErrorDomain] || [error.domain isEqual:AFURLResponseSerializationErrorDomain]) {

--- a/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
@@ -26,11 +26,9 @@
     DDLogError(@"Error on trying to guess XMLRPC site: %@", error);
     if ([error.domain isEqual:NSURLErrorDomain] && error.code == NSURLErrorUserCancelledAuthentication) {
         return error;
-    } else if ([error.domain isEqual:WPXMLRPCErrorDomain] && error.code == WPXMLRPCInvalidInputError) {
-        return error;
     } else {
         NSDictionary *userInfo = @{
-                                   NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to find a WordPress site at that URL. Tap 'Need Help?' to view the FAQ.", nil),
+                                   NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to read the WordPress site on that URL. Tap 'Need Help?' to view the FAQ.", nil),
                                    NSLocalizedFailureReasonErrorKey: error.localizedDescription
                                    };
         NSError *err = [NSError errorWithDomain:WordPressAppErrorDomain code:NSURLErrorBadURL userInfo:userInfo];

--- a/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
@@ -30,11 +30,11 @@
     } else if ([error.domain isEqual:AFURLRequestSerializationErrorDomain] || [error.domain isEqual:AFURLResponseSerializationErrorDomain]) {
         NSString *str = [NSString stringWithFormat:NSLocalizedString(@"There was a server error communicating with your site:\n%@\nTap 'Need Help?' to view the FAQ.", nil), [error localizedDescription]];
         NSDictionary *userInfo = @{NSLocalizedDescriptionKey: str};
-        NSError *err = [NSError errorWithDomain:@"org.wordpress.iphone" code:NSURLErrorBadServerResponse userInfo:userInfo];
+        NSError *err = [NSError errorWithDomain:WordPressAppErrorDomain code:NSURLErrorBadServerResponse userInfo:userInfo];
         return err;
     } else {
         NSDictionary *userInfo = @{NSLocalizedDescriptionKey: NSLocalizedString(@"Unable to find a WordPress site at that URL. Tap 'Need Help?' to view the FAQ.", nil)};
-        NSError *err = [NSError errorWithDomain:@"org.wordpress.iphone" code:NSURLErrorBadURL userInfo:userInfo];
+        NSError *err = [NSError errorWithDomain:WordPressAppErrorDomain code:NSURLErrorBadURL userInfo:userInfo];
         return err;
     }
 }

--- a/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
@@ -23,6 +23,7 @@
 
 - (NSError *)errorForGuessXMLRPCApiFailure:(NSError *)error
 {
+    DDLogError(@"Error on trying to guess XMLRPC site: %@", error);
     if ([error.domain isEqual:NSURLErrorDomain] && error.code == NSURLErrorUserCancelledAuthentication) {
         return error;
     } else if ([error.domain isEqual:WPXMLRPCErrorDomain] && error.code == WPXMLRPCInvalidInputError) {

--- a/WordPress/Classes/Utility/WPError.h
+++ b/WordPress/Classes/Utility/WPError.h
@@ -1,3 +1,5 @@
+extern NSString *const WordPressAppErrorDomain;
+
 @interface WPError : NSObject
 
 

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -7,6 +7,7 @@
 #import "NSString+Helpers.h"
 #import "SupportViewController.h"
 #import "WordPress-Swift.h"
+#import <WPXMLRPC/WPXMLRPC.h>
 
 NSInteger const SupportButtonIndex = 0;
 NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
@@ -110,7 +111,7 @@ NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
 {
     NSString *cleanedErrorMsg = [error localizedDescription];
 
-    if ([error.domain isEqualToString:WordPressXMLRPCApiErrorDomain] && error.code == 401){
+    if ([error.domain isEqualToString:WPXMLRPCFaultErrorDomain] && error.code == 401){
         cleanedErrorMsg = NSLocalizedString(@"Sorry, you cannot access this feature. Please check your User Role on this site.", @"");
     }
 

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -9,6 +9,7 @@
 #import "WordPress-Swift.h"
 
 NSInteger const SupportButtonIndex = 0;
+NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
 
 @interface WPError ()
 
@@ -110,7 +111,7 @@ NSInteger const SupportButtonIndex = 0;
     NSString *cleanedErrorMsg = [error localizedDescription];
 
     //org.wordpress.iphone --> XML-RPC errors
-    if ([error.domain isEqualToString:@"org.wordpress.iphone"] && error.code == 401){
+    if ([error.domain isEqualToString:WordPressAppErrorDomain] && error.code == 401){
         cleanedErrorMsg = NSLocalizedString(@"Sorry, you cannot access this feature. Please check your User Role on this site.", @"");
     }
 

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -110,8 +110,7 @@ NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
 {
     NSString *cleanedErrorMsg = [error localizedDescription];
 
-    //org.wordpress.iphone --> XML-RPC errors
-    if ([error.domain isEqualToString:WordPressAppErrorDomain] && error.code == 401){
+    if ([error.domain isEqualToString:WordPressXMLRPCApiErrorDomain] && error.code == 401){
         cleanedErrorMsg = NSLocalizedString(@"Sorry, you cannot access this feature. Please check your User Role on this site.", @"");
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -480,7 +480,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
         }
     }
 
-    if ([error code] == NSURLErrorBadURL) {
+    if ([error.domain isEqualToString:WordPressAppErrorDomain] && [error code] == NSURLErrorBadURL) {
         [self displayErrorMessageForBadUrl:message];
         return;
     }

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -459,7 +459,10 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     
     [self.presenter dismissLoginMessage];
     
-    NSString *message = [error localizedDescription];
+    NSString *message = message = NSLocalizedString(@"Sign in failed. Please try again.", "Generic message to show to the user when there is unknow login error");
+    if ( [error.localizedDescription trim].length > 0) {
+        message = [error localizedDescription];
+    }
     if (![[error domain] isEqualToString:WPXMLRPCFaultErrorDomain]
         && [error code] != NSURLErrorBadURL) {
         if ([self.helpshiftEnabledFacade isHelpshiftEnabled]) {
@@ -473,11 +476,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     if ([error code] == 403) {
         message = NSLocalizedString(@"Your username and password look incorrect can you please try entering your login details again.", "Message to show to the user when username and/or password details are incorrect");
     }
-    
-    if ([[message trim] length] == 0) {
-        message = NSLocalizedString(@"Sign in failed. Please try again.", "Generic message to show to the user when there is unknow login error");
-    }
-    
+
     if ([error code] == 405) {
         [self displayErrorMessageForXMLRPC:message];
     } else {

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -463,6 +463,12 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     if ( [error.localizedDescription trim].length > 0) {
         message = [error localizedDescription];
     }
+
+    if ([error.domain isEqual:NSURLErrorDomain] && error.code == NSURLErrorUserCancelledAuthentication) {
+        //Don't display any error if user canceled basic auth authentication.
+        return;
+    }
+    
     if (![[error domain] isEqualToString:WPXMLRPCFaultErrorDomain]
         && [error code] != NSURLErrorBadURL) {
         if ([self.helpshiftEnabledFacade isHelpshiftEnabled]) {
@@ -472,7 +478,9 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
         }
         return;
     }
-    
+
+
+
     if ([error code] == 403) {
         message = NSLocalizedString(@"Your username and password look incorrect can you please try entering your login details again.", "Message to show to the user when username and/or password details are incorrect");
     }

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -460,7 +460,8 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     [self.presenter dismissLoginMessage];
     
     NSString *message = [error localizedDescription];
-    if (![[error domain] isEqualToString:WPXMLRPCFaultErrorDomain] && [error code] != NSURLErrorBadURL) {
+    if (![[error domain] isEqualToString:WPXMLRPCFaultErrorDomain]
+        && [error code] != NSURLErrorBadURL) {
         if ([self.helpshiftEnabledFacade isHelpshiftEnabled]) {
             [self displayGenericErrorMessageWithHelpshiftButton:message];
         } else {

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -470,11 +470,11 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     }
     
     if ([error code] == 403) {
-        message = NSLocalizedString(@"Please try entering your login details again.", nil);
+        message = NSLocalizedString(@"Your username and password look incorrect can you please try entering your login details again.", "Message to show to the user when username and/or password details are incorrect");
     }
     
     if ([[message trim] length] == 0) {
-        message = NSLocalizedString(@"Sign in failed. Please try again.", nil);
+        message = NSLocalizedString(@"Sign in failed. Please try again.", "Generic message to show to the user when there is unknow login error");
     }
     
     if ([error code] == 405) {

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -471,7 +471,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
 
     if ([error.domain isEqualToString:WPXMLRPCFaultErrorDomain]) {
         if ([error code] == 403) {
-            message = NSLocalizedString(@"Your username and password look incorrect can you please try entering your login details again.", "Message to show to the user when username and/or password details are incorrect");
+            message = NSLocalizedString(@"Your site was accessible but the username/password combination was not accepted. Please try again.", "Message to show to the user when username and/or password details are incorrect");
         }
 
         if ([error code] == 405) {

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -468,7 +468,7 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
         //Don't display any error if user canceled basic auth authentication.
         return;
     }
-    
+
     if (![[error domain] isEqualToString:WPXMLRPCFaultErrorDomain]
         && [error code] != NSURLErrorBadURL) {
         if ([self.helpshiftEnabledFacade isHelpshiftEnabled]) {

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -469,30 +469,26 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
         return;
     }
 
-    if (![[error domain] isEqualToString:WPXMLRPCFaultErrorDomain]
-        && [error code] != NSURLErrorBadURL) {
-        if ([self.helpshiftEnabledFacade isHelpshiftEnabled]) {
-            [self displayGenericErrorMessageWithHelpshiftButton:message];
-        } else {
-            [self displayGenericErrorMessage:message];
+    if ([error.domain isEqualToString:WPXMLRPCFaultErrorDomain]) {
+        if ([error code] == 403) {
+            message = NSLocalizedString(@"Your username and password look incorrect can you please try entering your login details again.", "Message to show to the user when username and/or password details are incorrect");
         }
+
+        if ([error code] == 405) {
+            [self displayErrorMessageForXMLRPC:message];
+            return;
+        }
+    }
+
+    if ([error code] == NSURLErrorBadURL) {
+        [self displayErrorMessageForBadUrl:message];
         return;
     }
 
-
-
-    if ([error code] == 403) {
-        message = NSLocalizedString(@"Your username and password look incorrect can you please try entering your login details again.", "Message to show to the user when username and/or password details are incorrect");
-    }
-
-    if ([error code] == 405) {
-        [self displayErrorMessageForXMLRPC:message];
+    if ([self.helpshiftEnabledFacade isHelpshiftEnabled]) {
+        [self displayGenericErrorMessageWithHelpshiftButton:message];
     } else {
-        if ([error code] == NSURLErrorBadURL) {
-            [self displayErrorMessageForBadUrl:message];
-        } else {
-            [self displayGenericErrorMessage:message];
-        }
+        [self displayGenericErrorMessage:message];
     }
 }
 


### PR DESCRIPTION
Fixes: #4945 

This PR tries to improved the code around displaying error messages on login, and improve the login messages show to the user.

To test:

Try different scenarios on login:
 * For a self hosted site:
   * Login to a 404 site
   * Login to a 301 site
   * Login to a WordPress site with a version lower than 4.0
   * Login to sites with basic auth
     * Cancel the basic auth
     * put a wrong credential
     * put the right credential
  * Access sites with https setup correctly
  * Access sites with https setup with self signed certificate.
  
Needs review: @astralbodies and @bummytime 