### PR TITLE
Clean up default account changes on login.

### DIFF
--- a/WordPress/Classes/Services/AccountServiceFacade.h
+++ b/WordPress/Classes/Services/AccountServiceFacade.h
@@ -28,13 +28,6 @@
                             success:(void (^)())success
                             failure:(void (^)(NSError *error))failure;
 
-/**
- *  This will remove a previous legacy `WPAccount`.
- *
- *  @param newUsername username of the account to remove.
- */
--(void)removeLegacyAccount:(NSString *)newUsername;
-
 @end
 
 /**

--- a/WordPress/Classes/Services/AccountServiceFacade.m
+++ b/WordPress/Classes/Services/AccountServiceFacade.m
@@ -11,7 +11,13 @@
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
 
-    return [accountService createOrUpdateAccountWithUsername:username authToken:authToken];
+    WPAccount *account = [accountService createOrUpdateAccountWithUsername:username authToken:authToken];
+    if (![accountService.defaultWordPressComAccount.uuid isEqualToString:account.uuid]) {
+        [accountService removeDefaultWordPressComAccount];
+        [accountService setDefaultWordPressComAccount:account];
+    }
+    
+    return account;
 }
 
 - (void)updateUserDetailsForAccount:(WPAccount *)account success:(void (^)())success failure:(void (^)(NSError *))failure
@@ -19,18 +25,6 @@
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
     [accountService updateUserDetailsForAccount:account success:success failure:failure];
-}
-
--(void)removeLegacyAccount:(NSString *)newUsername
-{
-    NSParameterAssert(newUsername);
-    
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
-    
-    if (![accountService.defaultWordPressComAccount.username isEqual:newUsername]) {
-        [accountService removeDefaultWordPressComAccount];
-    }
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -493,10 +493,6 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     [self dismissLoginMessage];
     [self.presenter updateAutoFillLoginCredentialsIfNeeded:username password:self.password];
     
-    if (self.shouldReauthenticateDefaultAccount) {
-        [self.accountServiceFacade removeLegacyAccount:username];
-    }
-    
     [self createWordPressComAccountForUsername:username authToken:authToken requiredMultifactorCode:requiredMultifactorCode];
 }
 

--- a/WordPress/WordPressTest/LoginViewModelTests.m
+++ b/WordPress/WordPressTest/LoginViewModelTests.m
@@ -1599,28 +1599,6 @@ describe(@"LoginFacadeDelegate methods", ^{
             [mockViewModelPresenter verify];
         });
         
-        // https://github.com/wordpress-mobile/WordPress-iOS/issues/3401
-        context(@"the removal of the old legacy account", ^{
-            
-            it(@"should occur if shouldReauthenticateDefaultAccount is true", ^{
-                viewModel.shouldReauthenticateDefaultAccount = YES;
-                [[mockAccountServiceFacade expect] removeLegacyAccount:username];
-                
-                [viewModel finishedLoginWithUsername:username authToken:authToken requiredMultifactorCode:requiredMultifactorCode];
-                
-                [mockAccountServiceFacade verify];
-            });
-            
-            it(@"should not occur if shouldReauthenticateDefaultAccount is false", ^{
-                viewModel.shouldReauthenticateDefaultAccount = NO;
-                [[mockAccountServiceFacade reject] removeLegacyAccount:username];
-                
-                [viewModel finishedLoginWithUsername:username authToken:authToken requiredMultifactorCode:requiredMultifactorCode];
-                
-                [mockAccountServiceFacade verify];
-            });
-        });
-        
         context(@"the syncing of the newly added blogs", ^{
             
             it(@"should occur", ^{


### PR DESCRIPTION
Fixes #5042 

This expands an older fix (https://github.com/wordpress-mobile/WordPress-iOS/issues/3401) in which the current default account was removed when the user was re-authing and happened to change accounts. Now, we'll always remove the current default account if it is different than the newly authenticated account, on login.

Dropping this one for `develop` rather than `release/6.1` as the fixes are a bit different and not necessarily a hot-fix.

To test:
1. Run the steps in https://github.com/wordpress-mobile/WordPress-iOS/issues/5042
2. The newly authenticated account should now be the only connected account.

Needs review: @aerych at your convenience please señor. (We can hold off on this for now if your magic links change this)