### PR TITLE
Menus: model object additions and refactor

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -3,6 +3,12 @@
 This file documents changes in the data model. Please explain any changes to the
 data model as well as any custom migrations.
 
+## (@kurzee 2016-04-08)
+
+- `Menu` changing `menuId` attribute to `menuID` as a int_32 number instead of string.
+- `MenuItem` changing `itemId` attribute to `itemID` as an int_32 number instead of string.
+- `MenuItem` changing `contentId` attribute to `contentID` as an int_64 number instead of string.
+
 ## WordPress 48 (@sergioestevao 2016-04-05)
 
 - `Media` added new integer attribute `postID` to store the post to where the media is attached to.

--- a/WordPress/Classes/Models/Menu.h
+++ b/WordPress/Classes/Models/Menu.h
@@ -4,28 +4,35 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSInteger const MenuDefaultID;
+
 /**
  *  @brief    An object encapsulating a Menu, the locations using it, and the items belonging to it.
  */
 @interface Menu : NSManagedObject
 
-@property (nullable, nonatomic, retain) NSString *details;
-@property (nullable, nonatomic, retain) NSString *menuId;
-@property (nullable, nonatomic, retain) NSString *name;
+@property (nullable, nonatomic, strong) NSString *details;
+@property (nullable, nonatomic, strong) NSNumber *menuID;
+@property (nullable, nonatomic, strong) NSString *name;
 
 ///---------------------
 /// @name Relationships
 ///---------------------
 
-@property (nullable, nonatomic, retain) NSOrderedSet<MenuItem *> *items;
-@property (nullable, nonatomic, retain) NSSet<MenuLocation *> *locations;
-@property (nullable, nonatomic, retain) Blog *blog;
+@property (nullable, nonatomic, strong) NSOrderedSet<MenuItem *> *items;
+@property (nullable, nonatomic, strong) NSSet<MenuLocation *> *locations;
+@property (nullable, nonatomic, strong) Blog *blog;
 
 ///---------------------
 /// @name Helper methods
 ///---------------------
 
 + (NSString *)entityName;
+
++ (Menu *)newMenu:(NSManagedObjectContext *)managedObjectContext;
++ (Menu *)defaultMenuForBlog:(Blog *)blog;
++ (Menu *)newDefaultMenu:(NSManagedObjectContext *)managedObjectContext;
++ (NSString *)defaultMenuName;
 
 @end
 

