### PR TITLE
Share Extension: No more Empty Text

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -70,7 +70,7 @@ PODS:
   - FormatterKit/TimeIntervalFormatter (1.8.0)
   - FormatterKit/UnitOfInformationFormatter (1.8.0)
   - FormatterKit/URLRequestFormatter (1.8.0)
-  - Gridicons (0.1)
+  - Gridicons (0.2)
   - Helpshift (5.5.1)
   - HockeySDK (3.8.6):
     - HockeySDK/AllFeaturesLib (= 3.8.6)
@@ -271,7 +271,7 @@ SPEC CHECKSUMS:
   Expecta: 8c507baf13211207b1e9d0a741480600e6b4ed15
   Fabric: caf7580c725e64db144f610ac65cd60956911dc7
   FormatterKit: bddde83e054edf9d9ee14f9de3b3a5103db256f4
-  Gridicons: 6dfc3f24cc81ee8aae3492c2ba814bd45fcdf0c7
+  Gridicons: 5c33065054b19e56a47d252b52e321746b97a414
   Helpshift: 1b89b3632bf46af10d2c9d9f448e64a0ccf667ec
   HockeySDK: ab68303eec6680f6b539de65d747742dd276e934
   Lookback: 9ab9027ff246d2dc5ce34be483f70e4a6718280b

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -385,6 +385,10 @@
 		B54E1DF21A0A7BAA00807537 /* ReplyTextView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B54E1DEF1A0A7BAA00807537 /* ReplyTextView.xib */; };
 		B54E1DF41A0A7BBF00807537 /* NotificationMediaDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54E1DF31A0A7BBF00807537 /* NotificationMediaDownloader.swift */; };
 		B5509A9319CA38B3006D2E49 /* EditReplyViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B5509A9219CA38B3006D2E49 /* EditReplyViewController.m */; };
+		B5552D7E1CD101A600B26DF6 /* NSExtensionContext+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5552D7D1CD101A600B26DF6 /* NSExtensionContext+Extensions.swift */; };
+		B5552D801CD1028C00B26DF6 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5552D7F1CD1028C00B26DF6 /* String+Extensions.swift */; };
+		B5552D821CD1061F00B26DF6 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5552D811CD1061F00B26DF6 /* StringExtensionsTests.swift */; };
+		B5552D831CD1062400B26DF6 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5552D7F1CD1028C00B26DF6 /* String+Extensions.swift */; };
 		B555E1151C04A68D00CEC81B /* WordPress-41-42.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = B555E1141C04A68D00CEC81B /* WordPress-41-42.xcmappingmodel */; };
 		B55853F31962337500FAF6C3 /* NSScanner+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = B55853F21962337500FAF6C3 /* NSScanner+Helpers.m */; };
 		B55853F719630D5400FAF6C3 /* NSAttributedString+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = B55853F619630D5400FAF6C3 /* NSAttributedString+Util.m */; };
@@ -1485,6 +1489,9 @@
 		B54E1DF31A0A7BBF00807537 /* NotificationMediaDownloader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationMediaDownloader.swift; sourceTree = "<group>"; };
 		B5509A9119CA38B3006D2E49 /* EditReplyViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditReplyViewController.h; sourceTree = "<group>"; };
 		B5509A9219CA38B3006D2E49 /* EditReplyViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EditReplyViewController.m; sourceTree = "<group>"; };
+		B5552D7D1CD101A600B26DF6 /* NSExtensionContext+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSExtensionContext+Extensions.swift"; path = "WordPressShareExtension/NSExtensionContext+Extensions.swift"; sourceTree = SOURCE_ROOT; };
+		B5552D7F1CD1028C00B26DF6 /* String+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "String+Extensions.swift"; path = "WordPressShareExtension/String+Extensions.swift"; sourceTree = SOURCE_ROOT; };
+		B5552D811CD1061F00B26DF6 /* StringExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
 		B555E1131C04A1DD00CEC81B /* WordPress 42.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 42.xcdatamodel"; sourceTree = "<group>"; };
 		B555E1141C04A68D00CEC81B /* WordPress-41-42.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-41-42.xcmappingmodel"; sourceTree = "<group>"; };
 		B55853F11962337500FAF6C3 /* NSScanner+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSScanner+Helpers.h"; sourceTree = "<group>"; };
@@ -3619,6 +3626,8 @@
 			children = (
 				B50248B31C96FF8400AFBDED /* UIImageView+Extensions.swift */,
 				B50248AE1C96FF6200AFBDED /* WPStyleGuide+Share.swift */,
