### PR TITLE
Integrate WordPressApi inside the main repo

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,7 +47,6 @@ target 'WordPress', :exclusive => true do
   pod 'WPMediaPicker', '~> 0.9.1'
   pod 'WordPress-iOS-Editor', '1.5'
   pod 'WordPress-iOS-Shared', '0.5.6'
-  pod 'WordPressApi', '0.4.0'
   pod 'WordPressCom-Analytics-iOS', '0.1.9'
   ## This pod is only being included to support the share extension ATM - https://github.com/wordpress-mobile/WordPress-iOS/issues/5081
   pod 'WordPressComKit', :git => 'https://github.com/Automattic/WordPressComKit.git', :tag => '0.0.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -163,9 +163,6 @@ PODS:
     - WordPressCom-Analytics-iOS (~> 0.1.0)
   - WordPress-iOS-Shared (0.5.6):
     - CocoaLumberjack (~> 2.2.0)
-  - WordPressApi (0.4.0):
-    - AFNetworking (~> 2.6.0)
-    - wpxmlrpc (~> 0.8)
   - WordPressCom-Analytics-iOS (0.1.9)
   - WordPressCom-Stats-iOS/Services (0.7.0):
     - AFNetworking (~> 2.6.0)
@@ -222,7 +219,6 @@ DEPENDENCIES:
     `87bae8c770cfc4e053119f2d00f76b2f653b26ce`)
   - WordPress-iOS-Editor (= 1.5)
   - WordPress-iOS-Shared (= 0.5.6)
-  - WordPressApi (= 0.4.0)
   - WordPressCom-Analytics-iOS (= 0.1.9)
   - WordPressCom-Stats-iOS/Services (= 0.7.0)
   - WordPressCom-Stats-iOS/UI (= 0.7.0)
@@ -295,7 +291,6 @@ SPEC CHECKSUMS:
   WordPress-AppbotX: d0ebf5bb2d70bee56272796e1e7a97787b5bfb14
   WordPress-iOS-Editor: dcb5a4bb666c64a4f42b01915f375f5818970951
   WordPress-iOS-Shared: ce4b6e02763532e1737bf2bc7deed78d64ba4934
-  WordPressApi: 483767025bcdab26429b51bfe5171f17d3d30466
   WordPressCom-Analytics-iOS: 3fccb433506f136cc04b735e6ab2efae9edfae7e
   WordPressCom-Stats-iOS: d1996675fadd5a2c8548344a40663834898114f3
   WordPressComKit: 6f0c39c3e0af3599cd5244e4ec05192f5e4a7882

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -8,7 +8,7 @@
 #import "Constants.h"
 #import "WordPress-Swift.h"
 #import "SFHFKeychainUtils.h"
-#import <WordPressApi/WordPressApi.h>
+#import "WPXMLRPCClient.h"
 
 static NSInteger const ImageSizeSmallWidth = 240;
 static NSInteger const ImageSizeSmallHeight = 180;

--- a/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.m
@@ -1,8 +1,9 @@
 #import "BlogServiceRemoteXMLRPC.h"
 #import "NSMutableDictionary+Helpers.h"
-#import <WordPressApi/WordPressApi.h>
 #import "WordPress-Swift.h"
 #import "RemotePostType.h"
+#import "WPXMLRPCClient.h"
+#import "WPXMLRPCRequest.h"
 
 static NSString * const RemotePostTypeNameKey = @"name";
 static NSString * const RemotePostTypeLabelKey = @"label";

--- a/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
@@ -1,6 +1,6 @@
 #import "CommentServiceRemoteXMLRPC.h"
 #import "RemoteComment.h"
-#import <WordPressApi/WordPressApi.h>
+#import "WPXMLRPCClient.h"
 
 
 

--- a/WordPress/Classes/Networking/MediaServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteREST.m
@@ -2,7 +2,6 @@
 #import "WordPressComApi.h"
 #import "RemoteMedia.h"
 #import "NSDate+WordPressJSON.h"
-#import <WordPressApi/WordPressApi.h>
 
 const NSInteger WPRestErrorCodeMediaNew = 10;
 
@@ -151,7 +150,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
             NSError * error = nil;
             if (errorList.count > 0){
                 NSDictionary * errorDictionary = @{NSLocalizedDescriptionKey: errorList[0]};
-                error = [NSError errorWithDomain:WordPressRestApiErrorDomain code:WPRestErrorCodeMediaNew userInfo:errorDictionary];
+                error = [NSError errorWithDomain:NSStringFromClass([self class]) code:WPRestErrorCodeMediaNew userInfo:errorDictionary];
             }
             if (failure) {
                 failure(error);

--- a/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
@@ -1,6 +1,6 @@
 #import "MediaServiceRemoteXMLRPC.h"
 #import "RemoteMedia.h"
-#import <WordPressApi/WPXMLRPCClient.h>
+#import "WPXMLRPCClient.h"
 
 @implementation MediaServiceRemoteXMLRPC
 

--- a/WordPress/Classes/Networking/MenusServiceRemote.m
+++ b/WordPress/Classes/Networking/MenusServiceRemote.m
@@ -4,7 +4,7 @@
 #import "RemoteMenu.h"
 #import "RemoteMenuItem.h"
 #import "RemoteMenuLocation.h"
-#import "WordPressRestApi.h"
+#import "WordPressComApi.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
@@ -5,7 +5,7 @@
 #import "RemotePost.h"
 #import "RemotePostCategory.h"
 #import "NSMutableDictionary+Helpers.h"
-#import <WordPressApi/WordPressApi.h>
+#import "WPXMLRPCClient.h"
 
 const NSInteger HTTP404ErrorCode = 404;
 

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m
@@ -2,8 +2,8 @@
 #import "RemotePostCategory.h"
 #import "RemotePostTag.h"
 #import "RemoteTaxonomyPaging.h"
+#import "WPXMLRPCClient.h"
 #import <WordPressShared/NSString+Util.h>
-#import <WordPressApi/WordPressApi.h>
 
 static NSString * const TaxonomyXMLRPCCategoryIdentifier = @"category";
 static NSString * const TaxonomyXMLRPCTagIdentifier = @"post_tag";

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -23,8 +23,7 @@
 #import "WordPress-Swift.h"
 #import "RemotePostType.h"
 #import "PostType.h"
-
-#import <WordPressApi/WordPressApi.h>
+#import "WPXMLRPCClient.h"
 
 NSString *const LastUsedBlogURLDefaultsKey = @"LastUsedBlogURLDefaultsKey";
 NSString *const EditPostViewControllerLastUsedBlogURLOldKey = @"EditPostViewControllerLastUsedBlogURL";

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -11,9 +11,9 @@
 #import "UIImage+Resize.h"
 #import <MobileCoreServices/MobileCoreServices.h>
 #import "WordPress-swift.h"
-#import <WordPressApi/WordPressApi.h>
 #import "WPXMLRPCDecoder.h"
 #import "WordPressComApi.h"
+#import "WPXMLRPCClient.h"
 
 @implementation MediaService
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -11,7 +11,7 @@
 #import "WordPressComApi.h"
 #import "WordPress-Swift.h"
 #import "WPAccount.h"
-#import <WordPressApi/WordPressApi.h>
+#import "WordPressApi.h"
 
 NSString * const ReaderTopicDidChangeViaUserInteractionNotification = @"ReaderTopicDidChangeViaUserInteractionNotification";
 NSString * const ReaderTopicDidChangeNotification = @"ReaderTopicDidChangeNotification";

--- a/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
@@ -1,6 +1,6 @@
 #import "WordPressXMLRPCAPIFacade.h"
+#import "WordPressXMLRPCApi.h"
 #import <WPXMLRPC/WPXMLRPC.h>
-#import <WordPressApi/WordPressXMLRPCApi.h>
 
 
 @interface WordPressXMLRPCAPIFacade ()

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -10,7 +10,6 @@
 #import <Simperium/Simperium.h>
 #import <SVProgressHUD/SVProgressHUD.h>
 #import <UIDeviceIdentifier/UIDeviceHardware.h>
-#import <WordPressApi/WordPressApi.h>
 #import <WordPress_AppbotX/ABX.h>
 #import <WordPressShared/UIImage+Util.h>
 
@@ -45,6 +44,7 @@
 
 // Networking
 #import "WPUserAgent.h"
+#import "WordPressApi.h"
 #import "WordPressComApiCredentials.h"
 
 // Swift support

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -16,9 +16,9 @@
 #import "WordPress-Swift.h"
 #import "WPStyleGuide+ReadableMargins.h"
 #import "WPWebViewController.h"
+#import "WordPressXMLRPCApi.h"
 
 #import <SVProgressHUD/SVProgressHUD.h>
-#import <WordPressApi/WordPressApi.h>
 #import <WPXMLRPC/WPXMLRPC.h>
 
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.m
@@ -11,7 +11,7 @@
 #import "WordPressAppDelegate.h"
 #import "WPAppAnalytics.h"
 #import "WPSearchControllerConfigurator.h"
-#import <WordPressApi/WordPressApi.h>
+#import "WPXMLRPCClient.h"
 
 const NSTimeInterval PostsControllerRefreshInterval = 300; // 5 minutes
 const NSInteger HTTPErrorCodeForbidden = 403;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -513,6 +513,18 @@
 		E11450DF1C4E47E600A6BD0F /* NoticeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11450DE1C4E47E600A6BD0F /* NoticeAnimator.swift */; };
 		E114D79A153D85A800984182 /* WPError.m in Sources */ = {isa = PBXBuildFile; fileRef = E114D799153D85A800984182 /* WPError.m */; };
 		E116D4411C50D5F400DC5593 /* Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = E116D4401C50D5F400DC5593 /* Rx.swift */; };
+		E118650E1CCA77CB009235EB /* WPXMLRPCClient.m in Sources */ = {isa = PBXBuildFile; fileRef = E118650D1CCA77CB009235EB /* WPXMLRPCClient.m */; };
+		E11865131CCA77E5009235EB /* WPXMLRPCRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = E11865101CCA77E5009235EB /* WPXMLRPCRequest.m */; };
+		E11865141CCA77E5009235EB /* WPXMLRPCRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = E11865121CCA77E5009235EB /* WPXMLRPCRequestOperation.m */; };
+		E11865171CCA7803009235EB /* WPHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = E11865161CCA7803009235EB /* WPHTTPRequestOperation.m */; };
+		E118651A1CCA7826009235EB /* WPHTTPAuthenticationAlertController.m in Sources */ = {isa = PBXBuildFile; fileRef = E11865191CCA7826009235EB /* WPHTTPAuthenticationAlertController.m */; };
+		E118651D1CCA79B5009235EB /* WordPressXMLRPCApi.m in Sources */ = {isa = PBXBuildFile; fileRef = E118651C1CCA79B5009235EB /* WordPressXMLRPCApi.m */; };
+		E11865201CCA7AA2009235EB /* WPRSDParser.m in Sources */ = {isa = PBXBuildFile; fileRef = E118651F1CCA7AA2009235EB /* WPRSDParser.m */; };
+		E118652C1CCA7B9A009235EB /* WordPressApi.m in Sources */ = {isa = PBXBuildFile; fileRef = E11865221CCA7B9A009235EB /* WordPressApi.m */; };
+		E118652D1CCA7B9A009235EB /* WordPressRestApi.m in Sources */ = {isa = PBXBuildFile; fileRef = E11865251CCA7B9A009235EB /* WordPressRestApi.m */; };
+		E118652E1CCA7B9A009235EB /* WordPressRestApiJSONRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = E11865271CCA7B9A009235EB /* WordPressRestApiJSONRequestOperation.m */; };
+		E118652F1CCA7B9A009235EB /* WordPressRestApiJSONRequestOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E11865291CCA7B9A009235EB /* WordPressRestApiJSONRequestOperationManager.m */; };
+		E11865301CCA7B9A009235EB /* WPComOAuthController.m in Sources */ = {isa = PBXBuildFile; fileRef = E118652B1CCA7B9A009235EB /* WPComOAuthController.m */; };
 		E1209FA41BB4978B00D69778 /* PeopleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1209FA31BB4978B00D69778 /* PeopleService.swift */; };
 		E120D90E1B09D8C300FB9A6E /* JetpackState.m in Sources */ = {isa = PBXBuildFile; fileRef = E120D90D1B09D8C300FB9A6E /* JetpackState.m */; };
 		E1249B4319408C910035E895 /* RemoteComment.m in Sources */ = {isa = PBXBuildFile; fileRef = E1249B4219408C910035E895 /* RemoteComment.m */; };
