### PR TITLE
Reader: Adds missing endpoint path component.

### DIFF
--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -96,7 +96,7 @@ static const NSInteger MinutesToReadThreshold = 2;
           success:(void (^)(RemoteReaderPost *post))success
           failure:(void (^)(NSError *error))failure {
 
-    NSString *path = [NSString stringWithFormat:@"sites/%d/posts/%d/?meta=site", siteID, postID];
+    NSString *path = [NSString stringWithFormat:@"read/sites/%d/posts/%d/?meta=site", siteID, postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_2];
     


### PR DESCRIPTION
In #5221 I neglected to correct the path for the v 1.2 endpoint.  The result was api calls to `/sites/siteID/posts/postID` were 404ing.  

This pr adds the missing path component. 

To test: 
Try opening a post detail from a comment notification, or from a Discover editor's pick.  Confirm that the post loads correctly. 

Needs review: @koke 