### PR TITLE
Sharing: Changes text depending on state and number of connected accts.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -183,17 +183,27 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 {
     [WPStyleGuide configureTableViewActionCell:cell];
     cell.textLabel.textAlignment = NSTextAlignmentCenter;
+    cell.textLabel.text = [self titleForConnectionCell];
     if (self.connecting) {
-        cell.textLabel.text = NSLocalizedString(@"Connecting...", @"Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter.");
         UIActivityIndicatorView *activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
         cell.accessoryView = activityView;
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         [activityView startAnimating];
     } else {
-        cell.textLabel.text = NSLocalizedString(@"Connect", @"Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter.");
         cell.accessoryView = nil;
         cell.selectionStyle = UITableViewCellSelectionStyleGray;
     }
+}
+
+- (NSString *)titleForConnectionCell
+{
+    if (self.connecting) {
+        return NSLocalizedString(@"Connecting...", @"Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter.");
+    }
+    if ([self hasConnectedAccounts]) {
+        return NSLocalizedString(@"Connect Another Account", @"Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter.");
+    }
+    return NSLocalizedString(@"Connect", @"Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter.");
 }
 
 - (void)configurePublicizeCell:(UITableViewCell *)cell atIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
Fixes #4990 

To test: 
Go to the Sharing feature and tap on a publicize service that has no connections.  Confirm the cell text reads "Connect"

Connect to the service. Confirm the text still reads "Connecting..." and shows a spinner when the publicize authentication modal dismisses. 

Return to the connections screen. Now that you have an existing connection, confirm the cell text reads "Connect Another Service"

Needs review: @frosty 

