### PR TITLE
Remove hardcoded plans

### DIFF
--- a/WordPress/Classes/Models/Plan.swift
+++ b/WordPress/Classes/Models/Plan.swift
@@ -47,46 +47,12 @@ func < (lhs: Plan, rhs: Plan) -> Bool {
 // Obj-C bridge functions
 final class PlansBridge: NSObject {
     static func titleForPlan(withID planID: PlanID) -> String? {
-        return defaultPlans
-            .withID(planID)?
-            .title
+        // @koke 2016-04-21
+        // No quick way to do this without hardcoded plans
+        // We should get and cache the active plan title 
+        return nil
     }
 }
-
-
-// FIXME: not too happy with the global constant, but hardcoded plans are going away soon
-let defaultPlans: [Plan] = [
-    Plan(
-        id: 1,
-        title: NSLocalizedString("Free", comment: "Free plan name. As in https://store.wordpress.com/plans/"),
-        fullTitle: NSLocalizedString("WordPress.com Free", comment: "Free plan name. As in https://store.wordpress.com/plans/"),
-        tagline: NSLocalizedString("Anyone creating a simple blog or site.", comment: "Description of the Free plan"),
-        iconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-free.png")!,
-        activeIconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-free-active.png")!,
-        productIdentifier: nil,
-        featureGroups: []
-    ),
-    Plan(
-        id: 1003,
-        title: NSLocalizedString("Premium", comment: "Premium paid plan name. As in https://store.wordpress.com/plans/"),
-        fullTitle: NSLocalizedString("WordPress.com Premium", comment: "Premium paid plan name. As in https://store.wordpress.com/plans/"),
-        tagline: NSLocalizedString("Serious bloggers and creatives.", comment: "Description of the Premium plan"),
-        iconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-premium.png")!,
-        activeIconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-premium-active.png")!,
-        productIdentifier: "com.wordpress.test.premium.subscription.1year",
-        featureGroups: []
-    ),
-    Plan(
-        id: 1008,
-        title: NSLocalizedString("Business", comment: "Business paid plan name. As in https://store.wordpress.com/plans/"),
-        fullTitle: NSLocalizedString("WordPress.com Business", comment: "Business paid plan name. As in https://store.wordpress.com/plans/"),
-        tagline: NSLocalizedString("Business websites and ecommerce.", comment: "Description of the Business plan"),
-        iconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-business.png")!,
-        activeIconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-business-active.png")!,
-        productIdentifier: "com.wordpress.test.business.subscription.1year",
-        featureGroups: []
-    ),
-]
 
 protocol Identifiable {
     var id: Int { get }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -599,6 +599,7 @@
 		E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A03EE117422DCE0085D192 /* BlogToAccount.m */; };
 		E1A03F48174283E10085D192 /* BlogToJetpackAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A03F47174283E00085D192 /* BlogToJetpackAccount.m */; };
 		E1A0AC821C560F3A00070E2B /* RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A0AC811C560F3A00070E2B /* RxTests.swift */; };
+		E1A0BBB21CC9267500FE7256 /* TestPlans.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A0BBB11CC9267500FE7256 /* TestPlans.swift */; };
 		E1A0FAE7162F11CF0063B098 /* UIDevice+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A0FAE6162F11CE0063B098 /* UIDevice+Helpers.m */; };
 		E1A2A3F41CB504D400EAF51E /* PlansFeaturesRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A2A3F31CB504D400EAF51E /* PlansFeaturesRemote.swift */; };
 		E1A386C814DB05C300954CF8 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A386C714DB05C300954CF8 /* AVFoundation.framework */; };
