### PR TITLE
Refactor feature loading

### DIFF
--- a/WordPress/Classes/Extensions/String+Helpers.swift
+++ b/WordPress/Classes/Extensions/String+Helpers.swift
@@ -9,4 +9,9 @@ extension String {
     func stringByEncodingXMLCharacters() -> String {
         return NSString.encodeXMLCharactersIn(self)
     }
+
+    /// Returns `self` if not empty, or `nil` otherwise
+    func nonEmptyString() -> String? {
+        return isEmpty ? nil : self
+    }
 }

--- a/WordPress/Classes/Models/Plan.swift
+++ b/WordPress/Classes/Models/Plan.swift
@@ -9,11 +9,11 @@ typealias PlanID = Int
 /// - seealso: [WordPress.com Store](https://store.wordpress.com/plans/)
 struct Plan {
     let id: PlanID
-    let slug: String
     let title: String
     let fullTitle: String
     let description: String
     let productIdentifier: String?
+    let featureGroups: [PlanFeatureGroupPlaceholder]
 }
 
 extension Plan {
@@ -56,27 +56,27 @@ final class PlansBridge: NSObject {
 let defaultPlans: [Plan] = [
     Plan(
         id: 1,
-        slug: "free",
         title: NSLocalizedString("Free", comment: "Free plan name. As in https://store.wordpress.com/plans/"),
         fullTitle: NSLocalizedString("WordPress.com Free", comment: "Free plan name. As in https://store.wordpress.com/plans/"),
         description: NSLocalizedString("Anyone creating a simple blog or site.", comment: "Description of the Free plan"),
-        productIdentifier: nil
+        productIdentifier: nil,
+        featureGroups: []
     ),
     Plan(
         id: 1003,
-        slug: "premium",
         title: NSLocalizedString("Premium", comment: "Premium paid plan name. As in https://store.wordpress.com/plans/"),
         fullTitle: NSLocalizedString("WordPress.com Premium", comment: "Premium paid plan name. As in https://store.wordpress.com/plans/"),
         description: NSLocalizedString("Serious bloggers and creatives.", comment: "Description of the Premium plan"),
-        productIdentifier: "com.wordpress.test.premium.subscription.1year"
+        productIdentifier: "com.wordpress.test.premium.subscription.1year",
+        featureGroups: []
     ),
     Plan(
         id: 1008,
-        slug: "business",
         title: NSLocalizedString("Business", comment: "Business paid plan name. As in https://store.wordpress.com/plans/"),
         fullTitle: NSLocalizedString("WordPress.com Business", comment: "Business paid plan name. As in https://store.wordpress.com/plans/"),
         description: NSLocalizedString("Business websites and ecommerce.", comment: "Description of the Business plan"),
-        productIdentifier: "com.wordpress.test.business.subscription.1year"
+        productIdentifier: "com.wordpress.test.business.subscription.1year",
+        featureGroups: []
     ),
 ]
 
@@ -93,6 +93,21 @@ extension Array where Element: Identifiable {
 
 // Icons
 extension Plan {
+    // Temporary hardcoded map
+    // We need to store plan image URLs and use those
+    // https://github.com/wordpress-mobile/WordPress-iOS/issues/5099
+    var slug: String {
+        switch id {
+        case 1:
+            return "free"
+        case 1003:
+            return "premium"
+        case 1008:
+            return "business"
+        default:
+            return ""
+        }
+    }
     /// The name of the image that represents the plan when it's not the current plan
     var imageName: String {
         return "plan-\(slug)"
@@ -121,17 +136,12 @@ struct PlanFeature {
     let iconURL: NSURL
 }
 
-struct PlanFeatureGroup {
+struct PlanFeatureGroupPlaceholder {
     let title: String?
     let slugs: [String]
-    
-    static private var groups = [Plan: [PlanFeatureGroup]]()
-    
-    static func groupsForPlan(plan: Plan) -> [PlanFeatureGroup]? {
-        return groups[plan]
-    }
-    
-    static func setGroups(groups: [PlanFeatureGroup], forPlan plan: Plan) {
-        self.groups[plan] = groups
-    }
+}
+
+struct PlanFeatureGroup {
+    let title: String?
+    let features: [PlanFeature]
 }

--- a/WordPress/Classes/Models/Plan.swift
+++ b/WordPress/Classes/Models/Plan.swift
@@ -11,7 +11,7 @@ struct Plan {
     let id: PlanID
     let title: String
     let fullTitle: String
-    let description: String
+    let tagline: String
     let productIdentifier: String?
     let featureGroups: [PlanFeatureGroupPlaceholder]
 }
@@ -58,7 +58,7 @@ let defaultPlans: [Plan] = [
         id: 1,
         title: NSLocalizedString("Free", comment: "Free plan name. As in https://store.wordpress.com/plans/"),
         fullTitle: NSLocalizedString("WordPress.com Free", comment: "Free plan name. As in https://store.wordpress.com/plans/"),
-        description: NSLocalizedString("Anyone creating a simple blog or site.", comment: "Description of the Free plan"),
+        tagline: NSLocalizedString("Anyone creating a simple blog or site.", comment: "Description of the Free plan"),
         productIdentifier: nil,
         featureGroups: []
     ),
@@ -66,7 +66,7 @@ let defaultPlans: [Plan] = [
         id: 1003,
         title: NSLocalizedString("Premium", comment: "Premium paid plan name. As in https://store.wordpress.com/plans/"),
         fullTitle: NSLocalizedString("WordPress.com Premium", comment: "Premium paid plan name. As in https://store.wordpress.com/plans/"),
-        description: NSLocalizedString("Serious bloggers and creatives.", comment: "Description of the Premium plan"),
+        tagline: NSLocalizedString("Serious bloggers and creatives.", comment: "Description of the Premium plan"),
         productIdentifier: "com.wordpress.test.premium.subscription.1year",
         featureGroups: []
     ),
@@ -74,7 +74,7 @@ let defaultPlans: [Plan] = [
         id: 1008,
         title: NSLocalizedString("Business", comment: "Business paid plan name. As in https://store.wordpress.com/plans/"),
         fullTitle: NSLocalizedString("WordPress.com Business", comment: "Business paid plan name. As in https://store.wordpress.com/plans/"),
-        description: NSLocalizedString("Business websites and ecommerce.", comment: "Description of the Business plan"),
+        tagline: NSLocalizedString("Business websites and ecommerce.", comment: "Description of the Business plan"),
         productIdentifier: "com.wordpress.test.business.subscription.1year",
         featureGroups: []
     ),

--- a/WordPress/Classes/Networking/PlansRemote.swift
+++ b/WordPress/Classes/Networking/PlansRemote.swift
@@ -41,7 +41,7 @@ private func mapPlansResponse(response: AnyObject) throws -> (activePlan: Plan, 
         guard let planId = planDetails["product_id"] as? Int,
             let title = planDetails["product_name_short"] as? String,
             let fullTitle = planDetails["product_name"] as? String,
-            let description = planDetails["description"] as? String,
+            let tagline = planDetails["tagline"] as? String,
             let featureGroupsJson = planDetails["features_highlight"] as? [[String: AnyObject]] else {
             throw PlansRemote.Error.DecodeError
         }
@@ -49,7 +49,7 @@ private func mapPlansResponse(response: AnyObject) throws -> (activePlan: Plan, 
         let productIdentifier = (planDetails["apple_sku"] as? String).flatMap({ $0.nonEmptyString() })
         let featureGroups = try parseFeatureGroups(featureGroupsJson)
 
-        let plan = Plan(id: planId, title: title, fullTitle: fullTitle, description: description, productIdentifier: productIdentifier, featureGroups: featureGroups)
+        let plan = Plan(id: planId, title: title, fullTitle: fullTitle, tagline: tagline, productIdentifier: productIdentifier, featureGroups: featureGroups)
 
         let plans = result.1 + [plan]
         if let isCurrent = planDetails["current_plan"] as? Bool where

--- a/WordPress/Classes/Networking/PlansRemote.swift
+++ b/WordPress/Classes/Networking/PlansRemote.swift
@@ -20,6 +20,7 @@ class PlansRemote: ServiceRemoteREST {
                 do {
                     try success(mapPlansResponse(response))
                 } catch {
+                    DDLogSwift.logError("Error parsing plans response (\(error)): \(response)")
                     failure(error)
                 }
             }, failure: {
@@ -37,17 +38,19 @@ private func mapPlansResponse(response: AnyObject) throws -> (activePlan: Plan, 
 
     let parsedResponse: (Plan?, [Plan]) = try json.reduce((nil, []), combine: {
         (result, planDetails: [String: AnyObject]) in
-        guard let planId = planDetails["product_id"] as? Int else {
+        guard let planId = planDetails["product_id"] as? Int,
+            let title = planDetails["product_name_short"] as? String,
+            let fullTitle = planDetails["product_name"] as? String,
+            let description = planDetails["description"] as? String,
+            let featureGroupsJson = planDetails["features_highlight"] as? [[String: AnyObject]] else {
             throw PlansRemote.Error.DecodeError
         }
-        guard let plan = defaultPlans.withID(planId) else {
-            throw PlansRemote.Error.UnsupportedPlan
-        }
-  
-        if let featureGroupsJson = planDetails["features_highlight"] as? [[String: AnyObject]] {
-            try parseFeatureGroups(featureGroupsJson, forPlan: plan)
-        }
-        
+
+        let productIdentifier = (planDetails["apple_sku"] as? String).flatMap({ $0.nonEmptyString() })
+        let featureGroups = try parseFeatureGroups(featureGroupsJson)
+
+        let plan = Plan(id: planId, title: title, fullTitle: fullTitle, description: description, productIdentifier: productIdentifier, featureGroups: featureGroups)
+
         let plans = result.1 + [plan]
         if let isCurrent = planDetails["current_plan"] as? Bool where
             isCurrent {
@@ -64,12 +67,10 @@ private func mapPlansResponse(response: AnyObject) throws -> (activePlan: Plan, 
     return (activePlan, availablePlans)
 }
 
-private func parseFeatureGroups(json: [[String: AnyObject]], forPlan plan: Plan) throws {
-    let groups: [PlanFeatureGroup] = try json.flatMap { groupJson in
+private func parseFeatureGroups(json: [[String: AnyObject]]) throws -> [PlanFeatureGroupPlaceholder] {
+    return try json.flatMap { groupJson in
         guard let slugs = groupJson["items"] as? [String] else { throw PlansRemote.Error.DecodeError }
-        return PlanFeatureGroup(title: groupJson["title"] as? String, slugs: slugs)
+        return PlanFeatureGroupPlaceholder(title: groupJson["title"] as? String, slugs: slugs)
     }
-    
-    PlanFeatureGroup.setGroups(groups, forPlan: plan)
 }
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -200,7 +200,7 @@ class PlanDetailViewController: UIViewController {
         let plan = viewModel.plan
         planImageView.image = plan.image
         planTitleLabel.text = plan.fullTitle
-        planDescriptionLabel.text = plan.description
+        planDescriptionLabel.text = plan.tagline
         planPriceLabel.text = viewModel.priceText
         
         if viewModel.isActivePlan {

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -35,8 +35,7 @@ class PlanDetailViewController: UIViewController {
                 return ImmuTable.Empty
             case .Ready(let groups):
                 return ImmuTable(sections: groups.map { group in
-                    let features = group.slugs.flatMap { PlanService<StoreKitStore>.featureForPlan(plan, withSlug: $0) }
-                    let rows: [ImmuTableRow] = features.map({ feature in
+                    let rows: [ImmuTableRow] = group.features.map({ feature in
                         return FeatureItemRow(title: feature.title, description: feature.description, iconURL: feature.iconURL)
                     })
                     return ImmuTableSection(headerText: group.title, rows: rows, footerText: nil)

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -110,7 +110,7 @@ enum PlanListViewModel {
                     title: plan.title,
                     active: active,
                     price: price,
-                    description: plan.description,
+                    description: plan.tagline,
                     icon: icon,
                     action: action
                 )


### PR DESCRIPTION
Gets rid of both the global `planFeatures` and `PlanFeatureGroup.groups`.

The previous `PlanFeatureGroup` is now `PlanFeatureGroupPlaceholder` as it only holds the slugs of the features.

When the features are fetched from the API, we call `PlanService.featureGroupsForPlan(_:features:)` to combine the known plan groups with the full feature data for that plan.

This also makes `PlansRemote` actually get all the plan data from the JSON. Surprisingly the existing version still got just the planID and mapped the rest from the hardcoded plans list.

Fixes #5068 
Needs review: @frosty 