--- a/WordPress/Classes/Models/Menu.m
+++ b/WordPress/Classes/Models/Menu.m
@@ -39,7 +39,6 @@ NSInteger const MenuDefaultID = 0;
 
 + (Menu *)newDefaultMenu:(NSManagedObjectContext *)managedObjectContext
 {
-    // Create a new default menu.
     Menu *defaultMenu = [self newMenu:managedObjectContext];
     defaultMenu.menuID = @(MenuDefaultID);
     defaultMenu.name = [self defaultMenuName];

--- a/WordPress/Classes/Models/Menu.m
+++ b/WordPress/Classes/Models/Menu.m
@@ -1,11 +1,14 @@
 #import "Menu.h"
 #import "MenuItem.h"
 #import "MenuLocation.h"
+#import "Blog.h"
+
+NSInteger const MenuDefaultID = 0;
 
 @implementation Menu
 
 @dynamic details;
-@dynamic menuId;
+@dynamic menuID;
 @dynamic name;
 @dynamic items;
 @dynamic locations;
@@ -14,6 +17,38 @@
 + (NSString *)entityName
 {
     return NSStringFromClass([self class]);
+}
+
++ (Menu *)newMenu:(NSManagedObjectContext *)managedObjectContext
+{
+    Menu *newMenu = [NSEntityDescription insertNewObjectForEntityForName:[Menu entityName] inManagedObjectContext:managedObjectContext];
+    return newMenu;
+}
+
++ (Menu *)defaultMenuForBlog:(Blog *)blog
+{
+    Menu *defaultMenu = nil;
+    for (Menu *menu in blog.menus) {
+        if (menu.menuID.integerValue == MenuDefaultID) {
+            defaultMenu = menu;
+            break;
+        }
+    }
+    return defaultMenu;
+}
+
++ (Menu *)newDefaultMenu:(NSManagedObjectContext *)managedObjectContext
+{
+    // Create a new default menu.
+    Menu *defaultMenu = [self newMenu:managedObjectContext];
+    defaultMenu.menuID = @(MenuDefaultID);
+    defaultMenu.name = [self defaultMenuName];
+    return defaultMenu;
+}
+
++ (NSString *)defaultMenuName
+{
+    return NSLocalizedString(@"Default Menu", @"Menu name for the defaut menu that is automatically generated.");
 }
 
 @end

--- a/WordPress/Classes/Models/MenuItem.h
+++ b/WordPress/Classes/Models/MenuItem.h
@@ -98,7 +98,13 @@ extern NSString * const MenuItemLinkTargetBlank;
  */
 - (BOOL)isDescendantOfItem:(MenuItem *)item;
 
-- (MenuItem *)lastOrderedDescendantInOrderedItems:(NSOrderedSet *)orderedSet;
+/**
+ Search an ordered set for the last occurring descendant of self.
+ Useful for detecting the end of a list of related parent/child items for additions and ordering.
+ @param orderedItems an ordered set of items nested top-down as a parent followed by children. (as returned from the Menus API)
+ @returns MenuItem the last child of self to occur in the ordered set.
+ */
+- (MenuItem *)lastDescendantInOrderedItems:(NSOrderedSet *)orderedItems;
 
 /**
  The item's name is nil, empty, or the default string.

--- a/WordPress/Classes/Models/MenuItem.h
+++ b/WordPress/Classes/Models/MenuItem.h
@@ -1,101 +1,109 @@
 #import <CoreData/CoreData.h>
 
-typedef NS_ENUM(NSUInteger, MenuItemType) {
-    MenuItemTypeUnknown = 0,
-    
-    /* The majority of MenuItems are set as pages.
-     */
-    MenuItemTypePage,
-    
-    /*  API data returns type as "custom" for MenuItems that were set with specific URL sources.
-     Locally, the UI identifies interacting with custom MenuItems as "Links" with URL sources to edit.
-     */
-    MenuItemTypeCustom,
-    MenuItemTypeLink = MenuItemTypeCustom,
-    
-    /* Taxonomy MenuItems
-     */
-    MenuItemTypeCategory,
-    MenuItemTypeTag,
-    
-    /* MenuItem to a specific post.
-     The post could be considered a custom content post on a wp.org site, and may not be considered a "blog" post by the user.
-     */
-    MenuItemTypePost,
-    
-    /* Custom Jetpack MenuItems that link to specific a post with a custom content type managed by Jetpack.
-     */
-    MenuItemTypeJetpackTestimonial,
-    MenuItemTypeJetpackPortfolio
-};
-
 @class Menu;
+@class Blog;
 
 NS_ASSUME_NONNULL_BEGIN
 
-/* API identifier values for specific MenuItem types.
+/**
+ The majority of MenuItems are set as pages.
  */
-extern NSString * const MenuItemTypeIdentifierPage;
-extern NSString * const MenuItemTypeIdentifierCategory;
-extern NSString * const MenuItemTypeIdentifierCustom;
-extern NSString * const MenuItemTypeIdentifierTag;
-extern NSString * const MenuItemTypeIdentifierPost;
-extern NSString * const MenuItemTypeIdentifierJetpackTestimonial;
-extern NSString * const MenuItemTypeIdentifierJetpackPortfolio;
+extern NSString * const MenuItemTypePage;
+
+/** 
+ API data returns type as "custom" for MenuItems that were set with specific URL sources.
+ Locally, the UI identifies interacting with custom MenuItems as "Links" with URL sources to edit.
+ */
+extern NSString * const MenuItemTypeCustom;
+
+/**
+ Taxonomy MenuItems
+ */
+extern NSString * const MenuItemTypeCategory;
+extern NSString * const MenuItemTypeTag;
+
+/**
+ MenuItem to a specific post.
+ The post could be considered a custom content post on a wp.org site, and may not be considered a "blog" post by the user.
+ */
+extern NSString * const MenuItemTypePost;
+
+/**
+ Custom Jetpack MenuItems that link to specific a post with a custom content type managed by Jetpack.
+ */
+extern NSString * const MenuItemTypeJetpackTestimonial;
+extern NSString * const MenuItemTypeJetpackPortfolio;
+extern NSString * const MenuItemTypeJetpackComic;
+
+/**
+ The string value for an item link target opening a new window or tab.
+ */
+extern NSString * const MenuItemLinkTargetBlank;
 
 /**
  *  @brief    An object encapsulating an individual Menu item and it's API data.
  */
 @interface MenuItem : NSManagedObject
 
