### PR TITLE
Menus: Accessory views for editing MenuItem sources

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/Views/Menu+ViewDesign.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/Menu+ViewDesign.h
@@ -1,0 +1,12 @@
+
+extern CGFloat const MenusDesignStrokeWidth;
+extern CGFloat const MenusDesignDefaultCornerRadius;
+extern CGFloat const MenusDesignDefaultContentSpacing;
+
+#import "Menu.h"
+
+@interface Menu (ViewDesign)
+
++ (UIEdgeInsets)viewDefaultDesignInsets;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/Menu+ViewDesign.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/Menu+ViewDesign.h
@@ -1,10 +1,12 @@
+#import "Menu.h"
 
 extern CGFloat const MenusDesignStrokeWidth;
 extern CGFloat const MenusDesignDefaultCornerRadius;
 extern CGFloat const MenusDesignDefaultContentSpacing;
 
-#import "Menu.h"
-
+/**
+ * Design category for providing common values used for drawing, layout, and views involving a Menu object.
+ */
 @interface Menu (ViewDesign)
 
 + (UIEdgeInsets)viewDefaultDesignInsets;

--- a/WordPress/Classes/ViewRelated/Menus/Views/Menu+ViewDesign.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/Menu+ViewDesign.m
@@ -1,0 +1,14 @@
+#import "Menu+ViewDesign.h"
+
+CGFloat const MenusDesignStrokeWidth = 0.5;
+CGFloat const MenusDesignDefaultCornerRadius = 2.0;
+CGFloat const MenusDesignDefaultContentSpacing = 16.0;
+
+@implementation Menu (ViewDesign)
+
++ (UIEdgeInsets)viewDefaultDesignInsets
+{
+    return UIEdgeInsetsMake(10.0, 10.0, 10.0, 10.0);
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItem+ViewDesign.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItem+ViewDesign.h
@@ -3,6 +3,9 @@
 
 extern CGFloat const MenusDesignItemIconSize;
 
+/**
+ * Design category for providing common values used for drawing, layout, and views involving a MenuItem object.
+ */
 @interface MenuItem (ViewDesign)
 
 + (UIImage *)iconImageForItemType:(NSString *)itemType;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItem+ViewDesign.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItem+ViewDesign.h
@@ -1,0 +1,10 @@
+#import "MenuItem.h"
+#import "Menu+ViewDesign.h"
+
+extern CGFloat const MenusDesignItemIconSize;
+
+@interface MenuItem (ViewDesign)
+
++ (UIImage *)iconImageForItemType:(NSString *)itemType;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItem+ViewDesign.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItem+ViewDesign.m
@@ -1,0 +1,26 @@
+#import "MenuItem+ViewDesign.h"
+
+@import Gridicons;
+
+CGFloat const MenusDesignItemIconSize = 18.0;
+
+@implementation MenuItem (ViewDesign)
+
++ (UIImage *)iconImageForItemType:(NSString *)itemType
+{
+    UIImage *image = nil;
+    
+    if ([itemType isEqualToString:MenuItemTypePage]) {
+        image = [Gridicon iconOfType:GridiconTypePages];
+    } else if ([itemType isEqualToString:MenuItemTypeCustom]) {
+        image = [Gridicon iconOfType:GridiconTypeLink];
+    } else if ([itemType isEqualToString:MenuItemTypeCategory]) {
+        image = [Gridicon iconOfType:GridiconTypeFolder];
+    } else if ([itemType isEqualToString:MenuItemTypeTag]) {
+        image = [Gridicon iconOfType:GridiconTypeTag];
+    }
+    
+    return image ?: [Gridicon iconOfType:GridiconTypePosts];
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.h
@@ -1,0 +1,25 @@
+#import <UIKit/UIKit.h>
+
+@interface MenuItemCheckButtonView : UIView
+
+/**
+ Label used alongside the checkbox.
+ */
+@property (nonatomic, strong, readonly) UILabel *label;
+
+/**
+ Checked state of the view.
+ */
+@property (nonatomic, assign) BOOL checked;
+
+/**
+ Event handler if the checked state changes.
+ */
+@property (nonatomic, copy) void(^onChecked)();
+
+/**
+ Ideal layout height of the view.
+ */
+- (CGFloat)preferredHeightForLayout;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.m
@@ -49,7 +49,7 @@ static CGFloat const iconPadding = 3.0;
                                               [iconView.widthAnchor constraintEqualToAnchor:iconView.heightAnchor],
                                               [iconView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-iconPadding]
                                               ]];
-    self.iconView = iconView;
+    _iconView = iconView;
 }
 
 - (void)initLabel
@@ -64,9 +64,11 @@ static CGFloat const iconPadding = 3.0;
     
     [self addSubview:label];
     
