### PR TITLE
Alternate approach to PromptViewController

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -156,7 +156,7 @@ PODS:
   - SVProgressHUD (1.1.3)
   - UIDeviceIdentifier (0.5.0)
   - WordPress-AppbotX (1.0.6)
-  - WordPress-iOS-Editor (1.3):
+  - WordPress-iOS-Editor (1.4):
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.3)
@@ -221,7 +221,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
-  - WordPress-iOS-Editor (= 1.3)
+  - WordPress-iOS-Editor (= 1.4)
   - WordPress-iOS-Shared (= 0.5.4)
   - WordPressApi (= 0.4.0)
   - WordPressCom-Analytics-iOS (= 0.1.9)
@@ -294,7 +294,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
-  WordPress-iOS-Editor: 9c3178e89ccf5dbdaad24d6a444d0dbce3df763f
+  WordPress-iOS-Editor: ba96b59a25cce95d865df3f6a3b154131c36057f
   WordPress-iOS-Shared: 244f9ba88baea771e4509636029ee48340a4f98a
   WordPressApi: 483767025bcdab26429b51bfe5171f17d3d30466
   WordPressCom-Analytics-iOS: 3fccb433506f136cc04b735e6ab2efae9edfae7e

--- a/WordPress/Classes/Utility/ImmuTableViewController.swift
+++ b/WordPress/Classes/Utility/ImmuTableViewController.swift
@@ -27,6 +27,15 @@ extension ImmuTablePresenter where Self: UIViewController {
     }
 }
 
