### PR TITLE
Specifies the post type better when retrieveing posts.

### DIFF
--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -11,7 +11,7 @@ extern NSString * const PostServiceTypeAny;
 
 extern const NSUInteger PostServiceDefaultNumberToSync;
 
-typedef void(^PostServiceSyncSuccess)(NSArray<AbstractPost*> *posts);
+typedef void(^PostServiceSyncSuccess)(NSArray<AbstractPost *> *posts);
 typedef void(^PostServiceSyncFailure)(NSError *error);
 
 @interface PostService : LocalCoreDataService

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -11,7 +11,7 @@ extern NSString * const PostServiceTypeAny;
 
 extern const NSUInteger PostServiceDefaultNumberToSync;
 
-typedef void(^PostServiceSyncSuccess)(NSArray *posts);
+typedef void(^PostServiceSyncSuccess)(NSArray<AbstractPost*> *posts);
 typedef void(^PostServiceSyncFailure)(NSError *error);
 
 @interface PostService : LocalCoreDataService


### PR DESCRIPTION
Title has it.  This is a minor change that's needed for an upcoming [larger PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/5237) that I'm breaking up to make the review easier.

**To test:**
Simply build the code.
Verify the methods that use this block to make sure the new type is correct.

Needs review: @kwonye 