### PR TITLE
Media upload crashed on upload error

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -522,7 +522,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
 
 - (NSSet *)allowedFileTypes
 {
-    NSArray * allowedFileTypes = self.options[@"allowed_file_types"][@"value"];
+    NSArray *allowedFileTypes = [self.options arrayForKeyPath:@"allowed_file_types.value"];
     if (!allowedFileTypes || allowedFileTypes.count == 0) {
         return nil;
     }

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -4,6 +4,7 @@
 #import "UIDevice+Helpers.h"
 #import "WordPressAppDelegate.h"
 #import "WPUserAgent.h"
+#import "NSDictionary+SafeExpectations.h"
 
 static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.wordpress.com/rest/";
 static NSString *const WordPressComApiOauthBaseUrl = @"https://public-api.wordpress.com/oauth2";
@@ -106,8 +107,8 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
             } else {
                 errorDictionary = (NSDictionary *)operation.responseObject;
             }
-            NSString *errorMessage = (NSString *)errorDictionary[@"message"];
-            NSString *errorType = (NSString *)errorDictionary[@"error"];
+            NSString *errorMessage = [errorDictionary stringForKey:@"message"];
+            NSString *errorType = [errorDictionary stringForKey:@"error"];
             NSUInteger errorCode = WordPressComApiErrorJSON;
             if (errorType && errorMessage) {
                 if ([errorType isEqualToString:@"invalid_token"]) {


### PR DESCRIPTION
Fixes #4985

To test: Try to upload a image to a self-hosted site with jetpack installed that is returning a 403 error. User is a contributor for example.

Needs review: @sendhil 
