### PR TITLE
Updates the styling of the Me screen

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -46,7 +46,7 @@ target 'WordPress', :exclusive => true do
   pod 'Simperium', '0.8.15'
   pod 'WPMediaPicker', '~> 0.9.0'
   pod 'WordPress-iOS-Editor', '1.2'
-  pod 'WordPress-iOS-Shared', '0.5.3'
+  pod 'WordPress-iOS-Shared', '0.5.4'
   pod 'WordPressApi', '0.4.0'
   pod 'WordPressCom-Analytics-iOS', '0.1.8'
   pod 'WordPressCom-Stats-iOS/UI', '0.6.3'
@@ -56,11 +56,11 @@ end
 target 'WordPressShareExtension', :exclusive => true do
   pod 'CocoaLumberjack', '~> 2.2.0'
   pod 'WordPressComKit', :git => 'https://github.com/Automattic/WordPressComKit.git', :tag => '0.0.1'
-  pod 'WordPress-iOS-Shared', '0.5.3'
+  pod 'WordPress-iOS-Shared', '0.5.4'
 end
 
 target 'WordPressTodayWidget', :exclusive => true do
-  pod 'WordPress-iOS-Shared', '0.5.3'
+  pod 'WordPress-iOS-Shared', '0.5.4'
   pod 'WordPressCom-Stats-iOS/Services', '0.6.3'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -161,7 +161,7 @@ PODS:
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.3)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
-  - WordPress-iOS-Shared (0.5.3):
+  - WordPress-iOS-Shared (0.5.4):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (~> 2.2.0)
   - WordPressApi (0.4.0):
@@ -222,7 +222,7 @@ DEPENDENCIES:
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
   - WordPress-iOS-Editor (= 1.2)
-  - WordPress-iOS-Shared (= 0.5.3)
+  - WordPress-iOS-Shared (= 0.5.4)
   - WordPressApi (= 0.4.0)
   - WordPressCom-Analytics-iOS (= 0.1.8)
   - WordPressCom-Stats-iOS/Services (= 0.6.3)
@@ -295,7 +295,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
   WordPress-iOS-Editor: 4958ae44a2aedfa9b3a3afc9cba41e3ec989b175
-  WordPress-iOS-Shared: 43f55f24f0685e431167084071b7914d7c7134a8
+  WordPress-iOS-Shared: 244f9ba88baea771e4509636029ee48340a4f98a
   WordPressApi: 483767025bcdab26429b51bfe5171f17d3d30466
   WordPressCom-Analytics-iOS: ea4c9017698781ad54a30c4bbac3ad83f7838611
   WordPressCom-Stats-iOS: 75dbdf4765c09b90a8fe00375dc96a93e64feffa

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressShared
+import Gridicons
 
 class MeViewController: UITableViewController, UIViewControllerRestoration {
     static let restorationIdentifier = "WPMeRestorationID"
@@ -90,23 +91,28 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
     func tableViewModel(loggedIn: Bool, helpshiftBadgeCount: Int) -> ImmuTable {
         let myProfile = NavigationItemRow(
             title: NSLocalizedString("My Profile", comment: "Link to My Profile section"),
+            icon: Gridicon.iconOfType(.User),
             action: pushMyProfile())
 
         let accountSettings = NavigationItemRow(
             title: NSLocalizedString("Account Settings", comment: "Link to Account Settings section"),
+            icon: Gridicon.iconOfType(.Cog),
             action: pushAccountSettings())
 
         let notificationSettings = NavigationItemRow(
             title: NSLocalizedString("Notification Settings", comment: "Link to Notification Settings section"),
+            icon: Gridicon.iconOfType(.Bell),
             action: pushNotificationSettings())
 
         let helpAndSupport = BadgeNavigationItemRow(
             title: NSLocalizedString("Help & Support", comment: "Link to Help section"),
+            icon: Gridicon.iconOfType(.Help),
             badgeCount: helpshiftBadgeCount,
             action: pushHelp())
 
         let about = NavigationItemRow(
             title: NSLocalizedString("About", comment: "Link to About section (contains info about the app)"),
+            icon: Gridicon.iconOfType(.Info),
             action: pushAbout())
 
         let logIn = ButtonRow(


### PR DESCRIPTION
Closes #5113 

Adds missing Gravatar icons to the Me screen and applies the 10% lighten grey color to them.

To test:
* Look at the screenshot or launch the app in debug to see the updated screen
![simulator screen shot apr 8 2016 1 53 38 pm](https://cloud.githubusercontent.com/assets/373903/14394381/99386b38-fd91-11e5-90bf-8feab2849326.png)

Needs review: @frosty, @rickybanister