@@ -1662,6 +1674,31 @@
 		E114D799153D85A800984182 /* WPError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPError.m; sourceTree = "<group>"; };
 		E115F2D116776A2900CCF00D /* WordPress 8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 8.xcdatamodel"; sourceTree = "<group>"; };
 		E116D4401C50D5F400DC5593 /* Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Rx.swift; sourceTree = "<group>"; };
+		E118650C1CCA77CB009235EB /* WPXMLRPCClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPXMLRPCClient.h; sourceTree = "<group>"; };
+		E118650D1CCA77CB009235EB /* WPXMLRPCClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPXMLRPCClient.m; sourceTree = "<group>"; };
+		E118650F1CCA77E5009235EB /* WPXMLRPCRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPXMLRPCRequest.h; sourceTree = "<group>"; };
+		E11865101CCA77E5009235EB /* WPXMLRPCRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPXMLRPCRequest.m; sourceTree = "<group>"; };
+		E11865111CCA77E5009235EB /* WPXMLRPCRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPXMLRPCRequestOperation.h; sourceTree = "<group>"; };
+		E11865121CCA77E5009235EB /* WPXMLRPCRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPXMLRPCRequestOperation.m; sourceTree = "<group>"; };
+		E11865151CCA7803009235EB /* WPHTTPRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPHTTPRequestOperation.h; sourceTree = "<group>"; };
+		E11865161CCA7803009235EB /* WPHTTPRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPHTTPRequestOperation.m; sourceTree = "<group>"; };
+		E11865181CCA7826009235EB /* WPHTTPAuthenticationAlertController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPHTTPAuthenticationAlertController.h; sourceTree = "<group>"; };
+		E11865191CCA7826009235EB /* WPHTTPAuthenticationAlertController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPHTTPAuthenticationAlertController.m; sourceTree = "<group>"; };
+		E118651B1CCA79B5009235EB /* WordPressXMLRPCApi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressXMLRPCApi.h; sourceTree = "<group>"; };
+		E118651C1CCA79B5009235EB /* WordPressXMLRPCApi.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressXMLRPCApi.m; sourceTree = "<group>"; };
+		E118651E1CCA7AA2009235EB /* WPRSDParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPRSDParser.h; sourceTree = "<group>"; };
+		E118651F1CCA7AA2009235EB /* WPRSDParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPRSDParser.m; sourceTree = "<group>"; };
+		E11865211CCA7B9A009235EB /* WordPressApi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressApi.h; sourceTree = "<group>"; };
+		E11865221CCA7B9A009235EB /* WordPressApi.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressApi.m; sourceTree = "<group>"; };
+		E11865231CCA7B9A009235EB /* WordPressBaseApi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressBaseApi.h; sourceTree = "<group>"; };
+		E11865241CCA7B9A009235EB /* WordPressRestApi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressRestApi.h; sourceTree = "<group>"; };
+		E11865251CCA7B9A009235EB /* WordPressRestApi.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressRestApi.m; sourceTree = "<group>"; };
+		E11865261CCA7B9A009235EB /* WordPressRestApiJSONRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressRestApiJSONRequestOperation.h; sourceTree = "<group>"; };
+		E11865271CCA7B9A009235EB /* WordPressRestApiJSONRequestOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressRestApiJSONRequestOperation.m; sourceTree = "<group>"; };
+		E11865281CCA7B9A009235EB /* WordPressRestApiJSONRequestOperationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressRestApiJSONRequestOperationManager.h; sourceTree = "<group>"; };
+		E11865291CCA7B9A009235EB /* WordPressRestApiJSONRequestOperationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressRestApiJSONRequestOperationManager.m; sourceTree = "<group>"; };
+		E118652A1CCA7B9A009235EB /* WPComOAuthController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPComOAuthController.h; sourceTree = "<group>"; };
+		E118652B1CCA7B9A009235EB /* WPComOAuthController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPComOAuthController.m; sourceTree = "<group>"; };
 		E1209FA31BB4978B00D69778 /* PeopleService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeopleService.swift; sourceTree = "<group>"; };
 		E120D90C1B09D8C300FB9A6E /* JetpackState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JetpackState.h; sourceTree = "<group>"; };
 		E120D90D1B09D8C300FB9A6E /* JetpackState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JetpackState.m; sourceTree = "<group>"; };
@@ -3925,15 +3962,40 @@
 		E11F949814A3344300277D31 /* WordPressApi */ = {
 			isa = PBXGroup;
 			children = (
+				E1756E621694A08200D9EC00 /* gencredentials.rb */,
 				E1D086E0194214C600F0CC19 /* NSDate+WordPressJSON.h */,
 				E1D086E1194214C600F0CC19 /* NSDate+WordPressJSON.m */,
-				E1756E621694A08200D9EC00 /* gencredentials.rb */,
+				E11865211CCA7B9A009235EB /* WordPressApi.h */,
+				E11865221CCA7B9A009235EB /* WordPressApi.m */,
+				E11865231CCA7B9A009235EB /* WordPressBaseApi.h */,
 				E13EB7A3157D230000885780 /* WordPressComApi.h */,
 				E13EB7A4157D230000885780 /* WordPressComApi.m */,
 				E1756DD41694560100D9EC00 /* WordPressComApiCredentials.h */,
 				E1756DD51694560100D9EC00 /* WordPressComApiCredentials.m */,
 				E1634517183B733B005E967F /* WordPressComOAuthClient.h */,
 				E1634518183B733B005E967F /* WordPressComOAuthClient.m */,
+				E11865241CCA7B9A009235EB /* WordPressRestApi.h */,
+				E11865251CCA7B9A009235EB /* WordPressRestApi.m */,
+				E11865261CCA7B9A009235EB /* WordPressRestApiJSONRequestOperation.h */,
+				E11865271CCA7B9A009235EB /* WordPressRestApiJSONRequestOperation.m */,
+				E11865281CCA7B9A009235EB /* WordPressRestApiJSONRequestOperationManager.h */,
+				E11865291CCA7B9A009235EB /* WordPressRestApiJSONRequestOperationManager.m */,
+				E118651B1CCA79B5009235EB /* WordPressXMLRPCApi.h */,
+				E118651C1CCA79B5009235EB /* WordPressXMLRPCApi.m */,
+				E118652A1CCA7B9A009235EB /* WPComOAuthController.h */,
+				E118652B1CCA7B9A009235EB /* WPComOAuthController.m */,
+				E11865181CCA7826009235EB /* WPHTTPAuthenticationAlertController.h */,
+				E11865191CCA7826009235EB /* WPHTTPAuthenticationAlertController.m */,
+				E11865151CCA7803009235EB /* WPHTTPRequestOperation.h */,
+				E11865161CCA7803009235EB /* WPHTTPRequestOperation.m */,
+				E118651E1CCA7AA2009235EB /* WPRSDParser.h */,
+				E118651F1CCA7AA2009235EB /* WPRSDParser.m */,
+				E118650C1CCA77CB009235EB /* WPXMLRPCClient.h */,
+				E118650D1CCA77CB009235EB /* WPXMLRPCClient.m */,
+				E118650F1CCA77E5009235EB /* WPXMLRPCRequest.h */,
+				E11865101CCA77E5009235EB /* WPXMLRPCRequest.m */,
+				E11865111CCA77E5009235EB /* WPXMLRPCRequestOperation.h */,
+				E11865121CCA77E5009235EB /* WPXMLRPCRequestOperation.m */,
 			);
 			path = WordPressApi;
 			sourceTree = "<group>";
@@ -5091,6 +5153,7 @@
 				B535209F1AF7EFEC00B33BA8 /* PushAuthenticationServiceRemote.swift in Sources */,
 				30EABE0918A5903400B73A9C /* WPBlogTableViewCell.m in Sources */,
 				5D13FA551AF99C0300F06492 /* PageListSectionHeaderView.m in Sources */,
+				E118652C1CCA7B9A009235EB /* WordPressApi.m in Sources */,
 				B587797D19B799D800E57C5A /* UIDevice+Helpers.swift in Sources */,
 				E2AA87A518523E5300886693 /* UIView+Subviews.m in Sources */,
 				5D51ADAF19A832AF00539C0B /* WordPress-20-21.xcmappingmodel in Sources */,
@@ -5102,6 +5165,7 @@
 				B55853F719630D5400FAF6C3 /* NSAttributedString+Util.m in Sources */,
 				ACBAB5FE0E121C7300F38795 /* PostSettingsViewController.m in Sources */,
 				08CC677E1C49B65A00153AD7 /* MenuItem.m in Sources */,
+				E118651A1CCA7826009235EB /* WPHTTPAuthenticationAlertController.m in Sources */,
 				E1DD4CCB1CAE41B800C3863E /* PagedViewController.swift in Sources */,
 				B535209B1AF7BBB800B33BA8 /* PushAuthenticationManager.swift in Sources */,
 				319D6E8119E44C680013871C /* SuggestionsTableView.m in Sources */,
@@ -5174,6 +5238,7 @@
 				2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */,
 				591A428C1A6DC1B0003807A6 /* WPBackgroundDimmerView.m in Sources */,
 				B532D4EB199D4357006E4DF6 /* NoteBlockTableViewCell.swift in Sources */,
+				E11865301CCA7B9A009235EB /* WPComOAuthController.m in Sources */,
 				E6D2E1671B8AAD8C0000ED14 /* ReaderTagStreamHeader.swift in Sources */,
 				85D239B61AE5A6170074768D /* ReachabilityFacade.m in Sources */,
 				B5899ADE1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift in Sources */,
@@ -5209,11 +5274,13 @@
 				E1418A0E1C592F8C003214B7 /* Plan.swift in Sources */,
 				5D000DDE1AC076C000A7BAF9 /* PostCardActionBar.m in Sources */,
 				FFE3B2C71B2E651400E9F1E0 /* WPAndDeviceMediaLibraryDataSource.m in Sources */,
+				E11865131CCA77E5009235EB /* WPXMLRPCRequest.m in Sources */,
 				B59D994F1C0790CC0003D795 /* SettingsListEditorViewController.swift in Sources */,
 				F1FA2C4E1AED07FC00255FCD /* MFMailComposeViewController+StatusBarStyle.m in Sources */,
 				1724DDC81C60F1200099D273 /* PlanDetailViewController.swift in Sources */,
 				E6A09BA61C4492DC008626FB /* SharingAuthorizationWebViewController.m in Sources */,
 				E64E17641CA8493200BE7744 /* NUXNavigationController.swift in Sources */,
+				E11865141CCA77E5009235EB /* WPXMLRPCRequestOperation.m in Sources */,
 				E1F8E1261B0B422C0073E628 /* JetpackServiceRemote.m in Sources */,
 				5D6C4B091B603E03005E3C43 /* WPTableViewHandler.m in Sources */,
 				834CAE9F122D56B1003DDF49 /* UIImage+Alpha.m in Sources */,
@@ -5267,6 +5334,7 @@
 				E6417BA21CA07D910084050A /* Signin2FAViewController.swift in Sources */,
 				B587798619B799EB00E57C5A /* Notification+Interface.swift in Sources */,
 				B57B92BD1B73B08100DFF00B /* SeparatorsView.swift in Sources */,
+				E118652E1CCA7B9A009235EB /* WordPressRestApiJSONRequestOperation.m in Sources */,
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,
 				E127A0F11C43B7CB00085129 /* SiteServiceRemoteREST.m in Sources */,
 				462F4E0A18369F0B0028D2F8 /* BlogDetailsViewController.m in Sources */,
@@ -5274,6 +5342,7 @@
 				B55F1AA81C10936600FD04D4 /* BlogSettings+Discussion.swift in Sources */,
 				74F313EF1A9B97A200AA8B45 /* WPTooltip.m in Sources */,
 				B57AF5FA1ACDC73D0075A7D2 /* NoteBlockActionsTableViewCell.swift in Sources */,
+				E118652F1CCA7B9A009235EB /* WordPressRestApiJSONRequestOperationManager.m in Sources */,
 				85DA8C4418F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m in Sources */,
 				B55853FC19630E7900FAF6C3 /* Notification.m in Sources */,
 				93C1147F18EC5DD500DAC95C /* AccountService.m in Sources */,
@@ -5413,6 +5482,7 @@
 				85B6F74F1742DA1E00CE7F3A /* WPNUXMainButton.m in Sources */,
 				5DB93EEC19B6190700EC88EB /* CommentContentView.m in Sources */,
 				E14977181C0DC0770057CD60 /* MediaSizeSliderCell.swift in Sources */,
+				E11865201CCA7AA2009235EB /* WPRSDParser.m in Sources */,
 				85D239BB1AE5A6620074768D /* LoginFields.m in Sources */,
 				B5772AC91C9C859D0031F97E /* GravatarServiceRemote.swift in Sources */,
 				E61084C11B9B47BA008050C5 /* ReaderSiteTopic.swift in Sources */,
@@ -5440,6 +5510,7 @@
 				FACB36F11C5C2BF800C6DF4E /* ThemeWebViewController.swift in Sources */,
 				5D42A3E0175E7452005CFF05 /* BasePost.m in Sources */,
 				5D000DE11AC0879600A7BAF9 /* PostCardActionBarItem.m in Sources */,
+				E11865171CCA7803009235EB /* WPHTTPRequestOperation.m in Sources */,
 				E1249B4319408C910035E895 /* RemoteComment.m in Sources */,
 				E663D1901C65383E0017F109 /* SharingAccountViewController.swift in Sources */,
 				93DEB88219E5BF7100F9546D /* TodayExtensionService.m in Sources */,
@@ -5449,6 +5520,7 @@
 				FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */,
 				E1B289DB19F7AF7000DB0707 /* RemoteBlog.m in Sources */,
 				E1A6DBDA19DC7D080071AC1E /* RemotePostCategory.m in Sources */,
+				E118652D1CCA7B9A009235EB /* WordPressRestApi.m in Sources */,
 				599738401B87AD2600EC1C30 /* WordPressComServiceRemote.m in Sources */,
 				E61084C21B9B47BA008050C5 /* ReaderTagTopic.swift in Sources */,
 				B53B02B31CAC3AAC003190A0 /* GravatarPickerViewController.swift in Sources */,
@@ -5500,6 +5572,7 @@
 				B5416CF51C171D7100006DD8 /* PushNotificationsManager.swift in Sources */,
 				B5FD4543199D0F2800286FBB /* NotificationDetailsViewController.m in Sources */,
 				74D5FFD619ACDF6700389E8F /* WPLegacyEditPostViewController.m in Sources */,
+				E118650E1CCA77CB009235EB /* WPXMLRPCClient.m in Sources */,
 				B54E1DF41A0A7BBF00807537 /* NotificationMediaDownloader.swift in Sources */,
 				178EDE701C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift in Sources */,
 				E174F6E6172A73960004F23A /* WPAccount.m in Sources */,
@@ -5523,6 +5596,7 @@
 				5DF59C0B1770AE3A00171208 /* UILabel+SuggestSize.m in Sources */,
 				E6431DE61C4E892900FD8D90 /* SharingDetailViewController.m in Sources */,
 				B50EED791C0E5B2400D278CA /* SettingsPickerViewController.swift in Sources */,
+				E118651D1CCA79B5009235EB /* WordPressXMLRPCApi.m in Sources */,
 				E1F5A1BC1771C90A00E0495F /* WPTableImageSource.m in Sources */,
 				5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */,
 				B53AD9BF1BE9584B009AB87E /* SettingsSelectionViewController.m in Sources */,

--- a/WordPress/WordPressApi/WPComOAuthController.h
+++ b/WordPress/WordPressApi/WPComOAuthController.h
@@ -1,0 +1,25 @@
+#import <Foundation/Foundation.h>
+
+extern NSString *const WPComOAuthErrorDomain;
+typedef NS_ENUM(NSUInteger, WPComOAuthErrorCode) {
+    WPComOAuthErrorCodeUnknown
+};
+
+@interface WPComOAuthController : UIViewController
+
++ (WPComOAuthController *)sharedController;
+
+- (void)setWordPressComUsername:(NSString *)username;
+- (void)setWordPressComAuthToken:(NSString *)authToken;
+
+- (void)setClient:(NSString *)client;
+- (void)setRedirectUrl:(NSString *)redirectUrl;
+- (void)setSecret:(NSString *)secret;
+- (void)setCompletionBlock:(void (^)(NSString *token, NSString *blogId, NSString *blogUrl, NSString *scope, NSError *error))completionBlock;
+
+- (void)present;
+- (void)presentWithScope:(NSString *)scope blogId:(NSString *)blogId;
+- (void)getTokenWithCode:(NSString *)code secret:(NSString *)secret;
+- (BOOL)handleOpenURL:(NSURL *)URL;
+
+@end

--- a/WordPress/WordPressApi/WPComOAuthController.m
+++ b/WordPress/WordPressApi/WPComOAuthController.m
@@ -1,0 +1,358 @@
+#import <AFNetworking/AFNetworking.h>
+#import "WPComOAuthController.h"
+
+NSString *const WPComOAuthBaseUrl = @"https://public-api.wordpress.com/oauth2";
+NSString *const WPComOAuthLoginUrl = @"https://wordpress.com/wp-login.php";
+NSString *const WPComOAuthErrorDomain = @"WPComOAuthError";
+
+@interface WPComOAuthController () <UIWebViewDelegate,NSURLConnectionDelegate>
+@property IBOutlet UIWebView *webView;
+@end
+
+@implementation WPComOAuthController {
+    NSString *_clientId;
+    NSString *_redirectUrl;
+    NSString *_scope;
+    NSString *_blogId;
+    NSString *_secret;
+    NSString *_username;
+    NSString *_password;
+    NSString *_authToken;
+    BOOL _isSSO;
+    void (^_completionBlock)(NSString *token, NSString *blogId, NSString *blogUrl, NSString *scope, NSError *error);
+}
+
++ (WPComOAuthController *)sharedController {
+    static WPComOAuthController *_sharedController = nil;
+    static dispatch_once_t oncePredicate;
+    dispatch_once(&oncePredicate, ^{
+        _sharedController = [[self alloc] init];
+    });
+
+    return _sharedController;
+}
+
+- (void)present {
+    [self presentWithScope:nil blogId:nil];
+}
+
+- (void)presentWithScope:(NSString *)scope blogId:(NSString *)blogId {
+    NSAssert(_clientId != nil, @"WordPress.com OAuth can't be presented without the client id. Use setClient: before presenting");
+    NSAssert(_redirectUrl != nil, @"WordPress.com OAuth can't be presented without the redirect URL. Use setRedirectUrl: before presenting");
+    _scope = scope;
+    _blogId = blogId;
+
+    if (![[self class] isThisTheWordPressApp] && [[self class] isWordPressAppAvailable] && !_username && !_password) {
+        NSString *url = [NSString stringWithFormat:@"%@://authorize?client_id=%@&redirect_uri=%@", [[self class] wordpressAppURLScheme], _clientId, _redirectUrl];
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
+    } else {
+        [self presentMe];
+    }
+}
+
+- (void)setWordPressComUsername:(NSString *)username {
+    _username = username;
+}
+
+- (void)setWordPressComAuthToken:(NSString *)authToken {
+    _authToken = authToken;
+}
+
+- (void)setClient:(NSString *)client {
+    _clientId = client;
+}
+
+- (void)setRedirectUrl:(NSString *)redirectUrl {
+    _redirectUrl = redirectUrl;
+}
+
+- (void)setSecret:(NSString *)secret {
+    _secret = secret;
+}
+
+- (void)setCompletionBlock:(void (^)(NSString *token, NSString *blogId, NSString *blogUrl, NSString *scope, NSError *error))completionBlock {
+    _completionBlock = [completionBlock copy];
+}
+
+#pragma mark - View lifecycle
+
+- (NSString *)nibName {
+    return nil;
+}
+
+- (void)loadView {
+    UIView *view = [[UIView alloc] initWithFrame:CGRectZero];
+    view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    UIWebView* webView = [[UIWebView alloc] initWithFrame:CGRectZero];
+    webView.delegate = self;
+    webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [view addSubview:webView];
+    self.webView = webView;
+    self.view = view;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel:)];
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+
+    NSString *queryUrl = [NSString stringWithFormat:@"%@/authorize?client_id=%@&redirect_uri=%@&response_type=code", WPComOAuthBaseUrl, _clientId, _redirectUrl];
+    if (_scope) {
+        queryUrl = [queryUrl stringByAppendingFormat:@"&scope=%@", _scope];
+    }
+    if (_blogId) {
+        queryUrl = [queryUrl stringByAppendingFormat:@"&blog_id=%@", _blogId];
+    }
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:queryUrl]];
+    NSString *userAgent = [self userAgent];
+    if (userAgent) {
+        [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];
+    }
+    if (_username && _authToken) {
+        NSString *requestBody = [NSString stringWithFormat:@"%@=%@&%@=%@&%@=%@",
+                                 @"log", [self stringByUrlEncodingString:_username],
+                                 @"pwd", [NSString string],
+                                 @"redirect_to", [self stringByUrlEncodingString:queryUrl]];
+        
+        [request setURL:[NSURL URLWithString:WPComOAuthLoginUrl]];
+        [request setHTTPBody:[requestBody dataUsingEncoding:NSUTF8StringEncoding]];
+        [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)requestBody.length] forHTTPHeaderField:@"Content-Length"];
+        [request addValue:@"*/*" forHTTPHeaderField:@"Accept"];
+        [request addValue:[NSString stringWithFormat:@"Bearer %@", _authToken] forHTTPHeaderField:@"Authorization"];
+        [request setHTTPMethod:@"POST"];
+    }
+    [self.webView loadRequest:request];
+}
+
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
+{
+    return [super shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+}
+
+#pragma mark -
+
+- (IBAction)cancel:(id)sender {
+    [self dismissMe];
+
+    if (_isSSO) {
+        [self openCallbackWithQueryString:@"error=canceled"];
+    } else {
+        if (_completionBlock) {
+            _completionBlock(nil, nil, nil, nil, nil);
+        }
+    }
+}
+
+- (void)presentMe {
+    UINavigationController *navigation = [[UINavigationController alloc] initWithRootViewController:self];
+    UIWindow *window = [[UIApplication sharedApplication] keyWindow];
+    navigation.modalPresentationStyle = UIModalPresentationFormSheet;
+    UIViewController *presenter = window.rootViewController;
+    while (presenter.presentedViewController != nil) {
+        presenter = presenter.presentedViewController;
+    }
+    [presenter presentViewController:navigation animated:YES completion:nil];
+}
+
+- (void)dismissMe {
+    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (NSString *)userAgent {
+    return [[NSUserDefaults standardUserDefaults] objectForKey:@"UserAgent"];
+}
+
+- (NSMutableDictionary *)dictionaryFromQueryString:(NSString *)string {
+    if (!self)
+        return nil;
+
+    NSMutableDictionary *result = [NSMutableDictionary dictionary];
+
+    NSArray *pairs = [string componentsSeparatedByString:@"&"];
+    for (NSString *pair in pairs) {
+        NSRange separator = [pair rangeOfString:@"="];
+        NSString *key, *value;
+        if (separator.location != NSNotFound) {
+            key = [pair substringToIndex:separator.location];
+            value = [[pair substringFromIndex:separator.location + 1] stringByRemovingPercentEncoding];
+        } else {
+            key = pair;
+            value = @"";
+        }
+
+        key = [key stringByRemovingPercentEncoding];
+        [result setObject:value forKey:key];
+    }
+
+    return result;
+}
+
+- (NSString *)stringByUrlEncodingString:(NSString *)string {
+    return [string stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet characterSetWithCharactersInString:@"!*'();:@&=+$,/?%#[]"]];
+}
+
+
++ (NSString *)wordpressAppURLScheme{
+	return @"wordpress-oauth-v2";
+}
+
++ (BOOL)isWordPressAppAvailable {
+	return [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:[[self wordpressAppURLScheme] stringByAppendingString:@":"]]];
+}
+
++ (BOOL)isThisTheWordPressApp {
+    NSString *appIdentifier = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"];
+    return [appIdentifier isEqualToString:@"org.wordpress"];
+}
+
+#pragma mark -
+
+- (id)initForSSO {
+    self = [super init];
+    if (self) {
+        _isSSO = YES;
+    }
+    return self;
+}
+
+- (void)getTokenWithCode:(NSString *)code secret:(NSString *)secret {
+    NSAssert(secret != nil, @"WordPress.com OAuth can't be presented without the secret. Use setSecret: before presenting");
+    NSString *tokenUrl = [NSString stringWithFormat:@"%@/token", WPComOAuthBaseUrl];
+    __block NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:tokenUrl]];
+    NSString *userAgent = [self userAgent];
+    if (userAgent) {
+        [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];
+    }
+    NSString *request_body = [NSString stringWithFormat:@"client_id=%@&redirect_uri=%@&client_secret=%@&code=%@&grant_type=authorization_code",
+                              _clientId,
+                              _redirectUrl,
+                              secret,
+                              code];
+    [request setHTTPMethod:@"POST"];
+    [request setHTTPBody:[request_body dataUsingEncoding:NSUTF8StringEncoding]];
+    AFHTTPRequestOperation* operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
+    operation.responseSerializer = [[AFJSONResponseSerializer alloc] init];
+    [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
+        NSDictionary *response = (NSDictionary *)responseObject;
+        NSString *token = [response objectForKey:@"access_token"];
+        NSString *blogUrl = [response objectForKey:@"blog_url"];
+        NSString *blogId = [response objectForKey:@"blog_url"];
+        NSString *scope = [response objectForKey:@"scope"];
+        if (token && blogUrl) {
+            [self dismissMe];
+
+            if (_completionBlock) {
+                _completionBlock(token, blogId, blogUrl, scope, nil);
+            }
+        } else if ([response objectForKey:@"error_description"]) {
+            if (_completionBlock) {
+                _completionBlock(nil, nil, nil, nil, [NSError errorWithDomain:WPComOAuthErrorDomain code:WPComOAuthErrorCodeUnknown userInfo:@{NSLocalizedDescriptionKey: [response objectForKey:@"error_description"]}]);
+            }
+        } else {
+            if (_completionBlock) {
+                _completionBlock(nil, nil, nil, nil, nil);
+            }
+        }
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        [self cancel:nil];
+    }];
+    [self.webView loadHTMLString:@"Access granted, getting permament access..." baseURL:[NSURL URLWithString:WPComOAuthBaseUrl]];
+    [operation start];
+}
+
+- (BOOL)handleOpenURL:(NSURL *)URL {
+    if ([[URL scheme] isEqualToString:[[self class] wordpressAppURLScheme]] && [[URL host] isEqualToString:@"authorize"]) {
+        NSDictionary *params = [self dictionaryFromQueryString:[URL query]];
+        NSString *clientId = [params objectForKey:@"client_id"];
+        NSString *redirectUrl = [params objectForKey:@"redirect_uri"];
+        if (clientId && redirectUrl) {
+            WPComOAuthController *ssoController = [[WPComOAuthController alloc] initForSSO];
+            [ssoController setWordPressComUsername:_username];
+            [ssoController setWordPressComAuthToken:_authToken];
+            [ssoController setClient:clientId];
+            [ssoController setRedirectUrl:redirectUrl];
+            [ssoController present];
+            return YES;
+        }
+    }
+
+    if (![[self class] isThisTheWordPressApp] && [[URL scheme] hasPrefix:@"wordpress-"] && [[URL host] isEqualToString:@"wordpress-sso"]) {
+        NSDictionary *params = [self dictionaryFromQueryString:[URL query]];
+        NSString *code = [params objectForKey:@"code"];
+        if (code) {
+            [self getTokenWithCode:code secret:_secret];
+        } else if ([params objectForKey:@"error_description"]) {
+            if (_completionBlock) {
+                _completionBlock(nil, nil, nil, nil, [NSError errorWithDomain:WPComOAuthErrorDomain code:WPComOAuthErrorCodeUnknown userInfo:@{NSLocalizedDescriptionKey: [params objectForKey:@"error_description"]}]);
+            }
+        } else {
+            if (_completionBlock) {
+                _completionBlock(nil, nil, nil, nil, nil);
+            }
+        }
+        return YES;
+    }
+    return NO;
+}
+
+- (void)openCallbackWithQueryString:(NSString *)query {
+    _isSSO = NO;
+    NSString *callbackUrl = [NSString stringWithFormat:@"wordpress-%@://wordpress-sso?%@", _clientId, query];
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:callbackUrl]];
+}
+
+#pragma mark - UIWebViewDelegate
+
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType {
+    NSLog(@"webView should load %@", [request URL]);
+    NSURL *url = [request URL];
+    if ([[url absoluteString] isEqualToString:@"about:blank"]) {
+        return YES;
+    }
+    if ([[url absoluteString] hasPrefix:WPComOAuthBaseUrl] || [[url absoluteString] hasPrefix:WPComOAuthLoginUrl]) {
+        NSLog(@"loading %@", url);
+        return YES;
+    } else if ([[url absoluteString] hasPrefix:_redirectUrl]) {
+        NSLog(@"found redirect URL");
+        NSString *query = [url query];
+        NSArray *parameters = [query componentsSeparatedByString:@"&"];
+        NSString *code = nil;
+        for (NSString *parameter in parameters) {
+            if ([parameter hasPrefix:@"code="]) {
+                code = [[parameter componentsSeparatedByString:@"="] lastObject];
+                NSLog(@"found code: %@", code);
+                break;
+            }
+        }
+        if (code) {
+            if (_isSSO) {
+                [self openCallbackWithQueryString:query];
+            } else {
+                [self getTokenWithCode:code secret:_secret];
+            }
+            [self dismissMe];
+            return NO;
+        } else {
+            [self cancel:nil];
+        }
+    }
+    return YES;
+}
+
+- (void)webView:(UIWebView *)aWebView didFailLoadWithError:(NSError *)error {
+    // 102 is the error code when we refuse to load a request
+    if (error.code != 102) {
+        NSLog(@"webView failed loading %@: %@", aWebView.request.URL, [error localizedDescription]);
+        [self cancel:nil];
+    }
+}
+
+@end

