### PR TITLE
Prevent AutoFill prompt when adding a self-hosted site.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -268,6 +268,11 @@ static NSString * const LoginSharedWebCredentialFQDN = @"wordpress.com";
 
 - (void)autoFillLoginWithSharedWebCredentialsIfAvailable
 {
+    if (self.prefersSelfHosted || !self.viewModel.userIsDotCom) {
+        // Ignore self-hosted autofilling since we can only autofill for the WordPress.com domain.
+        return;
+    }
+    
     __weak __typeof(self)weakSelf = self;
     [self requestSharedWebCredentials:^(NSString *username, NSString *password) {
         


### PR DESCRIPTION
Fixes #5023

Now avoiding auto-filling login fields if the user has toggled to add a self-hosted site.

To test:
Follow same steps in #5023

Needs review: @aerych