### PR TITLE
Menus: model service and tests

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -31,6 +31,8 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     BlogFeaturePushNotifications,
     /// Does the blog support theme browsing?
     BlogFeatureThemeBrowsing,
+    /// Does the blog support Menus management?
+    BlogFeatureMenus,
     /// Does the blog support private visibility?
     BlogFeaturePrivate,
     /// Does the blog support sharing?

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -433,6 +433,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
         case BlogFeaturePushNotifications:
             return [self supportsPushNotifications];
         case BlogFeatureThemeBrowsing:
+        case BlogFeatureMenus:
             return [self isHostedAtWPcom] && [self isAdmin];
         case BlogFeaturePrivate:
             // Private visibility is only supported by wpcom blogs

--- a/WordPress/Classes/Services/MenusService.h
+++ b/WordPress/Classes/Services/MenusService.h
@@ -1,5 +1,7 @@
 #import "LocalCoreDataService.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class Blog;
 @class Menu;
 @class MenuLocation;
@@ -8,8 +10,8 @@
 typedef void(^MenusServiceSuccessBlock)();
 typedef void(^MenusServiceCreateMenuRequestSuccessBlock)(NSNumber *menuID);
 typedef void(^MenusServiceUpdateMenuRequestSuccessBlock)();
-typedef void(^MenusServiceMenusRequestSuccessBlock)(NSArray<Menu *> *menus);
-typedef void(^MenusServiceLocationsRequestSuccessBlock)(NSArray<MenuLocation *> *locations);
+typedef void(^MenusServiceMenusRequestSuccessBlock)(NSArray<Menu *> * _Nullable menus);
+typedef void(^MenusServiceLocationsRequestSuccessBlock)(NSArray<MenuLocation *> * _Nullable locations);
 typedef void(^MenusServiceFailureBlock)(NSError *error);
 
 @interface MenusService : LocalCoreDataService
@@ -37,8 +39,8 @@ typedef void(^MenusServiceFailureBlock)(NSError *error);
  *
  */
 - (void)syncMenusForBlog:(Blog *)blog
-                 success:(MenusServiceSuccessBlock)success
-                 failure:(MenusServiceFailureBlock)failure;
+                 success:(nullable MenusServiceSuccessBlock)success
+                 failure:(nullable MenusServiceFailureBlock)failure;
 
 #pragma mark - Creating and updating menus
 
@@ -53,8 +55,8 @@ typedef void(^MenusServiceFailureBlock)(NSError *error);
  */
 - (void)createMenuWithName:(NSString *)menuName
                       blog:(Blog *)blog
-                   success:(MenusServiceCreateMenuRequestSuccessBlock)success
-                   failure:(MenusServiceFailureBlock)failure;
+                   success:(nullable MenusServiceCreateMenuRequestSuccessBlock)success
+                   failure:(nullable MenusServiceFailureBlock)failure;
 
 /**
  *  @brief      Updates a menu.
@@ -67,8 +69,8 @@ typedef void(^MenusServiceFailureBlock)(NSError *error);
  */
 - (void)updateMenu:(Menu *)menu
            forBlog:(Blog *)blog
-           success:(MenusServiceUpdateMenuRequestSuccessBlock)success
-           failure:(MenusServiceFailureBlock)failure;
+           success:(nullable MenusServiceUpdateMenuRequestSuccessBlock)success
+           failure:(nullable MenusServiceFailureBlock)failure;
 
 /**
  *  @brief      Delete a menu.
@@ -81,8 +83,8 @@ typedef void(^MenusServiceFailureBlock)(NSError *error);
  */
 - (void)deleteMenu:(Menu *)menu
            forBlog:(Blog *)blog
-           success:(MenusServiceSuccessBlock)success
-           failure:(MenusServiceFailureBlock)failure;
+           success:(nullable MenusServiceSuccessBlock)success
+           failure:(nullable MenusServiceFailureBlock)failure;
 
 /**
  *  @brief      Generate a list MenuItems from the blog's top-level pages.
@@ -93,7 +95,9 @@ typedef void(^MenusServiceFailureBlock)(NSError *error);
  *
  */
 - (void)generateDefaultMenuItemsForBlog:(Blog *)blog