--- a/WordPress/WordPressApi/WPHTTPAuthenticationAlertController.h
+++ b/WordPress/WordPressApi/WPHTTPAuthenticationAlertController.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface WPHTTPAuthenticationAlertController : UIAlertController
++ (void)presentWithChallenge:(NSURLAuthenticationChallenge *)challenge;
+@end

--- a/WordPress/WordPressApi/WPHTTPAuthenticationAlertController.m
+++ b/WordPress/WordPressApi/WPHTTPAuthenticationAlertController.m
@@ -1,0 +1,87 @@
+#import "WPHTTPAuthenticationAlertController.h"
+
+@interface WPHTTPAuthenticationAlertController ()
+@property (nonatomic, strong) NSURLAuthenticationChallenge *challenge;
+@end
+
+@implementation WPHTTPAuthenticationAlertController
+
++ (void)presentWithChallenge:(NSURLAuthenticationChallenge *)challenge {
+    UIAlertController *controller;
+    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+        controller = [self controllerForServerTrustChallenge:challenge];
+    } else {
+        controller = [self controllerForUserAuthenticationChallenge:challenge];
+    }
+    UIViewController *presentingController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
+    if (presentingController.presentedViewController) {
+        presentingController = presentingController.presentedViewController;
+    }
+
+    [presentingController presentViewController:controller animated:YES completion:nil];
+}
+
++ (UIAlertController *)controllerForServerTrustChallenge:(NSURLAuthenticationChallenge *)challenge {
+    NSString *title = NSLocalizedString(@"Certificate error", @"Popup title for wrong SSL certificate.");
+    NSString *message = [NSString stringWithFormat:NSLocalizedString(@"The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.\n\nWould you like to trust the certificate anyway?", @""), challenge.protectionSpace.host];
+    UIAlertController *controller =  [UIAlertController alertControllerWithTitle:title
+                                                                         message:message
+                                                                  preferredStyle:UIAlertControllerStyleAlert];
+
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Cancel button label")
+                                                           style:UIAlertActionStyleDefault
+                                                         handler:^(UIAlertAction * _Nonnull action) {
+                                                             [challenge.sender cancelAuthenticationChallenge:challenge];
+                                                         }];
+    [controller addAction:cancelAction];
+
+    UIAlertAction *trustAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Trust", @"Connect when the SSL certificate is invalid")
+                                                          style:UIAlertActionStyleDefault
+                                                        handler:^(UIAlertAction * _Nonnull action) {
+                                                            NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
+
+                                                            [[NSURLCredentialStorage sharedCredentialStorage] setDefaultCredential:credential forProtectionSpace:challenge.protectionSpace];
+                                                            [challenge.sender useCredential:credential forAuthenticationChallenge:challenge];
+                                                        }];
+    [controller addAction:trustAction];
+    return controller;
+}
+
++ (UIAlertController *)controllerForUserAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
+    NSString *title = NSLocalizedString(@"Authentication required", @"Popup title to ask for user credentials.");
+    NSString *message = NSLocalizedString(@"Please enter your credentials", @"Popup message to ask for user credentials (fields shown below).");
+    UIAlertController *controller =  [UIAlertController alertControllerWithTitle:title
+                                                                         message:message
+                                                                  preferredStyle:UIAlertControllerStyleAlert];
+
+    [controller addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+        textField.placeholder = NSLocalizedString(@"Username", @"Login dialog username placeholder");
+    }];
+
+    [controller addTextFieldWithConfigurationHandler:^(UITextField * _Nonnull textField) {
+        textField.placeholder = NSLocalizedString(@"Password", @"Login dialog password placeholder");
+        textField.secureTextEntry = YES;
+    }];
+
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Cancel button label")
+                                                           style:UIAlertActionStyleDefault
+                                                         handler:^(UIAlertAction * _Nonnull action) {
+                                                             [challenge.sender cancelAuthenticationChallenge:challenge];
+                                                         }];
+    [controller addAction:cancelAction];
+
+    UIAlertAction *loginAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Log In", @"Log In button label.")
+                                                          style:UIAlertActionStyleDefault
+                                                        handler:^(UIAlertAction * _Nonnull action) {
+                                                            NSString *username = controller.textFields.firstObject.text;
+                                                            NSString *password = controller.textFields.lastObject.text;
+                                                            NSURLCredential *credential = [NSURLCredential credentialWithUser:username password:password persistence:NSURLCredentialPersistencePermanent];
+
+                                                            [[NSURLCredentialStorage sharedCredentialStorage] setDefaultCredential:credential forProtectionSpace:challenge.protectionSpace];
+                                                            [challenge.sender useCredential:credential forAuthenticationChallenge:challenge];
+                                                        }];
+    [controller addAction:loginAction];
+    return controller;
+}
+
+@end

