### PR TITLE
Share Extension NSURLSession Invalidation

### DIFF
--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -89,6 +89,13 @@ public class Tracks
                                     "Accept"        : "application/json",
                                     "User-Agent"    : "WPiOS App Extension"]
         
+        
+        // MARK: - Deinitializers
+        deinit {
+            session.finishTasksAndInvalidate()
+        }
+        
+        
         // MARK: - Initializers
         init(appGroupName: String) {
             super.init()

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -7,23 +7,24 @@ public class Tracks
     public var wpcomUsername        : String?
     
     // MARK: - Private Properties
-    private let appGroupName        : String
+    private let uploader            : Uploader
     
     // MARK: - Constants
     private static let version      = "1.0"
     private static let userAgent    = "Nosara Extensions Client for iOS Mark " + version
     
+    
+    
     // MARK: - Initializers
     init(appGroupName: String) {
-        self.appGroupName = appGroupName
+        uploader = Uploader(appGroupName: appGroupName)
     }
+    
     
     
     // MARK: - Public Methods
     public func track(eventName: String, properties: [String: AnyObject]? = nil) {
         let payload  = payloadWithEventName(eventName, properties: properties)
-        let uploader = Uploader(appGroupName: appGroupName)
-
         uploader.send(payload)
     }
     


### PR DESCRIPTION
#### Details:
In this (brief) PR, we're adding few good NSURLSession practises:

- The same Background NSURLSession is being reused for all of the Tracks calls
- On deinit, as per [Apple's documentation, we're invalidating the session](https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/URLLoadingSystem/NSURLSessionConcepts/NSURLSessionConcepts.html#//apple_ref/doc/uid/10000165i-CH2-SW42).

```
When your app no longer needs a session, invalidate it by calling either invalidateAndCancel (to cancel outstanding tasks) or finishTasksAndInvalidate (to allow outstanding tasks to finish before invalidating the object).
```

Needs review: @astralbodies 
Thanks in advance Aaron!

cc @SergioEstevao thanks for helping me out with this one!

