### PR TITLE
Issues/5083 crash comment video

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -193,7 +193,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 
     CGFloat width = CGRectGetWidth(self.view.frame);
     [self updateCellsAndRefreshMediaForWidth:width];
-    [self.tableView reloadRowsAtIndexPaths:[self.tableView indexPathsForVisibleRows] withRowAnimation:UITableViewRowAnimationNone];
+    [self.tableView reloadData];
 }
 
 
@@ -1112,19 +1112,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
     }
 
     [self.tableViewHandler invalidateCachedRowHeightAtIndexPath:indexPath];
-
-    // HACK:
-    // For some reason, a single call to reloadRowsAtIndexPath can result in an
-    // invalid row height. Calling twice seems to prevent any layout errors at
-    // the expense of an extra layout pass.
-    // Wrapping the calls in a performWithoutAnimation block ensures the are no
-    // strange transitions from the old height to the new.
-    // BOTH calls to reloadRowsAtIndexPaths:withRowAnimation are needed to avoid
-    // visual oddity.
-    [UIView performWithoutAnimation:^{
-        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
-        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
-    }];
+    [self.tableView reloadData];
 }
 
 - (void)commentCell:(UITableViewCell *)cell linkTapped:(NSURL *)url

--- a/WordPress/Classes/ViewRelated/Views/WPRichTextView.m
+++ b/WordPress/Classes/ViewRelated/Views/WPRichTextView.m
@@ -488,6 +488,11 @@ NSString * const WPRichTextDefaultFontName = @"Merriweather";
     }
     self.needsCheckPendingDownloadsAfterDelay = NO;
 
+    // Bail if there is no media needing layout.
+    if ([self.mediaIndexPathsNeedingLayout count] == 0) {
+        return;
+    }
+
     [self refreshLayoutForMediaAtIndexPaths:self.mediaIndexPathsNeedingLayout];
     [self.mediaIndexPathsNeedingLayout removeAllObjects];
     self.dateOfLastMediaRefresh = [NSDate date];


### PR DESCRIPTION
Fixes #5083 

To test: Open the reader to a list of comments where the comments contain embedded video.  Try playing the video, rotating the app while the video is playing, and scrolling the list after the video plays.  Confirm there is no crash.  
Additionally check for any layout wonkiness in both the post detail and the comment list as media is loading and while scrolling.
You can like the [Embeddables](https://wordpress.com/read/blogs/34823036/posts/5747) on my test blog and use its post detail and its comments for testing.  Or craft your own post with a mix of video and image embeds in the post body and in multiple comments.  

Needs review: @jleandroperez could I trouble you with this one? 
