### PR TITLE
Share Extension: Jetpack Blavatars

### DIFF
--- a/WordPress/Classes/Categories/UIImage+Alpha.h
+++ b/WordPress/Classes/Categories/UIImage+Alpha.h
@@ -3,6 +3,9 @@
 // Free for personal or commercial use, with or without modification.
 // No warranty is expressed or implied.
 
+#import <UIKit/UIKit.h>
+
+
 // Helper methods for adding an alpha layer to an image
 @interface UIImage (Alpha)
 - (BOOL)hasAlpha;

--- a/WordPress/Classes/Categories/UIImage+Resize.h
+++ b/WordPress/Classes/Categories/UIImage+Resize.h
@@ -3,6 +3,9 @@
 // Free for personal or commercial use, with or without modification.
 // No warranty is expressed or implied.
 
+#import <UIKit/UIKit.h>
+
+
 // Extends the UIImage class to support resizing/cropping
 @interface UIImage (Resize)
 - (UIImage *)croppedImage:(CGRect)bounds;

--- a/WordPress/Classes/Categories/UIImage+RoundedCorner.h
+++ b/WordPress/Classes/Categories/UIImage+RoundedCorner.h
@@ -3,6 +3,9 @@
 // Free for personal or commercial use, with or without modification.
 // No warranty is expressed or implied.
 
+#import <UIKit/UIKit.h>
+
+
 // Extends the UIImage class to support making rounded corners
 @interface UIImage (RoundedCorner)
 - (UIImage *)roundedCornerImage:(NSInteger)cornerSize borderSize:(NSInteger)borderSize;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -465,6 +465,9 @@
 		B5CEEB8E1B7920BE00E7B7B0 /* CommentsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CEEB8D1B7920BE00E7B7B0 /* CommentsTableViewCell.swift */; };
 		B5CEEB901B79244D00E7B7B0 /* CommentsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5CEEB8F1B79244D00E7B7B0 /* CommentsTableViewCell.xib */; };
 		B5D689FD1A5EBC900063D9E5 /* PushNotificationsManagerTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B5D689FC1A5EBC900063D9E5 /* PushNotificationsManagerTestHelper.m */; };
+		B5D7A0EB1CCFD1F6003C375D /* UIImage+Alpha.m in Sources */ = {isa = PBXBuildFile; fileRef = 834CAE9D122D56B1003DDF49 /* UIImage+Alpha.m */; };
+		B5D7A0EC1CCFD1FC003C375D /* UIImage+RoundedCorner.m in Sources */ = {isa = PBXBuildFile; fileRef = 834CAE9E122D56B1003DDF49 /* UIImage+RoundedCorner.m */; };
+		B5D7A0ED1CCFD1FF003C375D /* UIImage+Resize.m in Sources */ = {isa = PBXBuildFile; fileRef = 834CAE7B122D528A003DDF49 /* UIImage+Resize.m */; };
 		B5D889411BEBE30A007C4684 /* BlogSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D889401BEBE30A007C4684 /* BlogSettings.swift */; };
 		B5DB8AF21C949DA90059196A /* WPReusableTableViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB8AF11C949DA90059196A /* WPReusableTableViewCells.swift */; };
 		B5DB8AF41C949DC20059196A /* WPImmuTableRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DB8AF31C949DC20059196A /* WPImmuTableRows.swift */; };
@@ -5570,11 +5573,14 @@
 				B52937E01C94A2B100940C1C /* WPReusableTableViewCells.swift in Sources */,
 				B5BEA5621C7CE71D00C8035B /* WPDDLogWrapper.m in Sources */,
 				B50248B61C96FF8400AFBDED /* SitePickerViewController.swift in Sources */,
+				B5D7A0EC1CCFD1FC003C375D /* UIImage+RoundedCorner.m in Sources */,
+				B5D7A0EB1CCFD1F6003C375D /* UIImage+Alpha.m in Sources */,
 				B5BEA55F1C7CE6D100C8035B /* Constants.m in Sources */,
 				B50248B51C96FF8400AFBDED /* ShareViewController.swift in Sources */,
 				B5BEA5601C7CE6D700C8035B /* SFHFKeychainUtils.m in Sources */,
 				B504F5F51C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift in Sources */,
 				B51DAF001C7E2332007F474C /* NSString+Helpers.swift in Sources */,
