### PR TITLE
Account Settings: Email

### DIFF
--- a/WordPress/Classes/Extensions/NSString+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSString+Helpers.swift
@@ -3,17 +3,13 @@ import Foundation
 
 extension NSString
 {
-    /// Returns the string's hostname
-    ///
-    /// -   returns: hostname, if any
+    /// Returns the string's hostname, if any
     ///
     public func hostname() -> String? {
         return NSURLComponents(string: self as String)?.host
     }
     
-    /// Splits the lines contained in the current string
-    ///
-    /// -   returns: the unique values in a NSSet instance
+    /// Splits the lines contained in the current string, and returns the unique values in a NSSet instance
     ///
     public func uniqueStringComponentsSeparatedByNewline() -> NSSet {
         let components = componentsSeparatedByCharactersInSet(NSCharacterSet.newlineCharacterSet())
@@ -26,9 +22,7 @@ extension NSString
         return uniqueSet
     }
     
-    /// Validates the current string.
-    ///
-    /// -   returns: true if passes validation
+    /// Validates the current string. Returns true if passes validation
     ///
     public func isValidEmail() -> Bool {
         // From http://stackoverflow.com/a/3638271/1379066

--- a/WordPress/Classes/Extensions/NSString+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSString+Helpers.swift
@@ -3,12 +3,18 @@ import Foundation
 
 extension NSString
 {
-    /// Returns the string's hostname. If there's any
+    /// Returns the string's hostname
+    ///
+    /// -   returns: hostname, if any
+    ///
     public func hostname() -> String? {
         return NSURLComponents(string: self as String)?.host
     }
     
-    /// Splits the lines contained in the current string, and returns its unique values in a NSSet instance.
+    /// Splits the lines contained in the current string
+    ///
+    /// -   returns: the unique values in a NSSet instance
+    ///
     public func uniqueStringComponentsSeparatedByNewline() -> NSSet {
         let components = componentsSeparatedByCharactersInSet(NSCharacterSet.newlineCharacterSet())
         
@@ -18,5 +24,17 @@ extension NSString
         uniqueSet.addObjectsFromArray(filtered)
         
         return uniqueSet
+    }
+    
+    /// Validates the current string.
+    ///
+    /// -   returns: true if passes validation
+    ///
+    public func isValidEmail() -> Bool {
+        // From http://stackoverflow.com/a/3638271/1379066
+        let emailRegex = ".+@([A-Za-z0-9-]+\\.)+[A-Za-z]{2}[A-Za-z]*"
+        let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegex)
+        
+        return emailTest.evaluateWithObject(self)
     }
 }

--- a/WordPress/Classes/Extensions/NSString+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSString+Helpers.swift
@@ -26,7 +26,7 @@ extension NSString
     ///
     public func isValidEmail() -> Bool {
         // From http://stackoverflow.com/a/3638271/1379066
-        let emailRegex = ".+@([A-Za-z0-9-]+\\.)+[A-Za-z]{2}[A-Za-z]*"
+        let emailRegex = "^[^@\\s]+@[^@\\s]+$"
         let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegex)
         
         return emailTest.evaluateWithObject(self)

--- a/WordPress/Classes/Extensions/NSString+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSString+Helpers.swift
@@ -25,8 +25,7 @@ extension NSString
     /// Validates the current string. Returns true if passes validation
     ///
     public func isValidEmail() -> Bool {
-        // From http://stackoverflow.com/a/3638271/1379066
-        let emailRegex = "^[^@\\s]+@[^@\\s]+$"
+        let emailRegex = "^[^@]+@[^@]+$"
         let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegex)
         
         return emailTest.evaluateWithObject(self)

--- a/WordPress/Classes/Extensions/NSString+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSString+Helpers.swift
@@ -25,7 +25,7 @@ extension NSString
     /// Validates the current string. Returns true if passes validation
     ///
     public func isValidEmail() -> Bool {
-        let emailRegex = "^[^@]+@[^@]+$"
+        let emailRegex = "^.+@.+$"
         let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegex)
         
         return emailTest.evaluateWithObject(self)

--- a/WordPress/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIViewController+Helpers.swift
@@ -24,10 +24,4 @@ extension UIViewController
     public func isModal() -> Bool {
         return self.presentingViewController != nil
     }
-    
-    /// Determines if the current ViewController is the only one in the Navigation stack
-    ///
-    public func isRootInNavigation() -> Bool {
-        return navigationController?.viewControllers.count == 1
-    }
 }

--- a/WordPress/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIViewController+Helpers.swift
@@ -3,11 +3,25 @@ import Foundation
 
 extension UIViewController
 {
+    // Determines if the current ViewController's View is visible and onscreen
+    //
     public func isViewOnScreen() -> Bool {
         let visibleAsRoot       = view.window?.rootViewController == self
         let visibleAsTopOnStack = navigationController?.topViewController == self && view.window != nil
         let visibleAsPresented  = view.window?.rootViewController?.presentedViewController == self
         
         return visibleAsRoot || visibleAsTopOnStack || visibleAsPresented
+    }
+    
+    // Determines if the current ViewController is being presented modally
+    //
+    public func isModal() -> Bool {
+        return self.presentingViewController != nil
+    }
+    
+    // Determines if the current ViewController is the only one in the Navigation stack
+    //
+    public func isRootInNavigation() -> Bool {
+        return navigationController?.viewControllers.count == 1
     }
 }

--- a/WordPress/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIViewController+Helpers.swift
@@ -3,8 +3,8 @@ import Foundation
 
 extension UIViewController
 {
-    // Determines if the current ViewController's View is visible and onscreen
-    //
+    /// Determines if the current ViewController's View is visible and onscreen
+    ///
     public func isViewOnScreen() -> Bool {
         let visibleAsRoot       = view.window?.rootViewController == self
         let visibleAsTopOnStack = navigationController?.topViewController == self && view.window != nil
@@ -13,14 +13,20 @@ extension UIViewController
         return visibleAsRoot || visibleAsTopOnStack || visibleAsPresented
     }
     
-    // Determines if the current ViewController is being presented modally
-    //
+    /// Determines if the current ViewController's View is horizontally Compact
+    ///
+    public func isViewHorizontallyCompact() -> Bool {
+        return traitCollection.horizontalSizeClass == .Compact
+    }
+    
+    /// Determines if the current ViewController is being presented modally
+    ///
     public func isModal() -> Bool {
         return self.presentingViewController != nil
     }
     
-    // Determines if the current ViewController is the only one in the Navigation stack
-    //
+    /// Determines if the current ViewController is the only one in the Navigation stack
+    ///
     public func isRootInNavigation() -> Bool {
         return navigationController?.viewControllers.count == 1
     }

--- a/WordPress/Classes/Networking/AccountSettingsRemote.swift
+++ b/WordPress/Classes/Networking/AccountSettingsRemote.swift
@@ -138,7 +138,7 @@ class AccountSettingsRemote: ServiceRemoteREST {
         case .AboutMe(_):
             return "description"
         case .Email(_):
-            return "email"
+            return "user_email"
         case .PrimarySite(_):
             return "primary_site_ID"
         case .WebAddress(_):

--- a/WordPress/Classes/Utility/ImmuTableViewController.swift
+++ b/WordPress/Classes/Utility/ImmuTableViewController.swift
@@ -22,6 +22,7 @@ extension ImmuTablePresenter where Self: UIViewController {
         return {
             [unowned self] in
             let navigationController = UINavigationController(rootViewController: controllerGenerator($0))
+            navigationController.modalPresentationStyle = .FormSheet
             self.presentViewController(navigationController, animated: true, completion: nil)
         }
     }

--- a/WordPress/Classes/Utility/ImmuTableViewController.swift
+++ b/WordPress/Classes/Utility/ImmuTableViewController.swift
@@ -21,8 +21,8 @@ extension ImmuTablePresenter where Self: UIViewController {
     func present(controllerGenerator: ImmuTableRowControllerGenerator) -> ImmuTableAction {
         return {
             [unowned self] in
-            let controller = controllerGenerator($0)
-            self.presentViewController(controller, animated: true, completion: nil)
+            let navigationController = UINavigationController(rootViewController: controllerGenerator($0))
+            self.presentViewController(navigationController, animated: true, completion: nil)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
@@ -186,18 +186,10 @@ static CGFloat BlogCellRowHeight = 54.0;
     }
     
     if (self.dismissOnCancellation) {
-        [self dismissViewController];
+        [self dismissViewControllerAnimated:YES completion:nil];
     }
 }
 
-- (void)dismissViewController
-{
-    if (self.isModal && self.isRootInNavigation) {
-        [self dismissViewControllerAnimated:YES completion:nil];
-    } else {
-        [self.navigationController popViewControllerAnimated:YES];
-    }
-}
 
 #pragma mark - Table view data source
 
@@ -286,7 +278,7 @@ static CGFloat BlogCellRowHeight = 54.0;
             self.successHandler(self.selectedObjectID);
             
             if (self.dismissOnCompletion) {
-                [self dismissViewController];
+                [self dismissViewControllerAnimated:YES completion:nil];
             }
         });
     }

