### PR TITLE
Prevent race condition when changing settings

### DIFF
--- a/WordPress/Classes/Utility/ImmuTableViewController.swift
+++ b/WordPress/Classes/Utility/ImmuTableViewController.swift
@@ -69,14 +69,12 @@ final class ImmuTableViewController: UITableViewController, ImmuTablePresenter {
         title = controller.title
         registerRows(controller.immuTableRows)
         controller.tableViewModelWithPresenter(self)
-            .pausable(visible)
             .observeOn(MainScheduler.instance)
             .subscribeNext({ [weak self] in
                 self?.handler.viewModel = $0
                 })
             .addDisposableTo(bag)
         controller.noticeMessage
-            .pausable(visible)
             .observeOn(MainScheduler.instance)
             .subscribeNext({ [weak self] in
                 self?.noticeMessage = $0


### PR DESCRIPTION
Previously, when the SettingsTextViewController is dismissed, the value changes.
The service applies the change locally and saves immediately, then queues a
change request. When Profile/Settings appears again it triggers a remote
refresh, which brings back the old value. When the change request completes, it
doesn't update the local value.

The downside of this fix is that the VC will keep getting updates even if not
visible but I can live with that for now and the alternatives are much more
complicated.

Fixes #4888

Needs review: @jleandroperez 
