### PR TITLE
Share extension initialization

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -18,7 +18,7 @@ target 'WordPress', :exclusive => true do
   pod 'CocoaLumberjack', '~> 2.2.0'
   pod 'DTCoreText',   '1.6.16'
   pod 'FormatterKit', '~> 1.8.0'
-  pod 'Helpshift', '~> 5.3.0-support'
+  pod 'Helpshift', '~> 5.5.0-bitcode'
   pod 'HockeySDK', '~>3.8.0'
   pod 'Lookback', '1.1.4', :configurations => ['Release-Internal', 'Release-Alpha']
   pod 'MRProgress', '~>0.7.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -70,7 +70,7 @@ PODS:
   - FormatterKit/TimeIntervalFormatter (1.8.0)
   - FormatterKit/UnitOfInformationFormatter (1.8.0)
   - FormatterKit/URLRequestFormatter (1.8.0)
-  - Helpshift (5.3.0-supportXcode6)
+  - Helpshift (5.5.0)
   - HockeySDK (3.8.6):
     - HockeySDK/AllFeaturesLib (= 3.8.6)
   - HockeySDK/AllFeaturesLib (3.8.6)
@@ -201,7 +201,7 @@ DEPENDENCIES:
   - EmailChecker (from `https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec`)
   - Expecta (= 0.3.2)
   - FormatterKit (~> 1.8.0)
-  - Helpshift (~> 5.3.0-support)
+  - Helpshift (~> 5.5.0-bitcode)
   - HockeySDK (~> 3.8.0)
   - KIF/IdentifierTests (~> 3.1)
   - Lookback (= 1.1.4)
@@ -286,7 +286,7 @@ SPEC CHECKSUMS:
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   Fabric: caf7580c725e64db144f610ac65cd60956911dc7
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
-  Helpshift: af8567ca7991c6d2c1aa76e10ee6e6893409c0a1
+  Helpshift: b60067446b513002bd7ed8f13b7b67e4fb7f9237
   HockeySDK: ab68303eec6680f6b539de65d747742dd276e934
   KIF: 2275c6d59c77e5e56f660f006b99d73780130540
   Lookback: 9ab9027ff246d2dc5ce34be483f70e4a6718280b

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -88,7 +88,7 @@ extern NSString *const WPAccountEmailAndDefaultBlogUpdatedNotification;
 /**
  Initializes the WordPress iOS Extensions with the WordPress.com Default Account.
  */
-- (void)setupExtensionsWithDefaultAccount;
+- (void)setupAppExtensionsWithDefaultAccount;
 
 
 /**

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -86,6 +86,12 @@ extern NSString *const WPAccountEmailAndDefaultBlogUpdatedNotification;
 - (void)updateUserDetailsForAccount:(WPAccount *)account success:(void (^)())success failure:(void (^)(NSError *error))failure;
 
 /**
+ Initializes the WordPress iOS Extensions with the WordPress.com Default Account.
+ */
+- (void)setupExtensionsWithDefaultAccount;
+
+
+/**
  Removes an account if it won't be used anymore.
  
  For self hosted accounts, the account will be removed if there are no associated blogs

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -209,7 +209,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         // account.objectID can be temporary, so fetch via username/xmlrpc instead.
         WPAccount *fetchedAccount = [self findAccountWithUsername:username];
         [self updateAccount:fetchedAccount withUserDetails:remoteUser];
-        [self setupExtensionsWithDefaultAccount];
+        [self setupAppExtensionsWithDefaultAccount];
         dispatch_async(dispatch_get_main_queue(), ^{
             [WPAnalytics refreshMetadata];
         });
@@ -267,7 +267,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     [blogService flagBlogAsLastUsed:account.defaultBlog];
 }
 
-- (void)setupExtensionsWithDefaultAccount
+- (void)setupAppExtensionsWithDefaultAccount
 {
     WPAccount *defaultAccount = [self defaultWordPressComAccount];
     Blog *defaultBlog = [defaultAccount defaultBlog];

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -382,6 +382,9 @@ int ddLogLevel = DDLogLevelInfo;
         [MediaService cleanUnusedMediaFileFromTmpDir];
     });
     
+    // Configure Extensions
+    [self setupWordPressExtensions];
+    
     // Configure Today Widget
     [self determineIfTodayWidgetIsConfiguredAndShowAppropriately];
     
@@ -969,6 +972,16 @@ int ddLogLevel = DDLogLevelInfo;
 - (void)handleLowMemoryWarningNote:(NSNotification *)notification
 {
     [WPAnalytics track:WPAnalyticsStatLowMemoryWarning];
+}
+
+
+#pragma mark - Extensions
+
+- (void)setupWordPressExtensions
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    AccountService *accountService  = [[AccountService alloc] initWithManagedObjectContext:context];
+    [accountService setupExtensionsWithDefaultAccount];
 }
 
 

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -981,7 +981,7 @@ int ddLogLevel = DDLogLevelInfo;
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     AccountService *accountService  = [[AccountService alloc] initWithManagedObjectContext:context];
-    [accountService setupExtensionsWithDefaultAccount];
+    [accountService setupAppExtensionsWithDefaultAccount];
 }
 
 


### PR DESCRIPTION
#### Details:
In this PR we're exposing the Extension Initialization routine, so that it can be called from (anywhere else). This is meant to solve the "Extension doesn't get initialized after upgrading the app" glitch we've observed during our IPA tests.

Needs review: @astralbodies 