-                                success:(void(^)(NSArray <MenuItem *> *defaultItems))success
-                                failure:(void(^)(NSError *error))failure;
+                                success:(nullable void(^)(NSArray <MenuItem *> * _Nullable defaultItems))success
+                                failure:(nullable MenusServiceFailureBlock)failure;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Services/MenusService.h
+++ b/WordPress/Classes/Services/MenusService.h
@@ -1,0 +1,99 @@
+#import "LocalCoreDataService.h"
+
+@class Blog;
+@class Menu;
+@class MenuLocation;
+@class MenuItem;
+
+typedef void(^MenusServiceSuccessBlock)();
+typedef void(^MenusServiceCreateMenuRequestSuccessBlock)(NSNumber *menuID);
+typedef void(^MenusServiceUpdateMenuRequestSuccessBlock)();
+typedef void(^MenusServiceMenusRequestSuccessBlock)(NSArray<Menu *> *menus);
+typedef void(^MenusServiceLocationsRequestSuccessBlock)(NSArray<MenuLocation *> *locations);
+typedef void(^MenusServiceFailureBlock)(NSError *error);
+
+@interface MenusService : LocalCoreDataService
+
+#pragma mark - Menus availability
+
+/**
+ *  @brief      Call this method to know if a certain blog supports menus customization.
+ *  @details    Right now only blogs with WP.com or connected via Jetpack support menus customization.
+ *
+ *  @param      blog        The blog to query for menus customization support.  Cannot be nil.
+ *
+ *  @returns    YES if the blog supports menus customization, NO otherwise.
+ */
+- (BOOL)blogSupportsMenusCustomization:(Blog *)blog;
+
+#pragma mark - Getting menus and locations
+
+/**
+ *  @brief      Syncs the available menu and location objects for a specific blog.
+ *
+ *  @param      blog        The blog to get the available menus for.  Cannot be nil.
+ *  @param      success     The success handler.  Can be nil.
+ *  @param      failure     The failure handler.  Can be nil.
+ *
+ */
+- (void)syncMenusForBlog:(Blog *)blog
+                 success:(MenusServiceSuccessBlock)success
+                 failure:(MenusServiceFailureBlock)failure;
+
+#pragma mark - Creating and updating menus
+
+/**
+ *  @brief      Creates a menu.
+ *
+ *  @param      menuName  The name to create a new menu with.  Cannot be nil.
+ *  @param      blog      The blog to create a menu on.  Cannot be nil.
+ *  @param      success   The success handler.  Can be nil.
+ *  @param      failure   The failure handler.  Can be nil.
+ *
+ */
+- (void)createMenuWithName:(NSString *)menuName
+                      blog:(Blog *)blog
+                   success:(MenusServiceCreateMenuRequestSuccessBlock)success
+                   failure:(MenusServiceFailureBlock)failure;
+
+/**
+ *  @brief      Updates a menu.
+ *
+ *  @param      menu      The updated menu object to update with local storage and remotely.  Cannot be nil.
+ *  @param      blog      The blog to update a single menu on.  Cannot be nil.
+ *  @param      success   The success handler.  Can be nil.
+ *  @param      failure   The failure handler.  Can be nil.
+ *
+ */
+- (void)updateMenu:(Menu *)menu
+           forBlog:(Blog *)blog
+           success:(MenusServiceUpdateMenuRequestSuccessBlock)success
+           failure:(MenusServiceFailureBlock)failure;
+
+/**
+ *  @brief      Delete a menu.
+ *
+ *  @param      menu      The menu object to delete from local storage and remotely.  Cannot be nil.
+ *  @param      blog      The blog to delete a single menu from.  Cannot be nil.
+ *  @param      success   The success handler.  Can be nil.
+ *  @param      failure   The failure handler.  Can be nil.
+ *
+ */
+- (void)deleteMenu:(Menu *)menu
+           forBlog:(Blog *)blog
+           success:(MenusServiceSuccessBlock)success
+           failure:(MenusServiceFailureBlock)failure;
+
+/**
+ *  @brief      Generate a list MenuItems from the blog's top-level pages.
+ *
+ *  @param      blog      The blog to use for pages.  Cannot be nil.
+ *  @param      success   The success handler.  Can be nil.
+ *  @param      failure   The failure handler.  Can be nil.
+ *
+ */
+- (void)generateDefaultMenuItemsForBlog:(Blog *)blog
+                                success:(void(^)(NSArray <MenuItem *> *defaultItems))success
+                                failure:(void(^)(NSError *error))failure;
+
+@end

