### PR TITLE
Plan Detail: Fixes sizing of the table's header view.

### DIFF
--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -205,17 +205,27 @@ class PlanDetailViewController: UIViewController {
         } else if plan.isFreePlan {
             purchaseButton?.removeFromSuperview()
         }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         
+        layoutHeaderIfNeeded()
+    }
+    
+    private func layoutHeaderIfNeeded() {
         headerView.layoutIfNeeded()
         
         // Table header views don't automatically resize using Auto Layout,
         // so we need to calculate the correct size to fit the content, update the frame,
-        // and then reset the tableHeaderView property so that the new size takes effect. 
+        // and then reset the tableHeaderView property so that the new size takes effect.
         let size = headerView.systemLayoutSizeFittingSize(UILayoutFittingCompressedSize)
-        headerView.frame.size.height = size.height
-        tableView.tableHeaderView = headerView
+        if size.height != headerView.frame.size.height {
+            headerView.frame.size.height = size.height
+            tableView.tableHeaderView = headerView
+        }
     }
-
+    
     //MARK: - IBActions
 
     @IBAction private func purchaseTapped() {


### PR DESCRIPTION
After merging #5129, I was using the app and noticed that the plan detail header was collapsing the price or 'current plan' label. This PR moves the call to layout / resize the header (and only does so if the size has changed), which fixes the issue for me. 

Before:

<img width="375" alt="screen shot 2016-04-14 at 20 24 25" src="https://cloud.githubusercontent.com/assets/4780/14541378/a3b164a8-0281-11e6-9337-4145e0a04ba9.png">

After:

<img width="374" alt="screen shot 2016-04-14 at 20 56 18" src="https://cloud.githubusercontent.com/assets/4780/14541749/5d5c321a-0283-11e6-8eff-977b9f278a86.png">

Needs review: @koke 