+    NSAssert(_iconView != nil, @"iconView is nil");
+    
     [NSLayoutConstraint activateConstraints:@[
                                               [label.topAnchor constraintEqualToAnchor:self.topAnchor],
-                                              [label.leadingAnchor constraintEqualToAnchor:self.iconView.trailingAnchor constant:MenusDesignDefaultContentSpacing / 2.0],
+                                              [label.leadingAnchor constraintEqualToAnchor:_iconView.trailingAnchor constant:MenusDesignDefaultContentSpacing / 2.0],
                                               [label.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
                                               [label.bottomAnchor constraintEqualToAnchor:self.bottomAnchor]
                                               ]];

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.m
@@ -1,0 +1,158 @@
+#import "MenuItemCheckButtonView.h"
+#import "WPStyleGuide.h"
+#import "WPFontManager.h"
+#import "Menu+ViewDesign.h"
+
+@import Gridicons;
+
+static CGFloat const iconPadding = 3.0;
+
+@interface MenuItemCheckButtonView ()
+
+@property (nonatomic, strong) UIImageView *iconView;
+@property (nonatomic, assign) BOOL drawsHighlighted;
+@property (nonatomic, assign) CGPoint touchesBeganLocation;
+
+@end
+
+@implementation MenuItemCheckButtonView
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+     
+        self.translatesAutoresizingMaskIntoConstraints = NO;
+        self.backgroundColor = [UIColor whiteColor];
+        self.contentMode = UIViewContentModeRedraw;
+        
+        [self initIconView];
+        [self initLabel];
+    }
+    
+    return self;
+}
+
+- (void)initIconView
+{
+    UIImageView *iconView = [[UIImageView alloc] init];
+    iconView.translatesAutoresizingMaskIntoConstraints = NO;
+    iconView.image = [Gridicon iconOfType:GridiconTypeCheckmark];
+    iconView.tintColor = [WPStyleGuide mediumBlue];
+    iconView.contentMode = UIViewContentModeScaleAspectFit;
+    iconView.alpha = 0.0;
+    [self addSubview:iconView];
+    
+    [NSLayoutConstraint activateConstraints:@[
+                                              [iconView.topAnchor constraintEqualToAnchor:self.topAnchor constant:iconPadding],
+                                              [iconView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:iconPadding],
+                                              [iconView.widthAnchor constraintEqualToAnchor:iconView.heightAnchor],
+                                              [iconView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-iconPadding]
+                                              ]];
+    self.iconView = iconView;
+}
+
+- (void)initLabel
+{
+    UILabel *label = [[UILabel alloc] init];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.backgroundColor = [UIColor whiteColor];
+    
+    NSDictionary *attributes = [self attributesForText];
+    label.font = [attributes objectForKey:NSFontAttributeName];
+    label.textColor = [attributes objectForKey:NSForegroundColorAttributeName];
+    
+    [self addSubview:label];
+    
+    [NSLayoutConstraint activateConstraints:@[
+                                              [label.topAnchor constraintEqualToAnchor:self.topAnchor],
+                                              [label.leadingAnchor constraintEqualToAnchor:self.iconView.trailingAnchor constant:MenusDesignDefaultContentSpacing / 2.0],
+                                              [label.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+                                              [label.bottomAnchor constraintEqualToAnchor:self.bottomAnchor]
+                                              ]];
+    
+    _label = label;
+}
+
+- (CGFloat)preferredHeightForLayout
+{
+    CGSize size = [self.label.text sizeWithAttributes:[self attributesForText]];
+    return size.height;
+}
+
+- (void)setChecked:(BOOL)checked
+{
+    if (_checked != checked) {
+        _checked = checked;
+        self.iconView.alpha = checked ? 1.0 : 0.0;
+        self.drawsHighlighted = checked;
+    }
+}
+
+- (void)setDrawsHighlighted:(BOOL)drawsHighlighted
+{
+    if (_drawsHighlighted != drawsHighlighted) {
+        _drawsHighlighted = drawsHighlighted;
+        [self setNeedsDisplay];
+    }
+}
+
+- (NSDictionary *)attributesForText
+{
+    return @{NSFontAttributeName: [WPFontManager systemRegularFontOfSize:14.0], NSForegroundColorAttributeName: [UIColor blackColor]};
+}
+
+- (void)drawRect:(CGRect)rect
+{
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    if (self.drawsHighlighted) {
+        CGContextSetFillColorWithColor(context, [[WPStyleGuide mediumBlue] CGColor]);
+    } else  {
+        CGContextSetFillColorWithColor(context, [[WPStyleGuide greyLighten20] CGColor]);
+    }
+    
+    CGRect boxRect = CGRectZero;
+    boxRect.size.height = rect.size.height;
+    boxRect.size.width = boxRect.size.height;
+    
+    CGContextFillRect(context, boxRect);
+    
+    CGRect innerBoxRect = CGRectInset(boxRect, 1.0, 1.0);
+    CGContextSetFillColorWithColor(context, [self.backgroundColor CGColor]);
+    CGContextFillRect(context, innerBoxRect);
+}
+
+#pragma mark - touches
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesBegan:touches withEvent:event];
+    
+    self.touchesBeganLocation = [[touches anyObject] locationInView:self];
+    self.drawsHighlighted = YES;
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesCancelled:touches withEvent:event];
+    
+    self.touchesBeganLocation = CGPointZero;
+    self.drawsHighlighted = NO;
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesEnded:touches withEvent:event];
+    
+    self.drawsHighlighted = NO;
+    
+    if (CGRectContainsPoint(self.bounds, self.touchesBeganLocation) && CGRectContainsPoint(self.bounds, [[touches anyObject] locationInView:self])) {
+        self.checked = !self.checked;
+        if (self.onChecked) {
+            self.onChecked();
+        }
+    }
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.m
@@ -9,7 +9,7 @@ static CGFloat const iconPadding = 3.0;
 
 @interface MenuItemCheckButtonView ()
 
-@property (nonatomic, strong) UIImageView *iconView;
+@property (nonatomic, strong, readonly) UIImageView *iconView;
 @property (nonatomic, assign) BOOL drawsHighlighted;
 @property (nonatomic, assign) CGPoint touchesBeganLocation;
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.h
@@ -10,7 +10,7 @@
 /**
  Title label used for displaying header text for a MenuItem.
  */
