### PR TITLE
Improve support for Chinese languages in Languages helper

### DIFF
--- a/WordPress/Classes/Utility/Languages.swift
+++ b/WordPress/Classes/Utility/Languages.swift
@@ -79,14 +79,16 @@ class Languages : NSObject
     }
 
     private func languageWithSlug(slug: String) -> Language? {
+        let search = languageCodeReplacements[slug] ?? slug
+
         // Use lazy evaluation so we stop filtering as soon as we got the first match
-        return all.lazy.filter({ $0.slug == slug }).first
+        return all.lazy.filter({ $0.slug == search }).first
     }
 
     /// Overrides the device language. For testing purposes only.
     ///
     func _overrideDeviceLanguageCode(code: String) {
-        deviceLanguageCode = code
+        deviceLanguageCode = code.lowercaseString
     }
 
     // MARK: - Public Nested Classes
@@ -175,7 +177,11 @@ class Languages : NSObject
 
     // MARK: - Private Constants
     private let filename = "Languages"
-    
+
+    private let languageCodeReplacements: [String: String] = [
+        "zh-hans": "zh-cn",
+        "zh-hant": "zh-tw"
+    ]
     
     
     // MARK: - Private Nested Structures

--- a/WordPress/Classes/Utility/Languages.swift
+++ b/WordPress/Classes/Utility/Languages.swift
@@ -178,6 +178,8 @@ class Languages : NSObject
     // MARK: - Private Constants
     private let filename = "Languages"
 
+    // (@koke 2016-04-29) I'm not sure how correct this mapping is, but it matches
+    // what we do for the app translations, so they will at least be consistent
     private let languageCodeReplacements: [String: String] = [
         "zh-hans": "zh-cn",
         "zh-hant": "zh-tw"

--- a/WordPress/Classes/Utility/Languages.swift
+++ b/WordPress/Classes/Utility/Languages.swift
@@ -78,6 +78,8 @@ class Languages : NSObject
         return 1
     }
 