--- a/WordPress/WordPressApi/WPHTTPRequestOperation.h
+++ b/WordPress/WordPressApi/WPHTTPRequestOperation.h
@@ -1,0 +1,5 @@
+#import <AFNetworking/AFHTTPRequestOperation.h>
+
+@interface WPHTTPRequestOperation : AFHTTPRequestOperation
+
+@end

--- a/WordPress/WordPressApi/WPHTTPRequestOperation.m
+++ b/WordPress/WordPressApi/WPHTTPRequestOperation.m
@@ -1,0 +1,38 @@
+#import "WPHTTPRequestOperation.h"
+
+#import <AFNetworking/AFNetworking.h>
+#import "WPHTTPAuthenticationAlertController.h"
+
+@implementation WPHTTPRequestOperation
+
+#pragma mark - NSURLConnectionDelegate
+
+- (void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
+{
+	if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+		// Handle invalid certificates
+		SecTrustResultType result;
+		OSStatus certificateStatus = SecTrustEvaluate(challenge.protectionSpace.serverTrust, &result);
+		if (certificateStatus == 0 && result == kSecTrustResultRecoverableTrustFailure) {
+			dispatch_async(dispatch_get_main_queue(), ^(void) {
+                [WPHTTPAuthenticationAlertController presentWithChallenge:challenge];
+			});
+		} else {
+			[challenge.sender continueWithoutCredentialForAuthenticationChallenge:challenge];
+		}
+    } else if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodClientCertificate]) {
+        [challenge.sender continueWithoutCredentialForAuthenticationChallenge:challenge];
+	} else {
+		NSURLCredential *credential = [[NSURLCredentialStorage sharedCredentialStorage] defaultCredentialForProtectionSpace:[challenge protectionSpace]];
+		
+		if ([challenge previousFailureCount] == 0 && credential) {
+			[[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+		} else {
+			dispatch_async(dispatch_get_main_queue(), ^(void) {
+                [WPHTTPAuthenticationAlertController presentWithChallenge:challenge];
+			});
+		}
+	}
+}
+
+@end

--- a/WordPress/WordPressApi/WPRSDParser.h
+++ b/WordPress/WordPressApi/WPRSDParser.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+
+@interface WPRSDParser : NSObject<NSXMLParserDelegate>
+- (id)initWithXmlString:(NSString *)string;
+- (NSString *)parsedEndpointWithError:(NSError **)error;
+@end

--- a/WordPress/WordPressApi/WPRSDParser.m
+++ b/WordPress/WordPressApi/WPRSDParser.m
@@ -1,0 +1,42 @@
+#import "WPRSDParser.h"
+
+@implementation WPRSDParser {
+    NSXMLParser *_parser;
+    NSString *_endpoint;
+    NSError *_error;
+}
+
+- (id)initWithXmlString:(NSString *)string {
+    self = [super init];
+    if (self) {
+        _parser = [[NSXMLParser alloc] initWithData:[string dataUsingEncoding:NSUTF8StringEncoding]];
+        [_parser setDelegate:self];
+    }
+    return self;
+}
+
+- (NSString *)parsedEndpointWithError:(NSError **)error {
+    [_parser parse];
+    if (error) *error = _error;
+    return _endpoint;
+}
+
+#pragma mark - NSXMLParserDelegate
+
+- (void)parser:(NSXMLParser *)parser didStartElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName attributes:(NSDictionary *)attributeDict {
+    if ([elementName isEqualToString:@"api"]) {
+        NSString *apiName = attributeDict[@"name"];
+        if (apiName && [apiName isEqualToString:@"WordPress"]) {
+            _endpoint = attributeDict[@"apiLink"];
+            if (_endpoint) {
+                [_parser abortParsing];
+            }
+        }
+    }
+}
+
+- (void)parser:(NSXMLParser *)parser parseErrorOccurred:(NSError *)parseError {
+    _error = parseError;
+}
+
+@end

--- a/WordPress/WordPressApi/WPXMLRPCClient.h
+++ b/WordPress/WordPressApi/WPXMLRPCClient.h
@@ -1,0 +1,200 @@
+#import <Foundation/Foundation.h>
+#import <AFNetworking/AFNetworking.h>
+
+@class WPXMLRPCRequestOperation, WPXMLRPCRequest;
+
+extern NSString *const WPXMLRPCClientErrorDomain;
+
+/**
+ `AFXMLRPCClient` binds together AFNetworking and eczarny's XML-RPC library to interact with XML-RPC based APIs
+ */
+@interface WPXMLRPCClient : NSObject
+
+///---------------------------------------
+/// @name Accessing HTTP Client Properties
+///---------------------------------------
+
+/**
+ The url used as the XML-RPC endpoint
+ */
+@property (readonly, nonatomic, strong) NSURL *xmlrpcEndpoint;
+
+/**
+ The operation queue which manages operations enqueued by the HTTP client.
+ */
+@property (readonly, nonatomic, strong) NSOperationQueue *operationQueue;
+
+///------------------------------------------------
+/// @name Creating and Initializing XML-RPC Clients
+///------------------------------------------------
+
+/**
+ Creates and initializes an `AFXMLRPCClient` object with the specified base URL.
+
+ @param xmlrpcEndpoint The XML-RPC endpoint URL for the XML-RPC client. This argument must not be nil.
+
+ @return The newly-initialized XML-RPC client
+ */
++ (WPXMLRPCClient *)clientWithXMLRPCEndpoint:(NSURL *)xmlrpcEndpoint;
+
+/**
+ Initializes an `AFXMLRPCClient` object with the specified base URL.
+
+ @param xmlrpcEndpoint The XML-RPC endpoint URL for the XML-RPC client. This argument must not be nil.
+
+ @return The newly-initialized XML-RPC client
+ */
+- (id)initWithXMLRPCEndpoint:(NSURL *)xmlrpcEndpoint;
+
+///----------------------------------
+/// @name Managing HTTP Header Values
+///----------------------------------
+
+/**
+ Returns the value for the HTTP headers set in request objects created by the HTTP client.
+
+ @param header The HTTP header to return the default value for
+
+ @return The default value for the HTTP header, or `nil` if unspecified
+ */
+- (NSString *)defaultValueForHeader:(NSString *)header;
+
+/**
+ Sets the value for the HTTP headers set in request objects made by the HTTP client. If `nil`, removes the existing value for that header.
+
+ @param header The HTTP header to set a default value for
+ @param value The value set as default for the specified header, or `nil
+ */
+- (void)setDefaultHeader:(NSString *)header value:(NSString *)value;
+
+/**
+ Sets the "Authorization" HTTP header set in request objects made by the HTTP client to a token-based authentication value, such as an OAuth access token. This overwrites any existing value for this header.
+
+ @param token The authentication token
+ */
+- (void)setAuthorizationHeaderWithToken:(NSString *)token;
+
+/**
+ Clears any existing value for the "Authorization" HTTP header.
+ */
+- (void)clearAuthorizationHeader;
+
+///-------------------------------
+/// @name Creating Request Objects
+///-------------------------------
+
+/**
+ Creates a `NSMutableURLRequest` object with the specified XML-RPC method and parameters.
+
+ @param method The XML-RPC method for the request.
+ @param parameters The XML-RPC parameters to be set as the request body.
+
+ @return A `NSMutableURLRequest` object
+ */
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
+                                parameters:(NSArray *)parameters;
+
+/**
+ Creates a `NSMutableURLRequest` object with the specified XML-RPC method and parameters, but uses streaming to encode and send the XML-RPC request.
+
+ @param method The XML-RPC method for the request.
+ @param parameters The XML-RPC parameters to be set as the request body.
+ @param filePathForCache The path wehere the streaming request will be cached. This file can only be delete after 
+ @return A `NSMutableURLRequest` object
+ */
+- (NSMutableURLRequest *)streamingRequestWithMethod:(NSString *)method
+                                         parameters:(NSArray *)parameters
+                              usingFilePathForCache:(NSString *)filePath;
+
+/**
+ Creates an `AFXMLRPCRequest` object with the specified XML-RPC method and parameters.
+
+ @param method The XML-RPC method for the request.
+ @param parameters The XML-RPC parameters to be set as the request body.
+
+ @return An `AFXMLRPCRequest` object
+ */
+- (WPXMLRPCRequest *)XMLRPCRequestWithMethod:(NSString *)method
+                                  parameters:(NSArray *)parameters;
+
+///-------------------------------
+/// @name Creating HTTP Operations
+///-------------------------------
+
+/**
+ Creates an `AFHTTPRequestOperation`
+
+ @param request The request object to be loaded asynchronously during execution of the operation.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the resonse data. This block has no return value and takes two arguments:, the created request operation and the `NSError` object describing the network or parsing error that occurred.
+ */
+- (AFHTTPRequestOperation *)HTTPRequestOperationWithRequest:(NSURLRequest *)request
+                                                    success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+                                                    failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+
+/**
+ Creates an `AFXMLRPCRequestOperation`
+
+ @param request The request object to be loaded asynchronously during execution of the operation.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the resonse data. This block has no return value and takes two arguments:, the created request operation and the `NSError` object describing the network or parsing error that occurred.
+ */
+- (WPXMLRPCRequestOperation *)XMLRPCRequestOperationWithRequest:(WPXMLRPCRequest *)request
+                                                        success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+                                                        failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+
+/**
+ Creates an `AFHTTPRequestOperation` combining multiple XML-RPC calls in a single request using `system.multicall`
+
+ @param operations An array of `AFXMLRPCRequestOperation` objects
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the resonse data. This block has no return value and takes two arguments:, the created request operation and the `NSError` object describing the network or parsing error that occurred.
+ */
+- (AFHTTPRequestOperation *)combinedHTTPRequestOperationWithOperations:(NSArray *)operations
+                                                               success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+                                                               failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+
+///----------------------------------------
+/// @name Managing Enqueued HTTP Operations
+///----------------------------------------
+
+/**
+ Enqueues an `AFHTTPRequestOperation` to the XML-RPC client's operation queue.
+
+ @param operation The XML-RPC request operation to be enqueued.
+ */
+- (void)enqueueHTTPRequestOperation:(AFHTTPRequestOperation *)operation;
+
+/**
+ Enqueues an `AFXMLRPCRequestOperation` to the XML-RPC client's operation queue.
+
+ @param operation The XML-RPC request operation to be enqueued.
+ */
+- (void)enqueueXMLRPCRequestOperation:(WPXMLRPCRequestOperation *)operation;
+
+/**
+ Cancels all operations in the HTTP client's operation queue.
+ */
+- (void)cancelAllHTTPOperations;
+
+
+///------------------------------
+/// @name Making XML-RPC requests
+///------------------------------
+
+/**
+ Creates an `AFHTTPRequestOperation` with a `XML-RPC` request, and enqueues it to the HTTP client's operation queue.
+
+ @param method The XML-RPC method.
+ @param parameters The XML-RPC parameters to be set as the request body.
+ @param success A block object to be executed when the request operation finishes successfully. This block has no return value and takes two arguments: the created request operation and the object created from the response data of request.
+ @param failure A block object to be executed when the request operation finishes unsuccessfully, or that finishes successfully, but encountered an error while parsing the resonse data. This block has no return value and takes two arguments:, the created request operation and the `NSError` object describing the network or parsing error that occurred.
+
+ @see HTTPRequestOperationWithRequest:success:failure
+ */
+- (void)callMethod:(NSString *)method
+        parameters:(NSArray *)parameters
+           success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+           failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure;
+
+@end

--- a/WordPress/WordPressApi/WPXMLRPCClient.m
+++ b/WordPress/WordPressApi/WPXMLRPCClient.m
@@ -1,0 +1,310 @@
+#import <UIKit/UIKit.h>
+#import <WPXMLRPC/WPXMLRPC.h>
+#import <AFNetworking/AFNetworking.h>
+
+#import "WPXMLRPCClient.h"
+
+#import "WPXMLRPCRequest.h"
+#import "WPXMLRPCRequestOperation.h"
+#import "WPHTTPRequestOperation.h"
+
+#ifndef WPFLog
+#define WPFLog(...) NSLog(__VA_ARGS__)
+#endif
+
+NSString *const WPXMLRPCClientErrorDomain = @"XMLRPC";
+static NSUInteger const WPXMLRPCClientDefaultMaxConcurrentOperationCount = 4;
+
+@interface WPXMLRPCClient ()
+@property (readwrite, nonatomic, strong) NSURL *xmlrpcEndpoint;
+@property (readwrite, nonatomic, strong) NSMutableDictionary *defaultHeaders;
+@property (readwrite, nonatomic, strong) NSOperationQueue *operationQueue;
+@end
+
+@implementation WPXMLRPCClient
+
+#pragma mark - Creating and Initializing XML-RPC Clients
+
++ (WPXMLRPCClient *)clientWithXMLRPCEndpoint:(NSURL *)xmlrpcEndpoint {
+    return [[self alloc] initWithXMLRPCEndpoint:xmlrpcEndpoint];
+}
+
+- (id)initWithXMLRPCEndpoint:(NSURL *)xmlrpcEndpoint {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    self.xmlrpcEndpoint = xmlrpcEndpoint;
+
+    self.defaultHeaders = [NSMutableDictionary dictionary];
+
+	// Accept-Encoding HTTP Header; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3
+    if (([[[UIDevice currentDevice] systemVersion] compare:@"7.1" options:NSNumericSearch] != NSOrderedAscending)) {
+        // if iOS 7.1 or later
+        [self setDefaultHeader:@"Accept-Encoding" value:@"gzip, deflate"];
+    } else {
+        // Disable compression by default, since it causes connection problems with some hosts
+        // Fixed in iOS SDK 7.1 see: https://developer.apple.com/library/ios/releasenotes/General/RN-iOSSDK-7.1/
+        [self setDefaultHeader:@"Accept-Encoding" value:@"identity"];
+    }
+    [self setDefaultHeader:@"Content-Type" value:@"text/xml"];
+
+    NSString *applicationUserAgent = [[NSUserDefaults standardUserDefaults] objectForKey:@"UserAgent"];
+    if (applicationUserAgent) {
+        [self setDefaultHeader:@"User-Agent" value:applicationUserAgent];
+    } else {
+        [self setDefaultHeader:@"User-Agent" value:[NSString stringWithFormat:@"%@/%@ (%@, %@ %@, %@, Scale/%f)", [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleIdentifierKey], [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleVersionKey], @"unknown", [[UIDevice currentDevice] systemName], [[UIDevice currentDevice] systemVersion], [[UIDevice currentDevice] model], ([[UIScreen mainScreen] respondsToSelector:@selector(scale)] ? [[UIScreen mainScreen] scale] : 1.0)]];
+    }
+
+    self.operationQueue = [[NSOperationQueue alloc] init];
+	[self.operationQueue setMaxConcurrentOperationCount:WPXMLRPCClientDefaultMaxConcurrentOperationCount];
+
+    return self;
+}
+
+
+#pragma mark - Managing HTTP Header Values
+
+- (NSString *)defaultValueForHeader:(NSString *)header {
+	return [self.defaultHeaders valueForKey:header];
+}
+
+- (void)setDefaultHeader:(NSString *)header value:(NSString *)value {
+	[self.defaultHeaders setValue:value forKey:header];
+}
+
+- (void)setAuthorizationHeaderWithToken:(NSString *)token {
+    [self setDefaultHeader:@"Authorization" value:[NSString stringWithFormat:@"Bearer %@", token]];
+}
+
+- (void)clearAuthorizationHeader {
+	[self.defaultHeaders removeObjectForKey:@"Authorization"];
+}
+
+#pragma mark - Creating Request Objects
+
+- (NSMutableURLRequest *)requestWithMethod:(NSString *)method
+                                parameters:(NSArray *)parameters {
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.xmlrpcEndpoint];
+    [request setHTTPMethod:@"POST"];
+    [request setAllHTTPHeaderFields:self.defaultHeaders];
+
+    WPXMLRPCEncoder *encoder = [[WPXMLRPCEncoder alloc] initWithMethod:method andParameters:parameters];
+    [request setHTTPBody:[encoder dataEncodedWithError:nil]];
+
+    return request;
+}
+
+- (NSMutableURLRequest *)streamingRequestWithMethod:(NSString *)method
+                                         parameters:(NSArray *)parameters
+                              usingFilePathForCache:(NSString *)filePath
+{
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.xmlrpcEndpoint];
+    [request setHTTPMethod:@"POST"];
+    [request setAllHTTPHeaderFields:self.defaultHeaders];
+
+    WPXMLRPCEncoder *encoder = [[WPXMLRPCEncoder alloc] initWithMethod:method andParameters:parameters];
+    NSError *error = nil;
+    if (![encoder encodeToFile:filePath error:&error]){
+        WPFLog(@"Error encoding request to stream: %@",[error localizedDescription]);
+        return nil;
+    }
+    
+    NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:&error];
+    if (!attributes){
+        WPFLog(@"Error getting length of the request stream: %@",[error localizedDescription]);
+        return nil;
+    }
+    unsigned long long contentLength = [attributes[NSFileSize] unsignedLongLongValue];
+
+    NSInputStream * inputStream = [NSInputStream inputStreamWithFileAtPath:filePath];
+    [request setHTTPBodyStream:inputStream];
+    [request setValue:[NSString stringWithFormat:@"%llu", contentLength] forHTTPHeaderField:@"Content-Length"];
+
+    return request;
+}
+
+- (WPXMLRPCRequest *)XMLRPCRequestWithMethod:(NSString *)method
+                                  parameters:(NSArray *)parameters {
+    return [[WPXMLRPCRequest alloc] initWithMethod:method andParameters:parameters];
+}
+
+#pragma mark - Creating HTTP Operations
+
+- (AFHTTPRequestOperation *)HTTPRequestOperationWithRequest:(NSURLRequest *)request
+                                                    success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+                                                    failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure {
+    WPHTTPRequestOperation *operation = [[WPHTTPRequestOperation alloc] initWithRequest:request];
+
+    BOOL extra_debug_on = getenv("WPDebugXMLRPC") ? YES : NO;
+#ifndef DEBUG
+    NSNumber *extra_debug = [[NSUserDefaults standardUserDefaults] objectForKey:@"extra_debug"];
+    if ([extra_debug boolValue]) extra_debug_on = YES;
+#endif
+
+    void (^xmlrpcSuccess)(AFHTTPRequestOperation *, id) = ^(AFHTTPRequestOperation *operation, id responseObject) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
+            WPXMLRPCDecoder *decoder = [[WPXMLRPCDecoder alloc] initWithData:responseObject];
+            NSError *err = nil;
+            if ( extra_debug_on == YES ) {
+                WPFLog(@"[XML-RPC] < %@", operation.responseString);
+            }
+
+            if ([decoder isFault] || [decoder object] == nil) {
+                err = [decoder error];
+            }
+
+            if ([decoder object] == nil && extra_debug_on) {
+                WPFLog(@"Blog returned invalid data (URL: %@)\n%@", request.URL.absoluteString, operation.responseString);
+            }
+
+            id object = [[decoder object] copy];
+
+            dispatch_async(dispatch_get_main_queue(), ^(void) {
+                if (err) {
+                    if (failure) {
+                        failure(operation, err);
+                    }
+                } else {
+                    if (success) {
+                        success(operation, object);
+                    }
+                }
+            });
+        });
+    };
+    void (^xmlrpcFailure)(AFHTTPRequestOperation *, NSError *) = ^(AFHTTPRequestOperation *operation, NSError *error) {
+        if ( extra_debug_on == YES ) {
+            WPFLog(@"[XML-RPC] ! %@", [error localizedDescription]);
+        }
+
+        if (failure) {
+            failure(operation, error);
+        }
+    };
+    [operation setCompletionBlockWithSuccess:xmlrpcSuccess failure:xmlrpcFailure];
+
+    if ( extra_debug_on == YES ) {
+        NSString *requestString = [[NSString alloc] initWithData:[request HTTPBody] encoding:NSUTF8StringEncoding];
+        if (getenv("WPDebugXMLRPC")) {
+            WPFLog(@"[XML-RPC] > %@", requestString);
+        } else {
+            NSError *error = NULL;
+            NSRegularExpression *method = [NSRegularExpression regularExpressionWithPattern:@"<methodName>(.*)</methodName>" options:NSRegularExpressionCaseInsensitive error:&error];
+            NSArray *matches = [method matchesInString:requestString options:0 range:NSMakeRange(0, [requestString length])];
+            NSString *methodName = nil;
+            if (matches.count > 0) {
+                NSRange methodRange = [[matches objectAtIndex:0] rangeAtIndex:1];
+                if(methodRange.location != NSNotFound)
+                    methodName = [requestString substringWithRange:methodRange];
+            } else if ([request HTTPBodyStream] != nil) {
+                methodName = @"streaming request, unknown method";
+            }
+            WPFLog(@"[XML-RPC] > %@", methodName);
+        }
+    }
+
+    return operation;
+}
+
+- (WPXMLRPCRequestOperation *)XMLRPCRequestOperationWithRequest:(WPXMLRPCRequest *)request
+                                                        success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+                                                        failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure {
+    WPXMLRPCRequestOperation *operation = [[WPXMLRPCRequestOperation alloc] init];
+    operation.XMLRPCRequest = request;
+    operation.success = success;
+    operation.failure = failure;
+
+    return operation;
+}
+
+- (AFHTTPRequestOperation *)combinedHTTPRequestOperationWithOperations:(NSArray *)operations success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure {
+    NSMutableArray *parameters = [NSMutableArray array];
+
+    for (WPXMLRPCRequestOperation *operation in operations) {
+        NSDictionary *param = [NSDictionary dictionaryWithObjectsAndKeys:
+                               operation.XMLRPCRequest.method, @"methodName",
+                               operation.XMLRPCRequest.parameters, @"params",
+                               nil];
+        [parameters addObject:param];
+    }
+
+    NSURLRequest *request = [self requestWithMethod:@"system.multicall" parameters:parameters];
+    void (^_success)(AFHTTPRequestOperation *operation, id responseObject) = ^(AFHTTPRequestOperation *multicallOperation, id responseObject) {
+        NSArray *responses = (NSArray *)responseObject;
+        for (int i = 0; i < [responses count]; i++) {
+            WPXMLRPCRequestOperation *operation = [operations objectAtIndex:i];
+            id object = [responses objectAtIndex:i];
+
+            NSError *error = nil;
+            if ([object isKindOfClass:[NSDictionary class]] && [object objectForKey:@"faultCode"] && [object objectForKey:@"faultString"]) {
+                NSDictionary *usrInfo = [NSDictionary dictionaryWithObjectsAndKeys:[object objectForKey:@"faultString"], NSLocalizedDescriptionKey, nil];
+                error = [NSError errorWithDomain:WPXMLRPCClientErrorDomain code:[[object objectForKey:@"faultCode"] intValue] userInfo:usrInfo];
+            } else if ([object isKindOfClass:[NSArray class]] && [object count] == 1) {
+                object = [object objectAtIndex:0];
+            }
+
+
+            if (error) {
+                if (operation.failure) {
+                    operation.failure(multicallOperation, error);
+                }
+            } else {
+                if (operation.success) {
+                    operation.success(multicallOperation, object);
+                }
+            }
+        }
+        if (success) {
+            success(multicallOperation, responseObject);
+        }
+    };
+    void (^_failure)(AFHTTPRequestOperation *operation, NSError *error) = ^(AFHTTPRequestOperation *multicallOperation, NSError *error) {
+        for (WPXMLRPCRequestOperation *operation in operations) {
+            if (operation.failure) {
+                operation.failure(multicallOperation, error);
+            }
+        }
+        if (failure) {
+            failure(multicallOperation, error);
+        }
+    };
+    AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request
+                                                                      success:_success
+                                                                      failure:_failure];
+    return operation;
+}
+
+#pragma mark - Managing Enqueued HTTP Operations
+
+- (void)enqueueHTTPRequestOperation:(AFHTTPRequestOperation *)operation {
+    [self.operationQueue addOperation:operation];
+}
+
+- (void)enqueueXMLRPCRequestOperation:(WPXMLRPCRequestOperation *)operation {
+    NSURLRequest *request = [self requestWithMethod:operation.XMLRPCRequest.method parameters:operation.XMLRPCRequest.parameters];
+    AFHTTPRequestOperation *op = [self HTTPRequestOperationWithRequest:request success:operation.success failure:operation.failure];
+    [self enqueueHTTPRequestOperation:op];
+}
+
+- (void)cancelAllHTTPOperations {
+    for (AFHTTPRequestOperation *operation in [self.operationQueue operations]) {
+        [operation cancel];
+    }
+}
+
+#pragma mark - Making XML-RPC Requests
+
+- (void)callMethod:(NSString *)method
+        parameters:(NSArray *)parameters
+           success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+           failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure {
+    NSURLRequest *request = [self requestWithMethod:method parameters:parameters];
+    AFHTTPRequestOperation *operation = [self HTTPRequestOperationWithRequest:request success:success failure:failure];
+
+    [self enqueueHTTPRequestOperation:operation];
+}
+
+
+@end