-@property (nullable, nonatomic, retain) NSString *contentId;
-@property (nullable, nonatomic, retain) NSString *details;
-@property (nullable, nonatomic, retain) NSString *itemId;
-@property (nullable, nonatomic, retain) NSString *linkTarget;
-@property (nullable, nonatomic, retain) NSString *linkTitle;
-@property (nullable, nonatomic, retain) NSString *name;
-@property (nullable, nonatomic, retain) NSString *type;
-@property (nullable, nonatomic, retain) NSString *typeFamily;
-@property (nullable, nonatomic, retain) NSString *typeLabel;
-@property (nullable, nonatomic, retain) NSString *urlStr;
+@property (nullable, nonatomic, strong) NSNumber *contentID;
+@property (nullable, nonatomic, strong) NSString *details;
+@property (nullable, nonatomic, strong) NSNumber *itemID;
+@property (nullable, nonatomic, strong) NSString *linkTarget;
+@property (nullable, nonatomic, strong) NSString *linkTitle;
+@property (nullable, nonatomic, strong) NSString *name;
+@property (nullable, nonatomic, strong) NSString *type;
+@property (nullable, nonatomic, strong) NSString *typeFamily;
+@property (nullable, nonatomic, strong) NSString *typeLabel;
+@property (nullable, nonatomic, strong) NSString *urlStr;
 
 ///---------------------
 /// @name Relationships
 ///---------------------
 
-/* The Menu the item belongs to.
+/**
+ The Menu the item belongs to.
  */
-@property (nullable, nonatomic, retain) Menu *menu;
+@property (nullable, nonatomic, strong) Menu *menu;
 
-/* Direct children of the item.
+/**
+ Direct children of the item.
  NOTE: Does not include any descendents of this item's children.
  See method isDescendantOfItem: for detecting ancestry.
  */
-@property (nullable, nonatomic, retain) NSSet<MenuItem *> *children;
+@property (nullable, nonatomic, strong) NSSet<MenuItem *> *children;
 
-/* The parent of the item, if the item has one.
+/**
+ The parent of the item, if the item has one.
  */
-@property (nullable, nonatomic, retain) MenuItem *parent;
+@property (nullable, nonatomic, strong) MenuItem *parent;
 
 ///---------------------
 /// @name Helper methods
 ///---------------------
-
 + (NSString *)entityName;
 
 /**
- *  @brief      Call this method to know whether an item is a descendent of this item.
- *
- *  @returns    YES if the item is a descendent, NO if not.
+ The display label text for a MenuItemType string.
+ */
++ (NSString *)labelForType:(NSString *)itemType blog:(nullable Blog *)blog;
+
+/**
+ The localized default title text (name) to use with a newly created MenuItem.
+ */
++ (NSString *)defaultItemNameLocalized;
+
+/**
+ Call this method to know whether an item is a descendent of this item.
+ @returns YES if the item is a descendent, NO if not.
  */
 - (BOOL)isDescendantOfItem:(MenuItem *)item;
 
+- (MenuItem *)lastOrderedDescendantInOrderedItems:(NSOrderedSet *)orderedSet;
+
 /**
- *  @brief      Call this method to detect the itemType of the item for handling the item in UIs.
- *
- *  @returns    MenuItemType of the item as detected by the self.type identifier value.
+ The item's name is nil, empty, or the default string.
  */
-- (MenuItemType)itemType;
+- (BOOL)nameIsEmptyOrDefault;
 
 @end
 

--- a/WordPress/Classes/Models/MenuItem.m
+++ b/WordPress/Classes/Models/MenuItem.m
@@ -90,7 +90,10 @@ NSString * const MenuItemDefaultLinkTitle = @"New Item";
     return otherItemIsDescendant;
 }
 
