### PR TITLE
Removes a duplicated symbol.

### DIFF
--- a/WordPress/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIViewController+Helpers.swift
@@ -15,7 +15,7 @@ extension UIViewController
     
     /// Determines if the current ViewController's View is horizontally Compact
     ///
-    public func isViewHorizontallyCompact() -> Bool {
+    public func hasHorizontallyCompactView() -> Bool {
         return traitCollection.horizontalSizeClass == .Compact
     }
     

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -316,7 +316,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
                                                                                        successHandler:successHandler
                                                                                        dismissHandler:dismissHandler];
     vc.displaysPrimaryBlogOnTop = YES;
-    vc.displaysCancelButton = [self isViewHorizontallyCompact];
+    vc.displaysCancelButton = [self hasHorizontallyCompactView];
     vc.title = NSLocalizedString(@"Select Site", @"");
     
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -722,7 +722,7 @@ EditImageDetailsViewControllerDelegate
                                                                                        dismissHandler:dismissHandler];
     vc.title = NSLocalizedString(@"Select Site", @"");
     vc.displaysPrimaryBlogOnTop = YES;
-    vc.displaysCancelButton = [self isViewHorizontallyCompact];
+    vc.displaysCancelButton = [self hasHorizontallyCompactView];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:vc];
     navController.navigationBar.translucent = NO;
     navController.navigationBar.barStyle = UIBarStyleBlack;
@@ -1331,7 +1331,7 @@ EditImageDetailsViewControllerDelegate
                                                                                       attributes:@{ NSFontAttributeName : [WPFontManager systemSemiBoldFontOfSize:16.0] }];
         
         [blogButton setAttributedTitle:titleText forState:UIControlStateNormal];
-        if (![self isViewHorizontallyCompact]) {
+        if (![self hasHorizontallyCompactView]) {
             //size to fit here so the iPad popover works properly
             [blogButton sizeToFit];
         }
@@ -1358,7 +1358,7 @@ EditImageDetailsViewControllerDelegate
     
     // Update the width to the appropriate size for the horizontal size class
     CGFloat titleButtonWidth = CompactTitleButtonWidth;
-    if (![self isViewHorizontallyCompact]) {
+    if (![self hasHorizontallyCompactView]) {
         titleButtonWidth = RegularTitleButtonWidth;
     }
     _blogPickerButton.frame = CGRectMake(_blogPickerButton.frame.origin.x, _blogPickerButton.frame.origin.y, titleButtonWidth, RegularTitleButtonHeight);


### PR DESCRIPTION
Removes a duplicated symbol.  It's not failing currently in `develop` but it was causing trouble in [another PR I'm working on](https://github.com/wordpress-mobile/WordPress-iOS/pull/5156/files).

This is a temporary name change, as these methods should be unified (probably in the WPiOS Shared pod).  I've opened [an issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/5157) to track this task.

Needs Review: @jleandroperez 