--- a/WordPress/WordPressApi/WPXMLRPCRequest.h
+++ b/WordPress/WordPressApi/WPXMLRPCRequest.h
@@ -1,0 +1,34 @@
+#import <Foundation/Foundation.h>
+
+/**
+ `WPXMLRPCRequest` represents a XML-RPC request.
+ 
+ It is designed to combine multiple requests using `system.multicall` but can also be used for single requests
+ */
+@interface WPXMLRPCRequest : NSObject
+
+/**
+ Initializes a `WPXMLRPCRequest` object with the specified method and parameters.
+
+ @param method the XML-RPC method for this request
+ @param parameters an array containing the parameters for the request. If you want to support streaming, you can use either `NSInputStream` or `NSFileHandle` to encode binary data
+
+ @return The newly-initialized XML-RPC request
+ */
+- (id)initWithMethod:(NSString *)method andParameters:(NSArray *)parameters;
+
+/**
+ The XML-RPC method for this request.
+
+ This is a *read-only* property, as requests can't be reused.
+ */
+@property (nonatomic, readonly) NSString *method;
+
+/**
+ The XML-RPC parameters for this request.
+
+ This is a *read-only* property, as requests can't be reused.
+ */
+@property (nonatomic, readonly) NSArray *parameters;
+
+@end

--- a/WordPress/WordPressApi/WPXMLRPCRequest.m
+++ b/WordPress/WordPressApi/WPXMLRPCRequest.m
@@ -1,0 +1,14 @@
+#import "WPXMLRPCRequest.h"
+
+@implementation WPXMLRPCRequest
+
+- (id)initWithMethod:(NSString *)method andParameters:(NSArray *)parameters {
+    self = [super init];
+    if (self) {
+        _method = method;
+        _parameters = parameters;
+    }
+    return self;
+}
+
+@end

--- a/WordPress/WordPressApi/WPXMLRPCRequestOperation.h
+++ b/WordPress/WordPressApi/WPXMLRPCRequestOperation.h
@@ -1,0 +1,9 @@
+#import <AFNetworking/AFHTTPRequestOperation.h>
+
+@class WPXMLRPCRequest;
+
+@interface WPXMLRPCRequestOperation : NSObject
+@property (nonatomic, strong) WPXMLRPCRequest *XMLRPCRequest;
+@property (nonatomic, copy) void (^success)(AFHTTPRequestOperation *operation, id responseObject);
+@property (nonatomic, copy) void (^failure)(AFHTTPRequestOperation *operation, NSError *error);
+@end

--- a/WordPress/WordPressApi/WPXMLRPCRequestOperation.m
+++ b/WordPress/WordPressApi/WPXMLRPCRequestOperation.m
@@ -1,0 +1,5 @@
+#import "WPXMLRPCRequestOperation.h"
+
+@implementation WPXMLRPCRequestOperation
+
+@end

