### PR TITLE
Plan Detail: Table headers that wrap are now sized correctly.

### DIFF
--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -288,6 +288,14 @@ extension PlanDetailViewController: UITableViewDataSource, UITableViewDelegate {
             return nil
         }
     }
+    
+    func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if let headerView = self.tableView(tableView, viewForHeaderInSection: section) as? WPTableViewSectionHeaderFooterView {
+            return WPTableViewSectionHeaderFooterView.heightForHeader(headerView.title, width: CGRectGetWidth(view.bounds))
+        } else {
+            return 0
+        }
+    }
 }
 
 class FeatureItemCell: WPTableViewCell {


### PR DESCRIPTION
Fixed sizing for Plan Detail table headers with wrapped text.

I've added an implementation of `tableView(_:heightForHeaderInSection:)` that uses the uppercased string from the header view itself.

To test: View the section headers in Plan Details Business on an iPhone 4S sized simulator. Check that the wrapped header has enough padding below it.

Needs review: @koke 