### PR TITLE
Menus: remote menus service and tests

### DIFF
--- a/WordPress/Classes/Networking/MenusServiceRemote.h
+++ b/WordPress/Classes/Networking/MenusServiceRemote.h
@@ -1,5 +1,7 @@
 #import "ServiceRemoteREST.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString * const MenusRemoteKeyID;
 extern NSString * const MenusRemoteKeyMenu;
 extern NSString * const MenusRemoteKeyMenus;
@@ -42,8 +44,8 @@ typedef void(^MenusServiceRemoteFailureBlock)(NSError *error);
  */
 - (void)createMenuWithName:(NSString *)menuName
                       blog:(Blog *)blog
-                   success:(MenusServiceRemoteMenuRequestSuccessBlock)success
-                   failure:(MenusServiceRemoteFailureBlock)failure;
+                   success:(nullable MenusServiceRemoteMenuRequestSuccessBlock)success
+                   failure:(nullable MenusServiceRemoteFailureBlock)failure;
 
 /**
  *  @brief      Update a menu on a blog.
@@ -56,11 +58,11 @@ typedef void(^MenusServiceRemoteFailureBlock)(NSError *error);
  */
 - (void)updateMenuForID:(NSNumber *)menuID
                    blog:(Blog *)blog
-               withName:(NSString *)updatedName
-          withLocations:(NSArray<NSString *> *)locationNames
-              withItems:(NSArray<RemoteMenuItem *> *)updatedItems
-                success:(MenusServiceRemoteMenuRequestSuccessBlock)success
-                failure:(MenusServiceRemoteFailureBlock)failure;
+               withName:(nullable NSString *)updatedName
+          withLocations:(nullable NSArray<NSString *> *)locationNames
+              withItems:(nullable NSArray<RemoteMenuItem *> *)updatedItems
+                success:(nullable MenusServiceRemoteMenuRequestSuccessBlock)success
+                failure:(nullable MenusServiceRemoteFailureBlock)failure;
 
 /**
  *  @brief      Delete a menu from a blog.
@@ -73,8 +75,8 @@ typedef void(^MenusServiceRemoteFailureBlock)(NSError *error);
  */
 - (void)deleteMenuForID:(NSNumber *)menuID
                    blog:(Blog *)blog
-                success:(MenusServiceRemoteSuccessBlock)success
-                failure:(MenusServiceRemoteFailureBlock)failure;
+                success:(nullable MenusServiceRemoteSuccessBlock)success
+                failure:(nullable MenusServiceRemoteFailureBlock)failure;
 
 #pragma mark - Remote queries: Getting menus
 
@@ -87,7 +89,9 @@ typedef void(^MenusServiceRemoteFailureBlock)(NSError *error);
  *
  */
 - (void)getMenusForBlog:(Blog *)blog
-                success:(MenusServiceRemoteMenusRequestSuccessBlock)success
-                failure:(MenusServiceRemoteFailureBlock)failure;
+                success:(nullable MenusServiceRemoteMenusRequestSuccessBlock)success
+                failure:(nullable MenusServiceRemoteFailureBlock)failure;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Networking/MenusServiceRemote.h
+++ b/WordPress/Classes/Networking/MenusServiceRemote.h
@@ -26,8 +26,8 @@ extern NSString * const MenusRemoteKeyLocationDefaultState;
 
 typedef void(^MenusServiceRemoteSuccessBlock)();
 typedef void(^MenusServiceRemoteMenuRequestSuccessBlock)(RemoteMenu *menu);
-typedef void(^MenusServiceRemoteMenusRequestSuccessBlock)(NSArray<RemoteMenu *> *menus, NSArray<RemoteMenuLocation *> *locations);
-typedef void(^MenusServiceRemoteFailureBlock)(NSError *error);
+typedef void(^MenusServiceRemoteMenusRequestSuccessBlock)(NSArray<RemoteMenu *> * _Nullable menus,  NSArray<RemoteMenuLocation *> * _Nullable locations);
+typedef void(^MenusServiceRemoteFailureBlock)(NSError * _Nonnull error);
 
 @interface MenusServiceRemote : ServiceRemoteREST
 

--- a/WordPress/Classes/Networking/MenusServiceRemote.h
+++ b/WordPress/Classes/Networking/MenusServiceRemote.h
@@ -1,0 +1,93 @@
+#import "ServiceRemoteREST.h"
+
+extern NSString * const MenusRemoteKeyID;
+extern NSString * const MenusRemoteKeyMenu;
+extern NSString * const MenusRemoteKeyMenus;
+extern NSString * const MenusRemoteKeyLocations;
+extern NSString * const MenusRemoteKeyContentID;
+extern NSString * const MenusRemoteKeyDescription;
+extern NSString * const MenusRemoteKeyLinkTarget;
+extern NSString * const MenusRemoteKeyLinkTitle;
+extern NSString * const MenusRemoteKeyName;
+extern NSString * const MenusRemoteKeyType;
+extern NSString * const MenusRemoteKeyTypeFamily;
+extern NSString * const MenusRemoteKeyTypeLabel;
+extern NSString * const MenusRemoteKeyURL;
+extern NSString * const MenusRemoteKeyItems;
+extern NSString * const MenusRemoteKeyDeleted;
+extern NSString * const MenusRemoteKeyLocationDefaultState;
+
+@class Blog;
+@class RemoteMenu;
+@class RemoteMenuItem;
+@class RemoteMenuLocation;
+
+typedef void(^MenusServiceRemoteSuccessBlock)();
+typedef void(^MenusServiceRemoteMenuRequestSuccessBlock)(RemoteMenu *menu);
+typedef void(^MenusServiceRemoteMenusRequestSuccessBlock)(NSArray<RemoteMenu *> *menus, NSArray<RemoteMenuLocation *> *locations);
+typedef void(^MenusServiceRemoteFailureBlock)(NSError *error);
+
+@interface MenusServiceRemote : ServiceRemoteREST
+
+#pragma mark - Remote queries: Creating and modifying menus
+
+/**
+ *  @brief      Create a new menu on a blog.
+ *
+ *  @param      menuName    The name of the new menu to be created.  Cannot be nil.
+ *  @param      blog        The blog to create the menu on.  Cannot be nil.
+ *  @param      success     The success handler.  Can be nil.
+ *  @param      failure     The failure handler.  Can be nil.
+ *
+ */
+- (void)createMenuWithName:(NSString *)menuName
+                      blog:(Blog *)blog
+                   success:(MenusServiceRemoteMenuRequestSuccessBlock)success
+                   failure:(MenusServiceRemoteFailureBlock)failure;
+
+/**
+ *  @brief      Update a menu on a blog.
+ *
+ *  @param      menu        The updated menu object to update remotely.  Cannot be nil.
+ *  @param      blog        The blog to update the menu on.  Cannot be nil.
+ *  @param      success     The success handler.  Can be nil.
+ *  @param      failure     The failure handler.  Can be nil.
+ *
+ */
+- (void)updateMenuForID:(NSNumber *)menuID
+                   blog:(Blog *)blog
+               withName:(NSString *)updatedName
+          withLocations:(NSArray<NSString *> *)locationNames
+              withItems:(NSArray<RemoteMenuItem *> *)updatedItems
+                success:(MenusServiceRemoteMenuRequestSuccessBlock)success
+                failure:(MenusServiceRemoteFailureBlock)failure;
+
+/**
+ *  @brief      Delete a menu from a blog.
+ *
+ *  @param      menuId      The menuId of the menu to delete remotely.  Cannot be nil.
+ *  @param      blog        The blog to delete the menu from.  Cannot be nil.
+ *  @param      success     The success handler.  Can be nil.
+ *  @param      failure     The failure handler.  Can be nil.
+ *
+ */
+- (void)deleteMenuForID:(NSNumber *)menuID
+                   blog:(Blog *)blog
+                success:(MenusServiceRemoteSuccessBlock)success
+                failure:(MenusServiceRemoteFailureBlock)failure;
+
+#pragma mark - Remote queries: Getting menus
+
+/**
+ *  @brief      Gets the available menus for a specific blog.
+ *
+ *  @param      blog        The blog to get the available menus for.  Cannot be nil.
+ *  @param      success     The success handler.  Can be nil.
+ *  @param      failure     The failure handler.  Can be nil.
+ *
+ */
+- (void)getMenusForBlog:(Blog *)blog
+                success:(MenusServiceRemoteMenusRequestSuccessBlock)success
+                failure:(MenusServiceRemoteFailureBlock)failure;
+
+@end

