### PR TITLE
Sharing: Fixes the check for a changed sharing button label.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -686,7 +686,7 @@ import WordPressShared
 
         controller.title = labelTitle
         controller.onValueChanged = {[unowned self] (value) in
-            guard value == self.blog.settings.sharingLabel else {
+            guard value != self.blog.settings.sharingLabel else {
                 return
             }
             self.blog.settings.sharingLabel = value

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -523,7 +523,8 @@ import WordPressShared
             tableView.reloadData()
         }
 
-        let service = BlogService(managedObjectContext: managedObjectContext)
+        let context = ContextManager.sharedInstance().mainContext
+        let service = BlogService(managedObjectContext: context)
         service.updateSettingsForBlog(self.blog, success: nil, failure: { [weak self] (error: NSError!) in
             DDLogSwift.logError(error.description)
             self?.showErrorSyncingMessage(error)


### PR DESCRIPTION
While testing other things I noticed the sharing button label was not saving changes. The problem was due to faulty conditional.  This PR fixes the conditional so changes are properly saved.

To test: Navigate to the Sharing feature and manage sharing buttons.  Edit the text of the sharing label and confirm the change is A) reflected back on the management screen and B) propagated to the blog. 

Needs review: @kurzee would you mind a quick review sir? 

