### PR TITLE
3D Touch tests refactor

### DIFF
--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -1,5 +1,16 @@
 import UIKit
 
+public protocol ApplicationShortcutsProvider {
+    var shortcutItems: [UIApplicationShortcutItem]? { get set }
+    var is3DTouchAvailable: Bool { get }
+}
+
+extension UIApplication: ApplicationShortcutsProvider {
+    public var is3DTouchAvailable: Bool {
+        return keyWindow?.traitCollection.forceTouchCapability == .Available
+    }
+}
+
 public class WP3DTouchShortcutCreator: NSObject
 {
     enum LoggedIn3DTouchShortcutIndex: Int {
@@ -9,9 +20,9 @@ public class WP3DTouchShortcutCreator: NSObject
         NewPost
     }
     
-    var application: UIApplication!
-    var mainContext: NSManagedObjectContext!
-    var blogService: BlogService!
+    var shortcutsProvider: ApplicationShortcutsProvider
+    let mainContext = ContextManager.sharedInstance().mainContext
+    let blogService: BlogService
     
     private let logInShortcutIconImageName = "icon-shortcut-signin"
     private let notificationsShortcutIconImageName = "icon-shortcut-notifications"
@@ -19,18 +30,21 @@ public class WP3DTouchShortcutCreator: NSObject
     private let newPhotoPostShortcutIconImageName = "icon-shortcut-new-photo"
     private let newPostShortcutIconImageName = "icon-shortcut-new-post"
     
-    override public init() {
-        super.init()
-        application = UIApplication.sharedApplication()
-        mainContext = ContextManager.sharedInstance().mainContext
+    public init(shortcutsProvider: ApplicationShortcutsProvider) {
+        self.shortcutsProvider = shortcutsProvider
         blogService = BlogService(managedObjectContext: mainContext)
+        super.init()
+    }
+
+    public convenience override init() {
+        self.init(shortcutsProvider: UIApplication.sharedApplication())
     }
     
     public func createShortcutsIf3DTouchAvailable(loggedIn: Bool) {
-        if !is3DTouchAvailable() {
+        guard shortcutsProvider.is3DTouchAvailable else {
             return
         }
-        
+
         if loggedIn {
             if hasBlog() {
                 createLoggedInShortcuts()
@@ -100,21 +114,15 @@ public class WP3DTouchShortcutCreator: NSObject
         visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.NewPhotoPost.rawValue])
         visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.NewPost.rawValue])
         
-        application.shortcutItems = visibleShortcutArray
+        shortcutsProvider.shortcutItems = visibleShortcutArray
     }
     
     private func clearShortcuts() {
-        application.shortcutItems = nil
+        shortcutsProvider.shortcutItems = nil
     }
     
     private func createLoggedOutShortcuts() {
-        application.shortcutItems = loggedOutShortcutArray()
-    }
-    
-    private func is3DTouchAvailable() -> Bool {
-        let window = UIApplication.sharedApplication().keyWindow
-        
-        return window?.traitCollection.forceTouchCapability == .Available
+        shortcutsProvider.shortcutItems = loggedOutShortcutArray()
     }
     
     private func hasWordPressComAccount() -> Bool {

--- a/WordPress/WordPressTest/System/3DTouch/WP3DTouchShortcutCreatorTests.swift
+++ b/WordPress/WordPressTest/System/3DTouch/WP3DTouchShortcutCreatorTests.swift
@@ -17,7 +17,26 @@ class WP3DTouchShortcutCreatorTests: XCTestCase
     }
     
     func testCreateShortcutLoggedOutDoesNotCreatesLoggedOutShortcutsWith3DTouchNotAvailable() {
+        let provider = MockShortcutsProvider(available: false)
+        let testShortcutCreator = WP3DTouchShortcutCreator(shortcutsProvider: provider)
         testShortcutCreator.createShortcutsIf3DTouchAvailable(false)
-        XCTAssertEqual(UIApplication.sharedApplication().shortcutItems!.count, 0)
+        XCTAssertEqual(provider.shortcutItems!.count, 0)
+    }
+
+    func testCreateShortcutLoggedOutCreatesLoggedInShortcutWith3DTouchAvailable() {
+        let provider = MockShortcutsProvider(available: true)
+        let testShortcutCreator = WP3DTouchShortcutCreator(shortcutsProvider: provider)
+        testShortcutCreator.createShortcutsIf3DTouchAvailable(false)
+        XCTAssertEqual(provider.shortcutItems!.count, 1)
+        XCTAssertEqual(provider.shortcutItems![0].type, "org.wordpress.LogIn")
+    }
+}
+
+class MockShortcutsProvider: ApplicationShortcutsProvider {
+    var shortcutItems: [UIApplicationShortcutItem]? = []
+    let is3DTouchAvailable: Bool
+
+    init(available: Bool) {
+        is3DTouchAvailable = available
     }
 }


### PR DESCRIPTION
Improve 3D Touch shortcut creator testability. This test keep failing randomly when messing with the build scripts and CI, until I realized the `With3DTouchNotAvailable`. The previous tests passed on the iPhone 6 simulator, but failed on the iPhone 6S, since 3D touch was available there.

I've extracted what's needed from `UIApplication` to an `ApplicationShortcutsProvider` so we can mock it and pretend that 3D Touch is (un)available regardless of the device used in the simulator. 

To test:

- Run the test suite on iPhone 6/6S and make sure it passes on both.

Needs review: @kwonye 