+extension ImmuTablePresenter {
+    func prompt<T: UIViewController where T: Confirmable>(controllerGenerator: ImmuTableRow -> T) -> ImmuTableAction {
+        return present({
+            let controller = controllerGenerator($0)
+            return PromptViewController(viewController: controller)
+        })
+    }
+}
+
 protocol ImmuTableController {
     var title: String { get }
     var immuTableRows: [ImmuTableRow.Type] { get }

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -60,7 +60,7 @@ private struct AccountSettingsController: SettingsController {
         let email = EditableTextRow(
             title: NSLocalizedString("Email", comment: "Account Settings Email label"),
             value: settings?.email ?? "",
-            action: presenter.present(insideNavigationController(insidePromptController(editEmailAddress(service))))
+            action: presenter.prompt(editEmailAddress(service))
         )
         
         let primarySite = EditableTextRow(
@@ -72,7 +72,7 @@ private struct AccountSettingsController: SettingsController {
         let webAddress = EditableTextRow(
             title: NSLocalizedString("Web Address", comment: "Account Settings Web Address label"),
             value: settings?.webAddress ?? "",
-            action: presenter.present(insideNavigationController(insidePromptController(editWebAddress(service))))
+            action: presenter.prompt(editWebAddress(service))
         )
         
         return ImmuTable(sections: [
@@ -89,12 +89,12 @@ private struct AccountSettingsController: SettingsController {
     
     // MARK: - Actions
 
-    func editEmailAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
+    func editEmailAddress(service: AccountSettingsService) -> ImmuTableRow -> SettingsTextViewController {
         let hint = NSLocalizedString("Will not be publicly displayed.", comment: "Help text when editing email address")
         return editEmailAddress(AccountSettingsChange.Email, hint: hint, service: service)
     }
     
-    func editWebAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
+    func editWebAddress(service: AccountSettingsService) -> ImmuTableRow -> SettingsTextViewController {
         let hint = NSLocalizedString("Shown publicly when you comment on blogs.", comment: "Help text when editing web address")
         return editText(AccountSettingsChange.WebAddress, hint: hint, service: service)
     }

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -60,7 +60,7 @@ private struct AccountSettingsController: SettingsController {
         let email = EditableTextRow(
             title: NSLocalizedString("Email", comment: "Account Settings Email label"),
             value: settings?.email ?? "",
-            action: presenter.present(insideNavigationController(editEmailAddress(service)))
+            action: presenter.present(insideNavigationController(insidePromptController(editEmailAddress(service))))
         )
         
         let primarySite = EditableTextRow(
@@ -72,7 +72,7 @@ private struct AccountSettingsController: SettingsController {
         let webAddress = EditableTextRow(
             title: NSLocalizedString("Web Address", comment: "Account Settings Web Address label"),
             value: settings?.webAddress ?? "",
-            action: presenter.present(insideNavigationController(editWebAddress(service)))
+            action: presenter.present(insideNavigationController(insidePromptController(editWebAddress(service))))
         )
         
         return ImmuTable(sections: [
@@ -91,12 +91,12 @@ private struct AccountSettingsController: SettingsController {
 
     func editEmailAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
         let hint = NSLocalizedString("Will not be publicly displayed.", comment: "Help text when editing email address")
-        return editEmailAddress(AccountSettingsChange.Email, hint: hint, displaysNavigationButtons: true, service: service)
+        return editEmailAddress(AccountSettingsChange.Email, hint: hint, service: service)
     }
     
     func editWebAddress(service: AccountSettingsService) -> ImmuTableRowControllerGenerator {
         let hint = NSLocalizedString("Shown publicly when you comment on blogs.", comment: "Help text when editing web address")
-        return editText(AccountSettingsChange.WebAddress, hint: hint, displaysNavigationButtons: true, service: service)
+        return editText(AccountSettingsChange.WebAddress, hint: hint, service: service)
     }
     
     func editPrimarySite(settings: AccountSettings?, service: AccountSettingsService) -> ImmuTableRowControllerGenerator {

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -13,13 +13,7 @@ extension SettingsController {
         }
     }
     
-    func insidePromptController(generator: ImmuTableRowControllerGenerator) -> ImmuTableRowControllerGenerator {
-        return { row in
-            return PromptViewController(viewController: generator(row))
-        }
-    }
-
-    func editText(changeType: AccountSettingsChangeWithString, hint: String? = nil, service: AccountSettingsService) -> ImmuTableRowControllerGenerator
+    func editText(changeType: AccountSettingsChangeWithString, hint: String? = nil, service: AccountSettingsService) -> ImmuTableRow -> SettingsTextViewController
     {
         return { row in
             let editableRow = row as! EditableTextRow
@@ -27,7 +21,7 @@ extension SettingsController {
         }
     }
 
-    func editEmailAddress(changeType: AccountSettingsChangeWithString, hint: String? = nil, service: AccountSettingsService) -> ImmuTableRowControllerGenerator
+    func editEmailAddress(changeType: AccountSettingsChangeWithString, hint: String? = nil, service: AccountSettingsService) -> ImmuTableRow -> SettingsTextViewController
     {
         return { row in
             let editableRow = row as! EditableTextRow

--- a/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Me/SettingsCommon.swift
@@ -12,34 +12,26 @@ extension SettingsController {
             return navigation
         }
     }
-
-    func editText(changeType: AccountSettingsChangeWithString,
-                  hint: String? = nil,
-                  displaysNavigationButtons: Bool = false,
-                  service: AccountSettingsService) -> ImmuTableRowControllerGenerator
-    {
+    
+    func insidePromptController(generator: ImmuTableRowControllerGenerator) -> ImmuTableRowControllerGenerator {
         return { row in
-            let editableRow = row as! EditableTextRow
-            return self.controllerForEditableText(editableRow,
-                                                  changeType: changeType,
-                                                  hint: hint,
-                                                  displaysNavigationButtons: displaysNavigationButtons,
-                                                  service: service)
+            return PromptViewController(viewController: generator(row))
         }
     }
 
-    func editEmailAddress(changeType: AccountSettingsChangeWithString,
-                          hint: String? = nil,
-                          displaysNavigationButtons: Bool = false,
-                          service: AccountSettingsService) -> ImmuTableRowControllerGenerator
+    func editText(changeType: AccountSettingsChangeWithString, hint: String? = nil, service: AccountSettingsService) -> ImmuTableRowControllerGenerator
     {
         return { row in
             let editableRow = row as! EditableTextRow
-            let settingsViewController =  self.controllerForEditableText(editableRow,
-                                                                         changeType: changeType,
-                                                                         hint: hint,
-                                                                         displaysNavigationButtons: displaysNavigationButtons,
-                                                                         service: service)
+            return self.controllerForEditableText(editableRow, changeType: changeType, hint: hint, service: service)
+        }
+    }
+
+    func editEmailAddress(changeType: AccountSettingsChangeWithString, hint: String? = nil, service: AccountSettingsService) -> ImmuTableRowControllerGenerator
+    {
+        return { row in
+            let editableRow = row as! EditableTextRow
+            let settingsViewController =  self.controllerForEditableText(editableRow, changeType: changeType, hint: hint, service: service)
             settingsViewController.mode = .Email
             
             return settingsViewController
@@ -49,7 +41,6 @@ extension SettingsController {
     func controllerForEditableText(row: EditableTextRow,
                                    changeType: AccountSettingsChangeWithString,
                                    hint: String? = nil,
-                                   displaysNavigationButtons: Bool = false,
                                    service: AccountSettingsService) -> SettingsTextViewController
     {
         let title = row.title
@@ -58,7 +49,6 @@ extension SettingsController {
         let controller = SettingsTextViewController(text: value, placeholder: "\(title)...", hint: hint)
 
         controller.title = title
-        controller.displaysNavigationButtons = displaysNavigationButtons
         controller.onValueChanged = {
             value in
 

--- a/WordPress/Classes/ViewRelated/Tools/Confirmable.h
+++ b/WordPress/Classes/ViewRelated/Tools/Confirmable.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+@protocol Confirmable <NSObject>
+
+- (void)cancel;
+- (void)confirm;
+
+@end

--- a/WordPress/Classes/ViewRelated/Tools/PromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/PromptViewController.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+
+/// Protocol that defines the methods required by PromptViewController's Children(s).
+///
+@objc
+protocol PresentedViewController
+{
+    var doneButtonEnabled : Bool { get }
+    func cancelButtonWasPressed(sender: AnyObject)
+    func doneButtonWasPressed(sender: AnyObject)
+}
+
+
+/// ViewController container, that presents a Done / Cancel button, and forwards their events to
+/// the childrenViewController (which *must* implement PresentedViewController).
+///
+class PromptViewController : UIViewController
+{
+    deinit {
+        stopListeningToProperties(childrenViewController)
+    }
+    
+    init(viewController: UIViewController) {
+        super.init(nibName: nil, bundle: nil)
+        assert(viewController.conformsToProtocol(PresentedViewController))
+        
+        setupNavigationButtons()
+        attachChildrenViewController(viewController)
+        setupChildrenViewConstraints(viewController.view)
+        startListeningToProperties(viewController)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        fatalError("Not meant for Nib usage!")
+    }
+    
+    
+    
+    // MARK: - Private Helpers
+    
+    private func attachChildrenViewController(viewController: UIViewController) {
+        // Attach!
+        viewController.willMoveToParentViewController(self)
+        view.addSubview(viewController.view)
+        addChildViewController(viewController)
+        viewController.didMoveToParentViewController(self)
+        
+        // You stay with us, sir
+        childrenViewController = viewController
+    }
+    
+    private func setupChildrenViewConstraints(childrenView : UIView) {
+        // We grow, you grow. We shrink, you shrink. Capicci?
+        childrenView.translatesAutoresizingMaskIntoConstraints = false
+        childrenView.widthAnchor.constraintEqualToAnchor(view.widthAnchor).active = true
+        childrenView.heightAnchor.constraintEqualToAnchor(view.heightAnchor).active = true
+        childrenView.leftAnchor.constraintEqualToAnchor(view.leftAnchor).active = true
+        childrenView.topAnchor.constraintEqualToAnchor(view.topAnchor).active = true
+    }
+
+    
+    // MARK: - KVO Rocks!
+    
+    private func startListeningToProperties(viewController: UIViewController) {
+        for key in Properties.allKeys {
+            viewController.addObserver(self, forKeyPath: key.rawValue, options: [.Initial, .New], context: nil)
+        }
+    }
+    
+    private func stopListeningToProperties(viewController: UIViewController) {
+        for key in Properties.allKeys {
+            viewController.removeObserver(self, forKeyPath: key.rawValue)
+        }
+    }
+
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+        guard let unwrappedKeyPath = keyPath, let property = Properties(rawValue: unwrappedKeyPath) else {
+            return
+        }
+        
+        switch property {
+        case .titleKey:
+            title = change?[NSKeyValueChangeNewKey] as? String ?? String()
+        case .doneButtonEnabledKey:
+            navigationItem.rightBarButtonItem?.enabled = change?[NSKeyValueChangeNewKey] as? Bool ?? true
+        }
+    }
+    
+    
+    // MARK: - Navigation Buttons
+    
+    private func setupNavigationButtons() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel,
+                                                           target: self,
+                                                           action: #selector(cancelButtonWasPressed))
+        
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Done,
+                                                            target: self,
+                                                            action: #selector(doneButtonWasPressed))
+    }
+    
+    @IBAction func cancelButtonWasPressed(sender: AnyObject) {
+        (childrenViewController as? PresentedViewController)?.cancelButtonWasPressed(sender)
+    }
+    
+    @IBAction func doneButtonWasPressed(sender: AnyObject) {
+        (childrenViewController as? PresentedViewController)?.doneButtonWasPressed(sender)
+    }
+
+    
+ 
+    // MARK: - Private Constants
+    private enum Properties : String {
+        case titleKey               = "title"
+        case doneButtonEnabledKey   = "doneButtonEnabled"
+        static let allKeys          = [titleKey, doneButtonEnabledKey]
+    }
+    
+    // MARK: - Private Properties
+    private var childrenViewController : UIViewController!
+}

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
@@ -18,10 +18,6 @@ typedef void (^SettingsTextChanged)(NSString *);
 ///
 @property (nonatomic, copy) SettingsTextChanged onValueChanged;
 
-/// Specifies whether we should display navigation buttons (Cancel / Done) or not.
-///
-@property (nonatomic, assign) BOOL displaysNavigationButtons;
-
 /// Sets the Text Input Mode:
 ///
 /// - SettingsTextModesText: Default mode

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
@@ -1,5 +1,5 @@
 #import <UIKit/UIKit.h>
-
+#import "Confirmable.h"
 
 // Typedef's
 typedef NS_ENUM(NSInteger, SettingsTextModes) {
@@ -12,7 +12,7 @@ typedef void (^SettingsTextChanged)(NSString *);
 
 /// Reusable component that renders a UITextField + Hint onscreen. Useful for Text / Password / Email data entry.
 ///
-@interface SettingsTextViewController : UITableViewController
+@interface SettingsTextViewController : UITableViewController<Confirmable>
 
 /// Block to be executed on dismiss, if the value was effectively updated.
 ///

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -13,7 +13,7 @@ static CGFloat const HorizontalMargin = 15.0f;
 
 #pragma mark - Private Properties
 
-@interface SettingsTextViewController() <UITextFieldDelegate, PresentedViewController>
+@interface SettingsTextViewController() <UITextFieldDelegate>
 @property (nonatomic, strong) WPTableViewCell   *textFieldCell;
 @property (nonatomic, strong) UITextField       *textField;
 @property (nonatomic, strong) UIView            *hintView;
@@ -81,13 +81,13 @@ static CGFloat const HorizontalMargin = 15.0f;
 
 #pragma mark - NavigationItem Buttons
 
-- (IBAction)cancelButtonWasPressed:(id)sender
+- (void)cancel
 {
     self.shouldNotifyValue = NO;
     [self dismissViewController];
 }
 
-- (IBAction)doneButtonWasPressed:(id)sender
+- (void)confirm
 {
     [self dismissViewController];
 }
@@ -235,7 +235,7 @@ static CGFloat const HorizontalMargin = 15.0f;
 {
     BOOL isValid = self.textPassesValidation;
     if (isValid) {
-        [self doneButtonWasPressed:self];
+        [self confirm];
     }
     
     return isValid;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1846,6 +1846,7 @@
 		E1EBC36E1C118EA500F638E0 /* ImmuTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmuTable.swift; sourceTree = "<group>"; };
 		E1EBC3721C118ED200F638E0 /* ImmuTableTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmuTableTest.swift; sourceTree = "<group>"; };
 		E1EBC3741C118EDE00F638E0 /* ImmuTableTestViewCellWithNib.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ImmuTableTestViewCellWithNib.xib; sourceTree = "<group>"; };
+		E1EEFAD91CC4CC5700126533 /* Confirmable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Confirmable.h; sourceTree = "<group>"; };
 		E1F5A1BA1771C90A00E0495F /* WPTableImageSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPTableImageSource.h; sourceTree = "<group>"; };
 		E1F5A1BB1771C90A00E0495F /* WPTableImageSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPTableImageSource.m; sourceTree = "<group>"; };
 		E1F80823146420B000726BC7 /* UIImageView+Gravatar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+Gravatar.h"; sourceTree = "<group>"; };
@@ -3346,6 +3347,7 @@
 				B59D994E1C0790CC0003D795 /* SettingsListEditorViewController.swift */,
 				B56F4F8E1C6B9358001CEB09 /* SettingsListPickerViewController.swift */,
 				B50EED781C0E5B2400D278CA /* SettingsPickerViewController.swift */,
+				E1EEFAD91CC4CC5700126533 /* Confirmable.h */,
 			);
 			path = Tools;
 			sourceTree = "<group>";

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 		B54E1DF11A0A7BAA00807537 /* ReplyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54E1DEE1A0A7BAA00807537 /* ReplyTextView.swift */; };
 		B54E1DF21A0A7BAA00807537 /* ReplyTextView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B54E1DEF1A0A7BAA00807537 /* ReplyTextView.xib */; };
 		B54E1DF41A0A7BBF00807537 /* NotificationMediaDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54E1DF31A0A7BBF00807537 /* NotificationMediaDownloader.swift */; };
+		B55086211CC15CCB004EADB4 /* PromptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55086201CC15CCB004EADB4 /* PromptViewController.swift */; };
 		B5509A9319CA38B3006D2E49 /* EditReplyViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5509A9219CA38B3006D2E49 /* EditReplyViewController.m */; };
 		B555E1151C04A68D00CEC81B /* WordPress-41-42.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = B555E1141C04A68D00CEC81B /* WordPress-41-42.xcmappingmodel */; };
 		B55853F31962337500FAF6C3 /* NSScanner+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = B55853F21962337500FAF6C3 /* NSScanner+Helpers.m */; };
@@ -1478,6 +1479,7 @@
 		B54E1DEE1A0A7BAA00807537 /* ReplyTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReplyTextView.swift; sourceTree = "<group>"; };
 		B54E1DEF1A0A7BAA00807537 /* ReplyTextView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReplyTextView.xib; sourceTree = "<group>"; };
 		B54E1DF31A0A7BBF00807537 /* NotificationMediaDownloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationMediaDownloader.swift; sourceTree = "<group>"; };
+		B55086201CC15CCB004EADB4 /* PromptViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromptViewController.swift; sourceTree = "<group>"; };
 		B5509A9119CA38B3006D2E49 /* EditReplyViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditReplyViewController.h; sourceTree = "<group>"; };
 		B5509A9219CA38B3006D2E49 /* EditReplyViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EditReplyViewController.m; sourceTree = "<group>"; };
 		B555E1131C04A1DD00CEC81B /* WordPress 42.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 42.xcdatamodel"; sourceTree = "<group>"; };
@@ -3334,6 +3336,7 @@
 		B53AD9B31BE9560F009AB87E /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				B55086201CC15CCB004EADB4 /* PromptViewController.swift */,
 				B53AD9BD1BE9584A009AB87E /* SettingsSelectionViewController.h */,
 				B53AD9BE1BE9584A009AB87E /* SettingsSelectionViewController.m */,
 				B54127691C0F7D610015CA80 /* SettingsMultiTextViewController.h */,
@@ -5295,6 +5298,7 @@
 				B580E4791AEA91000091A094 /* UIViewController+Helpers.swift in Sources */,
 				85B6F7521742DAE800CE7F3A /* WPNUXBackButton.m in Sources */,
 				937F3E321AD6FDA7006BA498 /* WPAnalyticsTrackerAutomatticTracks.m in Sources */,
+				B55086211CC15CCB004EADB4 /* PromptViewController.swift in Sources */,
 				B5DB8AF21C949DA90059196A /* WPReusableTableViewCells.swift in Sources */,
 				B5B68BD41C19AAED00EB59E0 /* InteractiveNotificationsHandler.swift in Sources */,
 				B54E1DF01A0A7BAA00807537 /* ReplyBezierView.swift in Sources */,


### PR DESCRIPTION
Implemented some of the suggestions in #5147 for comparison.

Ironically I had to move the `Comparable` protocol to Objective-C so it could
be enforced in Swift. When I started adding the generic constraints to enforce
that the presented view controller was both a UIViewController and a
Confirmable, Swift wasn't picking up that SettingsTextViewController was a
Confirmable, because it was conforming to the protocol in the implementation
file. And the conformance couldn't be moved to the header file because we can't
import WordPress-Swift.h from there, and we can't do a forward declaration of a
protocol for conformance.

Until all the use cases are written in swift, we still have to internally store
a UIViewController and cast accordingly, but now the public interface only
allows for a view controller that implements Confirmable, enforced by the
compiler when using Swift, and at run time via an assertion when used from
Objective-C.

I've also wrapped PromptViewController inside it's own navigation controller
and added a helper `prompt` method to immutable that enforces the right type.

I haven't addressed other suggestions, and this would still need better
documentation.