--- a/WordPress/WordPressApi/WordPressApi.h
+++ b/WordPress/WordPressApi/WordPressApi.h
@@ -1,0 +1,29 @@
+#import <Foundation/Foundation.h>
+#ifndef _WORDPRESSAPI
+#define _WORDPRESSAPI
+#import "WPXMLRPCClient.h"
+#import "WPXMLRPCRequest.h"
+#import "WPXMLRPCRequestOperation.h"
+#import "WordPressBaseApi.h"
+#import "WordPressRestApi.h"
+#import "WordPressXMLRPCApi.h"
+#import "WPComOAuthController.h"
+#endif /* _WORDPRESSAPI */
+
+@interface WordPressApi : NSObject
++ (void)signInWithURL:(NSString *)url username:(NSString *)username password:(NSString *)password success:(void (^)(NSURL *xmlrpcURL))success failure:(void (^)(NSError *error))failure;
+
++ (void)signInWithXMLRPCURL:(NSURL *)xmlrpcURL username:(NSString *)username password:(NSString *)password success:(void (^)())success failure:(void (^)(NSError *error))failure;
++ (id<WordPressBaseApi>)apiWithXMLRPCURL:(NSURL *)xmlrpcURL username:(NSString *)username password:(NSString *)password;
+
++ (void)signInWithOauthWithSuccess:(void (^)(NSString *authToken, NSString *siteId))success failure:(void (^)(NSError *error))failure;
++ (id<WordPressBaseApi>)apiWithOauthToken:(NSString *)authToken siteId:(NSString *)siteId;
+
++ (void)signInWithJetpackUsername:(NSString *)username password:(NSString *)password success:(void (^)(NSString *authToken))success failure:(void (^)(NSError *error))failure;
+
++ (void)setWordPressComClient:(NSString *)clientId;
++ (void)setWordPressComSecret:(NSString *)secret;
++ (void)setWordPressComRedirectUrl:(NSString *)redirectUrl;
++ (BOOL)handleOpenURL:(NSURL *)URL;
+
+@end

--- a/WordPress/WordPressApi/WordPressApi.m
+++ b/WordPress/WordPressApi/WordPressApi.m
@@ -1,0 +1,54 @@
+#import "WordPressApi.h"
+#import "WordPressXMLRPCApi.h"
+#import "WordPressRestApi.h"
+
+@implementation WordPressApi
+
++ (void)signInWithURL:(NSString *)url username:(NSString *)username password:(NSString *)password success:(void (^)(NSURL *xmlrpcURL))success failure:(void (^)(NSError *error))failure {
+    [WordPressXMLRPCApi guessXMLRPCURLForSite:url success:^(NSURL *xmlrpcURL) {
+        [self signInWithXMLRPCURL:xmlrpcURL username:username password:password success:^{
+            if (success) {
+                success(xmlrpcURL);
+            }
+        } failure:failure];
+    } failure:failure];
+}
+
++ (void)signInWithXMLRPCURL:(NSURL *)xmlrpcURL username:(NSString *)username password:(NSString *)password success:(void (^)())success failure:(void (^)(NSError *error))failure {
+    WordPressXMLRPCApi *api = [self apiWithXMLRPCURL:xmlrpcURL username:username password:password];
+    [api authenticateWithSuccess:success failure:failure];
+}
+
++ (id<WordPressBaseApi>)apiWithXMLRPCURL:(NSURL *)xmlrpcURL username:(NSString *)username password:(NSString *)password {
+    return [WordPressXMLRPCApi apiWithXMLRPCEndpoint:xmlrpcURL username:username password:password];
+}
+
++ (void)signInWithOauthWithSuccess:(void (^)(NSString *authToken, NSString *siteId))success failure:(void (^)(NSError *error))failure {
+    [WordPressRestApi signInWithOauthWithSuccess:success failure:failure];
+}
+
++ (id<WordPressBaseApi>)apiWithOauthToken:(NSString *)authToken siteId:(NSString *)siteId {
+    return [[WordPressRestApi alloc] initWithOauthToken:authToken siteId:siteId];
+}
+
++ (void)signInWithJetpackUsername:(NSString *)username password:(NSString *)password success:(void (^)(NSString *authToken))success failure:(void (^)(NSError *error))failure {
+    [WordPressRestApi signInWithJetpackUsername:username password:password success:success failure:failure];
+}
+
++ (void)setWordPressComClient:(NSString *)clientId {
+    [WordPressRestApi setWordPressComClient:clientId];
+}
+
++ (void)setWordPressComSecret:(NSString *)secret {
+    [WordPressRestApi setWordPressComSecret:secret];
+}
+
++ (void)setWordPressComRedirectUrl:(NSString *)redirectUrl {
+    [WordPressRestApi setWordPressComRedirectUrl:redirectUrl];
+}
+
++ (BOOL)handleOpenURL:(NSURL *)URL {
+    return [WordPressRestApi handleOpenURL:URL];
+}
+
+@end

--- a/WordPress/WordPressApi/WordPressBaseApi.h
+++ b/WordPress/WordPressApi/WordPressBaseApi.h
@@ -1,0 +1,77 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@protocol WordPressBaseApi <NSObject>
+
+///-----------------------
+/// @name Quick Publishing
+///-----------------------
+
+/**
+ Publishes a post asynchronously with text/HTML only
+
+ All the parameters are optional, and can be set to `nil`
+
+ @param content The post content/body. It can be text only or HTML, but be aware that some HTML might be stripped in WordPress. [What's allowed in WordPress.com?](http://en.support.wordpress.com/code/)
+ @param title The post title.
+ @param success A block object to execute when the method successfully publishes the post. This block has no return value and takes two arguments: the resulting post ID, and the permalink (or [shortlink](http://en.support.wordpress.com/shortlinks/) if available).
+ @param failure A block object to execute when the method can't publish the post. This block has no return value and takes one argument: a NSError object with details on the error.
+ */
+- (void)publishPostWithText:(NSString *)content
+                      title:(NSString *)title
+                    success:(void (^)(NSUInteger postId, NSURL *permalink))success
+                    failure:(void (^)(NSError *error))failure;
+
+/**
+ Publishes a post asynchronously with an image
+
+ All the parameters are optional, and can be set to `nil`
+
+ @warning **Not implemented yet**. It just calls publishPostWIthText:title:success:failure: ignoring the image
+ @param image An image to add to the post. The image will be embedded **before** the content.
+ @param content The post content/body. It can be text only or HTML, but be aware that some HTML might be stripped in WordPress. [What's allowed in WordPress.com?](http://en.support.wordpress.com/code/)
+ @param title The post title.
+ @param success A block object to execute when the method successfully publishes the post. This block has no return value and takes two arguments: the resulting post ID, and the permalink (or [shortlink](http://en.support.wordpress.com/shortlinks/) if available).
+ @param failure A block object to execute when the method can't publish the post. This block has no return value and takes one argument: a NSError object with details on the error.
+ */
+- (void)publishPostWithImage:(UIImage *)image
+                 description:(NSString *)content
+                       title:(NSString *)title
+                     success:(void (^)(NSUInteger postId, NSURL *permalink))success
+                     failure:(void (^)(NSError *error))failure;
+
+/**
+ Publishes a post asynchronously with an image gallery
+
+ All the parameters are optional, and can be set to `nil`
+
+ @warning **Not implemented yet**. It just calls publishPostWIthText:title:success:failure: ignoring the images
+ @param images An array containing images (as UIImage) to add to the post. The gallery will be embedded **before** the content using the [[gallery]](http://en.support.wordpress.com/images/gallery/) shortcode.
+ @param content The post content/body. It can be text only or HTML, but be aware that some HTML might be stripped in WordPress. [What's allowed in WordPress.com?](http://en.support.wordpress.com/code/)
+ @param title The post title.
+ @param success A block object to execute when the method successfully publishes the post. This block has no return value and takes two arguments: the resulting post ID, and the permalink (or [shortlink](http://en.support.wordpress.com/shortlinks/) if available).
+ @param failure A block object to execute when the method can't publish the post. This block has no return value and takes one argument: a NSError object with details on the error.
+ */
+- (void)publishPostWithGallery:(NSArray *)images
+                   description:(NSString *)content
+                         title:(NSString *)title
+                       success:(void (^)(NSUInteger postId, NSURL *permalink))success
+                       failure:(void (^)(NSError *error))failure;
+
+
+///---------------------
+/// @name Managing posts
+///---------------------
+
+/**
+ Get a list of the recent posts
+
+ @param count Number of recent posts to get
+ @param success A block object to execute when the method successfully publishes the post. This block has no return value and takes one argument: an array with the latest posts.
+ @param failure A block object to execute when the method can't publish the post. This block has no return value and takes one argument: a NSError object with details on the error.
+ */
+- (void)getPosts:(NSUInteger)count
+         success:(void (^)(NSArray *posts))success
+         failure:(void (^)(NSError *error))failure;
+
+@end

--- a/WordPress/WordPressApi/WordPressRestApi.h
+++ b/WordPress/WordPressApi/WordPressRestApi.h
@@ -1,0 +1,37 @@
+#import <Foundation/Foundation.h>
+
+#import "WordPressBaseApi.h"
+
+typedef NS_ENUM(NSUInteger, WordPressRestApiError) {
+    WordPressRestApiErrorJSON,
+    WordPressRestApiErrorNoAccessToken,
+    WordPressRestApiErrorLoginFailed,
+    WordPressRestApiErrorInvalidToken,
+    WordPressRestApiErrorAuthorizationRequired,
+};
+
+extern NSString *const WordPressRestApiEndpointURL;
+extern NSString *const WordPressRestApiErrorDomain;
+extern NSString *const WordPressRestApiErrorCodeKey;
+
+@interface WordPressRestApi : NSObject <WordPressBaseApi>
+
++ (void)signInWithOauthWithSuccess:(void (^)(NSString *authToken, NSString *siteId))success failure:(void (^)(NSError *error))failure;
++ (void)signInWithJetpackUsername:(NSString *)username password:(NSString *)password success:(void (^)(NSString *authToken))success failure:(void (^)(NSError *error))failure;
+
+- (id<WordPressBaseApi>)initWithOauthToken:(NSString *)authToken siteId:(NSString *)siteId;
+
+/**
+ Helper function for [UIApplicationDelegate application:handleOpenURL:] to process the authentication callback from the WordPress app
+
+ @param url The url passed to [UIApplicationDelegate application:handleOpenURL:]
+ @param success A block called if the url could be processed. The block has no return value and takes two arguments: the XML-RPC endpoint for the blog and the OAuth token. We highly recommend you store these in a secure place like the keychain.
+ @returns YES if the url passed was a valid callback from authentication and it could be processed. Otherwise it returns NO.
+ */
++ (BOOL)handleOpenURL:(NSURL *)url;
+
++ (void)setWordPressComClient:(NSString *)clientId;
++ (void)setWordPressComSecret:(NSString *)secret;
++ (void)setWordPressComRedirectUrl:(NSString *)redirectUrl;
+
+@end

--- a/WordPress/WordPressApi/WordPressRestApi.m
+++ b/WordPress/WordPressApi/WordPressRestApi.m
@@ -1,0 +1,157 @@
+#import <UIKit/UIKit.h>
+#import <AFNetworking/AFNetworking.h>
+
+#import "WordPressRestApi.h"
+#import "WordPressRestApiJSONRequestOperation.h"
+#import "WordPressRestApiJSONRequestOperationManager.h"
+#import "WPComOAuthController.h"
+
+NSString *const WordPressRestApiEndpointURL = @"https://public-api.wordpress.com/rest/v1.1/";
+NSString *const WordPressRestApiErrorDomain = @"WordPressRestApiError";
+NSString *const WordPressRestApiErrorCodeKey = @"WordPressRestApiErrorCodeKey";
+
+@implementation WordPressRestApi {
+    NSString *_token;
+    NSString *_siteId;
+    AFHTTPRequestOperationManager *_operationManager;
+}
+
+static NSString *WordPressRestApiClient = nil;
+static NSString *WordPressRestApiSecret = nil;
+static NSString *WordPressRestApiRedirectUrl = nil;
+
++ (void)signInWithOauthWithSuccess:(void (^)(NSString *authToken, NSString *siteId))success failure:(void (^)(NSError *error))failure {
+    [[WPComOAuthController sharedController] setCompletionBlock:^(NSString *token, NSString *blogId, NSString *blogUrl, NSString *scope, NSError *error) {
+        if (error) {
+            failure(error);
+        } else {
+            success(token, blogId);
+        }
+    }];
+    [[WPComOAuthController sharedController] present];
+}
+
++ (void)signInWithJetpackUsername:(NSString *)username password:(NSString *)password success:(void (^)(NSString *authToken))success failure:(void (^)(NSError *error))failure {
+    NSAssert(NO, @"Not implemented yet");
+}
+
+- (id<WordPressBaseApi>)initWithOauthToken:(NSString *)authToken siteId:(NSString *)siteId {
+    self = [super init];
+    
+	if (self) {
+		NSURL* baseURL = [NSURL URLWithString:WordPressRestApiEndpointURL];
+		
+        _token = authToken;
+        _siteId = siteId;
+		
+        _operationManager = [[WordPressRestApiJSONRequestOperationManager alloc] initWithBaseURL:baseURL
+																						   token:_token];
+    }
+	
+    return self;
+}
+
++ (BOOL)handleOpenURL:(NSURL *)url {
+    return [[WPComOAuthController sharedController] handleOpenURL:url];
+}
+
++ (void)setWordPressComClient:(NSString *)clientId {
+    WordPressRestApiClient = clientId;
+    [[WPComOAuthController sharedController] setClient:clientId];
+}
+
++ (void)setWordPressComSecret:(NSString *)secret {
+    WordPressRestApiSecret = secret;
+    [[WPComOAuthController sharedController] setSecret:secret];
+}
+
++ (void)setWordPressComRedirectUrl:(NSString *)redirectUrl {
+    WordPressRestApiRedirectUrl = redirectUrl;
+    [[WPComOAuthController sharedController] setRedirectUrl:redirectUrl];
+}
+
+#pragma mark - WordPressBaseApi methods
+
+- (void)publishPostWithText:(NSString *)content title:(NSString *)title success:(void (^)(NSUInteger postId, NSURL *permalink))success failure:(void (^)(NSError *error))failure {
+    NSDictionary *parameters = @{
+                                 @"title": title,
+                                 @"content": content
+                                 };
+    [_operationManager POST:[self sitePath:@"posts/new"]
+				 parameters:parameters
+					success:^(AFHTTPRequestOperation *operation, id responseObject)
+	{
+		NSUInteger postId = [[responseObject objectForKey:@"ID"] unsignedIntegerValue];
+		NSURL *permalink = [NSURL URLWithString:[responseObject objectForKey:@"URL"]];
+		success(postId, permalink);
+	} failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+		failure(error);
+	}];
+}
+
+- (void)publishPostWithImage:(UIImage *)image description:(NSString *)content title:(NSString *)title success:(void (^)(NSUInteger postId, NSURL *permalink))success failure:(void (^)(NSError *error))failure {
+    if (image) {
+        [self publishPostWithGallery:@[image] description:content title:title success:success failure:failure];
+    } else {
+        [self publishPostWithText:content title:title success:success failure:failure];
+    }
+}
+
+- (void)publishPostWithGallery:(NSArray *)images description:(NSString *)content title:(NSString *)title success:(void (^)(NSUInteger postId, NSURL *permalink))success failure:(void (^)(NSError *error))failure {
+    if (![images count]) {
+        [self publishPostWithText:content title:title success:success failure:failure];
+    }
+
+	void(^contructionBlock)(id<AFMultipartFormData>) = ^(id<AFMultipartFormData> formData)
+	{
+		[images enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+			NSData *imageData = UIImageJPEGRepresentation(obj, 1.f);
+			[formData appendPartWithFileData:imageData name:@"media[]"
+									fileName:[NSString stringWithFormat:@"image-%lu.jpg", (unsigned long)idx]
+									mimeType:@"image/jpeg"];
+		}];
+	};
+	
+	void(^successBlock)(AFHTTPRequestOperation* operation, id responseObject) = ^(AFHTTPRequestOperation *operation,
+																				  id responseObject)
+	{
+		NSUInteger postId = [[responseObject objectForKey:@"ID"] unsignedIntegerValue];
+		NSURL *permalink = [NSURL URLWithString:[responseObject objectForKey:@"URL"]];
+		success(postId, permalink);
+	};
+	
+	void(^failureBlock)(AFHTTPRequestOperation *operation, NSError *error) = ^(AFHTTPRequestOperation *operation,
+																			   NSError *error)
+	{
+        failure(error);
+    };
+	
+    NSDictionary *parameters = @{
+                                 @"title": title,
+                                 @"content": content
+                                 };
+	[_operationManager POST:[self sitePath:@"posts/new"]
+				 parameters:parameters
+  constructingBodyWithBlock:contructionBlock
+					success:successBlock
+					failure:failureBlock];
+}
+
+- (void)getPosts:(NSUInteger)count success:(void (^)(NSArray *posts))success failure:(void (^)(NSError *error))failure {
+    [_operationManager GET:[self sitePath:@"posts"]
+				parameters:nil
+				   success:^(AFHTTPRequestOperation *operation, id responseObject)
+	{
+		success([responseObject objectForKey:@"posts"]);
+	} failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+		failure(error);
+	}];
+}
+
+#pragma mark - API Helpers
+
+- (NSString *)sitePath:(NSString *)path {
+    return [NSString stringWithFormat:@"sites/%@/%@", _siteId, path];
+}
+
+@end