-@property (nonatomic, strong) UILabel *titleLabel;
+@property (nonatomic, strong, readonly) UILabel *titleLabel;
 
 @end
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.h
@@ -1,0 +1,24 @@
+#import <UIKit/UIKit.h>
+#import "MenuItem.h"
+
+@protocol MenuItemSourceHeaderViewDelegate;
+
+@interface MenuItemSourceHeaderView : UIView
+
+@property (nonatomic, weak) id <MenuItemSourceHeaderViewDelegate> delegate;
+
+/**
+ Title label used for displaying header text for a MenuItem.
+ */
+@property (nonatomic, strong) UILabel *titleLabel;
+
+@end
+
+@protocol MenuItemSourceHeaderViewDelegate <NSObject>
+
+/**
+ User interaction detected a tap for toggling/selecting the headerView.
+ */
+- (void)sourceHeaderViewSelected:(MenuItemSourceHeaderView *)headerView;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
@@ -1,0 +1,113 @@
+#import "MenuItemSourceHeaderView.h"
+#import "WPStyleGuide.h"
+#import "WPFontManager.h"
+#import "MenuItem+ViewDesign.h"
+
+@import Gridicons;
+
+@interface MenuItemSourceHeaderView ()
+
+@property (nonatomic, strong) UIStackView *stackView;
+@property (nonatomic, strong) UIImageView *iconView;
+
+@end
+
+@implementation MenuItemSourceHeaderView
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        
+        self.translatesAutoresizingMaskIntoConstraints = NO;
+        self.backgroundColor = [UIColor whiteColor];
+        self.contentMode = UIViewContentModeRedraw;
+        
+        [self initStackView];
+        [self initIconView];
+        [self initTitleLabel];
+        
+        UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapGesture:)];
+        [self addGestureRecognizer:tap];
+    }
+    
+    return self;
+}
+
+- (void)initStackView
+{
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    stackView.alignment = UIStackViewAlignmentFill;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.axis = UILayoutConstraintAxisHorizontal;
+    stackView.spacing = MenusDesignDefaultContentSpacing;
+    
+    [self addSubview:stackView];
+    
+    NSLayoutConstraint *top = [stackView.topAnchor constraintEqualToAnchor:self.topAnchor constant:MenusDesignDefaultContentSpacing];
+    top.priority = 999;
+    
+    NSLayoutConstraint *bottom = [stackView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-MenusDesignDefaultContentSpacing];
+    bottom.priority = 999;
+    
+    [NSLayoutConstraint activateConstraints:@[
+                                              top,
+                                              [stackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:MenusDesignDefaultContentSpacing],
+                                              bottom,
+                                              [stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-MenusDesignDefaultContentSpacing]
+                                              ]];
+    [stackView setContentCompressionResistancePriority:999 forAxis:UILayoutConstraintAxisVertical];
+    self.stackView = stackView;
+}
+
+- (void)initIconView
+{
+    UIImageView *iconView = [[UIImageView alloc] init];
+    iconView.translatesAutoresizingMaskIntoConstraints = NO;
+    iconView.contentMode = UIViewContentModeScaleAspectFit;
+    iconView.backgroundColor = [UIColor whiteColor];
+    iconView.tintColor = [WPStyleGuide grey];
+    iconView.image = [Gridicon iconOfType:GridiconTypeChevronLeft];
+    
+    [self.stackView addArrangedSubview:iconView];
+    
+    NSLayoutConstraint *widthConstraint = [iconView.widthAnchor constraintEqualToConstant:MenusDesignItemIconSize];
+    widthConstraint.active = YES;
+    
+    self.iconView = iconView;
+}
+
+- (void)initTitleLabel
+{
+    UILabel *label = [[UILabel alloc] init];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.numberOfLines = 1;
+    label.lineBreakMode = NSLineBreakByTruncatingTail;
+    label.font = [WPFontManager systemRegularFontOfSize:16.0];
+    label.backgroundColor = [UIColor whiteColor];
+    
+    [self.stackView addArrangedSubview:label];
+    
+    [label setContentCompressionResistancePriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+    [label setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+    
+    self.titleLabel = label;
+}
+
+- (void)tapGesture:(UITapGestureRecognizer *)tapGesture
+{
+    [self.delegate sourceHeaderViewSelected:self];
+}
+
+- (void)drawRect:(CGRect)rect
+{    
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextSetLineWidth(context, 2.0);
+    CGContextSetStrokeColorWithColor(context, [[WPStyleGuide greyLighten30] CGColor]);
+    CGContextMoveToPoint(context, 0, rect.size.height);
+    CGContextAddLineToPoint(context, rect.size.width, rect.size.height);
+    CGContextStrokePath(context);
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
@@ -58,7 +58,7 @@
                                               [stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-MenusDesignDefaultContentSpacing]
                                               ]];
     [stackView setContentCompressionResistancePriority:999 forAxis:UILayoutConstraintAxisVertical];
-    self.stackView = stackView;
+    _stackView = stackView;
 }
 
 - (void)initIconView
@@ -70,12 +70,14 @@
     iconView.tintColor = [WPStyleGuide grey];
     iconView.image = [Gridicon iconOfType:GridiconTypeChevronLeft];
     
