### PR TITLE
Don't wrap controllers in navigation from present

### DIFF
--- a/WordPress/Classes/Utility/ImmuTableViewController.swift
+++ b/WordPress/Classes/Utility/ImmuTableViewController.swift
@@ -21,9 +21,8 @@ extension ImmuTablePresenter where Self: UIViewController {
     func present(controllerGenerator: ImmuTableRowControllerGenerator) -> ImmuTableAction {
         return {
             [unowned self] in
-            let navigationController = UINavigationController(rootViewController: controllerGenerator($0))
-            navigationController.modalPresentationStyle = .FormSheet
-            self.presentViewController(navigationController, animated: true, completion: nil)
+            let controller = controllerGenerator($0)
+            self.presentViewController(controller, animated: true, completion: nil)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -60,19 +60,19 @@ private struct AccountSettingsController: SettingsController {
         let email = EditableTextRow(
             title: NSLocalizedString("Email", comment: "Account Settings Email label"),
             value: settings?.email ?? "",
-            action: presenter.present(editEmailAddress(service))
+            action: presenter.present(insideNavigationController(editEmailAddress(service)))
         )
         
         let primarySite = EditableTextRow(
             title: NSLocalizedString("Primary Site", comment: "Primary Web Site"),
             value: primarySiteName ?? "",
-            action: presenter.present(editPrimarySite(settings, service: service))
+            action: presenter.present(insideNavigationController(editPrimarySite(settings, service: service)))
         )
         
         let webAddress = EditableTextRow(
             title: NSLocalizedString("Web Address", comment: "Account Settings Web Address label"),
             value: settings?.webAddress ?? "",
-            action: presenter.present(editWebAddress(service))
+            action: presenter.present(insideNavigationController(editWebAddress(service)))
         )
         
         return ImmuTable(sections: [

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -8,6 +8,7 @@ extension SettingsController {
         return { row in
             let controller = generator(row)
             let navigation = UINavigationController(rootViewController: controller)
+            navigation.modalPresentationStyle = .FormSheet
             return navigation
         }
     }

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -4,6 +4,14 @@ protocol SettingsController: ImmuTableController {}
 
 // MARK: - Actions
 extension SettingsController {
+    func insideNavigationController(generator: ImmuTableRowControllerGenerator) -> ImmuTableRowControllerGenerator {
+        return { row in
+            let controller = generator(row)
+            let navigation = UINavigationController(rootViewController: controller)
+            return navigation
+        }
+    }
+
     func editText(changeType: AccountSettingsChangeWithString,
                   hint: String? = nil,
                   displaysNavigationButtons: Bool = false,


### PR DESCRIPTION
Reverts the behavior introduced in f87900f7eccd6552b60a5fcaef665bead127d67c for #5087 and adds the more explicit `insideNavigationController` method to SettingsController.

This fixes an issue where presenting a plans list would try to wrap a navigation controller inside another navigation controller causing a crash.

To test:

- Go to Account Settings, make sure all the fields present the editor with a navigation controller.
- Go to a wp.com site > Plans, and tap on a plan. The plan comparison should open inside a navigation controller.

Needs review: @jleandroperez 
