### PR TITLE
Update Nimble/Alamofire to fix Xcode 7.3 warnings

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -69,7 +69,7 @@ target :WordPressTest, :exclusive => true do
   pod 'OCMock', '3.1.2'
   pod 'Specta', '1.0.5'
   pod 'Expecta', '0.3.2'
-  pod 'Nimble', '~> 3.2.0'
+  pod 'Nimble', '~> 4.0.0'
   pod 'RxSwift', '~> 2.3.1'
   pod 'RxTests', '~> 2.3.1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
   - AFNetworking/UIKit (2.6.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - Alamofire (3.2.1)
+  - Alamofire (3.3.1)
   - AMPopTip (0.10.2)
   - Automattic-Tracks-iOS (0.0.13):
     - CocoaLumberjack (~> 2.2.0)
@@ -257,7 +257,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   1PasswordExtension: 9f471645d378283cb88c6d4bf502e4381a42c0ad
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
-  Alamofire: f11d8624a05f5d39e0c99309b3e600a3ba64298a
+  Alamofire: 369bc67b6f5ac33ded3648d7bd21c5bfb91c2ecc
   AMPopTip: 0788a9452806049e3aa0d6d09324606fc41ea646
   Automattic-Tracks-iOS: ba47c35576a07376facc7a91740fb78867831e1c
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -107,7 +107,7 @@ PODS:
   - MRProgress/ProgressBaseClass (0.7.0)
   - MRProgress/Stopable (0.7.0):
     - MRProgress/Helper
-  - Nimble (3.2.0)
+  - Nimble (4.0.0)
   - NSObject-SafeExpectations (0.0.2)
   - NSURL+IDN (0.3)
   - OCMock (3.1.2)
@@ -202,7 +202,7 @@ DEPENDENCIES:
   - Lookback (= 1.1.4)
   - Mixpanel (= 2.9.4)
   - MRProgress (~> 0.7.0)
-  - Nimble (~> 3.2.0)
+  - Nimble (~> 4.0.0)
   - NSObject-SafeExpectations (= 0.0.2)
   - NSURL+IDN (= 0.3)
   - OCMock (= 3.1.2)
@@ -273,7 +273,7 @@ SPEC CHECKSUMS:
   Lookback: 9ab9027ff246d2dc5ce34be483f70e4a6718280b
   Mixpanel: 80d2ca9bb38ae91c1044d738e80fe448377ac89f
   MRProgress: 1cb0051b678be4a2ef4881414cd316768fc70028
-  Nimble: 703854335d181df169bbca9c97117b5cf8c47c1d
+  Nimble: 72bcc3e2f02242e6bfaaf8d9412ca7bfe3d8b417
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   NSURL+IDN: 82355a0afd532fe1de08f6417c134b49b1a1c4b3
   OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92


### PR DESCRIPTION
The existing versions of Alamofire and Nimble were throwing a bunch of warnings on build. This updates them both to newer versions which include fixes for Xcode 7.3

Needs review: @astralbodies 
