### PR TITLE
Fix typo in no comments message ("commment")

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -482,7 +482,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
         return NSLocalizedString(@"Fetching comments...", @"A brief prompt shown when the comment list is empty, letting the user know the app is currently fetching new comments.");
     }
     
-    return NSLocalizedString(@"Be the first to leave a commment.", @"Message shown encouraging the user to leave a comment on a post in the reader.");
+    return NSLocalizedString(@"Be the first to leave a comment.", @"Message shown encouraging the user to leave a comment on a post in the reader.");
 }
 
 - (void)updateCellForLayoutWidthConstraint:(CGFloat)width


### PR DESCRIPTION
When a post has no comments, this message is currently displayed:

<img width="369" alt="screen shot 2016-03-30 at 08 51 12" src="https://cloud.githubusercontent.com/assets/17325/14128571/9ad7786a-f654-11e5-88fc-24b85710d41e.png">

An extra "m" has snuck into "comments". This PR removes it :)

To test:
- In the post stream, tap the comment bubble on a post with no comments.
- Make sure "comments" is spelt correctly in the displayed message.

Needs review: @aerych 

