### PR TITLE
Add support for video in the legacy editor.

### DIFF
--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -200,36 +200,19 @@
 
         if (self.shortcode != nil) {
             result = self.shortcode;
+        } else if (self.videopressGUID.length > 0) {
+            result = [NSString stringWithFormat:
+                      @"[wpvideo %@]",
+                      self.videopressGUID];
         } else if (self.remoteURL != nil) {
-            self.remoteURL = [self.remoteURL stringByReplacingOccurrencesOfString:@"\"" withString:@""];
-            NSNumber *htmlPreference = [NSNumber numberWithInt:
-                                        [[[NSUserDefaults standardUserDefaults]
-                                          objectForKey:@"video_html_preference"] intValue]];
-
-            if ([htmlPreference intValue] == 0) {
-                // Use HTML 5 <video> tag
-                result = [NSString stringWithFormat:
-                          @"<video src=\"%@\" controls=\"controls\" width=\"%@\" height=\"%@\">"
-                          "Your browser does not support the video tag"
-                          "</video>",
-                          self.remoteURL,
-                          embedWidth,
-                          embedHeight];
-            } else {
-                // Use HTML 4 <object><embed> tags
-                embedHeight = [NSString stringWithFormat:@"%d", ([embedHeight intValue] + 16)];
-                result = [NSString stringWithFormat:
-                          @"<object classid=\"clsid:02BF25D5-8C17-4B23-BC80-D3488ABDDC6B\""
-                          "codebase=\"http://www.apple.com/qtactivex/qtplugin.cab\""
-                          "width=\"%@\" height=\"%@\">"
-                          "<param name=\"src\" value=\"%@\">"
-                          "<param name=\"autoplay\" value=\"false\">"
-                          "<embed src=\"%@\" autoplay=\"false\" "
-                          "width=\"%@\" height=\"%@\" type=\"video/quicktime\" "
-                          "pluginspage=\"http://www.apple.com/quicktime/download/\" "
-                          "/></object>",
-                          embedWidth, embedHeight, self.remoteURL, self.remoteURL, embedWidth, embedHeight];
-            }
+            // Use HTML 5 <video> tag
+            result = [NSString stringWithFormat:
+                      @"<video src=\"%@\" controls=\"controls\" width=\"%@\" height=\"%@\">"
+                      "Your browser does not support the video tag"
+                      "</video>",
+                      self.remoteURL,
+                      embedWidth,
+                      embedHeight];
 
             DDLogVerbose(@"media.html: %@", result);
         }

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -366,7 +366,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     picker.dataSource = self.mediaLibraryDataSource;
     picker.allowCaptureOfMedia = YES;
     picker.showMostRecentFirst = YES;
-    picker.filter = WPMediaTypeImage;
+    picker.filter = WPMediaTypeVideoOrImage;
     
     [self presentViewController:picker animated:YES completion:nil];
 }
@@ -901,7 +901,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)addDeviceMediaAsset:(PHAsset *)asset
 {
-    if (asset.mediaType == PHAssetMediaTypeImage) {
+    if (asset.mediaType == PHAssetMediaTypeImage || asset.mediaType == PHAssetMediaTypeVideo) {
         MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
         __weak __typeof__(self) weakSelf = self;
         NSString* imageUniqueId = [self uniqueIdForMedia];


### PR DESCRIPTION
This PR adds support for video insertion on the legacy editor

To test:

 - Disable the Visual editor in App Settings
 - Using the text editor click to add a media object
 - Select a video
 - Check if insertion happens
 
Check on WP.com sites and self-hosted.

Needs review: @astralbodies 

