### PR TITLE
Reader: Filter out svg and wpcom smilies from featured images.

### DIFF
--- a/WordPress/Classes/Utility/DisplayableImageHelper.m
+++ b/WordPress/Classes/Utility/DisplayableImageHelper.m
@@ -82,7 +82,13 @@ static NSString * const AttachmentsDictionaryKeyMimeType = @"mime_type";
 
         // Ignore WordPress emoji images
         if ([src rangeOfString:@"/images/core/emoji/"].location != NSNotFound ||
-            [src rangeOfString:@"/wp-includes/images/smilies/"].location != NSNotFound) {
+            [src rangeOfString:@"/wp-includes/images/smilies/"].location != NSNotFound ||
+            [src rangeOfString:@"/wp-content/mu-plugins/wpcom-smileys/"].location != NSNotFound) {
+            continue;
+        }
+
+        // Ignore .svg images since we can't display them in a UIImageView
+        if ([src rangeOfString:@".svg"].location != NSNotFound) {
             continue;
         }
 


### PR DESCRIPTION
Fixes #5205

To test:
View a feed where some of the posts contain a single .svg image, and where they contain a wpcom smiley. Make sure that none of the .svg images are picked up.

Needs review: @jleandroperez