--- a/WordPress/Classes/Services/MenusService.m
+++ b/WordPress/Classes/Services/MenusService.m
@@ -1,0 +1,401 @@
+#import "MenusService.h"
+#import "Blog.h"
+#import "MenusServiceRemote.h"
+#import "Menu.h"
+#import "MenuItem.h"
+#import "MenuLocation.h"
+#import "RemoteMenu.h"
+#import "RemoteMenuItem.h"
+#import "RemoteMenuLocation.h"
+#import "ContextManager.h"
+#import "PostService.h"
+#import "Page.h"
+
+@implementation MenusService
+
+#pragma mark - Menus availability
+
+- (BOOL)blogSupportsMenusCustomization:(Blog *)blog
+{
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
+    return [blog supports:BlogFeatureMenus];
+}
+
+#pragma mark - Remote queries: Getting menus
+
+- (void)syncMenusForBlog:(Blog *)blog
+                 success:(MenusServiceSuccessBlock)success
+                 failure:(MenusServiceFailureBlock)failure
+{
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
+    NSAssert([self blogSupportsMenusCustomization:blog], @"Do not call this method on unsupported blogs, check with blogSupportsMenusCustomization first.");
+    
+    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithApi:blog.restApi];
+    [remote getMenusForBlog:blog success:^(NSArray *remoteMenus, NSArray *remoteLocations) {
+        
+        [self.managedObjectContext performBlockAndWait:^{
+            
+            NSArray *locations = [self menuLocationsFromRemoteMenuLocations:remoteLocations];
+            NSArray *menus = [remoteMenus wp_map:^Menu *(RemoteMenu *remoteMenu) {
+                
+                Menu *menu = [self menuFromRemoteMenu:remoteMenu];
+                [self refreshLocationsForMenu:menu
+                  matchingRemoteLocationNames:remoteMenu.locationNames
+                           availableLocations:locations];
+                
+                return menu;
+            }];
+            
+            // Create a new default menu.
+            Menu *defaultMenu = [Menu newDefaultMenu:self.managedObjectContext];
+            // Ensure the default menu is the first menu in the list of menus.
+            NSMutableArray *mutableMenus = [NSMutableArray arrayWithArray:menus];
+            [mutableMenus insertObject:defaultMenu atIndex:0];
+            menus = mutableMenus;
+            
+            // Set the default menu to locations, if needed.
+            for (MenuLocation *location in locations) {
+                if (location.menu) {
+                    continue;
+                }
+                location.menu = defaultMenu;
+            }
+            
+            blog.menuLocations = [NSOrderedSet orderedSetWithArray:locations];
+            blog.menus = [NSOrderedSet orderedSetWithArray:menus];
+            
+            [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+        }];
+        
+        if (success) {
+            success();
+        }
+        
+    } failure:failure];
+}
+
+#pragma mark - Creating and updating menus
+
+- (void)createMenuWithName:(NSString *)menuName
+                      blog:(Blog *)blog
+                   success:(MenusServiceCreateMenuRequestSuccessBlock)success
+                   failure:(MenusServiceFailureBlock)failure
+{
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
+    NSAssert([self blogSupportsMenusCustomization:blog], @"Do not call this method on unsupported blogs, check with blogSupportsMenusCustomization first.");
+    
+    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithApi:blog.restApi];
+    [remote createMenuWithName:menuName
+                          blog:blog
+                       success:^(RemoteMenu *remoteMenu) {
+                           
+                           [self.managedObjectContext performBlockAndWait:^{
+                               if (success) {
+                                   success(remoteMenu.menuID);
+                               }
+                           }];
+                           
+                       } failure:failure];
+}
+
+- (void)updateMenu:(Menu *)menu
+           forBlog:(Blog *)blog
+           success:(MenusServiceUpdateMenuRequestSuccessBlock)success
+           failure:(MenusServiceFailureBlock)failure
+{
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
+    NSParameterAssert([menu isKindOfClass:[Menu class]]);
+    NSAssert([self blogSupportsMenusCustomization:blog], @"Do not call this method on unsupported blogs, check with blogSupportsMenusCustomization first.");
+    
+    NSMutableArray *locationNames = [NSMutableArray arrayWithCapacity:menu.locations.count];
+    for (MenuLocation *location in menu.locations) {
+        if (location.name.length) {
+            [locationNames addObject:location.name];
+        }
+    }
+    
+    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithApi:blog.restApi];
+    [remote updateMenuForID:menu.menuID
+                       blog:blog
+                   withName:menu.name
+              withLocations:locationNames
+                  withItems:[self remoteItemsFromMenuItems:menu.items]
+                    success:^(RemoteMenu *remoteMenu) {
+                        
+                        [self.managedObjectContext performBlockAndWait:^{
+                            
+                            /*
+                             Update the local menu with the fresh MenuItems from remote.
+                             We need to replace the MenuItems as it's difficult to keep track of
+                             which items are equal to one another, especially when a menuID is unknown.
+                             */
+                            menu.items = nil;
+                            for (RemoteMenuItem *remoteItem in remoteMenu.items) {
+                                [self addMenuItemFromRemoteMenuItem:remoteItem forMenu:menu];
+                            }
+                            
+                            [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+                            if (success) {
+                                success();
+                            }
+                        }];
+                        
+                    } failure:failure];
+}
+
+- (void)deleteMenu:(Menu *)menu
+           forBlog:(Blog *)blog
+           success:(MenusServiceSuccessBlock)success
+           failure:(MenusServiceFailureBlock)failure
+{
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
+    NSParameterAssert([menu isKindOfClass:[Menu class]]);
+    NSAssert([self blogSupportsMenusCustomization:blog], @"Do not call this method on unsupported blogs, check with blogSupportsMenusCustomization first.");
+    
+    void(^completeMenuDeletion)() = ^() {
+        [self.managedObjectContext performBlock:^{
+            [self.managedObjectContext deleteObject:menu];
+            [self.managedObjectContext processPendingChanges];
+            [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+            if (success) {
+                success();
+            }
+        }];
+    };
+    
+    if (!menu.menuID.integerValue) {
+        // Menu was only created locally, no need to delete remotely.
+        completeMenuDeletion();
+        return;
+    }
+    
+    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithApi:blog.restApi];
+    [remote deleteMenuForID:menu.menuID
+                       blog:blog
+                    success:completeMenuDeletion
+                    failure:failure];
+}
+
+- (void)generateDefaultMenuItemsForBlog:(Blog *)blog
+                                success:(void(^)(NSArray <MenuItem *> *defaultItems))success
+                                failure:(void(^)(NSError *error))failure
+{
+    // Get the latest list of Pages available to the site.
+    PostServiceSyncOptions *options = [[PostServiceSyncOptions alloc] init];
+    options.statuses = @[PostStatusPublish];
+    options.order = PostServiceResultsOrderAscending;
+    options.orderBy = PostServiceResultsOrderingByTitle;
+    PostService *postService = [[PostService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    [postService syncPostsOfType:PostServiceTypePage
+                     withOptions:options
+                         forBlog:blog
+                         success:^(NSArray *pages) {
+                             [self.managedObjectContext performBlock:^{
+                                 
+                                 if (!pages.count) {
+                                     success(nil);
+                                     return;
+                                 }
+                                 NSMutableArray *items = [NSMutableArray arrayWithCapacity:pages.count];
+                                 // Create menu items for the top parent pages.
+                                 for (Page *page in pages) {
+                                     if ([page.parentID integerValue] > 0) {
+                                         continue;
+                                     }
+                                     MenuItem *pageItem = [NSEntityDescription insertNewObjectForEntityForName:[MenuItem entityName] inManagedObjectContext:self.managedObjectContext];
+                                     pageItem.contentID = page.postID;
+                                     pageItem.name = page.titleForDisplay;
+                                     pageItem.type = MenuItemTypePage;
+                                     [items addObject:pageItem];
+                                 }
+                                 
+                                 [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+
+                                 if (success) {
+                                     success(items);
+                                 }
+                             }];
+                         }
+                         failure:failure];
+}
+
+#pragma mark - Menu managed objects from RemoteMenu objects
+
+- (NSArray *)menusFromRemoteMenus:(NSArray<RemoteMenu *> *)remoteMenus
+{
+    NSMutableArray *menus = [NSMutableArray arrayWithCapacity:remoteMenus.count];
+    for (RemoteMenu *remoteMenu in remoteMenus) {
+        [menus addObject:[self menuFromRemoteMenu:remoteMenu]];
+    }
+    
+    return [NSArray arrayWithArray:menus];
+}
+
+- (Menu *)menuFromRemoteMenu:(RemoteMenu *)remoteMenu
+{
+    NSEntityDescription *entityDescription = [NSEntityDescription entityForName:[Menu entityName]
+                                                         inManagedObjectContext:self.managedObjectContext];
+    
+    Menu *menu = [[Menu alloc] initWithEntity:entityDescription insertIntoManagedObjectContext:self.managedObjectContext];
+    menu.name = remoteMenu.name;
+    menu.details = remoteMenu.details;
+    menu.menuID = remoteMenu.menuID;
+    for (RemoteMenuItem *remoteItem in remoteMenu.items) {
+        [self addMenuItemFromRemoteMenuItem:remoteItem forMenu:menu];
+    }
+    
+    return menu;
+}
+
+#pragma mark - MenuItem managed objects via RemoteMenuItem objects
+
+- (MenuItem *)addMenuItemFromRemoteMenuItem:(RemoteMenuItem *)remoteMenuItem forMenu:(Menu *)menu
+{
+    NSEntityDescription *entityDescription = [NSEntityDescription entityForName:[MenuItem entityName]
+                                                         inManagedObjectContext:self.managedObjectContext];
+    
+    MenuItem *item = [[MenuItem alloc] initWithEntity:entityDescription insertIntoManagedObjectContext:self.managedObjectContext];
+    item.itemID = remoteMenuItem.itemID;
+    item.contentID = remoteMenuItem.contentID;
+    item.details = remoteMenuItem.details;
+    item.linkTarget = remoteMenuItem.linkTarget;
+    item.linkTitle = remoteMenuItem.linkTitle;
+    item.name = remoteMenuItem.name;
+    item.type = remoteMenuItem.type;
+    item.typeFamily = remoteMenuItem.typeFamily;
+    item.typeLabel = remoteMenuItem.typeLabel;
+    item.urlStr = remoteMenuItem.urlStr;
+    item.menu = menu;
+    
+    if (remoteMenuItem.children) {
+        
+        for (RemoteMenuItem *childRemoteItem in remoteMenuItem.children) {
+            MenuItem *childItem = [self addMenuItemFromRemoteMenuItem:childRemoteItem forMenu:menu];
+            childItem.parent = item;
+        }
+    }
+    
+    return item;
+}
+
+#pragma mark - MenuLocations managed objects from RemoteMenuLocation objects
+
+- (NSArray *)menuLocationsFromRemoteMenuLocations:(NSArray<RemoteMenuLocation *> *)remoteMenuLocations
+{
+    NSMutableArray *locations = [NSMutableArray arrayWithCapacity:remoteMenuLocations.count];
+    
+    [self.managedObjectContext performBlockAndWait:^{
+        
+        // remove the current menus related to the blog
+        for (RemoteMenuLocation *remoteMenuLocation in remoteMenuLocations) {
+            [locations addObject:[self menuLocationFromRemoteMenuLocation:remoteMenuLocation]];
+        }
+    }];
+    
+    return [NSArray arrayWithArray:locations];
+}
+
+- (MenuLocation *)menuLocationFromRemoteMenuLocation:(RemoteMenuLocation *)remoteMenuLocation
+{
+    NSEntityDescription *entityDescription = [NSEntityDescription entityForName:[MenuLocation entityName]
+                                                         inManagedObjectContext:self.managedObjectContext];
+    
+    MenuLocation *location = [[MenuLocation alloc] initWithEntity:entityDescription insertIntoManagedObjectContext:self.managedObjectContext];
+    location.name = remoteMenuLocation.name;
+    location.details = remoteMenuLocation.details;
+    location.defaultState = remoteMenuLocation.defaultState;
+    
+    return location;
+}
+
+#pragma mark - Local storage
+
+- (void)refreshLocationsForMenu:(Menu *)menu
+    matchingRemoteLocationNames:(NSArray *)remoteLocationNames
+             availableLocations:(NSArray *)locations
+{
+    NSArray *menuLocations = nil;
+    if (remoteLocationNames.count) {
+        menuLocations = [locations filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"name IN %@", remoteLocationNames]];
+    }
+    
+    [menu setLocations:[NSSet setWithArray:menuLocations]];
+}
+
+- (Menu *)findMenuWithId:(NSString *)menuId
+{
+    NSParameterAssert([menuId isKindOfClass:[NSString class]]);
+    
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[Menu entityName]];
+    request.predicate = [NSPredicate predicateWithFormat:@"menuId == %@", menuId];
+    
+    NSError *error;
+    NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
+    if (error) {
+        DDLogError(@"Fetch request for Menu failed: %@", error);
+    }
+    
+    Menu *menu = [results firstObject];
+    return menu;
+}
+
+#pragma mark - RemoteMenu objects from Menu objects
+
+- (NSArray *)remoteItemsFromMenuItems:(NSOrderedSet<MenuItem *> *)menuItems
+{
+    NSMutableArray *remoteItems = [NSMutableArray arrayWithCapacity:menuItems.count];
+    for (MenuItem *item in menuItems) {
+        // Only add top-level items since MenuItem keeps all associated items under it's children relationship.
+        if (item.parent) {
+            continue;
+        }
+        // Children of item will be added as remoteItem.children.
+        RemoteMenuItem *remoteItem = [self remoteItemFromItem:item];
+        [remoteItems addObject:remoteItem];
+    }
+    
+    return [NSArray arrayWithArray:remoteItems];
+}
+
+- (RemoteMenuItem *)remoteItemFromItem:(MenuItem *)item
+{
+    RemoteMenuItem *remoteItem = [[RemoteMenuItem alloc] init];
+    remoteItem.itemID = item.itemID;
+    remoteItem.contentID = item.contentID;
+    remoteItem.details = item.details;
+    remoteItem.linkTarget = item.linkTarget;
+    remoteItem.linkTitle = item.linkTitle;
+    remoteItem.name = item.name;
+    remoteItem.type = item.type;
+    
+    if (remoteItem.type) {
+        // Override the type_family param based on the type.
+        // This is a weird behavior of the API and is not documented.
+        NSString *typeFamily = item.typeFamily;
+        if ([remoteItem.type isEqualToString:MenuItemTypeCustom]) {
+            typeFamily = @"custom";
+        } else if ([remoteItem.type isEqualToString:MenuItemTypeTag] || [remoteItem.type isEqualToString:MenuItemTypeCategory]){
+            typeFamily = @"taxonomy";
+        } else {
+            typeFamily = @"post_type";
+        }
+        if (typeFamily.length) {
+            remoteItem.typeFamily = typeFamily;
+        }
+    }
+    
+    remoteItem.typeLabel = item.typeLabel;
+    remoteItem.urlStr = item.urlStr;
+    
+    if (item.children.count) {
+        NSMutableArray *childRemoteItems = [NSMutableArray arrayWithCapacity:item.children.count];
+        for (MenuItem *childItem in item.children) {
+            [childRemoteItems addObject:[self remoteItemFromItem:childItem]];
+        }
+        remoteItem.children = childRemoteItems;
+    }
+    
+    return remoteItem;
+}
+
+@end

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		0859DCFB1CB8482200EB4069 /* MenusServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = 0859DCFA1CB8482200EB4069 /* MenusServiceRemote.m */; };
 		0859DCFD1CB8488400EB4069 /* MenusServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0859DCFC1CB8488400EB4069 /* MenusServiceRemoteTests.m */; };
 		08A6FD9C1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A6FD9B1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m */; };
