### PR TITLE
Menus: Menu and Menu Location Header Selection Views

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.h
@@ -6,6 +6,10 @@
 
 @protocol MenusHeaderViewDelegate;
 
+/**
+ A top-most view encapsulating the use of
+ two MenusSelectionViews to represent selection options for Menus and MenuLocations.
+ */
 @interface MenusHeaderView : UIView
 
 @property (nonatomic, weak) id <MenusHeaderViewDelegate> delegate;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.h
@@ -1,0 +1,62 @@
+#import <UIKit/UIKit.h>
+
+@class Blog;
+@class MenuLocation;
+@class Menu;
+
+@protocol MenusHeaderViewDelegate;
+
+@interface MenusHeaderView : UIView
+
+@property (nonatomic, weak) id <MenusHeaderViewDelegate> delegate;
+
+/**
+ Set up the header with the Menus and MenuLocations for blog.
+ */
+- (void)setupWithMenusForBlog:(Blog *)blog;
+
+/**
+ Add a Menu to the header's selection options.
+ */
+- (void)addMenu:(Menu *)menu;
+
+/**
+ Remove a menu from the header's selection options.
+ */
+- (void)removeMenu:(Menu *)menu;
+
+/**
+ Set the header's currently selected MenuLocation.
+ */
+- (void)setSelectedLocation:(MenuLocation *)location;
+
+/**
+ Set the header's currently selected Menu.
+ */
+- (void)setSelectedMenu:(Menu *)menu;
+
+/**
+ Reload any views using data for Menu.
+ */
+- (void)refreshMenuViewsUsingMenu:(Menu *)menu;
+
+@end
+
+@protocol MenusHeaderViewDelegate <NSObject>
+
+/**
+ User selected a MenuLocation.
+ */
+- (void)headerView:(MenusHeaderView *)headerView selectedLocation:(MenuLocation *)location;
+
+/**
+ User selected a menu.
+ */
+- (void)headerView:(MenusHeaderView *)headerView selectedMenu:(Menu *)menu;
+
+/**
+ User selected the create new menu option.
+ */
+- (void)headerViewSelectedForCreatingNewMenu:(MenusHeaderView *)headerView;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.h
@@ -9,11 +9,7 @@
 @interface MenusHeaderView : UIView
 
 @property (nonatomic, weak) id <MenusHeaderViewDelegate> delegate;
