### PR TITLE
Corrected inset calculation for WPBlogSelectorButton

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
@@ -50,7 +50,7 @@
 - (CGRect)titleRectForContentRect:(CGRect)contentRect
 {
     CGRect frame = [super titleRectForContentRect:contentRect];
-    frame.size.width = MIN(frame.size.width, CGRectGetWidth(contentRect) - CGRectGetWidth([super imageRectForContentRect:contentRect]) - self.imageEdgeInsets.left - self.imageEdgeInsets.right);
+    frame.size.width = MIN(frame.size.width, CGRectGetWidth(contentRect) - CGRectGetWidth([super imageRectForContentRect:contentRect]) - self.imageEdgeInsets.right);
     switch (self.buttonStyle) {
         case WPBlogSelectorButtonTypeSingleLine:
             frame.origin.x = 0.0;


### PR DESCRIPTION
Fixes #4831

To test: view or edit a post. The back button/blog selector is no longer truncated.

![4831-before-after](https://cloud.githubusercontent.com/assets/517257/14034639/b0402396-f1ea-11e5-9342-e00712996e81.jpg)

Needs review: @aerych 