### PR TITLE
Remove MGImageUtilities pod from our project.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -33,7 +33,6 @@ target 'WordPress', :exclusive => true do
   # ----------------------------
   # Forked third party libraries
   # ----------------------------
-  pod 'MGImageUtilities', :git => 'git://github.com/wordpress-mobile/MGImageUtilities.git', :branch => 'gifsupport'
   pod 'WordPress-AppbotX', :git => 'https://github.com/wordpress-mobile/appbotx.git', :commit => '87bae8c770cfc4e053119f2d00f76b2f653b26ce'
 
   # --------------------

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -79,7 +79,6 @@ PODS:
     - KIF/Core
   - Lookback (1.1.4):
     - PDKTZipArchive
-  - MGImageUtilities (0.0.1)
   - Mixpanel (2.9.4):
     - Mixpanel/Mixpanel (= 2.9.4)
   - Mixpanel/Mixpanel (2.9.4)
@@ -205,8 +204,6 @@ DEPENDENCIES:
   - HockeySDK (~> 3.8.0)
   - KIF/IdentifierTests (~> 3.1)
   - Lookback (= 1.1.4)
-  - MGImageUtilities (from `git://github.com/wordpress-mobile/MGImageUtilities.git`,
-    branch `gifsupport`)
   - Mixpanel (= 2.9.4)
   - MRProgress (~> 0.7.0)
   - Nimble (~> 3.2.0)
@@ -243,9 +240,6 @@ EXTERNAL SOURCES:
     :tag: 0.0.13
   EmailChecker:
     :podspec: https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec
-  MGImageUtilities:
-    :branch: gifsupport
-    :git: git://github.com/wordpress-mobile/MGImageUtilities.git
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
@@ -257,9 +251,6 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.0.13
-  MGImageUtilities:
-    :commit: e946cf3d97eb95372f4fc4478bf2e0099e73f4b0
-    :git: git://github.com/wordpress-mobile/MGImageUtilities.git
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
@@ -285,7 +276,6 @@ SPEC CHECKSUMS:
   HockeySDK: ab68303eec6680f6b539de65d747742dd276e934
   KIF: 2275c6d59c77e5e56f660f006b99d73780130540
   Lookback: 9ab9027ff246d2dc5ce34be483f70e4a6718280b
-  MGImageUtilities: b54a815970e231903c495fff33699467158f61a0
   Mixpanel: 80d2ca9bb38ae91c1044d738e80fe448377ac89f
   MRProgress: 1cb0051b678be4a2ef4881414cd316768fc70028
   Nimble: 703854335d181df169bbca9c97117b5cf8c47c1d

--- a/WordPress/Classes/Categories/UIImage+Resize.m
+++ b/WordPress/Classes/Categories/UIImage+Resize.m
@@ -125,7 +125,7 @@
                                                 newRect.size.width,
                                                 newRect.size.height,
                                                 CGImageGetBitsPerComponent(imageRef),
-                                                0,
+                                                CGImageGetBytesPerRow(imageRef),
                                                 CGImageGetColorSpace(imageRef),
                                                 bitmapInfo);
 

--- a/WordPress/Classes/Utility/WPAvatarSource.m
+++ b/WordPress/Classes/Utility/WPAvatarSource.m
@@ -1,6 +1,5 @@
-#import <MGImageUtilities/UIImage+ProportionalFill.h>
 #import "NSString+Helpers.h"
-
+#import "UIImage+Resize.h"
 #import "WPAvatarSource.h"
 #import "WPImageSource.h"
 
@@ -219,17 +218,9 @@ static NSString *const GravatarBaseUrl = @"http://gravatar.com";
     return size;
 }
 
-/**
- Wrapper method to resize an image
-
- It uses a modified version of MGImageUtilities to return opaque images.
- I tried to use UIImage+Resize, but had some problems if it wasn't run on the main thread.
-
- The wrapper is still here in case we need to switch the resizing mechanism in the future.
- */
 - (UIImage *)resizeImage:(UIImage *)image toSize:(CGSize)size
 {
-    return [image imageCroppedToFitSize:size ignoreAlpha:YES];
+    return [image resizedImageWithContentMode:UIViewContentModeScaleAspectFill bounds:size interpolationQuality:kCGInterpolationHigh];
 }
 
 - (NSURL *)URLWithHash:(NSString *)hash type:(WPAvatarSourceType)type

--- a/WordPress/Classes/Utility/WPTableImageSource.m
+++ b/WordPress/Classes/Utility/WPTableImageSource.m
@@ -1,11 +1,10 @@
-#import <MGImageUtilities/UIImage+ProportionalFill.h>
-
 #import "WPTableImageSource.h"
 #import "AccountService.h"
 #import "ContextManager.h"
 #import "PhotonImageURLHelper.h"
 #import "WPAccount.h"
 #import "WPImageSource.h"
+#import "UIImage+Resize.h"
 
 static const NSInteger WPTableImageSourceMaxPhotonQuality = 100;
 static const NSInteger WPTableImageSourceMinPhotonQuality = 1;
@@ -197,17 +196,9 @@ static const NSInteger WPTableImageSourceMinPhotonQuality = 1;
     });
 }
 