-
-/**
- Set up the header with the Menus and MenuLocations for blog.
- */
-- (void)setupWithMenusForBlog:(Blog *)blog;
+@property (nonatomic, strong) Blog *blog;
 
 /**
  Add a Menu to the header's selection options.

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.m
@@ -10,7 +10,6 @@
 @interface MenusHeaderView () <MenusSelectionViewDelegate>
 
 @property (nonatomic, weak) IBOutlet UIStackView *stackView;
-@property (nonatomic, strong, readonly) Blog *blog;
 @property (nonatomic, weak) IBOutlet MenusSelectionView *locationsView;
 @property (nonatomic, weak) IBOutlet MenusSelectionView *menusView;
 @property (nonatomic, weak) IBOutlet UILabel *textLabel;
@@ -29,6 +28,8 @@
     
     self.locationsView.delegate = self;
     self.menusView.delegate = self;
+    self.locationsView.selectionType = MenusSelectionViewTypeLocations;
+    self.menusView.selectionType = MenusSelectionViewTypeMenus;
     
     self.textLabel.font = [WPFontManager systemRegularFontOfSize:13];
     self.textLabel.backgroundColor = [UIColor clearColor];
@@ -36,23 +37,24 @@
     self.textLabel.text = NSLocalizedString(@"USES", @"Menus label for describing which menu the location uses in the header.");
 }
 
-- (void)setupWithMenusForBlog:(Blog *)blog
+- (void)setBlog:(Blog *)blog
 {
-    _blog = blog;
-    
-    [self.locationsView removeAllSelectionItems];
-    [self.menusView removeAllSelectionItems];
-    
-    self.locationsView.selectionType = MenusSelectionViewTypeLocations;
-    self.menusView.selectionType = MenusSelectionViewTypeMenus;
-    
-    for (MenuLocation *location in blog.menuLocations) {
-        MenusSelectionItem *item = [MenusSelectionItem itemWithLocation:location];
-        [self.locationsView addSelectionViewItem:item];
-    }
-    for (Menu *menu in blog.menus) {
-        MenusSelectionItem *item = [MenusSelectionItem itemWithMenu:menu];
-        [self.menusView addSelectionViewItem:item];
+    if (_blog != blog) {
+        _blog = blog;
+        
+        [self.locationsView removeAllSelectionItems];
+        [self.menusView removeAllSelectionItems];
+        
+        if (blog) {
+            for (MenuLocation *location in blog.menuLocations) {
+                MenusSelectionItem *item = [MenusSelectionItem itemWithLocation:location];
+                [self.locationsView addSelectionViewItem:item];
+            }
+            for (Menu *menu in blog.menus) {
+                MenusSelectionItem *item = [MenusSelectionItem itemWithMenu:menu];
+                [self.menusView addSelectionViewItem:item];
+            }
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.m
@@ -1,0 +1,151 @@
+#import "MenusHeaderView.h"
+#import "MenusSelectionView.h"
+#import "Blog.h"
+#import "WPStyleGuide.h"
+#import "Menu.h"
+#import "Menu+ViewDesign.h"
+#import "MenuLocation.h"
+#import "WPFontManager.h"
+
+@interface MenusHeaderView () <MenusSelectionViewDelegate>
+
+@property (nonatomic, weak) IBOutlet UIStackView *stackView;
+@property (nonatomic, strong, readonly) Blog *blog;
+@property (nonatomic, weak) IBOutlet MenusSelectionView *locationsView;
+@property (nonatomic, weak) IBOutlet MenusSelectionView *menusView;
+@property (nonatomic, weak) IBOutlet UILabel *textLabel;
+
+@end
+
+@implementation MenusHeaderView
+
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+
+    self.stackView.spacing = MenusDesignDefaultContentSpacing / 2.0;
+    
+    self.backgroundColor = [WPStyleGuide greyLighten30];
+    
+    self.locationsView.delegate = self;
+    self.menusView.delegate = self;
+    
+    self.textLabel.font = [WPFontManager systemRegularFontOfSize:13];
+    self.textLabel.backgroundColor = [UIColor clearColor];
+    self.textLabel.textColor = [WPStyleGuide greyDarken20];
+    self.textLabel.text = NSLocalizedString(@"USES", @"Menus label for describing which menu the location uses in the header.");
+}
+
+- (void)setupWithMenusForBlog:(Blog *)blog
+{
+    _blog = blog;
+    
+    [self.locationsView removeAllSelectionItems];
+    [self.menusView removeAllSelectionItems];
+    
+    self.locationsView.selectionType = MenusSelectionViewTypeLocations;
+    self.menusView.selectionType = MenusSelectionViewTypeMenus;
+    
+    for (MenuLocation *location in blog.menuLocations) {
+        MenusSelectionItem *item = [MenusSelectionItem itemWithLocation:location];
+        [self.locationsView addSelectionViewItem:item];
+    }
+    for (Menu *menu in blog.menus) {
+        MenusSelectionItem *item = [MenusSelectionItem itemWithMenu:menu];
+        [self.menusView addSelectionViewItem:item];
+    }
+}
+
+- (void)addMenu:(Menu *)menu
+{
+    [self.menusView addSelectionViewItem:[MenusSelectionItem itemWithMenu:menu]];
+}
+
+- (void)removeMenu:(Menu *)menu
+{
+    MenusSelectionItem *selectionItem = [self.menusView itemWithItemObjectEqualTo:menu];
+    if (selectionItem) {
+        [self.menusView removeSelectionItem:selectionItem];
+    }
+}
+
+- (void)setSelectedLocation:(MenuLocation *)location
+{
+    MenusSelectionItem *locationItem = [self.locationsView itemWithItemObjectEqualTo:location];
+    [self.locationsView setSelectedItem:locationItem];
+}
+
+- (void)setSelectedMenu:(Menu *)menu
+{
+    MenusSelectionItem *menuItem = [self.menusView itemWithItemObjectEqualTo:menu];
+    [self.menusView setSelectedItem:menuItem];
+}
+
+- (void)refreshMenuViewsUsingMenu:(Menu *)menu
+{
+    MenusSelectionItem *item = [self.menusView itemWithItemObjectEqualTo:menu];
+    [item notifyItemObjectWasUpdated];
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+    
+    if (self.stackView.axis == UILayoutConstraintAxisHorizontal) {
+        // Toggle the selection on a trait collection change to a horizonal axis for the stack view
+        // this ensures both selection views are expanded if one already is
+        // otherwise the design looks odd with too much negative space
+        // see userInteractionDetectedForTogglingSelectionView:expand:
+        if (self.locationsView.selectionItemsExpanded || self.menusView.selectionItemsExpanded) {
+            if (self.locationsView.selectionItemsExpanded && !self.menusView.selectionItemsExpanded) {
+                
+                [self.menusView setSelectionItemsExpanded:YES animated:NO];
+                
+            } else  if (self.menusView.selectionItemsExpanded && !self.locationsView.selectionItemsExpanded) {
+             
+                [self.locationsView setSelectionItemsExpanded:YES animated:NO];
+            }
+        }
+    }
+}
+
+#pragma mark - private
+
+- (void)closeSelectionsIfNeeded
+{
+    // add a UX delay to selection close animation
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self.locationsView setSelectionItemsExpanded:NO animated:YES];
+        [self.menusView setSelectionItemsExpanded:NO animated:YES];
+    });
+}
+
+#pragma mark - MenusSelectionViewDelegate
+
+- (void)userInteractionDetectedForTogglingSelectionView:(MenusSelectionView *)selectionView expand:(BOOL)expand
+{
+    [selectionView setSelectionItemsExpanded:expand animated:YES];
+}
+
+- (void)selectionView:(MenusSelectionView *)selectionView selectedItem:(MenusSelectionItem *)item
+{
+    if ([item isMenuLocation]) {
+        
+        MenuLocation *location = item.itemObject;
+        [self.delegate headerView:self selectedLocation:location];
+        
+    } else  if ([item isMenu]) {
+        
+        Menu *menu = item.itemObject;
+        [self.delegate headerView:self selectedMenu:menu];
+    }
+    [self closeSelectionsIfNeeded];
+}
+
+- (void)selectionViewSelectedOptionForCreatingNewItem:(MenusSelectionView *)selectionView
+{
+    [self.delegate headerViewSelectedForCreatingNewMenu:self];
+    [self closeSelectionsIfNeeded];
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.m
@@ -89,28 +89,6 @@
     [item notifyItemObjectWasUpdated];
 }
 
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
-{
-    [super traitCollectionDidChange:previousTraitCollection];
-    
-    if (self.stackView.axis == UILayoutConstraintAxisHorizontal) {
-        // Toggle the selection on a trait collection change to a horizonal axis for the stack view
-        // this ensures both selection views are expanded if one already is
-        // otherwise the design looks odd with too much negative space
-        // see userInteractionDetectedForTogglingSelectionView:expand:
-        if (self.locationsView.selectionItemsExpanded || self.menusView.selectionItemsExpanded) {
-            if (self.locationsView.selectionItemsExpanded && !self.menusView.selectionItemsExpanded) {
-                
-                [self.menusView setSelectionItemsExpanded:YES animated:NO];
-                
-            } else  if (self.menusView.selectionItemsExpanded && !self.locationsView.selectionItemsExpanded) {
-             
-                [self.locationsView setSelectionItemsExpanded:YES animated:NO];
-            }
-        }
-    }
-}
-
 #pragma mark - private
 
 - (void)closeSelectionsIfNeeded

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.m
@@ -93,7 +93,7 @@ static CGFloat ViewExpansionAnimationDelay = 0.15;
 
 #pragma mark - private
 
-- (void)closeSelectionsIfNeeded
+- (void)contractSelectionsIfNeeded
 {
     // add a UX delay to selection close animation
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(ViewExpansionAnimationDelay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -121,13 +121,13 @@ static CGFloat ViewExpansionAnimationDelay = 0.15;
         Menu *menu = item.itemObject;
         [self.delegate headerView:self selectedMenu:menu];
     }
-    [self closeSelectionsIfNeeded];
+    [self contractSelectionsIfNeeded];
 }
 
 - (void)selectionViewSelectedOptionForCreatingNewItem:(MenusSelectionView *)selectionView
 {
     [self.delegate headerViewSelectedForCreatingNewMenu:self];
-    [self closeSelectionsIfNeeded];
+    [self contractSelectionsIfNeeded];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusHeaderView.m
@@ -7,6 +7,8 @@
 #import "MenuLocation.h"
 #import "WPFontManager.h"
 
+static CGFloat ViewExpansionAnimationDelay = 0.15;
+
 @interface MenusHeaderView () <MenusSelectionViewDelegate>
 
 @property (nonatomic, weak) IBOutlet UIStackView *stackView;
@@ -65,7 +67,7 @@
 
 - (void)removeMenu:(Menu *)menu
 {
-    MenusSelectionItem *selectionItem = [self.menusView itemWithItemObjectEqualTo:menu];
+    MenusSelectionItem *selectionItem = [self.menusView selectionItemForObject:menu];
     if (selectionItem) {
         [self.menusView removeSelectionItem:selectionItem];
     }
@@ -73,19 +75,19 @@
 
 - (void)setSelectedLocation:(MenuLocation *)location
 {
-    MenusSelectionItem *locationItem = [self.locationsView itemWithItemObjectEqualTo:location];
+    MenusSelectionItem *locationItem = [self.locationsView selectionItemForObject:location];
     [self.locationsView setSelectedItem:locationItem];
 }
 
 - (void)setSelectedMenu:(Menu *)menu
 {
-    MenusSelectionItem *menuItem = [self.menusView itemWithItemObjectEqualTo:menu];
+    MenusSelectionItem *menuItem = [self.menusView selectionItemForObject:menu];
     [self.menusView setSelectedItem:menuItem];
 }
 
 - (void)refreshMenuViewsUsingMenu:(Menu *)menu
 {
-    MenusSelectionItem *item = [self.menusView itemWithItemObjectEqualTo:menu];
+    MenusSelectionItem *item = [self.menusView selectionItemForObject:menu];
     [item notifyItemObjectWasUpdated];
 }
 
@@ -94,7 +96,7 @@
 - (void)closeSelectionsIfNeeded
 {
     // add a UX delay to selection close animation
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(ViewExpansionAnimationDelay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [self.locationsView setSelectionItemsExpanded:NO animated:YES];
         [self.menusView setSelectionItemsExpanded:NO animated:YES];
     });
@@ -102,7 +104,7 @@
 
 #pragma mark - MenusSelectionViewDelegate
 
-- (void)userInteractionDetectedForTogglingSelectionView:(MenusSelectionView *)selectionView expand:(BOOL)expand
+- (void)selectionView:(MenusSelectionView *)selectionView userTappedExpand:(BOOL)expand
 {
     [selectionView setSelectionItemsExpanded:expand animated:YES];
 }

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionDetailView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionDetailView.h
@@ -1,0 +1,36 @@
+#import <UIKit/UIKit.h>
+
+@class MenusSelectionItem;
+
+@protocol MenusSelectionDetailViewDelegate;
+
+@interface MenusSelectionDetailView : UIView
+
+@property (nonatomic, weak) id <MenusSelectionDetailViewDelegate> delegate;
+
+/**
+ Updates the design indicating the detailView is active, selected, or enabled.
+ */
+@property (nonatomic, assign) BOOL showsDesignActive;
+
+/**
+ Update the UI with the number of available selection items and the currently selected item.
+ */
+- (void)updatewithAvailableItems:(NSUInteger)numItemsAvailable selectedItem:(MenusSelectionItem *)selectedItem;
+
+@end
+
+@protocol MenusSelectionDetailViewDelegate <NSObject>
+@optional
+
+/**
+ User touches detected for updating the highlighted state of the detailView.
+ */
+- (void)selectionDetailView:(MenusSelectionDetailView *)detailView touchesHighlightedStateChanged:(BOOL)highlighted;
+
+/**
+ User touches detected for tapping the detailView.
+ */
+- (void)selectionDetailView:(MenusSelectionDetailView *)detailView tapGestureRecognized:(UITapGestureRecognizer *)tap;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionDetailView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionDetailView.h
@@ -4,6 +4,10 @@
 
 @protocol MenusSelectionDetailViewDelegate;
 
