### PR TITLE
Themes Header:Fix buttons on the header to be localizable.

### DIFF
--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
@@ -60,6 +60,7 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
         buttons.forEach { $0.exclusiveTouch = true }
 
         applyStyles()
+        setTextForLabels()
     }
     
     private func applyStyles() {
@@ -77,6 +78,13 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
 
         searchBar.backgroundColor = Styles.searchBarBackgroundColor
         searchBarBorders.forEach { $0.backgroundColor = Styles.searchBarBorderColor }
+    }
+    
+    private func setTextForLabels() {
+        currentThemeLabel.text = NSLocalizedString("Current Theme", comment: "Current Theme text that appears in the Theme Browser Header")
+        customizeButton.setTitle(NSLocalizedString("Customize", comment: "Customize button that appears in the Theme Browser Header"), forState: .Normal)
+        detailsButton.setTitle(NSLocalizedString("Details", comment: "Details button that appears in the Theme Browser Header"), forState: .Normal)
+        supportButton.setTitle(NSLocalizedString("Support", comment: "Support button that appears in the Theme Browser Header"), forState: .Normal)
     }
     
     override public func prepareForReuse() {


### PR DESCRIPTION
Fixes #5092 

To test:
1. At the present moment the text isn't localized so to make sure it works copy [this](https://cloudup.com/caRzGgIUq8M) Localizable.strings into the `Resources/es.lproj` directory
2. Open the app up and login with a .com account.
3. Open up the Themes page and verify that the "Current Theme", "Customize", "Support",  and "Details" labels are all localized(see screenshot below).

![simulator screen shot apr 6 2016 10 42 53 pm](https://cloud.githubusercontent.com/assets/437043/14341810/bd5ef75a-fc49-11e5-8066-44918305b1a1.png)

Needs review: @astralbodies 
