### PR TITLE
Signin: Switches order that blogs are updated and acct info is synced..

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninWPComSyncHandler.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninWPComSyncHandler.swift
@@ -36,9 +36,10 @@ extension SigninWPComSyncHandler
 
         let accountFacade = AccountServiceFacade()
         let account = accountFacade.createOrUpdateWordPressComAccountWithUsername(username, authToken: authToken)
-        accountFacade.updateUserDetailsForAccount(account, success: { [weak self] in
 
-            BlogSyncFacade().syncBlogsForAccount(account, success: { [weak self] in
+        BlogSyncFacade().syncBlogsForAccount(account, success: { [weak self] in
+                accountFacade.updateUserDetailsForAccount(account, success: { [weak self] in
+
                 self?.handleSyncSuccess(requiredMultifactor)
 
                 }, failure: { [weak self] (error: NSError!) in


### PR DESCRIPTION
Fixes #5229 
Blogs need to be synced before account info is updated. 

To test: Sign in via the new sign in flow.  Confirm that the default site is correctly displayed in the blogs list. 

Needs review: @astralbodies 
cc @jleandroperez 
