### PR TITLE
Move API credentials outside WordPressApi

### DIFF
--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -183,8 +183,8 @@ static NSString * const UserDictionaryDateKey = @"date";
     [self.api POST:path
         parameters:@{
                      @"email": email,
-                     @"client_id": [WordPressComApiCredentials client],
-                     @"client_secret": [WordPressComApiCredentials secret],
+                     @"client_id": [ApiCredentials client],
+                     @"client_secret": [ApiCredentials secret],
                      }
            success:^(AFHTTPRequestOperation *operation, id responseObject) {
                if (success) {

--- a/WordPress/Classes/Networking/WordPressComServiceRemote.m
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.m
@@ -1,7 +1,7 @@
 #import "WordPressComServiceRemote.h"
 #import "NSString+Helpers.h"
 #import "WordPressComApi.h"
-#import "WordPressComApiCredentials.h"
+#import "ApiCredentials.h"
 
 NSString *const WordPressComApiErrorDomain = @"com.wordpress.api";
 NSString *const WordPressComApiErrorMessageKey = @"WordPressComApiErrorMessageKey";
@@ -71,8 +71,8 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
                              @"username" : username,
                              @"password" : password,
                              @"validate" : @(validate),
-                             @"client_id" : [WordPressComApiCredentials client],
-                             @"client_secret" : [WordPressComApiCredentials secret]
+                             @"client_id" : [ApiCredentials client],
+                             @"client_secret" : [ApiCredentials secret]
                              };
     
     NSString *requestUrl = [self pathForEndpoint:@"users/new"
@@ -181,8 +181,8 @@ NSString *const WordPressComApiErrorCodeKey = @"WordPressComApiErrorCodeKey";
                              @"lang_id": languageId,
                              @"public": @(blogVisibility),
                              @"validate": @(validate),
-                             @"client_id": [WordPressComApiCredentials client],
-                             @"client_secret": [WordPressComApiCredentials secret]
+                             @"client_id": [ApiCredentials client],
+                             @"client_secret": [ApiCredentials secret]
                              };
     
     

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -88,7 +88,7 @@
 
 #import "WordPressAppDelegate.h"
 #import "WordPressComApi.h"
-#import "WordPressComApiCredentials.h"
+#import "ApiCredentials.h"
 #import "WordPressComOAuthClient.h"
 #import "WPAccount.h"
 #import "WPActivityDefaults.h"

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -45,7 +45,7 @@
 
 // Networking
 #import "WPUserAgent.h"
-#import "WordPressComApiCredentials.h"
+#import "ApiCredentials.h"
 
 // Swift support
 #import "WordPress-Swift.h"
@@ -142,7 +142,7 @@ int ddLogLevel = DDLogLevelInfo;
     // Kick this off on a background thread so as to not slow down the app initialization
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
         
-        NSString *lookbackToken = [WordPressComApiCredentials lookbackToken];
+        NSString *lookbackToken = [ApiCredentials lookbackToken];
         
         if ([lookbackToken length] > 0) {
             UIWindow *keyWindow = [UIApplication sharedApplication].keyWindow;
@@ -164,8 +164,8 @@ int ddLogLevel = DDLogLevelInfo;
 
 - (void)setupAppbotX
 {
-    if ([WordPressComApiCredentials appbotXAPIKey].length > 0) {
-        [[ABXApiClient instance] setApiKey:[WordPressComApiCredentials appbotXAPIKey]];
+    if ([ApiCredentials appbotXAPIKey].length > 0) {
+        [[ABXApiClient instance] setApiKey:[ApiCredentials appbotXAPIKey]];
     }
 }
 
@@ -242,11 +242,11 @@ int ddLogLevel = DDLogLevelInfo;
                 NSString *debugType = [params stringForKey:@"type"];
                 NSString *debugKey = [params stringForKey:@"key"];
 
-                if ([[WordPressComApiCredentials debuggingKey] isEqualToString:@""] || [debugKey isEqualToString:@""]) {
+                if ([[ApiCredentials debuggingKey] isEqualToString:@""] || [debugKey isEqualToString:@""]) {
                     return NO;
                 }
 
-                if ([debugKey isEqualToString:[WordPressComApiCredentials debuggingKey]]) {
+                if ([debugKey isEqualToString:[ApiCredentials debuggingKey]]) {
                     if ([debugType isEqualToString:@"crashlytics_crash"]) {
                         [[Crashlytics sharedInstance] crash];
                     }
@@ -705,7 +705,7 @@ int ddLogLevel = DDLogLevelInfo;
     return;
 #endif
     
-    NSString* apiKey = [WordPressComApiCredentials crashlyticsApiKey];
+    NSString* apiKey = [ApiCredentials crashlyticsApiKey];
     
     if (apiKey) {
         self.crashlytics = [[WPCrashlytics alloc] initWithAPIKey:apiKey];
@@ -782,14 +782,14 @@ int ddLogLevel = DDLogLevelInfo;
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     AccountService *accountService  = [[AccountService alloc] initWithManagedObjectContext:context];
     WPAccount *account              = [accountService defaultWordPressComAccount];
-    NSString *apiKey                = [WordPressComApiCredentials simperiumAPIKey];
+    NSString *apiKey                = [ApiCredentials simperiumAPIKey];
 
     if (!account.authToken.length || !apiKey.length) {
         return;
     }
 
     NSString *simperiumToken = [NSString stringWithFormat:@"WPCC/%@/%@", apiKey, account.authToken];
-    NSString *simperiumAppID = [WordPressComApiCredentials simperiumAppId];
+    NSString *simperiumAppID = [ApiCredentials simperiumAppId];
     [self.simperium authenticateWithAppID:simperiumAppID token:simperiumToken];
 }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -1,7 +1,7 @@
 #import "WPAnalyticsTrackerMixpanel.h"
 #import "MixpanelProxy.h"
 #import "WPAnalyticsTrackerMixpanelInstructionsForStat.h"
-#import "WordPressComApiCredentials.h"
+#import "ApiCredentials.h"
 #import "AccountService.h"
 #import "WPAccount.h"
 #import "ContextManager.h"
@@ -50,7 +50,7 @@ NSString *const SessionCount = @"session_count";
 
 - (void)beginSession
 {
-    [self.mixpanelProxy registerInstanceWithToken:[WordPressComApiCredentials mixpanelAPIToken]];
+    [self.mixpanelProxy registerInstanceWithToken:[ApiCredentials mixpanelAPIToken]];
     [self refreshMetadata];
     [self flagIfUserHasSeenLegacyEditor];
 }

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -5,7 +5,7 @@
 #import "WPAnalyticsTrackerWPCom.h"
 #import "WPAnalyticsTrackerAutomatticTracks.h"
 #import "WPTabBarController.h"
-#import "WordPressComApiCredentials.h"
+#import "ApiCredentials.h"
 #import "WordPressAppDelegate.h"
 #import "Blog.h"
 
@@ -74,7 +74,7 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 {
     [self initializeUsageTrackingIfNecessary];
     
-    if ([WordPressComApiCredentials mixpanelAPIToken].length > 0) {
+    if ([ApiCredentials mixpanelAPIToken].length > 0) {
         [WPAnalytics registerTracker:[[WPAnalyticsTrackerMixpanel alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]]];
     }
 

--- a/WordPress/Classes/Utility/HelpshiftUtils.m
+++ b/WordPress/Classes/Utility/HelpshiftUtils.m
@@ -1,6 +1,6 @@
 #import "HelpShiftUtils.h"
 #import <Mixpanel/MPTweakInline.h>
-#import "WordPressComApiCredentials.h"
+#import "ApiCredentials.h"
 #import <Helpshift/HelpshiftCore.h>
 #import <Helpshift/HelpshiftSupport.h>
 
@@ -34,7 +34,7 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
 {
     [HelpshiftCore initializeWithProvider:[HelpshiftSupport sharedInstance]];
     [[HelpshiftSupport sharedInstance] setDelegate:[HelpshiftUtils sharedInstance]];
-    [HelpshiftCore installForApiKey:[WordPressComApiCredentials helpshiftAPIKey] domainName:[WordPressComApiCredentials helpshiftDomainName] appID:[WordPressComApiCredentials helpshiftAppId]];
+    [HelpshiftCore installForApiKey:[ApiCredentials helpshiftAPIKey] domainName:[ApiCredentials helpshiftDomainName] appID:[ApiCredentials helpshiftAppId]];
 
     // We want to make sure Mixpanel updates the remote variable before we check for the flag
     [[HelpshiftUtils sharedInstance] performSelector:@selector(checkIfHelpshiftShouldBeEnabled)

--- a/WordPress/Classes/Utility/HockeyManager.m
+++ b/WordPress/Classes/Utility/HockeyManager.m
@@ -2,7 +2,7 @@
 
 #ifdef INTERNAL_BUILD
 #import "WordPressAppDelegate.h"
-#import "WordPressComApiCredentials.h"
+#import "ApiCredentials.h"
 #import "WPLogger.h"
 #import <HockeySDK/HockeySDK.h>
 
@@ -13,7 +13,7 @@
 @implementation HockeyManager
 
 - (void)configure {
-    [[BITHockeyManager sharedHockeyManager] configureWithIdentifier:[WordPressComApiCredentials hockeyappAppId]
+    [[BITHockeyManager sharedHockeyManager] configureWithIdentifier:[ApiCredentials hockeyappAppId]
                                                            delegate:self];
     [[BITHockeyManager sharedHockeyManager].authenticator setIdentificationType:BITAuthenticatorIdentificationTypeDevice];
     [[BITHockeyManager sharedHockeyManager] startManager];

--- a/WordPress/Credentials/ApiCredentials.h
+++ b/WordPress/Credentials/ApiCredentials.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-@interface WordPressComApiCredentials : NSObject
+@interface ApiCredentials : NSObject
 + (NSString *)client;
 + (NSString *)secret;
 + (NSString *)pocketConsumerKey;

--- a/WordPress/Credentials/ApiCredentials.m
+++ b/WordPress/Credentials/ApiCredentials.m
@@ -1,9 +1,9 @@
-#import "WordPressComApiCredentials.h"
+#import "ApiCredentials.h"
 
 #define WPCOM_API_CLIENT_ID @""
 #define WPCOM_API_CLIENT_SECRET @""
 
-@implementation WordPressComApiCredentials
+@implementation ApiCredentials
 
 + (NSString *)client {
     return WPCOM_API_CLIENT_ID;

--- a/WordPress/Credentials/gencredentials.rb
+++ b/WordPress/Credentials/gencredentials.rb
@@ -154,8 +154,8 @@ end
 
 def print_class(client, secret, pocket, mixpanel_dev, mixpanel_prod, crashlytics, hockeyapp, googleplus, helpshift_api_key, helpshift_domain_name, helpshift_app_id, simperium_api_key, simperium_app_id, debugging_key, lookback_token, appbotx_api_key)
   print <<-EOF
-#import "WordPressComApiCredentials.h"
-@implementation WordPressComApiCredentials
+#import "ApiCredentials.h"
+@implementation ApiCredentials
 EOF
   print_client(client)
   print_secret(secret)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4435,7 +4435,7 @@
 				1D60588D0D05DD3D006BFB54 /* Resources */,
 				832D4F01120A6F7C001708D4 /* CopyFiles */,
 				855804B81A5C5EED008D5A77 /* Generate Build Icon */,
-				E1756E61169493AD00D9EC00 /* Generate WP.com credentials */,
+				E1756E61169493AD00D9EC00 /* Generate API credentials */,
 				1D60588E0D05DD3D006BFB54 /* Sources */,
 				1D60588F0D05DD3D006BFB54 /* Frameworks */,
 				E1CCFB31175D62320016BD8A /* Run Fabric/Crashlytics */,
@@ -5006,7 +5006,7 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		E1756E61169493AD00D9EC00 /* Generate WP.com credentials */ = {
+		E1756E61169493AD00D9EC00 /* Generate API credentials */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -5014,7 +5014,7 @@
 			inputPaths = (
 				"$(SRCROOT)/Credentials/gencredentials.rb",
 			);
-			name = "Generate WP.com credentials";
+			name = "Generate API credentials";
 			outputPaths = (
 				/tmp/WordPress.build/ApiCredentials.m,
 			);

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -781,7 +781,7 @@
 		FFAC89101A96A85800CC06AC /* NSProcessInfo+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = FFAC890F1A96A85800CC06AC /* NSProcessInfo+Util.m */; };
 		FFB1FA9E1BF0EB840090C761 /* UIImage+Exporters.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1FA9D1BF0EB840090C761 /* UIImage+Exporters.swift */; };
 		FFB1FAA01BF0EC4E0090C761 /* PHAsset+Exporters.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1FA9F1BF0EC4E0090C761 /* PHAsset+Exporters.swift */; };
-		FFB7B8201A0012E80032E723 /* WordPressComApiCredentials.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB7B81D1A0012E80032E723 /* WordPressComApiCredentials.m */; };
+		FFB7B8201A0012E80032E723 /* ApiCredentials.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB7B81D1A0012E80032E723 /* ApiCredentials.m */; };
 		FFC6ADD41B56F295002F3C84 /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC6ADD21B56F295002F3C84 /* AboutViewController.swift */; };
 		FFC6ADD51B56F295002F3C84 /* AboutViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FFC6ADD31B56F295002F3C84 /* AboutViewController.xib */; };
 		FFC6ADDA1B56F366002F3C84 /* LocalCoreDataService.m in Sources */ = {isa = PBXBuildFile; fileRef = FFC6ADD91B56F366002F3C84 /* LocalCoreDataService.m */; };
@@ -1766,9 +1766,6 @@
 		E1703A5B1C28006B00C57FA0 /* UITableViewController+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Helpers.swift"; sourceTree = "<group>"; };
 		E1718E9E1CAD0800006F9E2D /* HockeyManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HockeyManager.h; sourceTree = "<group>"; };
 		E1718E9F1CAD0800006F9E2D /* HockeyManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HockeyManager.m; sourceTree = "<group>"; };
-		E1756DD41694560100D9EC00 /* WordPressComApiCredentials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressComApiCredentials.h; sourceTree = "<group>"; };
-		E1756DD51694560100D9EC00 /* WordPressComApiCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressComApiCredentials.m; sourceTree = "<group>"; };
-		E1756E621694A08200D9EC00 /* gencredentials.rb */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = gencredentials.rb; sourceTree = "<group>"; };
 		E177807F1C97FA9500FA7E14 /* StoreKit+Debug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StoreKit+Debug.swift"; sourceTree = "<group>"; };
 		E17B98E7171FFB450073E30D /* WordPress 11.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 11.xcdatamodel"; sourceTree = "<group>"; };
 		E17BE7A9134DEC12007285FD /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1819,6 +1816,9 @@
 		E1B289D919F7AF7000DB0707 /* RemoteBlog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteBlog.h; path = "Remote Objects/RemoteBlog.h"; sourceTree = "<group>"; };
 		E1B289DA19F7AF7000DB0707 /* RemoteBlog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteBlog.m; path = "Remote Objects/RemoteBlog.m"; sourceTree = "<group>"; };
 		E1B2FF581C637AE200F6BDEA /* PlanListViewControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanListViewControllerTest.swift; sourceTree = "<group>"; };
+		E1B34C0A1CCDFFCE00889709 /* gencredentials.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = gencredentials.rb; sourceTree = "<group>"; };
+		E1B34C0B1CCDFFCE00889709 /* ApiCredentials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApiCredentials.h; sourceTree = "<group>"; };
+		E1B34C0C1CCDFFCE00889709 /* ApiCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ApiCredentials.m; sourceTree = "<group>"; };
 		E1B62A7913AA61A100A6FCA4 /* WPWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPWebViewController.h; sourceTree = "<group>"; };
 		E1B62A7A13AA61A100A6FCA4 /* WPWebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPWebViewController.m; sourceTree = "<group>"; };
 		E1B912801BB00EFD003C25B9 /* People.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = People.storyboard; sourceTree = "<group>"; };
@@ -2045,7 +2045,7 @@
 		FFAC890F1A96A85800CC06AC /* NSProcessInfo+Util.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSProcessInfo+Util.m"; sourceTree = "<group>"; };
 		FFB1FA9D1BF0EB840090C761 /* UIImage+Exporters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Exporters.swift"; sourceTree = "<group>"; };
 		FFB1FA9F1BF0EC4E0090C761 /* PHAsset+Exporters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PHAsset+Exporters.swift"; sourceTree = "<group>"; };
-		FFB7B81D1A0012E80032E723 /* WordPressComApiCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WordPressComApiCredentials.m; sourceTree = "<group>"; };
+		FFB7B81D1A0012E80032E723 /* ApiCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ApiCredentials.m; sourceTree = "<group>"; };
 		FFC6ADD21B56F295002F3C84 /* AboutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
 		FFC6ADD31B56F295002F3C84 /* AboutViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AboutViewController.xib; sourceTree = "<group>"; };
 		FFC6ADD91B56F366002F3C84 /* LocalCoreDataService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LocalCoreDataService.m; sourceTree = "<group>"; };
@@ -2245,6 +2245,7 @@
 		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
+				E1B34C091CCDFFCE00889709 /* Credentials */,
 				E1756E661694AA1500D9EC00 /* Derived Sources */,
 				E11F949814A3344300277D31 /* WordPressApi */,
 				080E96DDFE201D6D7F000001 /* Classes */,
@@ -3942,11 +3943,8 @@
 			children = (
 				E1D086E0194214C600F0CC19 /* NSDate+WordPressJSON.h */,
 				E1D086E1194214C600F0CC19 /* NSDate+WordPressJSON.m */,
-				E1756E621694A08200D9EC00 /* gencredentials.rb */,
 				E13EB7A3157D230000885780 /* WordPressComApi.h */,
 				E13EB7A4157D230000885780 /* WordPressComApi.m */,
-				E1756DD41694560100D9EC00 /* WordPressComApiCredentials.h */,
-				E1756DD51694560100D9EC00 /* WordPressComApiCredentials.m */,
 				E1634517183B733B005E967F /* WordPressComOAuthClient.h */,
 				E1634518183B733B005E967F /* WordPressComOAuthClient.m */,
 			);
@@ -4149,7 +4147,7 @@
 			isa = PBXGroup;
 			children = (
 				FF27169E1CAAF5060006E2D4 /* WordPressTestCredentials.swift */,
-				FFB7B81D1A0012E80032E723 /* WordPressComApiCredentials.m */,
+				FFB7B81D1A0012E80032E723 /* ApiCredentials.m */,
 			);
 			name = "Derived Sources";
 			path = /private/tmp/WordPress.build;
@@ -4164,6 +4162,16 @@
 				E1A03F47174283E00085D192 /* BlogToJetpackAccount.m */,
 			);
 			path = "10-11";
+			sourceTree = "<group>";
+		};
+		E1B34C091CCDFFCE00889709 /* Credentials */ = {
+			isa = PBXGroup;
+			children = (
+				E1B34C0A1CCDFFCE00889709 /* gencredentials.rb */,
+				E1B34C0B1CCDFFCE00889709 /* ApiCredentials.h */,
+				E1B34C0C1CCDFFCE00889709 /* ApiCredentials.m */,
+			);
+			path = Credentials;
 			sourceTree = "<group>";
 		};
 		E1B9127F1BB00EF1003C25B9 /* People */ = {
@@ -5004,15 +5012,15 @@
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/WordPressApi/gencredentials.rb",
+				"$(SRCROOT)/Credentials/gencredentials.rb",
 			);
 			name = "Generate WP.com credentials";
 			outputPaths = (
-				/tmp/WordPress.build/WordPressComApiCredentials.m,
+				/tmp/WordPress.build/ApiCredentials.m,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "DERIVED_TMP_DIR=/tmp/WordPress.build\ncp ${SOURCE_ROOT}/WordPressApi/WordPressComApiCredentials.m ${DERIVED_TMP_DIR}/WordPressComApiCredentials.m\n\necho \"Checking for WordPress.com Oauth App Secret in $WPCOM_CONFIG\"\nif [ -a $WPCOM_CONFIG ]\nthen\necho \"Config found\"\nsource $WPCOM_CONFIG\nelse\necho \"No config found\"\nexit 0\nfi\n\nif [ -z $WPCOM_APP_ID ]\nthen\necho \"warning: Missing WPCOM_APP_ID\"\nexit 1\nfi\nif [ -z $WPCOM_APP_SECRET ]\nthen\necho \"warning: Missing WPCOM_APP_SECRET\"\nexit 1\nfi\n\necho \"Generating credentials file in ${DERIVED_TMP_DIR}/WordPressComApiCredentials.m\"\nruby ${SOURCE_ROOT}/WordPressApi/gencredentials.rb > ${DERIVED_TMP_DIR}/WordPressComApiCredentials.m\n";
+			shellScript = "DERIVED_TMP_DIR=/tmp/WordPress.build\ncp ${SOURCE_ROOT}/Credentials/ApiCredentials.m ${DERIVED_TMP_DIR}/ApiCredentials.m\n\necho \"Checking for WordPress.com Oauth App Secret in $WPCOM_CONFIG\"\nif [ -a $WPCOM_CONFIG ]\nthen\necho \"Config found\"\nsource $WPCOM_CONFIG\nelse\necho \"No config found\"\nexit 0\nfi\n\nif [ -z $WPCOM_APP_ID ]\nthen\necho \"warning: Missing WPCOM_APP_ID\"\nexit 1\nfi\nif [ -z $WPCOM_APP_SECRET ]\nthen\necho \"warning: Missing WPCOM_APP_SECRET\"\nexit 1\nfi\n\necho \"Generating credentials file in ${DERIVED_TMP_DIR}/ApiCredentials.m\"\nruby ${SOURCE_ROOT}/Credentials/gencredentials.rb > ${DERIVED_TMP_DIR}/ApiCredentials.m\n";
 			showEnvVarsInLog = 0;
 		};
 		E1CCFB31175D62320016BD8A /* Run Fabric/Crashlytics */ = {
@@ -5253,7 +5261,7 @@
 				E6417B9E1CA07D240084050A /* SigninEmailViewController.swift in Sources */,
 				E1D458691309589C00BF0235 /* Coordinate.m in Sources */,
 				E10A2E9B134E8AD3007643F9 /* PostAnnotation.m in Sources */,
-				FFB7B8201A0012E80032E723 /* WordPressComApiCredentials.m in Sources */,
+				FFB7B8201A0012E80032E723 /* ApiCredentials.m in Sources */,
 				B5DB8AF41C949DC20059196A /* WPImmuTableRows.swift in Sources */,
 				BEC62E2C1BF2F58D007685B2 /* CreateNewBlogViewController.m in Sources */,
 				E1B62A7B13AA61A100A6FCA4 /* WPWebViewController.m in Sources */,

--- a/WordPress/WordPressApi/WordPressComOAuthClient.m
+++ b/WordPress/WordPressApi/WordPressComOAuthClient.m
@@ -1,5 +1,5 @@
 #import "WordPressComOAuthClient.h"
-#import "WordPressComApiCredentials.h"
+#import "ApiCredentials.h"
 
 NSString * const WordPressComOAuthErrorDomain = @"WordPressComOAuthError";
 NSString * const WordPressComOAuthKeychainServiceName = @"public-api.wordpress.com";
@@ -31,8 +31,8 @@ static NSString * const WordPressComOAuthRedirectUrl = @"https://wordpress.com/"
         @"username": username,
         @"password": password,
         @"grant_type": @"password",
-        @"client_id": [WordPressComApiCredentials client],
-        @"client_secret": [WordPressComApiCredentials secret],
+        @"client_id": [ApiCredentials client],
+        @"client_secret": [ApiCredentials secret],
         @"wpcom_supports_2fa": @(YES)
     } mutableCopy];
     
@@ -66,8 +66,8 @@ static NSString * const WordPressComOAuthRedirectUrl = @"https://wordpress.com/"
         @"username": username,
         @"password": password,
         @"grant_type": @"password",
-        @"client_id": [WordPressComApiCredentials client],
-        @"client_secret": [WordPressComApiCredentials secret],
+        @"client_id": [ApiCredentials client],
+        @"client_secret": [ApiCredentials secret],
         @"wpcom_supports_2fa": @(YES),
         @"wpcom_resend_otp": @(YES)
     };

--- a/WordPress/WordPressTest/WPAppAnalyticsTests.m
+++ b/WordPress/WordPressTest/WPAppAnalyticsTests.m
@@ -3,7 +3,7 @@
 #import <XCTest/XCTest.h>
 
 #import "WordPressAppDelegate.h"
-#import "WordPressComApiCredentials.h"
+#import "ApiCredentials.h"
 #import "WPAppAnalytics.h"
 #import "WPAnalyticsTrackerMixpanel.h"
 #import "WPAnalyticsTrackerWPCom.h"
@@ -20,7 +20,7 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WPAppAnalyticsDefaultsKeyUsageTracking];
     
     id analyticsMock = [OCMockObject mockForClass:[WPAnalytics class]];
-    id apiCredentialsMock = [OCMockObject mockForClass:[WordPressComApiCredentials class]];
+    id apiCredentialsMock = [OCMockObject mockForClass:[ApiCredentials class]];
     
     OCMockInvocationBlock firstRegisterTrackerInvocationBlock = ^(NSInvocation *invocation) {
         __unsafe_unretained id<WPAnalyticsTracker> tracker = nil;
@@ -64,7 +64,7 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WPAppAnalyticsDefaultsKeyUsageTracking];
     
     id analyticsMock = [OCMockObject mockForClass:[WPAnalytics class]];
-    id apiCredentialsMock = [OCMockObject mockForClass:[WordPressComApiCredentials class]];
+    id apiCredentialsMock = [OCMockObject mockForClass:[ApiCredentials class]];
     
     OCMockInvocationBlock registerTrackerInvocationBlock = ^(NSInvocation *invocation) {
         __unsafe_unretained id<WPAnalyticsTracker> tracker = nil;
@@ -96,7 +96,7 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     [[NSUserDefaults standardUserDefaults] setBool:NO forKey:WPAppAnalyticsDefaultsKeyUsageTracking];
     
     id analyticsMock = [OCMockObject mockForClass:[WPAnalytics class]];
-    id apiCredentialsMock = [OCMockObject mockForClass:[WordPressComApiCredentials class]];
+    id apiCredentialsMock = [OCMockObject mockForClass:[ApiCredentials class]];
     
     OCMockInvocationBlock firstRegisterTrackerInvocationBlock = ^(NSInvocation *invocation) {
         __unsafe_unretained id<WPAnalyticsTracker> tracker = nil;


### PR DESCRIPTION
Before moving further with #5187 I'm moving the credentials code outside the WordPressApi directory, since it doesn't really belong there, but mostly because I don't want to put the credentials inside a framework.

Also renamed to ApiCredentials, since they don't just contain wp.com credentials
anymore.

Needs review: @SergioEstevao 