+    /// Searches for a WordPress.com language that matches a language tag.
+    ///
     private func languageWithSlug(slug: String) -> Language? {
         let search = languageCodeReplacements[slug] ?? slug
 
@@ -170,6 +172,9 @@ class Languages : NSObject
 
     
     // MARK: - Private Variables
+
+    /// The device's current preferred language, or English if there's no preferred language.
+    ///
     private lazy var deviceLanguageCode: String = {
         return NSLocale.preferredLanguages().first?.lowercaseString ?? "en"
     }()

--- a/WordPress/WordPressTest/LanguagesTests.swift
+++ b/WordPress/WordPressTest/LanguagesTests.swift
@@ -34,8 +34,8 @@ class LanguagesTests: XCTestCase
     func testNameForLanguageWithIdentifierReturnsTheRightName() {
         let languages = Languages.sharedInstance
         
-        let english = languages.nameForLanguageWithId(1)
-        let spanish = languages.nameForLanguageWithId(19)
+        let english = languages.nameForLanguageWithId(en)
+        let spanish = languages.nameForLanguageWithId(es)
         
         XCTAssert(english == "English")
         XCTAssert(spanish == "Español")
@@ -45,42 +45,76 @@ class LanguagesTests: XCTestCase
         let languages = Languages()
         languages._overrideDeviceLanguageCode("es")
 
-        XCTAssertEqual(languages.deviceLanguageId(), 19)
+        XCTAssertEqual(languages.deviceLanguageId(), es)
     }
 
     func testDeviceLanguageIdReturnsValueForSpanishSpainLowercase() {
         let languages = Languages()
         languages._overrideDeviceLanguageCode("es-es")
 
-        XCTAssertEqual(languages.deviceLanguageId(), 19)
+        XCTAssertEqual(languages.deviceLanguageId(), es)
     }
 
     func testDeviceLanguageIdReturnsValueForSpanishSpain() {
         let languages = Languages()
         languages._overrideDeviceLanguageCode("es-ES")
 
-        XCTAssertEqual(languages.deviceLanguageId(), 19)
+        XCTAssertEqual(languages.deviceLanguageId(), es)
     }
 
     func testDeviceLanguageIdReturnsEnglishForUnknownLanguage() {
         let languages = Languages()
         languages._overrideDeviceLanguageCode("not-a-language")
 
-        XCTAssertEqual(languages.deviceLanguageId(), 1)
+        XCTAssertEqual(languages.deviceLanguageId(), en)
     }
 
     func testDeviceLanguageIdReturnsValueForSpanishSpainExtra() {
         let languages = Languages()
         languages._overrideDeviceLanguageCode("es-ES-extra")
 
-        XCTAssertEqual(languages.deviceLanguageId(), 19)
+        XCTAssertEqual(languages.deviceLanguageId(), es)
     }
 
     func testDeviceLanguageIdReturnsValueForSpanishNO() {
         let languages = Languages()
         languages._overrideDeviceLanguageCode("es-NO")
 
-        XCTAssertEqual(languages.deviceLanguageId(), 19)
+        XCTAssertEqual(languages.deviceLanguageId(), es)
     }
+
+    func testDeviceLanguageIdReturnsZhCNForZhHans() {
+        let languages = Languages()
+        languages._overrideDeviceLanguageCode("zh-Hans")
+
+        XCTAssertEqual(languages.deviceLanguageId(), zhCN)
+    }
+
+    func testDeviceLanguageIdReturnsZhTWForZhHant() {
+        let languages = Languages()
+        languages._overrideDeviceLanguageCode("zh-Hant")
+
+        XCTAssertEqual(languages.deviceLanguageId(), zhTW)
+    }
+
+    func testDeviceLanguageIdReturnsZhCNForZhHansES() {
+        let languages = Languages()
+        languages._overrideDeviceLanguageCode("zh-Hans-ES")
+
+        XCTAssertEqual(languages.deviceLanguageId(), zhCN)
+    }
+
+    func testDeviceLanguageIdReturnsZhTWForZhHantES() {
+        let languages = Languages()
+        languages._overrideDeviceLanguageCode("zh-Hant-ES")
+
+        XCTAssertEqual(languages.deviceLanguageId(), zhTW)
+    }
+
+
+    private let en = 1
+    private let es = 19
+    private let zhCN = 449
+    private let zhTW = 452
 
 }

--- a/WordPress/WordPressTest/LanguagesTests.swift
+++ b/WordPress/WordPressTest/LanguagesTests.swift
@@ -69,4 +69,18 @@ class LanguagesTests: XCTestCase
         XCTAssertEqual(languages.deviceLanguageId(), 1)
     }
 
+    func testDeviceLanguageIdReturnsValueForSpanishSpainExtra() {
+        let languages = Languages()
+        languages._overrideDeviceLanguageCode("es-ES-extra")
+
+        XCTAssertEqual(languages.deviceLanguageId(), 19)
+    }
+
+    func testDeviceLanguageIdReturnsValueForSpanishNO() {
+        let languages = Languages()
+        languages._overrideDeviceLanguageCode("es-NO")
+
+        XCTAssertEqual(languages.deviceLanguageId(), 19)
+    }
+
 }


### PR DESCRIPTION
This fixes a couple issues:

- Apple uses `language-script` for Chinese languages, but we only do `language-region`. We already do a similar map on `update-translations.rb` to match the `.lproj` codes with GlotPress. I think this only affects the Chinese variants so far, so I added a couple exceptions, as properly parsing language tags was not a trivial task.

- While developing this, I realized that not only Apple did `language-script`, but it also appended the region. Before this PR, we'd search the full tag (`zh-Hans-ES`) and then the language (`zh`), and none of them matched the right language. Now we try the full tag and start dropping components from the end until we find a match (`zh-Hans-ES`, `zh-Hans`, `zh`, `en`)

Testing:

Try creating a new site with your device set to different languages, make sure the site has the right language.

Needs review: @jleandroperez 