### PR TITLE
Fixes #5195 – Toggling site visibility crashed the app

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/WPBlogTableViewCell.h
+++ b/WordPress/Classes/ViewRelated/Cells/WPBlogTableViewCell.h
@@ -3,6 +3,6 @@
 @interface WPBlogTableViewCell : WPTableViewCell
 
 @property (nonatomic, weak, nullable) UISwitch *visibilitySwitch;
-@property (nonatomic, copy, nullable) void (^visibilitySwitchToggled)(WPBlogTableViewCell *cell);
+@property (nonatomic, copy, nullable) void (^visibilitySwitchToggled)(WPBlogTableViewCell * _Nonnull cell);
 
 @end

--- a/WordPress/Classes/ViewRelated/Cells/WPBlogTableViewCell.h
+++ b/WordPress/Classes/ViewRelated/Cells/WPBlogTableViewCell.h
@@ -2,6 +2,7 @@
 
 @interface WPBlogTableViewCell : WPTableViewCell
 
-@property (nonatomic, weak) UISwitch *visibilitySwitch;
+@property (nonatomic, weak, nullable) UISwitch *visibilitySwitch;
+@property (nonatomic, copy, nullable) void (^visibilitySwitchToggled)(WPBlogTableViewCell *cell);
 
 @end

--- a/WordPress/Classes/ViewRelated/Cells/WPBlogTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/WPBlogTableViewCell.m
@@ -16,9 +16,19 @@
 {
     if (!self.visibilitySwitch) {
         UISwitch *visibilitySwitch = [UISwitch new];
-
+        [visibilitySwitch addTarget:self
+                             action:@selector(visibilitySwitchTapped)
+                   forControlEvents:UIControlEventValueChanged];
+        
         self.editingAccessoryView = visibilitySwitch;
         self.visibilitySwitch = visibilitySwitch;
+    }
+}
+
+- (void)visibilitySwitchTapped
+{
+    if (self.visibilitySwitchToggled) {
+        self.visibilitySwitchToggled(self);
     }
 }
 


### PR DESCRIPTION
Fixes #5195. See that issue for full details, and how to test.

I've tweaked the code so that it can now use the correct index path for each cell, rather than relying on a view tag (eww!)

Needs review: @jleandroperez 
Thanks!

