### PR TITLE
Rename Safari auto fill events to something more generic

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -48,7 +48,7 @@ target 'WordPress', :exclusive => true do
   pod 'WordPress-iOS-Editor', '1.2'
   pod 'WordPress-iOS-Shared', '0.5.3'
   pod 'WordPressApi', '0.4.0'
-  pod 'WordPressCom-Analytics-iOS', '0.1.5'
+  pod 'WordPressCom-Analytics-iOS', '0.1.6'
   pod 'WordPressCom-Stats-iOS/UI', '0.6.3'
   pod 'wpxmlrpc', '~> 0.8'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -170,7 +170,7 @@ PODS:
   - WordPressApi (0.4.0):
     - AFNetworking (~> 2.6.0)
     - wpxmlrpc (~> 0.8)
-  - WordPressCom-Analytics-iOS (0.1.5)
+  - WordPressCom-Analytics-iOS (0.1.6)
   - WordPressCom-Stats-iOS/Services (0.6.3):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (~> 2.2.0)
@@ -229,7 +229,7 @@ DEPENDENCIES:
   - WordPress-iOS-Editor (= 1.2)
   - WordPress-iOS-Shared (= 0.5.3)
   - WordPressApi (= 0.4.0)
-  - WordPressCom-Analytics-iOS (= 0.1.5)
+  - WordPressCom-Analytics-iOS (= 0.1.6)
   - WordPressCom-Stats-iOS/Services (= 0.6.3)
   - WordPressCom-Stats-iOS/UI (= 0.6.3)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag
@@ -307,7 +307,7 @@ SPEC CHECKSUMS:
   WordPress-iOS-Editor: 4958ae44a2aedfa9b3a3afc9cba41e3ec989b175
   WordPress-iOS-Shared: 43f55f24f0685e431167084071b7914d7c7134a8
   WordPressApi: 483767025bcdab26429b51bfe5171f17d3d30466
-  WordPressCom-Analytics-iOS: 09f9a0f043840009dab297f95adbb597387bdcbf
+  WordPressCom-Analytics-iOS: bffa9d5d6d8611cf371f368713481c2300138caf
   WordPressCom-Stats-iOS: 75dbdf4765c09b90a8fe00375dc96a93e64feffa
   WordPressComKit: 6f0c39c3e0af3599cd5244e4ec05192f5e4a7882
   WPMediaPicker: 2c399b1cbd4d8a7fcd312eb93107a349d26fb23f

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -312,6 +312,12 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         case WPAnalyticsStatLoginFailedToGuessXMLRPC:
             eventName = @"login_failed_to_guess_xmlrpc";
             break;
+        case WPAnalyticsStatLoginAutoFillCredentialsFilled:
+            eventName = @"login_autofill_credentials_filled";
+            break;
+        case WPAnalyticsStatLoginAutoFillCredentialsUpdated:
+            eventName = @"login_autofill_credentials_updated";
+            break;
         case WPAnalyticsStatLogout:
             eventName = @"account_logout";
             break;
@@ -537,12 +543,6 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
             break;
         case WPAnalyticsStatReaderTagUnfollowed:
             eventName = @"reader_reader_tag_unfollowed";
-            break;
-        case WPAnalyticsStatSafariCredentialsLoginFilled:
-            eventName = @"safari_credentials_login_filled";
-            break;
-        case WPAnalyticsStatSafariCredentialsLoginUpdated:
-            eventName = @"safari_credentials_login_updated";
             break;
         case WPAnalyticsStatSelectedInstallJetpack:
             eventName = @"stats_install_jetpack_selected";

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -840,17 +840,17 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatLoginFailedToGuessXMLRPC:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Login - Failed To Guess XMLRPC"];
             break;
+        case WPAnalyticsStatLoginAutoFillCredentialsFilled:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Login - Auto Fill Credentials Filled"];
+            break;
+        case WPAnalyticsStatLoginAutoFillCredentialsUpdated:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Login - Auto Fill Credentials Updated"];
+            break;
         case WPAnalyticsStatTwoFactorSentSMS:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Two Factor - Sent Verification Code SMS"];
             break;
         case WPAnalyticsStatTwoFactorCodeRequested:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Two Factor - Requested Verification Code"];
-            break;
-        case WPAnalyticsStatSafariCredentialsLoginFilled:
-            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Safari Credentials - Login Filled"];
-            break;
-        case WPAnalyticsStatSafariCredentialsLoginUpdated:
-            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Safari Credentials - Login Updated"];
             break;
         case WPAnalyticsStatShortcutLogIn:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"3D Touch Shortcut - Log In"];

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.m
@@ -289,7 +289,7 @@ static NSString * const LoginSharedWebCredentialFQDN = @"wordpress.com";
         weakSelf.autofilledUsernameCredentialHash = [username hash];
         weakSelf.autofilledPasswordCredentialHash = [password hash];
         
-        [WPAnalytics track:WPAnalyticsStatSafariCredentialsLoginFilled];
+        [WPAnalytics track:WPAnalyticsStatLoginAutoFillCredentialsFilled];
     }];
 }
 
@@ -321,7 +321,7 @@ static NSString * const LoginSharedWebCredentialFQDN = @"wordpress.com";
             return;
         }
         dispatch_async(dispatch_get_main_queue(), ^{
-            [WPAnalytics track:WPAnalyticsStatSafariCredentialsLoginUpdated];
+            [WPAnalytics track:WPAnalyticsStatLoginAutoFillCredentialsUpdated];
         });
     });
 }


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-Android/pull/3769 and https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS/pull/56