+/**
+ A detail view encapsulating labels displaying a currently 
+ selected MenusSelectionItem and a count of available MenusSelectionItems.
+ */
 @interface MenusSelectionDetailView : UIView
 
 @property (nonatomic, weak) id <MenusSelectionDetailViewDelegate> delegate;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionDetailView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionDetailView.m
@@ -1,0 +1,196 @@
+#import "MenusSelectionDetailView.h"
+#import "WPStyleGuide.h"
+#import "Menu+ViewDesign.h"
+#import "MenusSelectionView.h"
+#import "WPFontManager.h"
+
+@import Gridicons;
+
+@interface MenusSelectionDetailView ()
+
+@property (nonatomic, weak) IBOutlet UIStackView *stackView;
+@property (nonatomic, strong, readonly) UIStackView *labelsStackView;
+@property (nonatomic, strong, readonly) UILabel *titleLabel;
+@property (nonatomic, strong, readonly) UILabel *subTitleLabel;
+@property (nonatomic, strong, readonly) UIImageView *iconView;
+@property (nonatomic, strong, readonly) UIImageView *accessoryView;
+
+@end
+
+@implementation MenusSelectionDetailView
+
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    UIEdgeInsets margins = UIEdgeInsetsZero;
+    CGFloat spacing = MenusDesignDefaultContentSpacing;
+    // Spacing + tweak for design stroke offset.
+    margins.left = spacing;
+    margins.right = spacing;
+    self.stackView.layoutMargins = margins;
+    self.stackView.layoutMarginsRelativeArrangement = YES;
+    self.stackView.distribution = UIStackViewDistributionFill;
+    self.stackView.alignment = UIStackViewAlignmentCenter;
+    self.stackView.spacing = spacing;
+    
+    [self initIconView];
+    [self initLabelsStackView];
+    [self initSubtTitleLabel];
+    [self initTitleLabel];
+    [self initAccessoryView];
+    
+    self.backgroundColor = [UIColor clearColor];
+    
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tellDelegateTapGestureRecognized:)];
+    [self addGestureRecognizer:tap];
+}
+
+- (void)initIconView
+{
+    UIImageView *iconView = [[UIImageView alloc] init];
+    iconView.contentMode = UIViewContentModeScaleAspectFit;
+    iconView.tintColor = [WPStyleGuide grey];
+    [iconView.widthAnchor constraintEqualToConstant:24].active = YES;
+    [iconView.heightAnchor constraintEqualToConstant:24].active = YES;
+    [self.stackView addArrangedSubview:iconView];
+    _iconView = iconView;
+}
+
+- (void)initLabelsStackView
+{
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.alignment = UIStackViewAlignmentFill;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.axis = UILayoutConstraintAxisVertical;
+    [stackView setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+    _labelsStackView = stackView;
+    
+    [self.stackView addArrangedSubview:stackView];
+}
+
+- (void)initSubtTitleLabel
+{
+    UILabel *label = [[UILabel alloc] init];
+    label.numberOfLines = 0;
+    label.font = [WPFontManager systemRegularFontOfSize:13.0];
+    label.textColor = [WPStyleGuide grey];
+    _subTitleLabel = label;
+    
+    NSAssert(_labelsStackView != nil, @"labelsStackView is nil");
+    
+    [_labelsStackView addArrangedSubview:label];
+}
+
+- (void)initTitleLabel
+{
+    UILabel *label = [[UILabel alloc] init];
+    label.numberOfLines = 1;
+    label.font = [WPFontManager systemRegularFontOfSize:17.0];
+    label.textColor = [WPStyleGuide darkGrey];
+    label.adjustsFontSizeToFitWidth = YES;
+    label.minimumScaleFactor = 0.50;
+    label.allowsDefaultTighteningForTruncation = YES;
+    _titleLabel = label;
+    
+    NSAssert(_labelsStackView != nil, @"labelsStackView is nil");
+    
+    [_labelsStackView addArrangedSubview:label];
+}
+
+- (void)initAccessoryView
+{
+    UIImageView *accessoryView = [[UIImageView alloc] init];
+    accessoryView.contentMode = UIViewContentModeScaleAspectFit;
+    accessoryView.image = [Gridicon iconOfType:GridiconTypeChevronDown];
+    accessoryView.tintColor = [WPStyleGuide greyLighten20];
+    [accessoryView.widthAnchor constraintEqualToConstant:24].active = YES;
+    [accessoryView.heightAnchor constraintEqualToConstant:24].active = YES;
+    _accessoryView = accessoryView;
+    
+    [self.stackView addArrangedSubview:accessoryView];
+}
+
+- (void)setShowsDesignActive:(BOOL)showsDesignActive
+{
+    if (_showsDesignActive != showsDesignActive) {
+        _showsDesignActive = showsDesignActive;
+        
+        if (showsDesignActive) {
+            self.accessoryView.transform = CGAffineTransformMakeScale(1.0, -1.0);
+        } else  {
+            self.accessoryView.transform = CGAffineTransformIdentity;
+        }
+    }
+}
+
+- (void)updatewithAvailableItems:(NSUInteger)numItemsAvailable selectedItem:(MenusSelectionItem *)selectedItem
+{
+    NSString *localizedFormat = nil;
+    if ([selectedItem isMenuLocation]) {
+        
+        if (numItemsAvailable > 1) {
+            localizedFormat = NSLocalizedString(@"%i menu areas in this theme", @"The number of menu areas available in the theme");
+        } else  {
+            localizedFormat = NSLocalizedString(@"%i menu area in this theme", @"One menu area available in the theme");
+        }
+        self.iconView.image = [Gridicon iconOfType:GridiconTypeLayout];
+        
+    } else  if ([selectedItem isMenu]) {
+        
+        if (numItemsAvailable > 1) {
+            localizedFormat = NSLocalizedString(@"%i menus available", @"The number of menus on the site and area.");
+        } else  {
+            localizedFormat = NSLocalizedString(@"%i menu available", @"One menu is available in the site and area");
+        }
+        self.iconView.image = [Gridicon iconOfType:GridiconTypeMenus];
+    }
+    
+    [self setTitleText:selectedItem.displayName subTitleText:[NSString stringWithFormat:localizedFormat, numItemsAvailable]];
+}
+
+- (void)setTitleText:(NSString *)title subTitleText:(NSString *)subtitle
+{
+    self.subTitleLabel.text = subtitle;
+    self.titleLabel.text = title;
+    
+    [self.labelsStackView setNeedsLayout];
+    [self.labelsStackView layoutIfNeeded];
+}
+
+#pragma mark - overrides
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [self tellDelegateTouchesHighlightedStateChanged:YES];
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [self tellDelegateTouchesHighlightedStateChanged:NO];
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [self tellDelegateTouchesHighlightedStateChanged:NO];
+}
+
+#pragma mark - delegate helpers
+
+- (void)tellDelegateTapGestureRecognized:(UITapGestureRecognizer *)tap
+{
+    if ([self.delegate respondsToSelector:@selector(selectionDetailView:tapGestureRecognized:)]) {
+        [self.delegate selectionDetailView:self tapGestureRecognized:tap];
+    }
+}
+
+- (void)tellDelegateTouchesHighlightedStateChanged:(BOOL)highlighted
+{
+    if ([self.delegate respondsToSelector:@selector(selectionDetailView:touchesHighlightedStateChanged:)]) {
+        [self.delegate selectionDetailView:self touchesHighlightedStateChanged:highlighted];
+    }
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItem.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItem.h
@@ -1,0 +1,58 @@
+#import <Foundation/Foundation.h>
+
+@class Menu;
+@class MenuLocation;
+
+extern NSString * const MenusSelectionViewItemChangedSelectedNotification;
+extern NSString * const MenusSelectionViewItemUpdatedItemObjectNotification;
+
+@interface MenusSelectionItem : NSObject
+
+/**
+ The associated object the item represents.
+ */
+@property (nonatomic, strong) id itemObject;
+
+/**
+ Tracker for the selected state of the item.
+ */
+@property (nonatomic, assign) BOOL selected;
+
+/**
+ Helper for creating an item with a Menu.
+ */
++ (MenusSelectionItem *)itemWithMenu:(Menu *)menu;
+
+/**
+ Helper for creating an item with a MenuLocation.
+ */
++ (MenusSelectionItem *)itemWithLocation:(MenuLocation *)location;
+
+/**
+ Helper for detecting whether an item is a Menu.
+ */
+- (BOOL)isMenu;
+
+/**
+ Helper for detecting whether an item is a MenuLocation.
+ */
+- (BOOL)isMenuLocation;
+
+/**
+ Get the displayName of the item for the UI.
+ */
+- (NSString *)displayName;
+
+/**
+ Helper for posting the MenusSelectionViewItemUpdatedItemObjectNotification notification.
+ */
+- (void)notifyItemObjectWasUpdated;
+
+@end
+
+/**
+ Convienience class for an item that only represents creating a new item in the UI.
+ */
+@interface MenusSelectionAddMenuItem : MenusSelectionItem
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItem.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItem.h
@@ -6,6 +6,9 @@
 extern NSString * const MenusSelectionViewItemChangedSelectedNotification;
 extern NSString * const MenusSelectionViewItemUpdatedItemObjectNotification;
 
+/**
+ An abstract object class for representing a Menu or MenuLocation.
+ */
 @interface MenusSelectionItem : NSObject
 
 /**

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItem.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItem.m
@@ -1,0 +1,69 @@
+#import "MenusSelectionItem.h"
+#import "Menu.h"
+#import "MenuLocation.h"
+
+NSString * const MenusSelectionViewItemChangedSelectedNotification = @"MenusSelectionViewItemChangedSelectedNotification";
+NSString * const MenusSelectionViewItemUpdatedItemObjectNotification = @"MenusSelectionViewItemUpdatedItemObjectNotification";
+
+@implementation MenusSelectionItem
+
++ (MenusSelectionItem *)itemWithMenu:(Menu *)menu
+{
+    MenusSelectionItem *item = [MenusSelectionItem new];
+    item.itemObject = menu;
+    return item;
+}
+
++ (MenusSelectionItem *)itemWithLocation:(MenuLocation *)location
+{
+    MenusSelectionItem *item = [MenusSelectionItem new];
+    item.itemObject = location;
+    return item;
+}
+
+- (void)setSelected:(BOOL)selected
+{
+    if (_selected != selected) {
+        _selected = selected;
+        [[NSNotificationCenter defaultCenter] postNotificationName:MenusSelectionViewItemChangedSelectedNotification object:self];
+    }
+}
+
+- (BOOL)isMenu
+{
+    return [self.itemObject isKindOfClass:[Menu class]];
+}
+
+- (BOOL)isMenuLocation
+{
+    return [self.itemObject isKindOfClass:[MenuLocation class]];
+}
+
+- (NSString *)displayName
+{
+    NSString *name = nil;
+    if ([self isMenu]) {
+        Menu *menu = self.itemObject;
+        name = menu.name;
+    } else  if ([self isMenuLocation]) {
+        MenuLocation *location = self.itemObject;
+        name = location.details;
+    }
+    return name;
+}
+
+- (void)notifyItemObjectWasUpdated
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:MenusSelectionViewItemUpdatedItemObjectNotification object:self];
+}
+
+@end
+
+@implementation MenusSelectionAddMenuItem
+
+- (NSString *)displayName
+{
+    return NSLocalizedString(@"+ Add new menu", @"Menus button text for adding a new menu to a site.");
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItemView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItemView.h
@@ -1,0 +1,31 @@
+#import <UIKit/UIKit.h>
+
+@class MenusSelectionItem;
+
+@protocol MenusSelectionItemViewDelegate;
+
+@interface MenusSelectionItemView : UIView
+
+@property (nonatomic, weak) id <MenusSelectionItemViewDelegate> delegate;
+@property (nonatomic, strong) MenusSelectionItem *item;
+
+/**
+ Tracker for the previously listed itemView in a stack.
+ */
+@property (nonatomic, weak) MenusSelectionItemView *previousItemView;
+
+/**
+ Tracker for the next listed itemView in a stack.
+ */
+@property (nonatomic, weak) MenusSelectionItemView *nextItemView;
+
+@end
+
+@protocol MenusSelectionItemViewDelegate <NSObject>
+
+/**
+ User interaction detected for selection the itemView.
+ */
+- (void)selectionItemViewWasSelected:(MenusSelectionItemView *)itemView;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItemView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItemView.m
@@ -1,0 +1,170 @@
+#import "MenusSelectionItemView.h"
+#import "MenusSelectionView.h"
+#import "WPStyleGuide.h"
+#import "Menu+ViewDesign.h"
+
+@interface MenusSelectionItemView ()
+
+@property (nonatomic, strong, readonly) UILabel *label;
+@property (nonatomic, assign) BOOL drawsDesignLineSeparator;
+@property (nonatomic, assign) BOOL drawsHighlighted;
+
+@end
+
+@implementation MenusSelectionItemView
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        
+        self.backgroundColor = [UIColor clearColor];
+        self.translatesAutoresizingMaskIntoConstraints = NO;
+        
+        UILabel *label = [[UILabel alloc] init];
+        label.translatesAutoresizingMaskIntoConstraints = NO;
+        label.backgroundColor = [UIColor clearColor];
+        label.font = [[WPStyleGuide regularTextFont] fontWithSize:14];
+        label.textColor = [WPStyleGuide darkGrey];
+        [self addSubview:label];
+        _label = label;
+        
+        UIEdgeInsets insets = [Menu viewDefaultDesignInsets];
+        insets.left = MenusDesignDefaultContentSpacing;
+        insets.right = MenusDesignDefaultContentSpacing;
+        
+        [label.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:insets.left].active = YES;
+        [label.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:insets.right].active = YES;
+        [label.topAnchor constraintEqualToAnchor:self.topAnchor constant:0].active = YES;
+        [label.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:0].active = YES;
+        
+        _drawsDesignLineSeparator = YES; // defaults to YES
+        
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(itemSelectionChanged:) name:MenusSelectionViewItemChangedSelectedNotification object:nil];
+        
+        UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tellDelegateViewWasSelected)];
+        [self addGestureRecognizer:tap];
+    }
+    
+    return self;
+}
+
+- (void)setItem:(MenusSelectionItem *)item
+{
+    if (_item != item) {
+        _item = item;
+    }
+    self.label.text = item.displayName;
+}
+
+- (void)setDrawsDesignLineSeparator:(BOOL)drawsDesignLineSeparator
+{
+    if (_drawsDesignLineSeparator != drawsDesignLineSeparator) {
+        _drawsDesignLineSeparator = drawsDesignLineSeparator;
+        [self setNeedsDisplay];
+    }
+}
+
+- (void)setDrawsHighlighted:(BOOL)drawsHighlighted
+{
+    if (_drawsHighlighted != drawsHighlighted) {
+        _drawsHighlighted = drawsHighlighted;
+        
+        [self.previousItemView setNeedsDisplay];
+        [self.nextItemView setNeedsDisplay];
+        self.drawsDesignLineSeparator = !drawsHighlighted;
+        [self setNeedsDisplay];
+    }
+}
+
+- (void)setHidden:(BOOL)hidden
+{
+    [super setHidden:hidden];
+    [self setNeedsDisplay];
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+    [self setNeedsDisplay];
+}
+
+- (void)drawRect:(CGRect)rect
+{
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    if (self.drawsHighlighted) {
+        
+        [[WPStyleGuide greyLighten30] set];
+        CGContextFillRect(context, rect);
+        
+    } else  if (self.drawsDesignLineSeparator) {
+        
+        // draw the line separator
+        CGContextSetLineWidth(context, MenusDesignStrokeWidth);
+        
+        if (self.nextItemView && !self.nextItemView.drawsHighlighted) {
+            // draw a line on the bottom
+            CGContextMoveToPoint(context, MenusDesignDefaultContentSpacing, rect.size.height - (MenusDesignStrokeWidth / 2.0));
+            CGContextAddLineToPoint(context, rect.size.width, rect.size.height - (MenusDesignStrokeWidth / 2.0));
+        }
+        
+        CGContextSetStrokeColorWithColor(context, [[WPStyleGuide greyLighten20] CGColor]);
+        CGContextStrokePath(context);
+    }
+    
+    if (self.item.selected) {
+        // draw a checkmark
+        CGFloat checkStepLength = 10.0;
+        CGPoint checkOrigin = CGPointZero;
+        checkOrigin.x = rect.size.width - MenusDesignDefaultContentSpacing;
+        checkOrigin.x -= checkStepLength;
+        checkOrigin.y = rect.size.height / 2.0;
+        checkOrigin.y += checkStepLength / 2.0;
+        
+        CGContextSetLineWidth(context, 1.0);
+        CGContextMoveToPoint(context, checkOrigin.x, checkOrigin.y);
+        CGContextAddLineToPoint(context, checkOrigin.x + checkStepLength, checkOrigin.y - checkStepLength);
+        CGContextMoveToPoint(context, checkOrigin.x - (checkStepLength / 2.0), checkOrigin.y - (checkStepLength / 2.0));
+        CGContextAddLineToPoint(context, checkOrigin.x, checkOrigin.y);
+        CGContextSetStrokeColorWithColor(context, [[WPStyleGuide greyDarken10] CGColor]);
+        CGContextStrokePath(context);
+    }
+}
+
+#pragma mark - delegate helpers
+
+- (void)tellDelegateViewWasSelected
+{
+    [self.delegate selectionItemViewWasSelected:self];
+}
+
+#pragma mark - touches
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    self.drawsHighlighted = YES;
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    self.drawsHighlighted = NO;
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    self.drawsHighlighted = NO;
+}
+
+#pragma mark - notifications
+
+- (void)itemSelectionChanged:(NSNotification *)notification
+{
+    [self setNeedsDisplay];
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.h
@@ -1,0 +1,74 @@
+#import <UIKit/UIKit.h>
+#import "MenusSelectionItem.h"
+
+typedef NS_ENUM(NSUInteger, MenusSelectionViewType) {
+    MenusSelectionViewTypeMenus = 1,
+    MenusSelectionViewTypeLocations
+};
+
+@protocol MenusSelectionViewDelegate;
+
+@interface MenusSelectionView : UIView
+
+@property (nonatomic, weak) id <MenusSelectionViewDelegate> delegate;
+
+/**
+ The type of selection the selectionView should be configured for.
+ */
+@property (nonatomic, assign) MenusSelectionViewType selectionType;
+
+/**
+ Toggle the visual expansion of the selection items in the UI.
+ */
+@property (nonatomic, assign) BOOL selectionItemsExpanded;
+
+/**
+ The currently selected item in the UI.
+ */
+@property (nonatomic, strong) MenusSelectionItem *selectedItem;
+
+/**
+ Add a selection item to the list of available items for display.
+ */
+- (void)addSelectionViewItem:(MenusSelectionItem *)selectionItem;
+
+/**
+ Remove a selection item from the list of available items for display.
+ */
+- (void)removeSelectionItem:(MenusSelectionItem *)selectionItem;
+
+/**
+ Remove all selection items from the list of available items for display.
+ */
+- (void)removeAllSelectionItems;
+
+/**
+ Create a new selection item with an associated object the item represents.
+ */
+- (MenusSelectionItem *)itemWithItemObjectEqualTo:(id)itemObject;
+
+/**
+ Toggle the visual expansion of the selection items in the UI, with animation.
+ */
+- (void)setSelectionItemsExpanded:(BOOL)selectionItemsExpanded animated:(BOOL)animated;
+
+@end
+
+@protocol MenusSelectionViewDelegate <NSObject>
+
+/**
+ The user tapped or pressed to toggle the selection expansion of the UI.
+ */
+- (void)userInteractionDetectedForTogglingSelectionView:(MenusSelectionView *)selectionView expand:(BOOL)expand;
+
+/**
+ The user selected an item from the list of available items for display.
+ */
+- (void)selectionView:(MenusSelectionView *)selectionView selectedItem:(MenusSelectionItem *)item;
+
+/**
+ The user selected a special item representing creating a new item.
+ */
+- (void)selectionViewSelectedOptionForCreatingNewItem:(MenusSelectionView *)selectionView;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.h
@@ -8,6 +8,9 @@ typedef NS_ENUM(NSUInteger, MenusSelectionViewType) {
 
 @protocol MenusSelectionViewDelegate;
 
+/**
+ A view encapsulating the use of MenusSelectionItems as a list of options for either Menus or MenuLocations.
+ */
 @interface MenusSelectionView : UIView
 
 @property (nonatomic, weak) id <MenusSelectionViewDelegate> delegate;
@@ -43,9 +46,9 @@ typedef NS_ENUM(NSUInteger, MenusSelectionViewType) {
 - (void)removeAllSelectionItems;
 
 /**
- Create a new selection item with an associated object the item represents.
+ Get the corresponding MenusSelectionItem with an item.itemObject equal to the passed itemObject.
  */
-- (MenusSelectionItem *)itemWithItemObjectEqualTo:(id)itemObject;
+- (MenusSelectionItem *)selectionItemForObject:(id)itemObject;
 
 /**
  Toggle the visual expansion of the selection items in the UI, with animation.
@@ -57,9 +60,9 @@ typedef NS_ENUM(NSUInteger, MenusSelectionViewType) {
 @protocol MenusSelectionViewDelegate <NSObject>
 
 /**
- The user tapped or pressed to toggle the selection expansion of the UI.
+ The user tapped to toggle the selection expansion of the UI.
  */
-- (void)userInteractionDetectedForTogglingSelectionView:(MenusSelectionView *)selectionView expand:(BOOL)expand;
+- (void)selectionView:(MenusSelectionView *)selectionView userTappedExpand:(BOOL)expand;
 
 /**
  The user selected an item from the list of available items for display.

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.m
@@ -1,0 +1,271 @@
+#import "MenusSelectionView.h"
+#import "MenusSelectionDetailView.h"
+#import "MenusSelectionItemView.h"
+#import "Menu+ViewDesign.h"
+
+@interface MenusSelectionView () <MenusSelectionDetailViewDelegate, MenusSelectionItemViewDelegate>
+
+@property (nonatomic, strong, readonly) NSMutableArray <MenusSelectionItem *> *items;
+@property (nonatomic, weak) IBOutlet UIStackView *stackView;
+@property (nonatomic, weak) IBOutlet MenusSelectionDetailView *detailView;
+@property (nonatomic, strong, readonly) NSMutableArray *itemViews;
+@property (nonatomic, strong) MenusSelectionItemView *addNewItemView;
+@property (nonatomic, assign) BOOL drawsHighlighted;
+
+@end
+
+@implementation MenusSelectionView
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    
+    self.backgroundColor = [UIColor whiteColor];
+    self.layer.borderColor = [[WPStyleGuide greyLighten20] CGColor];
+    self.layer.borderWidth = MenusDesignStrokeWidth;
+    
+    _items = [NSMutableArray arrayWithCapacity:5];
+    _itemViews = [NSMutableArray array];
+
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    self.stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.stackView.alignment = UIStackViewAlignmentTop;
+    self.stackView.spacing = 0.0;
+        
+    self.detailView.delegate = self;
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(selectionItemObjectWasUpdatedNotification:) name:MenusSelectionViewItemUpdatedItemObjectNotification object:nil];
+}
+
+
+#pragma mark - instance
+
+- (void)setSelectionType:(MenusSelectionViewType)selectionType
+{
+    if (_selectionType != selectionType) {
+        _selectionType = selectionType;
+        if (selectionType == MenusSelectionViewTypeMenus) {
+            if (!self.addNewItemView) {
+                MenusSelectionItemView *itemView = [self insertSelectionItemViewWithItem:[MenusSelectionAddMenuItem new]];
+                self.addNewItemView = itemView;
+                [self.stackView addArrangedSubview:itemView];
+            }
+        }
+    }
+}
+
+- (void)setSelectedItem:(MenusSelectionItem *)selectedItem
+{
+    if (_selectedItem != selectedItem) {
+        
+        _selectedItem.selected = NO;
+        selectedItem.selected = YES;
+        _selectedItem = selectedItem;
+        
+        [self updateDetailsView];
+    }
+}
+
+- (void)addSelectionViewItem:(MenusSelectionItem *)selectionItem
+{
+    [self.items addObject:selectionItem];
+    [self insertSelectionItemViewWithItem:selectionItem];
+    
+    // Ensure the add new  item is at the bottom of the stack
+    [self.stackView insertArrangedSubview:self.addNewItemView atIndex:self.stackView.arrangedSubviews.count - 1];
+    
+    [self updateDetailsView];
+}
+
+- (void)removeSelectionItem:(MenusSelectionItem *)selectionItem
+{
+    MenusSelectionItemView *itemView = [self itemViewForSelectionItem:selectionItem];
+    [self.stackView removeArrangedSubview:itemView];
+    [self.itemViews removeObject:itemView];
+    [itemView removeFromSuperview];
+    [self.items removeObject:selectionItem];
+    
+    [self updateDetailsView];
+}
+
+- (void)removeAllSelectionItems
+{
+    NSArray *items = [NSArray arrayWithArray:self.items];
+    for (MenusSelectionItem *item in items) {
+        [self removeSelectionItem:item];
+    }
+}
+
+- (MenusSelectionItem *)itemWithItemObjectEqualTo:(id)itemObject
+{
+    MenusSelectionItem *matchingItem = nil;
+    for (MenusSelectionItem *item in self.items) {
+        if (item.itemObject == itemObject) {
+            matchingItem = item;
+            break;
+        }
+    }
+    return matchingItem;
+}
+
+- (void)setSelectionItemsExpanded:(BOOL)selectionItemsExpanded
+{
+    if (_selectionItemsExpanded != selectionItemsExpanded) {
+        _selectionItemsExpanded = selectionItemsExpanded;
+        for (MenusSelectionItemView *itemView in self.itemViews) {
+            itemView.hidden = !selectionItemsExpanded;
+            itemView.alpha = itemView.hidden ? 0.0 : 1.0;
+        }
+        
+        self.detailView.showsDesignActive = selectionItemsExpanded;
+    }
+}
+
+- (void)setSelectionItemsExpanded:(BOOL)selectionItemsExpanded animated:(BOOL)animated
+{
+    if (!animated) {
+        self.selectionItemsExpanded = selectionItemsExpanded;
+        return;
+    }
+    [UIView animateWithDuration:0.25 delay:0.0 options:UIViewAnimationOptionCurveEaseOut animations:^{
+        self.selectionItemsExpanded = selectionItemsExpanded;
+    } completion:nil];
+}
+
+#pragma mark - private
+
+- (MenusSelectionItemView *)insertSelectionItemViewWithItem:(MenusSelectionItem *)item
+{
+    MenusSelectionItemView *itemView = [[MenusSelectionItemView alloc] init];
+    itemView.item = item;
+    itemView.delegate = self;
+    
+    NSLayoutConstraint *heightContrainst = [itemView.heightAnchor constraintEqualToConstant:44];
+    heightContrainst.priority = UILayoutPriorityDefaultHigh;
+    heightContrainst.active = YES;
+    itemView.hidden = YES;
+    
+    [self.itemViews addObject:itemView];
+    [self.stackView addArrangedSubview:itemView];
+    
+    // set the width/trailing anchor equal to the stackView
+    [itemView.trailingAnchor constraintEqualToAnchor:self.stackView.trailingAnchor].active = YES;
+    
+    // setup ordering to help with any drawing
+    MenusSelectionItemView *lastItemView = nil;
+    for (MenusSelectionItemView *itemView in self.itemViews) {
+        lastItemView.nextItemView = itemView;
+        itemView.previousItemView = lastItemView;
+        lastItemView = itemView;
+    }
+    
+    return itemView;
+}
+
+- (MenusSelectionItemView *)itemViewForSelectionItem:(MenusSelectionItem *)item
+{
+    MenusSelectionItemView *itemView = nil;
+    for (MenusSelectionItemView *view in self.itemViews) {
+        if (view.item == item) {
+            itemView = view;
+            break;
+        }
+    }
+    return itemView;
+}
+
+- (void)updateDetailsView
+{
+    if (self.selectedItem) {
+        [self.detailView updatewithAvailableItems:self.items.count selectedItem:self.selectedItem];
+    }
+}
+
+#pragma mark - drawing
+
+- (void)setDrawsHighlighted:(BOOL)drawsHighlighted
+{
+    if (_drawsHighlighted != drawsHighlighted) {
+        _drawsHighlighted = drawsHighlighted;
+        self.backgroundColor = drawsHighlighted ? [UIColor colorWithRed:0.99 green:0.99 blue:1.0 alpha:1.0] : [UIColor whiteColor];
+    }
+}
+
+#pragma mark - delegate helpers
+
+- (void)tellDelegateUserInteractionDetectedForTogglingExpansion
+{
+    [self.delegate userInteractionDetectedForTogglingSelectionView:self expand:!self.selectionItemsExpanded];
+}
+
+- (void)tellDelegateSelectedItem:(MenusSelectionItem *)item
+{
+    [self.delegate selectionView:self selectedItem:item];
+}
+
+#pragma mark - MenusSelectionDetailViewDelegate
+
+- (void)selectionDetailView:(MenusSelectionDetailView *)detailView tapGestureRecognized:(UITapGestureRecognizer *)tap
+{
+    [self tellDelegateUserInteractionDetectedForTogglingExpansion];
+}
+
+- (void)selectionDetailView:(MenusSelectionDetailView *)detailView touchesHighlightedStateChanged:(BOOL)highlighted
+{
+    self.drawsHighlighted = highlighted;
+}
+
+#pragma mark - MenusSelectionItemViewDelegate
+
+- (void)selectionItemViewWasSelected:(MenusSelectionItemView *)itemView
+{
+    if (itemView == self.addNewItemView) {
+        
+        [self.delegate selectionViewSelectedOptionForCreatingNewItem:self];
+        
+    } else {
+
+        [self tellDelegateSelectedItem:itemView.item];
+    }
+}
+
+#pragma mark - notifications
+
+- (void)selectionItemObjectWasUpdatedNotification:(NSNotification *)notification
+{
+    MenusSelectionItem *updatedItem = notification.object;
+    BOOL haveItem = NO;
+    for (MenusSelectionItem *item in self.items) {
+        if (item == updatedItem) {
+            haveItem = YES;
+            break;
+        }
+    }
+    
+    if (!haveItem) {
+        // no updates needed
+        return;
+    }
+    
+    if (updatedItem.selected) {
+        // update the detailView
+        [self.detailView updatewithAvailableItems:self.items.count selectedItem:updatedItem];
+    }
+    
+    // update any itemViews using this item
+    for (MenusSelectionItemView *itemView in self.itemViews) {
+        
+        if (itemView.item == updatedItem) {
+            itemView.item = updatedItem;
+            break;
+        }
+    }
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.m
@@ -102,7 +102,7 @@
     }
 }
 
-- (MenusSelectionItem *)itemWithItemObjectEqualTo:(id)itemObject
+- (MenusSelectionItem *)selectionItemForObject:(id)itemObject
 {
     MenusSelectionItem *matchingItem = nil;
     for (MenusSelectionItem *item in self.items) {
@@ -199,9 +199,9 @@
 
 #pragma mark - delegate helpers
 
-- (void)tellDelegateUserInteractionDetectedForTogglingExpansion
+- (void)tellDelegateUserTappedForExpansion
 {
-    [self.delegate userInteractionDetectedForTogglingSelectionView:self expand:!self.selectionItemsExpanded];
+    [self.delegate selectionView:self userTappedExpand:!self.selectionItemsExpanded];
 }
 
 - (void)tellDelegateSelectedItem:(MenusSelectionItem *)item
@@ -213,7 +213,7 @@
 
 - (void)selectionDetailView:(MenusSelectionDetailView *)detailView tapGestureRecognized:(UITapGestureRecognizer *)tap
 {
-    [self tellDelegateUserInteractionDetectedForTogglingExpansion];
+    [self tellDelegateUserTappedForExpansion];
 }
 
 - (void)selectionDetailView:(MenusSelectionDetailView *)detailView touchesHighlightedStateChanged:(BOOL)highlighted

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -55,6 +55,10 @@
 		08CC677E1C49B65A00153AD7 /* MenuItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC67791C49B65A00153AD7 /* MenuItem.m */; };
 		08CC677F1C49B65A00153AD7 /* Menu.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC677A1C49B65A00153AD7 /* Menu.m */; };
 		08CC67801C49B65A00153AD7 /* MenuLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC677D1C49B65A00153AD7 /* MenuLocation.m */; };
