### PR TITLE
Languages naming refactor

### DIFF
--- a/WordPress/Classes/Utility/Languages.swift
+++ b/WordPress/Classes/Utility/Languages.swift
@@ -10,15 +10,15 @@ class WordPressComLanguageDatabase : NSObject
     
     /// Languages considered 'popular'
     ///
-    let popular : [WordPressComLanguage]
+    let popular : [Language]
     
     /// Every supported language
     ///
-    let all : [WordPressComLanguage]
-    
+    let all : [Language]
+
     /// Returns both, Popular and All languages, grouped
     ///
-    let grouped : [[WordPressComLanguage]]
+    let grouped : [[Language]]
     
     
     // MARK: - Public Methods
@@ -32,8 +32,8 @@ class WordPressComLanguageDatabase : NSObject
         let parsed = try! NSJSONSerialization.JSONObjectWithData(raw, options: [.MutableContainers, .MutableLeaves]) as? NSDictionary
         
         // Parse All + Popular: All doesn't contain Popular. Otherwise the json would have dupe data. Right?
-        let parsedAll = WordPressComLanguage.fromArray(parsed!.arrayForKey(Keys.all) as! [NSDictionary])
-        let parsedPopular = WordPressComLanguage.fromArray(parsed!.arrayForKey(Keys.popular) as! [NSDictionary])
+        let parsedAll = Language.fromArray(parsed!.arrayForKey(Keys.all) as! [NSDictionary])
+        let parsedPopular = Language.fromArray(parsed!.arrayForKey(Keys.popular) as! [NSDictionary])
         let merged = parsedAll + parsedPopular
         
         // Done!
@@ -76,7 +76,7 @@ class WordPressComLanguageDatabase : NSObject
 
     /// Searches for a WordPress.com language that matches a language tag.
     ///
-    private func languageWithSlug(slug: String) -> WordPressComLanguage? {
+    private func languageWithSlug(slug: String) -> Language? {
         let search = languageCodeReplacements[slug] ?? slug
 
         // Use lazy evaluation so we stop filtering as soon as we got the first match
@@ -93,7 +93,7 @@ class WordPressComLanguageDatabase : NSObject
     
     /// Represents a Language supported by WordPress.com
     ///
-    class WordPressComLanguage
+    class Language
     {
         /// Language Unique Identifier
         ///
@@ -136,9 +136,9 @@ class WordPressComLanguageDatabase : NSObject
         
         /// Given an array of raw languages, will return a parsed array.
         ///
-        static func fromArray(array : [NSDictionary]) -> [WordPressComLanguage] {
+        static func fromArray(array : [NSDictionary]) -> [Language] {
             return array.flatMap {
-                return WordPressComLanguage(dict: $0)
+                return Language(dict: $0)
             }
         }
     }

--- a/WordPress/Classes/Utility/Languages.swift
+++ b/WordPress/Classes/Utility/Languages.swift
@@ -142,30 +142,6 @@ class WordPressComLanguageDatabase : NSObject
             }
         }
     }
-
-    // MARK: - Private nested types
-
-    /// Provides a sequence of language tags from the specified string, from more to less specific
-    /// For instance, "zh-Hans-HK" will yield `["zh-Hans-HK", "zh-Hans", "zh"]`
-    ///
-    private struct LanguageTagVariants: SequenceType {
-        let string: String
-
-        func generate() -> AnyGenerator<String> {
-            var components = string.componentsSeparatedByString("-")
-            return AnyGenerator {
-                guard !components.isEmpty else {
-                    return nil
-                }
-
-                let current = components.joinWithSeparator("-")
-                components.removeLast()
-
-                return current
-            }
-        }
-    }
-
     
     // MARK: - Private Variables
 
@@ -198,5 +174,26 @@ class WordPressComLanguageDatabase : NSObject
         static let identifier   = "i"
         static let slug         = "s"
         static let name         = "n"
+    }
+}
+
+/// Provides a sequence of language tags from the specified string, from more to less specific
+/// For instance, "zh-Hans-HK" will yield `["zh-Hans-HK", "zh-Hans", "zh"]`
+///
+private struct LanguageTagVariants: SequenceType {
+    let string: String
+
+    func generate() -> AnyGenerator<String> {
+        var components = string.componentsSeparatedByString("-")
+        return AnyGenerator {
+            guard !components.isEmpty else {
+                return nil
+            }
+
+            let current = components.joinWithSeparator("-")
+            components.removeLast()
+
+            return current
+        }
     }
 }

--- a/WordPress/Classes/Utility/Languages.swift
+++ b/WordPress/Classes/Utility/Languages.swift
@@ -4,25 +4,21 @@ import Foundation
 
 /// This helper class allows us to map WordPress.com LanguageID's into human readable language strings.
 ///
