### PR TITLE
Issues/3973 schedule post bug

### DIFF
--- a/WordPress/Classes/Models/BasePost.h
+++ b/WordPress/Classes/Models/BasePost.h
@@ -80,9 +80,21 @@ extern NSString * const PostStatusDeleted;
 - (NSArray *)availableStatusesForEditing;
 
 /**
- Returns YES if the post is scheduled to be published on a specific date in the future.
+ Returns the correct "publish" status for the current value of date_created_gmt. 
+ Future dates return PostStatusScheduled. Otherwise PostStatusPublish. This is not
+ necessarily the current value of `status`
+ */
+- (NSString *)availableStatusForPublishOrScheduled;
+
+/**
+ Returns YES if the post is has a `future` post status
  */
 - (BOOL)isScheduled;
+
+/**
+ Returns YES if the post has a future date_created_gmt.
+ */
+- (BOOL)hasFuturePublishDate;
 
 /**
  *  Whether there was any attempt ever to upload this post, either successful or failed.

--- a/WordPress/Classes/Models/BasePost.h
+++ b/WordPress/Classes/Models/BasePost.h
@@ -93,6 +93,8 @@ extern NSString * const PostStatusDeleted;
 
 /**
  Returns YES if the post has a future date_created_gmt.
+ This is different from "isScheduled" in that  a post with a draft, pending, or 
+ trashed status can also have a date_created_gmt with a future value.
  */
 - (BOOL)hasFuturePublishDate;
 

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -182,7 +182,7 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 
     /*
      If the date is nil it means publish immediately so set the status to publish.
-     If the date is in the future set the status to scheduled.
+     If the date is in the future set the status to scheduled if current status is published.
      If the date is now or in the past, and the status is scheduled, set the status
      to published.
      */
@@ -190,11 +190,8 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
         // A nil date means publish immediately.
         self.status = PostStatusPublish;
 
-    } else if (self.date_created_gmt == [self.date_created_gmt laterDate:[NSDate date]]) {
-        // If its a future date, and we're not trashed, then the status is scheduled.
-        if (![self.status isEqualToString:PostStatusTrash]){
-            self.status = PostStatusScheduled;
-        }
+    } else if ([self hasFuturePublishDate] && [self.status isEqualToString:PostStatusPublish]) {
+        self.status = PostStatusScheduled;
 
     } else if ([self.status isEqualToString:PostStatusScheduled]) {
         self.status = PostStatusPublish;

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -190,9 +190,12 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
         // A nil date means publish immediately.
         self.status = PostStatusPublish;
 
-    } else if ([self hasFuturePublishDate] && [self.status isEqualToString:PostStatusPublish]) {
-        self.status = PostStatusScheduled;
-
+    } else if ([self hasFuturePublishDate]) {
+        // Needs to be a nested conditional so future date + scheduled status
+        // is handled correctly.
+        if ([self.status isEqualToString:PostStatusPublish]) {
+            self.status = PostStatusScheduled;
+        }
     } else if ([self.status isEqualToString:PostStatusScheduled]) {
         self.status = PostStatusPublish;
     }

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -123,9 +123,7 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
     return [BasePost titleForStatus:self.status];
 }
 
-// If the post has a future publish date. This is different from "isScheduled" in that
-// a post with a draft, pending, or trashed status can also have a date_created_gmt
-// with a future value.
+// This is different than isScheduled. See .h for details.
 - (BOOL)hasFuturePublishDate
 {
     if (!self.date_created_gmt) {

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -70,12 +70,20 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
     return [string stringByEllipsizingWithMaxLength:PostDerivedSummaryLength preserveWords:YES];
 }
 
+- (NSString *)availableStatusForPublishOrScheduled
+{
+    if ([self hasFuturePublishDate]) {
+        return PostStatusScheduled;
+    }
+    return PostStatusPublish;
+}
+
 - (NSArray *)availableStatusesForEditing
 {
     // Note: Read method description before changing values.
     return @[PostStatusDraft,
              PostStatusPending,
-             PostStatusPublish];
+             [self availableStatusForPublishOrScheduled]];
 }
 
 - (BOOL)hasNeverAttemptedToUpload
@@ -115,6 +123,18 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
     return [BasePost titleForStatus:self.status];
 }
 