+		08D345501CD7F50900358E8C /* MenusSelectionDetailView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D345491CD7F50900358E8C /* MenusSelectionDetailView.m */; };
+		08D345511CD7F50900358E8C /* MenusSelectionItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D3454B1CD7F50900358E8C /* MenusSelectionItem.m */; };
+		08D345521CD7F50900358E8C /* MenusSelectionItemView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D3454D1CD7F50900358E8C /* MenusSelectionItemView.m */; };
+		08D345531CD7F50900358E8C /* MenusSelectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D3454F1CD7F50900358E8C /* MenusSelectionView.m */; };
 		08D978551CD2AF7D0054F19A /* Menu+ViewDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */; };
 		08D978561CD2AF7D0054F19A /* MenuItem+ViewDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D9784E1CD2AF7D0054F19A /* MenuItem+ViewDesign.m */; };
 		08D978571CD2AF7D0054F19A /* MenuItemCheckButtonView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D978501CD2AF7D0054F19A /* MenuItemCheckButtonView.m */; };
@@ -912,6 +916,14 @@
 		08CC677B1C49B65A00153AD7 /* Menu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Menu.h; sourceTree = "<group>"; };
 		08CC677C1C49B65A00153AD7 /* MenuLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuLocation.h; sourceTree = "<group>"; };
 		08CC677D1C49B65A00153AD7 /* MenuLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuLocation.m; sourceTree = "<group>"; };
+		08D345481CD7F50900358E8C /* MenusSelectionDetailView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusSelectionDetailView.h; sourceTree = "<group>"; };
+		08D345491CD7F50900358E8C /* MenusSelectionDetailView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusSelectionDetailView.m; sourceTree = "<group>"; };
+		08D3454A1CD7F50900358E8C /* MenusSelectionItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusSelectionItem.h; sourceTree = "<group>"; };
+		08D3454B1CD7F50900358E8C /* MenusSelectionItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusSelectionItem.m; sourceTree = "<group>"; };
+		08D3454C1CD7F50900358E8C /* MenusSelectionItemView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusSelectionItemView.h; sourceTree = "<group>"; };
+		08D3454D1CD7F50900358E8C /* MenusSelectionItemView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusSelectionItemView.m; sourceTree = "<group>"; };
+		08D3454E1CD7F50900358E8C /* MenusSelectionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusSelectionView.h; sourceTree = "<group>"; };
+		08D3454F1CD7F50900358E8C /* MenusSelectionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusSelectionView.m; sourceTree = "<group>"; };
 		08D4C0E61C76F14E002E5BF6 /* WordPress 47.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 47.xcdatamodel"; sourceTree = "<group>"; };
 		08D9784B1CD2AF7D0054F19A /* Menu+ViewDesign.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Menu+ViewDesign.h"; sourceTree = "<group>"; };
 		08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Menu+ViewDesign.m"; sourceTree = "<group>"; };
@@ -2231,6 +2243,34 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
+		08D345461CD7F4E300358E8C /* Menu and Location Selection */ = {
+			isa = PBXGroup;
+			children = (
+				08D3454E1CD7F50900358E8C /* MenusSelectionView.h */,
+				08D3454F1CD7F50900358E8C /* MenusSelectionView.m */,
+				08D345481CD7F50900358E8C /* MenusSelectionDetailView.h */,
+				08D345491CD7F50900358E8C /* MenusSelectionDetailView.m */,
+				08D3454C1CD7F50900358E8C /* MenusSelectionItemView.h */,
+				08D3454D1CD7F50900358E8C /* MenusSelectionItemView.m */,
+				08D3454A1CD7F50900358E8C /* MenusSelectionItem.h */,
+				08D3454B1CD7F50900358E8C /* MenusSelectionItem.m */,
+			);
+			name = "Menu and Location Selection";
+			sourceTree = "<group>";
+		};
+		08D345471CD7F4EF00358E8C /* MenuItem Editing */ = {
+			isa = PBXGroup;
+			children = (
+				08D9784F1CD2AF7D0054F19A /* MenuItemCheckButtonView.h */,
+				08D978501CD2AF7D0054F19A /* MenuItemCheckButtonView.m */,
+				08D978511CD2AF7D0054F19A /* MenuItemSourceHeaderView.h */,
+				08D978521CD2AF7D0054F19A /* MenuItemSourceHeaderView.m */,
+				08D978531CD2AF7D0054F19A /* MenuItemSourceTextBar.h */,
+				08D978541CD2AF7D0054F19A /* MenuItemSourceTextBar.m */,
+			);
+			name = "MenuItem Editing";
+			sourceTree = "<group>";
+		};
 		08D978491CD2AF7D0054F19A /* Menus */ = {
 			isa = PBXGroup;
 			children = (
@@ -2246,12 +2286,8 @@
 				08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */,
 				08D9784D1CD2AF7D0054F19A /* MenuItem+ViewDesign.h */,
 				08D9784E1CD2AF7D0054F19A /* MenuItem+ViewDesign.m */,
-				08D9784F1CD2AF7D0054F19A /* MenuItemCheckButtonView.h */,
-				08D978501CD2AF7D0054F19A /* MenuItemCheckButtonView.m */,
-				08D978511CD2AF7D0054F19A /* MenuItemSourceHeaderView.h */,
-				08D978521CD2AF7D0054F19A /* MenuItemSourceHeaderView.m */,
-				08D978531CD2AF7D0054F19A /* MenuItemSourceTextBar.h */,
-				08D978541CD2AF7D0054F19A /* MenuItemSourceTextBar.m */,
+				08D345461CD7F4E300358E8C /* Menu and Location Selection */,
+				08D345471CD7F4EF00358E8C /* MenuItem Editing */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -5271,6 +5307,7 @@
 				B5C7D7B81BC6B5A3008E668A /* UIAlertController+Helpers.swift in Sources */,
 				B54866CA1A0D7042004AC79D /* NSAttributedString+Helpers.swift in Sources */,
 				834CAEA0122D56B1003DDF49 /* UIImage+RoundedCorner.m in Sources */,
+				08D345531CD7F50900358E8C /* MenusSelectionView.m in Sources */,
 				E18EE95119349EC300B0A40C /* ReaderTopicServiceRemote.m in Sources */,
 				B5FD4544199D0F2800286FBB /* NotificationsViewController.m in Sources */,
 				5D6C4B131B604190005E3C43 /* UITextView+RichTextView.swift in Sources */,
@@ -5391,6 +5428,7 @@
 				B532D4EE199D4418006E4DF6 /* NoteBlockImageTableViewCell.swift in Sources */,
 				E10B5ACF1C4518E100F6A390 /* AccountService+Rx.swift in Sources */,
 				93FA59DD18D88C1C001446BC /* PostCategoryService.m in Sources */,
+				08D345511CD7F50900358E8C /* MenusSelectionItem.m in Sources */,
 				E1BEEC631C4E35A8000B4FA0 /* Animator.swift in Sources */,
 				E1C5457E1C6B962D001CEB0E /* MediaSettings.swift in Sources */,
 				5DCC4CD819A50CC0003E548C /* ReaderSite.m in Sources */,
@@ -5580,6 +5618,7 @@
 				E1F5A1BC1771C90A00E0495F /* WPTableImageSource.m in Sources */,
 				5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */,
 				B53AD9BF1BE9584B009AB87E /* SettingsSelectionViewController.m in Sources */,
+				08D345521CD7F50900358E8C /* MenusSelectionItemView.m in Sources */,
 				851734431798C64700A30E27 /* NSURL+Util.m in Sources */,
 				FF4258501BA092EE00580C68 /* RelatedPostsSettingsViewController.m in Sources */,
 				FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */,
@@ -5598,6 +5637,7 @@
 				E120D90E1B09D8C300FB9A6E /* JetpackState.m in Sources */,
 				B5416D011C17693B00006DD8 /* UIApplication+Helpers.m in Sources */,
 				5D08B90419648C3400D5B381 /* ReaderSubscriptionViewController.m in Sources */,
+				08D345501CD7F50900358E8C /* MenusSelectionDetailView.m in Sources */,
 				E6D35FFC1C5ABC2700A46303 /* RemoteBlogOptionsHelper.m in Sources */,
 				E1EBC36F1C118EA500F638E0 /* ImmuTable.swift in Sources */,
 				5DDC44671A72BB07007F538E /* ReaderViewController.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		08D345511CD7F50900358E8C /* MenusSelectionItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D3454B1CD7F50900358E8C /* MenusSelectionItem.m */; };
 		08D345521CD7F50900358E8C /* MenusSelectionItemView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D3454D1CD7F50900358E8C /* MenusSelectionItemView.m */; };
 		08D345531CD7F50900358E8C /* MenusSelectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D3454F1CD7F50900358E8C /* MenusSelectionView.m */; };