@@ -1791,6 +1792,7 @@
 		E1A03F46174283DF0085D192 /* BlogToJetpackAccount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogToJetpackAccount.h; sourceTree = "<group>"; };
 		E1A03F47174283E00085D192 /* BlogToJetpackAccount.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogToJetpackAccount.m; sourceTree = "<group>"; };
 		E1A0AC811C560F3A00070E2B /* RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTests.swift; sourceTree = "<group>"; };
+		E1A0BBB11CC9267500FE7256 /* TestPlans.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPlans.swift; sourceTree = "<group>"; };
 		E1A0FAE5162F11CE0063B098 /* UIDevice+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "UIDevice+Helpers.h"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		E1A0FAE6162F11CE0063B098 /* UIDevice+Helpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = "UIDevice+Helpers.m"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		E1A2A3F31CB504D400EAF51E /* PlansFeaturesRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlansFeaturesRemote.swift; sourceTree = "<group>"; };
@@ -4122,6 +4124,7 @@
 				855408851A6F105700DDBD79 /* app-review-prompt-all-enabled.json */,
 				855408871A6F106800DDBD79 /* app-review-prompt-notifications-disabled.json */,
 				855408891A6F107D00DDBD79 /* app-review-prompt-global-disable.json */,
+				E1A0BBB11CC9267500FE7256 /* TestPlans.swift */,
 			);
 			name = "Mock Data";
 			path = "Test Data";
@@ -5621,6 +5624,7 @@
 				B576B48A1C6A2EC10027C754 /* LanguagesTests.swift in Sources */,
 				E66969C81B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift in Sources */,
 				E12E6E381C21E75F0033C5D0 /* FeatureFlagTest.swift in Sources */,
+				E1A0BBB21CC9267500FE7256 /* TestPlans.swift in Sources */,
 				931D26F519ED7E6D00114F17 /* BlogJetpackTest.m in Sources */,
 				E1EBC3731C118ED200F638E0 /* ImmuTableTest.swift in Sources */,
 				93B853231B4416A30064FE72 /* WPAnalyticsTrackerAutomatticTracksTests.m in Sources */,

--- a/WordPress/WordPressTest/PlanListViewControllerTest.swift
+++ b/WordPress/WordPressTest/PlanListViewControllerTest.swift
@@ -29,21 +29,21 @@ class PlanListViewControllerTest: XCTestCase {
     // MARK: - PlanListViewModel tests
 
     func testPlanImageWhenActivePlanSet() {
-        let model = PlanListViewModel.Ready((siteID: 123, activePlan: defaultPlans[1], availablePlans: plansWithPrices))
+        let model = PlanListViewModel.Ready((siteID: 123, activePlan: TestPlans.premium.plan, availablePlans: plansWithPrices))
         let tableViewModel = model.tableViewModelWithPresenter(nil, planService: nil)
         let freeRow = tableViewModel.planRowAtIndex(0)
         let premiumRow = tableViewModel.planRowAtIndex(1)
         let businessRow = tableViewModel.planRowAtIndex(2)
 
-        expect(freeRow.iconUrl).to(equal(defaultPlans[0].iconUrl))
-        expect(premiumRow.iconUrl).to(equal(defaultPlans[1].activeIconUrl))
-        expect(businessRow.iconUrl).to(equal(defaultPlans[2].iconUrl))
+        expect(freeRow.iconUrl).to(equal(TestPlans.free.plan.iconUrl))
+        expect(premiumRow.iconUrl).to(equal(TestPlans.premium.plan.activeIconUrl))
+        expect(businessRow.iconUrl).to(equal(TestPlans.business.plan.iconUrl))
     }
 
     let plansWithPrices: [PricedPlan] = [
-        (defaultPlans[0], ""),
-        (defaultPlans[1], "$99.99"),
-        (defaultPlans[2], "$299.99")
+        (TestPlans.free.plan, ""),
+        (TestPlans.premium.plan, "$99.99"),
+        (TestPlans.business.plan, "$299.99")
     ]
 }
 

