### PR TITLE
Fixes Notification Filters Logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -950,8 +950,8 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 
 - (NSString *)noResultsMessageText
 {
-    NSString *jetapackMessage   = NSLocalizedString(@"Jetpack supercharges your self-hosted WordPress site.", @"Notifications message displayed when a self-hosted user is not connected to Jetpack");
-    return self.shouldDisplayJetpackMessage ? jetapackMessage : nil;
+    NSString *jetpackMessage   = NSLocalizedString(@"Jetpack supercharges your self-hosted WordPress site.", @"Notifications message displayed when a self-hosted user is not connected to Jetpack");
+    return self.shouldDisplayJetpackMessage ? jetpackMessage : nil;
 }
 
 - (UIView *)noResultsAccessoryView

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -320,7 +320,14 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 
 - (BOOL)shouldDisplayFilters
 {
-    return !self.showsJetpackMessage && !self.showsEmptyStateLegend;
+    // Note:
+    // Filters should only be hidden whenever there are no Notifications in the bucket (contrary to the FRC's
+    // results, which are filtered by the active predicate!).
+    //
+    Simperium *simperium            = [[WordPressAppDelegate sharedInstance] simperium];
+    SPBucket *notesBucket           = [simperium bucketForName:self.entityName];
+    
+    return notesBucket.numObjects > 0;
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -890,7 +890,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 - (void)showNoResultsViewIfNeeded
 {
     // Remove If Needed
-    if (!self.showsEmptyStateLegend) {
+    if (!self.shouldDisplayNoResultsView) {
         [self.noResultsView removeFromSuperview];
         
         // Show filters if we have results
@@ -905,14 +905,14 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
         [self.tableView addSubviewWithFadeAnimation:noResultsView];
     }
     
-    // Hide the filter header if we're showing the Jetpack prompt
-    [self hideFiltersSegmentedControlIfApplicable];
-    
     // Refresh its properties: The user may have signed into WordPress.com
     noResultsView.titleText         = self.noResultsTitleText;
     noResultsView.messageText       = self.noResultsMessageText;
     noResultsView.accessoryView     = self.noResultsAccessoryView;
     noResultsView.buttonTitle       = self.noResultsButtonText;
+    
+    // Hide the filter header if we're showing the Jetpack prompt
+    [self hideFiltersSegmentedControlIfApplicable];
 }
 
 - (WPNoResultsView *)noResultsView
@@ -926,7 +926,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 
 - (NSString *)noResultsTitleText
 {
-    if (self.showsJetpackMessage) {
+    if (self.shouldDisplayJetpackMessage) {
         return NSLocalizedString(@"Connect to Jetpack", @"Notifications title displayed when a self-hosted user is not connected to Jetpack");
     }
     
@@ -944,20 +944,20 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 - (NSString *)noResultsMessageText
 {
     NSString *jetapackMessage   = NSLocalizedString(@"Jetpack supercharges your self-hosted WordPress site.", @"Notifications message displayed when a self-hosted user is not connected to Jetpack");
-    return self.showsJetpackMessage ? jetapackMessage : nil;
+    return self.shouldDisplayJetpackMessage ? jetapackMessage : nil;
 }
 
 - (UIView *)noResultsAccessoryView
 {
-    return self.showsJetpackMessage ? [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"icon-jetpack-gray"]] : nil;
+    return self.shouldDisplayJetpackMessage ? [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"icon-jetpack-gray"]] : nil;
 }
  
 - (NSString *)noResultsButtonText
 {
-    return self.showsJetpackMessage ? NSLocalizedString(@"Learn more", @"") : nil;
+    return self.shouldDisplayJetpackMessage ? NSLocalizedString(@"Learn more", @"") : nil;
 }
  
-- (BOOL)showsJetpackMessage
+- (BOOL)shouldDisplayJetpackMessage
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     AccountService *accountService  = [[AccountService alloc] initWithManagedObjectContext:context];
@@ -966,7 +966,7 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     return showsJetpackMessage;
 }
 
-- (BOOL)showsEmptyStateLegend
+- (BOOL)shouldDisplayNoResultsView
 {
     return (self.tableViewHandler.resultsController.fetchedObjects.count == 0);
 }


### PR DESCRIPTION
Fixes #4986

#### Scenario: WordPress.com Account
1. Log into a WordPress.com account with few notifications (i can hand over a test account via DM!)
2. Tap over the Notifications tab
3. Ensure that at least one of the filters produces zero results, and tap on it

As a result, the Notification Filters should remain visible.

Needs review: @frosty 
Thanks in advance James!

Props to @lancewillett for spotting this one + reporting it!
