### PR TITLE
Adds more specific type info in PostListFilter.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.h
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.h
@@ -13,7 +13,7 @@ typedef NS_ENUM(NSUInteger, PostListStatusFilter) {
 @property (nonatomic, strong, nullable) NSDate *oldestPostDate;
 @property (nonatomic, assign) PostListStatusFilter filterType;
 @property (nonatomic, strong, nullable) NSString *title;
-@property (nonatomic, strong, nullable) NSArray *statuses;
+@property (nonatomic, strong, nullable) NSArray<NSString*>* statuses;
 @property (nonatomic, strong, nullable) NSPredicate *predicateForFetchRequest;
 
 + (nonnull NSArray<PostListFilter*>*)newPostListFilters;


### PR DESCRIPTION
I missed a modification from a [previous PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/5238).  This change was and is still non-breaking so it can be handled separately.

This is also a part of an upcoming [large PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/5237).

**How to test:**
Just build the code and run the unit tests.

Needs review: @kurzee (sorry for the double PR!)
