### PR TITLE
Reader: Bumps page view when post is liked from the stream.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -693,59 +693,11 @@ final public class ReaderDetailViewController : UIViewController
 
 
     private func bumpPageViewsForPost() {
-        if didBumpPageViews || (post!.isExternal && !post!.isJetpack) {
+        if didBumpPageViews {
             return
         }
         didBumpPageViews = true
-
-        // Don't bump page views for feeds else the wrong blog/post get's bumped
-        if post!.isExternal && !post!.isJetpack {
-            return
-        }
-
-        // If the user is an admin on the post's site do not bump the page view unless
-        // the the post is private.
-        if !post!.isPrivate() && isUserAdminOnSiteWithID(post!.siteID) {
-            return
-        }
-
-        let site = NSURL(string: post!.blogURL)
-        if site?.host == nil {
-            return
-        }
-
-        let pixel = "https://pixel.wp.com/g.gif"
-        let params:NSArray = [
-            "v=wpcom",
-            "reader=1",
-            "ref=\(DetailAnalyticsConstants.PixelStatReferrer)",
-            "host=\(site!.host!)",
-            "blog=\(post!.siteID)",
-            "post=\(post!.postID)",
-            NSString(format:"t=%d", arc4random())
-        ]
-
-        let userAgent = WordPressAppDelegate.sharedInstance().userAgent.wordPressUserAgent
-        let path  = NSString(format: "%@?%@", pixel, params.componentsJoinedByString("&")) as String
-        let url = NSURL(string: path)
-
-        let request = NSMutableURLRequest(URL: url!)
-        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-        request.addValue(DetailAnalyticsConstants.PixelStatReferrer, forHTTPHeaderField: "Referer")
-
-        let session = NSURLSession.sharedSession()
-        let task = session.dataTaskWithRequest(request)
-        task.resume()
-    }
-
-
-    private func isUserAdminOnSiteWithID(siteID:NSNumber) -> Bool {
-        let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-        if let blog = blogService.blogByBlogId(siteID) {
-            return blog.isAdmin
-        }
-        return false
+        ReaderHelpers.bumpPageViewForPost(post!)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -134,6 +134,57 @@ import WordPressComAnalytics
     }
 
 
+    public class func bumpPageViewForPost(post: ReaderPost) {
+        // Don't bump page views for feeds else the wrong blog/post get's bumped
+        if post.isExternal && !post.isJetpack {
+            return
+        }
+
+        // If the user is an admin on the post's site do not bump the page view unless
+        // the the post is private.
+        if !post.isPrivate() && isUserAdminOnSiteWithID(post.siteID) {
+            return
+        }
+
+        guard let host = NSURL(string: post.blogURL)?.host else {
+            return
+        }
+
+        let pixelStatReferrer = "https://wordpress.com/"
+        let pixel = "https://pixel.wp.com/g.gif"
+        let params:NSArray = [
+            "v=wpcom",
+            "reader=1",
+            "ref=\(pixelStatReferrer)",
+            "host=\(host)",
+            "blog=\(post.siteID)",
+            "post=\(post.postID)",
+            NSString(format:"t=%d", arc4random())
+        ]
+
+        let userAgent = WordPressAppDelegate.sharedInstance().userAgent.wordPressUserAgent
+        let path  = NSString(format: "%@?%@", pixel, params.componentsJoinedByString("&")) as String
+        let url = NSURL(string: path)
+
+        let request = NSMutableURLRequest(URL: url!)
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.addValue(pixelStatReferrer, forHTTPHeaderField: "Referer")
+
+        let session = NSURLSession.sharedSession()
+        let task = session.dataTaskWithRequest(request)
+        task.resume()
+    }
+
+    public class func isUserAdminOnSiteWithID(siteID:NSNumber) -> Bool {
+        let context = ContextManager.sharedInstance().mainContext
+        let blogService = BlogService(managedObjectContext: context)
+        if let blog = blogService.blogByBlogId(siteID) {
+            return blog.isAdmin
+        }
+        return false
+    }
+
+
     // MARK: Logged in helper
 
     public class func isLoggedIn() -> Bool {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -635,6 +635,12 @@ import WordPressComAnalytics
     }
 
     private func toggleLikeForPost(post: ReaderPost) {
+        if !post.isLiked {
+            // Consider a like from the list to be enough to push a page view.
+            // Solves a long-standing question from folks who ask 'why do I
+            // have more likes than page views?'.
+            ReaderHelpers.bumpPageViewForPost(post);
+        }
         let service = ReaderPostService(managedObjectContext: managedObjectContext())
         service.toggleLikedForPost(post, success: nil, failure: { (error:NSError?) in
             if let anError = error {


### PR DESCRIPTION
Closes #5075 

To test: 
- Set a break point in ReaderHelpers.bumpPageViewForPost().
- Load a topic in the reader and like a post from one of the cards in the list. 
- Confirm the breakpoint catches the like. 
- Unlike the post.  Confirm the unlike action does not bump the page view. 

Needs review: @bummytime

