### PR TITLE
Improvements to build script

### DIFF
--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -12,13 +12,22 @@ else
   XCODE_SDK=iphonesimulator
 fi
 
-function build() {
-xcodebuild build test \
+function xcbuild() {
+xcodebuild \
   -destination "platform=iOS Simulator,name=iPhone 6" \
   -workspace "$XCODE_WORKSPACE" \
   -scheme "$XCODE_SCHEME" \
   -sdk "$XCODE_SDK" \
-  -configuration Debug
+  -configuration Debug \
+  $*
+}
+
+function build() {
+  xcbuild build test
+}
+
+function clean_build() {
+  xcbuild clean build test
 }
 
 function pretty_travis() {
@@ -29,12 +38,76 @@ function pretty_circleci() {
   xcpretty -c --report junit --output $CIRCLE_TEST_REPORTS/xcode/results.xml
 }
 
-function rawlog_circleci() {
-  tee $CIRCLE_ARTIFACTS/xcode_raw.log
+function rawlog() {
+  tee $1
 }
 
-if [ $CIRCLECI ];then
-  build | rawlog_circleci | pretty_circleci
-else
-  build | pretty_travis
+function rawlog_circleci() {
+  rawlog $CIRCLE_ARTIFACTS/xcode_raw.log
+}
+
+function usage() {
+  cat <<EOF
+Usage: $0 [-cdhv] [-l logfile]
+  -c  Force clean before building.
+  -d  Debug. Shows commands before running them.
+  -l  Store raw build log in the specified file.
+  -v  Verbose. Skips xcpretty.
+  -h  Show this message.
+EOF
+}
+
+CLEAN=0
+DEBUG=0
+LOGFILE=""
+VERBOSE=0
+while getopts ":cdhl:v" opt; do
+  case $opt in
+    c)
+      CLEAN=1
+      ;;
+    d)
+      DEBUG=1
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    l)
+      LOGFILE=$OPTARG
+      ;;
+    v)
+      VERBOSE=1
+      ;;
+    :)
+      echo "ERROR: -$OPTARG requires an argument" >&2
+      exit 1
+  esac
+done
+
+BUILD_CMD=build
+if [ $CLEAN == 1 ]; then
+  BUILD_CMD=clean_build
 fi
+
+CMD="$BUILD_CMD"
+
+if [ "$LOGFILE" != "" ]; then
+  CMD="$CMD | rawlog $LOGFILE"
+fi
+
+if [ $VERBOSE == 0 ]; then
+  if [ $CIRCLECI ]; then
+    CMD="$CMD | rawlog_circleci | pretty_circleci"
+  else
+    CMD="$CMD | pretty_travis"
+  fi
+fi
+
+if [ $DEBUG == 1 ]; then
+  echo $CMD
+  set -x
+fi
+
+eval $CMD
+


### PR DESCRIPTION
While trying to figure out some broken tests I wanted to run the same `xcodebuild` command as Travis, but `xcpretty` wasn't showing why everything was failing. It turned out it wasn't xcpretty's fault, but I think this additions are useful to debug the build script locally.

New functionality:

- Adds command line argument parsing to the script, `-h` to show usage
- `-c` will call `clean` before building. This isn't needed on Travis/CircleCI as we're building on "clean" VMs, but it's useful when running locally
- `-d` will show the exact command(s) that the script will run.
- `-l` will store the raw output of `xcodebuild` in a log file.
- `-v` will skip xcpretty and print the output of `xcodebuild` directly.

If you run it without arguments, the behavior shouldn't have changed since the previous version

Needs review: @SergioEstevao 