-class Languages : NSObject
+class WordPressComLanguageDatabase : NSObject
 {
     // MARK: - Public Properties
     
-    /// Shared Languages Instance
-    ///
-    static let sharedInstance = Languages()
-    
     /// Languages considered 'popular'
     ///
-    let popular : [Language]
+    let popular : [WordPressComLanguage]
     
     /// Every supported language
     ///
-    let all : [Language]
+    let all : [WordPressComLanguage]
     
     /// Returns both, Popular and All languages, grouped
     ///
-    let grouped : [[Language]]
+    let grouped : [[WordPressComLanguage]]
     
     
     // MARK: - Public Methods
@@ -36,8 +32,8 @@ class Languages : NSObject
         let parsed = try! NSJSONSerialization.JSONObjectWithData(raw, options: [.MutableContainers, .MutableLeaves]) as? NSDictionary
         
         // Parse All + Popular: All doesn't contain Popular. Otherwise the json would have dupe data. Right?
-        let parsedAll = Language.fromArray(parsed!.arrayForKey(Keys.all) as! [NSDictionary])
-        let parsedPopular = Language.fromArray(parsed!.arrayForKey(Keys.popular) as! [NSDictionary])
+        let parsedAll = WordPressComLanguage.fromArray(parsed!.arrayForKey(Keys.all) as! [NSDictionary])
+        let parsedPopular = WordPressComLanguage.fromArray(parsed!.arrayForKey(Keys.popular) as! [NSDictionary])
         let merged = parsedAll + parsedPopular
         
         // Done!
@@ -80,7 +76,7 @@ class Languages : NSObject
 
     /// Searches for a WordPress.com language that matches a language tag.
     ///
-    private func languageWithSlug(slug: String) -> Language? {
+    private func languageWithSlug(slug: String) -> WordPressComLanguage? {
         let search = languageCodeReplacements[slug] ?? slug
 
         // Use lazy evaluation so we stop filtering as soon as we got the first match
@@ -95,9 +91,9 @@ class Languages : NSObject
 
     // MARK: - Public Nested Classes
     
-    /// Represents a Language, which allows us to deal with WordPress.com settings
+    /// Represents a Language supported by WordPress.com
     ///
-    class Language
+    class WordPressComLanguage
     {
         /// Language Unique Identifier
         ///
@@ -140,9 +136,9 @@ class Languages : NSObject
         
         /// Given an array of raw languages, will return a parsed array.
         ///
-        static func fromArray(array : [NSDictionary]) -> [Language] {
+        static func fromArray(array : [NSDictionary]) -> [WordPressComLanguage] {
             return array.flatMap {
-                return Language(dict: $0)
+                return WordPressComLanguage(dict: $0)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
@@ -57,7 +57,7 @@ static UIEdgeInsets const CreateBlogCancelButtonPaddingPad  = {1.0, 13.0, 0.0, 0
     self = [super init];
     if (self) {
         _operationQueue = [[NSOperationQueue alloc] init];
-        _currentLanguageId = [[Languages sharedInstance] deviceLanguageId];
+        _currentLanguageId = [[WordPressComLanguageDatabase new] deviceLanguageId];
     }
     return self;
 }

--- a/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
@@ -93,7 +93,7 @@ public class LanguageViewController : UITableViewController
     private func configureTableViewCell(cell: UITableViewCell) {
         let languageId = blog.settings.languageID.integerValue
         cell.textLabel?.text = NSLocalizedString("Language", comment: "Language of the current blog")
-        cell.detailTextLabel?.text = Languages.sharedInstance.nameForLanguageWithId(languageId)
+        cell.detailTextLabel?.text = languageDatabase.nameForLanguageWithId(languageId)
     }
     
     private func pressedLanguageRow() {
@@ -103,7 +103,7 @@ public class LanguageViewController : UITableViewController
             NSLocalizedString("All languages", comment: "Section title for All Languages")
         ]
 
-        let languages   = Languages.sharedInstance.grouped
+        let languages   = languageDatabase.grouped
         let titles      = languages.map { $0.map { $0.name } }
         let subtitles   = languages.map { $0.map { $0.description } }
         let values      = languages.map { $0.map { $0.languageId } } as [[NSObject]]
@@ -129,7 +129,8 @@ public class LanguageViewController : UITableViewController
     private let reuseIdentifier = "reuseIdentifier"
     private let footerText = NSLocalizedString("The language in which this site is primarily written.",
                                                 comment: "Footer Text displayed in Blog Language Settings View")
-    
+
     // MARK: - Private Properties
     private var blog : Blog!
+    private let languageDatabase = WordPressComLanguageDatabase()
 }

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -437,7 +437,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         case SiteSettingsGeneralLanguage:
         {
             NSInteger languageId = self.blog.settings.languageID.integerValue;
-            NSString *name = [[Languages sharedInstance] nameForLanguageWithId:languageId];
+            NSString *name = [[WordPressComLanguageDatabase new] nameForLanguageWithId:languageId];
             
             [self.languageTextCell setTextValue:name];
             return self.languageTextCell;

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -83,7 +83,7 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
     if (self) {
         _shouldCorrectEmail = YES;
         _operationQueue = [[NSOperationQueue alloc] init];
-        _currentLanguageId = [[Languages sharedInstance] deviceLanguageId];
+        _currentLanguageId = [[WordPressComLanguageDatabase new] deviceLanguageId];
     }
     return self;
 }

--- a/WordPress/WordPressTest/LanguagesTests.swift
+++ b/WordPress/WordPressTest/LanguagesTests.swift
@@ -6,14 +6,14 @@ import XCTest
 class LanguagesTests: XCTestCase
 {
     func testLanguagesEffectivelyLoadJsonFile() {
-        let languages = Languages.sharedInstance
+        let languages = WordPressComLanguageDatabase()
         
         XCTAssert(languages.all.count != 0)
         XCTAssert(languages.popular.count != 0)
     }
     
     func testAllLanguagesHaveValidFields() {
-        let languages = Languages.sharedInstance
+        let languages = WordPressComLanguageDatabase()
         let sum = languages.all + languages.popular
         
         for language in sum {
@@ -23,7 +23,7 @@ class LanguagesTests: XCTestCase
     }
     
     func testAllLanguagesContainPopularLanguages() {
-        let languages = Languages.sharedInstance
+        let languages = WordPressComLanguageDatabase()
         
         for language in languages.popular {
             let filtered = languages.all.filter { $0.languageId == language.languageId }
@@ -32,7 +32,7 @@ class LanguagesTests: XCTestCase
     }
     
     func testNameForLanguageWithIdentifierReturnsTheRightName() {
-        let languages = Languages.sharedInstance
+        let languages = WordPressComLanguageDatabase()
         
         let english = languages.nameForLanguageWithId(en)
         let spanish = languages.nameForLanguageWithId(es)
@@ -42,70 +42,70 @@ class LanguagesTests: XCTestCase
     }
 
     func testDeviceLanguageIdReturnsValueForSpanish() {
-        let languages = Languages()
+        let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("es")
 
         XCTAssertEqual(languages.deviceLanguageId(), es)
     }
 
     func testDeviceLanguageIdReturnsValueForSpanishSpainLowercase() {
-        let languages = Languages()
+        let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("es-es")
 
         XCTAssertEqual(languages.deviceLanguageId(), es)
     }
 
     func testDeviceLanguageIdReturnsValueForSpanishSpain() {
-        let languages = Languages()
+        let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("es-ES")
 
         XCTAssertEqual(languages.deviceLanguageId(), es)
     }
 
     func testDeviceLanguageIdReturnsEnglishForUnknownLanguage() {
-        let languages = Languages()
+        let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("not-a-language")
 
         XCTAssertEqual(languages.deviceLanguageId(), en)
     }
 
     func testDeviceLanguageIdReturnsValueForSpanishSpainExtra() {
-        let languages = Languages()
+        let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("es-ES-extra")
 
         XCTAssertEqual(languages.deviceLanguageId(), es)
     }
 
     func testDeviceLanguageIdReturnsValueForSpanishNO() {
-        let languages = Languages()
+        let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("es-NO")
 
         XCTAssertEqual(languages.deviceLanguageId(), es)
     }
 
     func testDeviceLanguageIdReturnsZhCNForZhHans() {
-        let languages = Languages()
+        let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("zh-Hans")
 
         XCTAssertEqual(languages.deviceLanguageId(), zhCN)
     }
 
     func testDeviceLanguageIdReturnsZhTWForZhHant() {
-        let languages = Languages()
+        let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("zh-Hant")
 
         XCTAssertEqual(languages.deviceLanguageId(), zhTW)
     }
 
     func testDeviceLanguageIdReturnsZhCNForZhHansES() {
-        let languages = Languages()
+        let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("zh-Hans-ES")
 
         XCTAssertEqual(languages.deviceLanguageId(), zhCN)
     }
 
     func testDeviceLanguageIdReturnsZhTWForZhHantES() {
-        let languages = Languages()
+        let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("zh-Hant-ES")
 
         XCTAssertEqual(languages.deviceLanguageId(), zhTW)


### PR DESCRIPTION
I found the naming around the Language helpers way too ambiguous. Specially if we're already handling the different representations of languages between iOS and WordPress, if we have a `Language` type, it should be way more generic.

In this PR:

- I renamed `Languages` to `WordPressComLanguageDatabase`, which is closer to reality. This class is about WordPress.com supported languages.
- I renamed `Language` to `WordPressComLanguage`, as it's not a generic "language" but a representation of one in WordPress.com terms.
- I removed `sharedInstance`. Having a shared instance means that the list of languages is always in memory wether you need it or not. As languages are accessed very rarely, I'd rather load the database on demand.
- I make LanguageTagVariants a top level type. Even if it's currently private, it's not really related to WordPress.com, so it doesn't belong there. To be extra correct, this could be a generic method on `SequenceType` and I'm sure there's a name for that concept already, but I thought this was a good enough compromise.

I would have changed a few more things, but it felt like they were more a matter of style preferences. I think the current changes make the purpose of the types clearer and more semantically consistent.

Needs review: @jleandroperez 