--- a/WordPress/WordPressTest/StoreTests.swift
+++ b/WordPress/WordPressTest/StoreTests.swift
@@ -5,7 +5,7 @@ import Nimble
 class StoreTests: XCTestCase {
     func testGetPricesForPlans() {
         let store = MockStore.succeeding(after: 0)
-        store.getPricesForPlans(defaultPlans,
+        store.getPricesForPlans(TestPlans.allPlans,
             success: { pricedPlans in
                 expect(pricedPlans.count).to(equal(3))
                 expect(pricedPlans[0].price as String).to(equal(""))
@@ -21,7 +21,7 @@ class StoreTests: XCTestCase {
         store.products[0].priceLocale = NSLocale(localeIdentifier: "es-ES")
         store.products[1].priceLocale = NSLocale(localeIdentifier: "es-ES")
         store.getPricesForPlans(
-            defaultPlans,
+            TestPlans.allPlans,
             success: { pricedPlans in
                 expect(pricedPlans.count).to(equal(3))
                 expect(pricedPlans[0].price as String).to(equal(""))

--- a/WordPress/WordPressTest/Test Data/TestPlans.swift
+++ b/WordPress/WordPressTest/Test Data/TestPlans.swift
@@ -1,0 +1,54 @@
+@testable import WordPress
+
+enum TestPlans {
+    case free
+    case premium
+    case business
+
+    var plan: Plan {
+        switch self {
+        case .free:
+            return Plan(
+                id: 1,
+                title: NSLocalizedString("Free", comment: "Free plan name. As in https://store.wordpress.com/plans/"),
+                fullTitle: NSLocalizedString("WordPress.com Free", comment: "Free plan name. As in https://store.wordpress.com/plans/"),
+                tagline: NSLocalizedString("Anyone creating a simple blog or site.", comment: "Description of the Free plan"),
+                iconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-free.png")!,
+                activeIconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-free-active.png")!,
+                productIdentifier: nil,
+                featureGroups: []
+            )
+        case .premium:
+            return Plan(
+                id: 1003,
+                title: NSLocalizedString("Premium", comment: "Premium paid plan name. As in https://store.wordpress.com/plans/"),
+                fullTitle: NSLocalizedString("WordPress.com Premium", comment: "Premium paid plan name. As in https://store.wordpress.com/plans/"),
+                tagline: NSLocalizedString("Serious bloggers and creatives.", comment: "Description of the Premium plan"),
+                iconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-premium.png")!,
+                activeIconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-premium-active.png")!,
+                productIdentifier: "com.wordpress.test.premium.subscription.1year",
+                featureGroups: []
+            )
+        case .business:
+            return Plan(
+                id: 1008,
+                title: NSLocalizedString("Business", comment: "Business paid plan name. As in https://store.wordpress.com/plans/"),
+                fullTitle: NSLocalizedString("WordPress.com Business", comment: "Business paid plan name. As in https://store.wordpress.com/plans/"),
+                tagline: NSLocalizedString("Business websites and ecommerce.", comment: "Description of the Business plan"),
+                iconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-business.png")!,
+                activeIconUrl: NSURL(string: "http://s0.wordpress.com/i/store/plan-business-active.png")!,
+                productIdentifier: "com.wordpress.test.business.subscription.1year",
+                featureGroups: []
+            )
+        }
+    }
+
+    static let allPlans = {
+        return [
+            TestPlans.free,
+            TestPlans.premium,
+            TestPlans.business
+            ]
+            .map({ $0.plan })
+    }()
+}


### PR DESCRIPTION
Not sure if ready for merge, but I wanted some feedback:

`titleForPlan` worked with hardcoded plans, and there's no easy alternative. Right now the Site Details would just not show the active plan in the Plans row.

I was thinking of fixing that on a separate PR, since I'm not sure what's the best approach yet. I'm leaning towards getting a plan name along with the active plan ID.

In a way it seems wasteful to send an extra request for all plans just to show the site details. But then we might want to preload all the plan data in the app. I think this needs more thinking, and I really want to get rid of those hardcoded plans :)

Fixes #5069 
Needs review: @frosty 