+		08AAD69F1CBEA47D002B2418 /* MenusService.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD69E1CBEA47D002B2418 /* MenusService.m */; };
+		08AAD6A11CBEA610002B2418 /* MenusServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */; };
 		08B6D6F31C8F7DCE0052C52B /* PostType.m in Sources */ = {isa = PBXBuildFile; fileRef = 08B6D6F11C8F7DCE0052C52B /* PostType.m */; };
 		08B6D6F91C8F7EF20052C52B /* RemotePostType.m in Sources */ = {isa = PBXBuildFile; fileRef = 08B6D6F81C8F7EF20052C52B /* RemotePostType.m */; };
 		08CC677E1C49B65A00153AD7 /* MenuItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC67791C49B65A00153AD7 /* MenuItem.m */; };
@@ -860,6 +862,9 @@
 		0859DCFC1CB8488400EB4069 /* MenusServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusServiceRemoteTests.m; sourceTree = "<group>"; };
 		08A6FD9A1C5960AB00AC33E4 /* RemoteTaxonomyPaging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteTaxonomyPaging.h; path = "Remote Objects/RemoteTaxonomyPaging.h"; sourceTree = "<group>"; };
 		08A6FD9B1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteTaxonomyPaging.m; path = "Remote Objects/RemoteTaxonomyPaging.m"; sourceTree = "<group>"; };
+		08AAD69D1CBEA47D002B2418 /* MenusService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusService.h; sourceTree = "<group>"; };
+		08AAD69E1CBEA47D002B2418 /* MenusService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusService.m; sourceTree = "<group>"; };
+		08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusServiceTests.m; sourceTree = "<group>"; };
 		08B6D6F01C8F7DCE0052C52B /* PostType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostType.h; sourceTree = "<group>"; };
 		08B6D6F11C8F7DCE0052C52B /* PostType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostType.m; sourceTree = "<group>"; };
 		08B6D6F71C8F7EF20052C52B /* RemotePostType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemotePostType.h; path = "Remote Objects/RemotePostType.h"; sourceTree = "<group>"; };
@@ -3188,6 +3193,8 @@
 				5DA3EE141925090A00294E0B /* MediaService.h */,
 				5DA3EE151925090A00294E0B /* MediaService.m */,
 				E1C5457D1C6B962D001CEB0E /* MediaSettings.swift */,