-/**
- Wrapper method to resize an image
-
- It uses a modified version of MGImageUtilities to return opaque images.
- I tried to use UIImage+Resize, but had some problems if it wasn't run on the main thread.
-
- The wrapper is still here in case we need to switch the resizing mechanism in the future.
- */
 - (UIImage *)resizeImage:(UIImage *)image toSize:(CGSize)size
 {
-    return [image imageCroppedToFitSize:size ignoreAlpha:NO];
+    return [image resizedImageWithContentMode:UIViewContentModeScaleAspectFill bounds:size interpolationQuality:kCGInterpolationHigh];
 }
 
 #pragma mark - Cache handling

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -110,6 +110,9 @@ public class CommentsTableViewCell : WPTableViewCell
     
     private func refreshImages() {
         timestampImageView.image = Style.timestampImage(isApproved: approved)
+        if !approved {
+            timestampImageView.tintColor = WPStyleGuide.alertYellowDark()
+        }
     }
     
     

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
@@ -1,5 +1,4 @@
 import Foundation
-import MGImageUtilities
 import WordPressShared
 
 /**
@@ -66,7 +65,7 @@ extension WPStyleGuide
         
         public static func timestampImage(isApproved approved: Bool) -> UIImage {
             let timestampImage = UIImage(named: "reader-postaction-time")!
-            return approved ? timestampImage : timestampImage.imageTintedWithColor(WPStyleGuide.alertYellowDark())
+            return approved ? timestampImage : timestampImage.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
         }
 
 

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
@@ -65,7 +65,7 @@ extension WPStyleGuide
         
         public static func timestampImage(isApproved approved: Bool) -> UIImage {
             let timestampImage = UIImage(named: "reader-postaction-time")!
-            return approved ? timestampImage : timestampImage.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
+            return approved ? timestampImage : timestampImage.imageWithRenderingMode(.AlwaysTemplate)
         }
 
 

--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
@@ -26,8 +26,9 @@ public class AboutViewController : UITableViewController
     private func setupTableView() {
         // Load and Tint the Logo
         let color                   = WPStyleGuide.wordPressBlue()
-        let tintedImage             = UIImage(named: "icon-wp")?.imageTintedWithColor(color)
+        let tintedImage             = UIImage(named: "icon-wp")?.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
         let imageView               = UIImageView(image: tintedImage)
+        imageView.tintColor = color
         imageView.autoresizingMask  = [.FlexibleLeftMargin, .FlexibleRightMargin]
         imageView.contentMode       = .Top
         

--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
@@ -26,7 +26,7 @@ public class AboutViewController : UITableViewController
     private func setupTableView() {
         // Load and Tint the Logo
         let color                   = WPStyleGuide.wordPressBlue()
-        let tintedImage             = UIImage(named: "icon-wp")?.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
+        let tintedImage             = UIImage(named: "icon-wp")?.imageWithRenderingMode(.AlwaysTemplate)
         let imageView               = UIImageView(image: tintedImage)
         imageView.tintColor = color
         imageView.autoresizingMask  = [.FlexibleLeftMargin, .FlexibleRightMargin]

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import MGImageUtilities
 import WordPressShared
 import WordPressComAnalytics
 
@@ -149,6 +148,7 @@ public class NotificationSettingStreamsViewController : UITableViewController
         let disabled                = isDisabledDeviceStream(stream)
         
         cell.imageView?.image       = imageForStreamKind(stream.kind)
+        cell.imageView?.tintColor   = WPStyleGuide.greyLighten10()
         cell.textLabel?.text        = stream.kind.description() ?? String()
         cell.detailTextLabel?.text  = disabled ? NSLocalizedString("Off", comment: "Disabled") : String()
         cell.accessoryType          = .DisclosureIndicator
@@ -170,9 +170,8 @@ public class NotificationSettingStreamsViewController : UITableViewController
         case .Device:
             imageName = "notifications-phone"
         }
-        
-        let tintColor = WPStyleGuide.greyLighten10()
-        return UIImage(named: imageName)?.imageTintedWithColor(tintColor)
+
+        return UIImage(named: imageName)?.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
     }
     
     

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -171,7 +171,7 @@ public class NotificationSettingStreamsViewController : UITableViewController
             imageName = "notifications-phone"
         }
 
-        return UIImage(named: imageName)?.imageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate)
+        return UIImage(named: imageName)?.imageWithRenderingMode(.AlwaysTemplate)
     }
     
     

--- a/WordPress/WordPressTest/WPAvatarSourceTest.m
+++ b/WordPress/WordPressTest/WPAvatarSourceTest.m
@@ -1,7 +1,6 @@
 @import XCTest;
 @import OHHTTPStubs;
 @import OHHTTPStubs.OHPathHelpers;
-@import MGImageUtilities;
 
 #import "WPAvatarSource.h"
 
@@ -45,9 +44,9 @@
 
     XCTestExpectation *fetchExpectation = [self expectationWithDescription:@"fetch and download"];
     [_source fetchImageForGravatarEmail:email withSize:size success:^(UIImage *image) {
+        [fetchExpectation fulfill];
         XCTAssertNotNil(image, @"avatar should be downloaded");
         XCTAssertEqual(image.size.width, 48.f, @"avatar should be resized");
-        [fetchExpectation fulfill];
     }];
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
 


### PR DESCRIPTION
Fixes dependencies of outside pods:)

Check the comments section on the reader and the notifications section to see if all gravatar images are being displayed properly.


Needs review: @jleandroperez and @aerych I think the Reader and Notifications where the main users of these methods do you mind to have a look?