+				B5D7A0ED1CCFD1FF003C375D /* UIImage+Resize.m in Sources */,
 				B5FA22831C99F6180016CA7C /* Tracks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPress/WordPressShareExtension/UIImageView+Extensions.swift
+++ b/WordPress/WordPressShareExtension/UIImageView+Extensions.swift
@@ -54,16 +54,16 @@ extension UIImageView
     ///
     public func downloadBlavatar(url: NSURL) {
         let components = NSURLComponents(URL: url, resolvingAgainstBaseURL: true)
-        components?.query = String(format: Downloader.blavatarResizeFormat, blavatarSize())
+        components?.query = String(format: Downloader.blavatarResizeFormat, blavatarSize)
         
         if let updatedURL = components?.URL {
             downloadImage(updatedURL)
         }
     }
-    
+
     
     /// Returns the desired Blavatar Side-Size
-    private func blavatarSize() -> Int {
+    private var blavatarSize : Int {
         var size = Downloader.defaultImageSize
         
         if !CGSizeEqualToSize(bounds.size, CGSizeZero) {

--- a/WordPress/WordPressShareExtension/UIImageView+Extensions.swift
+++ b/WordPress/WordPressShareExtension/UIImageView+Extensions.swift
@@ -21,12 +21,15 @@ extension UIImageView
             downloadTask = nil
         }
         
+        // Helpers
+        let scale = mainScreenScale
+        let size = CGSize(width: blavatarSizeInPoints, height: blavatarSizeInPoints)
+        
         // Hit the Backend
         let request = NSMutableURLRequest(URL: url)
         request.HTTPShouldHandleCookies = false
         request.addValue("image/*", forHTTPHeaderField: "Accept")
         
-        let scale = mainScreenScale
         let session = NSURLSession.sharedSession()
         let task = session.dataTaskWithRequest(request) { [weak self] data, response, error in
             guard let data = data, let image = UIImage(data: data, scale: scale) else {
@@ -34,11 +37,18 @@ extension UIImageView
             }
             
             dispatch_async(dispatch_get_main_queue()) {
-                // Update the Cache
-                Downloader.cache.setObject(image, forKey: url)
+                // Resize if needed!
+                var resizedImage = image
                 
-                // Refresh!
-                self?.image = image
+                if image.size.height > size.height || image.size.width > size.width {
+                    resizedImage = image.resizedImageWithContentMode(.ScaleAspectFit,
+                                                                     bounds: size,
+                                                                     interpolationQuality: .High)
+                }
+                
+                // Update the Cache
+                Downloader.cache.setObject(resizedImage, forKey: url)
+                self?.image = resizedImage
             }
         }
         
@@ -62,16 +72,19 @@ extension UIImageView
     }
 
     
-    /// Returns the desired Blavatar Side-Size
+    /// Returns the desired Blavatar Side-Size, in pixels
     private var blavatarSize : Int {
+        return blavatarSizeInPoints * Int(mainScreenScale)
+    }
+
+    /// Returns the desired Blavatar Side-Size, in points
+    private var blavatarSizeInPoints : Int {
         var size = Downloader.defaultImageSize
         
         if !CGSizeEqualToSize(bounds.size, CGSizeZero) {
             size = max(bounds.width, bounds.height);
         }
-
-        size *= mainScreenScale
-    
+        
         return Int(size)
     }
     

--- a/WordPress/WordPressShareExtension/WordPressShare-Bridging-Header.h
+++ b/WordPress/WordPressShareExtension/WordPressShare-Bridging-Header.h
@@ -4,3 +4,4 @@
 // Shared Helpers
 #import "WPDDLogWrapper.h"
 #import "SFHFKeychainUtils.h"
+#import "UIImage+Resize.h"


### PR DESCRIPTION
Fixes #5192

#### Scenario:
1. Hack [this spot](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/WordPressShareExtension/SitePickerViewController.swift#L107) so that siteIconUrl gets initialized with the following url: `https://i1.wp.com/photos.happylinguist.com/wp-content/uploads/2013/12/cropped-conwycastle.jpg`.
2. Launch the share extension.
3. Verify that the Blavatars are properly sized down, when / if needed.

Needs review: @astralbodies 
Thanks in advance Aaron!