### PR TITLE
Issue/5042 duplicate logins

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -211,7 +211,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 - (WPAccount *)findAccountWithUsername:(NSString *)username
 {
     NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"Account"];
-    [request setPredicate:[NSPredicate predicateWithFormat:@"username like %@", username]];
+    [request setPredicate:[NSPredicate predicateWithFormat:@"username =[c] %@", username]];
     [request setIncludesPendingChanges:YES];
 
     NSArray *results = [self.managedObjectContext executeFetchRequest:request error:nil];

--- a/WordPress/Classes/Services/AccountServiceFacade.h
+++ b/WordPress/Classes/Services/AccountServiceFacade.h
@@ -29,11 +29,11 @@
                             failure:(void (^)(NSError *error))failure;
 
 /**
- *  This will remove a previous legacy `WPAccount`.
+ *  This will set the default WordPress.com account to use.
  *
- *  @param newUsername username of the account to remove.
+ *  @param account the WordPress.com account.
  */
--(void)removeLegacyAccount:(NSString *)newUsername;
+-(void)setDefaultWordPressComAccount:(WPAccount *)account;
 
 @end
 

--- a/WordPress/Classes/Services/AccountServiceFacade.m
+++ b/WordPress/Classes/Services/AccountServiceFacade.m
@@ -21,16 +21,21 @@
     [accountService updateUserDetailsForAccount:account success:success failure:failure];
 }
 
--(void)removeLegacyAccount:(NSString *)newUsername
+-(void)setDefaultWordPressComAccount:(WPAccount *)account
 {
-    NSParameterAssert(newUsername);
-    
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+
+    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
     
-    if (![accountService.defaultWordPressComAccount.username isEqual:newUsername]) {
+    if ([defaultAccount isEqual:account]) {
+        // No update needed.
+        return;
+    } else if (defaultAccount) {
+        // Remove the current unrelated account.
         [accountService removeDefaultWordPressComAccount];
     }
+    [accountService setDefaultWordPressComAccount:account];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewModel.m
@@ -497,10 +497,6 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     [self dismissLoginMessage];
     [self.presenter updateAutoFillLoginCredentialsIfNeeded:username password:self.password];
     
-    if (self.shouldReauthenticateDefaultAccount) {
-        [self.accountServiceFacade removeLegacyAccount:username];
-    }
-    
     [self createWordPressComAccountForUsername:username authToken:authToken requiredMultifactorCode:requiredMultifactorCode];
 }
 
@@ -520,6 +516,8 @@ static NSString *const ForgotPasswordRelativeUrl = @"/wp-login.php?action=lostpa
     [self displayLoginMessage:NSLocalizedString(@"Getting account information", nil)];
     
     WPAccount *account = [self.accountServiceFacade createOrUpdateWordPressComAccountWithUsername:username authToken:authToken];
+    [self.accountServiceFacade setDefaultWordPressComAccount:account];
+    
     [self.blogSyncFacade syncBlogsForAccount:account success:^{
         // once blogs for the accounts are synced, we want to update account details for it
         [self.accountServiceFacade updateUserDetailsForAccount:account success:^{

--- a/WordPress/Classes/ViewRelated/NUX/SigninWPComSyncHandler.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninWPComSyncHandler.swift
@@ -36,6 +36,7 @@ extension SigninWPComSyncHandler
 
         let accountFacade = AccountServiceFacade()
         let account = accountFacade.createOrUpdateWordPressComAccountWithUsername(username, authToken: authToken)
+        accountFacade.setDefaultWordPressComAccount(account)
         accountFacade.updateUserDetailsForAccount(account, success: { [weak self] in
 
             BlogSyncFacade().syncBlogsForAccount(account, success: { [weak self] in

--- a/WordPress/WordPressTest/LoginViewModelTests.m
+++ b/WordPress/WordPressTest/LoginViewModelTests.m
@@ -1600,28 +1600,6 @@ describe(@"LoginFacadeDelegate methods", ^{
             [mockViewModelPresenter verify];
         });
         
-        // https://github.com/wordpress-mobile/WordPress-iOS/issues/3401
-        context(@"the removal of the old legacy account", ^{
-            
-            it(@"should occur if shouldReauthenticateDefaultAccount is true", ^{
-                viewModel.shouldReauthenticateDefaultAccount = YES;
-                [[mockAccountServiceFacade expect] removeLegacyAccount:username];
-                
-                [viewModel finishedLoginWithUsername:username authToken:authToken requiredMultifactorCode:requiredMultifactorCode];
-                
-                [mockAccountServiceFacade verify];
-            });
-            
-            it(@"should not occur if shouldReauthenticateDefaultAccount is false", ^{
-                viewModel.shouldReauthenticateDefaultAccount = NO;
-                [[mockAccountServiceFacade reject] removeLegacyAccount:username];
-                
-                [viewModel finishedLoginWithUsername:username authToken:authToken requiredMultifactorCode:requiredMultifactorCode];
-                
-                [mockAccountServiceFacade verify];
-            });
-        });
-        
         context(@"the syncing of the newly added blogs", ^{
             
             it(@"should occur", ^{


### PR DESCRIPTION
Fixes #5042

This resolves an issue that pops every now and then in which a separate issue may allow a user to authenticate with a WordPress.com account while the user is currently authenticated with another account. Upon login, the typical handling of `AccountService` does not replace the current default account and instead just adds a new one.

To test:

1. If needed, sign in to a WordPress.com account.
2. On the "My Sites" tab hit the + button and select "Add self-hosted site".
3. Instead of self-hosted credentials, enter a WordPress.com username and password different from the account that is currently authenticated.
4. For the site address, enter the primary site for new account, such as "username.wordpress.com".
5. Upon login, the newly entered account will be the only account and sites listed under the My Sites and Me tabs.

To reproduce the original issue, repeat steps above on the branch `develop`.

Needs review: @aerych 