-- (MenuItem *)lastOrderedDescendantInOrderedItems:(NSOrderedSet *)orderedItems
+/**
+ Traverse the orderedItems for parent items equal to self or that are a descendant of self (a child of a child).
+ */
+- (MenuItem *)lastDescendantInOrderedItems:(NSOrderedSet *)orderedItems
 {
     MenuItem *lastChildItem = nil;
     NSUInteger parentIndex = [orderedItems indexOfObject:self];

--- a/WordPress/Classes/Models/MenuItem.m
+++ b/WordPress/Classes/Models/MenuItem.m
@@ -1,19 +1,25 @@
 #import "MenuItem.h"
 #import "Menu.h"
+#import "PostType.h"
+#import "Blog.h"
 
-NSString * const MenuItemTypeIdentifierPage = @"page";
-NSString * const MenuItemTypeIdentifierCategory = @"category";
-NSString * const MenuItemTypeIdentifierTag = @"post_tag";
-NSString * const MenuItemTypeIdentifierPost = @"post";
-NSString * const MenuItemTypeIdentifierCustom = @"custom";
-NSString * const MenuItemTypeIdentifierJetpackTestimonial = @"jetpack-testimonial";
-NSString * const MenuItemTypeIdentifierJetpackPortfolio = @"jetpack-portfolio";
+NSString * const MenuItemTypePage = @"page";
+NSString * const MenuItemTypeCustom = @"custom";
+NSString * const MenuItemTypeCategory = @"category";
+NSString * const MenuItemTypeTag = @"post_tag";
+NSString * const MenuItemTypePost = @"post";
+NSString * const MenuItemTypeJetpackTestimonial = @"jetpack-testimonial";
+NSString * const MenuItemTypeJetpackPortfolio = @"jetpack-portfolio";
+NSString * const MenuItemTypeJetpackComic = @"jetpack-comic";
+
+NSString * const MenuItemLinkTargetBlank = @"_blank";
+NSString * const MenuItemDefaultLinkTitle = @"New Item";
 
 @implementation MenuItem
 
-@dynamic contentId;
+@dynamic contentID;
 @dynamic details;
-@dynamic itemId;
+@dynamic itemID;
 @dynamic linkTarget;
 @dynamic linkTitle;
 @dynamic name;
@@ -30,7 +36,45 @@ NSString * const MenuItemTypeIdentifierJetpackPortfolio = @"jetpack-portfolio";
     return NSStringFromClass([self class]);
 }
 
-/* Traverse parent's of the item until we reach nil or a parent object equal to self.
++ (NSString *)labelForType:(NSString *)itemType blog:(nullable Blog *)blog
+{
+    NSString *label = nil;
+    if ([itemType isEqualToString:MenuItemTypePage]) {
+        label = NSLocalizedString(@"Page", @"Menu item label for linking a page.");
+    } else if ([itemType isEqualToString:MenuItemTypePost]) {
+        label = NSLocalizedString(@"Post", @"Menu item label for linking a post.");
+    } else if ([itemType isEqualToString:MenuItemTypeCustom]) {
+        label = NSLocalizedString(@"Link", @"Menu item label for linking a custom source URL.");
+    } else if ([itemType isEqualToString:MenuItemTypeCategory]) {
+        label = NSLocalizedString(@"Category", @"Menu item label for linking a specific category.");
+    } else if ([itemType isEqualToString:MenuItemTypeTag]) {
+        label = NSLocalizedString(@"Tag", @"Menu item label for linking a specific tag.");
+    } else if ([itemType isEqualToString:MenuItemTypeJetpackTestimonial]) {
+        label = NSLocalizedString(@"Testimonials", @"Menu item label for linking a testimonial post.");
+    } else if ([itemType isEqualToString:MenuItemTypeJetpackPortfolio]) {
+        label = NSLocalizedString(@"Projects", @"Menu item label for linking a project page.");
+    } else if ([itemType isEqualToString:MenuItemTypeJetpackComic]) {
+        label = NSLocalizedString(@"Comics", @"Menu item label for linking a comic page.");
+    } else if (blog) {
+        // Check any custom postTypes that may have a label for the itemType.
+        for (PostType *postType in blog.postTypes) {
+            // If the postType name matches, use its label.
+            if ([postType.name isEqualToString:itemType]) {
+                label = postType.label;
+                break;
+            }
+        }
+    }
+    return label;
+}
+
++ (NSString *)defaultItemNameLocalized
+{
+    return NSLocalizedString(@"New item", @"Menu item title text used as default when creating a new menu item.");
+}
+
+/**
+ Traverse parent's of the item until we reach nil or a parent object equal to self.
 */
 - (BOOL)isDescendantOfItem:(MenuItem *)item
 {
@@ -46,30 +90,25 @@ NSString * const MenuItemTypeIdentifierJetpackPortfolio = @"jetpack-portfolio";
     return otherItemIsDescendant;
 }
 
