### PR TITLE
Move strip gps information setting from blog settings to account settings.

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -55,7 +55,7 @@
     }
 
     MediaSettings *mediaSettings = [MediaSettings new];
-    BOOL stripGeoLocation = !mediaSettings.removeLocationSetting;
+    BOOL stripGeoLocation = mediaSettings.removeLocationSetting;
     
     NSInteger maxImageSize = [mediaSettings imageSizeForUpload];
     CGSize maximumResolution = CGSizeMake(maxImageSize, maxImageSize);

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -54,7 +54,7 @@
         mediaType = MediaTypeVideo;
     }
     
-    BOOL geoLocationEnabled = post.blog.settings.geolocationEnabled;
+    BOOL geoLocationEnabled = NO;
     
     NSInteger maxImageSize = [[MediaSettings new] imageSizeForUpload];
     CGSize maximumResolution = CGSizeMake(maxImageSize, maxImageSize);

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -53,10 +53,11 @@
         allowedFileTypes = nil;
         mediaType = MediaTypeVideo;
     }
+
+    MediaSettings *mediaSettings = [MediaSettings new];
+    BOOL stripGeoLocation = !mediaSettings.removeLocationSetting;
     
-    BOOL geoLocationEnabled = NO;
-    
-    NSInteger maxImageSize = [[MediaSettings new] imageSizeForUpload];
+    NSInteger maxImageSize = [mediaSettings imageSizeForUpload];
     CGSize maximumResolution = CGSizeMake(maxImageSize, maxImageSize);
 
     NSURL *mediaURL = [self urlForMediaWithFilename:[asset originalFilename] andExtension:extension];
@@ -75,7 +76,7 @@
             [asset exportToURL:mediaURL
                      targetUTI:assetUTI
              maximumResolution:maximumResolution
-              stripGeoLocation:!geoLocationEnabled
+              stripGeoLocation:stripGeoLocation
                 successHandler:^(CGSize resultingSize)
                 {
                     [self createMediaForPost:postObjectID

--- a/WordPress/Classes/Services/MediaSettings.swift
+++ b/WordPress/Classes/Services/MediaSettings.swift
@@ -8,6 +8,8 @@ protocol MediaSettingsStorage {
 class MediaSettings: NSObject {
     // MARK: - Constants
     private let maxImageSizeKey = "SavedMaxImageSizeSetting"
+    private let removeLocationKey = "SavedRemoveLocationSetting"
+
     private let minImageDimension = 150
     private let maxImageDimension = 3000
 
@@ -63,6 +65,19 @@ class MediaSettings: NSObject {
         set {
             let size = newValue.clamp(min: minImageDimension, max: maxImageDimension)
             storage.setValue(size, forKey: maxImageSizeKey)
+        }
+    }
+
+    var removeLocationSetting: Bool {
+        get {
+            if let savedRemoveLocation = storage.valueForKey(removeLocationKey) as? Bool {
+                return savedRemoveLocation
+            } else {
+                return true;
+            }
+        }
+        set {
+            storage.setValue(newValue, forKey: removeLocationKey)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -44,13 +44,6 @@ NS_ENUM(NSInteger, SiteSettingsWriting) {
     SiteSettingsWritingCount,
 };
 
-NS_ENUM(NSInteger, SiteSettingsDevice) {
-    SiteSettingsDeviceGeotagging = 0,
-    SiteSettingsDeviceDefaultCategory,
-    SiteSettingsDeviceDefaultPostFormat,
-    SiteSettingsDeviceCount,
-};
-
 NS_ENUM(NSInteger, SiteSettingsAdvanced) {
     SiteSettingsAdvancedStartOver = 0,
     SiteSettingsAdvancedExportContent,
@@ -63,7 +56,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     SiteSettingsSectionAccount,
     SiteSettingsSectionWriting,
     SiteSettingsSectionDiscussion,
-    SiteSettingsSectionDevice,
     SiteSettingsSectionRemoveSite,
     SiteSettingsSectionAdvanced,
 };
@@ -163,8 +155,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         [sections addObject:@(SiteSettingsSectionDiscussion)];
     }
 
-    [sections addObject:@(SiteSettingsSectionDevice)];
-
     if ([self.blog supports:BlogFeatureRemovable]) {
         [sections addObject:@(SiteSettingsSectionRemoveSite)];
     }
@@ -215,15 +205,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         case SiteSettingsSectionDiscussion:
         {
             return 1;
-        }
-        case SiteSettingsSectionDevice:
-        {
-            if ([self.blog supports:BlogFeatureWPComRESTAPI]) {
-                // NOTE: Brent Coursey (2016-02-03): Only show geotagging cell for user of the REST API (REST).
-                // Any post default options are available in the Writing section for REST users.
-                return 1;
-            }
-            return SiteSettingsDeviceCount;
         }
         case SiteSettingsSectionRemoveSite:
         {
@@ -281,21 +262,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 
     }
     return nil;
-}
-
-- (SwitchTableViewCell *)geotaggingCell
-{
-    if (_geotaggingCell) {
-        return _geotaggingCell;
-    }
-    _geotaggingCell = [SwitchTableViewCell new];
-    _geotaggingCell.name = NSLocalizedString(@"Geotagging", @"Enables geotagging in blog settings (short label)");
-    _geotaggingCell.on = self.blog.settings.geolocationEnabled;
-    __weak SiteSettingsViewController *weakSelf = self;
-    _geotaggingCell.onChange = ^(BOOL value){
-        [weakSelf toggleGeolocation:value];
-    };
-    return _geotaggingCell;
 }
 
 - (SettingTableViewCell *)defaultCategoryCell
@@ -380,23 +346,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 
         case (SiteSettingsWritingRelatedPosts):
             return self.relatedPostsCell;
-    }
-    return nil;
-}
-
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForDeviceSettingsAtRow:(NSInteger)row
-{
-    switch (row) {
-        case (SiteSettingsDeviceGeotagging):
-            return self.geotaggingCell;
-
-        case (SiteSettingsDeviceDefaultCategory):
-            [self configureDefaultCategoryCell];
-            return self.defaultCategoryCell;
-
-        case (SiteSettingsDeviceDefaultPostFormat):
-            [self configureDefaultPostFormatCell];
-            return self.defaultPostFormatCell;
     }
     return nil;
 }
@@ -569,9 +518,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         case SiteSettingsSectionDiscussion:
             return self.discussionSettingsCell;
 
-        case SiteSettingsSectionDevice:
-            return [self tableView:tableView cellForDeviceSettingsAtRow:indexPath.row];
-
         case SiteSettingsSectionRemoveSite:
             return self.removeSiteCell;
 
@@ -624,10 +570,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 
         case SiteSettingsSectionWriting:
             headingTitle = NSLocalizedString(@"Writing", @"Title for the writing section in site settings screen");
-            break;
-
-        case SiteSettingsSectionDevice:
-            headingTitle = NSLocalizedString(@"This Device", @"Title for the device section in site settings screen");
             break;
 
         case SiteSettingsSectionAdvanced:
@@ -851,19 +793,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     }
 }
 
-- (void)tableView:(UITableView *)tableView didSelectInDeviceSectionRow:(NSInteger)row
-{
-    switch (row) {
-        case SiteSettingsDeviceDefaultCategory:
-            [self showDefaultCategorySelector];
-            break;
-
-        case SiteSettingsDeviceDefaultPostFormat:
-            [self showPostFormatSelector];
-            break;
-    }
-}
-
 - (void)showStartOverForBlog:(Blog *)blog
 {
     NSParameterAssert([blog supportsSiteManagementServices]);
@@ -910,10 +839,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             [self showDiscussionSettingsForBlog:self.blog];
             break;
 
-        case SiteSettingsSectionDevice:
-            [self tableView:tableView didSelectInDeviceSectionRow:indexPath.row];
-            break;
-
         case SiteSettingsSectionRemoveSite:
             [self showRemoveSiteForBlog:self.blog];
             [tableView deselectSelectedRowWithAnimation:YES];
@@ -946,14 +871,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     }];
     
 }