+				B5552D7D1CD101A600B26DF6 /* NSExtensionContext+Extensions.swift */,
+				B5552D7F1CD1028C00B26DF6 /* String+Extensions.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -4132,6 +4141,7 @@
 				E1A0AC811C560F3A00070E2B /* RxTests.swift */,
 				E63C89791CB9A0BB00649C8F /* StringHelperTests.swift */,
 				E63C897B1CB9A0D700649C8F /* UITextFieldTextHelperTests.swift */,
+				B5552D811CD1061F00B26DF6 /* StringExtensionsTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -5387,6 +5397,7 @@
 				FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */,
 				B5BE31C41CB825A100BDF770 /* NSURLCache+Helpers.swift in Sources */,
 				85AD6AEC173CCF9E002CB896 /* WPNUXPrimaryButton.m in Sources */,
+				B5552D831CD1062400B26DF6 /* String+Extensions.swift in Sources */,
 				E1A6DBDB19DC7D080071AC1E /* RemotePost.m in Sources */,
 				082AB9D91C4EEEF4000CA523 /* PostTagService.m in Sources */,
 				E1249B4619408D0F0035E895 /* CommentServiceRemoteXMLRPC.m in Sources */,
@@ -5571,6 +5582,8 @@
 				B5BEA5621C7CE71D00C8035B /* WPDDLogWrapper.m in Sources */,
 				B50248B61C96FF8400AFBDED /* SitePickerViewController.swift in Sources */,
 				B5BEA55F1C7CE6D100C8035B /* Constants.m in Sources */,
+				B5552D7E1CD101A600B26DF6 /* NSExtensionContext+Extensions.swift in Sources */,
+				B5552D801CD1028C00B26DF6 /* String+Extensions.swift in Sources */,
 				B50248B51C96FF8400AFBDED /* ShareViewController.swift in Sources */,
 				B5BEA5601C7CE6D700C8035B /* SFHFKeychainUtils.m in Sources */,
 				B504F5F51C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift in Sources */,
@@ -5642,6 +5655,7 @@
 				F1564E5B18946087009F8F97 /* NSStringHelpersTest.m in Sources */,
 				93EF094C19ED533500C89770 /* ContextManagerTests.swift in Sources */,
 				B5D689FD1A5EBC900063D9E5 /* PushNotificationsManagerTestHelper.m in Sources */,
+				B5552D821CD1061F00B26DF6 /* StringExtensionsTests.swift in Sources */,
 				08AAD6A11CBEA610002B2418 /* MenusServiceTests.m in Sources */,
 				BEA0E4851BD83565000AEE81 /* WP3DTouchShortcutCreatorTests.swift in Sources */,
 				85F8E19B1B017AA6000859BB /* PushAuthenticationServiceRemoteTests.swift in Sources */,

--- a/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
+++ b/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
@@ -18,12 +18,12 @@ extension NSExtensionContext {
             return itemProvider.hasItemConformingToTypeIdentifier(publicUrlIdentifier)
         }
         