+		08D345561CD7FBA900358E8C /* MenusHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D345551CD7FBA900358E8C /* MenusHeaderView.m */; };
 		08D978551CD2AF7D0054F19A /* Menu+ViewDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */; };
 		08D978561CD2AF7D0054F19A /* MenuItem+ViewDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D9784E1CD2AF7D0054F19A /* MenuItem+ViewDesign.m */; };
 		08D978571CD2AF7D0054F19A /* MenuItemCheckButtonView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D978501CD2AF7D0054F19A /* MenuItemCheckButtonView.m */; };
@@ -924,6 +925,8 @@
 		08D3454D1CD7F50900358E8C /* MenusSelectionItemView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusSelectionItemView.m; sourceTree = "<group>"; };
 		08D3454E1CD7F50900358E8C /* MenusSelectionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusSelectionView.h; sourceTree = "<group>"; };
 		08D3454F1CD7F50900358E8C /* MenusSelectionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusSelectionView.m; sourceTree = "<group>"; };
+		08D345541CD7FBA900358E8C /* MenusHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusHeaderView.h; sourceTree = "<group>"; };
+		08D345551CD7FBA900358E8C /* MenusHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusHeaderView.m; sourceTree = "<group>"; };
 		08D4C0E61C76F14E002E5BF6 /* WordPress 47.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 47.xcdatamodel"; sourceTree = "<group>"; };
 		08D9784B1CD2AF7D0054F19A /* Menu+ViewDesign.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Menu+ViewDesign.h"; sourceTree = "<group>"; };
 		08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Menu+ViewDesign.m"; sourceTree = "<group>"; };
@@ -2286,6 +2289,8 @@
 				08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */,
 				08D9784D1CD2AF7D0054F19A /* MenuItem+ViewDesign.h */,
 				08D9784E1CD2AF7D0054F19A /* MenuItem+ViewDesign.m */,
