### PR TITLE
Hide add wpcom site option when not signed in.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -223,10 +223,7 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
     if ([self numSites] > 0) {
         return;
     }
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-    if (!defaultAccount) {
+    if (![self defaultWordPressComAccount]) {
         [WPAnalytics track:WPAnalyticsStatLogout];
         [[WordPressAppDelegate sharedInstance] showWelcomeScreenIfNeededAnimated:YES];
     }
@@ -624,11 +621,15 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
     UIAlertController *addSiteAlertController = [UIAlertController alertControllerWithTitle:nil
                                                                                     message:nil
                                                                              preferredStyle:UIAlertControllerStyleActionSheet];
-    UIAlertAction *addNewWordPressAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Create WordPress.com site", @"Create WordPress.com site button")
-                                                                    style:UIAlertActionStyleDefault
-                                                                  handler:^(UIAlertAction *action) {
-                                                                      [self showAddNewWordPressController];
-                                                                  }];
+    if ([self defaultWordPressComAccount]) {
+        UIAlertAction *addNewWordPressAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Create WordPress.com site", @"Create WordPress.com site button")
+                                                                        style:UIAlertActionStyleDefault
+                                                                      handler:^(UIAlertAction *action) {
+                                                                          [self showAddNewWordPressController];
+                                                                      }];
+        [addSiteAlertController addAction:addNewWordPressAction];
+    }
+
     UIAlertAction *addSiteAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Add self-hosted site", @"Add self-hosted site button")
                                                             style:UIAlertActionStyleDefault
                                                           handler:^(UIAlertAction *action) {
@@ -637,7 +638,7 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
     UIAlertAction *cancel = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Cancel button")
                                                      style:UIAlertActionStyleCancel
                                                    handler:nil];
-    [addSiteAlertController addAction:addNewWordPressAction];
+
     [addSiteAlertController addAction:addSiteAction];
     [addSiteAlertController addAction:cancel];
     addSiteAlertController.popoverPresentationController.barButtonItem = self.addSiteButton;
@@ -646,10 +647,16 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
     self.addSiteAlertController = addSiteAlertController;
 }
 
+- (WPAccount *)defaultWordPressComAccount
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+    return [accountService defaultWordPressComAccount];
+}
+
 - (void)showAddNewWordPressController
 {
     [self setEditing:NO animated:NO];
-    
     CreateNewBlogViewController *createNewBlogViewController = [[CreateNewBlogViewController alloc] init];
     [self.navigationController presentViewController:createNewBlogViewController animated:YES completion:nil];
 }
@@ -659,12 +666,8 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
     [self setEditing:NO animated:NO];
     LoginViewController *loginViewController = [[LoginViewController alloc] init];
     loginViewController.cancellable = YES;
-    
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-    
-    if (!defaultAccount) {
+
+    if (![self defaultWordPressComAccount]) {
         loginViewController.prefersSelfHosted = YES;
     }
     loginViewController.dismissBlock = ^(BOOL cancelled){


### PR DESCRIPTION
Fixes #5019 
Ideally we'd show the NUX controller to add a new account, which was the direction I started down initially.  However, doing so would require a small refactor of that controller.  Since there is *already* a refactor planned as a follow up to the work currently being done on sign in I've opted to just hide the button when the user isn't signed in. 

To test:
Repeat the steps outlined in the issue. 
Confirm the add wpcom site option does not appear unless signed into wpcom. 

Needs review: @jleandroperez 