-        guard urlItemProviders.count > 0 else {
+        guard let urlItemProvider = urlItemProviders.first else {
             completion(nil)
             return
         }
         
-        itemProviders.first!.loadItemForTypeIdentifier(publicUrlIdentifier, options: nil) { (url, error) in
+        urlItemProvider.loadItemForTypeIdentifier(publicUrlIdentifier, options: nil) { (url, error) in
             guard let theURL = url as? NSURL else {
                 completion(nil)
                 return

--- a/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
+++ b/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// Encapsulates NSExtensionContext Helper Methods.
 ///
-extension NSExtensionContext
-{
+extension NSExtensionContext {
+    
     func loadWebsiteUrl(completion: (NSURL? -> Void)) {
         let publicUrlIdentifier = "public.url"
         

--- a/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
+++ b/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Encapsulates NSExtensionContext Helper Methods.
+///
+extension NSExtensionContext
+{
+    func loadWebsiteUrl(completion: (NSURL? -> Void)) {
+        let publicUrlIdentifier = "public.url"
+        
+        guard let item = inputItems.first as? NSExtensionItem,
+            let itemProviders = item.attachments as? [NSItemProvider] else
+        {
+            completion(nil)
+            return
+        }
+        
+        let urlItemProviders = itemProviders.filter { (itemProvider) in
+            return itemProvider.hasItemConformingToTypeIdentifier(publicUrlIdentifier)
+        }
+        
+        guard urlItemProviders.count > 0 else {
+            completion(nil)
+            return
+        }
+        
+        itemProviders.first!.loadItemForTypeIdentifier(publicUrlIdentifier, options: nil) { (url, error) in
+            guard let theURL = url as? NSURL else {
+                completion(nil)
+                return
+            }
+            
+            completion(theURL)
+        }
+    }
+}

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -156,8 +156,9 @@ class ShareViewController: SLComposeServiceViewController {
             dispatch_async(dispatch_get_main_queue()) {
                 let current = self.contentText ?? String()
                 let source  = url?.absoluteString ?? String()
+                let spacing = current.isEmpty ? String() : "\n\n"
                 
-                self.textView.text = "\(current)\n\n\(source)"
+                self.textView.text = "\(current)\(spacing)\(source)"
             }
         }
     }

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -31,14 +31,9 @@ class ShareViewController: SLComposeServiceViewController {
         tracks.wpcomUsername = username
 
         // TextView
-        loadWebsiteUrl { (url) in
-            dispatch_async(dispatch_get_main_queue()) {
-                let current = self.contentText ?? String()
-                let source  = url?.absoluteString ?? String()
-                
-                self.textView.text = "\(current)\n\n\(source)"
-            }
-        }
+        loadTextViewContent()
+    }
+    
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
         
@@ -147,6 +142,17 @@ class ShareViewController: SLComposeServiceViewController {
         pushConfigurationViewController(pickerViewController)
     }
     
+    private func loadTextViewContent() {
+        extensionContext?.loadWebsiteUrl { url in
+            dispatch_async(dispatch_get_main_queue()) {
+                let current = self.contentText ?? String()
+                let source  = url?.absoluteString ?? String()
+                
+                self.textView.text = "\(current)\n\n\(source)"
+            }
+        }
+    }
+
     
     // TODO: This should eventually be moved into WordPressComKit
     private let postStatuses = [
@@ -160,32 +166,5 @@ class ShareViewController: SLComposeServiceViewController {
         let restOfText = indexOfFirstNewline != nil ? fullText.substringFromIndex(indexOfFirstNewline!.endIndex) : ""
 
         return (firstLineOfText, restOfText)
-    }
-    
-    private func loadWebsiteUrl(completion: (NSURL? -> Void)) {
-        guard let item = extensionContext?.inputItems.first as? NSExtensionItem,
-            let itemProviders = item.attachments as? [NSItemProvider] else
-        {
-            completion(nil)
-            return
-        }
-        
-        let urlItemProviders = itemProviders.filter({ (itemProvider) -> Bool in
-            return itemProvider.hasItemConformingToTypeIdentifier("public.url")
-        })
-        
-        guard urlItemProviders.count > 0 else {
-            completion(nil)
-            return
-        }
-        
-        itemProviders.first!.loadItemForTypeIdentifier("public.url", options: nil) { (url, error) -> Void in
-            guard let theURL = url as? NSURL else {
-                completion(nil)
-                return
-            }
-            
-            completion(theURL)
-        }
     }
 }

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -73,7 +73,8 @@ class ShareViewController: SLComposeServiceViewController
         configuration.sharedContainerIdentifier = WPAppGroupName
         
         let service = PostService(configuration: configuration)
-        let (subject, body) = splitContentTextIntoSubjectAndBody(contentText)
+        let linkified = contentText.stringWithAnchoredLinks()
+        let (subject, body) = splitContentTextIntoSubjectAndBody(linkified)
         
         service.createPost(siteID: selectedSiteID!, status: postStatus, title: subject, body: body) {
             (post, error) in

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -31,10 +31,10 @@ class ShareViewController: SLComposeServiceViewController {
         tracks.wpcomUsername = username
 
         // TextView
-        loadWebsiteUrl { (url: NSURL?) in
+        loadWebsiteUrl { (url) in
             dispatch_async(dispatch_get_main_queue()) {
                 let current = self.contentText ?? String()
-                let source = url?.absoluteString ?? String()
+                let source  = url?.absoluteString ?? String()
                 
                 self.textView.text = "\(current)\n\n\(source)"
             }
@@ -96,7 +96,7 @@ class ShareViewController: SLComposeServiceViewController {
         
         let statusPickerItem = SLComposeSheetConfigurationItem()
         statusPickerItem.title = NSLocalizedString("Post Status:", comment: "Post status picker title in Share Extension")
-        statusPickerItem.value = self.postStatuses[postStatus]!
+        statusPickerItem.value = postStatuses[postStatus]!
         statusPickerItem.tapHandler = { [weak self] in
             self?.displayStatusPicker()
         }
@@ -117,7 +117,7 @@ class ShareViewController: SLComposeServiceViewController {
         let accept = NSLocalizedString("Cancel Share", comment: "Dismiss Extension and cancel Share OP")
         
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .Alert)
-        let alertAction = UIAlertAction(title: accept, style: .Default) { (action: UIAlertAction) -> Void in
+        let alertAction = UIAlertAction(title: accept, style: .Default) { (action) in
             self.cancel()
         }
         

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -3,32 +3,36 @@ import Social
 import WordPressComKit
 
 
-class ShareViewController: SLComposeServiceViewController {
+class ShareViewController: SLComposeServiceViewController
+{
     // MARK: - Private Properties
-    private var wpcomUsername: String?
-    private var oauth2Token: NSString?
-    private var selectedSiteID: Int?
-    private var selectedSiteName: String?
-    private var postStatus = "publish"
-    private var tracks: Tracks!
+    private lazy var wpcomUsername: String? = {
+        ShareExtensionService.retrieveShareExtensionUsername()
+    }()
+    
+    private lazy var oauth2Token: String? = {
+        ShareExtensionService.retrieveShareExtensionToken()
+    }()
+    
+    private lazy var selectedSiteID: Int? = {
+        ShareExtensionService.retrieveShareExtensionPrimarySite()?.siteID
+    }()
+    
+    private lazy var selectedSiteName: String? = {
+        ShareExtensionService.retrieveShareExtensionPrimarySite()?.siteName
+    }()
+    
+    private lazy var tracks: Tracks = {
+        Tracks(appGroupName: WPAppGroupName)
+    }()
+    
+    private lazy var postStatus = "publish"
     
     
     // MARK: - UIViewController Methods
     override func viewDidLoad() {
-        // Retrieve all of the settings
-        let username = ShareExtensionService.retrieveShareExtensionUsername()
-        let token = ShareExtensionService.retrieveShareExtensionToken()
-        let defaultSite = ShareExtensionService.retrieveShareExtensionPrimarySite()
-        
-        // Properties
-        wpcomUsername = username
-        oauth2Token = token
-        selectedSiteID = defaultSite?.siteID
-        selectedSiteName = defaultSite?.siteName
-
         // Tracker
-        tracks = Tracks(appGroupName: WPAppGroupName)
-        tracks.wpcomUsername = username
+        tracks.wpcomUsername = wpcomUsername
 
         // TextView
         loadTextViewContent()
@@ -62,7 +66,7 @@ class ShareViewController: SLComposeServiceViewController {
     }
     
     override func didSelectPost() {
-        RequestRouter.bearerToken = oauth2Token! as String
+        RequestRouter.bearerToken = oauth2Token!
 
         let identifier = WPAppGroupName + "." + NSUUID().UUIDString
         let configuration = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier(identifier)

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -3,8 +3,8 @@ import Social
 import WordPressComKit
 
 
-class ShareViewController: SLComposeServiceViewController
-{
+class ShareViewController: SLComposeServiceViewController {
+    
     // MARK: - Private Properties
     private lazy var wpcomUsername: String? = {
         ShareExtensionService.retrieveShareExtensionUsername()

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -66,7 +66,11 @@ class ShareViewController: SLComposeServiceViewController {
     }
     
     override func didSelectPost() {
-        RequestRouter.bearerToken = oauth2Token!
+        guard let oauth2Token = oauth2Token, selectedSiteID = selectedSiteID else {
+            fatalError("The view should have been dismissed on viewDidAppear!")
+        }
+        
+        RequestRouter.bearerToken = oauth2Token
 
         let identifier = WPAppGroupName + "." + NSUUID().UUIDString
         let configuration = NSURLSessionConfiguration.backgroundSessionConfigurationWithIdentifier(identifier)
@@ -76,7 +80,7 @@ class ShareViewController: SLComposeServiceViewController {
         let linkified = contentText.stringWithAnchoredLinks()
         let (subject, body) = splitContentTextIntoSubjectAndBody(linkified)
         
-        service.createPost(siteID: selectedSiteID!, status: postStatus, title: subject, body: body) {
+        service.createPost(siteID: selectedSiteID, status: postStatus, title: subject, body: body) {
             (post, error) in
             print("Post \(post) Error \(error)")
         }

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -29,16 +29,15 @@ class ShareViewController: SLComposeServiceViewController {
         // Tracker
         tracks = Tracks(appGroupName: WPAppGroupName)
         tracks.wpcomUsername = username
-    }
-    
-    override func viewWillAppear(animated: Bool) {
-        super.viewWillAppear(animated)
-        
+
+        // TextView
         loadWebsiteUrl { (url: NSURL?) in
-            let current = self.contentText ?? String()
-            let source = url?.absoluteString ?? String()
-            
-            self.textView.text = "\(current)\n\n\(source)"
+            dispatch_async(dispatch_get_main_queue()) {
+                let current = self.contentText ?? String()
+                let source = url?.absoluteString ?? String()
+                
+                self.textView.text = "\(current)\n\n\(source)"
+            }
         }
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)

--- a/WordPress/WordPressShareExtension/String+Extensions.swift
+++ b/WordPress/WordPressShareExtension/String+Extensions.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Social
+
+/// Encapsulates String Helper Methods.
+///
+extension String
+{
+    func stringWithAnchoredLinks() -> String {
+        guard let output = (self as NSString).mutableCopy() as? NSMutableString,
+                let detector = try? NSDataDetector(types: NSTextCheckingType.Link.rawValue) else
+        {
+            return self
+        }
+
+        let range   = NSMakeRange(0, characters.count)
+        var offset  = 0
+        
+        detector.enumerateMatchesInString(self, options: [], range: range) { (result, flags, stop) in
+            guard let range = result?.range else {
+                return
+            }
+
+            let rangeWithOffset = NSMakeRange(range.location + offset, range.length)
+            let rawURL          = output.substringWithRange(rangeWithOffset)
+            let anchoredURL     = "<a href=\"\(rawURL)\">\(rawURL)</a>"
+
+            output.replaceCharactersInRange(rangeWithOffset, withString: anchoredURL)
+            offset += anchoredURL.characters.count - rawURL.characters.count
+        }
+        
+        return output as String
+    }
+}

--- a/WordPress/WordPressTest/Extensions/StringExtensionsTests.swift
+++ b/WordPress/WordPressTest/Extensions/StringExtensionsTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import XCTest
+@testable import WordPress
+
+
+class StringExtensionsTests: XCTestCase
+{
+    // Note:
+    // Specially extra aligned for my RWC friends. With love.
+    //
+    private let links   = ["http://www.google.com", "http://www.automattic.com", "http://wordpress.com?some=random"]
+    private let text    = " Lorem Ipsum Matarem Les Idiotum Sarasum Zorrentum Modus Operandum "
+    private let anchor  = "<a href=\"%@\">%@</a>"
+    
+    
+    public func testLinkifyingPlainLinks() {
+        for link in links {
+            let linkified = String(format: anchor, link, link)
+            XCTAssertEqual(link.stringWithAnchoredLinks(), linkified, "Oh noes!")
+        }
+    }
+    
+    public func testLinkifyingLinksWithinText() {
+        var plain       = String()
+        var linkified   = String()
+        
+        for link in links {
+            plain       += text + link
+            linkified   += text + String(format: anchor, link, link)
+        }
+
+        XCTAssertEqual(plain.stringWithAnchoredLinks(), linkified, "Oh noes!")
+    }
+    
+    public func testLinkifyingPlainText() {
+        XCTAssertEqual(text.stringWithAnchoredLinks(), text, "Oh noes!")
+    }
+}


### PR DESCRIPTION
Fixes #5191

Testing steps described in the issue itself. Until we implement the JS Extension Add-on, fix consists on:

- Always append the URL, and make it visible
- Linkify the text, whenever the user hits Post

Few things have been prettified here and there.

Needs review: @astralbodies 
Thanks in advance, YO!
