### PR TITLE
Sharing: Allow sharing mgt for private blogs.

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -443,7 +443,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
 
 -(BOOL)supportsSharing
 {
-    return ([self supportsPublicize] || [self supportsShareButtons]) && [self isAdmin] && ![self isPrivate];
+    return ([self supportsPublicize] || [self supportsShareButtons]) && [self isAdmin];
 }
 
 - (BOOL)supportsPublicize


### PR DESCRIPTION
Fixes #4992 

To test: 
Using a private wpcom blog, perform the following actions:
Connect to a publicize service. 
Disconnect from a publicize service. 
Add sharing buttons.
Add more buttons. 
Reorder buttons. 
Change sharing button settings. 
Confirm the changes are propagated to the private blog. 

Needs review: @jleandroperez would you do the honors sir? 