-    [self.stackView addArrangedSubview:iconView];
+    NSAssert(_stackView != nil, @"stackView is nil");
+    
+    [_stackView addArrangedSubview:iconView];
     
     NSLayoutConstraint *widthConstraint = [iconView.widthAnchor constraintEqualToConstant:MenusDesignItemIconSize];
     widthConstraint.active = YES;
     
-    self.iconView = iconView;
+    _iconView = iconView;
 }
 
 - (void)initTitleLabel
@@ -87,12 +89,14 @@
     label.font = [WPFontManager systemRegularFontOfSize:16.0];
     label.backgroundColor = [UIColor whiteColor];
     
-    [self.stackView addArrangedSubview:label];
+    NSAssert(_stackView != nil, @"stackView is nil");
+    
+    [_stackView addArrangedSubview:label];
     
     [label setContentCompressionResistancePriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
     [label setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
     
-    self.titleLabel = label;
+    _titleLabel = label;
 }
 
 - (void)tapGesture:(UITapGestureRecognizer *)tapGesture

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
@@ -7,8 +7,8 @@
 
 @interface MenuItemSourceHeaderView ()
 
-@property (nonatomic, strong) UIStackView *stackView;
-@property (nonatomic, strong) UIImageView *iconView;
+@property (nonatomic, strong, readonly) UIStackView *stackView;
+@property (nonatomic, strong, readonly) UIImageView *iconView;
 
 @end
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.h
@@ -1,0 +1,47 @@
+#import <UIKit/UIKit.h>
+
+/**
+ Object for configuring infrequent updates on a textField's text changes.
+ */
+@interface MenuItemSourceTextBarFieldObserver : NSObject
+
+@property (nonatomic, assign) NSTimeInterval interval;
+@property (nonatomic, copy) void(^onTextChange)(NSString *text);
+
+@end
+
+@protocol MenuItemSourceTextBarDelegate;
+
+@interface MenuItemSourceTextBar : UIView
+
+@property (nonatomic, weak) id <MenuItemSourceTextBarDelegate> delegate;
+
+/**
+ Icon imagView to the left of the textField.
+ */
+@property (nonatomic, strong, readonly) UIImageView *iconView;
+
+/**
+ Input textField for the bar.
+ */
+@property (nonatomic, strong, readonly) UITextField *textField;
+
+/**
+ Configure as a searchBar.
+ */
+- (id)initAsSearchBar;
+
+/**
+ Add an observer for onTextChange events within MenuItemSourceTextBarFieldObserver.
+ */
+- (void)addTextObserver:(MenuItemSourceTextBarFieldObserver *)textObserver;
+
+@end
+
+@protocol MenuItemSourceTextBarDelegate <NSObject>
+
+- (void)sourceTextBarDidBeginEditing:(MenuItemSourceTextBar *)textBar;
+- (void)sourceTextBarDidEndEditing:(MenuItemSourceTextBar *)textBar;
+- (void)sourceTextBar:(MenuItemSourceTextBar *)textBar didUpdateWithText:(NSString *)text;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
@@ -15,10 +15,10 @@
 
 @interface MenuItemSourceTextBar () <UITextFieldDelegate>
 
-@property (nonatomic, strong) UIStackView *stackView;
-@property (nonatomic, strong) UIView *contentView;
-@property (nonatomic, strong) UIStackView *contentStackView;
-@property (nonatomic, strong) UILabel *cancelLabel;
+@property (nonatomic, strong, readonly) UIStackView *stackView;
+@property (nonatomic, strong, readonly) UIView *contentView;
+@property (nonatomic, strong, readonly) UIStackView *contentStackView;
+@property (nonatomic, strong, readonly) UILabel *cancelLabel;
 @property (nonatomic, strong) NSMutableArray <MenuItemSourceTextBarFieldObserver *> *textObservers;
 
 @end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
@@ -1,0 +1,286 @@
+#import "MenuItemSourceTextBar.h"
+#import "WPStyleGuide.h"
+#import "WPFontManager.h"
+#import "Menu+ViewDesign.h"
+
+@import Gridicons;
+
+@interface MenuItemSourceTextBarFieldObserver ()
+
+@property (nonatomic, strong) UITextField *textField;
+@property (nonatomic, copy) NSString *lastTextObserved;
+@property (nonatomic, strong) NSTimer *timer;
+
+@end
+
+@interface MenuItemSourceTextBar () <UITextFieldDelegate>
+
+@property (nonatomic, strong) UIStackView *stackView;
+@property (nonatomic, strong) UIView *contentView;
+@property (nonatomic, strong) UIStackView *contentStackView;
+@property (nonatomic, strong) UILabel *cancelLabel;
+@property (nonatomic, strong) NSMutableArray <MenuItemSourceTextBarFieldObserver *> *textObservers;
+
+@end
+
+@implementation MenuItemSourceTextBar
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        
+        self.backgroundColor = [UIColor whiteColor];
+        self.translatesAutoresizingMaskIntoConstraints = NO;
+
+        [self initStackView];
+        [self initContentStackView];
+        [self initIconView];
+        [self initTextField];
+        [self initCancelLabel];
+    }
+    
+    return self;
+}
+
+- (id)initAsSearchBar
+{
+    self = [self init];
+    if (self) {
+        
+        self.iconView.image = [Gridicon iconOfType:GridiconTypeSearch];
+        self.iconView.hidden = NO;
+        
+        UIFont *font = [WPFontManager systemRegularFontOfSize:16.0];
+        NSString *placeholder = NSLocalizedString(@"Search...", @"Menus search bar placeholder text.");
+        NSDictionary *attributes = @{NSFontAttributeName: font, NSForegroundColorAttributeName: [WPStyleGuide greyDarken10]};
+        self.textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder attributes:attributes];
+    }
+    
+    return self;
+}
+
+- (void)initStackView
+{
+    const CGFloat spacing = ceilf(MenusDesignDefaultContentSpacing / 2.0);
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.alignment = UIStackViewAlignmentFill;
+    stackView.axis = UILayoutConstraintAxisHorizontal;
+    stackView.spacing = spacing;
+    
+    [self addSubview:stackView];
+    
+    const CGFloat padding = 3.0;
+    NSLayoutConstraint *top = [stackView.topAnchor constraintEqualToAnchor:self.topAnchor constant:padding];
+    top.priority = 999;
+    NSLayoutConstraint *bottom = [stackView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-padding];
+    bottom.priority = 999;
+    [NSLayoutConstraint activateConstraints:@[
+                                              top,
+                                              [stackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+                                              [stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+                                              bottom
+                                              ]];
+    self.stackView = stackView;
+}
+
+- (void)initContentStackView
+{
+    UIView *contentView = [[UIView alloc] init];
+    contentView.translatesAutoresizingMaskIntoConstraints = NO;
+    contentView.layer.borderColor = [[WPStyleGuide greyLighten20] CGColor];
+    contentView.layer.borderWidth = MenusDesignStrokeWidth;
+    contentView.backgroundColor = [UIColor whiteColor];
+    
+    [self.stackView addArrangedSubview:contentView];
+    self.contentView = contentView;
+    
+    UIStackView *contentStackView = [[UIStackView alloc] init];
+    contentStackView.translatesAutoresizingMaskIntoConstraints = NO;
+    contentStackView.distribution = UIStackViewDistributionFill;
+    contentStackView.alignment = UIStackViewAlignmentFill;
+    contentStackView.axis = UILayoutConstraintAxisHorizontal;
+    
+    const CGFloat spacing = self.stackView.spacing;
+    contentStackView.spacing = spacing;
+    
+    [contentView addSubview:contentStackView];
+    
+    [NSLayoutConstraint activateConstraints:@[
+                                              [contentStackView.topAnchor constraintEqualToAnchor:contentView.topAnchor constant:spacing],
+                                              [contentStackView.leadingAnchor constraintEqualToAnchor:contentView.leadingAnchor constant:spacing],
+                                              [contentStackView.bottomAnchor constraintEqualToAnchor:contentView.bottomAnchor constant:-spacing],
+                                              [contentStackView.trailingAnchor constraintEqualToAnchor:contentView.trailingAnchor constant:-spacing]
+                                              ]];
+    
+    self.contentStackView = contentStackView;
+}
+
+- (void)initIconView
+{
+    UIImageView *iconView = [[UIImageView alloc] init];
+    iconView.translatesAutoresizingMaskIntoConstraints = NO;
+    iconView.tintColor = [WPStyleGuide greyDarken10];
+    iconView.contentMode = UIViewContentModeScaleAspectFit;
+    
+    [self.contentStackView addArrangedSubview:iconView];
+    
+    NSLayoutConstraint *width = [iconView.widthAnchor constraintEqualToConstant:20.0];
+    width.priority = 999;
+    width.active = YES;
+    
+    iconView.hidden = YES;
+    _iconView = iconView;
+}
+
+- (void)initTextField
+{
+    UITextField *textField = [[UITextField alloc] init];
+    textField.delegate = self;
+    textField.clearButtonMode = UITextFieldViewModeWhileEditing;
+    textField.returnKeyType = UIReturnKeyDone;
+    textField.autocapitalizationType = UITextAutocapitalizationTypeWords;
+    textField.autocorrectionType = UITextAutocorrectionTypeNo;
+    textField.opaque = YES;
+    
+    [textField addTarget:self action:@selector(textFieldDidEndOnExit:) forControlEvents:UIControlEventEditingDidEndOnExit];
+    [textField addTarget:self action:@selector(textFieldValueDidChange:) forControlEvents:UIControlEventEditingChanged];
+    
+    UIFont *font = [WPFontManager systemRegularFontOfSize:16.0];
+    textField.font = font;
+    
+    [self.contentStackView addArrangedSubview:textField];
+    
+    [textField setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+    
+    _textField = textField;
+}
+
+- (void)initCancelLabel
+{
+    UILabel *label = [[UILabel alloc] init];
+    label.text = NSLocalizedString(@"Cancel", @"Menus cancel button within text bar while editing items.");
+    label.textColor = [WPStyleGuide greyDarken20];
+    label.font = [WPFontManager systemRegularFontOfSize:14.0];
+    label.userInteractionEnabled = YES;
+    [self.stackView addArrangedSubview:label];
+    
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(cancelTapGesture:)];
+    [label addGestureRecognizer:tap];
+    
+    [label setContentHuggingPriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
+    
+    self.cancelLabel = label;
+    [self setCancelLabelHidden:YES animated:NO];
+}
+
+- (void)addTextObserver:(MenuItemSourceTextBarFieldObserver *)textObserver
+{
+    if (!self.textObservers) {
+        self.textObservers = [NSMutableArray array];
+    }
+    
+    textObserver.textField = self.textField;
+    [self.textObservers addObject:textObserver];
+}
+
+- (BOOL)isFirstResponder
+{
+    return [self.textField isFirstResponder];
+}
+
+- (BOOL)resignFirstResponder
+{
+    if ([self.textField isFirstResponder]) {
+        return [self.textField resignFirstResponder];
+    }
+    
+    return [super resignFirstResponder];
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+    
+    [self setNeedsDisplay];
+}
+
+- (void)setCancelLabelHidden:(BOOL)hidden animated:(BOOL)animated
+{
+    if (self.cancelLabel.hidden != hidden) {
+        
+        void(^toggleButton)() = ^() {
+            self.cancelLabel.hidden = hidden;
+            self.cancelLabel.alpha = hidden ? 0.0 : 1.0;
+        };
+        
+        if (animated) {
+            [UIView animateWithDuration:0.20 animations:^{
+                toggleButton();
+            }];
+        } else  {
+            toggleButton();
+        }
+    }
+}
+
+- (void)cancelTapGesture:(UITapGestureRecognizer *)tap
+{
+    [self.textField resignFirstResponder];
+}
+
+#pragma mark - UITextFieldDelegate
+
+- (void)textFieldDidBeginEditing:(UITextField *)textField
+{
+    [self setCancelLabelHidden:NO animated:YES];
+    [self.delegate sourceTextBarDidBeginEditing:self];
+}
+
+- (void)textFieldDidEndEditing:(UITextField *)textField
+{
+    [self setCancelLabelHidden:YES animated:YES];
+    [self.delegate sourceTextBarDidEndEditing:self];
+}
+
+- (void)textFieldValueDidChange:(UITextField *)textField
+{
+    for (MenuItemSourceTextBarFieldObserver *textObserver in self.textObservers) {
+        
+        [textObserver.timer invalidate];
+        textObserver.timer = [NSTimer scheduledTimerWithTimeInterval:textObserver.interval target:textObserver selector:@selector(timerFired) userInfo:nil repeats:NO];
+    }
+    
+    [self.delegate sourceTextBar:self didUpdateWithText:textField.text];
+}
+
+- (void)textFieldDidEndOnExit:(UITextField *)textField
+{
+    [textField resignFirstResponder];
+}
+
+@end
+
+@implementation MenuItemSourceTextBarFieldObserver
+
+- (void)dealloc
+{
+    [self.timer invalidate];
+}
+
+- (void)timerFired
+{
+    if ([self.textField.text isEqualToString:self.lastTextObserved]) {
+        // text hasn't changed, no observation needed
+        return;
+    }
+    // text is different, change should be observed
+    self.lastTextObserved = self.textField.text;
+    if (self.onTextChange) {
+        self.onTextChange(self.textField.text);
+    }
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
@@ -48,13 +48,17 @@
     self = [self init];
     if (self) {
         
-        self.iconView.image = [Gridicon iconOfType:GridiconTypeSearch];
-        self.iconView.hidden = NO;
+        NSAssert(_iconView != nil, @"iconView is nil");
+        
+        _iconView.image = [Gridicon iconOfType:GridiconTypeSearch];
+        _iconView.hidden = NO;
+        
+        NSAssert(_textField != nil, @"textField is nil");
         
         UIFont *font = [WPFontManager systemRegularFontOfSize:16.0];
         NSString *placeholder = NSLocalizedString(@"Search...", @"Menus search bar placeholder text.");
         NSDictionary *attributes = @{NSFontAttributeName: font, NSForegroundColorAttributeName: [WPStyleGuide greyDarken10]};
-        self.textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder attributes:attributes];
+        _textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:placeholder attributes:attributes];
     }
     
     return self;
@@ -83,7 +87,7 @@
                                               [stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
                                               bottom
                                               ]];
-    self.stackView = stackView;
+    _stackView = stackView;
 }
 
 - (void)initContentStackView
