### PR TITLE
Don't log OAuth2 tokens

### DIFF
--- a/WordPress/WordPressApi/WordPressComOAuthClient.m
+++ b/WordPress/WordPressApi/WordPressComOAuthClient.m
@@ -133,7 +133,7 @@ static NSString * const WordPressComOAuthRedirectUrl = @"https://wordpress.com/"
     if (![response isKindOfClass:[NSDictionary class]]) {
         return response;
     }
-    if (![(NSDictionary *)response objectForKey:@"access_token"]) {
+    if ([(NSDictionary *)response objectForKey:@"access_token"] == nil) {
         return response;
     }
     NSMutableDictionary *dict = [(NSDictionary *)response mutableCopy];

--- a/WordPress/WordPressApi/WordPressComOAuthClient.m
+++ b/WordPress/WordPressApi/WordPressComOAuthClient.m
@@ -43,7 +43,7 @@ static NSString * const WordPressComOAuthRedirectUrl = @"https://wordpress.com/"
     [self POST:@"token"
 	parameters:parameters
 	   success:^(AFHTTPRequestOperation *operation, id responseObject) {
-               DDLogVerbose(@"Received OAuth2 response: %@", responseObject);
+               DDLogVerbose(@"Received OAuth2 response: %@", [self cleanedUpResponseForLogging:responseObject]);
                NSString *authToken = [responseObject stringForKey:@"access_token"];
                if (success) {
                    success(authToken);
@@ -127,6 +127,18 @@ static NSString * const WordPressComOAuthRedirectUrl = @"https://wordpress.com/"
         }
     }
     return error;
+}
+
+- (id)cleanedUpResponseForLogging:(id)response {
+    if (![response isKindOfClass:[NSDictionary class]]) {
+        return response;
+    }
+    if (![(NSDictionary *)response objectForKey:@"access_token"]) {
+        return response;
+    }
+    NSMutableDictionary *dict = [(NSDictionary *)response mutableCopy];
+    dict[@"access_token"] = @"*** REDACTED ***";
+    return dict;
 }
 
 @end


### PR DESCRIPTION
To test:

- Log in to WordPress.com
- Make sure there's no real `access_token` in the log

Needs review: @sendhil 

