### PR TITLE
Back button text

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -650,7 +650,11 @@ EditImageDetailsViewControllerDelegate
  */
 - (void)showBlogSelectorPrompt:(WPBlogSelectorButton*)sender
 {
-    if (![self.post hasSiteSpecificChanges]) {
+    if ([self isSingleSiteMode])
+    {
+        [self cancelEditing];
+    }
+    else if (![self.post hasSiteSpecificChanges]) {
         [self showBlogSelector];
         return;
     }
@@ -1011,6 +1015,19 @@ EditImageDetailsViewControllerDelegate
     return blogCount;
 }
 
+- (BOOL)isSingleSiteMode
+{
+    // The blog picker is in single site mode if one of the following is true:
+    // editor screen is in preview mode, there is only 1 blog, or the user
+    // is editing an existing post.
+
+    if (self.currentBlogCount <= 1 || !self.isEditing || (self.isEditing && self.post.hasRemote))
+    {
+        return YES;
+    }
+    return NO;
+}
+
 #pragma mark - UI Manipulation
 
 /**
@@ -1284,10 +1301,7 @@ EditImageDetailsViewControllerDelegate
             [blogButton sizeToFit];
         }
         
-        // The blog picker is in single site mode if one of the following is true:
-        // editor screen is in preview mode, there is only 1 blog, or the user
-        // is editing an existing post.
-        if (self.currentBlogCount <= 1 || !self.isEditing || (self.isEditing && self.post.hasRemote)) {
+        if ([self isSingleSiteMode]) {
             blogButton.buttonMode = WPBlogSelectorButtonSingleSite;
         } else {
             blogButton.buttonMode = WPBlogSelectorButtonMultipleSite;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -652,6 +652,7 @@ EditImageDetailsViewControllerDelegate
 {
     if ([self isSingleSiteMode]) {
         [self cancelEditing];
+        return;
     } else if (![self.post hasSiteSpecificChanges]) {
         [self showBlogSelector];
         return;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -650,11 +650,9 @@ EditImageDetailsViewControllerDelegate
  */
 - (void)showBlogSelectorPrompt:(WPBlogSelectorButton*)sender
 {
-    if ([self isSingleSiteMode])
-    {
+    if ([self isSingleSiteMode]) {
         [self cancelEditing];
-    }
-    else if (![self.post hasSiteSpecificChanges]) {
+    } else if (![self.post hasSiteSpecificChanges]) {
         [self showBlogSelector];
         return;
     }
@@ -1021,8 +1019,7 @@ EditImageDetailsViewControllerDelegate
     // editor screen is in preview mode, there is only 1 blog, or the user
     // is editing an existing post.
 
-    if (self.currentBlogCount <= 1 || !self.isEditing || (self.isEditing && self.post.hasRemote))
-    {
+    if (self.currentBlogCount <= 1 || !self.isEditing || (self.isEditing && self.post.hasRemote)) {
         return YES;
     }
     return NO;

--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
@@ -72,12 +72,8 @@
         UIImage *blankFillerImage = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
         [self setImage:blankFillerImage forState:UIControlStateNormal];
-        
-        self.userInteractionEnabled = NO;
     } else {
         [self setImage:[UIImage imageNamed:@"icon-nav-chevron"] forState:UIControlStateNormal];
-        
-        self.userInteractionEnabled = YES;
     }
 }
 


### PR DESCRIPTION
Fixes #5026

To test:

View or edit a post that has been published to a site, so that the site selector isn't shown. The text part of the back button is now tappable.

Needs review: @aerych – as  this one is similar to the last