@@ -94,8 +98,10 @@
     contentView.layer.borderWidth = MenusDesignStrokeWidth;
     contentView.backgroundColor = [UIColor whiteColor];
     
-    [self.stackView addArrangedSubview:contentView];
-    self.contentView = contentView;
+    NSAssert(_stackView != nil, @"stackView is nil");
+    
+    [_stackView addArrangedSubview:contentView];
+    _contentView = contentView;
     
     UIStackView *contentStackView = [[UIStackView alloc] init];
     contentStackView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -103,7 +109,7 @@
     contentStackView.alignment = UIStackViewAlignmentFill;
     contentStackView.axis = UILayoutConstraintAxisHorizontal;
     
-    const CGFloat spacing = self.stackView.spacing;
+    const CGFloat spacing = _stackView.spacing;
     contentStackView.spacing = spacing;
     
     [contentView addSubview:contentStackView];
@@ -115,7 +121,7 @@
                                               [contentStackView.trailingAnchor constraintEqualToAnchor:contentView.trailingAnchor constant:-spacing]
                                               ]];
     
-    self.contentStackView = contentStackView;
+    _contentStackView = contentStackView;
 }
 
 - (void)initIconView
@@ -125,7 +131,9 @@
     iconView.tintColor = [WPStyleGuide greyDarken10];
     iconView.contentMode = UIViewContentModeScaleAspectFit;
     
