### PR TITLE
Refactor Plan Comparison and use remote data

### DIFF
--- a/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
@@ -29,7 +29,8 @@ class PlanComparisonViewController: UIViewController {
     private lazy var viewControllers: [PlanDetailViewController] = {
         return self.allPlans.map { plan in
             let isActive = self.activePlan == plan
-            let controller = PlanDetailViewController.controllerWithPlan(plan, siteID: self.siteID, isActive: isActive)
+            // TODO: Pass the prices, we should know them when showing the details
+            let controller = PlanDetailViewController.controllerWithPlan(plan, siteID: self.siteID, isActive: isActive, price: "FIXME")
 
             return controller
         }
@@ -78,9 +79,14 @@ class PlanComparisonViewController: UIViewController {
     
     private func fetchFeatures() {
         service?.updateAllPlanFeatures({ [weak self] in
-            self?.viewControllers.forEach { $0.viewModel = .Ready($0.plan) }
+            self?.viewControllers.forEach { controller in
+                let groups = PlanFeatureGroup.groupsForPlan(controller.viewModel.plan)
+                // TODO: Avoid the optional groups
+                controller.viewModel = controller.viewModel.withFeatures(.Ready(groups!))
+            }
         }, failure: { [weak self] error in
-            self?.viewControllers.forEach { $0.viewModel = .Error(String(error))
+            self?.viewControllers.forEach { controller in
+                controller.viewModel = controller.viewModel.withFeatures(.Error(String(error)))
             }
         })
     }

--- a/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
@@ -1,227 +1,71 @@
 import UIKit
 import WordPressShared
 
-class PlanComparisonViewController: UIViewController {
-    private let embedIdentifier = "PageViewControllerEmbedSegue"
-    
-    @IBOutlet weak var pageControl: UIPageControl!
-    @IBOutlet weak var divider: UIView!
-    @IBOutlet weak var scrollView: UIScrollView!
-    @IBOutlet weak var planStackView: UIStackView!
-    
-    var service: PlanService<StoreKitStore>? = nil
-    
-    var activePlan: Plan?
-    var siteID: Int!
-    
-    var currentPlan: Plan = defaultPlans[0] {
-        didSet {
-            if currentPlan != oldValue {
-                updateForCurrentPlan()
-            }
-        }
-    }
-
-    private var currentIndex: Int {
-        return allPlans.indexOf(currentPlan) ?? 0
-    }
-    
-    private lazy var viewControllers: [PlanDetailViewController] = {
-        return self.allPlans.map { plan in
-            let isActive = self.activePlan == plan
-            // TODO: Pass the prices, we should know them when showing the details
-            let controller = PlanDetailViewController.controllerWithPlan(plan, siteID: self.siteID, isActive: isActive, price: "FIXME")
-
-            return controller
-        }
-    }()
-    
-    private let allPlans = defaultPlans
-    
+class PlanComparisonViewController: PagedViewController {
     lazy private var cancelXButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(image: UIImage(named: "gridicons-cross"), style: .Plain, target: self, action: #selector(PlanPostPurchaseViewController.closeTapped))
+        let button = UIBarButtonItem(image: UIImage(named: "gridicons-cross"), style: .Plain, target: self, action: #selector(PlanComparisonViewController.closeTapped))
         button.accessibilityLabel = NSLocalizedString("Close", comment: "Dismiss the current view")
-        
+
         return button
     }()
-    
-    class func controllerWithInitialPlan(plan: Plan, activePlan: Plan? = nil, siteID: Int, planService: PlanService<StoreKitStore>) -> PlanComparisonViewController {
-        let storyboard = UIStoryboard(name: "Plans", bundle: NSBundle.mainBundle())
-        let controller = storyboard.instantiateViewControllerWithIdentifier(NSStringFromClass(self)) as! PlanComparisonViewController
 
-        // @koke 2016-03-15
-        // This is very fragile. If we set siteID after currentPlan it will crash.
-        // Setting the current plan causes the UI to update, which lazily loads the view controllers,
-        // and they can't be initialized properly without a siteID.
-        controller.siteID = siteID
-
-        controller.activePlan = activePlan
-        controller.currentPlan = plan
-        controller.service = planService
-
-        return controller
+    @IBAction func closeTapped() {
+        dismissViewControllerAnimated(true, completion: nil)
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        view.backgroundColor = WPStyleGuide.greyLighten30()
-        divider.backgroundColor = WPStyleGuide.greyLighten30()
-        pageControl.currentPageIndicatorTintColor = WPStyleGuide.grey()
-        pageControl.pageIndicatorTintColor = WPStyleGuide.grey().colorWithAlphaComponent(0.5)
-        
         navigationItem.leftBarButtonItem = cancelXButton
-        
-        initializePlanDetailViewControllers()
-        updateForCurrentPlan()
         fetchFeatures()
     }
+
+    let siteID: Int
+    let pricedPlans: [PricedPlan]
+    let activePlan: Plan
+    let initialPlan: Plan
+    let service: PlanService<StoreKitStore>
+
+    // Keep a more specific reference to the view controllers rather than force
+    // downcast viewControllers.
+    private let detailViewControllers: [PlanDetailViewController]
+
+    init(sitePricedPlans: SitePricedPlans, initialPlan: Plan, service: PlanService<StoreKitStore>) {
+        self.siteID = sitePricedPlans.siteID
+        self.pricedPlans = sitePricedPlans.availablePlans
+        self.activePlan = sitePricedPlans.activePlan
+        self.initialPlan = initialPlan
+        self.service = service
+
+        let viewControllers: [PlanDetailViewController] = pricedPlans.map({ (plan, price) in
+            let isActive = sitePricedPlans.activePlan == plan
+            let controller = PlanDetailViewController.controllerWithPlan(plan, siteID: sitePricedPlans.siteID, isActive: isActive, price: price)
+
+            return controller
+        })
+        self.detailViewControllers = viewControllers
+
+        let initialIndex = pricedPlans.indexOf { plan, _ in
+            return plan == initialPlan
+        }
+
+        super.init(viewControllers: viewControllers, initialIndex: initialIndex!)
+    }
     
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     private func fetchFeatures() {
-        service?.updateAllPlanFeatures({ [weak self] in
-            self?.viewControllers.forEach { controller in
+        service.updateAllPlanFeatures({ [weak self] in
+            self?.detailViewControllers.forEach { controller in
                 let groups = PlanFeatureGroup.groupsForPlan(controller.viewModel.plan)
                 // TODO: Avoid the optional groups
                 controller.viewModel = controller.viewModel.withFeatures(.Ready(groups!))
             }
-        }, failure: { [weak self] error in
-            self?.viewControllers.forEach { controller in
-                controller.viewModel = controller.viewModel.withFeatures(.Error(String(error)))
-            }
-        })
-    }
-    
-    override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-
-        // If the view is changing size (e.g. on rotation, or multitasking), scroll to the correct page boundary based on the new size
-        coordinator.animateAlongsideTransition({ context in
-            self.scrollView.setContentOffset(CGPoint(x: CGFloat(self.currentIndex) * size.width, y: 0), animated: false)
-        }, completion: nil)
-    }
-    
-    override func shouldAutorotate() -> Bool {
-        return false
-    }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        scrollToPage(currentIndex, animated: false)
-    }
-
-    func initializePlanDetailViewControllers() {
-        for controller in viewControllers {
-            addChildViewController(controller)
-            
-            controller.view.translatesAutoresizingMaskIntoConstraints = false
-            planStackView.addArrangedSubview(controller.view)
-            
-            controller.view.shouldGroupAccessibilityChildren = true
-            controller.view.widthAnchor.constraintEqualToAnchor(view.widthAnchor, multiplier: 1.0).active = true
-            controller.view.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
-            controller.view.bottomAnchor.constraintEqualToAnchor(divider.topAnchor).active = true
-            
-            controller.didMoveToParentViewController(self)
-        }
-    }
-    
-    func updateForCurrentPlan() {
-        title = currentPlan.title
-        
-        updatePageControl()
-        
-        for (index, viewController) in viewControllers.enumerate() {
-            viewController.view.accessibilityElementsHidden = index != currentIndex
-        }
-    }
-    
-    // MARK: - IBActions
-    
-    @IBAction private func closeTapped() {
-        dismissViewControllerAnimated(true, completion: nil)
-    }
-    
-    @IBAction func pageControlChanged() {
-        guard !scrollView.dragging else {
-            // If the user is currently dragging, reset the change and ignore it
-            pageControl.currentPage = currentIndex
-            return
-        }
-        
-        // Stop the user interacting whilst we animate a scroll
-        scrollView.userInteractionEnabled = false
-        
-        var targetPage = currentIndex
-        if pageControl.currentPage > currentIndex {
-            targetPage += 1
-        } else if pageControl.currentPage < currentIndex {
-            targetPage -= 1
-        }
-        
-        scrollToPage(targetPage, animated: true)
-    }
-    
-    private func updatePageControl() {
-        pageControl?.currentPage = currentIndex
-    }
-}
-
-extension PlanComparisonViewController: UIScrollViewDelegate {
-    func scrollViewDidScroll(scrollView: UIScrollView) {
-        // Ignore programmatic scrolling
-        if scrollView.dragging {
-            currentPlan = allPlans[currentScrollViewPage()]
-        }
-    }
-    
-    override func accessibilityScroll(direction: UIAccessibilityScrollDirection) -> Bool {
-        var targetPage = currentIndex
-        
-        switch direction {
-        case .Right: targetPage -= 1
-        case .Left: targetPage += 1
-        default: break
-        }
-        
-        let success = scrollToPage(targetPage, animated: false)
-        if success {
-            accessibilityAnnounceCurrentPlan()
-        }
-        
-        return success
-    }
-    
-    func scrollViewDidEndScrollingAnimation(scrollView: UIScrollView) {
-        scrollView.userInteractionEnabled = true
-        
-        accessibilityAnnounceCurrentPlan()
-    }
-    
-    private func accessibilityAnnounceCurrentPlan() {
-        let currentViewController = viewControllers[currentIndex]
-        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, currentViewController.planTitleLabel)
-    }
-    
-    private func currentScrollViewPage() -> Int {
-        // Calculate which plan's VC is at the center of the view
-        let pageWidth = scrollView.bounds.width
-        let centerX = scrollView.contentOffset.x + (pageWidth / 2)
-        let currentPage = Int(floor(centerX / pageWidth))
-
-        // Keep it within bounds
-        return currentPage.clamp(min: 0, max: allPlans.count - 1)
-    }
-
-    /// - returns: True if there was valid page to scroll to, false if we've reached the beginning / end
-    private func scrollToPage(page: Int, animated: Bool) -> Bool {
-        guard allPlans.indices.contains(page) else { return false }
-        
-        let pageWidth = view.bounds.width
-        scrollView.setContentOffset(CGPoint(x: CGFloat(page) * pageWidth, y: 0), animated: animated)
-    
-        currentPlan = allPlans[page]
-        
-        return true
+            }, failure: { [weak self] error in
+                self?.detailViewControllers.forEach { controller in
+                    controller.viewModel = controller.viewModel.withFeatures(.Error(String(error)))
+                }
+            })
     }
 }

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -74,7 +74,7 @@ class PlanDetailViewController: UIViewController {
     }
     var viewModel: ViewModel! {
         didSet {
-            self.tableViewModel = viewModel.tableViewModel
+            tableViewModel = viewModel.tableViewModel
             title = viewModel.plan.title
             accessibilityLabel = viewModel.plan.fullTitle
             if isViewLoaded() {

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -76,6 +76,7 @@ class PlanDetailViewController: UIViewController {
         didSet {
             self.tableViewModel = viewModel.tableViewModel
             title = viewModel.plan.title
+            accessibilityLabel = viewModel.plan.fullTitle
             if isViewLoaded() {
                 populateHeader()
                 updateNoResults()

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -8,8 +8,8 @@ class PlanDetailViewController: UIViewController {
 
         let isActivePlan: Bool
 
-        /// Plan price, or `nil` for a free plan
-        let price: String?
+        /// Plan price. Empty string for a free plan
+        let price: String
 
         let features: FeaturesViewModel
 
@@ -58,6 +58,14 @@ class PlanDetailViewController: UIViewController {
                     message: NSLocalizedString("There was an error loading the plan", comment: ""),
                     buttonTitle: NSLocalizedString("Contact support", comment: "")
                 )
+            }
+        }
+
+        var priceText: String {
+            if price.isEmpty  {
+                return NSLocalizedString("Free for life", comment: "Price label for the free plan")
+            } else {
+                return String(format: NSLocalizedString("%@ per year", comment: "Plan yearly price"), price)
             }
         }
     }
@@ -134,7 +142,7 @@ class PlanDetailViewController: UIViewController {
     
     @IBOutlet weak var headerInfoStackView: UIStackView!
 
-    class func controllerWithPlan(plan: Plan, siteID: Int, isActive: Bool, price: String?) -> PlanDetailViewController {
+    class func controllerWithPlan(plan: Plan, siteID: Int, isActive: Bool, price: String) -> PlanDetailViewController {
         let storyboard = UIStoryboard(name: "Plans", bundle: NSBundle.mainBundle())
         let controller = storyboard.instantiateViewControllerWithIdentifier(NSStringFromClass(self)) as! PlanDetailViewController
 
@@ -194,7 +202,7 @@ class PlanDetailViewController: UIViewController {
         planImageView.image = plan.image
         planTitleLabel.text = plan.fullTitle
         planDescriptionLabel.text = plan.description
-        planPriceLabel.text = viewModel.price
+        planPriceLabel.text = viewModel.priceText
         
         if viewModel.isActivePlan {
             purchaseButton?.removeFromSuperview()

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -102,7 +102,8 @@ enum PlanListViewModel {
                 var action: ImmuTableAction? = nil
                 if let presenter = presenter,
                     let planService = planService {
-                    action = presenter.present(self.controllerForPlanDetails(plan, activePlan: activePlan, siteID: siteID, planService: planService))
+                    let sitePricedPlans = (siteID: siteID, activePlan: activePlan, availablePlans: plans)
+                    action = presenter.present(self.controllerForPlanDetails(sitePricedPlans, initialPlan: plan, planService: planService))
                 }
                 
                 return PlanListRow(
@@ -122,9 +123,9 @@ enum PlanListViewModel {
         }
     }
 
-    func controllerForPlanDetails(plan: Plan, activePlan: Plan, siteID: Int, planService: PlanService<StoreKitStore>) -> ImmuTableRowControllerGenerator {
+    func controllerForPlanDetails(sitePricedPlans: SitePricedPlans, initialPlan: Plan, planService: PlanService<StoreKitStore>) -> ImmuTableRowControllerGenerator {
         return { row in
-            let planVC = PlanComparisonViewController.controllerWithInitialPlan(plan, activePlan: activePlan, siteID: siteID, planService: planService)
+            let planVC = PlanComparisonViewController(sitePricedPlans: sitePricedPlans, initialPlan: initialPlan, service: planService)
             let navigationVC = RotationAwareNavigationViewController(rootViewController: planVC)
             navigationVC.modalPresentationStyle = .FormSheet
             return navigationVC

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -86,90 +86,6 @@
             </objects>
             <point key="canvasLocation" x="853" y="1059"/>
         </scene>
-        <!--Plan Comparison View Controller-->
-        <scene sceneID="CYw-U0-oI7">
-            <objects>
-                <viewController storyboardIdentifier="WordPress.PlanComparisonViewController" id="s5h-iz-0HE" customClass="PlanComparisonViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="lq2-Q7-GhV"/>
-                        <viewControllerLayoutGuide type="bottom" id="Ygn-aZ-YVi"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="DDG-cG-6UG">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ZY0-qL-r53">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                                <subviews>
-                                    <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ftR-lg-UD4">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="540"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Ba2-eJ-6aE">
-                                                <rect key="frame" x="0.0" y="0.0" width="600" height="540"/>
-                                            </stackView>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstItem="Ba2-eJ-6aE" firstAttribute="leading" secondItem="ftR-lg-UD4" secondAttribute="leading" id="2Zx-zX-Oqk"/>
-                                            <constraint firstAttribute="bottom" secondItem="Ba2-eJ-6aE" secondAttribute="bottom" id="ciG-Fi-9vX"/>
-                                            <constraint firstItem="Ba2-eJ-6aE" firstAttribute="top" secondItem="ftR-lg-UD4" secondAttribute="top" id="jxy-j0-dHk"/>
-                                            <constraint firstAttribute="trailing" secondItem="Ba2-eJ-6aE" secondAttribute="trailing" id="mMa-Dr-hN7"/>
-                                            <constraint firstItem="Ba2-eJ-6aE" firstAttribute="height" secondItem="ftR-lg-UD4" secondAttribute="height" placeholder="YES" id="mek-QN-aIi" userLabel="Placeholder content height"/>
-                                        </constraints>
-                                        <connections>
-                                            <outlet property="delegate" destination="s5h-iz-0HE" id="JhT-Ps-vCX"/>
-                                        </connections>
-                                    </scrollView>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f0d-zt-grM">
-                                        <rect key="frame" x="0.0" y="540" width="600" height="1"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="Ar8-74-nXx"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8En-Ia-Wlh">
-                                        <rect key="frame" x="0.0" y="541" width="600" height="59"/>
-                                        <subviews>
-                                            <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="HLT-dO-RyH">
-                                                <rect key="frame" x="8" y="8" width="584" height="43"/>
-                                                <color key="pageIndicatorTintColor" red="0.72326811719999995" green="0.869224102" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <color key="currentPageIndicatorTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <connections>
-                                                    <action selector="pageControlChanged" destination="s5h-iz-0HE" eventType="valueChanged" id="I3s-63-M21"/>
-                                                </connections>
-                                            </pageControl>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="bottomMargin" secondItem="HLT-dO-RyH" secondAttribute="bottom" id="81N-Sg-1d8"/>
-                                            <constraint firstAttribute="height" constant="59" id="9sq-hY-CdS"/>
-                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="trailing" secondItem="8En-Ia-Wlh" secondAttribute="trailingMargin" id="OiO-eD-sc9"/>
-                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="leading" secondItem="8En-Ia-Wlh" secondAttribute="leadingMargin" id="dei-oZ-v5R"/>
-                                            <constraint firstItem="HLT-dO-RyH" firstAttribute="top" secondItem="8En-Ia-Wlh" secondAttribute="topMargin" id="mHh-yT-0WZ"/>
-                                        </constraints>
-                                    </view>
-                                </subviews>
-                            </stackView>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="ZY0-qL-r53" firstAttribute="top" secondItem="DDG-cG-6UG" secondAttribute="top" id="9aF-PV-qII"/>
-                            <constraint firstItem="Ygn-aZ-YVi" firstAttribute="top" secondItem="ZY0-qL-r53" secondAttribute="bottom" id="FF2-u9-9d4"/>
-                            <constraint firstItem="Ba2-eJ-6aE" firstAttribute="width" secondItem="DDG-cG-6UG" secondAttribute="width" placeholder="YES" id="HyI-ca-bSZ" userLabel="Placeholder content width"/>
-                            <constraint firstAttribute="trailing" secondItem="ZY0-qL-r53" secondAttribute="trailing" id="eQp-nW-JVq"/>
-                            <constraint firstItem="ZY0-qL-r53" firstAttribute="leading" secondItem="DDG-cG-6UG" secondAttribute="leading" id="eUm-og-PEa"/>
-                        </constraints>
-                    </view>
-                    <connections>
-                        <outlet property="divider" destination="f0d-zt-grM" id="at9-Wz-9lj"/>
-                        <outlet property="pageControl" destination="HLT-dO-RyH" id="lQJ-N9-WAz"/>
-                        <outlet property="planStackView" destination="Ba2-eJ-6aE" id="LYo-0W-yKg"/>
-                        <outlet property="scrollView" destination="ftR-lg-UD4" id="wfO-df-2xS"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="SjQ-fQ-CVI" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="853" y="-327"/>
-        </scene>
         <!--Plan Detail View Controller-->
         <scene sceneID="9Cj-IU-3xt">
             <objects>
@@ -206,19 +122,19 @@
                                                         <rect key="frame" x="24" y="72" width="536" height="59"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
-                                                                <rect key="frame" x="173" y="0.0" width="192" height="17"/>
+                                                                <rect key="frame" x="172" y="0.0" width="192" height="17"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Perfect for bloggers, creatives, &amp; other professionals" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="edq-hC-GnQ" userLabel="Plan Description Label">
-                                                                <rect key="frame" x="108" y="22" width="321" height="17"/>
+                                                                <rect key="frame" x="108" y="22" width="321" height="16"/>
                                                                 <fontDescription key="fontDescription" type="italicSystem" pointSize="13"/>
                                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$99.99 per year" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fju-eH-OS6" userLabel="Plan Price Label">
-                                                                <rect key="frame" x="213" y="43" width="111" height="17"/>
+                                                                <rect key="frame" x="213" y="42" width="111" height="17"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -272,7 +188,7 @@
                                         <color key="sectionIndexBackgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="WordPress.FeatureItemCell" rowHeight="80" id="zaq-fe-bpz" customClass="FeatureItemCell" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="49.5" width="600" height="80"/>
+                                                <rect key="frame" x="0.0" y="50" width="600" height="80"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zaq-fe-bpz" id="dGV-Jz-XSf">
                                                     <rect key="frame" x="0.0" y="0.0" width="600" height="80"/>

--- a/WordPress/Classes/ViewRelated/System/PagedViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/PagedViewController.swift
@@ -148,10 +148,7 @@ extension PagedViewController: UIScrollViewDelegate {
     }
 
     private func accessibilityAnnounceCurrentPage() {
-        guard let label = currentViewController.accessibilityLabel else {
-            return
-        }
-        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, label)
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, currentViewController.view)
     }
 
     private func currentScrollViewPage() -> Int {

--- a/WordPress/Classes/ViewRelated/System/PagedViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/PagedViewController.swift
@@ -1,0 +1,178 @@
+import UIKit
+import WordPressShared
+
+class PagedViewController: UIViewController {
+    @IBOutlet weak var pagedStackView: UIStackView!
+    @IBOutlet weak var divider: UIView!
+    @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet weak var pageControl: UIPageControl!
+
+    let viewControllers: [UIViewController]
+    var currentIndex: Int = 0 {
+        didSet {
+            if currentIndex != oldValue {
+                updateForCurrentIndex()
+            }
+        }
+    }
+
+    init(viewControllers: [UIViewController], initialIndex: Int) {
+        precondition(viewControllers.indices.contains(initialIndex))
+
+        self.viewControllers = viewControllers
+        self.currentIndex = initialIndex
+        super.init(nibName: "PagedViewController", bundle: NSBundle(forClass: PagedViewController.self))
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        applyWPStyles()
+        addViewControllers()
+        updateForCurrentIndex()
+    }
+
+    override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
+
+        // If the view is changing size (e.g. on rotation, or multitasking), scroll to the correct page boundary based on the new size
+        coordinator.animateAlongsideTransition({ context in
+            self.scrollView.setContentOffset(CGPoint(x: CGFloat(self.currentIndex) * size.width, y: 0), animated: false)
+            }, completion: nil)
+    }
+
+    override func shouldAutorotate() -> Bool {
+        return false
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        scrollToPage(currentIndex, animated: false)
+    }
+
+    private func applyWPStyles() {
+        view.backgroundColor = WPStyleGuide.greyLighten30()
+        divider.backgroundColor = WPStyleGuide.greyLighten30()
+        pageControl.currentPageIndicatorTintColor = WPStyleGuide.grey()
+        pageControl.pageIndicatorTintColor = WPStyleGuide.grey().colorWithAlphaComponent(0.5)
+    }
+
+    private func addViewControllers() {
+        for controller in viewControllers {
+            addChildViewController(controller)
+
+            controller.view.translatesAutoresizingMaskIntoConstraints = false
+            pagedStackView.addArrangedSubview(controller.view)
+
+            controller.view.shouldGroupAccessibilityChildren = true
+            controller.view.widthAnchor.constraintEqualToAnchor(view.widthAnchor, multiplier: 1.0).active = true
+            controller.view.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
+            controller.view.bottomAnchor.constraintEqualToAnchor(divider.topAnchor).active = true
+
+            controller.didMoveToParentViewController(self)
+        }
+    }
+
+    @IBAction func pageControlChanged() {
+        guard !scrollView.dragging else {
+            // If the user is currently dragging, reset the change and ignore it
+            pageControl.currentPage = currentIndex
+            return
+        }
+
+        // Stop the user interacting whilst we animate a scroll
+        scrollView.userInteractionEnabled = false
+
+        var targetPage = currentIndex
+        if pageControl.currentPage > currentIndex {
+            targetPage += 1
+        } else if pageControl.currentPage < currentIndex {
+            targetPage -= 1
+        }
+
+        scrollToPage(targetPage, animated: true)
+    }
+
+    private func updateForCurrentIndex() {
+        title = currentViewController.title
+
+        updatePageControl()
+
+        for (index, viewController) in viewControllers.enumerate() {
+            viewController.view.accessibilityElementsHidden = index != currentIndex
+        }
+    }
+
+    private func updatePageControl() {
+        pageControl?.currentPage = currentIndex
+    }
+
+    private var currentViewController: UIViewController {
+        return viewControllers[currentIndex]
+    }
+}
+
+extension PagedViewController: UIScrollViewDelegate {
+    func scrollViewDidScroll(scrollView: UIScrollView) {
+        // Ignore programmatic scrolling
+        if scrollView.dragging {
+            currentIndex = currentScrollViewPage()
+        }
+    }
+
+    override func accessibilityScroll(direction: UIAccessibilityScrollDirection) -> Bool {
+        var targetPage = currentIndex
+
+        switch direction {
+        case .Right: targetPage -= 1
+        case .Left: targetPage += 1
+        default: break
+        }
+
+        let success = scrollToPage(targetPage, animated: false)
+        if success {
+            accessibilityAnnounceCurrentPage()
+        }
+
+        return success
+    }
+
+    func scrollViewDidEndScrollingAnimation(scrollView: UIScrollView) {
+        scrollView.userInteractionEnabled = true
+
+        accessibilityAnnounceCurrentPage()
+    }
+
+    private func accessibilityAnnounceCurrentPage() {
+        guard let label = currentViewController.accessibilityLabel else {
+            return
+        }
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, label)
+    }
+
+    private func currentScrollViewPage() -> Int {
+        // Calculate which plan's VC is at the center of the view
+        let pageWidth = scrollView.bounds.width
+        let centerX = scrollView.contentOffset.x + (pageWidth / 2)
+        let currentPage = Int(floor(centerX / pageWidth))
+
+        // Keep it within bounds
+        return currentPage.clamp(min: 0, max: viewControllers.count - 1)
+    }
+
+    /// - returns: True if there was valid page to scroll to, false if we've reached the beginning / end
+    private func scrollToPage(page: Int, animated: Bool) -> Bool {
+        guard viewControllers.indices.contains(page) else { return false }
+
+        let pageWidth = view.bounds.width
+        scrollView.setContentOffset(CGPoint(x: CGFloat(page) * pageWidth, y: 0), animated: animated)
+
+        currentIndex = page
+
+        return true
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/PagedViewController.xib
+++ b/WordPress/Classes/ViewRelated/System/PagedViewController.xib
@@ -77,7 +77,7 @@
                 <constraint firstItem="zq7-WR-Khc" firstAttribute="leading" secondItem="738-EE-kwR" secondAttribute="leading" id="EBW-CO-mV7"/>
                 <constraint firstAttribute="bottom" secondItem="zq7-WR-Khc" secondAttribute="bottom" id="JBT-lu-ELa"/>
                 <constraint firstAttribute="trailing" secondItem="zq7-WR-Khc" secondAttribute="trailing" id="hgv-Jp-E0H"/>
-                <constraint firstItem="F8R-PU-KTv" firstAttribute="width" secondItem="738-EE-kwR" secondAttribute="width" priority="250" id="xkT-Vs-oM2"/>
+                <constraint firstItem="F8R-PU-KTv" firstAttribute="width" secondItem="738-EE-kwR" secondAttribute="width" priority="250" placeholder="YES" id="xkT-Vs-oM2"/>
             </constraints>
         </view>
     </objects>

--- a/WordPress/Classes/ViewRelated/System/PagedViewController.xib
+++ b/WordPress/Classes/ViewRelated/System/PagedViewController.xib
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PagedViewController" customModule="WordPress" customModuleProvider="target">
+            <connections>
+                <outlet property="divider" destination="DfB-RW-b4e" id="ZGU-T8-tPg"/>
+                <outlet property="pageControl" destination="OD7-ow-FrX" id="LKd-e1-wpI"/>
+                <outlet property="pagedStackView" destination="F8R-PU-KTv" id="ISp-Vo-PkW"/>
+                <outlet property="scrollView" destination="u97-ah-1GZ" id="hbv-B8-wZD"/>
+                <outlet property="view" destination="738-EE-kwR" id="fJz-KN-nQW"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="738-EE-kwR">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="zq7-WR-Khc">
+                    <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                    <subviews>
+                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u97-ah-1GZ">
+                            <rect key="frame" x="0.0" y="0.0" width="600" height="540"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="F8R-PU-KTv">
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="540"/>
+                                </stackView>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="F8R-PU-KTv" firstAttribute="leading" secondItem="u97-ah-1GZ" secondAttribute="leading" id="0FP-pf-PZX"/>
+                                <constraint firstItem="F8R-PU-KTv" firstAttribute="height" secondItem="u97-ah-1GZ" secondAttribute="height" placeholder="YES" id="U9d-cq-8W2" userLabel="Placeholder content height"/>
+                                <constraint firstAttribute="trailing" secondItem="F8R-PU-KTv" secondAttribute="trailing" id="V1b-Qi-WAJ"/>
+                                <constraint firstItem="F8R-PU-KTv" firstAttribute="top" secondItem="u97-ah-1GZ" secondAttribute="top" id="c9C-Ck-gCb"/>
+                                <constraint firstAttribute="bottom" secondItem="F8R-PU-KTv" secondAttribute="bottom" id="eNd-A7-kjJ"/>
+                            </constraints>
+                            <connections>
+                                <outlet property="delegate" destination="-1" id="XsE-pe-Bw1"/>
+                            </connections>
+                        </scrollView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DfB-RW-b4e">
+                            <rect key="frame" x="0.0" y="540" width="600" height="1"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="1" id="F6Q-x3-V3d"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BGa-Zn-NkJ">
+                            <rect key="frame" x="0.0" y="541" width="600" height="59"/>
+                            <subviews>
+                                <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="OD7-ow-FrX">
+                                    <rect key="frame" x="8" y="8" width="584" height="43"/>
+                                    <color key="pageIndicatorTintColor" red="0.72326811719999995" green="0.869224102" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="currentPageIndicatorTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <connections>
+                                        <action selector="pageControlChanged" destination="-1" eventType="valueChanged" id="6G1-q1-JEg"/>
+                                    </connections>
+                                </pageControl>
+                            </subviews>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstItem="OD7-ow-FrX" firstAttribute="leading" secondItem="BGa-Zn-NkJ" secondAttribute="leadingMargin" id="EaK-83-v6o"/>
+                                <constraint firstAttribute="bottomMargin" secondItem="OD7-ow-FrX" secondAttribute="bottom" id="FOz-Rh-EHk"/>
+                                <constraint firstItem="OD7-ow-FrX" firstAttribute="trailing" secondItem="BGa-Zn-NkJ" secondAttribute="trailingMargin" id="S7f-9P-Cij"/>
+                                <constraint firstItem="OD7-ow-FrX" firstAttribute="top" secondItem="BGa-Zn-NkJ" secondAttribute="topMargin" id="V0C-gV-RTA"/>
+                                <constraint firstAttribute="height" constant="59" id="itt-bY-NEu"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="zq7-WR-Khc" firstAttribute="top" secondItem="738-EE-kwR" secondAttribute="top" id="4UH-Rl-iNO"/>
+                <constraint firstItem="zq7-WR-Khc" firstAttribute="leading" secondItem="738-EE-kwR" secondAttribute="leading" id="EBW-CO-mV7"/>
+                <constraint firstAttribute="bottom" secondItem="zq7-WR-Khc" secondAttribute="bottom" id="JBT-lu-ELa"/>
+                <constraint firstAttribute="trailing" secondItem="zq7-WR-Khc" secondAttribute="trailing" id="hgv-Jp-E0H"/>
+                <constraint firstItem="F8R-PU-KTv" firstAttribute="width" secondItem="738-EE-kwR" secondAttribute="width" priority="250" id="xkT-Vs-oM2"/>
+            </constraints>
+        </view>
+    </objects>
+</document>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -620,6 +620,8 @@
 		E1D86E691B2B414300DD2192 /* WordPress-32-33.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E1D86E681B2B414300DD2192 /* WordPress-32-33.xcmappingmodel */; };
 		E1D91456134A853D0089019C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E1D91454134A853D0089019C /* Localizable.strings */; };
 		E1D95EB817A28F5E00A3E9F3 /* WPActivityDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D95EB717A28F5E00A3E9F3 /* WPActivityDefaults.m */; };
+		E1DD4CCB1CAE41B800C3863E /* PagedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DD4CCA1CAE41B800C3863E /* PagedViewController.swift */; };
+		E1DD4CCD1CAE41C800C3863E /* PagedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = E1DD4CCC1CAE41C800C3863E /* PagedViewController.xib */; };
 		E1DF5DFD19E7CFAE004E70D5 /* TaxonomyServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = E1DF5DFA19E7CFAE004E70D5 /* TaxonomyServiceRemoteREST.m */; };
 		E1DF5DFE19E7CFAE004E70D5 /* TaxonomyServiceRemoteXMLRPC.m in Sources */ = {isa = PBXBuildFile; fileRef = E1DF5DFC19E7CFAE004E70D5 /* TaxonomyServiceRemoteXMLRPC.m */; };
 		E1E1AA8D1B7DEDFC001C8645 /* WPMapFilterReduce.m in Sources */ = {isa = PBXBuildFile; fileRef = E1E1AA8C1B7DEDFC001C8645 /* WPMapFilterReduce.m */; };
@@ -1793,6 +1795,8 @@
 		E1D91457134A854A0089019C /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E1D95EB617A28F5E00A3E9F3 /* WPActivityDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPActivityDefaults.h; sourceTree = "<group>"; };
 		E1D95EB717A28F5E00A3E9F3 /* WPActivityDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPActivityDefaults.m; sourceTree = "<group>"; };
+		E1DD4CCA1CAE41B800C3863E /* PagedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagedViewController.swift; sourceTree = "<group>"; };
+		E1DD4CCC1CAE41C800C3863E /* PagedViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PagedViewController.xib; sourceTree = "<group>"; };
 		E1DF5DF919E7CFAE004E70D5 /* TaxonomyServiceRemoteREST.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TaxonomyServiceRemoteREST.h; sourceTree = "<group>"; };
 		E1DF5DFA19E7CFAE004E70D5 /* TaxonomyServiceRemoteREST.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TaxonomyServiceRemoteREST.m; sourceTree = "<group>"; };
 		E1DF5DFB19E7CFAE004E70D5 /* TaxonomyServiceRemoteXMLRPC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TaxonomyServiceRemoteXMLRPC.h; sourceTree = "<group>"; };
@@ -2982,6 +2986,8 @@
 				5DBFC8AA1A9C0EEF00E00DE4 /* WPScrollableViewController.h */,
 				FFA9148D1BA6E5170068F8BF /* RotationAwareNavigationViewController.h */,
 				FFA9148E1BA6E5170068F8BF /* RotationAwareNavigationViewController.m */,
+				E1DD4CCA1CAE41B800C3863E /* PagedViewController.swift */,
+				E1DD4CCC1CAE41C800C3863E /* PagedViewController.xib */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -4499,6 +4505,7 @@
 				4645AFC51961E1FB005F7509 /* AppImages.xcassets in Resources */,
 				B5C66B761ACF072C00F68370 /* NoteBlockCommentTableViewCell.xib in Resources */,
 				E18165FD14E4428B006CE885 /* loader.html in Resources */,
+				E1DD4CCD1CAE41C800C3863E /* PagedViewController.xib in Resources */,
 				E6A3384E1BB0A50900371587 /* ReaderGapMarkerCell.xib in Resources */,
 				5DB767411588F64D00EBE36C /* postPreview.html in Resources */,
 				85ED988817DFA00000090D0B /* Images.xcassets in Resources */,
@@ -4960,6 +4967,7 @@
 				B55853F719630D5400FAF6C3 /* NSAttributedString+Util.m in Sources */,
 				ACBAB5FE0E121C7300F38795 /* PostSettingsViewController.m in Sources */,
 				08CC677E1C49B65A00153AD7 /* MenuItem.m in Sources */,
+				E1DD4CCB1CAE41B800C3863E /* PagedViewController.swift in Sources */,
 				B535209B1AF7BBB800B33BA8 /* PushAuthenticationManager.swift in Sources */,
 				319D6E8119E44C680013871C /* SuggestionsTableView.m in Sources */,
 				F1A0C49C1AF65B02001B544C /* MFMessageComposeViewController+StatusBarStyle.m in Sources */,


### PR DESCRIPTION
Besides making PlanComparisonViewController use real plans and prices, this PR changes a few things:

- Refactored UI logic of the custom page controller to a generic PagedViewController. The view controllers to show are passed on initialization, although it could be modified to make it dynamic if that's necessary.
- Switched from storyboards to a single XIB for PagedViewController, so we can have `let` properties populated on initialization.
- Plan Comparison subclasses this new paged controller and just adds: close button, feature fetching, and transforming the plan information into view controllers.

Known issues:

- Tweaked the accessibility announce to use the VC's `accessibilityLabel` if present. I haven't been able to test this since VoiceOver is not announcing the layout change for some reason (the code hits `UIAccessibilityPostNotification` but nothing is spoken). I could use some help with this one.

To test:

Functionality should be the same, only plan info/prices come from the API/StoreKit now.

Fixes #5034, #5036
Needs review: @frosty 