### PR TITLE
Prevent purchase of plans in certain cases

### DIFF
--- a/WordPress/Classes/Services/Store.swift
+++ b/WordPress/Classes/Services/Store.swift
@@ -69,12 +69,16 @@ class StoreCoordinator<S: Store> {
         })
     }
 
-    func purchaseAvailability(forPlan plan: Plan, siteID: Int) -> PurchaseAvailability {
-        guard store.canMakePayments && plan.isPaidPlan else {
+    func purchaseAvailability(forPlan plan: Plan, siteID: Int, activePlan: Plan) -> PurchaseAvailability {
+        guard store.canMakePayments
+            && plan.isPaidPlan
+            && plan != activePlan
+            // Disallow upgrades/downgrades for now
+            && activePlan.isFreePlan else {
             return .unavailable
         }
         if let pendingPayment = pendingPayment {
-            if pendingPayment.siteID == siteID {
+            if pendingPayment == (plan, siteID) {
                 return .pending
             } else {
                 return .unavailable

--- a/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
@@ -38,8 +38,7 @@ class PlanComparisonViewController: PagedViewController {
         self.service = service
 
         let viewControllers: [PlanDetailViewController] = pricedPlans.map({ (plan, price) in
-            let isActive = sitePricedPlans.activePlan == plan
-            let controller = PlanDetailViewController.controllerWithPlan(plan, siteID: sitePricedPlans.siteID, isActive: isActive, price: price)
+            let controller = PlanDetailViewController.controllerWithPlan(plan, siteID: sitePricedPlans.siteID, activePlan: sitePricedPlans.activePlan, price: price)
 
             return controller
         })

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -67,6 +67,20 @@ class PlanDetailViewController: UIViewController {
                 return String(format: NSLocalizedString("%@ per year", comment: "Plan yearly price"), price)
             }
         }
+
+        var purchaseButtonVisible: Bool {
+            return !isActivePlan
+                && (purchaseAvailability == .available
+                    || purchaseAvailability == .pending)
+        }
+
+        var purchaseButtonSelected: Bool {
+            return purchaseAvailability == .pending
+        }
+
+        private var purchaseAvailability: PurchaseAvailability {
+            return StoreKitCoordinator.instance.purchaseAvailability(forPlan: plan, siteID: siteID)
+        }
     }
 
     private let cellIdentifier = "PlanFeatureListItem"
@@ -199,12 +213,15 @@ class PlanDetailViewController: UIViewController {
         planDescriptionLabel.text = plan.tagline
         planPriceLabel.text = viewModel.priceText
 
-        if viewModel.isActivePlan {
+        if !viewModel.purchaseButtonVisible {
             purchaseButton?.removeFromSuperview()
+        } else {
+            purchaseButton?.selected = viewModel.purchaseButtonSelected
+        }
+
+        if viewModel.isActivePlan {
             purchaseWrapperView.addSubview(currentPlanLabel)
             purchaseWrapperView.pinSubviewToAllEdgeMargins(currentPlanLabel)
-        } else if plan.isFreePlan {
-            purchaseButton?.removeFromSuperview()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -5,8 +5,7 @@ class PlanDetailViewController: UIViewController {
     struct ViewModel {
         let plan: Plan
         let siteID: Int
-
-        let isActivePlan: Bool
+        let activePlan: Plan
 
         /// Plan price. Empty string for a free plan
         let price: String
@@ -23,7 +22,7 @@ class PlanDetailViewController: UIViewController {
             return ViewModel(
                 plan: plan,
                 siteID: siteID,
-                isActivePlan: isActivePlan,
+                activePlan: activePlan,
                 price: price,
                 features: features
             )
@@ -60,6 +59,10 @@ class PlanDetailViewController: UIViewController {
             }
         }
 
+        var isActivePlan: Bool {
+            return activePlan == plan
+        }
+
         var priceText: String {
             if price.isEmpty  {
                 return NSLocalizedString("Free for life", comment: "Price label for the free plan")
@@ -69,9 +72,8 @@ class PlanDetailViewController: UIViewController {
         }
 
         var purchaseButtonVisible: Bool {
-            return !isActivePlan
-                && (purchaseAvailability == .available
-                    || purchaseAvailability == .pending)
+            return purchaseAvailability == .available
+                || purchaseAvailability == .pending
         }
 
         var purchaseButtonSelected: Bool {
@@ -79,7 +81,7 @@ class PlanDetailViewController: UIViewController {
         }
 
         private var purchaseAvailability: PurchaseAvailability {
-            return StoreKitCoordinator.instance.purchaseAvailability(forPlan: plan, siteID: siteID)
+            return StoreKitCoordinator.instance.purchaseAvailability(forPlan: plan, siteID: siteID, activePlan: activePlan)
         }
     }
 
@@ -153,11 +155,11 @@ class PlanDetailViewController: UIViewController {
         return wrapper
     }()
 
-    class func controllerWithPlan(plan: Plan, siteID: Int, isActive: Bool, price: String) -> PlanDetailViewController {
+    class func controllerWithPlan(plan: Plan, siteID: Int, activePlan: Plan, price: String) -> PlanDetailViewController {
         let storyboard = UIStoryboard(name: "Plans", bundle: NSBundle.mainBundle())
         let controller = storyboard.instantiateViewControllerWithIdentifier(NSStringFromClass(self)) as! PlanDetailViewController
 
-        controller.viewModel = ViewModel(plan: plan, siteID: siteID, isActivePlan: isActive, price: price, features: .Loading)
+        controller.viewModel = ViewModel(plan: plan, siteID: siteID, activePlan: activePlan, price: price, features: .Loading)
 
         return controller
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -610,6 +610,7 @@
 		E1A6DBE119DC7D140071AC1E /* PostServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A6DBDE19DC7D140071AC1E /* PostServiceRemoteREST.m */; };
 		E1A6DBE219DC7D140071AC1E /* PostServiceRemoteXMLRPC.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A6DBE019DC7D140071AC1E /* PostServiceRemoteXMLRPC.m */; };
 		E1A6DBE519DC7D230071AC1E /* PostService.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A6DBE419DC7D230071AC1E /* PostService.m */; };
+		E1A7CA4B1CC9FD7800373E06 /* StoreCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A7CA4A1CC9FD7800373E06 /* StoreCoordinatorTests.swift */; };
 		E1A8CACB1C22FF7C0038689E /* MeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A8CACA1C22FF7C0038689E /* MeViewController.swift */; };
 		E1AC282D18282423004D394C /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		E1B23B081BFB3B370006559B /* MyProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B23B071BFB3B370006559B /* MyProfileViewController.swift */; };
@@ -1809,6 +1810,8 @@
 		E1A6DBE019DC7D140071AC1E /* PostServiceRemoteXMLRPC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostServiceRemoteXMLRPC.m; sourceTree = "<group>"; };
 		E1A6DBE319DC7D230071AC1E /* PostService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostService.h; sourceTree = "<group>"; };
 		E1A6DBE419DC7D230071AC1E /* PostService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PostService.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		E1A7CA4A1CC9FD7800373E06 /* StoreCoordinatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreCoordinatorTests.swift; sourceTree = "<group>"; };
+		E1A7CA4C1CCA002600373E06 /* StoreCoordinatorTests.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = StoreCoordinatorTests.swift.gyb; sourceTree = "<group>"; };
 		E1A8CACA1C22FF7C0038689E /* MeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeViewController.swift; sourceTree = "<group>"; };
 		E1B23B071BFB3B370006559B /* MyProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyProfileViewController.swift; sourceTree = "<group>"; };
 		E1B289D919F7AF7000DB0707 /* RemoteBlog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteBlog.h; path = "Remote Objects/RemoteBlog.h"; sourceTree = "<group>"; };
@@ -3529,6 +3532,8 @@
 				E66969C71B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift */,
 				FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */,
 				E124CE711C86D27100F7BA99 /* StoreTests.swift */,
+				E1A7CA4A1CC9FD7800373E06 /* StoreCoordinatorTests.swift */,
+				E1A7CA4C1CCA002600373E06 /* StoreCoordinatorTests.swift.gyb */,
 				59FBD5611B5684F300734466 /* ThemeServiceTests.m */,
 			);
 			name = Services;
@@ -5638,6 +5643,7 @@
 				59E2AAEC1B20E5CE0051DC06 /* PostServiceRemoteRESTTests.m in Sources */,
 				5D7A57801AFBFD940097C028 /* BasePostTest.m in Sources */,
 				8514B8D41AE85B19007E58BA /* WPAnalyticsTrackerMixpanelTests.m in Sources */,
+				E1A7CA4B1CC9FD7800373E06 /* StoreCoordinatorTests.swift in Sources */,
 				0859DCFD1CB8488400EB4069 /* MenusServiceRemoteTests.m in Sources */,
 				931D26F719ED7F7500114F17 /* ReaderPostServiceTest.m in Sources */,
 				B5772AC61C9C84900031F97E /* GravatarServiceTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1811,7 +1811,6 @@
 		E1A6DBE319DC7D230071AC1E /* PostService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostService.h; sourceTree = "<group>"; };
 		E1A6DBE419DC7D230071AC1E /* PostService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PostService.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		E1A7CA4A1CC9FD7800373E06 /* StoreCoordinatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreCoordinatorTests.swift; sourceTree = "<group>"; };
-		E1A7CA4C1CCA002600373E06 /* StoreCoordinatorTests.swift.gyb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = StoreCoordinatorTests.swift.gyb; sourceTree = "<group>"; };
 		E1A8CACA1C22FF7C0038689E /* MeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MeViewController.swift; sourceTree = "<group>"; };
 		E1B23B071BFB3B370006559B /* MyProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyProfileViewController.swift; sourceTree = "<group>"; };
 		E1B289D919F7AF7000DB0707 /* RemoteBlog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteBlog.h; path = "Remote Objects/RemoteBlog.h"; sourceTree = "<group>"; };
@@ -3533,7 +3532,6 @@
 				FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */,
 				E124CE711C86D27100F7BA99 /* StoreTests.swift */,
 				E1A7CA4A1CC9FD7800373E06 /* StoreCoordinatorTests.swift */,
-				E1A7CA4C1CCA002600373E06 /* StoreCoordinatorTests.swift.gyb */,
 				59FBD5611B5684F300734466 /* ThemeServiceTests.m */,
 			);
 			name = Services;

--- a/WordPress/WordPressTest/StoreCoordinatorTests.swift
+++ b/WordPress/WordPressTest/StoreCoordinatorTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Nimble
+@testable import WordPress
+
+
+class StoreCoordinatorTests: XCTestCase {
+    func testPurchaseUnavailableWithPaymentDisabled() {
+        let availability = availabilityWith(plan: business, active: free, paymentsEnabled: false, pendingState: .none)
+        XCTAssertEqual(availability, PurchaseAvailability.unavailable)
+    }
+
+    func testPurchaseUnavailableForDowngrade() {
+        let availability = availabilityWith(plan: premium, active: business, paymentsEnabled: true, pendingState: .none)
+        XCTAssertEqual(availability, PurchaseAvailability.unavailable)
+    }
+
+    func testPurchaseUnavailableForUpgrade() {
+        let availability = availabilityWith(plan: business, active: premium, paymentsEnabled: true, pendingState: .none)
+        XCTAssertEqual(availability, PurchaseAvailability.unavailable)
+    }
+
+    func testPurchaseUnavailableForFreePlan() {
+        // This test doesn't make much sense now as we don't allow any downgrades right now
+        // When we support that however, we still shouldn't allow "purchasing" a Free plan
+        let availability = availabilityWith(plan: free, active: premium, paymentsEnabled: true, pendingState: .none)
+        XCTAssertEqual(availability, PurchaseAvailability.unavailable)
+    }
+
+    func testPurchaseUnavailableForActivePlan() {
+        let availability = availabilityWith(plan: premium, active: premium, paymentsEnabled: true, pendingState: .none)
+        XCTAssertEqual(availability, PurchaseAvailability.unavailable)
+    }
+
+    func testPurchasePendingForSameSitePlan() {
+        let availability = availabilityWith(plan: premium, active: free, paymentsEnabled: true, pendingState: .sameSitePlan)
+        XCTAssertEqual(availability, PurchaseAvailability.pending)
+    }
+
+    func testPurchaseUnavailableForSameSite() {
+        let availability = availabilityWith(plan: premium, active: free, paymentsEnabled: true, pendingState: .sameSite)
+        XCTAssertEqual(availability, PurchaseAvailability.unavailable)
+    }
+
+    func testPurchaseUnavailableForSamePlan() {
+        let availability = availabilityWith(plan: premium, active: free, paymentsEnabled: true, pendingState: .samePlan)
+        XCTAssertEqual(availability, PurchaseAvailability.unavailable)
+    }
+
+    func testPurchaseUnavailableForDifferentSitePlan() {
+        let availability = availabilityWith(plan: premium, active: free, paymentsEnabled: true, pendingState: .differentSitePlan)
+        XCTAssertEqual(availability, PurchaseAvailability.unavailable)
+    }
+
+    func testPurchaseAvailableOtherwise() {
+        let availability = availabilityWith(plan: premium, active: free, paymentsEnabled: true, pendingState: .none)
+        XCTAssertEqual(availability, PurchaseAvailability.available)
+    }
+
+    // ========================= END OF TESTS =============================== //
+
+
+    // MARK: - Helpers
+
+    private func availabilityWith(plan plan: Plan, active: Plan, paymentsEnabled: Bool, pendingState: PendingState) -> PurchaseAvailability {
+        let pendingPayment = pending(plan: plan, siteID: testSite, state: pendingState)
+        let coordinator = storeCoordinator(paymentsEnabled: paymentsEnabled, pending: pendingPayment)
+        return coordinator.purchaseAvailability(forPlan: plan, siteID: testSite, activePlan: active)
+    }
+
+    private func storeCoordinator(paymentsEnabled paymentsEnabled: Bool, pending: (Plan, Int)?) -> StoreCoordinator<MockStore> {
+        var store = MockStore.succeeding()
+        store.canMakePayments = paymentsEnabled
+        let coordinator = StoreCoordinator(store: store)
+        coordinator.pendingPayment = pending
+        return coordinator
+    }
+
+    private func pending(plan plan: Plan, siteID: Int, state: PendingState) -> (Plan, Int)? {
+        switch state {
+        case .none: return nil
+        case .sameSitePlan: return (plan, siteID)
+        case .sameSite: return (otherPlan(plan), siteID)
+        case .samePlan: return (plan, otherSite)
+        case .differentSitePlan: return (otherPlan(plan), otherSite)
+        }
+    }
+
+    private func otherPlan(plan: Plan) -> Plan {
+        if plan == business {
+            return premium
+        } else {
+            return business
+        }
+    }
+
+    private enum PendingState {
+        case none
+        case sameSitePlan
+        case sameSite
+        case samePlan
+        case differentSitePlan
+    }
+
+    private let free = TestPlans.free.plan
+    private let premium = TestPlans.premium.plan
+    private let business = TestPlans.business.plan
+    private let testSite = 123
+    private let otherSite = 321
+}


### PR DESCRIPTION
Part of #5033, #5167 

Please review the unit tests as I think I covered all relevant cases. For manual testing:

- A Purchase button should only show for sites without an existing paid plan
-To test the `pending` state, you can tap purchase on the simulator, then cancel. When you come back to the plan details, it should show the animating button. This obviously needs to be improved, but it's been helpful to test this PR

Needs review: @frosty 