--- a/WordPress/Classes/Networking/MenusServiceRemote.m
+++ b/WordPress/Classes/Networking/MenusServiceRemote.m
@@ -1,0 +1,379 @@
+#import "MenusServiceRemote.h"
+#import "Blog.h"
+#import "WordPressComApi.h"
+#import "RemoteMenu.h"
+#import "RemoteMenuItem.h"
+#import "RemoteMenuLocation.h"
+
+NSString * const MenusRemoteKeyID = @"id";
+NSString * const MenusRemoteKeyMenu = @"menu";
+NSString * const MenusRemoteKeyMenus = @"menus";
+NSString * const MenusRemoteKeyLocations = @"locations";
+NSString * const MenusRemoteKeyContentID = @"content_id";
+NSString * const MenusRemoteKeyDescription = @"description";
+NSString * const MenusRemoteKeyLinkTarget = @"link_target";
+NSString * const MenusRemoteKeyLinkTitle = @"link_title";
+NSString * const MenusRemoteKeyName = @"name";
+NSString * const MenusRemoteKeyType = @"type";
+NSString * const MenusRemoteKeyTypeFamily = @"type_family";
+NSString * const MenusRemoteKeyTypeLabel = @"type_label";
+NSString * const MenusRemoteKeyURL = @"url";
+NSString * const MenusRemoteKeyItems = @"items";
+NSString * const MenusRemoteKeyDeleted = @"deleted";
+NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
+
+@implementation MenusServiceRemote
+
+#pragma mark - Remote queries: Creating and modifying menus
+
+- (void)createMenuWithName:(NSString *)menuName
+                      blog:(Blog *)blog
+                   success:(MenusServiceRemoteMenuRequestSuccessBlock)success
+                   failure:(MenusServiceRemoteFailureBlock)failure
+{
+    NSNumber *blogId = [blog dotComID];
+    NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
+    NSParameterAssert([menuName isKindOfClass:[NSString class]]);
+    
+    NSString *path = [NSString stringWithFormat:@"sites/%@/menus/new", blogId];
+    NSString *requestURL = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteRESTApiVersion_1_1];
+    
+    [self.api POST:requestURL
+        parameters:@{MenusRemoteKeyName: menuName}
+           success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+               if (success) {
+                   NSAssert([responseObject isKindOfClass:[NSDictionary class]], @"Expected a dictionary");
+                   
+                   NSNumber *menuID = [responseObject numberForKey:MenusRemoteKeyID];
+                   RemoteMenu *menu = nil;
+                   if (menuID) {
+                       menu = [RemoteMenu new];
+                       menu.menuID = menuID;
+                       menu.name = menuName;
+                   }
+                   
+                   success(menu);
+               }
+           } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
+               
+               if (failure) {
+                   failure(error);
+               }
+           }];
+}
+
+- (void)updateMenuForID:(NSNumber *)menuID
+                   blog:(Blog *)blog
+               withName:(NSString *)updatedName
+          withLocations:(NSArray <NSString *> *)locationNames
+              withItems:(NSArray <RemoteMenuItem *> *)updatedItems
+                success:(MenusServiceRemoteMenuRequestSuccessBlock)success
+                failure:(MenusServiceRemoteFailureBlock)failure
+{
+    NSNumber *blogId = [blog dotComID];
+    NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
+    NSParameterAssert([menuID isKindOfClass:[NSNumber class]]);
+    
+    NSString *path = [NSString stringWithFormat:@"sites/%@/menus/%@", blogId, menuID];
+    NSString *requestURL = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteRESTApiVersion_1_1];
+    
+    NSMutableDictionary *params = [NSMutableDictionary dictionaryWithCapacity:2];
+    if (updatedName.length) {
+        [params setObject:updatedName forKey:MenusRemoteKeyName];
+    }
+    if (updatedItems.count) {
+        [params setObject:[self menuItemJSONDictionariesFromMenuItems:updatedItems] forKey:MenusRemoteKeyItems];
+    }
+    if (locationNames.count) {
+        [params setObject:locationNames forKey:MenusRemoteKeyLocations];
+    }
+    
+    // temporarily need to force the id for the menu update to work until fixed in Jetpack endpoints
+    // Brent Coursey - 10/1/2015
+    [params setObject:menuID forKey:MenusRemoteKeyID];
+    
+    [self.api POST:requestURL
+        parameters:params
+           success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+               if (success) {
+                   NSAssert([responseObject isKindOfClass:[NSDictionary class]], @"Expected a dictionary...");
+                   NSDictionary *menuDictionary = [responseObject dictionaryForKey:MenusRemoteKeyMenu];
+                   success([self menuFromJSONDictionary:menuDictionary]);
+               }
+           } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
+               
+               if (failure) {
+                   failure(error);
+               }
+           }];
+}
+
+- (void)deleteMenuForID:(NSNumber *)menuID
+                   blog:(Blog *)blog
+                success:(MenusServiceRemoteSuccessBlock)success
+                failure:(MenusServiceRemoteFailureBlock)failure
+{
+    NSNumber *blogId = [blog dotComID];
+    NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
+    NSParameterAssert([menuID isKindOfClass:[NSNumber class]]);
+    
+    NSString *path = [NSString stringWithFormat:@"sites/%@/menus/%@/delete", blogId, menuID];
+    NSString *requestURL = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteRESTApiVersion_1_1];
+    [self.api POST:requestURL
+        parameters:nil
+           success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+               if (success) {
+                   NSAssert([responseObject isKindOfClass:[NSDictionary class]], @"Expected a dictionary");
+                   
+                   NSDictionary *response = responseObject;
+                   BOOL deleted = [[response numberForKey:MenusRemoteKeyDeleted] boolValue];
+                   if (deleted) {
+                       success();
+                   } else {
+                       failure(nil);
+                   }
+               }
+           } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
+               
+               if (failure) {
+                   failure(error);
+               }
+           }];
+}
+
+#pragma mark - Remote queries: Getting menus
+
+- (void)getMenusForBlog:(Blog *)blog
+                success:(MenusServiceRemoteMenusRequestSuccessBlock)success
+                failure:(MenusServiceRemoteFailureBlock)failure
+{
+    NSNumber *blogId = [blog dotComID];
+    NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
+    
+    NSString *path = [NSString stringWithFormat:@"sites/%@/menus", blogId];
+    NSString *requestURL = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteRESTApiVersion_1_1];
+    
+    [self.api GET:requestURL
+       parameters:nil
+          success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+              if (success) {
+                  
+                  NSArray *menus = [self remoteMenusFromJSONArray:[responseObject arrayForKey:MenusRemoteKeyMenus]];
+                  NSArray *locations = [self remoteMenuLocationsFromJSONArray:[responseObject arrayForKey:MenusRemoteKeyLocations]];
+                  success(menus, locations);
+              }
+              
+          } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
+              
+              if (failure) {
+                  failure(error);
+              }
+          }];
+}
+
+#pragma mark - Remote Model from JSON
+
+- (NSArray *)remoteMenusFromJSONArray:(NSArray<NSDictionary *> *)jsonMenus
+{
+    return [jsonMenus wp_map:^id(NSDictionary *dictionary) {
+        return [self menuFromJSONDictionary:dictionary];
+    }];
+}
+
+- (NSArray *)menuItemsFromJSONDictionaries:(NSArray<NSDictionary *> *)dictionaries parent:(RemoteMenuItem *)parent
+{
+    NSParameterAssert([dictionaries isKindOfClass:[NSArray class]]);
+    
+    return [dictionaries wp_map:^id(NSDictionary *dictionary) {
+        
+        RemoteMenuItem *item = [self menuItemFromJSONDictionary:dictionary];
+        item.parentItem = parent;
+        
+        return item;
+    }];
+}
+
+- (NSArray *)remoteMenuLocationsFromJSONArray:(NSArray<NSDictionary *> *)jsonLocations
+{
+    return [jsonLocations wp_map:^id(NSDictionary *dictionary) {
+        return [self menuLocationFromJSONDictionary:dictionary];
+    }];
+}
+
+/**
+ *  @brief      Creates a remote menu object from the specified dictionary with nested menu items.
+ *
+ *  @param      dictionary      The dictionary containing the menu information.  Cannot be nil.
+ *
+ *  @returns    A remote menu object.
+ */
+- (RemoteMenu *)menuFromJSONDictionary:(NSDictionary *)dictionary
+{
+    NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
+    
+    NSNumber *menuID = [dictionary numberForKey:MenusRemoteKeyID];
+    if (!menuID.integerValue) {
+        // empty menu dictionary
+        return nil;
+    }
+    
+    RemoteMenu *menu = [RemoteMenu new];
+    menu.menuID = menuID;
+    menu.details = [dictionary stringForKey:MenusRemoteKeyDescription];
+    menu.name = [dictionary stringForKey:MenusRemoteKeyName];
+    menu.locationNames = [dictionary arrayForKey:MenusRemoteKeyLocations];
+    
+    NSArray *itemDicts = [dictionary arrayForKey:MenusRemoteKeyItems];
+    if (itemDicts.count) {
+        menu.items = [self menuItemsFromJSONDictionaries:itemDicts parent:nil];
+    }
+    
+    return menu;
+}
+
+/**
+ *  @brief      Creates a remote menu item object from the specified dictionary along with any child items.
+ *
+ *  @param      dictionary      The dictionary containing the menu items.  Cannot be nil.
+ *
+ *  @returns    A remote menu item object.
+ */
+- (RemoteMenuItem *)menuItemFromJSONDictionary:(NSDictionary *)dictionary
+{
+    NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
+    
+    RemoteMenuItem *item = [RemoteMenuItem new];
+    item.itemID = [dictionary numberForKey:MenusRemoteKeyID];
+    item.contentID = [dictionary numberForKey:MenusRemoteKeyContentID];
+    item.details = [dictionary stringForKey:MenusRemoteKeyDescription];
+    item.linkTarget = [dictionary stringForKey:MenusRemoteKeyLinkTarget];
+    item.linkTitle = [dictionary stringForKey:MenusRemoteKeyLinkTitle];
+    item.name = [dictionary stringForKey:MenusRemoteKeyName];
+    item.type = [dictionary stringForKey:MenusRemoteKeyType];
+    item.typeFamily = [dictionary stringForKey:MenusRemoteKeyTypeFamily];
+    item.typeLabel = [dictionary stringForKey:MenusRemoteKeyTypeLabel];
+    item.urlStr = [dictionary stringForKey:MenusRemoteKeyURL];
+    
+    NSArray *itemDicts = [dictionary arrayForKey:MenusRemoteKeyItems];
+    if (itemDicts.count) {
+        item.children = [self menuItemsFromJSONDictionaries:itemDicts parent:item];
+    }
+    
+    return item;
+}
+
+/**
+ *  @brief      Creates a remote menu location object from the specified dictionary.
+ *
+ *  @param      dictionary      The dictionary containing the locations.  Cannot be nil.
+ *
+ *  @returns    A remote menu location object.
+ */
+- (RemoteMenuLocation *)menuLocationFromJSONDictionary:(NSDictionary *)dictionary
+{
+    NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
+    
+    RemoteMenuLocation *location = [RemoteMenuLocation new];
+    location.defaultState = [dictionary stringForKey:MenusRemoteKeyLocationDefaultState];
+    location.details = [dictionary stringForKey:MenusRemoteKeyDescription];
+    location.name = [dictionary stringForKey:MenusRemoteKeyName];
+    
+    return location;
+}
+
+#pragma mark - Remote model to JSON
+
+/**
+ *  @brief      Creates remote menu item JSON dictionaries from the remote menu item objects.
+ *
+ *  @param      menuItems      The array containing the menu items.  Cannot be nil.
+ *
+ *  @returns    An array with menu item JSON dictionary representations.
+ */
+- (NSArray *)menuItemJSONDictionariesFromMenuItems:(NSArray<RemoteMenuItem *> *)menuItems
+{
+    NSMutableArray *dictionaries = [NSMutableArray arrayWithCapacity:menuItems.count];
+    for (RemoteMenuItem *item in menuItems) {
+        [dictionaries addObject:[self menuItemJSONDictionaryFromItem:item]];
+    }
+    
+    return [NSArray arrayWithArray:dictionaries];
+}
+
+/**
+ *  @brief      Creates a remote menu item JSON dictionary from the remote menu item object, with nested item dictionaries.
+ *
+ *  @param      item      The remote menu item object.  Cannot be nil.
+ *
+ *  @returns    A JSON dictionary representation of the menu item object.
+ */
+- (NSDictionary *)menuItemJSONDictionaryFromItem:(RemoteMenuItem *)item
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    
+    if (item.itemID.integerValue) {
+        dictionary[MenusRemoteKeyID] = item.itemID;
+    }
+    
+    if (item.contentID.integerValue) {
+        dictionary[MenusRemoteKeyContentID] = item.contentID;
+    }
+    
+    if (item.details.length) {
+        dictionary[MenusRemoteKeyDescription] = item.details;
+    }
+    
+    if (item.linkTarget.length) {
+        dictionary[MenusRemoteKeyLinkTarget] = item.linkTarget;
+    }
+    
+    if (item.linkTitle.length) {
+        dictionary[MenusRemoteKeyLinkTitle] = item.linkTitle;
+    }
+    
+    if (item.name.length) {
+        dictionary[MenusRemoteKeyName] = item.name;
+    }
+    
+    if (item.type.length) {
+        dictionary[MenusRemoteKeyType] = item.type;
+    }
+    
+    if (item.typeFamily.length) {
+        dictionary[MenusRemoteKeyTypeFamily] = item.typeFamily;
+    }
+    
+    if (item.typeLabel.length) {
+        dictionary[MenusRemoteKeyTypeLabel] = item.typeLabel;
+    }
+    
+    if (item.urlStr.length) {
+        dictionary[MenusRemoteKeyURL] = item.urlStr;
+    }
+    
+    if (item.children.count) {
+        
+        NSMutableArray *dictionaryItems = [NSMutableArray arrayWithCapacity:item.children.count];
+        for (RemoteMenuItem *remoteItem in item.children) {
+            [dictionaryItems addObject:[self menuItemJSONDictionaryFromItem:remoteItem]];
+        }
+        
+        dictionary[MenusRemoteKeyItems] = [NSArray arrayWithArray:dictionaryItems];
+    }
+    
+    return [NSDictionary dictionaryWithDictionary:dictionary];
+}
+
+- (NSDictionary *)menuLocationJSONDictionaryFromLocation:(RemoteMenuLocation *)location
+{
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionary];
+    [dictionary setObject:MenusRemoteKeyName forKey:location.name];
+    
+    return [NSDictionary dictionaryWithDictionary:dictionary];
+}
+
+@end

