### PR TITLE
Renames WPContentViewProvider to PostContentProvider.

### DIFF
--- a/WordPress/Classes/Models/BasePost.h
+++ b/WordPress/Classes/Models/BasePost.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "Blog.h"
 #import "DateUtils.h"
-#import "WPContentViewProvider.h"
+#import "PostContentProvider.h"
 
 typedef enum {
     AbstractPostRemoteStatusPushing,    // Uploading post
@@ -18,7 +18,7 @@ extern NSString * const PostStatusScheduled;
 extern NSString * const PostStatusTrash;
 extern NSString * const PostStatusDeleted;
 
-@interface BasePost : NSManagedObject<WPContentViewProvider>
+@interface BasePost : NSManagedObject<PostContentProvider>
 
 // Attributes
 @property (nonatomic, strong) NSNumber * postID;

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -187,7 +187,7 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 {
 }
 
-#pragma mark - WPContentViewProvider protocol
+#pragma mark - PostContentProvider protocol
 
 - (NSString *)titleForDisplay
 {

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -100,7 +100,7 @@ NSString * const CommentStatusDraft = @"draft";
 }
 
 
-#pragma mark - WPContentViewProvider protocol
+#pragma mark - PostContentProvider protocol
 
 - (BOOL)isPrivateContent
 {

--- a/WordPress/Classes/Models/PostContentProvider.h
+++ b/WordPress/Classes/Models/PostContentProvider.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-@protocol WPContentViewProvider <NSObject>
+@protocol PostContentProvider <NSObject>
 - (NSString *)titleForDisplay;
 - (NSString *)authorForDisplay;
 - (NSString *)blogNameForDisplay;

--- a/WordPress/Classes/Models/ReaderPost.m
+++ b/WordPress/Classes/Models/ReaderPost.m
@@ -144,7 +144,7 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
     return ([content rangeOfString:featuredImage].location != NSNotFound);
 }
 
-#pragma mark - WPContentViewProvider protocol
+#pragma mark - PostContentProvider protocol
 
 - (NSString *)blogNameForDisplay
 {

--- a/WordPress/Classes/Models/ReaderPostContentProvider.h
+++ b/WordPress/Classes/Models/ReaderPostContentProvider.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import "WPContentViewProvider.h"
+#import "PostContentProvider.h"
 
 typedef NS_ENUM(NSUInteger, SourceAttributionStyle) {
     SourceAttributionStyleNone,
@@ -7,7 +7,7 @@ typedef NS_ENUM(NSUInteger, SourceAttributionStyle) {
     SourceAttributionStyleSite,
 };
 
-@protocol ReaderPostContentProvider <WPContentViewProvider>
+@protocol ReaderPostContentProvider <PostContentProvider>
 - (NSURL *)siteIconForDisplayOfSize:(NSInteger)size;
 - (SourceAttributionStyle)sourceAttributionStyle;
 - (NSString *)sourceAuthorNameForDisplay;

--- a/WordPress/Classes/Models/WPCommentContentViewProvider.h
+++ b/WordPress/Classes/Models/WPCommentContentViewProvider.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
-#import "WPContentViewProvider.h"
+#import "PostContentProvider.h"
 
-@protocol WPCommentContentViewProvider <WPContentViewProvider>
+@protocol WPCommentContentViewProvider <PostContentProvider>
 
 - (BOOL)isLiked;
 - (BOOL)authorIsPostAuthor;

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -85,7 +85,7 @@
 #import "WPAnalyticsTrackerWPCom.h"
 #import "WPAppAnalytics.h"
 #import "WPBlogTableViewCell.h"
-#import "WPContentViewProvider.h"
+#import "PostContentProvider.h"
 #import "WPGUIConstants.h"
 #import "WPImageViewController.h"
 #import "WPNoResultsView+AnimatedBox.h"

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.m
@@ -426,7 +426,7 @@ static NSString * const CurrentPageListStatusFilterKey = @"CurrentPageListStatus
 
 #pragma mark - Cell Delegate Methods
 
-- (void)cell:(UITableViewCell *)cell receivedMenuActionFromButton:(UIButton *)button forProvider:(id<WPContentViewProvider>)contentProvider
+- (void)cell:(UITableViewCell *)cell receivedMenuActionFromButton:(UIButton *)button forProvider:(id<PostContentProvider>)contentProvider
 {
     Page *page = (Page *)contentProvider;
     NSManagedObjectID *objectID = page.objectID;
@@ -510,7 +510,7 @@ static NSString * const CurrentPageListStatusFilterKey = @"CurrentPageListStatus
     return page;
 }
 
-- (void)cell:(UITableViewCell *)cell receivedRestoreActionForProvider:(id<WPContentViewProvider>)contentProvider
+- (void)cell:(UITableViewCell *)cell receivedRestoreActionForProvider:(id<PostContentProvider>)contentProvider
 {
     AbstractPost *apost = (AbstractPost *)contentProvider;
     [self restorePost:apost];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1103,7 +1103,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 
 #pragma mark - CommentContentView Delegate methods
 
-- (void)commentView:(CommentContentView *)commentView updatedAttachmentViewsForProvider:(id<WPContentViewProvider>)contentProvider
+- (void)commentView:(CommentContentView *)commentView updatedAttachmentViewsForProvider:(id<PostContentProvider>)contentProvider
 {
     Comment *comment = (Comment *)contentProvider;
     NSIndexPath *indexPath = [self.tableViewHandler.resultsController indexPathForObject:comment];
@@ -1134,7 +1134,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
     [self presentViewController:navController animated:YES completion:nil];
 }
 
-- (void)handleReplyTapped:(id<WPContentViewProvider>)contentProvider
+- (void)handleReplyTapped:(id<PostContentProvider>)contentProvider
 {
     // if a row is already selected don't allow selection of another
     if (self.replyTextView.isFirstResponder) {
@@ -1154,7 +1154,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
     [self refreshReplyTextViewPlaceholder];
 }
 
-- (void)toggleLikeStatus:(id<WPContentViewProvider>)contentProvider
+- (void)toggleLikeStatus:(id<PostContentProvider>)contentProvider
 {
     Comment *comment = (Comment *)contentProvider;
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -924,7 +924,7 @@
 		462F4E0618369F0B0028D2F8 /* BlogDetailsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogDetailsViewController.h; sourceTree = "<group>"; };
 		462F4E0718369F0B0028D2F8 /* BlogDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BlogDetailsViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		4645AFC41961E1FB005F7509 /* AppImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = AppImages.xcassets; path = Resources/AppImages.xcassets; sourceTree = "<group>"; };
-		46F84612185A8B7E009D0DA5 /* WPContentViewProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPContentViewProvider.h; sourceTree = "<group>"; };
+		46F84612185A8B7E009D0DA5 /* PostContentProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostContentProvider.h; sourceTree = "<group>"; };
 		46F8714D1838C41600BC149B /* NSDate+StringFormatting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+StringFormatting.h"; sourceTree = "<group>"; };
 		46F8714E1838C41600BC149B /* NSDate+StringFormatting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+StringFormatting.m"; sourceTree = "<group>"; };
 		4AACD85BFF0E9B208BED08CB /* Pods-WordPressTest.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -2341,7 +2341,7 @@
 				E105E9CD1726955600C0D9E7 /* WPAccount.h */,
 				E105E9CE1726955600C0D9E7 /* WPAccount.m */,
 				E12DB07A1C48D1C200A6C1D4 /* WPAccount+AccountSettings.swift */,
-				46F84612185A8B7E009D0DA5 /* WPContentViewProvider.h */,
+				46F84612185A8B7E009D0DA5 /* PostContentProvider.h */,
 				5D35F7581A042255004E7B0D /* WPCommentContentViewProvider.h */,
 				5D333A561AA7A9E200DA295F /* WPPostContentViewProvider.h */,
 			);


### PR DESCRIPTION
Small change to our codebase.  Renames `WPContentViewProvider` to `PostContentProvider`, since it's basically providing post-related information only.

The name `WPContentViewProvider` was not too clear and sounded too generic.

To test:
- Just make sure the app compiles and runs.
- Review the code changes.

Needs review: @aerych.