--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
@@ -75,7 +75,7 @@ static CGFloat BlogCellRowHeight = 54.0;
                                                object:nil];
 
     // Cancel button
-    if ([UIDevice isPhone] && self.displaysCancelButton) {
+    if (self.displaysCancelButton) {
         UIBarButtonItem *cancelButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
                                                                                           target:self
                                                                                           action:@selector(cancelButtonTapped:)];

--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
@@ -186,6 +186,15 @@ static CGFloat BlogCellRowHeight = 54.0;
     }
     
     if (self.dismissOnCancellation) {
+        [self dismissViewController];
+    }
+}
+
+- (void)dismissViewController
+{
+    if (self.isModal && self.isRootInNavigation) {
+        [self dismissViewControllerAnimated:YES completion:nil];
+    } else {
         [self.navigationController popViewControllerAnimated:YES];
     }
 }
@@ -277,7 +286,7 @@ static CGFloat BlogCellRowHeight = 54.0;
             self.successHandler(self.selectedObjectID);
             
             if (self.dismissOnCompletion) {
-                [self.navigationController popViewControllerAnimated:YES];
+                [self dismissViewController];
             }
         });
     }

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -683,7 +683,7 @@ import WordPressShared
         let text = blog.settings.sharingLabel
         let placeholder = NSLocalizedString("Type a label", comment: "A placeholder for the sharing label.")
         let hint = NSLocalizedString("Change the text of the sharing button's label. This text won't appear until you add at least one sharing button.", comment: "Instructions for editing the sharing label.")