-/* Return the MenuItemType based on the matching identifier for self.type
- */
-- (MenuItemType)itemType
+- (MenuItem *)lastOrderedDescendantInOrderedItems:(NSOrderedSet *)orderedItems
 {
-    NSString *typeStr = self.type;
-    MenuItemType itemType = MenuItemTypeUnknown;
-    
-    if ([typeStr isEqualToString:MenuItemTypeIdentifierPage]) {
-        itemType = MenuItemTypePage;
-    } else if ([typeStr isEqualToString:MenuItemTypeIdentifierCustom]) {
-        itemType = MenuItemTypeCustom;
-    } else if ([typeStr isEqualToString:MenuItemTypeIdentifierCategory]) {
-        itemType = MenuItemTypeCategory;
-    } else if ([typeStr isEqualToString:MenuItemTypeIdentifierTag]) {
-        itemType = MenuItemTypeTag;
-    } else if ([typeStr isEqualToString:MenuItemTypeIdentifierPost]) {
-        itemType = MenuItemTypePost;
-    } else if ([typeStr isEqualToString:MenuItemTypeIdentifierJetpackTestimonial]) {
-        itemType = MenuItemTypeJetpackTestimonial;
-    } else if ([typeStr isEqualToString:MenuItemTypeIdentifierJetpackPortfolio]) {
-        itemType = MenuItemTypeJetpackPortfolio;
+    MenuItem *lastChildItem = nil;
+    NSUInteger parentIndex = [orderedItems indexOfObject:self];
+    for (NSUInteger i = parentIndex + 1; i < orderedItems.count; i++) {
+        MenuItem *child = [orderedItems objectAtIndex:i];
+        if (child.parent == self) {
+            lastChildItem = child;
+        }
+        if (![lastChildItem isDescendantOfItem:self]) {
+            break;
+        }
     }
-    
-    return itemType;
+    return lastChildItem;
+}
+
+- (BOOL)nameIsEmptyOrDefault
+{
+    return self.name.length == 0 || [self.name isEqualToString:[MenuItem defaultItemNameLocalized]];
 }
 
 @end

--- a/WordPress/Classes/Models/MenuLocation.h
+++ b/WordPress/Classes/Models/MenuLocation.h
@@ -9,16 +9,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MenuLocation : NSManagedObject
 
-@property (nullable, nonatomic, retain) NSString *defaultState;
-@property (nullable, nonatomic, retain) NSString *details;
-@property (nullable, nonatomic, retain) NSString *name;
+@property (nullable, nonatomic, strong) NSString *defaultState;
+@property (nullable, nonatomic, strong) NSString *details;
+@property (nullable, nonatomic, strong) NSString *name;
 
 ///---------------------
 /// @name Relationships
 ///---------------------
 
-@property (nullable, nonatomic, retain) Blog *blog;
-@property (nullable, nonatomic, retain) Menu *menu;
+@property (nullable, nonatomic, strong) Blog *blog;
+@property (nullable, nonatomic, strong) Menu *menu;
 
 ///---------------------
 /// @name Helper methods

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 48.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 48.xcdatamodel/contents
@@ -323,16 +323,16 @@
     </entity>
     <entity name="Menu" representedClassName="Menu" syncable="YES">
         <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="menuId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="menuID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="menus" inverseEntity="Blog" syncable="YES"/>
         <relationship name="items" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="MenuItem" inverseName="menu" inverseEntity="MenuItem" syncable="YES"/>
         <relationship name="locations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MenuLocation" inverseName="menu" inverseEntity="MenuLocation" syncable="YES"/>
     </entity>
     <entity name="MenuItem" representedClassName="MenuItem" syncable="YES">
-        <attribute name="contentId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="contentID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="itemId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="itemID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="linkTarget" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="linkTitle" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>


### PR DESCRIPTION
Adding changes to the Menus model objects since developing the UI in branch `feature/menus-views`.
- New string `const` for Menus.
- Includes new helper methods on `Menu` and `MenuItem`.
- Using `strong` instead of `retain` on CoreData generated attributes in code.
- Updating the CoreData model version 48 to refactor Menu ID attributes to instead be `NSNumber` integers rather than strings.

To test:
- No tests available for the model changes here, but tests are available for the upcoming `MenusService` PR utilizing this model.

Needs review: @diegoreymendez 🎉