-
-- (void)toggleGeolocation:(BOOL)value
-{
-    // Save the change
-    self.blog.settings.geolocationEnabled = value;
-    [[ContextManager sharedInstance] saveContext:self.blog.managedObjectContext];
-}
-
 
 #pragma mark - Authentication methods
 

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -68,6 +68,12 @@ private struct AccountSettingsController: SettingsController {
             value: Int(MediaSettings().maxImageSizeSetting),
             onChange: mediaSizeChanged())
 
+        let mediaRemoveLocation = SwitchRow(
+            title: NSLocalizedString("Remove Location From Media", comment: "Option to enable the removal of location information/gps from photos and videos"),
+            value: Bool(MediaSettings().removeLocationSetting),
+            onChange: mediaRemoveLocationChanged()
+        )
+
         let editorHeader = NSLocalizedString("Editor", comment: "Title label for the editor settings section in the app settings")
         let visualEditor = SwitchRow(
             title: NSLocalizedString("Visual Editor", comment: "Option to enable the visual editor"),
@@ -109,7 +115,8 @@ private struct AccountSettingsController: SettingsController {
                 ImmuTableSection(
                     headerText: mediaHeader,
                     rows: [
-                        uploadSize
+                        uploadSize,
+                        mediaRemoveLocation
                     ],
                     footerText: nil),
                 ImmuTableSection(
@@ -169,6 +176,13 @@ private struct AccountSettingsController: SettingsController {
         return {
             value in
             MediaSettings().maxImageSizeSetting = value
+        }
+    }
+
+    func mediaRemoveLocationChanged() -> Bool -> Void {
+        return {
+            value in
+            MediaSettings().removeLocationSetting = value
         }
     }
 


### PR DESCRIPTION
Fixes #4850

To test:
 - Go to account settings and check if new option to strip GPS location is there
 - Create a new post, add image with GPS information (make sure you the photos you use has location information)
 - See if the options has the desired effect of keeping and removing GPS information by downloading the image from  the server and checking the properties on Preview.

Needs review: @koke 