+				08D345541CD7FBA900358E8C /* MenusHeaderView.h */,
+				08D345551CD7FBA900358E8C /* MenusHeaderView.m */,
 				08D345461CD7F4E300358E8C /* Menu and Location Selection */,
 				08D345471CD7F4EF00358E8C /* MenuItem Editing */,
 			);
@@ -5266,6 +5271,7 @@
 				B5899ADE1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift in Sources */,
 				FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */,
 				B57B99D519A2C20200506504 /* NoteTableHeaderView.swift in Sources */,
+				08D345561CD7FBA900358E8C /* MenusHeaderView.m in Sources */,
 				83418AAA11C9FA6E00ACF00C /* Comment.m in Sources */,
 				E125443C12BF5A7200D87A0A /* WordPress.xcdatamodeld in Sources */,
 				B574CE111B5D8F8600A84FFD /* WPStyleGuide+AlertView.swift in Sources */,


### PR DESCRIPTION
Adding a collection of views responsible for handling the selection and display of Menus and Menu Locations in the header of the primary Menus view.

<img width="414" alt="screen shot 2016-05-02 at 4 08 41 pm" src="https://cloud.githubusercontent.com/assets/1873422/14968018/2a7ae9f8-1080-11e6-8c89-af6fb561bb42.png">

- `MenusHeaderView` is the top-most view encapsulating the use of two `MenusSelectionViews` to represent selection options for `Menus` and `MenuLocations` (areas).
- `MenusSelectionView` is a view encapsulating the use of `MenusSelectionItems` as a list of options.
- `MenusSelectionDetailView` is the detail view encapsulating labels displaying a currently selected `MenusSelectionItem` and a count of available `MenusSelectionItems`.
- `MenusSelectionItem` is an abstract object used for representing a `Menu` or `MenuLocation`.

Note: This is primarily a code review as testing in proper context will occur within a smaller PR merging the view controller using this view along side additional menus views.

For context now, you can build and run the staging branch `feature/menus-views` for testing out the interaction on Menus when selecting Menu Locations and Menus in the header under Blog > Menus.

![menus_selections](https://cloud.githubusercontent.com/assets/1873422/14968073/983c38de-1080-11e6-8669-96fa01d8c8a8.gif)

Needs review: @diegoreymendez (I promise it's not as big as it looks 😅)