+				08AAD69D1CBEA47D002B2418 /* MenusService.h */,
+				08AAD69E1CBEA47D002B2418 /* MenusService.m */,
 				B5EFB1C11B31B98E007608A3 /* NotificationsService.swift */,
 				E1209FA31BB4978B00D69778 /* PeopleService.swift */,
 				93FA59DB18D88C1C001446BC /* PostCategoryService.h */,
@@ -3485,6 +3492,7 @@
 				B5772AC51C9C84900031F97E /* GravatarServiceTests.swift */,
 				59A9AB391B4C3ECD00A433DC /* LocalCoreDataServiceTests.m */,
 				E1C5457F1C6C79BB001CEB0E /* MediaSettingsTests.swift */,
+				08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */,
 				B5EFB1C81B333C5A007608A3 /* NotificationsServiceTests.swift */,
 				5DE8A0401912D95B00B2FF59 /* ReaderPostServiceTest.m */,
 				E66969C71B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift */,
@@ -5079,6 +5087,7 @@
 				838C672E1210C3C300B09CA3 /* Post.m in Sources */,
 				B5AC00681BE3C4E100F8E7C3 /* DiscussionSettingsViewController.swift in Sources */,
 				834CAE7C122D528A003DDF49 /* UIImage+Resize.m in Sources */,