-    [self.contentStackView addArrangedSubview:iconView];
+    NSAssert(_contentStackView != nil, @"contentStackView is nil");
+    
+    [_contentStackView addArrangedSubview:iconView];
     
     NSLayoutConstraint *width = [iconView.widthAnchor constraintEqualToConstant:20.0];
     width.priority = 999;
@@ -151,7 +159,9 @@
     UIFont *font = [WPFontManager systemRegularFontOfSize:16.0];
     textField.font = font;
     
-    [self.contentStackView addArrangedSubview:textField];
+    NSAssert(_contentStackView != nil, @"contentStackView is nil");
+    
+    [_contentStackView addArrangedSubview:textField];
     
     [textField setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
     
@@ -165,15 +175,20 @@
     label.textColor = [WPStyleGuide greyDarken20];
     label.font = [WPFontManager systemRegularFontOfSize:14.0];
     label.userInteractionEnabled = YES;
-    [self.stackView addArrangedSubview:label];
+    
+    NSAssert(_stackView != nil, @"stackView is nil");
+
+    [_stackView addArrangedSubview:label];
     
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(cancelTapGesture:)];
     [label addGestureRecognizer:tap];
     
     [label setContentHuggingPriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
     
-    self.cancelLabel = label;
-    [self setCancelLabelHidden:YES animated:NO];
+    label.hidden = YES;
+    label.alpha = 0.0;
+    
+    _cancelLabel = label;
 }
 
 - (void)addTextObserver:(MenuItemSourceTextBarFieldObserver *)textObserver

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -55,6 +55,11 @@
 		08CC677E1C49B65A00153AD7 /* MenuItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC67791C49B65A00153AD7 /* MenuItem.m */; };
 		08CC677F1C49B65A00153AD7 /* Menu.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC677A1C49B65A00153AD7 /* Menu.m */; };
 		08CC67801C49B65A00153AD7 /* MenuLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC677D1C49B65A00153AD7 /* MenuLocation.m */; };