+// If the post has a future publish date. This is different from "isScheduled" in that
+// a post with a draft, pending, or trashed status can also have a date_created_gmt
+// with a future value.
+- (BOOL)hasFuturePublishDate
+{
+    if (!self.date_created_gmt) {
+        return NO;
+    }
+    return (self.date_created_gmt == [self.date_created_gmt laterDate:[NSDate date]]);
+}
+
+// If the post has a scheduled status.
 - (BOOL)isScheduled
 {
     return ([self.status isEqualToString:PostStatusScheduled]);

--- a/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
@@ -322,7 +322,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 {
     // Scheduled posts are synced with a post_status of 'publish' but we want to
     // work with a status of 'future' from within the app.
-    if (date == [date laterDate:[NSDate date]]) {
+    if ([status isEqualToString:PostStatusPublish] && date == [date laterDate:[NSDate date]]) {
         return PostStatusScheduled;
     }
     return status;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -566,7 +566,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         // Publish date
         cell = [self getWPTableViewCell];
         if (self.apost.dateCreated) {
-            if ([self.apost isScheduled]) {
+            if ([self.apost hasFuturePublishDate]) {
                 cell.textLabel.text = NSLocalizedString(@"Scheduled for", @"Scheduled for [date]");
             } else {
                 cell.textLabel.text = NSLocalizedString(@"Published on", @"Published on [date]");
@@ -844,7 +844,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     }];
 
     NSDictionary *statusDict = @{
-                                 @"DefaultValue": PostStatusPublish,
+                                 @"DefaultValue": [self.apost availableStatusForPublishOrScheduled],
                                  @"Title" : NSLocalizedString(@"Status", nil),
                                  @"Titles" : titles,
                                  @"Values" : statuses,

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1870,7 +1870,7 @@ EditImageDetailsViewControllerDelegate
 
 - (void)actionSheetSaveDraftButtonPressed
 {
-    if (![self.post hasRemote] && [self.post.status isEqualToString:PostStatusPublish]) {
+    if (![self.post hasRemote] && (self.post.isScheduled || [self.post.status isEqualToString:PostStatusPublish])) {
         self.post.status = PostStatusDraft;
     }
     

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1445,7 +1445,7 @@ EditImageDetailsViewControllerDelegate
 
     [self.view endEditing:YES];
     
-    if (!self.post.isScheduled && [self.post.original.status isEqualToString:PostStatusDraft]  && [self.post.status isEqualToString:PostStatusPublish]) {
+    if (!self.post.hasFuturePublishDate && [self.post.original.status isEqualToString:PostStatusDraft]  && [self.post.status isEqualToString:PostStatusPublish]) {
         self.post.dateCreated = [NSDate date];
     }
     self.post = self.post.original;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1433,6 +1433,13 @@ EditImageDetailsViewControllerDelegate
     [self dismissEditView:YES];
 }
 
+- (BOOL)shouldPublishImmediately
+{
+    return !self.post.hasFuturePublishDate &&
+        [self.post.original.status isEqualToString:PostStatusDraft] &&
+        [self.post.status isEqualToString:PostStatusPublish];
+}
+
 /**
  *  @brief      Saves the post being edited and uploads it.
  *  @details    Saves the post being edited and uploads it. If the post is NOT already scheduled, 
@@ -1445,7 +1452,7 @@ EditImageDetailsViewControllerDelegate
 
     [self.view endEditing:YES];
     
-    if (!self.post.hasFuturePublishDate && [self.post.original.status isEqualToString:PostStatusDraft]  && [self.post.status isEqualToString:PostStatusPublish]) {
+    if ([self shouldPublishImmediately]) {
         self.post.dateCreated = [NSDate date];
     }
     self.post = self.post.original;


### PR DESCRIPTION
Refs #3973 

This PR addresses a couple of issues with scheduled posts.  

First, there was an issue where the XMLRPC remote would incorrectly set the post status to "publish" for any post with a future date.  This was problematic as posts with a pending, draft, or trashed status can also have future dates. This resulted in the app "loosing" certain posts, particularly drafts that were set to a future publish date.  The intended draft would vanish from the drafts filter when saved.  Switching to the scheduled filter would briefly show the post, but it would quickly disappear once scheduled posts were resynced. 

Second, some of the labeling in the UI has been updated to better indicate the intended publish status. Now if a post has a future date, the post status selector will show "Scheduled" as an available status instead of "Published". 


To test:
Create a new post. 
Set its status to draft
Set its publish date to the future. 
Save the post. 
The post should appear under the list of drafts and display a future date. 

Edit the draft and change its status to scheduled. 
Confirm that the post appears correctly in the scheduled list.

Trash the post. 
Confirm the post appears correctly in the trashed list and displays a future date. 

Restore the post. 
Confirm the post reappears in the scheduled list.

Finally tap the "Publish" button on the post card for the scheduled post in the post list.
Confirm the post is published with the *current* date.

Perform the above test for a wpcom and a self-hosted blog

Please note that you may run afoul of #4968 and/or #4969 while testing. 

Needs review: @diegoreymendez 
cc @bummytime 