+				08AAD69F1CBEA47D002B2418 /* MenusService.m in Sources */,
 				E1418A0E1C592F8C003214B7 /* Plan.swift in Sources */,
 				5D000DDE1AC076C000A7BAF9 /* PostCardActionBar.m in Sources */,
 				FFE3B2C71B2E651400E9F1E0 /* WPAndDeviceMediaLibraryDataSource.m in Sources */,
@@ -5517,6 +5526,7 @@
 				F1564E5B18946087009F8F97 /* NSStringHelpersTest.m in Sources */,
 				93EF094C19ED533500C89770 /* ContextManagerTests.swift in Sources */,
 				B5D689FD1A5EBC900063D9E5 /* PushNotificationsManagerTestHelper.m in Sources */,
+				08AAD6A11CBEA610002B2418 /* MenusServiceTests.m in Sources */,
 				BEA0E4851BD83565000AEE81 /* WP3DTouchShortcutCreatorTests.swift in Sources */,
 				85F8E19B1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift in Sources */,
 				E13BF2CA1C522A1300275BE9 /* AccountSettingsRemoteTests.swift in Sources */,

--- a/WordPress/WordPressTest/MenusServiceTests.m
+++ b/WordPress/WordPressTest/MenusServiceTests.m
@@ -1,0 +1,279 @@
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+#import "MenusService.h"
+#import "Blog.h"
+#import "WordPressComApi.h"
+#import "Menu.h"
+#import "MenuLocation.h"
+#import "MenuItem.h"
+
+@interface MenuForStubbing : Menu
+@property (nullable, nonatomic, strong) NSNumber *menuID;
+@property (nullable, nonatomic, strong) NSString *name;
+@property (nullable, nonatomic, strong) NSSet<MenuLocation *> *locations;
+@property (nullable, nonatomic, strong) NSOrderedSet<MenuItem *> *items;
+@end
+
+@implementation MenuForStubbing
+@synthesize name;
+@synthesize menuID;
+@synthesize locations;
+@synthesize items;
+@end
+
+@interface MenuLocationForStubbing : MenuLocation
+@property (nullable, nonatomic, retain) NSString *name;
+@end
+
+@implementation MenuLocationForStubbing
+@synthesize name;
+@end
+
+@interface MenuItemForStubbing : MenuItem
+@property (nullable, nonatomic, strong) NSNumber *itemID;
+@property (nullable, nonatomic, strong) NSNumber *contentID;
+@property (nullable, nonatomic, strong) NSString *details;
+@property (nullable, nonatomic, strong) NSString *linkTarget;
+@property (nullable, nonatomic, strong) NSString *linkTitle;
+@property (nullable, nonatomic, strong) NSString *name;
+@property (nullable, nonatomic, strong) NSString *type;
+@property (nullable, nonatomic, strong) NSString *typeFamily;
+@property (nullable, nonatomic, strong) NSString *typeLabel;
+@property (nullable, nonatomic, strong) NSString *urlStr;
+@property (nullable, nonatomic, strong) NSSet<MenuItem *> *children;
+@property (nullable, nonatomic, strong) MenuItem *parent;
+@end
+@implementation MenuItemForStubbing
+@synthesize itemID;
+@synthesize contentID;
+@synthesize details;
+@synthesize linkTarget;
+@synthesize linkTitle;
+@synthesize name;
+@synthesize type;
+@synthesize typeFamily;
+@synthesize typeLabel;
+@synthesize urlStr;
+@synthesize children;
+@synthesize parent;
+@end
+
+@interface MenusServiceTests : XCTestCase
+
+@end
+
+@implementation MenusServiceTests
+
+- (void)testThatInitializationFailsWithoutAManagedObjectContext
+{
+    XCTAssertThrows([[MenusService alloc] initWithManagedObjectContext:nil]);
+}
+
+- (void)testThatWordPressBlogSupportsMenusServices
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    
+    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog dotComID]).andReturn(@1);
+    OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
+    
+    NSManagedObjectContext *context = OCMStrictClassMock([NSManagedObjectContext class]);
+    
+    MenusService *service = [[MenusService alloc] initWithManagedObjectContext:context];
+    BOOL blogSupportsMenus = NO;
+    
+    XCTAssertNoThrow(blogSupportsMenus = [service blogSupportsMenusCustomization:blog]);
+    XCTAssertTrue(blogSupportsMenus);
+}
+
+- (void)testThatWordPressBlogDoesNotSupportMenusServices
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    
+    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog dotComID]).andReturn(@1);
+    OCMStub([blog supports:BlogFeatureMenus]).andReturn(NO);
+    
+    NSManagedObjectContext *context = OCMStrictClassMock([NSManagedObjectContext class]);
+    
+    MenusService *service = [[MenusService alloc] initWithManagedObjectContext:context];
+    BOOL blogSupportsMenus = NO;
+    
+    XCTAssertNoThrow(blogSupportsMenus = [service blogSupportsMenusCustomization:blog]);
+    XCTAssertFalse(blogSupportsMenus);
+}
+
+- (void)testThatSyncMenusForBlogWorks
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    
+    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog dotComID]).andReturn(@1);
+    OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
+    
+    NSString* url = [NSString stringWithFormat:@"v1.1/sites/%@/menus", [blog dotComID]];
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    NSManagedObjectContext *context = OCMStrictClassMock([NSManagedObjectContext class]);
+    
+    MenusService *service = nil;
+    XCTAssertNoThrow(service = [[MenusService alloc] initWithManagedObjectContext:context]);
+    XCTAssertNoThrow([service syncMenusForBlog:blog
+                                       success:^(){}
+                                       failure:^(NSError *error) {}]);
+}
+
+- (void)testThatCreateMenuWithNameWorks
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    
+    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog dotComID]).andReturn(@1);
+    OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
+    
+    NSString* url = [NSString stringWithFormat:@"v1.1/sites/%@/menus/new", [blog dotComID]];
+    NSString *name = @"SomeName";
+    BOOL (^parametersCheckBlock)(id obj) = ^BOOL(NSDictionary *parameters) {
+        return ([parameters isKindOfClass:[NSDictionary class]]
+                && [[parameters objectForKey:@"name"] isEqualToString:name]);
+    };
+    
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+    
+    NSManagedObjectContext *context = OCMStrictClassMock([NSManagedObjectContext class]);
+    
+    MenusService *service = nil;
+    XCTAssertNoThrow(service = [[MenusService alloc] initWithManagedObjectContext:context]);
+    XCTAssertNoThrow([service createMenuWithName:name
+                                            blog:blog
+                                         success:^(NSNumber *menuID) {}
+                                         failure:^(NSError *error) {}]);
+}
+
+- (void)testThatUpdateMenuWorks
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    
+    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog dotComID]).andReturn(@1);
+    OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
+    
+    MenuLocation *location = OCMStrictClassMock([MenuLocationForStubbing class]);
+    OCMStub([location name]).andReturn(@"name");
+    NSSet *locations = [NSSet setWithObject:location];
+    
+    MenuItem *item = OCMStrictClassMock([MenuItemForStubbing class]);
+    OCMStub([item itemID]).andReturn(@(1));
+    OCMStub([item contentID]).andReturn(@(1));
+    OCMStub([item details]).andReturn(@"item details");
+    OCMStub([item linkTarget]).andReturn(MenuItemLinkTargetBlank);
+    OCMStub([item linkTitle]).andReturn(@"Item");
+    OCMStub([item name]).andReturn(@"name");
+    OCMStub([item type]).andReturn(MenuItemTypePage);
+    OCMStub([item typeFamily]).andReturn(MenuItemTypePage);
+    OCMStub([item typeLabel]).andReturn(@"Page");
+    OCMStub([item urlStr]).andReturn(@"http://wordpress.com/");
+    OCMStub([item children]).andReturn(nil);
+    OCMStub([item parent]).andReturn(nil);
+    NSOrderedSet *items = [NSOrderedSet orderedSetWithObject:item];
+    
+    Menu *menu = OCMStrictClassMock([MenuForStubbing class]);
+    OCMStub([menu menuID]).andReturn(@(1));
+    OCMStub([menu locations]).andReturn(locations);
+    OCMStub([menu name]).andReturn(@"name");
+    OCMStub([menu items]).andReturn(items);
+
+    NSString* url = [NSString stringWithFormat:@"v1.1/sites/%@/menus/%@", [blog dotComID], menu.menuID];
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg isKindOfClass:[NSDictionary class]]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+    
+    NSManagedObjectContext *context = OCMStrictClassMock([NSManagedObjectContext class]);
+    
+    MenusService *service = nil;
+    XCTAssertNoThrow(service = [[MenusService alloc] initWithManagedObjectContext:context]);
+    XCTAssertNoThrow([service updateMenu:menu
+                                 forBlog:blog
+                                 success:^(){}
+                                 failure:^(NSError *error) {}]);
+}
+
+- (void)testThatDeleteMenuWithIdWorks
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    
+    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog dotComID]).andReturn(@1);
+    OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
+    
+    Menu *menu = OCMStrictClassMock([MenuForStubbing class]);
+    OCMStub([menu menuID]).andReturn(@(1));
+    
+    NSString* url = [NSString stringWithFormat:@"v1.1/sites/%@/menus/%@/delete", [blog dotComID], menu.menuID];
+    
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg isNil]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+    
+    NSManagedObjectContext *context = OCMStrictClassMock([NSManagedObjectContext class]);
+    
+    MenusService *service = nil;
+    XCTAssertNoThrow(service = [[MenusService alloc] initWithManagedObjectContext:context]);
+    XCTAssertNoThrow([service deleteMenu:menu
+                                 forBlog:blog
+                                 success:^(){}
+                                 failure:^(NSError *error) {}]);
+}
+
+- (void)testThatDeleteMenuWithoutIdWorks
+{
+    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    
+    Blog *blog = OCMStrictClassMock([Blog class]);
+    
+    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog dotComID]).andReturn(@1);
+    OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
+    
+    Menu *menu = OCMStrictClassMock([MenuForStubbing class]);
+    OCMStub([menu menuID]).andReturn(nil);
+    
+    NSString* url = [NSString stringWithFormat:@"v1.1/sites/%@/menus/%@/delete", [blog dotComID], menu.menuID];
+    
+    OCMStub([api POST:[OCMArg isEqual:url]
+           parameters:[OCMArg isNil]
+              success:[OCMArg isNotNil]
+              failure:[OCMArg isNotNil]]);
+    
+    NSManagedObjectContext *context = OCMStrictClassMock([NSManagedObjectContext class]);
+    OCMStub([context performBlock:[OCMArg any]]).andDo(nil);
+    
+    MenusService *service = nil;
+    XCTAssertNoThrow(service = [[MenusService alloc] initWithManagedObjectContext:context]);
+    XCTAssertNoThrow([service deleteMenu:menu
+                                 forBlog:blog
+                                 success:^(){}
+                                 failure:^(NSError *error) {}]);
+}
+
+@end


### PR DESCRIPTION
Adds the Menus model service and unit tests. The Menus service wraps around `MenuServiceRemote` with the CoreData model for persistence and relationships.

- `Menu` is a site menu itself.
- `MenuLocation` is a location/area in which a menu can appear on a site/theme.
- `MenuItem` are the individual items/link for a menu.

Currently, every sync of Menus is intended to wipe the `menus` and `menuLocations` relationships on `Blog`, not trying and update existing objects.

**To test:**
Run the tests under MenusServiceTests and check for all passing.

Needs review: @diegoreymendez would you please review? 🙈