+		08D978551CD2AF7D0054F19A /* Menu+ViewDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */; };
+		08D978561CD2AF7D0054F19A /* MenuItem+ViewDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D9784E1CD2AF7D0054F19A /* MenuItem+ViewDesign.m */; };
+		08D978571CD2AF7D0054F19A /* MenuItemCheckButtonView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D978501CD2AF7D0054F19A /* MenuItemCheckButtonView.m */; };
+		08D978581CD2AF7D0054F19A /* MenuItemSourceHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D978521CD2AF7D0054F19A /* MenuItemSourceHeaderView.m */; };
+		08D978591CD2AF7D0054F19A /* MenuItemSourceTextBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D978541CD2AF7D0054F19A /* MenuItemSourceTextBar.m */; };
 		1724DDC81C60F1200099D273 /* PlanDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1724DDC71C60F1200099D273 /* PlanDetailViewController.swift */; };
 		1724DDCC1C6121D00099D273 /* Plans.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1724DDCB1C6121D00099D273 /* Plans.storyboard */; };
 		176579F71C63A40F0000978E /* PurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176579F61C63A40F0000978E /* PurchaseButton.swift */; };
@@ -912,6 +917,16 @@
 		08CC677C1C49B65A00153AD7 /* MenuLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuLocation.h; sourceTree = "<group>"; };
 		08CC677D1C49B65A00153AD7 /* MenuLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuLocation.m; sourceTree = "<group>"; };
 		08D4C0E61C76F14E002E5BF6 /* WordPress 47.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 47.xcdatamodel"; sourceTree = "<group>"; };
+		08D9784B1CD2AF7D0054F19A /* Menu+ViewDesign.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Menu+ViewDesign.h"; sourceTree = "<group>"; };
+		08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Menu+ViewDesign.m"; sourceTree = "<group>"; };
+		08D9784D1CD2AF7D0054F19A /* MenuItem+ViewDesign.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MenuItem+ViewDesign.h"; sourceTree = "<group>"; };
+		08D9784E1CD2AF7D0054F19A /* MenuItem+ViewDesign.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MenuItem+ViewDesign.m"; sourceTree = "<group>"; };
+		08D9784F1CD2AF7D0054F19A /* MenuItemCheckButtonView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemCheckButtonView.h; sourceTree = "<group>"; };
+		08D978501CD2AF7D0054F19A /* MenuItemCheckButtonView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemCheckButtonView.m; sourceTree = "<group>"; };
+		08D978511CD2AF7D0054F19A /* MenuItemSourceHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemSourceHeaderView.h; sourceTree = "<group>"; };
+		08D978521CD2AF7D0054F19A /* MenuItemSourceHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemSourceHeaderView.m; sourceTree = "<group>"; };
+		08D978531CD2AF7D0054F19A /* MenuItemSourceTextBar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemSourceTextBar.h; sourceTree = "<group>"; };
+		08D978541CD2AF7D0054F19A /* MenuItemSourceTextBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemSourceTextBar.m; sourceTree = "<group>"; };
 		08F37EC61C7554EF0095BE8B /* PostServiceRemoteOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostServiceRemoteOptions.h; sourceTree = "<group>"; };
 		0FB0432256BC979BCD2B1F08 /* Pods-WordPressShareExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		16593FACF2FA8D408C4CEBFA /* Pods-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release.xcconfig"; sourceTree = "<group>"; };
@@ -2228,6 +2243,31 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
+		08D978491CD2AF7D0054F19A /* Menus */ = {
+			isa = PBXGroup;
+			children = (
+				08D9784A1CD2AF7D0054F19A /* Views */,
+			);
+			path = Menus;
+			sourceTree = "<group>";
+		};
+		08D9784A1CD2AF7D0054F19A /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				08D9784B1CD2AF7D0054F19A /* Menu+ViewDesign.h */,
+				08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */,
+				08D9784D1CD2AF7D0054F19A /* MenuItem+ViewDesign.h */,
+				08D9784E1CD2AF7D0054F19A /* MenuItem+ViewDesign.m */,
+				08D9784F1CD2AF7D0054F19A /* MenuItemCheckButtonView.h */,
+				08D978501CD2AF7D0054F19A /* MenuItemCheckButtonView.m */,
+				08D978511CD2AF7D0054F19A /* MenuItemSourceHeaderView.h */,
+				08D978521CD2AF7D0054F19A /* MenuItemSourceHeaderView.m */,
+				08D978531CD2AF7D0054F19A /* MenuItemSourceTextBar.h */,
+				08D978541CD2AF7D0054F19A /* MenuItemSourceTextBar.m */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		19C28FACFE9D520D11CA2CBB /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -2958,6 +2998,7 @@
 				C533CF320E6D3AB3000C3DE8 /* Comments */,
 				31F4F6641A13858F00196A98 /* Me */,
 				5DA5BF4A18E32DE2005F11F9 /* Media */,