--- a/WordPress/WordPressApi/WordPressRestApiJSONRequestOperation.h
+++ b/WordPress/WordPressApi/WordPressRestApiJSONRequestOperation.h
@@ -1,0 +1,5 @@
+#import <AFNetworking/AFHTTPRequestOperation.h>
+
+@interface WordPressRestApiJSONRequestOperation : AFHTTPRequestOperation
+
+@end

--- a/WordPress/WordPressApi/WordPressRestApiJSONRequestOperationManager.h
+++ b/WordPress/WordPressApi/WordPressRestApiJSONRequestOperationManager.h
@@ -1,0 +1,11 @@
+#import <AFNetworking/AFHTTPRequestOperationManager.h>
+
+@interface WordPressRestApiJSONRequestOperationManager : AFHTTPRequestOperationManager
+
+/**
+ *	@brief		Default initializer.
+ */
+- (id)initWithBaseURL:(NSURL *)url
+				token:(NSString*)token;
+
+@end

--- a/WordPress/WordPressApi/WordPressRestApiJSONRequestOperationManager.m
+++ b/WordPress/WordPressApi/WordPressRestApiJSONRequestOperationManager.m
@@ -1,0 +1,50 @@
+#import "WordPressRestApiJSONRequestOperationManager.h"
+#import "WordPressRestApiJSONRequestOperation.h"
+
+@implementation WordPressRestApiJSONRequestOperationManager
+
+/**
+ *	@brief		This method is not supported by this class.  Use initWithBaseUrl:token: instead.
+ */
+- (id)initWithBaseURL:(NSURL *)url
+{
+	[self doesNotRecognizeSelector:_cmd];
+	self = nil;
+	return self;
+}
+
+- (id)initWithBaseURL:(NSURL *)url
+				token:(NSString*)token
+{
+	NSParameterAssert([url isKindOfClass:[NSURL class]]);
+	NSParameterAssert([token isKindOfClass:[NSString class]]);
+	
+	self = [super initWithBaseURL:url];
+	
+	if (self)
+	{
+		NSString* bearerString = [NSString stringWithFormat:@"Bearer %@", token];
+		
+		[self.requestSerializer setValue:bearerString forHTTPHeaderField:@"Authorization"];
+	}
+	
+	return self;
+}
+
+- (AFHTTPRequestOperation *)HTTPRequestOperationWithRequest:(NSURLRequest *)request
+                                                    success:(void (^)(AFHTTPRequestOperation *operation, id responseObject))success
+                                                    failure:(void (^)(AFHTTPRequestOperation *operation, NSError *error))failure
+{
+    WordPressRestApiJSONRequestOperation *operation = [[WordPressRestApiJSONRequestOperation alloc] initWithRequest:request];
+	
+	operation.responseSerializer = [[AFJSONResponseSerializer alloc] init];
+    operation.shouldUseCredentialStorage = self.shouldUseCredentialStorage;
+    operation.credential = self.credential;
+    operation.securityPolicy = self.securityPolicy;
+	
+    [operation setCompletionBlockWithSuccess:success failure:failure];
+	
+    return operation;
+}
+
+@end

--- a/WordPress/WordPressApi/WordPressXMLRPCApi.h
+++ b/WordPress/WordPressApi/WordPressXMLRPCApi.h
@@ -1,0 +1,104 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import "WordPressBaseApi.h"
+
+extern NSString *const WordPressXMLRPCApiErrorDomain;
+
+typedef NS_ENUM(NSInteger, WordPressXMLRPCApiError) {
+    WordPressXMLRPCApiEmptyURL, // The URL provided was nil, empty or just whitespaces
+    WordPressXMLRPCApiInvalidURL, // The URL provided was an invalid URL
+    WordPressXMLRPCApiInvalidScheme, // The URL provided was an invalid scheme, only HTTP and HTTPS supported
+    WordPressXMLRPCApiNotWordPressError, // That's a XML-RPC endpoint but doesn't look like WordPress
+    WordPressXMLRPCApiMobilePluginRedirectedError, // There's some "mobile" plugin redirecting everything to their site
+    WordPressXMLRPCApiInvalid, // Doesn't look to be valid XMLRPC Endpoint.
+};
+
+/**
+ WordPress API for iOS 
+*/
+@interface WordPressXMLRPCApi : NSObject <WordPressBaseApi>
+
+///-----------------------------------------
+/// @name Accessing WordPress API properties
+///-----------------------------------------
+
+@property (readonly, nonatomic, retain) NSURL *xmlrpc;
+@property (readonly, nonatomic, strong) NSOperationQueue *operationQueue;
+
+
+///-------------------------------------------------------
+/// @name Creating and Initializing a WordPress API Client
+///-------------------------------------------------------
+
+/**
+ Creates and initializes a `WordPressAPI` client using password authentication.
+ 
+ @param xmlrpc The XML-RPC endpoint URL, e.g.: https://en.blog.wordpress.com/xmlrpc.php
+ @param username The user name
+ @param password The password
+ */
++ (WordPressXMLRPCApi *)apiWithXMLRPCEndpoint:(NSURL *)xmlrpc username:(NSString *)username password:(NSString *)password;
+
+/**
+ Initializes a `WordPressAPI` client using password authentication.
+ 
+ @param xmlrpc The XML-RPC endpoint URL, e.g.: https://en.blog.wordpress.com/xmlrpc.php
+ @param username The user name
+ @param password The password
+ */
+- (id)initWithXMLRPCEndpoint:(NSURL *)xmlrpc username:(NSString *)username password:(NSString *)password;
+
+///-------------------
+/// @name Authenticate
+///-------------------
+
+/**
+ Performs a XML-RPC test call just to verify that the credentials are correct.
+ 
+ @param success A block object to execute when the credentials are valid. This block has no return value.
+ @param failure A block object to execute when the credentials can't be verified. This block has no return value and takes one argument: a NSError object with details on the error.
+ */
+- (void)authenticateWithSuccess:(void (^)())success
+                        failure:(void (^)(NSError *error))failure;
+
+/**
+ Authenticates and returns a list of the blogs which the user can access
+
+ @param success A block object to execute when the login is successful. This block has no return value and takes one argument: an array with the blogs list.
+ @param failure A block object to execute when the login failed. This block has no return value and takes one argument: a NSError object with details on the error.
+ */
+- (void)getBlogsWithSuccess:(void (^)(NSArray *blogs))success failure:(void (^)(NSError *error))failure;
+
+/**
+ Authenticates and returns a dictionary of the blog's options.
+
+ @param success A block object to execute when the login is successful. This block has no return value and takes one argument: a dictionary with the blog options.
+ @param failure A block object to execute when the login failed. This block has no return value and takes one argument: a NSError object with details on the error.
+ */
+- (void)getBlogOptionsWithSuccess:(void (^)(id options))success failure:(void (^)(NSError *error))failure;
+
+///--------------
+/// @name Helpers
+///--------------
+
+/**
+ Given a site URL, tries to guess the URL for the XML-RPC endpoint
+ 
+ When asked for a site URL, sometimes users type the XML-RPC url, or the xmlrpc.php has been moved/renamed. This method would try a few methods to find the proper XML-RPC endpoint:
+ 
+ * Try to load the given URL adding `/xmlrpc.php` at the end. This is the most common use case for proper site URLs
+ * If that fails, try a test XML-RPC request given URL, maybe it was the XML-RPC URL already
+ * If that fails, fetch the given URL and search for an `EditURI` link pointing to the XML-RPC endpoint
+ 
+ For additional URL typo fixing, see [NSURL-Guess](https://github.com/koke/NSURL-Guess)
+ 
+ @param url what the user entered as the URL, e.g.: myblog.com
+ @param success A block object to execute when the method finds a suitable XML-RPC endpoint on the site provided. This block has no return value and takes two arguments: the original site URL, and the found XML-RPC endpoint URL.
+ @param failure A block object to execute when the method doesn't find a suitable XML-RPC endpoint on the site. This block has no return value and takes one argument: a NSError object with details on the error.
+ */
++ (void)guessXMLRPCURLForSite:(NSString *)url
+                      success:(void (^)(NSURL *xmlrpcURL))success
+                      failure:(void (^)(NSError *error))failure;
+
+
+@end

