### PR TITLE
New post cards show the first actionBar page by default.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.h
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.h
@@ -2,6 +2,16 @@
 
 @interface PostCardActionBar : UIView
 
+/**
+ *  Shows the first page of the action bar items.
+ */
+- (void)showFirstPage;
+
+/**
+ *  Sets the action bar items.
+ *
+ *  @param  items       The array of items for the action bar.
+ */
 - (void)setItems:(NSArray *)items;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
@@ -196,6 +196,14 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
     }
 }
 
+#pragma mark - GUI related
+
+- (void)showFirstPage
+{
+    self.currentBatch = 0;
+    
+    [self configureButtons];
+}
 
 #pragma mark - Configuration
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -457,6 +457,8 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
         // anything else (draft, pending, scheduled, something custom) treat as draft
         [self configureDraftActionBar];
     }
+    
+    [self.actionBar showFirstPage];
 }
 
 - (void)configurePublishedActionBar


### PR DESCRIPTION
Fixes #5006 

**To test:**

Create new posts, press the "More" button in exiting ones, repeat.  Make sure new posts always show the action bar in its first page.

**Needs review:** @jleandroperez 

/cc @aerych 