--- a/WordPress/Classes/Networking/MenusServiceRemote.m
+++ b/WordPress/Classes/Networking/MenusServiceRemote.m
@@ -6,6 +6,8 @@
 #import "RemoteMenuLocation.h"
 #import "WordPressRestApi.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 NSString * const MenusRemoteKeyID = @"id";
 NSString * const MenusRemoteKeyMenu = @"menu";
 NSString * const MenusRemoteKeyMenus = @"menus";
@@ -29,8 +31,8 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
 
 - (void)createMenuWithName:(NSString *)menuName
                       blog:(Blog *)blog
-                   success:(MenusServiceRemoteMenuRequestSuccessBlock)success
-                   failure:(MenusServiceRemoteFailureBlock)failure
+                   success:(nullable MenusServiceRemoteMenuRequestSuccessBlock)success
+                   failure:(nullable MenusServiceRemoteFailureBlock)failure
 {
     NSNumber *blogId = [blog dotComID];
     NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
@@ -43,23 +45,22 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
     [self.api POST:requestURL
         parameters:@{MenusRemoteKeyName: menuName}
            success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+               void(^responseFailure)() = ^() {
+                   NSString *message = NSLocalizedString(@"An error occurred creating the Menu.", @"An error description explaining that a Menu could not be created.");
+                   [self handleResponseErrorWithMessage:message url:requestURL failure:failure];
+               };
+               NSNumber *menuID = [responseObject numberForKey:MenusRemoteKeyID];
+               if (!menuID) {
+                   responseFailure();
+                   return;
+               }
                if (success) {
-                   if (![responseObject isKindOfClass:[NSDictionary class]]) {
-                       NSString *message = NSLocalizedString(@"An error occurred creating the Menu.", @"An error description explaining that a Menu could not be created.");
-                       [self handleResponseErrorWithMessage:message url:requestURL failure:failure];
-                       return;
-                   }
-                   NSNumber *menuID = [responseObject numberForKey:MenusRemoteKeyID];
-                   RemoteMenu *menu = nil;
-                   if (menuID) {
-                       menu = [RemoteMenu new];
-                       menu.menuID = menuID;
-                       menu.name = menuName;
-                   }
+                   RemoteMenu *menu = [RemoteMenu new];
+                   menu.menuID = menuID;
+                   menu.name = menuName;
                    success(menu);
                }
            } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
-               
                if (failure) {
                    failure(error);
                }
@@ -68,11 +69,11 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
 
 - (void)updateMenuForID:(NSNumber *)menuID
                    blog:(Blog *)blog
-               withName:(NSString *)updatedName
-          withLocations:(NSArray <NSString *> *)locationNames
-              withItems:(NSArray <RemoteMenuItem *> *)updatedItems
-                success:(MenusServiceRemoteMenuRequestSuccessBlock)success
-                failure:(MenusServiceRemoteFailureBlock)failure
+               withName:(nullable NSString *)updatedName
+          withLocations:(nullable NSArray <NSString *> *)locationNames
+              withItems:(nullable NSArray <RemoteMenuItem *> *)updatedItems
+                success:(nullable MenusServiceRemoteMenuRequestSuccessBlock)success
+                failure:(nullable MenusServiceRemoteFailureBlock)failure
 {
     NSNumber *blogId = [blog dotComID];
     NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
@@ -100,17 +101,23 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
     [self.api POST:requestURL
         parameters:params
            success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+               void(^responseFailure)() = ^() {
+                   NSString *message = NSLocalizedString(@"An error occurred updating the Menu.", @"An error description explaining that a Menu could not be updated.");
+                   [self handleResponseErrorWithMessage:message url:requestURL failure:failure];
+               };
+               if (![responseObject isKindOfClass:[NSDictionary class]]) {
+                   responseFailure();
+                   return;
+               }
+               RemoteMenu *menu = [self menuFromJSONDictionary:[responseObject dictionaryForKey:MenusRemoteKeyMenu]];
+               if (!menu) {
+                   responseFailure();
+                   return;
+               }
                if (success) {
-                   if (![responseObject isKindOfClass:[NSDictionary class]]) {
-                       NSString *message = NSLocalizedString(@"An error occurred updating the Menu.", @"An error description explaining that a Menu could not be updated.");
-                       [self handleResponseErrorWithMessage:message url:requestURL failure:failure];
-                       return;
-                   }
-                   NSDictionary *menuDictionary = [responseObject dictionaryForKey:MenusRemoteKeyMenu];
-                   success([self menuFromJSONDictionary:menuDictionary]);
+                   success(menu);
                }
            } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
-               
                if (failure) {
                    failure(error);
                }
@@ -119,8 +126,8 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
 
 - (void)deleteMenuForID:(NSNumber *)menuID
                    blog:(Blog *)blog
-                success:(MenusServiceRemoteSuccessBlock)success
-                failure:(MenusServiceRemoteFailureBlock)failure
+                success:(nullable MenusServiceRemoteSuccessBlock)success
+                failure:(nullable MenusServiceRemoteFailureBlock)failure
 {
     NSNumber *blogId = [blog dotComID];
     NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
@@ -132,22 +139,23 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
     [self.api POST:requestURL
         parameters:nil
            success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
-               if (success) {
-                   if (![responseObject isKindOfClass:[NSDictionary class]]) {
-                       NSString *message = NSLocalizedString(@"An error occurred deleting the Menu.", @"An error description explaining that a Menu could not be deleted.");
-                       [self handleResponseErrorWithMessage:message url:requestURL failure:failure];
-                       return;
-                   }
-                   NSDictionary *response = responseObject;
-                   BOOL deleted = [[response numberForKey:MenusRemoteKeyDeleted] boolValue];
-                   if (deleted) {
+               void(^responseFailure)() = ^() {
+                   NSString *message = NSLocalizedString(@"An error occurred deleting the Menu.", @"An error description explaining that a Menu could not be deleted.");
+                   [self handleResponseErrorWithMessage:message url:requestURL failure:failure];
+               };
+               if (![responseObject isKindOfClass:[NSDictionary class]]) {
+                   responseFailure();
+                   return;
+               }
+               BOOL deleted = [[responseObject numberForKey:MenusRemoteKeyDeleted] boolValue];
+               if (deleted) {
+                   if (success) {
                        success();
-                   } else {
-                       failure(nil);
                    }
+               } else {
+                   responseFailure();
                }
            } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
-               
                if (failure) {
                    failure(error);
                }
@@ -157,8 +165,8 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
 #pragma mark - Remote queries: Getting menus
 
 - (void)getMenusForBlog:(Blog *)blog
-                success:(MenusServiceRemoteMenusRequestSuccessBlock)success
-                failure:(MenusServiceRemoteFailureBlock)failure
+                success:(nullable MenusServiceRemoteMenusRequestSuccessBlock)success
+                failure:(nullable MenusServiceRemoteFailureBlock)failure
 {
     NSNumber *blogId = [blog dotComID];
     NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
@@ -182,7 +190,6 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
               }
               
           } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
-              
               if (failure) {
                   failure(error);
               }
@@ -191,17 +198,16 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
 
 #pragma mark - Remote Model from JSON
 
-- (NSArray *)remoteMenusFromJSONArray:(NSArray<NSDictionary *> *)jsonMenus
+- (nullable NSArray *)remoteMenusFromJSONArray:(nullable NSArray<NSDictionary *> *)jsonMenus
 {
     return [jsonMenus wp_map:^id(NSDictionary *dictionary) {
         return [self menuFromJSONDictionary:dictionary];
     }];
 }
 
-- (NSArray *)menuItemsFromJSONDictionaries:(NSArray<NSDictionary *> *)dictionaries parent:(RemoteMenuItem *)parent
+- (nullable NSArray *)menuItemsFromJSONDictionaries:(nullable NSArray<NSDictionary *> *)dictionaries parent:(nullable RemoteMenuItem *)parent
 {
     NSParameterAssert([dictionaries isKindOfClass:[NSArray class]]);
-    
     return [dictionaries wp_map:^id(NSDictionary *dictionary) {
         
         RemoteMenuItem *item = [self menuItemFromJSONDictionary:dictionary];
@@ -211,7 +217,7 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
     }];
 }
 
-- (NSArray *)remoteMenuLocationsFromJSONArray:(NSArray<NSDictionary *> *)jsonLocations
+- (nullable NSArray *)remoteMenuLocationsFromJSONArray:(nullable NSArray<NSDictionary *> *)jsonLocations
 {
     return [jsonLocations wp_map:^id(NSDictionary *dictionary) {
         return [self menuLocationFromJSONDictionary:dictionary];
@@ -225,7 +231,7 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
  *
  *  @returns    A remote menu object.
  */
-- (RemoteMenu *)menuFromJSONDictionary:(NSDictionary *)dictionary
+- (nullable RemoteMenu *)menuFromJSONDictionary:(nullable NSDictionary *)dictionary
 {
     NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
     if (![dictionary isKindOfClass:[NSDictionary class]]) {
@@ -259,10 +265,10 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
  *
  *  @returns    A remote menu item object.
  */
-- (RemoteMenuItem *)menuItemFromJSONDictionary:(NSDictionary *)dictionary
+- (nullable RemoteMenuItem *)menuItemFromJSONDictionary:(nullable NSDictionary *)dictionary
 {
     NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
-    if (![dictionary isKindOfClass:[NSDictionary class]]) {
+    if (![dictionary isKindOfClass:[NSDictionary class]] || !dictionary.count) {
         return nil;
     }
     
@@ -293,10 +299,10 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
  *
  *  @returns    A remote menu location object.
  */
-- (RemoteMenuLocation *)menuLocationFromJSONDictionary:(NSDictionary *)dictionary
+- (nullable RemoteMenuLocation *)menuLocationFromJSONDictionary:(nullable NSDictionary *)dictionary
 {
     NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
-    if (![dictionary isKindOfClass:[NSDictionary class]]) {
+    if (![dictionary isKindOfClass:[NSDictionary class]] || !dictionary.count) {
         return nil;
     }
     
@@ -401,7 +407,7 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
 
 #pragma mark - errors
 
-- (void)handleResponseErrorWithMessage:(NSString *)message url:(NSString *)urlStr failure:(MenusServiceRemoteFailureBlock)failure
+- (void)handleResponseErrorWithMessage:(NSString *)message url:(NSString *)urlStr failure:(nullable MenusServiceRemoteFailureBlock)failure
 {
     DDLogError(@"%@ - URL: %@", message, urlStr);
     NSError *error = [NSError errorWithDomain:NSURLErrorDomain
@@ -413,3 +419,5 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Networking/Remote Objects/RemoteMenu.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteMenu.h
@@ -5,10 +5,10 @@
 
 @interface RemoteMenu : NSObject
 
-@property (nonatomic, copy) NSNumber *menuID;
-@property (nonatomic, copy) NSString *details;
-@property (nonatomic, copy) NSString *name;
-@property (nonatomic, strong) NSArray<RemoteMenuItem *> *items;
-@property (nonatomic, strong) NSArray<NSString *> *locationNames;
+@property (nullable, nonatomic, copy) NSNumber *menuID;
+@property (nullable, nonatomic, copy) NSString *details;
+@property (nullable, nonatomic, copy) NSString *name;
+@property (nullable, nonatomic, strong) NSArray<RemoteMenuItem *> *items;
+@property (nullable, nonatomic, strong) NSArray<NSString *> *locationNames;
 
 @end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteMenu.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteMenu.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+@class RemoteMenuItem;
+@class RemoteMenuLocation;
+
+@interface RemoteMenu : NSObject
+
+@property (nonatomic, copy) NSNumber *menuID;
+@property (nonatomic, copy) NSString *details;
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, strong) NSArray<RemoteMenuItem *> *items;
+@property (nonatomic, strong) NSArray<NSString *> *locationNames;
+
+@end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteMenu.m
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteMenu.m
@@ -1,0 +1,5 @@
+#import "RemoteMenu.h"
+
+@implementation RemoteMenu
+
+@end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteMenuItem.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteMenuItem.h
@@ -2,18 +2,18 @@
 
 @interface RemoteMenuItem : NSObject
 
-@property (nonatomic, copy) NSNumber *itemID;
-@property (nonatomic, copy) NSNumber *contentID;
-@property (nonatomic, copy) NSString *details;
-@property (nonatomic, copy) NSString *linkTarget;
-@property (nonatomic, copy) NSString *linkTitle;
-@property (nonatomic, copy) NSString *name;
-@property (nonatomic, copy) NSString *type;
-@property (nonatomic, copy) NSString *typeFamily;
-@property (nonatomic, copy) NSString *typeLabel;
-@property (nonatomic, copy) NSString *urlStr;
+@property (nullable, nonatomic, copy) NSNumber *itemID;
+@property (nullable, nonatomic, copy) NSNumber *contentID;
+@property (nullable, nonatomic, copy) NSString *details;
+@property (nullable, nonatomic, copy) NSString *linkTarget;
+@property (nullable, nonatomic, copy) NSString *linkTitle;
+@property (nullable, nonatomic, copy) NSString *name;
+@property (nullable, nonatomic, copy) NSString *type;
+@property (nullable, nonatomic, copy) NSString *typeFamily;
+@property (nullable, nonatomic, copy) NSString *typeLabel;
+@property (nullable, nonatomic, copy) NSString *urlStr;
 
-@property (nonatomic, strong) NSArray<RemoteMenuItem *> *children;
-@property (nonatomic, weak) RemoteMenuItem *parentItem;
+@property (nullable, nonatomic, strong) NSArray<RemoteMenuItem *> *children;
+@property (nullable, nonatomic, weak) RemoteMenuItem *parentItem;
 
 @end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteMenuItem.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteMenuItem.h
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+
+@interface RemoteMenuItem : NSObject
+
+@property (nonatomic, copy) NSNumber *itemID;
+@property (nonatomic, copy) NSNumber *contentID;
+@property (nonatomic, copy) NSString *details;
+@property (nonatomic, copy) NSString *linkTarget;
+@property (nonatomic, copy) NSString *linkTitle;
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, copy) NSString *type;
+@property (nonatomic, copy) NSString *typeFamily;
+@property (nonatomic, copy) NSString *typeLabel;
+@property (nonatomic, copy) NSString *urlStr;
+
+@property (nonatomic, strong) NSArray<RemoteMenuItem *> *children;
+@property (nonatomic, weak) RemoteMenuItem *parentItem;
+
+@end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteMenuItem.m
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteMenuItem.m
@@ -1,0 +1,5 @@
+#import "RemoteMenuItem.h"
+
+@implementation RemoteMenuItem
+
+@end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteMenuLocation.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteMenuLocation.h
@@ -2,8 +2,8 @@
 
 @interface RemoteMenuLocation : NSObject
 
-@property (nonatomic, copy) NSString *name;
-@property (nonatomic, copy) NSString *defaultState;
-@property (nonatomic, copy) NSString *details;
+@property (nullable, nonatomic, copy) NSString *name;
+@property (nullable, nonatomic, copy) NSString *defaultState;
+@property (nullable, nonatomic, copy) NSString *details;
 
 @end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteMenuLocation.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteMenuLocation.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@interface RemoteMenuLocation : NSObject
+
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, copy) NSString *defaultState;
+@property (nonatomic, copy) NSString *details;
+
+@end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteMenuLocation.m
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteMenuLocation.m
@@ -1,0 +1,5 @@
+#import "RemoteMenuLocation.h"
+
+@implementation RemoteMenuLocation
+
+@end

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -39,6 +39,11 @@
 		082AB9D91C4EEEF4000CA523 /* PostTagService.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9D81C4EEEF4000CA523 /* PostTagService.m */; };
 		082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9DC1C4F035E000CA523 /* PostTag.m */; };
 		08472A201C727E020040769D /* PostServiceOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 08472A1F1C727E020040769D /* PostServiceOptions.m */; };
+		0859DCF61CB847F700EB4069 /* RemoteMenu.m in Sources */ = {isa = PBXBuildFile; fileRef = 0859DCF11CB847F700EB4069 /* RemoteMenu.m */; };
+		0859DCF71CB847F700EB4069 /* RemoteMenuItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 0859DCF31CB847F700EB4069 /* RemoteMenuItem.m */; };
+		0859DCF81CB847F700EB4069 /* RemoteMenuLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0859DCF51CB847F700EB4069 /* RemoteMenuLocation.m */; };
+		0859DCFB1CB8482200EB4069 /* MenusServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = 0859DCFA1CB8482200EB4069 /* MenusServiceRemote.m */; };
+		0859DCFD1CB8488400EB4069 /* MenusServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0859DCFC1CB8488400EB4069 /* MenusServiceRemoteTests.m */; };
 		08A6FD9C1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A6FD9B1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m */; };
 		08B6D6F31C8F7DCE0052C52B /* PostType.m in Sources */ = {isa = PBXBuildFile; fileRef = 08B6D6F11C8F7DCE0052C52B /* PostType.m */; };
 		08B6D6F91C8F7EF20052C52B /* RemotePostType.m in Sources */ = {isa = PBXBuildFile; fileRef = 08B6D6F81C8F7EF20052C52B /* RemotePostType.m */; };
@@ -837,6 +842,15 @@
 		082AB9DC1C4F035E000CA523 /* PostTag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostTag.m; sourceTree = "<group>"; };
 		08472A1E1C7273FA0040769D /* PostServiceOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PostServiceOptions.h; sourceTree = "<group>"; };
 		08472A1F1C727E020040769D /* PostServiceOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostServiceOptions.m; sourceTree = "<group>"; };
+		0859DCF01CB847F700EB4069 /* RemoteMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteMenu.h; path = "Remote Objects/RemoteMenu.h"; sourceTree = "<group>"; };
+		0859DCF11CB847F700EB4069 /* RemoteMenu.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteMenu.m; path = "Remote Objects/RemoteMenu.m"; sourceTree = "<group>"; };
+		0859DCF21CB847F700EB4069 /* RemoteMenuItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteMenuItem.h; path = "Remote Objects/RemoteMenuItem.h"; sourceTree = "<group>"; };
+		0859DCF31CB847F700EB4069 /* RemoteMenuItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteMenuItem.m; path = "Remote Objects/RemoteMenuItem.m"; sourceTree = "<group>"; };
+		0859DCF41CB847F700EB4069 /* RemoteMenuLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteMenuLocation.h; path = "Remote Objects/RemoteMenuLocation.h"; sourceTree = "<group>"; };
+		0859DCF51CB847F700EB4069 /* RemoteMenuLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteMenuLocation.m; path = "Remote Objects/RemoteMenuLocation.m"; sourceTree = "<group>"; };
+		0859DCF91CB8482200EB4069 /* MenusServiceRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusServiceRemote.h; sourceTree = "<group>"; };
+		0859DCFA1CB8482200EB4069 /* MenusServiceRemote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusServiceRemote.m; sourceTree = "<group>"; };
+		0859DCFC1CB8488400EB4069 /* MenusServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusServiceRemoteTests.m; sourceTree = "<group>"; };
 		08A6FD9A1C5960AB00AC33E4 /* RemoteTaxonomyPaging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteTaxonomyPaging.h; path = "Remote Objects/RemoteTaxonomyPaging.h"; sourceTree = "<group>"; };
 		08A6FD9B1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteTaxonomyPaging.m; path = "Remote Objects/RemoteTaxonomyPaging.m"; sourceTree = "<group>"; };
 		08B6D6F01C8F7DCE0052C52B /* PostType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostType.h; sourceTree = "<group>"; };
@@ -2430,6 +2444,7 @@
 				E13BF2C91C522A1300275BE9 /* AccountSettingsRemoteTests.swift */,
 				591CFB081B28AC8C009E61B3 /* BlogServiceRemoteRESTTests.m */,
 				FA9E74471C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift */,
+				0859DCFC1CB8488400EB4069 /* MenusServiceRemoteTests.m */,
 				59E2AAEB1B20E5CE0051DC06 /* PostServiceRemoteRESTTests.m */,
 				59E2AAE71B20E3EA0051DC06 /* ServiceRemoteRESTTests.m */,
 				598F86AA1B67BD7600550C9C /* ThemeServiceRemoteTests.m */,
@@ -2767,6 +2782,8 @@
 				E149D64B19349E69006A843D /* MediaServiceRemoteREST.m */,
 				E149D64C19349E69006A843D /* MediaServiceRemoteXMLRPC.h */,
 				E149D64D19349E69006A843D /* MediaServiceRemoteXMLRPC.m */,
+				0859DCF91CB8482200EB4069 /* MenusServiceRemote.h */,
+				0859DCFA1CB8482200EB4069 /* MenusServiceRemote.m */,
 				B5EFB1C41B31BAA2007608A3 /* NotificationsServiceRemote.swift */,
 				E166FA211BB1359E00374B5B /* PeopleRemote.swift */,
 				93D6D6461924FDAD00A4F44A /* TaxonomyServiceRemote.h */,
@@ -3916,6 +3933,12 @@
 				E1B289DA19F7AF7000DB0707 /* RemoteBlog.m */,
 				FF3DD6BF19F2B77A003A52CB /* RemoteMedia.h */,
 				FF3DD6BD19F2B6B3003A52CB /* RemoteMedia.m */,
+				0859DCF01CB847F700EB4069 /* RemoteMenu.h */,
+				0859DCF11CB847F700EB4069 /* RemoteMenu.m */,
+				0859DCF21CB847F700EB4069 /* RemoteMenuItem.h */,
+				0859DCF31CB847F700EB4069 /* RemoteMenuItem.m */,
+				0859DCF41CB847F700EB4069 /* RemoteMenuLocation.h */,
+				0859DCF51CB847F700EB4069 /* RemoteMenuLocation.m */,
 				B52D29A41B66BEB70010BD3D /* RemoteNotificationSettings.swift */,
 				E6E27D5F1C613B3C0063F821 /* RemoteSharingButton.swift */,
 				5DED0E121B42E3E400431FCD /* RemoteSourcePostAttribution.h */,
@@ -4948,6 +4971,7 @@
 				594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */,
 				C56636E91868D0CE00226AAB /* StatsViewController.m in Sources */,
 				F128C31C1AFCC95B008C2404 /* WPMediaPickerViewController+StatusBarStyle.m in Sources */,
+				0859DCF81CB847F700EB4069 /* RemoteMenuLocation.m in Sources */,
 				E12E6E331C21BA170033C5D0 /* FeatureFlag.swift in Sources */,
 				E1B9128F1BB05B1D003C25B9 /* PeopleCell.swift in Sources */,
 				313AE4A019E3F20400AAFABE /* CommentViewController.m in Sources */,
@@ -5079,10 +5103,12 @@
 				E1F80825146420B000726BC7 /* UIImageView+Gravatar.m in Sources */,
 				B576B4881C6A22FB0027C754 /* Languages.swift in Sources */,
 				E6E27D621C6144DB0063F821 /* SharingButton.swift in Sources */,
+				0859DCFB1CB8482200EB4069 /* MenusServiceRemote.m in Sources */,
 				E6374DC01C444D8B00F24720 /* PublicizeConnection.swift in Sources */,
 				5D17F0BE1A1D4C5F0087CCB8 /* PrivateSiteURLProtocol.m in Sources */,
 				E14B40FF1C58B93F005046F6 /* SettingsCommon.swift in Sources */,
 				B58FD8CE1C7256DF00E5F6A4 /* NotificationsViewController+RowActions.swift in Sources */,
+				0859DCF71CB847F700EB4069 /* RemoteMenuItem.m in Sources */,
 				937D9A0F19F83812007B9D5F /* WordPress-22-23.xcmappingmodel in Sources */,
 				5D1D04761B7A50B100CDE646 /* ReaderStreamViewController.swift in Sources */,
 				B587798619B799EB00E57C5A /* Notification+Interface.swift in Sources */,
@@ -5272,6 +5298,7 @@
 				E66969DA1B9E55AB00EC9C00 /* ReaderTopicToReaderTagTopic37to38.swift in Sources */,
 				85D239AD1AE5A5FC0074768D /* AccountServiceFacade.m in Sources */,
 				B54E1DF11A0A7BAA00807537 /* ReplyTextView.swift in Sources */,
+				0859DCF61CB847F700EB4069 /* RemoteMenu.m in Sources */,
 				5DF94E461962BAA700359241 /* WPRichTextView.m in Sources */,
 				FA87F1AC1C4F2DEF004A92D1 /* SiteManagementServiceRemote.swift in Sources */,
 				E6D3E8491BEBD871002692E8 /* ReaderCrossPostCell.swift in Sources */,
@@ -5442,6 +5469,7 @@
 				59E2AAEC1B20E5CE0051DC06 /* PostServiceRemoteRESTTests.m in Sources */,
 				5D7A57801AFBFD940097C028 /* BasePostTest.m in Sources */,
 				8514B8D41AE85B19007E58BA /* WPAnalyticsTrackerMixpanelTests.m in Sources */,
+				0859DCFD1CB8488400EB4069 /* MenusServiceRemoteTests.m in Sources */,
 				931D26F719ED7F7500114F17 /* ReaderPostServiceTest.m in Sources */,
 				B5772AC61C9C84900031F97E /* GravatarServiceTests.swift in Sources */,
 				E1E1AA8F1B7DF54B001C8645 /* WPMapFilterReduceTest.m in Sources */,

--- a/WordPress/WordPressTest/MenusServiceRemoteTests.m
+++ b/WordPress/WordPressTest/MenusServiceRemoteTests.m
@@ -1,0 +1,129 @@
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+#import "Blog.h"
+#import "ContextManager.h"
+#import "MenusServiceRemote.h"
+#import "TestContextManager.h"
+#import "WordPressComApi.h"
+#import "RemoteMenu.h"
+
+@interface MenusServicRemoteTests : XCTestCase
+
+@end
+
+@implementation MenusServicRemoteTests
+
+- (void)testThatCreateMenuWithNameWorks
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    MenusServiceRemote *service = nil;
+    
+    RemoteMenu *menu = OCMClassMock([RemoteMenu class]);
+    OCMStub([menu menuID]).andReturn(@(1));
+    OCMStub([menu name]).andReturn(@"Name");
+
+    NSString* url = [NSString stringWithFormat:@"v1.1/sites/%@/menus/new", [blog dotComID]];
+    NSString *name = @"SomeName";
+    
+    BOOL (^parametersCheckBlock)(id obj) = ^BOOL(NSDictionary *parameters) {
+        
+        return ([parameters isKindOfClass:[NSDictionary class]]
+                && [[parameters objectForKey:@"name"] isEqualToString:name]);
+    };
+    
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithApi:api]);
+    
+    [service createMenuWithName:name
+                           blog:blog
+                        success:^(RemoteMenu *menu) {}
+                        failure:^(NSError *error) {}];
+}
+
+- (void)testThatUpdateMenuWorks
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    MenusServiceRemote *service = nil;
+    
+    RemoteMenu *menu = OCMClassMock([RemoteMenu class]);
+    OCMStub([menu menuID]).andReturn(@(1));
+    OCMStub([menu name]).andReturn(@"Name");
+    
+    NSString* url = [NSString stringWithFormat:@"v1.1/sites/%@/menus/%@", [blog dotComID], menu.menuID];
+    
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg isKindOfClass:[NSDictionary class]]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithApi:api]);
+
+    [service updateMenuForID:menu.menuID
+                        blog:blog
+                    withName:menu.name
+               withLocations:nil
+                   withItems:nil
+                     success:^(RemoteMenu *menu) {}
+                     failure:^(NSError *error) {}];
+}
+
+- (void)testThatDeleteMenuWorks
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    MenusServiceRemote *service = nil;
+    
+    RemoteMenu *menu = OCMClassMock([RemoteMenu class]);
+    OCMStub([menu menuID]).andReturn(@(1));
+    OCMStub([menu name]).andReturn(@"Name");
+    
+    NSString* url = [NSString stringWithFormat:@"v1.1/sites/%@/menus/%@/delete", [blog dotComID], menu.menuID];
+    
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg isNil]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithApi:api]);
+    
+    [service deleteMenuForID:menu.menuID
+                        blog:blog
+                    success:^{}
+                    failure:^(NSError *error) {}];
+}
+
+- (void)testThatGetMenusWorks
+{
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    OCMStub([blog dotComID]).andReturn(@10);
+    
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    MenusServiceRemote *service = nil;
+    
+    NSString* url = [NSString stringWithFormat:@"v1.1/sites/%@/menus", [blog dotComID]];
+    
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithApi:api]);
+    
+    [service getMenusForBlog:blog
+                     success:^(NSArray<RemoteMenu *> *menus, NSArray<RemoteMenuLocation *> *locations) {}
+                     failure:^(NSError *error) {}];
+}
+
+@end


### PR DESCRIPTION
Adds the Menus remote service and unit tests. The Menus API is only available over the REST API, so no XML-RPC remote is needed here.

- `RemoteMenu` is a site menu itself.
- `RemoteMenuLocation` is a location/area in which a menu can appear on a site/theme.
- `RemoteMenuItem` are the individual items/link for a menu.

To test:
- Run the tests under `MenusServiceRemoteTests` and check for all passing.

Needs review: @diegoreymendez would please review? 💃💃💃
