### PR TITLE
Issues/5205 die svg die

### DIFF
--- a/WordPress/Classes/Utility/DisplayableImageHelper.m
+++ b/WordPress/Classes/Utility/DisplayableImageHelper.m
@@ -82,7 +82,13 @@ static NSString * const AttachmentsDictionaryKeyMimeType = @"mime_type";
 
         // Ignore WordPress emoji images
         if ([src rangeOfString:@"/images/core/emoji/"].location != NSNotFound ||
-            [src rangeOfString:@"/wp-includes/images/smilies/"].location != NSNotFound) {
+            [src rangeOfString:@"/wp-includes/images/smilies/"].location != NSNotFound ||
+            [src rangeOfString:@"/wp-content/mu-plugins/wpcom-smileys/"].location != NSNotFound) {
+            continue;
+        }
+
+        // Ignore .svg images since we can't display them in a UIImageView
+        if ([src rangeOfString:@".svg"].location != NSNotFound) {
             continue;
         }
 

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -35,7 +35,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6.2</string>
+	<string>6.2.0.1</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.2.0.20160418</string>
+	<string>6.2.0.20160419</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6.2.0.20160418</string>
+	<string>6.2.0.20160419</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>

--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.1.0.20160411</string>
+	<string>6.2.0.20160418</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6.1.0.20160411</string>
+	<string>6.2.0.20160418</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>

--- a/WordPress/WordPressShareExtension/Info.plist
+++ b/WordPress/WordPressShareExtension/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>6.2</string>
+	<string>6.2.0.1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WordPress/WordPressTodayWidget/Info.plist
+++ b/WordPress/WordPressTodayWidget/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>6.2</string>
+	<string>6.2.0.1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>


### PR DESCRIPTION
Fixes #5205

To test:
View a feed where some of the posts contain a single .svg image, and where they contain a wpcom smiley.  Make sure that none of the .svg images are picked up.

Needs review: @jleandroperez 
