### PR TITLE
Fixing UIKit Violent Crash

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -156,7 +156,7 @@ PODS:
   - SVProgressHUD (1.1.3)
   - UIDeviceIdentifier (0.5.0)
   - WordPress-AppbotX (1.0.6)
-  - WordPress-iOS-Editor (1.2):
+  - WordPress-iOS-Editor (1.4):
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.3)
@@ -221,7 +221,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
-  - WordPress-iOS-Editor (= 1.2)
+  - WordPress-iOS-Editor (= 1.4)
   - WordPress-iOS-Shared (= 0.5.4)
   - WordPressApi (= 0.4.0)
   - WordPressCom-Analytics-iOS (= 0.1.9)
@@ -294,7 +294,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
-  WordPress-iOS-Editor: 4958ae44a2aedfa9b3a3afc9cba41e3ec989b175
+  WordPress-iOS-Editor: ba96b59a25cce95d865df3f6a3b154131c36057f
   WordPress-iOS-Shared: 244f9ba88baea771e4509636029ee48340a4f98a
   WordPressApi: 483767025bcdab26429b51bfe5171f17d3d30466
   WordPressCom-Analytics-iOS: 3fccb433506f136cc04b735e6ab2efae9edfae7e

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1858,15 +1858,17 @@ EditImageDetailsViewControllerDelegate
                                   if (!strongSelf) {
                                       return;
                                   }
-                                  createMediaProgress.completedUnitCount++;
-                                  if (error || !media || !media.absoluteLocalURL) {
-                                      [strongSelf stopTrackingProgressOfMediaWithId:mediaUniqueID];
-                                      [WPError showAlertWithTitle:NSLocalizedString(@"Failed to export media",
-                                                                                    @"The title for an alert that says to the user the media (image or video) he selected couldn't be used on the post.")
-                                                          message:error.localizedDescription];
-                                      return;
-                                  }
-                                  [strongSelf uploadMedia:media trackingId:mediaUniqueID];
+                                  [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+                                      createMediaProgress.completedUnitCount++;
+                                      if (error || !media || !media.absoluteLocalURL) {
+                                          [strongSelf stopTrackingProgressOfMediaWithId:mediaUniqueID];
+                                          [WPError showAlertWithTitle:NSLocalizedString(@"Failed to export media",
+                                                                                        @"The title for an alert that says to the user the media (image or video) he selected couldn't be used on the post.")
+                                                              message:error.localizedDescription];
+                                          return;
+                                      }
+                                      [strongSelf uploadMedia:media trackingId:mediaUniqueID];
+                                  }];
                               }];
 }
 


### PR DESCRIPTION
Fixes #5144

Moved `mediaService` onError callback to the main thread, since it was triggering a cute UIKit crash.

Needs review: @SergioEstevao 
Sir, may i trouble you with a violent review?

Thanks in advance!