+				08D978491CD2AF7D0054F19A /* Menus */,
 				CC1D800D1656D8B2002A542F /* Notifications */,
 				850D22B21729EE8600EC6A16 /* NUX */,
 				EC4696A80EA74DAC0040EE8E /* Pages */,
@@ -5168,6 +5209,7 @@
 				E66969E41B9E68B200EC9C00 /* ReaderPostToReaderPost37to38.swift in Sources */,
 				5D3D559A18F88C5E00782892 /* ReaderPostServiceRemote.m in Sources */,
 				5DED0E181B432E0400431FCD /* SourcePostAttribution.m in Sources */,
+				08D978561CD2AF7D0054F19A /* MenuItem+ViewDesign.m in Sources */,
 				B52C4C7F199D74AE009FD823 /* NoteTableViewCell.swift in Sources */,
 				315FC2C51A2CB29300E7CDA2 /* MeHeaderView.m in Sources */,
 				082AB9D61C4EEA72000CA523 /* RemotePostTag.m in Sources */,
@@ -5179,6 +5221,7 @@
 				7059CD210F332B6500A0660B /* WPCategoryTree.m in Sources */,
 				B5E167F419C08D18009535AA /* NSCalendar+Helpers.swift in Sources */,
 				08A6FD9C1C5960AB00AC33E4 /* RemoteTaxonomyPaging.m in Sources */,
+				08D978581CD2AF7D0054F19A /* MenuItemSourceHeaderView.m in Sources */,
 				BE1071FC1BC75E7400906AFF /* WPStyleGuide+Blog.swift in Sources */,
 				E149D64E19349E69006A843D /* AccountServiceRemoteREST.m in Sources */,
 				5D9282F91B54697D00066CED /* RemoteReaderSiteInfo.m in Sources */,
@@ -5252,6 +5295,7 @@
 				FFC6ADD41B56F295002F3C84 /* AboutViewController.swift in Sources */,
 				B56F0F541C3337670076C48D /* AccountSettings.swift in Sources */,
 				08CC67801C49B65A00153AD7 /* MenuLocation.m in Sources */,
+				08D978571CD2AF7D0054F19A /* MenuItemCheckButtonView.m in Sources */,
 				83D180FA12329B1A002DCCB0 /* EditPageViewController.m in Sources */,
 				E125445612BF5B3900D87A0A /* PostCategory.m in Sources */,
 				E6C892D61C601D55007AD612 /* SharingButtonsViewController.swift in Sources */,
@@ -5333,6 +5377,7 @@
 				85D239AE1AE5A5FC0074768D /* BlogSyncFacade.m in Sources */,
 				5DB93EED19B6190700EC88EB /* ReaderCommentCell.m in Sources */,
 				5D97C2F315CAF8D8009B44DD /* UINavigationController+KeyboardFix.m in Sources */,
+				08D978591CD2AF7D0054F19A /* MenuItemSourceTextBar.m in Sources */,
 				5D1EE80215E7AF3E007F1F02 /* JetpackSettingsViewController.m in Sources */,
 				E1A8CACB1C22FF7C0038689E /* MeViewController.swift in Sources */,
 				E6B896DC1CB7FB1F00E3FD8F /* SigninLinkAuthViewController.swift in Sources */,
@@ -5417,6 +5462,7 @@
 				31EC15081A5B6675009FC8B3 /* WPStyleGuide+Suggestions.m in Sources */,
 				5DAFEAB81AF2CA6E00B3E1D7 /* PostMetaButton.m in Sources */,
 				85C720B11730CEFA00460645 /* WPWalkthroughTextField.m in Sources */,
+				08D978551CD2AF7D0054F19A /* Menu+ViewDesign.m in Sources */,
 				B587797A19B799D800E57C5A /* NSDate+Helpers.swift in Sources */,
 				E142007A1C117A3B00B3B115 /* ManagedAccountSettings+CoreDataProperties.swift in Sources */,
 				B535209D1AF7EB9F00B33BA8 /* PushAuthenticationService.swift in Sources */,


### PR DESCRIPTION
Adding accessory views used in Menus when editing sources.

Adding a few of the accessory views used when editing a MenuItem. Also adds generic categories used 
throughout Menus for design consts and helpers with `Menu+ViewDesign` and `MenuItem+ViewDesign`.

Note: this is primarily a code review as the users of these views will UI include testing within their context.

Needs review: @diegoreymendez