--- a/WordPress/WordPressApi/WordPressXMLRPCApi.m
+++ b/WordPress/WordPressApi/WordPressXMLRPCApi.m
@@ -1,0 +1,433 @@
+#import "WordPressXMLRPCApi.h"
+#import "WPXMLRPCClient.h"
+#import "WPRSDParser.h"
+
+NSString *const WordPressXMLRPCApiErrorDomain = @"WordPressXMLRPCApiError";
+
+@interface WordPressXMLRPCApi ()
+
+@property (readwrite, nonatomic, retain) NSURL *xmlrpc;
+@property (readwrite, nonatomic, retain) NSString *username;
+@property (readwrite, nonatomic, retain) NSString *password;
+@property (readwrite, nonatomic, retain) WPXMLRPCClient *client;
+
+@end
+
+@implementation WordPressXMLRPCApi
+
++ (WordPressXMLRPCApi *)apiWithXMLRPCEndpoint:(NSURL *)xmlrpc username:(NSString *)username password:(NSString *)password {
+    return [[self alloc] initWithXMLRPCEndpoint:xmlrpc username:username password:password];
+}
+
+- (id)initWithXMLRPCEndpoint:(NSURL *)xmlrpc username:(NSString *)username password:(NSString *)password
+{
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+
+    self.xmlrpc = xmlrpc;
+    self.username = username;
+    self.password = password;
+
+    self.client = [WPXMLRPCClient clientWithXMLRPCEndpoint:xmlrpc];
+
+    return self;
+}
+
+- (NSOperationQueue *)operationQueue
+{
+    return self.client.operationQueue;
+}
+
+
+#pragma mark - Authentication
+
+- (void)authenticateWithSuccess:(void (^)())success
+                        failure:(void (^)(NSError *error))failure {
+    NSArray *parameters = [NSArray arrayWithObjects:self.username, self.password, nil];
+    [self.client callMethod:@"wp.getUsersBlogs"
+                 parameters:parameters
+                    success:^(AFHTTPRequestOperation *operation, id responseObject) {
+                        if (success) {
+                            success();
+                        }
+                    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                        if (failure) {
+                            failure(error);
+                        }
+                    }];
+}
+
+- (void)getBlogsWithSuccess:(void (^)(NSArray *blogs))success failure:(void (^)(NSError *error))failure {
+    [self.client callMethod:@"wp.getUsersBlogs"
+                 parameters:[NSArray arrayWithObjects:self.username, self.password, nil]
+                    success:^(AFHTTPRequestOperation *operation, id responseObject) {
+                        if (success) {
+                            success(responseObject);
+                        }
+                    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                        if (failure) {
+                            failure(error);
+                        }
+                    }];
+}
+
+- (void)getBlogOptionsWithSuccess:(void (^)(id options))success failure:(void (^)(NSError *error))failure
+{
+    [self.client callMethod:@"wp.getOptions"
+                 parameters:[NSArray arrayWithObjects:@(1), self.username, self.password, nil]
+                    success:^(AFHTTPRequestOperation *operation, id responseObject) {
+                        if (success) {
+                            success(responseObject);
+                        }
+                    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                        if (failure) {
+                            failure(error);
+                        }
+                    }];
+}
+
+#pragma mark - Publishing a post
+
+- (void)publishPostWithText:(NSString *)content title:(NSString *)title success:(void (^)(NSUInteger, NSURL *))success failure:(void (^)(NSError *))failure {
+    NSDictionary *postParameters = [NSDictionary dictionaryWithObjectsAndKeys:
+                                    title, @"post_title",
+                                    content, @"post_content",
+                                    @"publish", @"post_status",
+                                    nil];
+    NSArray *parameters = [self buildParametersWithExtra:postParameters];
+    [self.client callMethod:@"wp.newPost"
+                 parameters:parameters
+                    success:^(AFHTTPRequestOperation *operation, id responseObject) {
+                        if (success) {
+                            success([responseObject intValue], nil);
+                        }
+                    }
+                    failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                        if (failure) {
+                            failure(error);
+                        }
+                    }];
+}
+
+- (void)publishPostWithImage:(UIImage *)image
+                 description:(NSString *)content
+                       title:(NSString *)title
+                     success:(void (^)(NSUInteger postId, NSURL *permalink))success
+                     failure:(void (^)(NSError *error))failure {
+    [self publishPostWithText:content title:title success:success failure:failure];
+}
+
+- (void)publishPostWithGallery:(NSArray *)images
+                   description:(NSString *)content
+                         title:(NSString *)title
+                       success:(void (^)(NSUInteger postId, NSURL *permalink))success
+                       failure:(void (^)(NSError *error))failure {
+    [self publishPostWithText:content title:title success:success failure:failure];
+}
+
+- (void)publishPostWithVideo:(NSString *)videoPath
+                 description:(NSString *)content
+                       title:(NSString *)title
+                     success:(void (^)(NSUInteger postId, NSURL *permalink))success
+                     failure:(void (^)(NSError *error))failure {
+    [self publishPostWithText:content title:title success:success failure:failure];
+}
+
+#pragma mark - Managing posts
+
+- (void)getPosts:(NSUInteger)count
+         success:(void (^)(NSArray *posts))success
+         failure:(void (^)(NSError *error))failure {
+    NSArray *parameters = [self buildParametersWithExtra:nil];
+    [self.client callMethod:@"metaWeblog.getRecentPosts"
+                 parameters:parameters
+                    success:^(AFHTTPRequestOperation *operation, id responseObject) {
+                        if (success) {
+                            success((NSArray *)responseObject);
+                        }
+                    }
+                    failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                        if (failure) {
+                            failure(error);
+                        }
+                    }];
+}
+
+#pragma mark - Helpers
+
++ (NSURL *)urlForXMLRPCFromUrl:(NSString *)url addXMLRPC:(BOOL) addXMLRPC error:(NSError **)error
+{
+    NSString *xmlrpc;
+    // ------------------------------------------------
+    // Is an empty url? Sorry, no psychic powers yet
+    // ------------------------------------------------
+    if (url == nil || [url stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length == 0) {
+        *error = [NSError errorWithDomain:WordPressXMLRPCApiErrorDomain
+                                     code:WordPressXMLRPCApiEmptyURL
+                                 userInfo:@{NSLocalizedDescriptionKey:NSLocalizedString(@"Empty URL", @"")}];
+        return nil;
+    }
+
+    // ------------------------------------------------------------------------
+    // Check if it's a valid URL
+    // Not a valid URL. Could be a bad protocol (htpp://), syntax error (http//), ...
+    // See https://github.com/koke/NSURL-Guess for extra help cleaning user typed URLs
+    // ------------------------------------------------------------------------
+    NSURL *baseURL = [NSURL URLWithString:url];
+    if (baseURL == nil) {
+        *error = [NSError errorWithDomain:WordPressXMLRPCApiErrorDomain
+                                     code:WordPressXMLRPCApiInvalidURL
+                                 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Invalid URL", @"")}];
+        return nil;
+    }
+    // ------------------------------------------------------------------------
+    // Let's see if a scheme is provided and it's HTTP or HTTPS
+    // ------------------------------------------------------------------------
+    NSString *scheme = [baseURL.scheme lowercaseString];
+    if (!scheme) {
+        url = [NSString stringWithFormat:@"http://%@", url];
+        scheme = @"http";
+    }
+    if (!([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"])) {
+        *error = [NSError errorWithDomain:WordPressXMLRPCApiErrorDomain
+                                             code:WordPressXMLRPCApiInvalidScheme
+                                         userInfo:@{NSLocalizedDescriptionKey:NSLocalizedString(@"Invalid URL scheme inserted, only HTTP and HTTPS are supported.", @"Message to explay to the user he should only use HTTP or HTTPS for is self-hosted WordPress sites")}];
+        return nil;
+    }
+
+    // ------------------------------------------------------------------------
+    // Assume the given url is the home page and XML-RPC sits at /xmlrpc.php
+    // ------------------------------------------------------------------------
+    [self logExtraInfo: @"Assume the given url is the home page and XML-RPC sits at /xmlrpc.php" ];
+    if ([[baseURL lastPathComponent] isEqualToString:@"xmlrpc.php"] || !addXMLRPC) {
+        xmlrpc = url;
+    } else {
+        xmlrpc = [NSString stringWithFormat:@"%@/xmlrpc.php", url];
+    }
+    return [NSURL URLWithString:xmlrpc];;
+}
+
++ (void)guessXMLRPCURLForSite:(NSString *)url
+                      success:(void (^)(NSURL *xmlrpcURL))success
+                      failure:(void (^)(NSError *error))failure {
+    NSError *error = nil;
+    NSURL *xmlrpcURL = [self urlForXMLRPCFromUrl:url addXMLRPC:YES error:&error];
+    if (xmlrpcURL == nil) {
+        [self logExtraInfo: [error localizedDescription]];
+        if (failure) {
+            failure(error);
+        }
+        return;
+    }
+    [self logExtraInfo: @"Trying the following URL: %@", xmlrpcURL ];
+    [self validateXMLRPCUrl:xmlrpcURL success:^(NSURL *validatedXmlrpcURL){
+        if (success) {
+            success(validatedXmlrpcURL);
+        }
+    } failure:^(NSError *error){
+        [self logError:error];
+        if (([error.domain isEqual:NSURLErrorDomain] && error.code == NSURLErrorUserCancelledAuthentication)
+            || ([error.domain isEqual:WordPressXMLRPCApiErrorDomain] && error.code == WordPressXMLRPCApiMobilePluginRedirectedError)) {
+            if (failure) {
+                failure(error);
+            }
+            return;
+        }
+        // -------------------------------------------
+        // Try the original given url as an XML-RPC endpoint
+        // -------------------------------------------
+        NSURL *originalXmlrpcURL = [self urlForXMLRPCFromUrl:url addXMLRPC:NO error:nil];
+        [self logExtraInfo: @"Try the given url as an XML-RPC endpoint: %@", originalXmlrpcURL];
+        [self validateXMLRPCUrl:originalXmlrpcURL success:^(NSURL *validatedXmlrpcURL){
+            if (success) {
+                success(validatedXmlrpcURL);
+            }
+        } failure:^(NSError *error){
+            [self logError:error];
+            if ([error.domain isEqual:WordPressXMLRPCApiErrorDomain] && error.code == WordPressXMLRPCApiMobilePluginRedirectedError) {
+                if (failure) {
+                    failure(error);
+                }
+                return;
+            }
+            // Fetch the original url and look for the RSD link
+            [self guessXMLRPCURLFromHTMLURL:originalXmlrpcURL success:success failure:failure];
+        }];
+    }];}
+
++ (void)guessXMLRPCURLFromHTMLURL:(NSURL *)htmlURL
+                      success:(void (^)(NSURL *xmlrpcURL))success
+                      failure:(void (^)(NSError *error))failure {
+    [self logExtraInfo:@"Fetch the original url and look for the RSD link by using RegExp"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:htmlURL];
+    AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
+    [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
+        NSError *error = nil;
+        NSString *responseString = operation.responseString;
+        NSArray *matches = nil;
+        if (responseString) {
+            NSRegularExpression *rsdURLRegExp = [NSRegularExpression regularExpressionWithPattern:@"<link\\s+rel=\"EditURI\"\\s+type=\"application/rsd\\+xml\"\\s+title=\"RSD\"\\s+href=\"([^\"]*)\"[^/]*/>" options:NSRegularExpressionCaseInsensitive error:&error];
+            matches = [rsdURLRegExp matchesInString:responseString options:0 range:NSMakeRange(0, [responseString length])];
+        }
+        NSString *rsdURL = nil;
+        if ([matches count]) {
+            NSRange rsdURLRange = [[matches objectAtIndex:0] rangeAtIndex:1];
+            if(rsdURLRange.location != NSNotFound)
+                rsdURL = [responseString substringWithRange:rsdURLRange];
+        }
+
+        if (rsdURL == nil) {
+            if (failure) {
+                if (error == nil) {
+                    error = [NSError errorWithDomain:WordPressXMLRPCApiErrorDomain
+                                                code:WordPressXMLRPCApiInvalid
+                                            userInfo:@{NSLocalizedDescriptionKey:NSLocalizedString(@"Cannot find a valid WordPress XMLRPC endpoint", @"Message to show when not valid WordPress XMLRPC endpoint is found on the URL provided")}];
+                }
+                failure(error);
+            }
+            return;
+        }
+        // Try removing "?rsd" from the url, it should point to the XML-RPC endpoint
+        NSString *xmlrpc = [rsdURL stringByReplacingOccurrencesOfString:@"?rsd" withString:@""];
+        if (![xmlrpc isEqualToString:rsdURL]) {
+            NSURL *xmlrpcURL = [NSURL URLWithString:xmlrpc];
+            [self validateXMLRPCUrl:xmlrpcURL success:^(NSURL *validatedXmlrpcURL){
+                if (success) {
+                    success(validatedXmlrpcURL);
+                }
+            } failure:^(NSError *error){
+                [self guessXMLRPCURLFromRSD:rsdURL success:success failure:failure];
+            }];
+        } else {
+            [self guessXMLRPCURLFromRSD:rsdURL success:success failure:failure];
+        }
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        [self logError:error];
+        if (failure) failure(error);
+    }];
+    NSOperationQueue *queue = [[NSOperationQueue alloc] init];
+    [queue addOperation:operation];
+}
+
++ (void)guessXMLRPCURLFromRSD:(NSString *)rsd
+                         success:(void (^)(NSURL *xmlrpcURL))success
+                         failure:(void (^)(NSError *error))failure {
+    [self logExtraInfo:@"Parse the RSD document at the following URL: %@", rsd];
+    NSURL *rsdURL = [NSURL URLWithString:rsd];
+    NSURLRequest *request = [NSURLRequest requestWithURL:rsdURL];
+    AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
+    [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
+        NSError *error;
+        WPRSDParser *parser = [[WPRSDParser alloc] initWithXmlString:operation.responseString];
+        NSString *parsedEndpoint = [parser parsedEndpointWithError:&error];
+        if (parsedEndpoint == nil) {
+            if (failure) {
+                failure(error);
+            }
+            return;
+        }
+        NSString *xmlrpc = parsedEndpoint;
+        NSURL *xmlrpcURL = [NSURL URLWithString:xmlrpc];
+        [self logExtraInfo:@"Bingo! We found the WordPress XML-RPC element: %@", xmlrpcURL];
+        [self validateXMLRPCUrl:xmlrpcURL success:^(NSURL *validatedXmlrpcURL){
+            if (success) {
+                success(validatedXmlrpcURL);
+            }
+        } failure:^(NSError *error){
+            [self logError:error];
+            if (failure) failure(error);
+        }];
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        [self logError:error];
+        if (failure) failure(error);
+    }];
+    NSOperationQueue *queue = [[NSOperationQueue alloc] init];
+    [queue addOperation:operation];
+}
+#pragma mark - Private Methods
+
+- (NSArray *)buildParametersWithExtra:(id)extra {
+    NSMutableArray *result = [NSMutableArray array];
+    [result addObject:@"1"];
+    [result addObject:self.username];
+    [result addObject:self.password];
+    if ([extra isKindOfClass:[NSArray class]]) {
+        [result addObjectsFromArray:extra];
+    } else if ([extra isKindOfClass:[NSDictionary class]]) {
+        [result addObject:extra];
+    }
+
+    return [NSArray arrayWithArray:result];
+}
+
++ (void)validateXMLRPCUrl:(NSURL *)url success:(void (^)(NSURL *validatedXmlrpURL))success failure:(void (^)(NSError *error))failure {
+    WPXMLRPCClient *client = [WPXMLRPCClient clientWithXMLRPCEndpoint:url];
+    NSURLRequest *request = [client requestWithMethod:@"system.listMethods" parameters:@[]];
+    __block BOOL isRedirected = NO;
+    AFHTTPRequestOperation *operation = [client HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
+        NSArray *methods = responseObject;
+        if ([methods isKindOfClass:[NSArray class]] && [methods containsObject:@"wp.getUsersBlogs"]) {
+            NSURL *xmlrpcURL = operation.response.URL;
+            [self logExtraInfo:@"Found XML-RPC endpoint at %@", xmlrpcURL];
+            if (success) {
+                success(xmlrpcURL);
+            }
+        } else {
+            if (failure) {
+                NSError *error = [NSError errorWithDomain:WordPressXMLRPCApiErrorDomain code:WordPressXMLRPCApiNotWordPressError userInfo:@{NSLocalizedDescriptionKey: NSLocalizedStringFromTable(@"That doesn't look like a WordPress site", @"WordPressApi", nil)}];
+                failure(error);
+            }
+        }
+    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+        if (isRedirected) {
+            if (operation.responseString != nil
+                && ([operation.responseString rangeOfString:@"<meta name=\"GENERATOR\" content=\"www.dudamobile.com\">"].location != NSNotFound
+                 || [operation.responseString rangeOfString:@"dm404Container"].location != NSNotFound)) {
+                error = [NSError errorWithDomain:WordPressXMLRPCApiErrorDomain code:WordPressXMLRPCApiMobilePluginRedirectedError userInfo:@{NSLocalizedDescriptionKey: NSLocalizedStringFromTable(@"You seem to have installed a mobile plugin from DudaMobile which is preventing the app to connect to your blog", @"WordPressApi", nil)}];
+            }
+        }
+        if (failure) {
+            failure(error);
+        }
+    }];
+    [operation setRedirectResponseBlock:^NSURLRequest *(NSURLConnection *connection, NSURLRequest *redirectRequest, NSURLResponse *redirectResponse) {
+        isRedirected = YES;
+
+        if (redirectResponse) {
+            [self logExtraInfo:@"Redirected to %@", redirectRequest.URL];
+            NSMutableURLRequest *postRequest = postRequest = [client requestWithMethod:@"system.listMethods" parameters:@[]];
+            [postRequest setURL:redirectRequest.URL];
+            return postRequest;
+        }
+
+        return redirectRequest;
+    }];
+
+    [client enqueueHTTPRequestOperation:operation];
+}
+
++ (void)logExtraInfo:(NSString *)format, ... {
+    BOOL extraDebugIsActive = NO;
+    NSNumber *extra_debug = [[NSUserDefaults standardUserDefaults] objectForKey:@"extra_debug"];
+    if ([extra_debug boolValue]) {
+        extraDebugIsActive = YES;
+    }
+#ifdef DEBUG
+    extraDebugIsActive = YES;
+#endif
+
+    if( extraDebugIsActive == NO ) return;
+
+    va_list ap;
+	va_start(ap, format);
+	NSString *message = [[NSString alloc] initWithFormat:format arguments:ap];
+    NSLog(@"[WordPressApi] < %@", message);
+}
+
++ (void)logError:(NSError *)error {
+    [self logExtraInfo:@"Error: %@", error];
+}
+
+@end


### PR DESCRIPTION
For an initial PR, I've tried to stick to just moving the code. I think there's
a lot that can be cleaned up, but I think it's better to refactor once inside
the main project.

Some things I've noticed:

- I'm not sure if SSO has ever been used, but I wouldn't mind removing it. I added the feature a long time ago, but never had any publicity, documentation, or continued testing.
- ReaderTopicService was referencing some of WordPressApi's constants directly to prepend the REST API path to a topic's path. @aerych I think we should store a relative path, as this might be problematic if we want to bump the endpoint version.
- There's a lot of code that was meant for this as a library, but can be removed now. There's also some duplication with WordPressComApi. 

Needs review: @SergioEstevao 