### PR TITLE
Plans design amends

### DIFF
--- a/WordPress/Classes/Extensions/UIView+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIView+Helpers.swift
@@ -39,6 +39,13 @@ extension UIView
         addConstraints(newConstraints)
     }
     
+    public func pinSubviewToAllEdgeMargins(subview: UIView) {
+        subview.topAnchor.constraintEqualToAnchor(layoutMarginsGuide.topAnchor).active = true
+        subview.bottomAnchor.constraintEqualToAnchor(layoutMarginsGuide.bottomAnchor).active = true
+        subview.leadingAnchor.constraintEqualToAnchor(layoutMarginsGuide.leadingAnchor).active = true
+        subview.trailingAnchor.constraintEqualToAnchor(layoutMarginsGuide.trailingAnchor).active = true
+    }
+    
     public func constraintForAttribute(attribute: NSLayoutAttribute) -> CGFloat? {
         for constraint in constraints {
             if constraint.firstItem as! NSObject == self {

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -180,10 +180,6 @@ class PlanDetailViewController: UIViewController {
     private func configureTableView() {
         tableView.rowHeight = UITableViewAutomaticDimension
         tableView.estimatedRowHeight = 80.0
-
-        // This is required to remove the extra grouped tableview
-        // padding at the top of the tableview
-        tableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 1))
     }
     
     private func configurePlanImageDropshadow() {

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -140,8 +140,6 @@ class PlanDetailViewController: UIViewController {
         return wrapper
     }()
 
-    @IBOutlet weak var headerInfoStackView: UIStackView!
-
     class func controllerWithPlan(plan: Plan, siteID: Int, isActive: Bool, price: String) -> PlanDetailViewController {
         let storyboard = UIStoryboard(name: "Plans", bundle: NSBundle.mainBundle())
         let controller = storyboard.instantiateViewControllerWithIdentifier(NSStringFromClass(self)) as! PlanDetailViewController
@@ -162,6 +160,15 @@ class PlanDetailViewController: UIViewController {
         configureTableView()
         populateHeader()
         updateNoResults()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        let size = headerView.systemLayoutSizeFittingSize(UILayoutFittingCompressedSize)
+        headerView.frame.size.height = size.height
+        tableView.tableHeaderView = headerView
+        view.layoutIfNeeded()
     }
 
     private func configureAppearance() {
@@ -191,9 +198,9 @@ class PlanDetailViewController: UIViewController {
         dropshadowImageView.layer.shadowPath = UIBezierPath(ovalInRect: dropshadowImageView.bounds).CGPath
     }
 
-    @IBOutlet weak var headerStackView: UIStackView!
     @IBOutlet weak var headerView: UIView!
-
+    @IBOutlet weak var purchaseWrapperView: UIView!
+    
     private func populateHeader() {
         let plan = viewModel.plan
         planImageView.image = plan.image
@@ -203,16 +210,13 @@ class PlanDetailViewController: UIViewController {
 
         if viewModel.isActivePlan {
             purchaseButton?.removeFromSuperview()
-            headerStackView.addArrangedSubview(currentPlanLabel)
+            purchaseWrapperView.addSubview(currentPlanLabel)
+            purchaseWrapperView.pinSubviewToAllEdgeMargins(currentPlanLabel)
         } else if plan.isFreePlan {
             purchaseButton?.removeFromSuperview()
-
-            // Table header views don't play nicely with Auto Layout, so we need to calculate
-            // the new size and then reset the table's header view property for it to take effect
-            let size = headerView.systemLayoutSizeFittingSize(UILayoutFittingCompressedSize)
-            headerView.frame.size.height = size.height
-            tableView.tableHeaderView = headerView
         }
+        
+        headerView.layoutIfNeeded()
     }
 
     //MARK: - IBActions

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -201,7 +201,7 @@ class PlanDetailViewController: UIViewController {
         planDescriptionLabel.text = plan.description
         planPriceLabel.text = viewModel.priceText
 
-        if isActivePlan {
+        if viewModel.isActivePlan {
             purchaseButton?.removeFromSuperview()
             headerStackView.addArrangedSubview(currentPlanLabel)
         } else if plan.isFreePlan {

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -161,15 +161,6 @@ class PlanDetailViewController: UIViewController {
         populateHeader()
         updateNoResults()
     }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        
-        let size = headerView.systemLayoutSizeFittingSize(UILayoutFittingCompressedSize)
-        headerView.frame.size.height = size.height
-        tableView.tableHeaderView = headerView
-        view.layoutIfNeeded()
-    }
 
     private func configureAppearance() {
         planTitleLabel.textColor = WPStyleGuide.darkGrey()
@@ -217,6 +208,13 @@ class PlanDetailViewController: UIViewController {
         }
         
         headerView.layoutIfNeeded()
+        
+        // Table header views don't automatically resize using Auto Layout,
+        // so we need to calculate the correct size to fit the content, update the frame,
+        // and then reset the tableHeaderView property so that the new size takes effect. 
+        let size = headerView.systemLayoutSizeFittingSize(UILayoutFittingCompressedSize)
+        headerView.frame.size.height = size.height
+        tableView.tableHeaderView = headerView
     }
 
     //MARK: - IBActions

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -71,10 +71,10 @@ class PlanDetailViewController: UIViewController {
     }
 
     private let cellIdentifier = "PlanFeatureListItem"
-    
+
     private let tableViewHorizontalMargin: CGFloat = 24.0
     private let planImageDropshadowRadius: CGFloat = 3.0
-    
+
     private var tableViewModel = ImmuTable.Empty {
         didSet {
             tableView?.reloadData()
@@ -91,9 +91,9 @@ class PlanDetailViewController: UIViewController {
             }
         }
     }
-    
+
     private let noResultsView = WPNoResultsView()
-    
+
     func updateNoResults() {
         if let noResultsViewModel = viewModel.noResultsViewModel {
             showNoResults(noResultsViewModel)
@@ -109,7 +109,7 @@ class PlanDetailViewController: UIViewController {
             tableView.addSubviewWithFadeAnimation(noResultsView)
         }
     }
-    
+
     func hideNoResults() {
         noResultsView.removeFromSuperview()
     }
@@ -136,10 +136,10 @@ class PlanDetailViewController: UIViewController {
         wrapper.translatesAutoresizingMaskIntoConstraints = false
         wrapper.addSubview(label)
         wrapper.pinSubviewToAllEdges(label)
-        
+
         return wrapper
     }()
-    
+
     @IBOutlet weak var headerInfoStackView: UIStackView!
 
     class func controllerWithPlan(plan: Plan, siteID: Int, isActive: Bool, price: String) -> PlanDetailViewController {
@@ -150,38 +150,38 @@ class PlanDetailViewController: UIViewController {
 
         return controller
     }
-    
+
     override func prefersStatusBarHidden() -> Bool {
         return true
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         configureAppearance()
         configureTableView()
         populateHeader()
         updateNoResults()
     }
-    
+
     private func configureAppearance() {
         planTitleLabel.textColor = WPStyleGuide.darkGrey()
         planDescriptionLabel.textColor = WPStyleGuide.grey()
         planPriceLabel.textColor = WPStyleGuide.grey()
-        
+
         purchaseButton?.tintColor = WPStyleGuide.wordPressBlue()
-        
+
         dropshadowImageView.backgroundColor = UIColor.whiteColor()
         configurePlanImageDropshadow()
-        
+
         separator.backgroundColor = WPStyleGuide.greyLighten30()
     }
-    
+
     private func configureTableView() {
         tableView.rowHeight = UITableViewAutomaticDimension
         tableView.estimatedRowHeight = 80.0
     }
-    
+
     private func configurePlanImageDropshadow() {
         dropshadowImageView.layer.masksToBounds = false
         dropshadowImageView.layer.shadowColor = WPStyleGuide.greyLighten30().CGColor
@@ -190,27 +190,33 @@ class PlanDetailViewController: UIViewController {
         dropshadowImageView.layer.shadowOffset = .zero
         dropshadowImageView.layer.shadowPath = UIBezierPath(ovalInRect: dropshadowImageView.bounds).CGPath
     }
-    
-    lazy var paddingView = UIView()
-    
+
+    @IBOutlet weak var headerStackView: UIStackView!
+    @IBOutlet weak var headerView: UIView!
+
     private func populateHeader() {
         let plan = viewModel.plan
         planImageView.image = plan.image
         planTitleLabel.text = plan.fullTitle
         planDescriptionLabel.text = plan.description
         planPriceLabel.text = viewModel.priceText
-        
-        if viewModel.isActivePlan {
+
+        if isActivePlan {
             purchaseButton?.removeFromSuperview()
-            headerInfoStackView.addArrangedSubview(currentPlanLabel)
+            headerStackView.addArrangedSubview(currentPlanLabel)
         } else if plan.isFreePlan {
             purchaseButton?.removeFromSuperview()
-            headerInfoStackView.addArrangedSubview(paddingView)
+
+            // Table header views don't play nicely with Auto Layout, so we need to calculate
+            // the new size and then reset the table's header view property for it to take effect
+            let size = headerView.systemLayoutSizeFittingSize(UILayoutFittingCompressedSize)
+            headerView.frame.size.height = size.height
+            tableView.tableHeaderView = headerView
         }
     }
-    
+
     //MARK: - IBActions
-    
+
     @IBAction private func purchaseTapped() {
         guard let identifier = viewModel.plan.productIdentifier else {
             return
@@ -242,20 +248,20 @@ extension PlanDetailViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let row = tableViewModel.rowAtIndexPath(indexPath)
         let cell = tableView.dequeueReusableCellWithIdentifier(row.reusableIdentifier, forIndexPath: indexPath)
-        
+
         row.configureCell(cell)
-        
+
         return cell
     }
-    
+
     func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
         guard let cell = cell as? FeatureItemCell else { return }
-        
+
         let separatorInset: CGFloat = 15
         let isLastCellInSection = indexPath.row == self.tableView(tableView, numberOfRowsInSection: indexPath.section) - 1
         let isLastSection = indexPath.section == self.numberOfSectionsInTableView(tableView) - 1
-        
-        // The separator for the last cell in each section has no insets, 
+
+        // The separator for the last cell in each section has no insets,
         // except for in the last section, where there's no separator at all.
         if isLastCellInSection {
             if isLastSection {
@@ -267,11 +273,11 @@ extension PlanDetailViewController: UITableViewDataSource, UITableViewDelegate {
             cell.separatorInset = UIEdgeInsets(top: 0, left: separatorInset, bottom: 0, right: separatorInset)
         }
     }
-    
+
     func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return tableViewModel.sections[section].headerText
     }
-    
+
     func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         if let title = self.tableView(tableView, titleForHeaderInSection: section) where !title.isEmpty {
             let header = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
@@ -289,7 +295,7 @@ class FeatureItemCell: WPTableViewCell {
     @IBOutlet weak var featureDescriptionLabel: UILabel!
     @IBOutlet weak var separator: UIView!
     @IBOutlet var separatorEdgeConstraints: [NSLayoutConstraint]!
-    
+
     override var separatorInset: UIEdgeInsets {
         didSet {
             for constraint in separatorEdgeConstraints {
@@ -299,28 +305,28 @@ class FeatureItemCell: WPTableViewCell {
                     constraint.constant = separatorInset.right
                 }
             }
-            
+
             separator.layoutIfNeeded()
         }
     }
-    
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
         layoutMargins = UIEdgeInsetsZero
-        
+
         separator.backgroundColor = WPStyleGuide.greyLighten30()
     }
-    
+
     override func prepareForReuse() {
         super.prepareForReuse()
-        
+
         separator.hidden = false
     }
-    
+
     override func layoutSubviews() {
         super.layoutSubviews()
-        
+
         // This is required to fix an issue where only the first line of text would
         // is displayed on the iPhone 6(s) Plus due to a fractional Y position.
         featureDescriptionLabel.frame = CGRectIntegral(featureDescriptionLabel.frame)
@@ -329,35 +335,35 @@ class FeatureItemCell: WPTableViewCell {
 
 struct FeatureItemRow : ImmuTableRow {
     static let cell = ImmuTableCell.Class(FeatureItemCell)
-    
+
     let title: String
     let description: String
     let iconURL: NSURL
     let action: ImmuTableAction? = nil
-    
+
     func configureCell(cell: UITableViewCell) {
         guard let cell = cell as? FeatureItemCell else { return }
-        
+
         cell.featureTitleLabel?.text = title
-        
+
         if let featureDescriptionLabel = cell.featureDescriptionLabel {
             cell.featureDescriptionLabel?.attributedText = attributedDescriptionText(description, font: featureDescriptionLabel.font)
         }
-        
+
         cell.featureIconImageView?.setImageWithURL(iconURL, placeholderImage: nil)
-        
+
         cell.featureTitleLabel.textColor = WPStyleGuide.darkGrey()
         cell.featureDescriptionLabel.textColor = WPStyleGuide.grey()
         WPStyleGuide.configureTableViewCell(cell)
     }
-    
+
     private func attributedDescriptionText(text: String, font: UIFont) -> NSAttributedString {
         let lineHeight: CGFloat = 18
-        
+
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.maximumLineHeight = lineHeight
         paragraphStyle.minimumLineHeight = lineHeight
-        
+
         let attributedText = NSMutableAttributedString(string: text, attributes: [NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName: font])
         return attributedText
     }

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -20,6 +20,7 @@ struct PlanListRow: ImmuTableRow {
         cell.textLabel?.adjustsFontSizeToFitWidth = true
         cell.detailTextLabel?.text = description
         cell.detailTextLabel?.textColor = WPStyleGuide.grey()
+        cell.detailTextLabel?.font = WPFontManager.systemRegularFontOfSize(14.0)
         cell.separatorInset = UIEdgeInsetsZero
     }
 
@@ -37,8 +38,8 @@ struct PlanListRow: ImmuTableRow {
             NSForegroundColorAttributeName: WPStyleGuide.darkGrey()
         ]
         static let pricePeriodAttributes = [
-            NSFontAttributeName: WPFontManager.systemItalicFontOfSize(13.0),
-            NSForegroundColorAttributeName: WPStyleGuide.greyLighten20()
+            NSFontAttributeName: WPFontManager.systemItalicFontOfSize(14.0),
+            NSForegroundColorAttributeName: WPStyleGuide.grey()
         ]
 
         static func attributedTitle(title: String, price: String, active: Bool) -> NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -103,22 +103,22 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <color key="sectionIndexBackgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="rNB-K6-2G7" userLabel="Header View">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="240"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="260"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LCp-BY-dNt" userLabel="Separator">
-                                            <rect key="frame" x="0.0" y="239" width="600" height="1"/>
+                                            <rect key="frame" x="0.0" y="259" width="600" height="1"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="1" id="hg2-4K-vsh"/>
                                             </constraints>
                                         </view>
-                                        <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nps-70-EDE" userLabel="Dropshadow Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                            <rect key="frame" x="269" y="25" width="62" height="62"/>
+                                        <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nps-70-EDE" userLabel="Dropshadow Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                                            <rect key="frame" x="58" y="36" width="9" height="60"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         </imageView>
-                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="HN0-n6-ORp">
-                                            <rect key="frame" x="32" y="26" width="536" height="188"/>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sWC-Ef-Tro">
+                                            <rect key="frame" x="32" y="26" width="536" height="207"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" image="plan-premium" translatesAutoresizingMaskIntoConstraints="NO" id="f6b-b4-ZgP" userLabel="Plan Image View">
                                                     <rect key="frame" x="238" y="0.0" width="60" height="60"/>
@@ -127,68 +127,85 @@
                                                         <constraint firstAttribute="height" constant="60" id="pkL-hL-79c"/>
                                                     </constraints>
                                                 </imageView>
-                                                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" distribution="equalSpacing" spacing="20" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jAy-0N-D1K">
-                                                    <rect key="frame" x="0.0" y="81.5" width="536" height="60"/>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UWf-eO-DKz">
+                                                    <rect key="frame" x="218" y="170" width="100" height="37"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
-                                                            <rect key="frame" x="0.0" y="0.0" width="536" height="21"/>
+                                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJf-48-mlv" userLabel="Purchase Button" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
+                                                            <rect key="frame" x="0.0" y="12" width="100" height="25"/>
+                                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="21" placeholder="YES" id="0rn-oB-0AU"/>
-                                                                <constraint firstAttribute="width" constant="536" placeholder="YES" id="0uw-K1-aJo"/>
+                                                                <constraint firstAttribute="height" constant="25" id="WX3-mf-WwP"/>
                                                             </constraints>
-                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Perfect for bloggers, creatives, &amp; other professionals" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="edq-hC-GnQ" userLabel="Plan Description Label">
-                                                            <rect key="frame" x="0.0" y="23" width="536" height="17"/>
-                                                            <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="$99.99 per year" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fju-eH-OS6" userLabel="Plan Price Label">
-                                                            <rect key="frame" x="0.0" y="42" width="536" height="18"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
+                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="11"/>
+                                                            <state key="normal" title="PURCHASE">
+                                                                <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                            </state>
+                                                            <connections>
+                                                                <action selector="purchaseTapped" destination="msO-08-fqQ" eventType="touchUpInside" id="Wub-Tq-SYx"/>
+                                                            </connections>
+                                                        </button>
                                                     </subviews>
-                                                </stackView>
-                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJf-48-mlv" userLabel="Purchase Button" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
-                                                    <rect key="frame" x="218" y="163" width="100" height="25"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="25" id="WX3-mf-WwP"/>
+                                                        <constraint firstAttribute="trailing" secondItem="WJf-48-mlv" secondAttribute="trailing" id="OQd-w2-8Ah"/>
+                                                        <constraint firstItem="WJf-48-mlv" firstAttribute="leading" secondItem="UWf-eO-DKz" secondAttribute="leading" id="Xvp-me-HsF"/>
+                                                        <constraint firstItem="WJf-48-mlv" firstAttribute="top" secondItem="UWf-eO-DKz" secondAttribute="topMargin" id="cJY-HJ-WD7"/>
+                                                        <constraint firstAttribute="bottom" secondItem="WJf-48-mlv" secondAttribute="bottom" id="jqm-v7-DRR"/>
                                                     </constraints>
-                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="11"/>
-                                                    <state key="normal" title="PURCHASE">
-                                                        <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                    </state>
-                                                    <connections>
-                                                        <action selector="purchaseTapped" destination="msO-08-fqQ" eventType="touchUpInside" id="Wub-Tq-SYx"/>
-                                                    </connections>
-                                                </button>
+                                                    <edgeInsets key="layoutMargins" top="12" left="0.0" bottom="0.0" right="0.0"/>
+                                                </view>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Perfect for bloggers, creatives, &amp; other professionals" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="edq-hC-GnQ" userLabel="Plan Description Label">
+                                                    <rect key="frame" x="0.0" y="94" width="536" height="52.5"/>
+                                                    <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
+                                                    <rect key="frame" x="0.0" y="72" width="536" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="$99.99 per year" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fju-eH-OS6" userLabel="Plan Price Label">
+                                                    <rect key="frame" x="0.0" y="152" width="536" height="18"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
-                                        </stackView>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="Fju-eH-OS6" secondAttribute="trailing" id="0sp-hI-cZF"/>
+                                                <constraint firstAttribute="trailing" secondItem="edq-hC-GnQ" secondAttribute="trailing" id="7vD-SG-h1i"/>
+                                                <constraint firstItem="UWf-eO-DKz" firstAttribute="top" secondItem="Fju-eH-OS6" secondAttribute="bottom" id="JhX-rU-5Hs"/>
+                                                <constraint firstItem="isU-1g-ArF" firstAttribute="top" secondItem="f6b-b4-ZgP" secondAttribute="bottom" constant="12" id="OTa-uB-1yH"/>
+                                                <constraint firstItem="f6b-b4-ZgP" firstAttribute="centerX" secondItem="sWC-Ef-Tro" secondAttribute="centerX" id="Rjy-0E-w7v"/>
+                                                <constraint firstAttribute="trailing" secondItem="isU-1g-ArF" secondAttribute="trailing" id="WAM-zu-L2r"/>
+                                                <constraint firstItem="UWf-eO-DKz" firstAttribute="centerX" secondItem="sWC-Ef-Tro" secondAttribute="centerX" id="Wah-eM-pVY"/>
+                                                <constraint firstItem="isU-1g-ArF" firstAttribute="leading" secondItem="sWC-Ef-Tro" secondAttribute="leading" id="Ygm-aB-pot"/>
+                                                <constraint firstItem="Fju-eH-OS6" firstAttribute="firstBaseline" secondItem="edq-hC-GnQ" secondAttribute="bottom" constant="20" id="d4f-g1-ifm"/>
+                                                <constraint firstAttribute="bottom" secondItem="UWf-eO-DKz" secondAttribute="bottom" id="mZw-Q4-P9V"/>
+                                                <constraint firstItem="f6b-b4-ZgP" firstAttribute="top" secondItem="sWC-Ef-Tro" secondAttribute="top" id="oQX-9b-V4A"/>
+                                                <constraint firstItem="edq-hC-GnQ" firstAttribute="firstBaseline" secondItem="isU-1g-ArF" secondAttribute="firstBaseline" constant="20" id="r34-GW-NxA"/>
+                                                <constraint firstItem="edq-hC-GnQ" firstAttribute="leading" secondItem="sWC-Ef-Tro" secondAttribute="leading" id="sAa-9T-IyL"/>
+                                                <constraint firstItem="Fju-eH-OS6" firstAttribute="leading" secondItem="sWC-Ef-Tro" secondAttribute="leading" id="vS1-vV-Cpt"/>
+                                            </constraints>
+                                        </view>
                                     </subviews>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <constraints>
-                                        <constraint firstAttribute="bottom" secondItem="HN0-n6-ORp" secondAttribute="bottom" constant="26" id="5eP-AO-KFL"/>
-                                        <constraint firstItem="HN0-n6-ORp" firstAttribute="top" secondItem="rNB-K6-2G7" secondAttribute="top" constant="26" id="776-sg-xlU"/>
                                         <constraint firstItem="LCp-BY-dNt" firstAttribute="leading" secondItem="rNB-K6-2G7" secondAttribute="leading" id="7Cr-4D-XKo"/>
-                                        <constraint firstItem="nps-70-EDE" firstAttribute="trailing" secondItem="f6b-b4-ZgP" secondAttribute="trailing" constant="1" id="EAa-eq-6bk"/>
-                                        <constraint firstItem="nps-70-EDE" firstAttribute="top" secondItem="f6b-b4-ZgP" secondAttribute="top" constant="-1" id="F1s-SM-4v2"/>
+                                        <constraint firstItem="LCp-BY-dNt" firstAttribute="top" secondItem="sWC-Ef-Tro" secondAttribute="bottom" constant="26" id="Evt-Kf-ahB"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="sWC-Ef-Tro" secondAttribute="trailing" constant="24" id="FFf-xx-80H"/>
+                                        <constraint firstItem="sWC-Ef-Tro" firstAttribute="leading" secondItem="rNB-K6-2G7" secondAttribute="leadingMargin" constant="24" id="HlN-DF-m0E"/>
                                         <constraint firstAttribute="bottom" secondItem="LCp-BY-dNt" secondAttribute="bottom" id="OEQ-sb-7c2"/>
-                                        <constraint firstItem="nps-70-EDE" firstAttribute="bottom" secondItem="f6b-b4-ZgP" secondAttribute="bottom" constant="1" id="QCU-tk-yh6"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="HN0-n6-ORp" secondAttribute="trailing" constant="24" id="Z7D-8c-oE8"/>
-                                        <constraint firstItem="nps-70-EDE" firstAttribute="leading" secondItem="f6b-b4-ZgP" secondAttribute="leading" constant="-1" id="a3m-ZB-Ixh"/>
-                                        <constraint firstItem="HN0-n6-ORp" firstAttribute="leading" secondItem="rNB-K6-2G7" secondAttribute="leadingMargin" constant="24" id="j5R-Fl-do0"/>
+                                        <constraint firstItem="sWC-Ef-Tro" firstAttribute="top" secondItem="rNB-K6-2G7" secondAttribute="top" constant="26" id="khv-LW-EYl"/>
                                         <constraint firstAttribute="trailing" secondItem="LCp-BY-dNt" secondAttribute="trailing" id="yVc-gF-FXi"/>
                                     </constraints>
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="WordPress.FeatureItemCell" rowHeight="80" id="zaq-fe-bpz" customClass="FeatureItemCell" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="289.5" width="600" height="80"/>
+                                        <rect key="frame" x="0.0" y="309.5" width="600" height="80"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zaq-fe-bpz" id="dGV-Jz-XSf">
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="80"/>
@@ -271,14 +288,13 @@
                     </view>
                     <connections>
                         <outlet property="dropshadowImageView" destination="nps-70-EDE" id="fyT-av-Rh8"/>
-                        <outlet property="headerInfoStackView" destination="jAy-0N-D1K" id="JdG-2j-zaW"/>
-                        <outlet property="headerStackView" destination="HN0-n6-ORp" id="aSy-zq-se9"/>
                         <outlet property="headerView" destination="rNB-K6-2G7" id="Y7e-0Y-RBY"/>
                         <outlet property="planDescriptionLabel" destination="edq-hC-GnQ" id="8Cy-Z5-E3i"/>
                         <outlet property="planImageView" destination="f6b-b4-ZgP" id="6nb-u6-9DE"/>
                         <outlet property="planPriceLabel" destination="Fju-eH-OS6" id="pPs-DS-Dzv"/>
                         <outlet property="planTitleLabel" destination="isU-1g-ArF" id="7ON-Pb-HTu"/>
                         <outlet property="purchaseButton" destination="WJf-48-mlv" id="MaJ-C0-mTb"/>
+                        <outlet property="purchaseWrapperView" destination="UWf-eO-DKz" id="BUe-5j-sVg"/>
                         <outlet property="separator" destination="LCp-BY-dNt" id="hIU-n2-EfO"/>
                         <outlet property="tableView" destination="DH7-9o-kVF" id="rTb-5w-w0a"/>
                     </connections>

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -103,11 +103,11 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <color key="sectionIndexBackgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="rNB-K6-2G7" userLabel="Header View">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="220"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="240"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LCp-BY-dNt" userLabel="Separator">
-                                            <rect key="frame" x="0.0" y="219" width="600" height="1"/>
+                                            <rect key="frame" x="0.0" y="239" width="600" height="1"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="1" id="hg2-4K-vsh"/>
@@ -118,17 +118,17 @@
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         </imageView>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="HN0-n6-ORp">
-                                            <rect key="frame" x="8" y="26" width="584" height="168"/>
+                                            <rect key="frame" x="32" y="26" width="536" height="188"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" image="plan-premium" translatesAutoresizingMaskIntoConstraints="NO" id="f6b-b4-ZgP" userLabel="Plan Image View">
-                                                    <rect key="frame" x="262" y="0.0" width="60" height="60"/>
+                                                    <rect key="frame" x="238" y="0.0" width="60" height="60"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="60" id="MsP-RS-pGE"/>
                                                         <constraint firstAttribute="height" constant="60" id="pkL-hL-79c"/>
                                                     </constraints>
                                                 </imageView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" distribution="equalSpacing" spacing="20" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jAy-0N-D1K">
-                                                    <rect key="frame" x="24" y="72" width="536" height="59"/>
+                                                    <rect key="frame" x="0.0" y="81.5" width="536" height="60"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
                                                             <rect key="frame" x="0.0" y="0.0" width="536" height="21"/>
@@ -141,13 +141,13 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Perfect for bloggers, creatives, &amp; other professionals" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="edq-hC-GnQ" userLabel="Plan Description Label">
-                                                            <rect key="frame" x="0.0" y="23" width="536" height="16"/>
+                                                            <rect key="frame" x="0.0" y="23" width="536" height="17"/>
                                                             <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="$99.99 per year" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fju-eH-OS6" userLabel="Plan Price Label">
-                                                            <rect key="frame" x="0.0" y="41" width="536" height="18"/>
+                                                            <rect key="frame" x="0.0" y="42" width="536" height="18"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -155,7 +155,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJf-48-mlv" userLabel="Purchase Button" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
-                                                    <rect key="frame" x="242" y="143" width="100" height="25"/>
+                                                    <rect key="frame" x="218" y="163" width="100" height="25"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="25" id="WX3-mf-WwP"/>
@@ -169,10 +169,6 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="jAy-0N-D1K" firstAttribute="leading" secondItem="HN0-n6-ORp" secondAttribute="leading" constant="24" id="4mr-rU-aLN"/>
-                                                <constraint firstAttribute="trailing" secondItem="jAy-0N-D1K" secondAttribute="trailing" constant="24" id="oZ4-Ve-ine"/>
-                                            </constraints>
                                         </stackView>
                                     </subviews>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -184,16 +180,15 @@
                                         <constraint firstItem="nps-70-EDE" firstAttribute="top" secondItem="f6b-b4-ZgP" secondAttribute="top" constant="-1" id="F1s-SM-4v2"/>
                                         <constraint firstAttribute="bottom" secondItem="LCp-BY-dNt" secondAttribute="bottom" id="OEQ-sb-7c2"/>
                                         <constraint firstItem="nps-70-EDE" firstAttribute="bottom" secondItem="f6b-b4-ZgP" secondAttribute="bottom" constant="1" id="QCU-tk-yh6"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="HN0-n6-ORp" secondAttribute="trailing" id="Z7D-8c-oE8"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="HN0-n6-ORp" secondAttribute="trailing" constant="24" id="Z7D-8c-oE8"/>
                                         <constraint firstItem="nps-70-EDE" firstAttribute="leading" secondItem="f6b-b4-ZgP" secondAttribute="leading" constant="-1" id="a3m-ZB-Ixh"/>
-                                        <constraint firstItem="HN0-n6-ORp" firstAttribute="leading" secondItem="rNB-K6-2G7" secondAttribute="leadingMargin" id="j5R-Fl-do0"/>
-                                        <constraint firstAttribute="height" constant="220" placeholder="YES" id="sLG-6E-6KH"/>
+                                        <constraint firstItem="HN0-n6-ORp" firstAttribute="leading" secondItem="rNB-K6-2G7" secondAttribute="leadingMargin" constant="24" id="j5R-Fl-do0"/>
                                         <constraint firstAttribute="trailing" secondItem="LCp-BY-dNt" secondAttribute="trailing" id="yVc-gF-FXi"/>
                                     </constraints>
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="WordPress.FeatureItemCell" rowHeight="80" id="zaq-fe-bpz" customClass="FeatureItemCell" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="269.5" width="600" height="80"/>
+                                        <rect key="frame" x="0.0" y="289.5" width="600" height="80"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zaq-fe-bpz" id="dGV-Jz-XSf">
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="80"/>

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -99,7 +99,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="751" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" allowsSelection="NO" rowHeight="64" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="DH7-9o-kVF">
-                                <rect key="frame" x="0.0" y="20" width="600" height="580"/>
+                                <rect key="frame" x="-0.5" y="20" width="600" height="580"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <color key="sectionIndexBackgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="rNB-K6-2G7" userLabel="Header View">
@@ -127,30 +127,30 @@
                                                         <constraint firstAttribute="height" constant="60" id="pkL-hL-79c"/>
                                                     </constraints>
                                                 </imageView>
-                                                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" distribution="fillEqually" alignment="center" spacing="22" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jAy-0N-D1K">
+                                                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" distribution="equalSpacing" spacing="22" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jAy-0N-D1K">
                                                     <rect key="frame" x="24" y="72" width="536" height="59"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
-                                                            <rect key="frame" x="167" y="0.0" width="202" height="17"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" misplaced="YES" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
+                                                            <rect key="frame" x="0.0" y="0.0" width="536" height="21"/>
                                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Perfect for bloggers, creatives, &amp; other professionals" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="edq-hC-GnQ" userLabel="Plan Description Label">
-                                                            <rect key="frame" x="98" y="21" width="342" height="17"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" misplaced="YES" text="Perfect for bloggers, creatives, &amp; other professionals" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="edq-hC-GnQ" userLabel="Plan Description Label">
+                                                            <rect key="frame" x="0.0" y="25" width="536" height="13"/>
                                                             <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="$99.99 per year" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fju-eH-OS6" userLabel="Plan Price Label">
-                                                            <rect key="frame" x="213" y="42" width="111" height="17"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="$99.99 per year" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fju-eH-OS6" userLabel="Plan Price Label">
+                                                            <rect key="frame" x="0.0" y="41" width="536" height="18"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
                                                 </stackView>
-                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJf-48-mlv" userLabel="Purchase Button" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
+                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJf-48-mlv" userLabel="Purchase Button" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
                                                     <rect key="frame" x="242" y="143" width="100" height="25"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
@@ -183,7 +183,7 @@
                                         <constraint firstAttribute="trailingMargin" secondItem="HN0-n6-ORp" secondAttribute="trailing" id="Z7D-8c-oE8"/>
                                         <constraint firstItem="nps-70-EDE" firstAttribute="leading" secondItem="f6b-b4-ZgP" secondAttribute="leading" constant="-1" id="a3m-ZB-Ixh"/>
                                         <constraint firstItem="HN0-n6-ORp" firstAttribute="leading" secondItem="rNB-K6-2G7" secondAttribute="leadingMargin" id="j5R-Fl-do0"/>
-                                        <constraint firstAttribute="height" constant="220" id="sLG-6E-6KH"/>
+                                        <constraint firstAttribute="height" constant="220" placeholder="YES" id="sLG-6E-6KH"/>
                                         <constraint firstAttribute="trailing" secondItem="LCp-BY-dNt" secondAttribute="trailing" id="yVc-gF-FXi"/>
                                     </constraints>
                                 </view>
@@ -260,15 +260,17 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="DH7-9o-kVF" firstAttribute="top" secondItem="ass-i7-57P" secondAttribute="bottom" id="MiC-bK-9eD"/>
-                            <constraint firstItem="DH7-9o-kVF" firstAttribute="leading" secondItem="fcR-is-wCN" secondAttribute="leading" id="Wtx-Gv-fgs"/>
-                            <constraint firstAttribute="trailing" secondItem="DH7-9o-kVF" secondAttribute="trailing" id="erY-c1-E8E"/>
-                            <constraint firstItem="pmz-SB-Zco" firstAttribute="top" secondItem="DH7-9o-kVF" secondAttribute="bottom" id="sJ1-iZ-X1B"/>
+                            <constraint firstItem="pmz-SB-Zco" firstAttribute="top" secondItem="DH7-9o-kVF" secondAttribute="bottom" id="5HF-la-REz"/>
+                            <constraint firstAttribute="trailing" secondItem="DH7-9o-kVF" secondAttribute="trailing" id="EN9-IN-baF"/>
+                            <constraint firstItem="DH7-9o-kVF" firstAttribute="leading" secondItem="fcR-is-wCN" secondAttribute="leading" id="Ivh-az-eBH"/>
+                            <constraint firstItem="DH7-9o-kVF" firstAttribute="top" secondItem="ass-i7-57P" secondAttribute="bottom" id="uca-g6-JxL"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="dropshadowImageView" destination="nps-70-EDE" id="fyT-av-Rh8"/>
                         <outlet property="headerInfoStackView" destination="jAy-0N-D1K" id="JdG-2j-zaW"/>
+                        <outlet property="headerStackView" destination="HN0-n6-ORp" id="aSy-zq-se9"/>
+                        <outlet property="headerView" destination="rNB-K6-2G7" id="Y7e-0Y-RBY"/>
                         <outlet property="planDescriptionLabel" destination="edq-hC-GnQ" id="8Cy-Z5-E3i"/>
                         <outlet property="planImageView" destination="f6b-b4-ZgP" id="6nb-u6-9DE"/>
                         <outlet property="planPriceLabel" destination="Fju-eH-OS6" id="pPs-DS-Dzv"/>

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -30,7 +30,7 @@
                                 <rect key="frame" x="270" y="150" width="60" height="60"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kpj-Yk-lXp" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="276" y="388" width="49" height="30"/>
+                                <rect key="frame" x="256" y="388" width="89" height="32"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                 <state key="normal" title="Button"/>
@@ -127,17 +127,21 @@
                                                         <constraint firstAttribute="height" constant="60" id="pkL-hL-79c"/>
                                                     </constraints>
                                                 </imageView>
-                                                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" distribution="equalSpacing" spacing="22" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jAy-0N-D1K">
+                                                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" distribution="equalSpacing" spacing="20" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jAy-0N-D1K">
                                                     <rect key="frame" x="24" y="72" width="536" height="59"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" misplaced="YES" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
                                                             <rect key="frame" x="0.0" y="0.0" width="536" height="21"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="21" placeholder="YES" id="0rn-oB-0AU"/>
+                                                                <constraint firstAttribute="width" constant="536" placeholder="YES" id="0uw-K1-aJo"/>
+                                                            </constraints>
                                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" misplaced="YES" text="Perfect for bloggers, creatives, &amp; other professionals" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="edq-hC-GnQ" userLabel="Plan Description Label">
-                                                            <rect key="frame" x="0.0" y="25" width="536" height="13"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Perfect for bloggers, creatives, &amp; other professionals" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="edq-hC-GnQ" userLabel="Plan Description Label">
+                                                            <rect key="frame" x="0.0" y="23" width="536" height="16"/>
                                                             <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -151,7 +155,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJf-48-mlv" userLabel="Purchase Button" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
-                                                    <rect key="frame" x="261" y="143" width="62" height="25"/>
+                                                    <rect key="frame" x="242" y="143" width="100" height="25"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="25" id="WX3-mf-WwP"/>
@@ -198,14 +202,18 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nuR-h6-384">
                                                     <rect key="frame" x="72" y="16" width="505" height="48"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kr8-eT-Qom">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kr8-eT-Qom">
                                                             <rect key="frame" x="0.0" y="0.0" width="505" height="20"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="20" placeholder="YES" id="RYI-iO-uJJ"/>
+                                                                <constraint firstAttribute="width" constant="505" placeholder="YES" id="TXd-ry-W0z"/>
+                                                            </constraints>
                                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="999" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WW-WL-C4o">
-                                                            <rect key="frame" x="0.0" y="22" width="505" height="27"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="999" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WW-WL-C4o">
+                                                            <rect key="frame" x="0.0" y="22" width="505" height="26"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -29,8 +29,8 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="plan-premium-active" translatesAutoresizingMaskIntoConstraints="NO" id="VMO-qT-QAn">
                                 <rect key="frame" x="270" y="150" width="60" height="60"/>
                             </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kpj-Yk-lXp" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="256" y="388" width="89" height="32"/>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kpj-Yk-lXp" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
+                                <rect key="frame" x="276" y="388" width="49" height="30"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                 <state key="normal" title="Button"/>
@@ -99,7 +99,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="751" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" allowsSelection="NO" rowHeight="64" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="DH7-9o-kVF">
-                                <rect key="frame" x="-0.5" y="20" width="600" height="580"/>
+                                <rect key="frame" x="0.0" y="20" width="600" height="580"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <color key="sectionIndexBackgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="rNB-K6-2G7" userLabel="Header View">
@@ -151,7 +151,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJf-48-mlv" userLabel="Purchase Button" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
-                                                    <rect key="frame" x="242" y="143" width="100" height="25"/>
+                                                    <rect key="frame" x="261" y="143" width="62" height="25"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="25" id="WX3-mf-WwP"/>

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -29,7 +29,7 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="plan-premium-active" translatesAutoresizingMaskIntoConstraints="NO" id="VMO-qT-QAn">
                                 <rect key="frame" x="270" y="150" width="60" height="60"/>
                             </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kpj-Yk-lXp" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
+                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kpj-Yk-lXp" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="256" y="388" width="89" height="32"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
@@ -98,173 +98,172 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="hbr-M8-kwi">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                                <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rNB-K6-2G7" userLabel="Header View">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="220"/>
-                                        <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nps-70-EDE" userLabel="Dropshadow Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="269" y="25" width="62" height="62"/>
-                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            </imageView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="HN0-n6-ORp">
-                                                <rect key="frame" x="8" y="26" width="584" height="168"/>
-                                                <subviews>
-                                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" image="plan-premium" translatesAutoresizingMaskIntoConstraints="NO" id="f6b-b4-ZgP" userLabel="Plan Image View">
-                                                        <rect key="frame" x="262" y="0.0" width="60" height="60"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="60" id="MsP-RS-pGE"/>
-                                                            <constraint firstAttribute="height" constant="60" id="pkL-hL-79c"/>
-                                                        </constraints>
-                                                    </imageView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" distribution="fillEqually" alignment="center" spacing="22" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jAy-0N-D1K">
-                                                        <rect key="frame" x="24" y="72" width="536" height="59"/>
-                                                        <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
-                                                                <rect key="frame" x="172" y="0.0" width="192" height="17"/>
-                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
-                                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Perfect for bloggers, creatives, &amp; other professionals" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="edq-hC-GnQ" userLabel="Plan Description Label">
-                                                                <rect key="frame" x="108" y="22" width="321" height="16"/>
-                                                                <fontDescription key="fontDescription" type="italicSystem" pointSize="13"/>
-                                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="$99.99 per year" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fju-eH-OS6" userLabel="Plan Price Label">
-                                                                <rect key="frame" x="213" y="42" width="111" height="17"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                        </subviews>
-                                                    </stackView>
-                                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJf-48-mlv" userLabel="Purchase Button" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="242" y="143" width="100" height="25"/>
-                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="25" id="WX3-mf-WwP"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="11"/>
-                                                        <state key="normal" title="PURCHASE">
-                                                            <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="purchaseTapped" destination="msO-08-fqQ" eventType="touchUpInside" id="Wub-Tq-SYx"/>
-                                                        </connections>
-                                                    </button>
-                                                </subviews>
-                                                <constraints>
-                                                    <constraint firstItem="jAy-0N-D1K" firstAttribute="leading" secondItem="HN0-n6-ORp" secondAttribute="leading" constant="24" id="4mr-rU-aLN"/>
-                                                    <constraint firstAttribute="trailing" secondItem="jAy-0N-D1K" secondAttribute="trailing" constant="24" id="oZ4-Ve-ine"/>
-                                                </constraints>
-                                            </stackView>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="HN0-n6-ORp" secondAttribute="bottom" constant="26" id="5eP-AO-KFL"/>
-                                            <constraint firstItem="HN0-n6-ORp" firstAttribute="top" secondItem="rNB-K6-2G7" secondAttribute="top" constant="26" id="776-sg-xlU"/>
-                                            <constraint firstItem="nps-70-EDE" firstAttribute="trailing" secondItem="f6b-b4-ZgP" secondAttribute="trailing" constant="1" id="EAa-eq-6bk"/>
-                                            <constraint firstItem="nps-70-EDE" firstAttribute="top" secondItem="f6b-b4-ZgP" secondAttribute="top" constant="-1" id="F1s-SM-4v2"/>
-                                            <constraint firstItem="nps-70-EDE" firstAttribute="bottom" secondItem="f6b-b4-ZgP" secondAttribute="bottom" constant="1" id="QCU-tk-yh6"/>
-                                            <constraint firstAttribute="trailingMargin" secondItem="HN0-n6-ORp" secondAttribute="trailing" id="Z7D-8c-oE8"/>
-                                            <constraint firstItem="nps-70-EDE" firstAttribute="leading" secondItem="f6b-b4-ZgP" secondAttribute="leading" constant="-1" id="a3m-ZB-Ixh"/>
-                                            <constraint firstItem="HN0-n6-ORp" firstAttribute="leading" secondItem="rNB-K6-2G7" secondAttribute="leadingMargin" id="j5R-Fl-do0"/>
-                                            <constraint firstAttribute="height" constant="220" id="sLG-6E-6KH"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LCp-BY-dNt" userLabel="Separator">
-                                        <rect key="frame" x="0.0" y="220" width="600" height="1"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="1" id="hg2-4K-vsh"/>
-                                        </constraints>
-                                    </view>
-                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" allowsSelection="NO" rowHeight="64" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="DH7-9o-kVF">
-                                        <rect key="frame" x="0.0" y="221" width="600" height="379"/>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <color key="sectionIndexBackgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <prototypes>
-                                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="WordPress.FeatureItemCell" rowHeight="80" id="zaq-fe-bpz" customClass="FeatureItemCell" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="50" width="600" height="80"/>
-                                                <autoresizingMask key="autoresizingMask"/>
-                                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zaq-fe-bpz" id="dGV-Jz-XSf">
-                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="80"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="751" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" allowsSelection="NO" rowHeight="64" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="DH7-9o-kVF">
+                                <rect key="frame" x="0.0" y="20" width="600" height="580"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="sectionIndexBackgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <view key="tableHeaderView" contentMode="scaleToFill" id="rNB-K6-2G7" userLabel="Header View">
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="220"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LCp-BY-dNt" userLabel="Separator">
+                                            <rect key="frame" x="0.0" y="219" width="600" height="1"/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="1" id="hg2-4K-vsh"/>
+                                            </constraints>
+                                        </view>
+                                        <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="nps-70-EDE" userLabel="Dropshadow Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                                            <rect key="frame" x="269" y="25" width="62" height="62"/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </imageView>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="HN0-n6-ORp">
+                                            <rect key="frame" x="8" y="26" width="584" height="168"/>
+                                            <subviews>
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" image="plan-premium" translatesAutoresizingMaskIntoConstraints="NO" id="f6b-b4-ZgP" userLabel="Plan Image View">
+                                                    <rect key="frame" x="262" y="0.0" width="60" height="60"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="60" id="MsP-RS-pGE"/>
+                                                        <constraint firstAttribute="height" constant="60" id="pkL-hL-79c"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" distribution="fillEqually" alignment="center" spacing="22" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jAy-0N-D1K">
+                                                    <rect key="frame" x="24" y="72" width="536" height="59"/>
                                                     <subviews>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nuR-h6-384">
-                                                            <rect key="frame" x="72" y="16" width="505" height="48"/>
-                                                            <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kr8-eT-Qom">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="505" height="18"/>
-                                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WW-WL-C4o">
-                                                                    <rect key="frame" x="0.0" y="22" width="505" height="26"/>
-                                                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                            </subviews>
-                                                        </stackView>
-                                                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cDa-ym-Q7f">
-                                                            <rect key="frame" x="28" y="16" width="20" height="20"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="20" id="bGy-K6-cEV"/>
-                                                                <constraint firstAttribute="width" constant="20" id="xEa-iR-c5a"/>
-                                                            </constraints>
-                                                        </imageView>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4OK-zA-asu" userLabel="Separator">
-                                                            <rect key="frame" x="15" y="79" width="570" height="1"/>
-                                                            <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="1" id="Zq4-kP-be6"/>
-                                                            </constraints>
-                                                        </view>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
+                                                            <rect key="frame" x="173" y="0.0" width="192" height="17"/>
+                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Perfect for bloggers, creatives, &amp; other professionals" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="edq-hC-GnQ" userLabel="Plan Description Label">
+                                                            <rect key="frame" x="108" y="22" width="321" height="17"/>
+                                                            <fontDescription key="fontDescription" type="italicSystem" pointSize="13"/>
+                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="$99.99 per year" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fju-eH-OS6" userLabel="Plan Price Label">
+                                                            <rect key="frame" x="213" y="43" width="111" height="17"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
                                                     </subviews>
+                                                </stackView>
+                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJf-48-mlv" userLabel="Purchase Button" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
+                                                    <rect key="frame" x="261" y="143" width="62" height="25"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
-                                                        <constraint firstItem="cDa-ym-Q7f" firstAttribute="leading" secondItem="dGV-Jz-XSf" secondAttribute="leading" constant="28" id="1JE-LD-8ha"/>
-                                                        <constraint firstItem="nuR-h6-384" firstAttribute="top" secondItem="cDa-ym-Q7f" secondAttribute="top" id="3s0-eL-XYh"/>
-                                                        <constraint firstAttribute="bottom" secondItem="nuR-h6-384" secondAttribute="bottom" constant="16" id="K4S-rE-kOI"/>
-                                                        <constraint firstItem="cDa-ym-Q7f" firstAttribute="top" secondItem="dGV-Jz-XSf" secondAttribute="top" constant="16" id="dJd-FF-J8C"/>
-                                                        <constraint firstItem="4OK-zA-asu" firstAttribute="leading" secondItem="dGV-Jz-XSf" secondAttribute="leading" constant="15" id="efH-h4-JLu"/>
-                                                        <constraint firstAttribute="trailingMargin" secondItem="nuR-h6-384" secondAttribute="trailing" constant="15" id="f0D-XH-r63"/>
-                                                        <constraint firstAttribute="bottom" secondItem="4OK-zA-asu" secondAttribute="bottom" id="g2k-dK-Z9N"/>
-                                                        <constraint firstItem="nuR-h6-384" firstAttribute="leading" secondItem="cDa-ym-Q7f" secondAttribute="trailing" constant="24" id="pII-ha-EvF"/>
-                                                        <constraint firstAttribute="trailing" secondItem="4OK-zA-asu" secondAttribute="trailing" constant="15" id="zbb-Qq-q9y"/>
+                                                        <constraint firstAttribute="height" constant="25" id="WX3-mf-WwP"/>
                                                     </constraints>
-                                                </tableViewCellContentView>
-                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                                <inset key="separatorInset" minX="15" minY="0.0" maxX="15" maxY="0.0"/>
-                                                <connections>
-                                                    <outlet property="featureDescriptionLabel" destination="3WW-WL-C4o" id="z1e-A9-RE0"/>
-                                                    <outlet property="featureIconImageView" destination="cDa-ym-Q7f" id="dny-Xs-BQc"/>
-                                                    <outlet property="featureTitleLabel" destination="Kr8-eT-Qom" id="Pn5-r6-qF8"/>
-                                                    <outlet property="separator" destination="4OK-zA-asu" id="LVd-hM-Fsp"/>
-                                                    <outletCollection property="separatorEdgeConstraints" destination="zbb-Qq-q9y" collectionClass="NSMutableArray" id="JO1-xW-pcc"/>
-                                                    <outletCollection property="separatorEdgeConstraints" destination="efH-h4-JLu" collectionClass="NSMutableArray" id="H4W-Td-CWu"/>
-                                                </connections>
-                                            </tableViewCell>
-                                        </prototypes>
+                                                    <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="11"/>
+                                                    <state key="normal" title="PURCHASE">
+                                                        <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="purchaseTapped" destination="msO-08-fqQ" eventType="touchUpInside" id="Wub-Tq-SYx"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="jAy-0N-D1K" firstAttribute="leading" secondItem="HN0-n6-ORp" secondAttribute="leading" constant="24" id="4mr-rU-aLN"/>
+                                                <constraint firstAttribute="trailing" secondItem="jAy-0N-D1K" secondAttribute="trailing" constant="24" id="oZ4-Ve-ine"/>
+                                            </constraints>
+                                        </stackView>
+                                    </subviews>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="HN0-n6-ORp" secondAttribute="bottom" constant="26" id="5eP-AO-KFL"/>
+                                        <constraint firstItem="HN0-n6-ORp" firstAttribute="top" secondItem="rNB-K6-2G7" secondAttribute="top" constant="26" id="776-sg-xlU"/>
+                                        <constraint firstItem="LCp-BY-dNt" firstAttribute="leading" secondItem="rNB-K6-2G7" secondAttribute="leading" id="7Cr-4D-XKo"/>
+                                        <constraint firstItem="nps-70-EDE" firstAttribute="trailing" secondItem="f6b-b4-ZgP" secondAttribute="trailing" constant="1" id="EAa-eq-6bk"/>
+                                        <constraint firstItem="nps-70-EDE" firstAttribute="top" secondItem="f6b-b4-ZgP" secondAttribute="top" constant="-1" id="F1s-SM-4v2"/>
+                                        <constraint firstAttribute="bottom" secondItem="LCp-BY-dNt" secondAttribute="bottom" id="OEQ-sb-7c2"/>
+                                        <constraint firstItem="nps-70-EDE" firstAttribute="bottom" secondItem="f6b-b4-ZgP" secondAttribute="bottom" constant="1" id="QCU-tk-yh6"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="HN0-n6-ORp" secondAttribute="trailing" id="Z7D-8c-oE8"/>
+                                        <constraint firstItem="nps-70-EDE" firstAttribute="leading" secondItem="f6b-b4-ZgP" secondAttribute="leading" constant="-1" id="a3m-ZB-Ixh"/>
+                                        <constraint firstItem="HN0-n6-ORp" firstAttribute="leading" secondItem="rNB-K6-2G7" secondAttribute="leadingMargin" id="j5R-Fl-do0"/>
+                                        <constraint firstAttribute="height" constant="220" id="sLG-6E-6KH"/>
+                                        <constraint firstAttribute="trailing" secondItem="LCp-BY-dNt" secondAttribute="trailing" id="yVc-gF-FXi"/>
+                                    </constraints>
+                                </view>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="WordPress.FeatureItemCell" rowHeight="80" id="zaq-fe-bpz" customClass="FeatureItemCell" customModule="WordPress" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="269.5" width="600" height="80"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zaq-fe-bpz" id="dGV-Jz-XSf">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="80"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nuR-h6-384">
+                                                    <rect key="frame" x="72" y="16" width="505" height="48"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kr8-eT-Qom">
+                                                            <rect key="frame" x="0.0" y="0.0" width="505" height="18"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WW-WL-C4o">
+                                                            <rect key="frame" x="0.0" y="22" width="505" height="26"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cDa-ym-Q7f">
+                                                    <rect key="frame" x="28" y="16" width="20" height="20"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="20" id="bGy-K6-cEV"/>
+                                                        <constraint firstAttribute="width" constant="20" id="xEa-iR-c5a"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4OK-zA-asu" userLabel="Separator">
+                                                    <rect key="frame" x="15" y="79" width="570" height="1"/>
+                                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="1" id="Zq4-kP-be6"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="cDa-ym-Q7f" firstAttribute="leading" secondItem="dGV-Jz-XSf" secondAttribute="leading" constant="28" id="1JE-LD-8ha"/>
+                                                <constraint firstItem="nuR-h6-384" firstAttribute="top" secondItem="cDa-ym-Q7f" secondAttribute="top" id="3s0-eL-XYh"/>
+                                                <constraint firstAttribute="bottom" secondItem="nuR-h6-384" secondAttribute="bottom" constant="16" id="K4S-rE-kOI"/>
+                                                <constraint firstItem="cDa-ym-Q7f" firstAttribute="top" secondItem="dGV-Jz-XSf" secondAttribute="top" constant="16" id="dJd-FF-J8C"/>
+                                                <constraint firstItem="4OK-zA-asu" firstAttribute="leading" secondItem="dGV-Jz-XSf" secondAttribute="leading" constant="15" id="efH-h4-JLu"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="nuR-h6-384" secondAttribute="trailing" constant="15" id="f0D-XH-r63"/>
+                                                <constraint firstAttribute="bottom" secondItem="4OK-zA-asu" secondAttribute="bottom" id="g2k-dK-Z9N"/>
+                                                <constraint firstItem="nuR-h6-384" firstAttribute="leading" secondItem="cDa-ym-Q7f" secondAttribute="trailing" constant="24" id="pII-ha-EvF"/>
+                                                <constraint firstAttribute="trailing" secondItem="4OK-zA-asu" secondAttribute="trailing" constant="15" id="zbb-Qq-q9y"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <inset key="separatorInset" minX="15" minY="0.0" maxX="15" maxY="0.0"/>
                                         <connections>
-                                            <outlet property="dataSource" destination="msO-08-fqQ" id="cbF-gf-JY2"/>
-                                            <outlet property="delegate" destination="msO-08-fqQ" id="2cJ-7W-6ja"/>
+                                            <outlet property="featureDescriptionLabel" destination="3WW-WL-C4o" id="z1e-A9-RE0"/>
+                                            <outlet property="featureIconImageView" destination="cDa-ym-Q7f" id="dny-Xs-BQc"/>
+                                            <outlet property="featureTitleLabel" destination="Kr8-eT-Qom" id="Pn5-r6-qF8"/>
+                                            <outlet property="separator" destination="4OK-zA-asu" id="LVd-hM-Fsp"/>
+                                            <outletCollection property="separatorEdgeConstraints" destination="zbb-Qq-q9y" collectionClass="NSMutableArray" id="JO1-xW-pcc"/>
+                                            <outletCollection property="separatorEdgeConstraints" destination="efH-h4-JLu" collectionClass="NSMutableArray" id="H4W-Td-CWu"/>
                                         </connections>
-                                    </tableView>
-                                </subviews>
-                            </stackView>
+                                    </tableViewCell>
+                                </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="msO-08-fqQ" id="cbF-gf-JY2"/>
+                                    <outlet property="delegate" destination="msO-08-fqQ" id="2cJ-7W-6ja"/>
+                                </connections>
+                            </tableView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="hbr-M8-kwi" secondAttribute="trailing" id="6ip-Dn-ZPq"/>
-                            <constraint firstItem="hbr-M8-kwi" firstAttribute="leading" secondItem="fcR-is-wCN" secondAttribute="leading" id="E83-q6-H8b"/>
-                            <constraint firstItem="pmz-SB-Zco" firstAttribute="top" secondItem="hbr-M8-kwi" secondAttribute="bottom" id="KVY-8b-0ot"/>
-                            <constraint firstItem="hbr-M8-kwi" firstAttribute="top" secondItem="fcR-is-wCN" secondAttribute="top" id="yZR-eR-iAo"/>
+                            <constraint firstItem="DH7-9o-kVF" firstAttribute="top" secondItem="ass-i7-57P" secondAttribute="bottom" id="MiC-bK-9eD"/>
+                            <constraint firstItem="DH7-9o-kVF" firstAttribute="leading" secondItem="fcR-is-wCN" secondAttribute="leading" id="Wtx-Gv-fgs"/>
+                            <constraint firstAttribute="trailing" secondItem="DH7-9o-kVF" secondAttribute="trailing" id="erY-c1-E8E"/>
+                            <constraint firstItem="pmz-SB-Zco" firstAttribute="top" secondItem="DH7-9o-kVF" secondAttribute="bottom" id="sJ1-iZ-X1B"/>
                         </constraints>
                     </view>
                     <connections>

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -130,28 +130,28 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" axis="vertical" distribution="fillEqually" alignment="center" spacing="22" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jAy-0N-D1K">
                                                     <rect key="frame" x="24" y="72" width="536" height="59"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
-                                                            <rect key="frame" x="173" y="0.0" width="192" height="17"/>
-                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
+                                                            <rect key="frame" x="167" y="0.0" width="202" height="17"/>
+                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Perfect for bloggers, creatives, &amp; other professionals" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="edq-hC-GnQ" userLabel="Plan Description Label">
-                                                            <rect key="frame" x="108" y="22" width="321" height="17"/>
-                                                            <fontDescription key="fontDescription" type="italicSystem" pointSize="13"/>
+                                                            <rect key="frame" x="98" y="21" width="342" height="17"/>
+                                                            <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="$99.99 per year" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fju-eH-OS6" userLabel="Plan Price Label">
-                                                            <rect key="frame" x="213" y="43" width="111" height="17"/>
+                                                            <rect key="frame" x="213" y="42" width="111" height="17"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
                                                 </stackView>
-                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJf-48-mlv" userLabel="Purchase Button" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
-                                                    <rect key="frame" x="261" y="143" width="62" height="25"/>
+                                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJf-48-mlv" userLabel="Purchase Button" customClass="PurchaseButton" customModule="WordPress" customModuleProvider="target">
+                                                    <rect key="frame" x="242" y="143" width="100" height="25"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="25" id="WX3-mf-WwP"/>
@@ -198,15 +198,15 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nuR-h6-384">
                                                     <rect key="frame" x="72" y="16" width="505" height="48"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kr8-eT-Qom">
-                                                            <rect key="frame" x="0.0" y="0.0" width="505" height="18"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kr8-eT-Qom">
+                                                            <rect key="frame" x="0.0" y="0.0" width="505" height="20"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WW-WL-C4o">
-                                                            <rect key="frame" x="0.0" y="22" width="505" height="26"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="999" misplaced="YES" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WW-WL-C4o">
+                                                            <rect key="frame" x="0.0" y="22" width="505" height="27"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>


### PR DESCRIPTION
#A couple of quick design amends for Plans:

* Plan detail header now scrolls with the tableview.
* Plan detail header shrinks if necessary – to test this, go to a site that currently has Premium and then view the Free plan.
* "per year" period labels for plans are now in `grey`, not `greyLighten20`.
* Some font size changes:

<img width="388" alt="screen-shot-2016-04-04-at-6-41-46-pm" src="https://cloud.githubusercontent.com/assets/4780/14294956/79725980-fb6b-11e5-85f0-7363b84e6eaf.png">

<img width="388" alt="screen-shot-2016-04-04-at-6-41-21-pm" src="https://cloud.githubusercontent.com/assets/4780/14294957/7d018c2e-fb6b-11e5-838b-118b238341ad.png">

Needs review: @koke 