### PR TITLE
Issue/fix image rotation issues

### DIFF
--- a/WordPress/Classes/Extensions/PHAsset+Exporters.swift
+++ b/WordPress/Classes/Extensions/PHAsset+Exporters.swift
@@ -101,11 +101,11 @@ extension PHAsset {
         var resultingMetadata = fromMetadata
         for attribute in attributes {
             resultingMetadata.removeValueForKey(attribute)
-            if attribute == "Orientation" {
+            if attribute == kCGImagePropertyOrientation as String{
                 if let tiffMetadata = resultingMetadata[kCGImagePropertyTIFFDictionary as String] as? [String:AnyObject]{
-                    var tiffMetadata = tiffMetadata
-                    tiffMetadata[kCGImagePropertyTIFFOrientation as String] = 1
-                    resultingMetadata[kCGImagePropertyTIFFDictionary as String] = tiffMetadata
+                    var newTiffMetadata = tiffMetadata
+                    newTiffMetadata.removeValueForKey(kCGImagePropertyTIFFOrientation as String)
+                    resultingMetadata[kCGImagePropertyTIFFDictionary as String] = newTiffMetadata
                 }
             }
         }

--- a/WordPress/Classes/Extensions/PHAsset+Exporters.swift
+++ b/WordPress/Classes/Extensions/PHAsset+Exporters.swift
@@ -113,6 +113,14 @@ extension PHAsset {
         return resultingMetadata
     }
 
+    /**
+     Makes sure the metadata of the image is matching the attributes in the Image.
+
+     - parameter metadata: the original metadata of the image
+     - parameter image:    the current image
+
+     - returns: a new metadata object where the values match the values on the UIImage
+     */
     func matchMetadata(metadata: [String:AnyObject], image: UIImage) -> [String:AnyObject] {
         var resultingMetadata = metadata
         let correctOrientation = image.metadataOrientation

--- a/WordPress/Classes/Extensions/PHAsset+Exporters.swift
+++ b/WordPress/Classes/Extensions/PHAsset+Exporters.swift
@@ -210,7 +210,7 @@ extension PHAsset {
                     return
                 }
                 do {
-                    try image.writeJPEGToURL(url)
+                    try image.writeToURL(url, type: self.defaultThumbnailUTI, compressionQuality: 0.9, metadata: nil)
                     successHandler(resultingSize: image.size)
                 } catch let error as NSError {
                     errorHandler(error: error)

--- a/WordPress/Classes/Extensions/PHAsset+Exporters.swift
+++ b/WordPress/Classes/Extensions/PHAsset+Exporters.swift
@@ -81,7 +81,7 @@ extension PHAsset {
             }
             self.requestMetadataWithCompletionBlock({ (metadata) -> () in
                 do {
-                    var attributesToRemove = ["Orientation", "AdjustmentXMP"]
+                    var attributesToRemove = [String]()
                     if (stripGeoLocation) {
                         attributesToRemove.append(kCGImagePropertyGPSDictionary as String)
                     }

--- a/WordPress/Classes/Extensions/UIImage+Exporters.swift
+++ b/WordPress/Classes/Extensions/UIImage+Exporters.swift
@@ -25,6 +25,10 @@ extension UIImage {
      */
     func writeToURL(url: NSURL, type: String, compressionQuality: Float = 0.9,  metadata: [String:AnyObject]? = nil) throws {
         let properties: [String:AnyObject] = [kCGImageDestinationLossyCompressionQuality as String: compressionQuality]
+        var finalMetadata = metadata
+        if metadata == nil {
+            finalMetadata = [kCGImagePropertyOrientation as String: Int(metadataOrientation.rawValue)]
+        }
 
         guard let destination = CGImageDestinationCreateWithURL(url, type, 1, nil),
               let imageRef = self.CGImage
@@ -34,7 +38,7 @@ extension UIImage {
                 )
         }
         CGImageDestinationSetProperties(destination, properties);
-        CGImageDestinationAddImage(destination, imageRef, metadata);
+        CGImageDestinationAddImage(destination, imageRef, finalMetadata);
         if (!CGImageDestinationFinalize(destination)) {
             throw errorForCode(.FailedToWrite,
                 failureReason: NSLocalizedString("Unable to write image to file", comment: "Error reason to display when the writing of a image to a file fails")

--- a/WordPress/Classes/Extensions/UIImage+Exporters.swift
+++ b/WordPress/Classes/Extensions/UIImage+Exporters.swift
@@ -42,11 +42,18 @@ extension UIImage {
         }
     }
 
+    /**
+     Writes an image to a url location using the JPEG format.
+
+     - Parameters:
+     - url: file url to where the asset should be exported, this must be writable location
+     */
     func writeJPEGToURL(url: NSURL) throws {
         let data = UIImageJPEGRepresentation(self, 0.9)
         try data?.writeToURL(url, options: NSDataWritingOptions())
     }
 
+    // Converts the imageOrientation from the image to the CGImagePropertyOrientation to use in the file metadata.
     var metadataOrientation: CGImagePropertyOrientation {
         get {
             switch imageOrientation {

--- a/WordPress/Classes/Extensions/UIImage+Exporters.swift
+++ b/WordPress/Classes/Extensions/UIImage+Exporters.swift
@@ -25,7 +25,7 @@ extension UIImage {
      */
     func writeToURL(url: NSURL, type: String, compressionQuality: Float = 0.9,  metadata: [String:AnyObject]? = nil) throws {
         let properties: [String:AnyObject] = [kCGImageDestinationLossyCompressionQuality as String: compressionQuality]
-        
+
         guard let destination = CGImageDestinationCreateWithURL(url, type, 1, nil),
               let imageRef = self.CGImage
         else {
@@ -39,6 +39,26 @@ extension UIImage {
             throw errorForCode(.FailedToWrite,
                 failureReason: NSLocalizedString("Unable to write image to file", comment: "Error reason to display when the writing of a image to a file fails")
             )
+        }
+    }
+
+    func writeJPEGToURL(url: NSURL) throws {
+        let data = UIImageJPEGRepresentation(self, 0.9)
+        try data?.writeToURL(url, options: NSDataWritingOptions())
+    }
+
+    var metadataOrientation: CGImagePropertyOrientation {
+        get {
+            switch imageOrientation {
+            case .Up: return CGImagePropertyOrientation.Up
+            case .Down: return CGImagePropertyOrientation.Down
+            case .Left: return CGImagePropertyOrientation.Left
+            case .Right: return CGImagePropertyOrientation.Right
+            case .UpMirrored: return CGImagePropertyOrientation.UpMirrored
+            case .DownMirrored: return CGImagePropertyOrientation.DownMirrored
+            case .LeftMirrored: return CGImagePropertyOrientation.LeftMirrored
+            case .RightMirrored: return CGImagePropertyOrientation.RightMirrored
+            }
         }
     }
 }


### PR DESCRIPTION
Fix bugs where images inserted in the editor appeared rotated randomly

To test:
 - On a real device: Take 4 photos while holding the phone in the four possible positions: Landscape left/right Portrait up/upside down
 - Create a new post
 - Insert the 4 images
 - Check if the image all display correctly while uploading and after the upload is finished
 - Check on the web if the image are all right, and download them to the local device and check in preview if they display correctly and all the EXIF info information is available 

Needs review: @jleandroperez 