-        let controller = SettingsTextViewController(text: text, placeholder: placeholder, hint: hint, isPassword: false)
+        let controller = SettingsTextViewController(text: text, placeholder: placeholder, hint: hint)
 
         controller.title = labelTitle
         controller.onValueChanged = {[unowned self] (value) in
@@ -742,7 +742,7 @@ import WordPressShared
         let text = blog.settings.sharingTwitterName
         let placeholder = NSLocalizedString("Username", comment: "A placeholder for the twitter username")
         let hint = NSLocalizedString("This will be included in tweets when people share using the Twitter button.", comment: "Information about the twitter sharing feature.")
-        let controller = SettingsTextViewController(text: text, placeholder: placeholder, hint: hint, isPassword: false)
+        let controller = SettingsTextViewController(text: text, placeholder: placeholder, hint: hint)
 
         controller.title = twitterUsernameTitle
         controller.onValueChanged = {[unowned self] (value) in

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -720,8 +720,8 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     }
     SettingsTextViewController *siteTitleViewController = [[SettingsTextViewController alloc] initWithText:self.blog.password
                                                                                                placeholder:NSLocalizedString(@"Enter password", @"(placeholder) Help enter WordPress password")
-                                                                                                      hint:@""
-                                                                                                isPassword:YES];
+                                                                                                      hint:@""];
+    siteTitleViewController.isPassword = YES;
     siteTitleViewController.title = NSLocalizedString(@"Password", @"Title for screen that shows self hosted password editor.");
     siteTitleViewController.onValueChanged = ^(id value) {
         if (![value isEqualToString:self.blog.password]) {
@@ -740,8 +740,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 
     SettingsTextViewController *siteTitleViewController = [[SettingsTextViewController alloc] initWithText:self.blog.settings.name
                                                                                                placeholder:NSLocalizedString(@"A title for the site", @"Placeholder text for the title of a site")
-                                                                                                      hint:@""
-                                                                                                isPassword:NO];
+                                                                                                      hint:@""];
     siteTitleViewController.title = NSLocalizedString(@"Site Title", @"Title for screen that show site title editor");
     siteTitleViewController.onValueChanged = ^(NSString *value) {
         self.siteTitleCell.detailTextLabel.text = value;

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -721,8 +721,8 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     SettingsTextViewController *siteTitleViewController = [[SettingsTextViewController alloc] initWithText:self.blog.password
                                                                                                placeholder:NSLocalizedString(@"Enter password", @"(placeholder) Help enter WordPress password")
                                                                                                       hint:@""];
-    siteTitleViewController.isPassword = YES;
     siteTitleViewController.title = NSLocalizedString(@"Password", @"Title for screen that shows self hosted password editor.");
+    siteTitleViewController.mode = SettingsTextModesPassword;
     siteTitleViewController.onValueChanged = ^(id value) {
         if (![value isEqualToString:self.blog.password]) {
             self.password = value;

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -169,7 +169,7 @@ private struct AccountSettingsController: SettingsController {
             selectorViewController.dismissOnCompletion = true
             selectorViewController.dismissOnCancellation = true
             
-            return UINavigationController(rootViewController: selectorViewController)
+            return selectorViewController
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -144,12 +144,12 @@ private struct AccountSettingsController: SettingsController {
 
     func editEmailAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
         let hint = NSLocalizedString("Will not be publicly displayed.", comment: "Help text when editing email address")
-        return editEmailAddress(AccountSettingsChange.Email, hint: hint, service: service)
+        return editEmailAddress(AccountSettingsChange.Email, hint: hint, displaysNavigationButtons: true, service: service)
     }
     
     func editWebAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
         let hint = NSLocalizedString("Shown publicly when you comment on blogs.", comment: "Help text when editing web address")
-        return editText(AccountSettingsChange.WebAddress, hint: hint, service: service)
+        return editText(AccountSettingsChange.WebAddress, hint: hint, displaysNavigationButtons: true, service: service)
     }
     
     func editPrimarySite(settings: AccountSettings?, service: AccountSettingsService) -> ImmuTableRowControllerGenerator {

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -85,19 +85,19 @@ private struct AccountSettingsController: SettingsController {
             let email = EditableTextRow(
                 title: NSLocalizedString("Email", comment: "Account Settings Email label"),
                 value: settings?.email ?? "",
-                action: presenter.push(editEmailAddress(service))
+                action: presenter.present(editEmailAddress(service))
             )
             
             let primarySite = EditableTextRow(
                 title: NSLocalizedString("Primary Site", comment: "Primary Web Site"),
                 value: primarySiteName ?? "",
-                action: presenter.push(editPrimarySite(settings, service: service))
+                action: presenter.present(editPrimarySite(settings, service: service))
             )
             
             let webAddress = EditableTextRow(
                 title: NSLocalizedString("Web Address", comment: "Account Settings Web Address label"),
                 value: settings?.webAddress ?? "",
-                action: presenter.push(editWebAddress(service))
+                action: presenter.present(editWebAddress(service))
             )
             
             return ImmuTable(sections: [
@@ -144,12 +144,12 @@ private struct AccountSettingsController: SettingsController {
 
     func editEmailAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
         let hint = NSLocalizedString("Will not be publicly displayed.", comment: "Help text when editing email address")
-        return editText(AccountSettingsChange.Email, hint: hint, isEmail: true, service: service)
+        return editText(AccountSettingsChange.Email, hint: hint, isEmail: true, isPresented: true, service: service)
     }
     
     func editWebAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
         let hint = NSLocalizedString("Shown publicly when you comment on blogs.", comment: "Help text when editing web address")
-        return editText(AccountSettingsChange.WebAddress, hint: hint, service: service)
+        return editText(AccountSettingsChange.WebAddress, hint: hint, isPresented: true, service: service)
     }
     
     func editPrimarySite(settings: AccountSettings?, service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
@@ -165,11 +165,11 @@ private struct AccountSettingsController: SettingsController {
 
             selectorViewController.title = NSLocalizedString("Primary Site", comment: "Primary Site Picker's Title");
             selectorViewController.displaysOnlyDefaultAccountSites = true
-            selectorViewController.displaysCancelButton = false
+            selectorViewController.displaysCancelButton = true
             selectorViewController.dismissOnCompletion = true
             selectorViewController.dismissOnCancellation = true
             
-            return selectorViewController
+            return UINavigationController(rootViewController: selectorViewController)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -82,9 +82,11 @@ private struct AccountSettingsController: SettingsController {
                 title: NSLocalizedString("Username", comment: "Account Settings Username label"),
                 value: settings?.username ?? "")
             
-            let email = TextRow(
+            let email = EditableTextRow(
                 title: NSLocalizedString("Email", comment: "Account Settings Email label"),
-                value: settings?.email ?? "")
+                value: settings?.email ?? "",
+                action: presenter.push(editEmailAddress(service))
+            )
             
             let primarySite = EditableTextRow(
                 title: NSLocalizedString("Primary Site", comment: "Primary Web Site"),
@@ -140,8 +142,14 @@ private struct AccountSettingsController: SettingsController {
     
     // MARK: - Actions
 
+    func editEmailAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
+        let hint = NSLocalizedString("Will not be publicly displayed.", comment: "Help text when editing email address")
+        return editText(AccountSettingsChange.Email, hint: hint, isEmail: true, service: service)
+    }
+    
     func editWebAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
-        return editText(AccountSettingsChange.WebAddress, hint: NSLocalizedString("Shown publicly when you comment on blogs.", comment: "Help text when editing web address"), service: service)
+        let hint = NSLocalizedString("Shown publicly when you comment on blogs.", comment: "Help text when editing web address")
+        return editText(AccountSettingsChange.WebAddress, hint: hint, service: service)
     }
     
     func editPrimarySite(settings: AccountSettings?, service: AccountSettingsService) -> ImmuTableRowControllerGenerator {

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -144,12 +144,12 @@ private struct AccountSettingsController: SettingsController {
 
     func editEmailAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
         let hint = NSLocalizedString("Will not be publicly displayed.", comment: "Help text when editing email address")
-        return editEmailAddress(AccountSettingsChange.Email, hint: hint, isPresented: true, service: service)
+        return editEmailAddress(AccountSettingsChange.Email, hint: hint, service: service)
     }
     
     func editWebAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
         let hint = NSLocalizedString("Shown publicly when you comment on blogs.", comment: "Help text when editing web address")
-        return editText(AccountSettingsChange.WebAddress, hint: hint, isPresented: true, service: service)
+        return editText(AccountSettingsChange.WebAddress, hint: hint, service: service)
     }
     
     func editPrimarySite(settings: AccountSettings?, service: AccountSettingsService) -> ImmuTableRowControllerGenerator {

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -144,7 +144,7 @@ private struct AccountSettingsController: SettingsController {
 
     func editEmailAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
         let hint = NSLocalizedString("Will not be publicly displayed.", comment: "Help text when editing email address")
-        return editText(AccountSettingsChange.Email, hint: hint, isEmail: true, isPresented: true, service: service)
+        return editEmailAddress(AccountSettingsChange.Email, hint: hint, isPresented: true, service: service)
     }
     
     func editWebAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -4,19 +4,33 @@ protocol SettingsController: ImmuTableController {}
 
 // MARK: - Actions
 extension SettingsController {
-    func editText(changeType: AccountSettingsChangeWithString, hint: String? = nil, service: AccountSettingsService) -> ImmuTableRowControllerGenerator
+    func editText(changeType: AccountSettingsChangeWithString,
+                  hint: String? = nil,
+                  displaysNavigationButtons: Bool = false,
+                  service: AccountSettingsService) -> ImmuTableRowControllerGenerator
     {
         return { row in
             let editableRow = row as! EditableTextRow
-            return self.controllerForEditableText(editableRow, changeType: changeType, hint: hint, service: service)
+            return self.controllerForEditableText(editableRow,
+                                                  changeType: changeType,
+                                                  hint: hint,
+                                                  displaysNavigationButtons: displaysNavigationButtons,
+                                                  service: service)
         }
     }
 
-    func editEmailAddress(changeType: AccountSettingsChangeWithString, hint: String? = nil, service: AccountSettingsService) -> ImmuTableRowControllerGenerator
+    func editEmailAddress(changeType: AccountSettingsChangeWithString,
+                          hint: String? = nil,
+                          displaysNavigationButtons: Bool = false,
+                          service: AccountSettingsService) -> ImmuTableRowControllerGenerator
     {
         return { row in
             let editableRow = row as! EditableTextRow
-            let settingsViewController =  self.controllerForEditableText(editableRow, changeType: changeType, hint: hint, service: service)
+            let settingsViewController =  self.controllerForEditableText(editableRow,
+                                                                         changeType: changeType,
+                                                                         hint: hint,
+                                                                         displaysNavigationButtons: displaysNavigationButtons,
+                                                                         service: service)
             settingsViewController.mode = .Email
             
             return settingsViewController
@@ -26,6 +40,7 @@ extension SettingsController {
     func controllerForEditableText(row: EditableTextRow,
                                    changeType: AccountSettingsChangeWithString,
                                    hint: String? = nil,
+                                   displaysNavigationButtons: Bool = false,
                                    service: AccountSettingsService) -> SettingsTextViewController
     {
         let title = row.title
@@ -34,6 +49,7 @@ extension SettingsController {
         let controller = SettingsTextViewController(text: value, placeholder: "\(title)...", hint: hint)
 
         controller.title = title
+        controller.displaysNavigationButtons = displaysNavigationButtons
         controller.onValueChanged = {
             value in
 

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -8,15 +8,22 @@ extension SettingsController {
                   hint: String? = nil,
                   isEmail: Bool = false,
                   isPassword: Bool = false,
+                  isPresented: Bool = false,
                   service: AccountSettingsService) -> ImmuTableRowControllerGenerator
     {
         return { row in
-            return self.controllerForEditableText(row as! EditableTextRow,
-                                                  changeType: changeType,
-                                                  hint: hint,
-                                                  isEmail: isEmail,
-                                                  isPassword: isPassword,
-                                                  service: service)
+            let editionViewController = self.controllerForEditableText(row as! EditableTextRow,
+                                                                       changeType: changeType,
+                                                                       hint: hint,
+                                                                       isEmail: isEmail,
+                                                                       isPassword: isPassword,
+                                                                       service: service)
+            
+            if isPresented {
+                return UINavigationController(rootViewController: editionViewController)
+            }
+            
+            return editionViewController
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -4,43 +4,19 @@ protocol SettingsController: ImmuTableController {}
 
 // MARK: - Actions
 extension SettingsController {
-    func editText(changeType: AccountSettingsChangeWithString,
-                  hint: String? = nil,
-                  isPresented: Bool = false,
-                  service: AccountSettingsService) -> ImmuTableRowControllerGenerator
+    func editText(changeType: AccountSettingsChangeWithString, hint: String? = nil, service: AccountSettingsService) -> ImmuTableRowControllerGenerator
     {
         return { row in
-            let editionViewController = self.controllerForEditableText(row as! EditableTextRow,
-                                                                       changeType: changeType,
-                                                                       hint: hint,
-                                                                       isEmail: false,
-                                                                       service: service)
-            
-            if isPresented {
-                return UINavigationController(rootViewController: editionViewController)
-            }
-            
-            return editionViewController
+            let editableRow = row as! EditableTextRow
+            return self.controllerForEditableText(editableRow, changeType: changeType, hint: hint, service: service)
         }
     }
 
-    func editEmailAddress(changeType: AccountSettingsChangeWithString,
-                          hint: String? = nil,
-                          isPresented: Bool = false,
-                          service: AccountSettingsService) -> ImmuTableRowControllerGenerator
+    func editEmailAddress(changeType: AccountSettingsChangeWithString, hint: String? = nil, service: AccountSettingsService) -> ImmuTableRowControllerGenerator
     {
         return { row in
-            let editionViewController = self.controllerForEditableText(row as! EditableTextRow,
-                                                                       changeType: changeType,
-                                                                       hint: hint,
-                                                                       isEmail: true,
-                                                                       service: service)
-            
-            if isPresented {
-                return UINavigationController(rootViewController: editionViewController)
-            }
-            
-            return editionViewController
+            let editableRow = row as! EditableTextRow
+            return self.controllerForEditableText(editableRow, changeType: changeType, hint: hint, isEmail: true, service: service)
         }
     }
     

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -16,14 +16,16 @@ extension SettingsController {
     {
         return { row in
             let editableRow = row as! EditableTextRow
-            return self.controllerForEditableText(editableRow, changeType: changeType, hint: hint, isEmail: true, service: service)
+            let settingsViewController =  self.controllerForEditableText(editableRow, changeType: changeType, hint: hint, service: service)
+            settingsViewController.mode = .Email
+            
+            return settingsViewController
         }
     }
     
     func controllerForEditableText(row: EditableTextRow,
                                    changeType: AccountSettingsChangeWithString,
                                    hint: String? = nil,
-                                   isEmail: Bool = false,
                                    service: AccountSettingsService) -> SettingsTextViewController
     {
         let title = row.title
@@ -32,7 +34,6 @@ extension SettingsController {
         let controller = SettingsTextViewController(text: value, placeholder: "\(title)...", hint: hint)
 
         controller.title = title
-        controller.isEmail = isEmail
         controller.onValueChanged = {
             value in
 

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -4,10 +4,19 @@ protocol SettingsController: ImmuTableController {}
 
 // MARK: - Actions
 extension SettingsController {
-    func editText(changeType: (AccountSettingsChangeWithString), hint: String? = nil, service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
+    func editText(changeType: AccountSettingsChangeWithString,
+                  hint: String? = nil,
+                  isEmail: Bool = false,
+                  isPassword: Bool = false,
+                  service: AccountSettingsService) -> ImmuTableRowControllerGenerator
+    {
         return { row in
-            let row = row as! EditableTextRow
-            return self.controllerForEditableText(row, changeType: changeType, hint: hint, service: service)
+            return self.controllerForEditableText(row as! EditableTextRow,
+                                                  changeType: changeType,
+                                                  hint: hint,
+                                                  isEmail: isEmail,
+                                                  isPassword: isPassword,
+                                                  service: service)
         }
     }
 
@@ -24,6 +33,7 @@ extension SettingsController {
         let controller = SettingsTextViewController(text: value, placeholder: "\(title)...", hint: hint)
 
         controller.title = title
+        controller.isEmail = isEmail
         controller.isPassword = isPassword
         controller.onValueChanged = {
             value in

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -11,17 +11,20 @@ extension SettingsController {
         }
     }
 
-    func controllerForEditableText(row: EditableTextRow, changeType: (AccountSettingsChangeWithString), hint: String? = nil, isPassword: Bool = false, service: AccountSettingsService) -> SettingsTextViewController {
+    func controllerForEditableText(row: EditableTextRow,
+                                   changeType: AccountSettingsChangeWithString,
+                                   hint: String? = nil,
+                                   isEmail: Bool = false,
+                                   isPassword: Bool = false,
+                                   service: AccountSettingsService) -> SettingsTextViewController
+    {
         let title = row.title
         let value = row.value
 
-        let controller = SettingsTextViewController(
-            text: value,
-            placeholder: "\(title)...",
-            hint: hint,
-            isPassword: isPassword)
+        let controller = SettingsTextViewController(text: value, placeholder: "\(title)...", hint: hint)
 
         controller.title = title
+        controller.isPassword = isPassword
         controller.onValueChanged = {
             value in
 

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -7,7 +7,6 @@ extension SettingsController {
     func editText(changeType: AccountSettingsChangeWithString,
                   hint: String? = nil,
                   isEmail: Bool = false,
-                  isPassword: Bool = false,
                   isPresented: Bool = false,
                   service: AccountSettingsService) -> ImmuTableRowControllerGenerator
     {
@@ -16,7 +15,6 @@ extension SettingsController {
                                                                        changeType: changeType,
                                                                        hint: hint,
                                                                        isEmail: isEmail,
-                                                                       isPassword: isPassword,
                                                                        service: service)
             
             if isPresented {
@@ -31,7 +29,6 @@ extension SettingsController {
                                    changeType: AccountSettingsChangeWithString,
                                    hint: String? = nil,
                                    isEmail: Bool = false,
-                                   isPassword: Bool = false,
                                    service: AccountSettingsService) -> SettingsTextViewController
     {
         let title = row.title
@@ -41,7 +38,6 @@ extension SettingsController {
 
         controller.title = title
         controller.isEmail = isEmail
-        controller.isPassword = isPassword
         controller.onValueChanged = {
             value in
 

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -6,7 +6,6 @@ protocol SettingsController: ImmuTableController {}
 extension SettingsController {
     func editText(changeType: AccountSettingsChangeWithString,
                   hint: String? = nil,
-                  isEmail: Bool = false,
                   isPresented: Bool = false,
                   service: AccountSettingsService) -> ImmuTableRowControllerGenerator
     {
@@ -14,7 +13,7 @@ extension SettingsController {
             let editionViewController = self.controllerForEditableText(row as! EditableTextRow,
                                                                        changeType: changeType,
                                                                        hint: hint,
-                                                                       isEmail: isEmail,
+                                                                       isEmail: false,
                                                                        service: service)
             
             if isPresented {
@@ -25,6 +24,26 @@ extension SettingsController {
         }
     }
 
+    func editEmailAddress(changeType: AccountSettingsChangeWithString,
+                          hint: String? = nil,
+                          isPresented: Bool = false,
+                          service: AccountSettingsService) -> ImmuTableRowControllerGenerator
+    {
+        return { row in
+            let editionViewController = self.controllerForEditableText(row as! EditableTextRow,
+                                                                       changeType: changeType,
+                                                                       hint: hint,
+                                                                       isEmail: true,
+                                                                       service: service)
+            
+            if isPresented {
+                return UINavigationController(rootViewController: editionViewController)
+            }
+            
+            return editionViewController
+        }
+    }
+    
     func controllerForEditableText(row: EditableTextRow,
                                    changeType: AccountSettingsChangeWithString,
                                    hint: String? = nil,

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -302,7 +302,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
                                                                                        successHandler:successHandler
                                                                                        dismissHandler:dismissHandler];
     vc.displaysPrimaryBlogOnTop = YES;
-    vc.displaysCancelButton = [UIDevice isPhone];
+    vc.displaysCancelButton = [self isViewHorizontallyCompact];
     vc.title = NSLocalizedString(@"Select Site", @"");
     
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -302,8 +302,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
                                                                                        successHandler:successHandler
                                                                                        dismissHandler:dismissHandler];
     vc.displaysPrimaryBlogOnTop = YES;
+    vc.displaysCancelButton = [UIDevice isPhone];
     vc.title = NSLocalizedString(@"Select Site", @"");
-
+    
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];
     navController.navigationBar.translucent = NO;
     navController.navigationBar.barStyle = UIBarStyleBlack;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -719,6 +719,7 @@ EditImageDetailsViewControllerDelegate
                                                                                        dismissHandler:dismissHandler];
     vc.title = NSLocalizedString(@"Select Site", @"");
     vc.displaysPrimaryBlogOnTop = YES;
+    vc.displaysCancelButton = [UIDevice isPhone];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];
     navController.navigationBar.translucent = NO;
     navController.navigationBar.barStyle = UIBarStyleBlack;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -719,7 +719,7 @@ EditImageDetailsViewControllerDelegate
                                                                                        dismissHandler:dismissHandler];
     vc.title = NSLocalizedString(@"Select Site", @"");
     vc.displaysPrimaryBlogOnTop = YES;
-    vc.displaysCancelButton = [UIDevice isPhone];
+    vc.displaysCancelButton = [self isViewHorizontallyCompact];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];
     navController.navigationBar.translucent = NO;
     navController.navigationBar.barStyle = UIBarStyleBlack;
@@ -1110,14 +1110,6 @@ EditImageDetailsViewControllerDelegate
 }
 
 #pragma mark - Custom UI elements
-
-- (BOOL)isViewHorizontallyCompact
-{
-    if ([self respondsToSelector:@selector(traitCollection)] == false) {
-        return ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) == false;
-    }
-    return self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;
-}
 
 - (WPButtonForNavigationBar*)buttonForBarWithImageNamed:(NSString*)imageName
 												  frame:(CGRect)frame

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
@@ -62,7 +62,7 @@ public class SettingsListEditorViewController : UITableViewController
     
     // MARK: - Button Handlers
     @IBAction func addItemPressed(sender: AnyObject?) {
-        let settingsViewController = SettingsTextViewController(text: nil, placeholder: nil, hint: nil, isPassword: false)
+        let settingsViewController = SettingsTextViewController(text: nil, placeholder: nil, hint: nil)
         settingsViewController.title = insertTitle
         settingsViewController.onValueChanged = { (updatedValue : String!) in
             self.insertString(updatedValue)
@@ -130,7 +130,7 @@ public class SettingsListEditorViewController : UITableViewController
         // Edit!
         let oldText = stringAtIndexPath(indexPath)
         
-        let settingsViewController = SettingsTextViewController(text: oldText, placeholder: nil, hint: nil, isPassword: false)
+        let settingsViewController = SettingsTextViewController(text: oldText, placeholder: nil, hint: nil)
         settingsViewController.title = editTitle
         settingsViewController.onValueChanged = { (newText : String!) in
             self.replaceString(oldText, newText: newText)

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
@@ -1,31 +1,38 @@
 #import <UIKit/UIKit.h>
 
 
+// Typedef's
+typedef NS_ENUM(NSInteger, SettingsTextModes) {
+    SettingsTextModesText,
+    SettingsTextModesEmail,
+    SettingsTextModesPassword
+};
+
 typedef void (^SettingsTextChanged)(NSString *);
 
-// Reusable component that renders a UITextField + Hint onscreen. Useful for Text / Password / Email data entry.
-//
+/// Reusable component that renders a UITextField + Hint onscreen. Useful for Text / Password / Email data entry.
+///
 @interface SettingsTextViewController : UITableViewController
 
-// Block to be executed on dismiss, if the value was effectively updated.
-//
+/// Block to be executed on dismiss, if the value was effectively updated.
+///
 @property (nonatomic, copy) SettingsTextChanged onValueChanged;
 
-// Property to indicate whether email validation should be performed, or not.
-//
-@property (nonatomic, assign) BOOL isEmail;
+/// Sets the Text Input Mode:
+///
+/// - SettingsTextModesText: Default mode
+/// - SettingsTextModesEmail: Will perform Email validation before hitting the callback.
+/// - SettingsTextModesPassword: Secure Text Entry is enabled.
+///
+@property (nonatomic, assign) SettingsTextModes mode;
 
-// Indicates whether secure text entry is requried, or not.
-//
-@property (nonatomic, assign) BOOL isPassword;
-
-// Required initializer.
-//
-// Parameters:
-//  - text: The raw string (current value) to edit.
-//  - placeholder: Placeholder string to be displayed, in case the text is empty.
-//  - hint: String to be displayed at the bottom.
-//
+/// Required initializer.
+///
+/// Parameters:
+///  - text: The raw string (current value) to edit.
+///  - placeholder: Placeholder string to be displayed, in case the text is empty.
+///  - hint: String to be displayed at the bottom.
+///
 - (instancetype)initWithText:(NSString *)text placeholder:(NSString *)placeholder hint:(NSString *)hint;
 
 @end

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
@@ -18,6 +18,10 @@ typedef void (^SettingsTextChanged)(NSString *);
 ///
 @property (nonatomic, copy) SettingsTextChanged onValueChanged;
 
+/// Specifies whether we should display navigation buttons (Cancel / Done) or not.
+///
+@property (nonatomic, assign) BOOL displaysNavigationButtons;
+
 /// Sets the Text Input Mode:
 ///
 /// - SettingsTextModesText: Default mode

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
@@ -1,13 +1,27 @@
 #import <UIKit/UIKit.h>
 
+
+typedef void (^SettingsTextChanged)(NSString *);
+
+// Reusable component that renders a UITextField + Hint onscreen. Useful for Text / Password / Email data entry.
+//
 @interface SettingsTextViewController : UITableViewController
 
-@property (nonatomic, copy) void(^onValueChanged)(NSString *);
-@property (nonatomic, copy) void(^onCancel)();
+// Block to be executed on dismiss, if the value was effectively updated.
+//
+@property (nonatomic, copy) SettingsTextChanged onValueChanged;
 
-- (instancetype)initWithText:(NSString *)text
-                 placeholder:(NSString *)placeholder
-                        hint:(NSString *)hint
-                  isPassword:(BOOL)isPassword;
+// Indicates whether secure text entry is requried, or not.
+//
+@property (nonatomic, assign) BOOL isPassword;
+
+// Required initializer.
+//
+// Parameters:
+//  - text: The raw string (current value) to edit.
+//  - placeholder: Placeholder string to be displayed, in case the text is empty.
+//  - hint: String to be displayed at the bottom.
+//
+- (instancetype)initWithText:(NSString *)text placeholder:(NSString *)placeholder hint:(NSString *)hint;
 
 @end

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
@@ -11,6 +11,10 @@ typedef void (^SettingsTextChanged)(NSString *);
 //
 @property (nonatomic, copy) SettingsTextChanged onValueChanged;
 
+// Property to indicate whether email validation should be performed, or not.
+//
+@property (nonatomic, assign) BOOL isEmail;
+
 // Indicates whether secure text entry is requried, or not.
 //
 @property (nonatomic, assign) BOOL isPassword;

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -56,6 +56,7 @@ static CGFloat const HorizontalMargin = 15.0f;
     [super viewDidLoad];
     [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
+    [self startListeningNotifications];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -101,6 +102,15 @@ static CGFloat const HorizontalMargin = 15.0f;
                                                                                            action:@selector(doneButtonWasPressed:)];
 }
 
+- (void)startListeningNotifications
+{
+    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+    [notificationCenter addObserver:self
+                           selector:@selector(validateTextInput:)
+                               name:UITextFieldTextDidChangeNotification
+                             object:_textField];
+}
+
 - (IBAction)cancelButtonWasPressed:(id)sender
 {
     [self dismissViewControllerAnimated:true completion:nil];
@@ -108,9 +118,7 @@ static CGFloat const HorizontalMargin = 15.0f;
 
 - (IBAction)doneButtonWasPressed:(id)sender
 {
-    if (self.textPassesValidation == false) {
-        [self displayValidationAlert];
-    } else if (self.isRootInNavigation && self.isModal) {
+    if (self.isRootInNavigation && self.isModal) {
         [self dismissViewControllerAnimated:true completion:nil];
     } else {
         [self.navigationController popViewControllerAnimated:YES];
@@ -120,22 +128,10 @@ static CGFloat const HorizontalMargin = 15.0f;
 
 #pragma mark - Validation
 
-- (void)displayValidationAlert
+- (void)validateTextInput:(id)sender
 {
-    NSString *title = NSLocalizedString(@"Invalid Email", @"Invalid Email");
-    NSString *message = NSLocalizedString(@"Please, enter a valid email", @"Text displayed whenever an invalid email is entered.");
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
-                                                                             message:message
-                                                                      preferredStyle:UIAlertControllerStyleAlert];
-
-    [alertController addDefaultActionWithTitle:NSLocalizedString(@"Accept", @"Accept") handler:nil];
-    
-    [self presentViewController:alertController animated:YES completion:nil];
-}
-
-- (BOOL)textPassesValidation
-{
-    return (self.isEmail == false || (self.isEmail && self.textField.text.isValidEmail));
+    BOOL isValid = (self.isEmail == false || (self.isEmail && self.textField.text.isValidEmail));
+    self.navigationItem.rightBarButtonItem.enabled = isValid;
 }
 
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -140,7 +140,8 @@ static CGFloat const HorizontalMargin = 15.0f;
 
 - (BOOL)textPassesValidation
 {
-    return (self.isEmail == false || (self.isEmail && self.textField.text.isValidEmail));
+    BOOL isEmail = (self.mode == SettingsTextModesEmail);
+    return (isEmail == false || (isEmail && self.textField.text.isValidEmail));
 }
 
 - (void)validateTextInput:(id)sender
@@ -151,14 +152,10 @@ static CGFloat const HorizontalMargin = 15.0f;
 
 #pragma mark - Properties
 
-- (BOOL)isPassword
+- (void)setMode:(SettingsTextModes)mode
 {
-    return self.textField.secureTextEntry;
-}
-
-- (void)setIsPassword:(BOOL)isPassword
-{
-    self.textField.secureTextEntry = isPassword;
+    _mode = mode;
+    [self updateModeSettings:mode];
 }
 
 - (WPTableViewCell *)textFieldCell
@@ -167,21 +164,30 @@ static CGFloat const HorizontalMargin = 15.0f;
         return _textFieldCell;
     }
     _textFieldCell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
-    
-    self.textField = [[UITextField alloc] initWithFrame:CGRectInset(_textFieldCell.bounds, HorizontalMargin, 0)];
-    self.textField.clearButtonMode = UITextFieldViewModeAlways;
-    self.textField.font = [WPStyleGuide tableviewTextFont];
-    self.textField.textColor = [WPStyleGuide darkGrey];
-    self.textField.text = self.text;
-    self.textField.placeholder = self.placeholder;
-    self.textField.returnKeyType = UIReturnKeyDone;
-    self.textField.keyboardType = UIKeyboardTypeDefault;
-    self.textField.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-    self.textField.delegate = self;
-    
     [_textFieldCell.contentView addSubview:self.textField];
+    _textField.frame = CGRectInset(_textFieldCell.bounds, HorizontalMargin, 0);
     
     return _textFieldCell;
+}
+
+- (UITextField *)textField
+{
+    if (_textField) {
+        return _textField;
+    }
+    
+    _textField = [[UITextField alloc] initWithFrame:CGRectZero];
+    _textField.clearButtonMode = UITextFieldViewModeAlways;
+    _textField.font = [WPStyleGuide tableviewTextFont];
+    _textField.textColor = [WPStyleGuide darkGrey];
+    _textField.text = self.text;
+    _textField.placeholder = self.placeholder;
+    _textField.returnKeyType = UIReturnKeyDone;
+    _textField.keyboardType = UIKeyboardTypeDefault;
+    _textField.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    _textField.delegate = self;
+
+    return _textField;
 }
 
 - (UIView *)hintView
@@ -239,6 +245,27 @@ static CGFloat const HorizontalMargin = 15.0f;
     
     self.onValueChanged(self.textField.text);
     self.onValueChanged = nil;
+}
+
+
+- (void)updateModeSettings:(SettingsTextModes)newMode
+{
+    BOOL requiresSecureTextEntry = NO;
+    
+    switch (newMode) {
+        case SettingsTextModesPassword:
+        {
+            requiresSecureTextEntry = YES;
+        }
+            break;
+        default:
+        {
+            // No OP
+        }
+            break;
+    }
+    
+    self.textField.secureTextEntry = requiresSecureTextEntry;
 }
 
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -74,7 +74,10 @@ static CGFloat const HorizontalMargin = 15.0f;
 {
     [super viewWillDisappear:animated];
     [self.view endEditing:YES];
-    [self notifyValueDidChangeIfNeeded];
+    
+    if (self.isModal == NO) {
+        [self notifyValueDidChange];
+    }
 }
 
 
@@ -112,7 +115,7 @@ static CGFloat const HorizontalMargin = 15.0f;
 
 - (IBAction)doneButtonWasPressed:(id)sender
 {
-    [self notifyValueDidChangeIfNeeded];
+    [self notifyValueDidChange];
     [self dismissViewController];
 }
 
@@ -218,12 +221,16 @@ static CGFloat const HorizontalMargin = 15.0f;
     }
 }
 
-- (void)notifyValueDidChangeIfNeeded
+- (void)notifyValueDidChange
 {
     if (self.onValueChanged == nil || [self.textField.text isEqualToString:self.text]) {
         return;
     }
     
+    // `onValueChanged` should only be called *once*. We'll clean up its reference, in order to prevent double call,
+    // in the scenario in which the VC is in a NavigationController stack, and gets dismissed thru the keyboard.
+    // This is done for simplicity reasons, instead of adding yet another boolean to track state.
+    //
     self.onValueChanged(self.textField.text);
     self.onValueChanged = nil;
 }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -73,6 +73,8 @@ static CGFloat const HorizontalMargin = 15.0f;
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
+
+    [self.view endEditing:YES];
     
     if (self.onValueChanged && ![self.textField.text isEqualToString:self.text] && self.textPassesValidation) {
         self.onValueChanged(self.textField.text);
@@ -85,7 +87,7 @@ static CGFloat const HorizontalMargin = 15.0f;
 - (void)setupModalButtonsIfNeeded
 {
     // Proceed only if this is the only VC in the current navigationController
-    if (self.isBeingPresented == true || self.navigationController.viewControllers.count > 1) {
+    if (self.isBeingPresented == true || self.isRootViewController == false) {
         return;
     }
     
@@ -99,6 +101,11 @@ static CGFloat const HorizontalMargin = 15.0f;
                                                                                            action:@selector(doneButtonWasPressed:)];
 }
 
+- (BOOL)isRootViewController
+{
+    return self.navigationController.viewControllers.count == 1;
+}
+
 - (IBAction)cancelButtonWasPressed:(id)sender
 {
     [self dismissViewControllerAnimated:true completion:nil];
@@ -108,8 +115,10 @@ static CGFloat const HorizontalMargin = 15.0f;
 {
     if (self.textPassesValidation == false) {
         [self displayValidationAlert];
-    } else {
+    } else if (self.isRootViewController && self.presentingViewController) {
         [self dismissViewControllerAnimated:true completion:nil];
+    } else {
+        [self.navigationController popViewControllerAnimated:YES];
     }
 }
 
@@ -219,6 +228,10 @@ static CGFloat const HorizontalMargin = 15.0f;
         [self.navigationController popViewControllerAnimated:YES];
     }
 
+    if ([string isEqualToString:@"\n"]) {
+        [self doneButtonWasPressed:self];
+    }
+    
     return YES;
 }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -232,20 +232,14 @@ static CGFloat const HorizontalMargin = 15.0f;
 - (void)updateModeSettings:(SettingsTextModes)newMode
 {
     BOOL requiresSecureTextEntry = NO;
+    UIKeyboardType keyboardType = UIKeyboardTypeDefault;
     
-    switch (newMode) {
-        case SettingsTextModesPassword:
-        {
-            requiresSecureTextEntry = YES;
-        }
-            break;
-        default:
-        {
-            // No OP
-        }
-            break;
+    if (newMode == SettingsTextModesPassword) {
+        requiresSecureTextEntry = YES;
+        keyboardType = UIKeyboardTypeEmailAddress;
     }
     
+    self.textField.keyboardType = keyboardType;
     self.textField.secureTextEntry = requiresSecureTextEntry;
 }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -231,6 +231,7 @@ static CGFloat const HorizontalMargin = 15.0f;
     
     if (newMode == SettingsTextModesPassword) {
         requiresSecureTextEntry = YES;
+    } else if (newMode == SettingsTextModesEmail) {
         keyboardType = UIKeyboardTypeEmailAddress;
     }
     

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -87,7 +87,7 @@ static CGFloat const HorizontalMargin = 15.0f;
 - (void)setupModalButtonsIfNeeded
 {
     // Proceed only if this is the only VC in the current navigationController
-    if (self.isBeingPresented == true || self.isRootViewController == false) {
+    if (self.isBeingPresented == true || self.isModal == false) {
         return;
     }
     
@@ -101,11 +101,6 @@ static CGFloat const HorizontalMargin = 15.0f;
                                                                                            action:@selector(doneButtonWasPressed:)];
 }
 
-- (BOOL)isRootViewController
-{
-    return self.navigationController.viewControllers.count == 1;
-}
-
 - (IBAction)cancelButtonWasPressed:(id)sender
 {
     [self dismissViewControllerAnimated:true completion:nil];
@@ -115,7 +110,7 @@ static CGFloat const HorizontalMargin = 15.0f;
 {
     if (self.textPassesValidation == false) {
         [self displayValidationAlert];
-    } else if (self.isRootViewController && self.presentingViewController) {
+    } else if (self.isRootInNavigation && self.isModal) {
         [self dismissViewControllerAnimated:true completion:nil];
     } else {
         [self.navigationController popViewControllerAnimated:YES];

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -3,19 +3,26 @@
 #import "WPStyleGuide.h"
 #import "WPTableViewSectionHeaderFooterView.h"
 
+
+
+#pragma mark - Constants
+
 static CGFloat const HorizontalMargin = 15.0f;
 
+
+#pragma mark - Private Properties
+
 @interface SettingsTextViewController() <UITextFieldDelegate>
-
-@property (nonatomic, strong) WPTableViewCell *textFieldCell;
-@property (nonatomic, strong) UITextField *textField;
-@property (nonatomic, strong) UIView *hintView;
-@property (nonatomic, strong) NSString *hint;
-@property (nonatomic, assign) BOOL isPassword;
-@property (nonatomic, strong) NSString *placeholder;
-@property (nonatomic, strong) NSString *text;
-
+@property (nonatomic, strong) WPTableViewCell   *textFieldCell;
+@property (nonatomic, strong) UITextField       *textField;
+@property (nonatomic, strong) UIView            *hintView;
+@property (nonatomic, strong) NSString          *hint;
+@property (nonatomic, strong) NSString          *placeholder;
+@property (nonatomic, strong) NSString          *text;
 @end
+
+
+#pragma mark - SettingsTextViewController
 
 @implementation SettingsTextViewController
 
@@ -24,25 +31,24 @@ static CGFloat const HorizontalMargin = 15.0f;
     _textField.delegate = nil;
 }
 
-- (instancetype)initWithText:(NSString *)text
-                 placeholder:(NSString *)placeholder
-                        hint:(NSString *)hint
-                  isPassword:(BOOL)isPassword
+- (instancetype)initWithStyle:(UITableViewStyle)style
+{
+    return [self initWithText:@"" placeholder:@"" hint:@""];
+}
+
+- (instancetype)initWithText:(NSString *)text placeholder:(NSString *)placeholder hint:(NSString *)hint
 {
     self = [super initWithStyle:UITableViewStyleGrouped];
     if (self) {
         _text = text;
         _placeholder = placeholder;
         _hint = hint;
-        _isPassword = isPassword;
     }
     return self;
 }
 
-- (instancetype)initWithStyle:(UITableViewStyle)style
-{
-    return [self initWithText:@"" placeholder:@"" hint:@"" isPassword:NO];
-}
+
+#pragma mark - View Lifecycle
 
 - (void)viewDidAppear:(BOOL)animated
 {
@@ -55,6 +61,24 @@ static CGFloat const HorizontalMargin = 15.0f;
     [super viewDidLoad];
     [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+    if (self.onValueChanged && ![self.textField.text isEqualToString:self.text]) {
+        self.onValueChanged(self.textField.text);
+    }
+    
+    [super viewWillDisappear:animated];
+}
+
+
+#pragma mark - Helpers
+
+- (void)setIsPassword:(BOOL)isPassword
+{
+    _isPassword = isPassword;
+    self.textField.secureTextEntry = isPassword;
 }
 
 - (WPTableViewCell *)textFieldCell
@@ -72,7 +96,6 @@ static CGFloat const HorizontalMargin = 15.0f;
     self.textField.placeholder = self.placeholder;
     self.textField.returnKeyType = UIReturnKeyDone;
     self.textField.keyboardType = UIKeyboardTypeDefault;
-    self.textField.secureTextEntry = self.isPassword;
     self.textField.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     self.textField.delegate = self;
     
@@ -86,20 +109,15 @@ static CGFloat const HorizontalMargin = 15.0f;
     if (_hintView) {
         return _hintView;
     }
+    
     WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
     [footerView setTitle:_hint];
     _hintView = footerView;
     return _hintView;
 }
 
-- (void)viewWillDisappear:(BOOL)animated
-{
-    if (self.onValueChanged && ![self.textField.text isEqualToString:self.text]) {
-        self.onValueChanged(self.textField.text);
-    }
-        
-    [super viewWillDisappear:animated];
-}
+
+#pragma mark - UITableViewDelegate
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
@@ -113,10 +131,10 @@ static CGFloat const HorizontalMargin = 15.0f;
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (indexPath.section == 0 && indexPath.row == 0)
-    {
+    if (indexPath.section == 0 && indexPath.row == 0) {
         return self.textFieldCell;
     }
+    
     return nil;
 }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -62,7 +62,6 @@ static CGFloat const HorizontalMargin = 15.0f;
 {
     [super viewWillAppear:animated];
     [self setupNavigationButtonsIfNeeded];
-    [self startListeningToNotifications];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -75,8 +74,6 @@ static CGFloat const HorizontalMargin = 15.0f;
 {
     [super viewWillDisappear:animated];
     [self.view endEditing:YES];
-    
-    [self stopListeningToNotifications];
     [self notifyValueDidChangeIfNeeded];
 }
 
@@ -97,6 +94,8 @@ static CGFloat const HorizontalMargin = 15.0f;
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
                                                                                            target:self
                                                                                            action:@selector(doneButtonWasPressed:)];
+    
+    [_textField addTarget:self action:@selector(validateTextInput:) forControlEvents:UIControlEventEditingChanged];
 }
 
 - (BOOL)shouldDisplayNavigationButtons
@@ -115,24 +114,6 @@ static CGFloat const HorizontalMargin = 15.0f;
 {
     [self notifyValueDidChangeIfNeeded];
     [self dismissViewController];
-}
-
-
-#pragma mark - Notifications
-
-- (void)startListeningToNotifications
-{
-    if (self.shouldDisplayNavigationButtons == false) {
-        return;
-    }
-    
-    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-    [nc addObserver:self selector:@selector(validateTextInput:) name:UITextFieldTextDidChangeNotification object:_textField];
-}
-
-- (void)stopListeningToNotifications
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -75,8 +75,8 @@ static CGFloat const HorizontalMargin = 15.0f;
     [super viewWillDisappear:animated];
     [self.view endEditing:YES];
     
-    if (self.isModal == NO) {
-        [self notifyValueDidChange];
+    if (self.displaysNavigationButtons == NO) {
+        [self notifyValueDidChangeIfNeeded];
     }
 }
 
@@ -85,7 +85,7 @@ static CGFloat const HorizontalMargin = 15.0f;
 
 - (void)setupNavigationButtonsIfNeeded
 {
-    if (self.shouldDisplayNavigationButtons == NO) {
+    if (self.displaysNavigationButtons == NO) {
         return;
     }
     
@@ -101,21 +101,14 @@ static CGFloat const HorizontalMargin = 15.0f;
     [_textField addTarget:self action:@selector(validateTextInput:) forControlEvents:UIControlEventEditingChanged];
 }
 
-- (BOOL)shouldDisplayNavigationButtons
-{
-    return self.isModal;
-}
-
 - (IBAction)cancelButtonWasPressed:(id)sender
 {
-    // Make sure the callback doesn't get hit
-    self.onValueChanged = nil;
     [self dismissViewController];
 }
 
 - (IBAction)doneButtonWasPressed:(id)sender
 {
-    [self notifyValueDidChange];
+    [self notifyValueDidChangeIfNeeded];
     [self dismissViewController];
 }
 
@@ -221,18 +214,13 @@ static CGFloat const HorizontalMargin = 15.0f;
     }
 }
 
-- (void)notifyValueDidChange
+- (void)notifyValueDidChangeIfNeeded
 {
     if (self.onValueChanged == nil || [self.textField.text isEqualToString:self.text]) {
         return;
     }
     
-    // `onValueChanged` should only be called *once*. We'll clean up its reference, in order to prevent double call,
-    // in the scenario in which the VC is in a NavigationController stack, and gets dismissed thru the keyboard.
-    // This is done for simplicity reasons, instead of adding yet another boolean to track state.
-    //
     self.onValueChanged(self.textField.text);
-    self.onValueChanged = nil;
 }
 
 

--- a/WordPress/WordPressTest/NSStringHelpersTest.m
+++ b/WordPress/WordPressTest/NSStringHelpersTest.m
@@ -208,6 +208,8 @@
     // Although rare, TLDs can have email too
     XCTAssertTrue([@"koke@com" isValidEmail]);
     
+    // Unusual but valid!
+    XCTAssertTrue([@"\"Jorge Bernal\"@example.com" isValidEmail]);
     
     // The hyphen is permitted if it is surrounded by characters, digits or hyphens,
     // although it is not to start or end a label
@@ -220,6 +222,7 @@
     
     // Now, the invalid scenario
     XCTAssertFalse([@"notavalid.email" isValidEmail]);
+    XCTAssertFalse([@"koke@@com" isValidEmail]);
 }
 
 @end

--- a/WordPress/WordPressTest/NSStringHelpersTest.m
+++ b/WordPress/WordPressTest/NSStringHelpersTest.m
@@ -222,7 +222,6 @@
     
     // Now, the invalid scenario
     XCTAssertFalse([@"notavalid.email" isValidEmail]);
-    XCTAssertFalse([@"koke@@com" isValidEmail]);
 }
 
 @end

--- a/WordPress/WordPressTest/NSStringHelpersTest.m
+++ b/WordPress/WordPressTest/NSStringHelpersTest.m
@@ -203,4 +203,23 @@
     XCTAssert([testSet count] == 0, @"Invalid count");
 }
 
+- (void)testIsValidEmail
+{
+    // Although rare, TLDs can have email too
+    XCTAssertTrue([@"koke@com" isValidEmail]);
+    
+    
+    // The hyphen is permitted if it is surrounded by characters, digits or hyphens,
+    // although it is not to start or end a label
+    XCTAssertTrue([@"koke@-example.com" isValidEmail]);
+    XCTAssertTrue([@"koke@example-.com" isValidEmail]);
+    
+    // https://en.wikipedia.org/wiki/International_email
+    XCTAssertTrue([@"用户@例子.广告" isValidEmail]);
+    XCTAssertTrue([@"उपयोगकर्ता@उदाहरण.कॉम" isValidEmail]);
+    
+    // Now, the invalid scenario
+    XCTAssertFalse([@"notavalid.email" isValidEmail]);
+}
+
 @end


### PR DESCRIPTION
#### Details:
In this PR we're adding the `Edit Account Email` feature. Please, note that for the sake of consistency, all of the Account editable fields now present a modal viewController on tap.

Reason for this is: validation must be performed before dismissal.

Please, note that the **Email change pending validation** will be handled via #5086.

Closes #4823

#### Scenario: Account Email
1. Log into a WordPress.com account
2. Open `Me` > `Account Settings` > `Email`
3. Enter an invalid email
4. Verify that an AlertController gets displayed
5. Enter a valid email

Verify that the change is effectively persisted. Please, test on both, iPad / iPhone devices.

#### Scenario: Account Web Address / Primary Site
1. Log into a WordPress.com account
2. Open `Me` > `Account Settings`
3. Open `Primary Site` and verify that it gets presented modally
4. Open `Web Address` and verify that it gets presented modally

Needs review: @koke 
Thanks in advance!
