### PR TITLE
Adds nullability info to PostListFilter.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.h
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.h
@@ -10,12 +10,12 @@ typedef NS_ENUM(NSUInteger, PostListStatusFilter) {
 @interface PostListFilter : NSObject
 
 @property (nonatomic, assign) BOOL hasMore;
-@property (nonatomic, strong) NSDate *oldestPostDate;
+@property (nonatomic, strong, nullable) NSDate *oldestPostDate;
 @property (nonatomic, assign) PostListStatusFilter filterType;
-@property (nonatomic, strong) NSString *title;
-@property (nonatomic, strong) NSArray *statuses;
-@property (nonatomic, strong) NSPredicate *predicateForFetchRequest;
+@property (nonatomic, strong, nullable) NSString *title;
+@property (nonatomic, strong, nullable) NSArray *statuses;
+@property (nonatomic, strong, nullable) NSPredicate *predicateForFetchRequest;
 
-+ (NSArray *)newPostListFilters;
++ (nonnull NSArray<PostListFilter*>*)newPostListFilters;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.m
@@ -7,7 +7,7 @@
 
 @implementation PostListFilter
 
-+ (NSArray *)newPostListFilters
++ (NSArray<PostListFilter*>*)newPostListFilters
 {
     return @[
              [self newPublishedFilter],


### PR DESCRIPTION
Adds nullability information to `PostListFilter`.  Also adds additional type information for an array.

PS: this is a very atomic PR aimed at solving these issues as part of another [large upcoming PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/5237).

**To test:**
Simply build the code and run the unit tests to make sure nothing broke.

Needs review: @kurzee 
