### PR TITLE
Gridicons pod now uses Cocoapods trunk.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -40,7 +40,7 @@ target 'WordPress', :exclusive => true do
   # --------------------
   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.0.13'
   pod 'EmailChecker', :podspec => 'https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec'
-  pod 'Gridicons', :podspec => 'https://raw.github.com/Automattic/Gridicons-iOS/develop/Gridicons.podspec'
+  pod 'Gridicons', '0.2'
   pod 'NSObject-SafeExpectations', '0.0.2'
   pod 'NSURL+IDN', '0.3'
   pod 'Simperium', '0.8.15'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -70,7 +70,7 @@ PODS:
   - FormatterKit/TimeIntervalFormatter (1.8.0)
   - FormatterKit/UnitOfInformationFormatter (1.8.0)
   - FormatterKit/URLRequestFormatter (1.8.0)
-  - Gridicons (0.1)
+  - Gridicons (0.2)
   - Helpshift (5.5.1)
   - HockeySDK (3.8.6):
     - HockeySDK/AllFeaturesLib (= 3.8.6)
@@ -197,7 +197,7 @@ DEPENDENCIES:
   - EmailChecker (from `https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec`)
   - Expecta (= 0.3.2)
   - FormatterKit (~> 1.8.0)
-  - Gridicons (from `https://raw.github.com/Automattic/Gridicons-iOS/develop/Gridicons.podspec`)
+  - Gridicons (= 0.2)
   - Helpshift (~> 5.5.1)
   - HockeySDK (~> 3.8.0)
   - Lookback (= 1.1.4)
@@ -237,8 +237,6 @@ EXTERNAL SOURCES:
     :tag: 0.0.13
   EmailChecker:
     :podspec: https://raw.github.com/wordpress-mobile/EmailChecker/develop/ios/EmailChecker.podspec
-  Gridicons:
-    :podspec: https://raw.github.com/Automattic/Gridicons-iOS/develop/Gridicons.podspec
   WordPress-AppbotX:
     :commit: 87bae8c770cfc4e053119f2d00f76b2f653b26ce
     :git: https://github.com/wordpress-mobile/appbotx.git
@@ -271,7 +269,7 @@ SPEC CHECKSUMS:
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   Fabric: caf7580c725e64db144f610ac65cd60956911dc7
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
-  Gridicons: 6dfc3f24cc81ee8aae3492c2ba814bd45fcdf0c7
+  Gridicons: 5c33065054b19e56a47d252b52e321746b97a414
   Helpshift: 1b89b3632bf46af10d2c9d9f448e64a0ccf667ec
   HockeySDK: ab68303eec6680f6b539de65d747742dd276e934
   Lookback: 9ab9027ff246d2dc5ce34be483f70e4a6718280b


### PR DESCRIPTION
Switching to using Gridicons from Cocoapods' spec repo instead of pointing directly at the podspec.

Needs review: @SergioEstevao 
Thanks!
