### PR TITLE
Menus: Views for editing a MenuItem's source.

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.m
@@ -26,14 +26,14 @@ static CGFloat const iconPadding = 3.0;
         self.backgroundColor = [UIColor whiteColor];
         self.contentMode = UIViewContentModeRedraw;
         
-        [self initIconView];
-        [self initLabel];
+        [self setupIconView];
+        [self setupLabel];
     }
     
     return self;
 }
 
-- (void)initIconView
+- (void)setupIconView
 {
     UIImageView *iconView = [[UIImageView alloc] init];
     iconView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -52,7 +52,7 @@ static CGFloat const iconPadding = 3.0;
     _iconView = iconView;
 }
 
-- (void)initLabel
+- (void)setupLabel
 {
     UILabel *label = [[UILabel alloc] init];
     label.translatesAutoresizingMaskIntoConstraints = NO;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCategoryView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCategoryView.h
@@ -1,0 +1,5 @@
+#import "MenuItemSourceView.h"
+
+@interface MenuItemSourceCategoryView : MenuItemSourceView
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCategoryView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCategoryView.m
@@ -111,19 +111,13 @@ static NSUInteger const MenuItemSourceCategorySyncLimit = 1000;
     self.displayCategories = [tree getAllObjects];
     
     // Get the indentation level of each category.
-    NSUInteger count = [self.displayCategories count];
-    
     NSMutableDictionary *categoryDict = [NSMutableDictionary dictionary];
-    for (NSInteger i = 0; i < count; i++) {
-        PostCategory *category = [self.displayCategories objectAtIndex:i];
+    for (PostCategory *category in self.displayCategories) {
         [categoryDict setObject:category forKey:category.categoryID];
     }
-    
-    for (NSInteger i = 0; i < count; i++) {
-        PostCategory *category = [self.displayCategories objectAtIndex:i];
-        
-        NSInteger indentationLevel = [self indentationLevelForCategory:category.parentID categoryCollection:categoryDict];
-        
+    for (PostCategory *category in self.displayCategories) {
+        NSInteger indentationLevel = [self indentationLevelForCategory:category.parentID
+                                                    categoryCollection:categoryDict];
         [self.categoryIndentationDict setValue:[NSNumber numberWithInteger:indentationLevel]
                                         forKey:[category.categoryID stringValue]];
     }
@@ -136,7 +130,6 @@ static NSUInteger const MenuItemSourceCategorySyncLimit = 1000;
     if ([parentID intValue] == 0) {
         return 0;
     }
-    
     PostCategory *category = [categoryDict objectForKey:parentID];
     return ([self indentationLevelForCategory:category.parentID categoryCollection:categoryDict]) + 1;
 }
@@ -154,16 +147,6 @@ static NSUInteger const MenuItemSourceCategorySyncLimit = 1000;
 }
 
 #pragma mark - NSFetchedResultsControllerDelegate
-
-- (void)controllerWillChangeContent:(NSFetchedResultsController *)controller
-{
-    // do nothing
-}
-
-- (void)controller:(NSFetchedResultsController *)controller didChangeObject:(id)anObject atIndexPath:(NSIndexPath *)indexPath forChangeType:(NSFetchedResultsChangeType)type newIndexPath:(NSIndexPath *)newIndexPath
-{
-    // do nothing
-}
 
 - (void)controllerDidChangeContent:(NSFetchedResultsController *)controller
 {

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCategoryView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCategoryView.m
@@ -1,0 +1,173 @@
+#import "MenuItemSourceCategoryView.h"
+#import "PostCategory.h"
+#import "PostCategoryService.h"
+#import "Menu.h"
+#import "MenuItem.h"
+#import "Blog.h"
+#import "WPCategoryTree.h"
+
+static NSUInteger const MenuItemSourceCategorySyncLimit = 1000;
+
+@interface MenuItemSourceCategoryView ()
+
+@property (nonatomic, strong) NSArray *displayCategories;
+@property (nonatomic, strong) NSMutableDictionary *categoryIndentationDict;
+
+@end
+
+@implementation MenuItemSourceCategoryView
+
+- (void)setBlog:(Blog *)blog
+{
+    [super setBlog:blog];
+    [self syncCategories];
+}
+
+- (NSString *)sourceItemType
+{
+    return MenuItemTypeCategory;
+}
+
+- (NSFetchRequest *)fetchRequest
+{
+    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
+    NSEntityDescription *entity = [NSEntityDescription entityForName:[PostCategory entityName] inManagedObjectContext:[self managedObjectContext]];
+    [fetchRequest setEntity:entity];
+    [fetchRequest setPredicate:[self defaultFetchRequestPredicate]];
+    [fetchRequest setFetchLimit:MenuItemSourceCategorySyncLimit];
+    
+    NSSortDescriptor *sortNameDescriptor = [[NSSortDescriptor alloc] initWithKey:@"categoryName"
+                                                                       ascending:YES
+                                                                        selector:@selector(caseInsensitiveCompare:)];
+    
+    [fetchRequest setSortDescriptors:[NSArray arrayWithObjects:sortNameDescriptor, nil]];
+    
+    return fetchRequest;
+}
+
+- (void)syncCategories
+{
+    self.displayCategories = [NSMutableArray array];
+    [self performResultsControllerFetchRequest];
+    
+    [self showLoadingSourcesIndicatorIfEmpty];
+    void(^stopLoading)() = ^() {
+        [self hideLoadingSourcesIndicator];
+    };
+    PostCategoryService *categoryService = [[PostCategoryService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    [categoryService syncCategoriesForBlog:[self blog]
+                                    number:@(MenuItemSourceCategorySyncLimit)
+                                    offset:@(0)
+                                   success:^(NSArray<PostCategory *> *categories) {
+                                       stopLoading();
+                                   } failure:^(NSError *error) {
+                                       stopLoading();
+                                       [self showLoadingErrorMessageForResults];
+                                   }];
+}
+
+#pragma mark - TableView methods
+
+- (void)configureSourceCell:(MenuItemSourceCell *)cell forIndexPath:(NSIndexPath *)indexPath
+{
+    PostCategory *category = [self.displayCategories objectAtIndex:indexPath.row];
+    
+    if ([self itemTypeMatchesSourceItemType] && [self.item.contentID integerValue] == [category.categoryID integerValue]) {
+        cell.sourceSelected = YES;
+    } else {
+        cell.sourceSelected = NO;
+    }
+    
+    [cell setTitle:category.categoryName];
+    
+    NSInteger indentationLevel = [[self.categoryIndentationDict objectForKey:[category.categoryID stringValue]] integerValue];
+    [cell setSourceHierarchyIndentation:indentationLevel];
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    [super tableView:tableView didSelectRowAtIndexPath:indexPath];
+    
+    PostCategory *category = [self.displayCategories objectAtIndex:indexPath.row];
+    [self setItemSourceWithContentID:category.categoryID name:category.categoryName];
+    
+    [self deselectVisibleSourceCellsIfNeeded];
+    
+    MenuItemSourceCell *selectedCell = [tableView cellForRowAtIndexPath:indexPath];
+    selectedCell.sourceSelected = YES;
+}
+
+#pragma mark -
+
+- (void)updateDisplayCategories
+{
+    // Get sorted categories by parent/child relationship
+    self.categoryIndentationDict = [NSMutableDictionary dictionary];
+    
+    // Get sorted categories by parent/child relationship
+    WPCategoryTree *tree = [[WPCategoryTree alloc] initWithParent:nil];
+    [tree getChildrenFromObjects:self.resultsController.fetchedObjects];
+    
+    self.displayCategories = [tree getAllObjects];
+    
+    // Get the indentation level of each category.
+    NSUInteger count = [self.displayCategories count];
+    
+    NSMutableDictionary *categoryDict = [NSMutableDictionary dictionary];
+    for (NSInteger i = 0; i < count; i++) {
+        PostCategory *category = [self.displayCategories objectAtIndex:i];
+        [categoryDict setObject:category forKey:category.categoryID];
+    }
+    
+    for (NSInteger i = 0; i < count; i++) {
+        PostCategory *category = [self.displayCategories objectAtIndex:i];
+        
+        NSInteger indentationLevel = [self indentationLevelForCategory:category.parentID categoryCollection:categoryDict];
+        
+        [self.categoryIndentationDict setValue:[NSNumber numberWithInteger:indentationLevel]
+                                        forKey:[category.categoryID stringValue]];
+    }
+    
+    [self.tableView reloadData];
+}
+
+- (NSInteger)indentationLevelForCategory:(NSNumber *)parentID categoryCollection:(NSMutableDictionary *)categoryDict
+{
+    if ([parentID intValue] == 0) {
+        return 0;
+    }
+    
+    PostCategory *category = [categoryDict objectForKey:parentID];
+    return ([self indentationLevelForCategory:category.parentID categoryCollection:categoryDict]) + 1;
+}
+
+#pragma mark - UITableView
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
+{
+    return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+    return self.displayCategories.count;
+}
+
+#pragma mark - NSFetchedResultsControllerDelegate
+
+- (void)controllerWillChangeContent:(NSFetchedResultsController *)controller
+{
+    // do nothing
+}
+
+- (void)controller:(NSFetchedResultsController *)controller didChangeObject:(id)anObject atIndexPath:(NSIndexPath *)indexPath forChangeType:(NSFetchedResultsChangeType)type newIndexPath:(NSIndexPath *)newIndexPath
+{
+    // do nothing
+}
+
+- (void)controllerDidChangeContent:(NSFetchedResultsController *)controller
+{
+    [self updateDisplayCategories];
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.h
@@ -1,0 +1,25 @@
+#import <UIKit/UIKit.h>
+
+@interface MenuItemSourceCell : UITableViewCell
+
+/**
+ Selected state of the cell.
+ */
+@property (nonatomic, assign) BOOL sourceSelected;
+
+/**
+ Title for displaying within the cell.
+ */
+@property (nonatomic, copy) NSString *title;
+
+/**
+ Visual representation of indentation for parent/child relationships.
+ */
+@property (nonatomic, assign) NSUInteger sourceHierarchyIndentation;
+
+/**
+ The current drawing rect of the label.
+ */
+- (CGRect)drawingRectForLabel;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.m
@@ -1,0 +1,165 @@
+#import "MenuItemSourceCell.h"
+#import "WPStyleGuide.h"
+#import "WPFontManager.h"
+#import "Menu+ViewDesign.h"
+
+#pragma mark - MenuItemSourceRadioButton
+
+@interface MenuItemSourceRadioButton : UIView
+
+@property (nonatomic, assign) BOOL selected;
+@property (nonatomic, assign) BOOL drawsHighlighted;
+
+@end
+
+#pragma mark - MenuItemSourceOptionView
+
+static CGFloat const MenuItemSourceCellHierarchyIdentationWidth = 17.0;
+
+@interface MenuItemSourceCell ()
+
+@property (nonatomic, strong, readonly) UIStackView *stackView;
+@property (nonatomic, strong, readonly) UIStackView *labelsStackView;
+@property (nonatomic, strong, readonly) UILabel *label;
+@property (nonatomic, strong, readonly) NSLayoutConstraint *leadingLayoutConstraintForContentViewIndentation;
+@property (nonatomic, strong, readonly) NSLayoutConstraint *topLayoutConstraintForContentViewIndentation;
+@property (nonatomic, strong, readonly) NSLayoutConstraint *topLayoutDefaultConstraint;
+
+@end
+
+@implementation MenuItemSourceCell
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier
+{
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        
+        self.backgroundColor = [UIColor whiteColor];
+        
+        [self initStackView];
+        [self initLabelsStackView];
+        [self initLabel];
+    }
+    
+    return self;
+}
+
+- (void)initStackView
+{
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.alignment = UIStackViewAlignmentLeading;
+    stackView.axis = UILayoutConstraintAxisHorizontal;
+    
+    UIEdgeInsets margins = UIEdgeInsetsZero;
+    margins.top = 10.0;
+    margins.left = MenusDesignDefaultContentSpacing;
+    margins.right = MenusDesignDefaultContentSpacing;
+    margins.bottom = 10.0;
+    
+    stackView.layoutMargins = margins;
+    stackView.layoutMarginsRelativeArrangement = YES;
+    stackView.spacing = MenusDesignDefaultContentSpacing / 2.0;
+    [self.contentView addSubview:stackView];
+    
+    _leadingLayoutConstraintForContentViewIndentation = [stackView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor];
+    _topLayoutDefaultConstraint = [stackView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor];
+    _topLayoutConstraintForContentViewIndentation = [stackView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:-(margins.top)];
+    
+    [NSLayoutConstraint activateConstraints:@[
+                                              _topLayoutDefaultConstraint,
+                                              _leadingLayoutConstraintForContentViewIndentation,
+                                              [stackView.trailingAnchor constraintLessThanOrEqualToAnchor:self.contentView.trailingAnchor],
+                                              [stackView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor]
+                                              ]];
+    
+    _stackView = stackView;
+}
+
+- (void)initLabelsStackView
+{
+    UIStackView *labelsStackView = [[UIStackView alloc] init];
+    labelsStackView.translatesAutoresizingMaskIntoConstraints = NO;
+    labelsStackView.distribution = UIStackViewDistributionFill;
+    labelsStackView.alignment = UIStackViewAlignmentTop;
+    labelsStackView.axis = UILayoutConstraintAxisHorizontal;
+    labelsStackView.spacing = self.stackView.spacing;
+    _labelsStackView = labelsStackView;
+
+    NSAssert(_stackView != nil, @"stackView is nil");
+    [_stackView addArrangedSubview:labelsStackView];
+}
+
+- (void)initLabel
+{
+    UILabel *label = [[UILabel alloc] init];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.font = [WPStyleGuide tableviewTextFont];
+    label.textColor = [WPStyleGuide greyDarken30];
+    label.backgroundColor = [UIColor whiteColor];
+    label.numberOfLines = 0;
+    label.lineBreakMode = NSLineBreakByTruncatingTail;
+    
+    [label setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+    [label setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+    _label = label;
+
+    NSAssert(_labelsStackView != nil, @"labelsStackView is nil");
+    [self.labelsStackView addArrangedSubview:label];
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    [self updateSeparatorInsets];
+}
+
+- (void)setSourceSelected:(BOOL)sourceSelected
+{
+    if (_sourceSelected != sourceSelected) {
+        _sourceSelected = sourceSelected;
+        self.accessoryType = sourceSelected ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    }
+}
+
+- (void)setTitle:(NSString *)title
+{
+    if (_title != title) {
+        _title = [title copy];
+        self.label.text = title;
+    }
+}
+
+- (void)setSourceHierarchyIndentation:(NSUInteger)sourceHierarchyIndentation
+{
+    if (_sourceHierarchyIndentation != sourceHierarchyIndentation) {
+        _sourceHierarchyIndentation = sourceHierarchyIndentation;
+        self.leadingLayoutConstraintForContentViewIndentation.constant = sourceHierarchyIndentation * MenuItemSourceCellHierarchyIdentationWidth;
+        [self updateSeparatorInsets];
+    }
+}
+
+- (void)updateSeparatorInsets
+{
+    CGFloat left = self.sourceHierarchyIndentation * MenuItemSourceCellHierarchyIdentationWidth;
+    left += self.stackView.layoutMargins.left;
+    self.separatorInset = UIEdgeInsetsMake(0, left, 0, 0);
+}
+
+- (CGRect)drawingRectForLabel
+{
+    CGRect rect = [self convertRect:self.label.frame fromView:self.label.superview];
+    rect.size.width = self.contentView.frame.size.width - (self.stackView.layoutMargins.right);
+    rect.size.width -= rect.origin.x;
+    
+    return rect;
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.m
@@ -138,7 +138,7 @@ static CGFloat const MenuItemSourceCellHierarchyIdentationWidth = 17.0;
 - (CGRect)drawingRectForLabel
 {
     CGRect rect = [self convertRect:self.label.frame fromView:self.label.superview];
-    rect.size.width = self.contentView.frame.size.width - (self.stackView.layoutMargins.right);
+    rect.size.width = self.contentView.frame.size.width - self.stackView.layoutMargins.right;
     rect.size.width -= rect.origin.x;
     
     return rect;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.m
@@ -42,7 +42,6 @@ static CGFloat const MenuItemSourceCellHierarchyIdentationWidth = 17.0;
         self.backgroundColor = [UIColor whiteColor];
         
         [self initStackView];
-        [self initLabelsStackView];
         [self initLabel];
     }
     
@@ -75,25 +74,11 @@ static CGFloat const MenuItemSourceCellHierarchyIdentationWidth = 17.0;
     [NSLayoutConstraint activateConstraints:@[
                                               _topLayoutDefaultConstraint,
                                               _leadingLayoutConstraintForContentViewIndentation,
-                                              [stackView.trailingAnchor constraintLessThanOrEqualToAnchor:self.contentView.trailingAnchor],
+                                              [stackView.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor],
                                               [stackView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor]
                                               ]];
     
     _stackView = stackView;
-}
-
-- (void)initLabelsStackView
-{
-    UIStackView *labelsStackView = [[UIStackView alloc] init];
-    labelsStackView.translatesAutoresizingMaskIntoConstraints = NO;
-    labelsStackView.distribution = UIStackViewDistributionFill;
-    labelsStackView.alignment = UIStackViewAlignmentTop;
-    labelsStackView.axis = UILayoutConstraintAxisHorizontal;
-    labelsStackView.spacing = self.stackView.spacing;
-    _labelsStackView = labelsStackView;
-
-    NSAssert(_stackView != nil, @"stackView is nil");
-    [_stackView addArrangedSubview:labelsStackView];
 }
 
 - (void)initLabel
@@ -105,13 +90,10 @@ static CGFloat const MenuItemSourceCellHierarchyIdentationWidth = 17.0;
     label.backgroundColor = [UIColor whiteColor];
     label.numberOfLines = 0;
     label.lineBreakMode = NSLineBreakByTruncatingTail;
-    
-    [label setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
-    [label setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
     _label = label;
-
-    NSAssert(_labelsStackView != nil, @"labelsStackView is nil");
-    [self.labelsStackView addArrangedSubview:label];
+    
+    NSAssert(_stackView != nil, @"stackView is nil");
+    [_stackView addArrangedSubview:label];
 }
 
 - (void)layoutSubviews

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceFooterView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceFooterView.h
@@ -1,0 +1,25 @@
+#import <UIKit/UIKit.h>
+
+@interface MenuItemSourceFooterView : UIView
+
+/**
+ The animating state of the loadingIndicator.
+ */
+@property (nonatomic, assign) BOOL isAnimating;
+
+/**
+ Add a message with text within the view.
+ */
+- (void)toggleMessageWithText:(NSString *)text;
+
+/**
+ Show the animated loading indicator.
+ */
+- (void)startLoadingIndicatorAnimation;
+
+/**
+ Stop the animated loading indicator.
+ */
+- (void)stopLoadingIndicatorAnimation;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceFooterView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceFooterView.m
@@ -43,14 +43,14 @@ static NSTimeInterval const PulseAnimationDuration = 0.35;
         
         self.backgroundColor = [UIColor whiteColor];
         
-        [self initSourceCell];
-        [self initDrawView];
+        [self setupSourceCell];
+        [self setupDrawView];
     }
     
     return self;
 }
 
-- (void)initSourceCell
+- (void)setupSourceCell
 {
     MenuItemSourceCell *cell = [[MenuItemSourceCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
     cell.frame = self.bounds;
@@ -61,7 +61,7 @@ static NSTimeInterval const PulseAnimationDuration = 0.35;
     self.sourceCell = cell;
 }
 
-- (void)initDrawView
+- (void)setupDrawView
 {
     MenuItemSourceLoadingDrawView *drawView = [[MenuItemSourceLoadingDrawView alloc] initWithFrame:self.bounds];
     drawView.backgroundColor = [UIColor whiteColor];

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceFooterView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceFooterView.m
@@ -1,0 +1,196 @@
+#import "MenuItemSourceFooterView.h"
+#import "MenuItemSourceCell.h"
+#import "WPStyleGuide.h"
+#import "Menu+ViewDesign.h"
+
+static NSTimeInterval const PulseAnimationDuration = 0.35;
+
+@protocol MenuItemSourceLoadingDrawViewDelegate <NSObject>
+
+- (void)drawViewDrawRect:(CGRect)rect;
+
+@end
+
+@interface MenuItemSourceLoadingDrawView : UIView
+
+@property (nonatomic, weak) id <MenuItemSourceLoadingDrawViewDelegate> drawDelegate;
+
+@end
+
+@interface MenuItemSourceFooterView () <MenuItemSourceLoadingDrawViewDelegate>
+
+@property (nonatomic, copy) NSString *labelText;
+@property (nonatomic, assign) BOOL drawsLabelTextIfNeeded;
+@property (nonatomic, strong) MenuItemSourceCell *sourceCell;
+@property (nonatomic, strong) MenuItemSourceLoadingDrawView *drawView;
+@property (nonatomic, strong) NSTimer *beginLoadingAnimationsTimer;
+@property (nonatomic, strong) NSTimer *endLoadingAnimationsTimer;
+
+@end
+
+@implementation MenuItemSourceFooterView
+
+- (void)dealloc
+{
+    [self.beginLoadingAnimationsTimer invalidate];
+    [self.endLoadingAnimationsTimer invalidate];
+}
+
+- (id)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        
+        self.backgroundColor = [UIColor whiteColor];
+        
+        [self initSourceCell];
+        [self initDrawView];
+    }
+    
+    return self;
+}
+
+- (void)initSourceCell
+{
+    MenuItemSourceCell *cell = [[MenuItemSourceCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    cell.frame = self.bounds;
+    cell.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    cell.alpha = 0.0;
+    [cell setTitle:@"Dummy Text For Sizing the Label"];
+    [self addSubview:cell];
+    self.sourceCell = cell;
+}
+
+- (void)initDrawView
+{
+    MenuItemSourceLoadingDrawView *drawView = [[MenuItemSourceLoadingDrawView alloc] initWithFrame:self.bounds];
+    drawView.backgroundColor = [UIColor whiteColor];
+    drawView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    drawView.drawDelegate = self;
+    drawView.contentMode = UIViewContentModeRedraw;
+    [self.sourceCell addSubview:drawView];
+    self.drawView = drawView;
+}
+
+- (void)toggleMessageWithText:(NSString *)text
+{
+    self.labelText = text;
+    if (!self.beginLoadingAnimationsTimer && !self.endLoadingAnimationsTimer) {
+        self.drawsLabelTextIfNeeded = YES;
+    }
+}
+
+- (void)startLoadingIndicatorAnimation
+{
+    if (self.isAnimating) {
+        return;
+    }
+    
+    self.drawsLabelTextIfNeeded = NO;
+    
+    [self.beginLoadingAnimationsTimer invalidate];
+    self.beginLoadingAnimationsTimer = nil;
+    [self.endLoadingAnimationsTimer invalidate];
+    self.endLoadingAnimationsTimer = nil;
+    
+    self.isAnimating = YES;
+    self.sourceCell.hidden = NO;
+    
+    // Will begin animations on next runloop incase there are upcoming layout upates in-which the animation won't play.
+    NSTimer *timer = [NSTimer timerWithTimeInterval:0.0 target:self selector:@selector(beginCellAnimations) userInfo:nil repeats:NO];
+    self.beginLoadingAnimationsTimer = timer;
+    // Add the timer to the runloop scheduling under common modes, to not pause for UIScrollView scrolling.
+    [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
+}
+
+- (void)stopLoadingIndicatorAnimation
+{
+    if (!self.isAnimating) {
+        return;
+    }
+    
+    [self.beginLoadingAnimationsTimer invalidate];
+    self.beginLoadingAnimationsTimer = nil;
+    [self.endLoadingAnimationsTimer invalidate];
+    self.endLoadingAnimationsTimer = nil;
+    
+    self.isAnimating = NO;
+    // Let the animation play for just a bit before ending it. This avoids flickering.
+    NSTimer *timer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(endCellAnimations) userInfo:nil repeats:NO];
+    self.endLoadingAnimationsTimer = timer;
+    // Add the timer to the runloop scheduling under common modes, to not pause for UIScrollView scrolling.
+    [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
+}
+
+- (void)beginCellAnimations
+{
+    CABasicAnimation *animation = [CABasicAnimation new];
+    animation.fromValue = @(0.0);
+    animation.toValue = @(1.0);
+    animation.keyPath = @"opacity";
+    animation.autoreverses = YES;
+    animation.repeatCount = HUGE_VALF;
+    animation.duration = PulseAnimationDuration;
+    [self.sourceCell.layer addAnimation:animation forKey:@"pulse"];
+}
+
+- (void)endCellAnimations
+{
+    self.drawsLabelTextIfNeeded = YES;
+    
+    [self.sourceCell.layer removeAllAnimations];
+    self.sourceCell.hidden = YES;
+}
+
+- (void)setLabelText:(NSString *)labelText
+{
+    if (_labelText != labelText) {
+        _labelText = labelText;
+        [self setNeedsDisplay];
+    }
+}
+
+- (void)setDrawsLabelTextIfNeeded:(BOOL)drawsLabelTextIfNeeded
+{
+    if (_drawsLabelTextIfNeeded != drawsLabelTextIfNeeded) {
+        _drawsLabelTextIfNeeded = drawsLabelTextIfNeeded;
+        [self setNeedsDisplay];
+    }
+}
+
+- (void)drawRect:(CGRect)rect
+{
+    if (self.labelText && self.drawsLabelTextIfNeeded) {
+        CGRect textRect = CGRectInset(rect, MenusDesignDefaultContentSpacing + 4.0, 0);
+        textRect.origin.y = MenusDesignDefaultContentSpacing / 2.0;;
+        textRect.size.height -= textRect.origin.y;
+        NSMutableParagraphStyle *style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+        NSDictionary *attributes = @{
+                                     NSFontAttributeName: [WPStyleGuide regularTextFont],
+                                     NSForegroundColorAttributeName: [WPStyleGuide greyDarken10],
+                                     NSParagraphStyleAttributeName: style
+                                     };
+        [self.labelText drawInRect:textRect withAttributes:attributes];
+    }
+}
+
+#pragma mark - MenuItemSourceLoadingDrawViewDelegate
+
+- (void)drawViewDrawRect:(CGRect)rect
+{
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextSetFillColorWithColor(context, [[WPStyleGuide lightGrey] CGColor]);
+    CGRect labelRect = self.sourceCell.drawingRectForLabel;
+    CGContextFillRect(context, labelRect);
+}
+
+@end
+
+@implementation MenuItemSourceLoadingDrawView
+
+- (void)drawRect:(CGRect)rect
+{
+    [self.drawDelegate drawViewDrawRect:rect];
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceFooterView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceFooterView.m
@@ -118,7 +118,7 @@ static NSTimeInterval const PulseAnimationDuration = 0.35;
     // Let the animation play for just a bit before ending it. This avoids flickering.
     NSTimer *timer = [NSTimer scheduledTimerWithTimeInterval:1.0 target:self selector:@selector(endCellAnimations) userInfo:nil repeats:NO];
     self.endLoadingAnimationsTimer = timer;
-    // Add the timer to the runloop scheduling under common modes, to not pause for UIScrollView scrolling.
+    // Add the timer to the runloop scheduling under common modes so it does not pause while a UIScrollView scrolls.
     [[NSRunLoop mainRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
 }
 
@@ -161,7 +161,8 @@ static NSTimeInterval const PulseAnimationDuration = 0.35;
 - (void)drawRect:(CGRect)rect
 {
     if (self.labelText && self.drawsLabelTextIfNeeded) {
-        CGRect textRect = CGRectInset(rect, MenusDesignDefaultContentSpacing + 4.0, 0);
+        const CGFloat textVerticalInsetPadding = 4.0;
+        CGRect textRect = CGRectInset(rect, MenusDesignDefaultContentSpacing + textVerticalInsetPadding, 0);
         textRect.origin.y = MenusDesignDefaultContentSpacing / 2.0;;
         textRect.size.height -= textRect.origin.y;
         NSMutableParagraphStyle *style = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
@@ -23,9 +23,9 @@
         self.backgroundColor = [UIColor whiteColor];
         self.contentMode = UIViewContentModeRedraw;
         
-        [self initStackView];
-        [self initIconView];
-        [self initTitleLabel];
+        [self setupStackView];
+        [self setupIconView];
+        [self setupTitleLabel];
         
         UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapGesture:)];
         [self addGestureRecognizer:tap];
@@ -34,7 +34,7 @@
     return self;
 }
 
-- (void)initStackView
+- (void)setupStackView
 {
     UIStackView *stackView = [[UIStackView alloc] init];
     stackView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -61,7 +61,7 @@
     _stackView = stackView;
 }
 
-- (void)initIconView
+- (void)setupIconView
 {
     UIImageView *iconView = [[UIImageView alloc] init];
     iconView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -80,7 +80,7 @@
     _iconView = iconView;
 }
 
-- (void)initTitleLabel
+- (void)setupTitleLabel
 {
     UILabel *label = [[UILabel alloc] init];
     label.translatesAutoresizingMaskIntoConstraints = NO;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceLinkView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceLinkView.h
@@ -1,0 +1,5 @@
+#import "MenuItemSourceView.h"
+
+@interface MenuItemSourceLinkView : MenuItemSourceView
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceLinkView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceLinkView.m
@@ -18,15 +18,15 @@
     self = [super init];
     if (self) {
         
-        [self initLabel];
-        [self initTextBar];
-        [self initCheckButtonView];
+        [self setupLabel];
+        [self setupTextBar];
+        [self setupCheckButtonView];
     }
     
     return self;
 }
 
-- (void)initLabel
+- (void)setupLabel
 {
     UILabel *label = [[UILabel alloc] init];
     label.translatesAutoresizingMaskIntoConstraints = NO;
@@ -38,7 +38,7 @@
     _label = label;
 }
 
-- (void)initTextBar
+- (void)setupTextBar
 {
     MenuItemSourceTextBar *textBar = [[MenuItemSourceTextBar alloc] init];
     textBar.translatesAutoresizingMaskIntoConstraints = NO;
@@ -56,7 +56,7 @@
     _textBar = textBar;
 }
 
-- (void)initCheckButtonView
+- (void)setupCheckButtonView
 {
     MenuItemCheckButtonView *checkButtonView = [[MenuItemCheckButtonView alloc] init];
     checkButtonView.label.text = NSLocalizedString(@"Open link in new window/tab", @"Menus label for checkbox when editig item as a link.");

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceLinkView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceLinkView.m
@@ -3,6 +3,8 @@
 #import "WPFontManager.h"
 #import "MenuItemCheckButtonView.h"
 
+static CGFloat const LinkTextBarHeight = 48.0;
+
 @interface MenuItemSourceLinkView () <MenuItemSourceTextBarDelegate>
 
 @property (nonatomic, strong, readonly) UILabel *label;
@@ -48,7 +50,7 @@
     textBar.delegate = self;
     [self.stackView addArrangedSubview:textBar];
     
-    NSLayoutConstraint *heightConstraint = [textBar.heightAnchor constraintEqualToConstant:48.0];
+    NSLayoutConstraint *heightConstraint = [textBar.heightAnchor constraintEqualToConstant:LinkTextBarHeight];
     heightConstraint.priority = UILayoutPriorityDefaultHigh;
     heightConstraint.active = YES;
     

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceLinkView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceLinkView.m
@@ -1,0 +1,118 @@
+#import "MenuItemSourceLinkView.h"
+#import "WPStyleGuide.h"
+#import "WPFontManager.h"
+#import "MenuItemCheckButtonView.h"
+
+@interface MenuItemSourceLinkView () <MenuItemSourceTextBarDelegate>
+
+@property (nonatomic, strong, readonly) UILabel *label;
+@property (nonatomic, strong, readonly) MenuItemSourceTextBar *textBar;
+@property (nonatomic, strong, readonly) MenuItemCheckButtonView *checkButtonView;
+
+@end
+
+@implementation MenuItemSourceLinkView
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        
+        [self initLabel];
+        [self initTextBar];
+        [self initCheckButtonView];
+    }
+    
+    return self;
+}
+
+- (void)initLabel
+{
+    UILabel *label = [[UILabel alloc] init];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.text = [NSLocalizedString(@"Link Address (URL)", @"Menus title label when editing a menu item as a link.") uppercaseString];
+    label.textColor = [WPStyleGuide greyDarken10];
+    label.font = [WPFontManager systemSemiBoldFontOfSize:12.0];
+    
+    [self.stackView addArrangedSubview:label];
+    _label = label;
+}
+
+- (void)initTextBar
+{
+    MenuItemSourceTextBar *textBar = [[MenuItemSourceTextBar alloc] init];
+    textBar.translatesAutoresizingMaskIntoConstraints = NO;
+    textBar.textField.autocorrectionType = UITextAutocorrectionTypeNo;
+    textBar.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    textBar.textField.keyboardType = UIKeyboardTypeURL;
+    textBar.delegate = self;
+    [self.stackView addArrangedSubview:textBar];
+    
+    NSLayoutConstraint *heightConstraint = [textBar.heightAnchor constraintEqualToConstant:48.0];
+    heightConstraint.priority = UILayoutPriorityDefaultHigh;
+    heightConstraint.active = YES;
+    
+    [textBar setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisVertical];
+    _textBar = textBar;
+}
+
+- (void)initCheckButtonView
+{
+    MenuItemCheckButtonView *checkButtonView = [[MenuItemCheckButtonView alloc] init];
+    checkButtonView.label.text = NSLocalizedString(@"Open link in new window/tab", @"Menus label for checkbox when editig item as a link.");
+    __weak __typeof__(self) weakSelf = self;
+    checkButtonView.onChecked = ^() {
+        [weakSelf updateItemLinkTargetOption];
+    };
+    [self.stackView addArrangedSubview:checkButtonView];
+    
+    NSLayoutConstraint *heightConstraint = [checkButtonView.heightAnchor constraintEqualToConstant:[checkButtonView preferredHeightForLayout]];
+    heightConstraint.active = YES;
+    
+    _checkButtonView = checkButtonView;
+}
+
+- (NSString *)sourceItemType
+{
+    return MenuItemTypeCustom;
+}
+
+- (void)setItem:(MenuItem *)item
+{
+    [super setItem:item];
+    
+    self.textBar.textField.text = item.urlStr ?: @"";
+    
+    if ([self itemTypeMatchesSourceItemType]) {
+        self.checkButtonView.checked = item.linkTarget && [item.linkTarget isEqualToString:MenuItemLinkTargetBlank];
+    }
+}
+
+- (void)updateItemLinkTargetOption
+{
+    if (self.checkButtonView.checked) {
+        self.item.linkTarget = MenuItemLinkTargetBlank;
+    } else {
+        self.item.linkTarget = nil;
+    }
+}
+
+- (BOOL)resignFirstResponder
+{
+    if ([self.textBar isFirstResponder]) {
+        return [self.textBar resignFirstResponder];
+    }
+    return [super resignFirstResponder];
+}
+
+#pragma mark - MenuItemSourceTextBarDelegate
+
+- (void)sourceTextBar:(MenuItemSourceTextBar *)textBar didUpdateWithText:(NSString *)text
+{
+    if (![self itemTypeMatchesSourceItemType]) {
+        [self setItemSourceWithContentID:nil name:[self sourceItemType]];
+    }
+    self.item.urlStr = text.length ? text : nil;
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePageView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePageView.h
@@ -1,0 +1,5 @@
+#import "MenuItemSourcePostAbstractView.h"
+
+@interface MenuItemSourcePageView : MenuItemSourcePostAbstractView
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePageView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePageView.m
@@ -1,0 +1,42 @@
+#import "MenuItemSourcePageView.h"
+#import "PostService.h"
+#import "Page.h"
+
+@interface MenuItemSourcePostAbstractView () <MenuItemSourcePostAbstractViewSubclass>
+@end
+
+@interface MenuItemSourcePageView ()
+@property (nonatomic, strong) NSString *oldestSyncedPageTitle;
+@end
+
+@implementation MenuItemSourcePageView
+
+- (NSString *)sourceItemType
+{
+    return MenuItemTypePage;
+}
+
+- (NSFetchRequest *)fetchRequest
+{
+    NSFetchRequest *fetchRequest = [super fetchRequest];
+    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"postTitle"
+                                                                   ascending:YES
+                                                                    selector:@selector(caseInsensitiveCompare:)];
+    [fetchRequest setSortDescriptors:@[sortDescriptor]];
+    return fetchRequest;
+}
+
+- (Class)entityClass
+{
+    return [Page class];
+}
+
+- (PostServiceSyncOptions *)syncOptions
+{
+    PostServiceSyncOptions *options = [super syncOptions];
+    options.order = PostServiceResultsOrderAscending;
+    options.orderBy = PostServiceResultsOrderingByTitle;
+    return options;
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostAbstractView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostAbstractView.h
@@ -1,0 +1,12 @@
+#import "MenuItemSourceView.h"
+
+@interface MenuItemSourcePostAbstractView : MenuItemSourceView
+
+@end
+
+@class PostServiceSyncOptions;
+
+@protocol MenuItemSourcePostAbstractViewSubclass <NSObject>
+- (Class)entityClass;
+- (PostServiceSyncOptions *)syncOptions;
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostAbstractView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostAbstractView.m
@@ -74,7 +74,12 @@
     } else {
         cell.sourceSelected = NO;
     }
-    [cell setTitle:post.titleForDisplay];
+    
+    NSString *postTitle = post.titleForDisplay;
+    if (!postTitle.length) {
+        postTitle = NSLocalizedString(@"(Untitled Post)", @"Menus title label text for a post that has no set title.");
+    }
+    [cell setTitle:postTitle];
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostAbstractView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostAbstractView.m
@@ -1,0 +1,199 @@
+#import "MenuItemSourcePostAbstractView.h"
+#import "PostService.h"
+#import "AbstractPost.h"
+
+@interface MenuItemSourcePostAbstractView () <MenuItemSourcePostAbstractViewSubclass>
+
+@property (nonatomic, assign) NSUInteger numberOfSyncedPosts;
+@property (nonatomic, assign) BOOL additionalPostsAvailableForSync;
+
+@end
+
+@implementation MenuItemSourcePostAbstractView
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        [self insertSearchBarIfNeeded];
+    }
+    
+    return self;
+}
+
+- (void)setBlog:(Blog *)blog
+{
+    [super setBlog:blog];
+    [self syncPosts];
+}
+
+- (NSFetchRequest *)fetchRequest
+{
+    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
+    NSEntityDescription *entity = [NSEntityDescription entityForName:NSStringFromClass([self entityClass]) inManagedObjectContext:[self managedObjectContext]];
+    [fetchRequest setEntity:entity];
+    fetchRequest.predicate = [self defaultFetchRequestPredicate];
+    fetchRequest.fetchLimit = PostServiceDefaultNumberToSync;
+    return fetchRequest;
+}
+
+- (NSPredicate *)defaultFetchRequestPredicate
+{
+    NSPredicate *basePredicate = [super defaultFetchRequestPredicate];
+    NSPredicate *filteredPredicate = [NSPredicate predicateWithFormat:@"original == nil && status IN %@", @[PostStatusPublish, PostStatusPrivate]];
+    NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[basePredicate, filteredPredicate]];
+    return predicate;
+}
+
+- (void)syncPosts
+{
+    [self performResultsControllerFetchRequest];
+    [self showLoadingSourcesIndicatorIfEmpty];
+    self.additionalPostsAvailableForSync = YES;
+    
+    PostService *service = [[PostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    PostServiceSyncOptions *options = [self syncOptions];
+    [service syncPostsOfType:[self sourceItemType]
+                 withOptions:options
+                     forBlog:[self blog]
+                     success:^(NSArray *posts) {
+                         [self didFinishSyncingPosts:posts options:options];
+                     } failure:^(NSError *error) {
+                         [self didFinishSyncingPosts:nil options:options];
+                         [self showLoadingErrorMessageForResults];
+                     }];
+}
+
+#pragma mark - TableView methods
+
+- (void)configureSourceCell:(MenuItemSourceCell *)cell forIndexPath:(NSIndexPath *)indexPath
+{
+    AbstractPost *post = [self.resultsController objectAtIndexPath:indexPath];
+    if ([self itemTypeMatchesSourceItemType] && post.postID.integerValue == [self.item.contentID integerValue]) {
+        cell.sourceSelected = YES;
+    } else {
+        cell.sourceSelected = NO;
+    }
+    [cell setTitle:post.titleForDisplay];
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    [super tableView:tableView didSelectRowAtIndexPath:indexPath];
+    
+    AbstractPost *post = [self.resultsController objectAtIndexPath:indexPath];
+    [self setItemSourceWithContentID:post.postID name:post.titleForDisplay];
+    
+    [self deselectVisibleSourceCellsIfNeeded];
+    
+    MenuItemSourceCell *selectedCell = [tableView cellForRowAtIndexPath:indexPath];
+    selectedCell.sourceSelected = YES;
+}
+
+#pragma mark - MenuItemSourcePostAbstractViewSubclass
+
+- (Class)entityClass
+{
+    // Subclasses return the proper entity class
+    return nil;
+}
+
+- (PostServiceSyncOptions *)syncOptions
+{
+    PostServiceSyncOptions *options = [[PostServiceSyncOptions alloc] init];
+    options.statuses = @[PostStatusPublish, PostStatusPrivate];
+    options.number = @(PostServiceDefaultNumberToSync);
+    return options;
+}
+
+- (void)didFinishSyncingPosts:(NSArray *)posts options:(PostServiceSyncOptions *)options
+{
+    if (posts) {
+        self.numberOfSyncedPosts = self.numberOfSyncedPosts + posts.count;
+        self.additionalPostsAvailableForSync = posts.count >= options.number.unsignedIntegerValue;
+        self.resultsController.fetchRequest.fetchLimit = self.numberOfSyncedPosts;
+        [self performResultsControllerFetchRequest];
+        [self.tableView reloadData];
+    }
+    [self hideLoadingSourcesIndicator];
+}
+
+#pragma mark - paging
+
+- (void)scrollingWillDisplayEndOfTableView:(UITableView *)tableView
+{
+    if (!self.additionalPostsAvailableForSync || [self searchBarInputIsActive]) {
+        return;
+    }
+    [self showLoadingSourcesIndicator];
+    PostService *service = [[PostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    PostServiceSyncOptions *options = [self syncOptions];
+    options.offset = @(self.resultsController.fetchedObjects.count);
+    [service syncPostsOfType:[self sourceItemType]
+                 withOptions:options
+                     forBlog:[self blog]
+                     success:^(NSArray *posts) {
+                         [self didFinishSyncingPosts:posts options:options];
+                     } failure:^(NSError *error) {
+                         [self didFinishSyncingPosts:nil options:options];
+                         [self showLoadingErrorMessageForResults];
+                     }];
+}
+
+#pragma mark - searching
+
+- (void)searchBarInputChangeDetectedForLocalResultsUpdateWithText:(NSString *)searchText
+{
+    NSPredicate *defaultPredicate = [self defaultFetchRequestPredicate];
+    NSPredicate *predicate = nil;
+    
+    if (searchText.length) {
+        NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"postTitle CONTAINS[cd] %@", searchText];
+        predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[defaultPredicate, searchPredicate]];
+        if ([self.resultsController.fetchRequest.predicate isEqual:predicate]) {
+            // same predicate, no update needed
+            return;
+        }
+        if (self.additionalPostsAvailableForSync) {
+            self.defersFooterViewMessageUpdates = YES;
+        }
+    } else {
+        predicate = defaultPredicate;
+    }
+    
+    DDLogDebug(@"MenuItemSourcePostView: Updating fetch request predicate");
+    self.resultsController.fetchRequest.predicate = predicate;
+    [self performResultsControllerFetchRequest];
+    [self.tableView reloadData];
+}
+
+- (void)searchBarInputChangeDetectedForRemoteResultsUpdateWithText:(NSString *)searchText
+{
+    if (!searchText.length || !self.additionalPostsAvailableForSync) {
+        self.defersFooterViewMessageUpdates = NO;
+        return;
+    }
+    
+    self.defersFooterViewMessageUpdates = NO;
+    
+    [self showLoadingSourcesIndicator];
+    void(^stopLoading)() = ^() {
+        [self hideLoadingSourcesIndicator];
+    };
+    
+    DDLogDebug(@"MenuItemSourcePostView: Searching posts via PostService");
+    PostService *service = [[PostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    PostServiceSyncOptions *options = [self syncOptions];
+    options.search = searchText;
+    [service syncPostsOfType:[self sourceItemType]
+                 withOptions:options
+                     forBlog:[self blog]
+                     success:^(NSArray *posts) {
+                         stopLoading();
+                     } failure:^(NSError *error) {
+                         stopLoading();
+                         [self showLoadingErrorMessageForResults];
+                     }];
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostAbstractView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostAbstractView.m
@@ -99,7 +99,7 @@
 
 - (Class)entityClass
 {
-    // Subclasses return the proper entity class
+    AssertSubclassMethod();
     return nil;
 }
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostView.h
@@ -1,0 +1,7 @@
+#import "MenuItemSourcePostAbstractView.h"
+
+@interface MenuItemSourcePostView : MenuItemSourcePostAbstractView
+
+@property (nonatomic, strong) NSString *postType;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourcePostView.m
@@ -1,0 +1,38 @@
+#import "MenuItemSourcePostView.h"
+#import "PostService.h"
+#import "Post.h"
+
+@interface MenuItemSourcePostAbstractView () <MenuItemSourcePostAbstractViewSubclass>
+@end
+
+@interface MenuItemSourcePostView ()
+@end
+
+@implementation MenuItemSourcePostView
+
+- (NSString *)sourceItemType
+{
+    return self.postType;
+}
+
+- (NSPredicate *)defaultFetchRequestPredicate
+{
+    NSPredicate *predicate = [super defaultFetchRequestPredicate];
+    NSPredicate *postTypePredicate = [NSPredicate predicateWithFormat:@"postType = %@", self.sourceItemType];
+    return [NSCompoundPredicate andPredicateWithSubpredicates:@[predicate, postTypePredicate]];
+}
+
+- (NSFetchRequest *)fetchRequest
+{
+    NSFetchRequest *fetchRequest = [super fetchRequest];
+    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"date_created_gmt" ascending:NO];
+    [fetchRequest setSortDescriptors:@[sortDescriptor]];
+    return fetchRequest;
+}
+
+- (Class)entityClass
+{
+    return [Post class];
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTagView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTagView.h
@@ -1,0 +1,5 @@
+#import "MenuItemSourceView.h"
+
+@interface MenuItemSourceTagView : MenuItemSourceView
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTagView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTagView.m
@@ -27,6 +27,7 @@ static NSUInteger const MenuItemSourceTagSyncLimit = 100;
     self = [super init];
     if (self) {
         [self insertSearchBarIfNeeded];
+        self.searchBar.textField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     }
     
     return self;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTagView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTagView.m
@@ -1,0 +1,222 @@
+#import "MenuItemSourceTagView.h"
+#import "PostTagService.h"
+#import "PostTag.h"
+#import "Menu.h"
+#import "MenuItem.h"
+#import "Blog.h"
+
+static NSUInteger const MenuItemSourceTagSyncLimit = 100;
+
+@interface MenuItemSourceTagView ()
+
+@property (nonatomic, strong) NSTimer *searchRemoteServiceTimer;
+@property (nonatomic, strong) PostTagService *searchTagService;
+@property (nonatomic, assign) BOOL loadedAllAvailableTags;
+
+@end
+
+@implementation MenuItemSourceTagView
+
+- (void)dealloc
+{
+    [self.searchRemoteServiceTimer invalidate];
+}
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        [self insertSearchBarIfNeeded];
+    }
+    
+    return self;
+}
+
+- (void)setBlog:(Blog *)blog
+{
+    [super setBlog:blog];
+    [self syncTags];
+}
+
+- (NSString *)sourceItemType
+{
+    return MenuItemTypeTag;
+}
+
+- (NSFetchRequest *)fetchRequest
+{
+    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
+    NSEntityDescription *entity = [NSEntityDescription entityForName:[PostTag entityName] inManagedObjectContext:[self managedObjectContext]];
+    [fetchRequest setEntity:entity];
+    // Specify criteria for filtering which objects to fetch
+    [fetchRequest setPredicate:[self defaultFetchRequestPredicate]];
+    // Specify how the fetched objects should be sorted
+    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"name"
+                                                                   ascending:YES
+                                                                    selector:@selector(caseInsensitiveCompare:)];
+    
+    [fetchRequest setSortDescriptors:[NSArray arrayWithObjects:sortDescriptor, nil]];
+    [fetchRequest setFetchLimit:MenuItemSourceTagSyncLimit];
+    
+    return fetchRequest;
+}
+
+- (void)syncTags
+{
+    PostTagService *tagService = [[PostTagService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    
+    [self performResultsControllerFetchRequest];
+    
+    [self showLoadingSourcesIndicatorIfEmpty];
+    void(^stopLoading)() = ^() {
+        [self hideLoadingSourcesIndicator];
+    };
+    
+    [tagService syncTagsForBlog:[self blog]
+                         number:@(MenuItemSourceTagSyncLimit)
+                         offset:@(0)
+                        success:^(NSArray<PostTag *> *tags) {
+                            stopLoading();
+                        } failure:^(NSError *error) {
+                            stopLoading();
+                            [self showLoadingErrorMessageForResults];
+                        }];
+}
+
+#pragma mark - TableView methods
+
+- (void)configureSourceCell:(MenuItemSourceCell *)cell forIndexPath:(NSIndexPath *)indexPath
+{
+    PostTag *tag = [self.resultsController objectAtIndexPath:indexPath];
+    if ([self itemTypeMatchesSourceItemType] && [self.item.contentID integerValue] == [tag.tagID integerValue]) {
+        cell.sourceSelected = YES;
+    } else {
+        cell.sourceSelected = NO;
+    }
+    [cell setTitle:tag.name];
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    [super tableView:tableView didSelectRowAtIndexPath:indexPath];
+    
+    PostTag *tag = [self.resultsController objectAtIndexPath:indexPath];
+    [self setItemSourceWithContentID:tag.tagID name:tag.name];
+
+    [self deselectVisibleSourceCellsIfNeeded];
+    
+    MenuItemSourceCell *selectedCell = [tableView cellForRowAtIndexPath:indexPath];
+    selectedCell.sourceSelected = YES;
+}
+
+#pragma mark - 
+
+- (void)scrollingWillDisplayEndOfTableView:(UITableView *)tableView
+{
+    if (self.loadedAllAvailableTags || [self searchBarInputIsActive]) {
+        return;
+    }
+    
+    // Check how many tags are currently loaded
+    id <NSFetchedResultsSectionInfo> sectionInfo = [self.resultsController.sections lastObject];
+    NSUInteger initialCount = [sectionInfo numberOfObjects];
+    if (initialCount < MenuItemSourceTagSyncLimit) {
+        // Additional tags not available, not limit or remote paging needed.
+        return;
+    }
+    
+    // First try and increment the fetchLimit for local results.
+    // This also allows the resultsController to load any additional tags synced afterwards.
+    self.resultsController.fetchRequest.fetchLimit = self.resultsController.fetchRequest.fetchLimit + MenuItemSourceTagSyncLimit;
+    [self performResultsControllerFetchRequest];
+    
+    sectionInfo = [self.resultsController.sections lastObject];
+    NSUInteger countWithLimitIncrease = [sectionInfo numberOfObjects];
+    if (countWithLimitIncrease > initialCount) {
+        // Additional local results are available for display in the tableView.
+        [tableView reloadData];
+    }
+    
+    // Check if any additional tags are available locally based on the fetchLimit increase
+    self.loadedAllAvailableTags = countWithLimitIncrease - initialCount < MenuItemSourceTagSyncLimit;
+    
+    // Show the loading indicator
+    [self showLoadingSourcesIndicator];
+    void(^stopLoading)() = ^() {
+        [self hideLoadingSourcesIndicator];
+    };
+    
+    // Load any additional tags available remotely.
+    // This will sync exsiting tags that may already be available locally, as well as loading additional tags.
+    PostTagService *tagService = [[PostTagService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    [tagService syncTagsForBlog:[self blog]
+                              number:@(MenuItemSourceTagSyncLimit)
+                              offset:@(initialCount)
+                             success:^(NSArray<PostTag *> *tags) {
+                                 
+                                 // If the loaded tags count match the requested number, there is probably more tags available.
+                                 self.loadedAllAvailableTags = tags.count < MenuItemSourceTagSyncLimit;
+                                 stopLoading();
+                                 
+                             } failure:^(NSError *error) {
+                                 stopLoading();
+                                 [self showLoadingErrorMessageForResults];
+                             }];
+}
+
+#pragma mark - searching
+
+- (void)searchBarInputChangeDetectedForLocalResultsUpdateWithText:(NSString *)searchText
+{
+    NSPredicate *defaultPredicate = [self defaultFetchRequestPredicate];
+    NSPredicate *searchPredicate = [NSPredicate predicateWithFormat:@"name BEGINSWITH[c] %@", searchText];
+    NSPredicate *predicate = nil;
+    
+    if (searchText.length) {
+        self.defersFooterViewMessageUpdates = YES;
+        predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[defaultPredicate, searchPredicate]];
+    } else {
+        self.defersFooterViewMessageUpdates = NO;
+        predicate = defaultPredicate;
+    }
+    
+    if ([self.resultsController.fetchRequest.predicate isEqual:predicate]) {
+        // same predicate, no update needed
+        return;
+    }
+    
+    DDLogDebug(@"MenuItemSourceTagView: Updating fetch request predicate");
+    self.resultsController.fetchRequest.predicate = predicate;
+    [self performResultsControllerFetchRequest];
+    [self.tableView reloadData];
+}
+
+- (void)searchBarInputChangeDetectedForRemoteResultsUpdateWithText:(NSString *)searchText
+{
+    if (!searchText.length) {
+        self.defersFooterViewMessageUpdates = NO;
+        return;
+    }
+    
+    self.defersFooterViewMessageUpdates = NO;
+    
+    [self showLoadingSourcesIndicator];
+    void(^stopLoading)() = ^() {
+        [self hideLoadingSourcesIndicator];
+    };
+    
+    if (!self.searchTagService) {
+        self.searchTagService = [[PostTagService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    }
+    DDLogDebug(@"MenuItemSourceTagView: Searching tags PostTagService");
+    [self.searchTagService searchTagsWithName:searchText
+                                         blog:[self blog]
+                                      success:^(NSArray<PostTag *> *tags) {
+                                          stopLoading();
+                                      } failure:^(NSError *error) {
+                                          stopLoading();
+                                          [self showLoadingErrorMessageForResults];
+                                      }];
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
@@ -33,11 +33,11 @@
         self.backgroundColor = [UIColor whiteColor];
         self.translatesAutoresizingMaskIntoConstraints = NO;
 
-        [self initStackView];
-        [self initContentStackView];
-        [self initIconView];
-        [self initTextField];
-        [self initCancelLabel];
+        [self setupStackView];
+        [self setupContentStackView];
+        [self setupIconView];
+        [self setupTextField];
+        [self setupCancelLabel];
     }
     
     return self;
@@ -64,7 +64,7 @@
     return self;
 }
 
-- (void)initStackView
+- (void)setupStackView
 {
     const CGFloat spacing = ceilf(MenusDesignDefaultContentSpacing / 2.0);
     UIStackView *stackView = [[UIStackView alloc] init];
@@ -90,7 +90,7 @@
     _stackView = stackView;
 }
 
-- (void)initContentStackView
+- (void)setupContentStackView
 {
     UIView *contentView = [[UIView alloc] init];
     contentView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -124,7 +124,7 @@
     _contentStackView = contentStackView;
 }
 
-- (void)initIconView
+- (void)setupIconView
 {
     UIImageView *iconView = [[UIImageView alloc] init];
     iconView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -143,7 +143,7 @@
     _iconView = iconView;
 }
 
-- (void)initTextField
+- (void)setupTextField
 {
     UITextField *textField = [[UITextField alloc] init];
     textField.delegate = self;
@@ -168,7 +168,7 @@
     _textField = textField;
 }
 
-- (void)initCancelLabel
+- (void)setupCancelLabel
 {
     UILabel *label = [[UILabel alloc] init];
     label.text = NSLocalizedString(@"Cancel", @"Menus cancel button within text bar while editing items.");

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceView.h
@@ -1,0 +1,177 @@
+#import <UIKit/UIKit.h>
+#import "MenuItemSourceTextBar.h"
+#import "MenuItemSourceCell.h"
+#import "MenuItem.h"
+
+@class Blog;
+@class MenuItem;
+
+@protocol MenuItemSourceViewDelegate;
+
+@interface MenuItemSourceView : UIView <MenuItemSourceTextBarDelegate, UITableViewDataSource, UITableViewDelegate, NSFetchedResultsControllerDelegate>
+
+@property (nonatomic, weak) id <MenuItemSourceViewDelegate> delegate;
+
+/**
+ The blog the view is sourcing data from.
+ */
+@property (nonatomic, strong) Blog *blog;
+
+/**
+ The MenuItem the view is editing.
+ */
+@property (nonatomic, strong) MenuItem *item;
+
+/**
+ A stackView for adding any views that aren't cells before the tableView, Ex. searchBar, label, design views
+ */
+@property (nonatomic, strong, readonly) UIStackView *stackView;
+
+/**
+ A tableView for inserting cells of data relating to the source
+ */
+@property (nonatomic, strong, readonly) UITableView *tableView;
+
+/**
+ Configurable fetchedResultsController for populating the tableView with source data.
+ */
+@property (nonatomic, strong) NSFetchedResultsController *resultsController;
+
+/**
+ Searchbar created and implemented via insertSearchBarIfNeeded
+ */
+@property (nonatomic, strong, readonly) MenuItemSourceTextBar *searchBar;
+
+/**
+ Helpers flag for preventing text updates within the footerView.
+ */
+@property (nonatomic, assign) BOOL defersFooterViewMessageUpdates;
+
+/**
+ Refreshes any data appearences within the view.
+ */
+- (void)refresh;
+
+/**
+ Adds the custom searchBar view to the stackView, if not already added.
+ */
+- (void)insertSearchBarIfNeeded;
+
+/**
+ The searchBar is active as a firstResponder or the user has text input within the the searchBar.
+ */
+- (BOOL)searchBarInputIsActive;
+
+/**
+ A searchBar text update has changed in a way that local results should be fetched to reflect the search.
+ */
+- (void)searchBarInputChangeDetectedForLocalResultsUpdateWithText:(NSString *)searchText;
+
+/**
+ A searchBar text update has changed in a way that remote results should be fetched to reflect the search.
+ */
+- (void)searchBarInputChangeDetectedForRemoteResultsUpdateWithText:(NSString *)searchText;
+
+/**
+ Shows an animated loading indicator in the tableFooterView, if the data set is empty.
+ */
+- (void)showLoadingSourcesIndicatorIfEmpty;
+
+/**
+ Shows an animated loading indicator in the tableFooterView.
+ */
+- (void)showLoadingSourcesIndicator;
+
+/**
+ Hides the animated loading indicator shown via showLoadingSourcesIndicator.
+ */
+- (void)hideLoadingSourcesIndicator;
+
+/**
+ Displays an error message in the footer of the tableView.
+ */
+- (void)showLoadingErrorMessageForResults;
+
+/**
+ The item type matches the sourceItemType of the view.
+ */
+- (BOOL)itemTypeMatchesSourceItemType;
+
+/**
+ Called when a source has been selected and the MenuItem should be updated.
+ @param contentId - The ID of the source such as a postID, tagID, categoryID, etc.
+ @param itemType - The type of the source.
+ @param name - The name that should be used for the source.
+ */
+- (void)setItemSourceWithContentID:(NSNumber *)contentID name:(NSString *)name;
+
+/**
+ The item type the view uses as a source.
+ */
+- (NSString *)sourceItemType;
+
+/**
+ The managedObjectContext the view is working with.
+ */
+- (NSManagedObjectContext *)managedObjectContext;
+
+/**
+ Configurable fetchRequest within subclasses for the resultsController to initialize with.
+ */
+- (NSFetchRequest *)fetchRequest;
+
+/**
+ Configurable predicate for fetchRequest
+ */
+- (NSPredicate *)defaultFetchRequestPredicate;
+
+/**
+ Configurable sectionName key within subclasses for the fetchRequest and resultsController to initialize with.
+ */
+- (NSString *)fetechedResultsControllerSectionNameKeyPath;
+
+/**
+ Handles performing the fetchRequest on the resultsController and any errors that occur.
+ */
+- (void)performResultsControllerFetchRequest;
+
+/**
+ Deselects any visible MenuItemSourceCells that are selected.
+ */
+- (void)deselectVisibleSourceCellsIfNeeded;
+
+/**
+ Method for subclasses to handle the cell configuraton based on the data being used for that subclass.
+ */
+- (void)configureSourceCell:(MenuItemSourceCell *)cell forIndexPath:(NSIndexPath *)indexPath;
+
+/**
+ Scrolling behavior will display the end of the tableView.
+ */
+- (void)scrollingWillDisplayEndOfTableView:(UITableView *)tableView;
+
+@end
+
+@protocol MenuItemSourceViewDelegate <NSObject>
+
+/**
+ Helper method for informing whether or not the name should be overriden by itemType changes.
+ */
+- (BOOL)sourceViewItemNameCanBeOverridden:(MenuItemSourceView *)sourceView;
+
+/**
+ The associated MenuItem was updated.
+ */
+- (void)sourceViewDidUpdateItem:(MenuItemSourceView *)sourceView;
+
+/**
+ Helper method for updating any layout constraints for keyboard changes.
+ */
+- (void)sourceViewDidBeginEditingWithKeyBoard:(MenuItemSourceView *)sourceView;
+
+/**
+ Helper method for updating any layout constraints for keyboard changes.
+ */
+- (void)sourceViewDidEndEditingWithKeyboard:(MenuItemSourceView *)sourceView;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceView.m
@@ -1,0 +1,475 @@
+#import "MenuItemSourceView.h"
+#import "MenuItemSourceTextBar.h"
+#import "Menu.h"
+#import "MenuItemSourceFooterView.h"
+#import "Blog.h"
+#import "Menu+ViewDesign.h"
+#import "WPStyleGuide.h"
+
+static NSTimeInterval const SearchBarFetchRequestUpdateDelay = 0.10;
+static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
+
+@interface MenuItemSourceView () <MenuItemSourceTextBarDelegate>
+
+/**
+ View used as the tableView.tableHeaderView container view for self.stackView.
+ */
+@property (nonatomic, strong, readonly) UIView *stackedTableHeaderView;
+
+@property (nonatomic, strong, readonly) MenuItemSourceFooterView *footerView;
+@property (nonatomic, assign) BOOL observeUserScrollingForEndOfTableView;
+
+@end
+
+@implementation MenuItemSourceView
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        
+        self.translatesAutoresizingMaskIntoConstraints = NO;
+        self.backgroundColor = [UIColor whiteColor];
+        
+        [self initTableView];
+        [self initStackedTableHeaderView];
+        [self initStackView];
+        [self initFooterView];
+    }
+    
+    return self;
+}
+
+- (void)initTableView
+{
+    UITableView *tableView = [[UITableView alloc] init];
+    tableView.translatesAutoresizingMaskIntoConstraints = NO;
+    tableView.dataSource = self;
+    tableView.delegate = self;
+    tableView.separatorColor = [WPStyleGuide greyLighten20];
+    UIEdgeInsets inset = tableView.contentInset;
+    inset.top = MenusDesignDefaultContentSpacing / 2.0;
+    tableView.contentInset = inset;
+    [self addSubview:tableView];
+    
+    [NSLayoutConstraint activateConstraints:@[
+                                              [tableView.topAnchor constraintEqualToAnchor:self.topAnchor],
+                                              [tableView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+                                              [tableView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
+                                              [tableView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor]
+                                              ]];
+    _tableView = tableView;
+}
+
+- (void)initStackedTableHeaderView
+{
+    // setup the tableHeaderView and keep translatesAutoresizingMaskIntoConstraints to default YES
+    // this allows the tableView to handle sizing the view as any other tableHeaderView
+    UIView *stackedTableHeaderView = [[UIView alloc] init];
+    _stackedTableHeaderView = stackedTableHeaderView;
+}
+
+- (void)initStackView
+{
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.alignment = UIStackViewAlignmentFill;
+    stackView.axis = UILayoutConstraintAxisVertical;
+    stackView.spacing = MenusDesignDefaultContentSpacing / 2.0;
+    
+    UIEdgeInsets margins = UIEdgeInsetsZero;
+    margins.bottom = stackView.spacing;
+    margins.left = MenusDesignDefaultContentSpacing;
+    margins.right = MenusDesignDefaultContentSpacing;
+    stackView.layoutMargins = margins;
+    stackView.layoutMarginsRelativeArrangement = YES;
+    
+    NSAssert(_stackedTableHeaderView != nil, @"stackedTableHeaderView is nil");
+    [_stackedTableHeaderView addSubview:stackView];
+    // setup the constraints for the stackView
+    // constrain the horiztonal edges to sync the width to the stackedTableHeaderView
+    // do not include a bottom constraint so the stackView can layout its intrinsic height
+    [NSLayoutConstraint activateConstraints:@[
+                                              [stackView.topAnchor constraintEqualToAnchor:_stackedTableHeaderView.topAnchor],
+                                              [stackView.leadingAnchor constraintEqualToAnchor:_stackedTableHeaderView.leadingAnchor],
+                                              [stackView.trailingAnchor constraintEqualToAnchor:_stackedTableHeaderView.trailingAnchor]
+                                              ]];
+    _stackView = stackView;
+}
+
+- (void)initFooterView
+{
+    MenuItemSourceFooterView *footerView = [[MenuItemSourceFooterView alloc] initWithFrame:CGRectMake(0, 0, self.tableView.frame.size.width, 60.0)];
+    
+    NSAssert(_tableView != nil, @"tableView is nil");
+    _tableView.tableFooterView = footerView;
+    
+    _footerView = footerView;
+}
+
+- (BOOL)resignFirstResponder
+{
+    if ([self.searchBar isFirstResponder]) {
+        return [self.searchBar resignFirstResponder];
+    }
+    return [super resignFirstResponder];
+}
+
+#pragma mark - view configuration
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    BOOL needsOffsetFix = NO;
+    if (!self.tableView.tableHeaderView) {
+        // set the tableHeaderView after we have called layoutSubviews the first time
+        // this add the stackedTableHeaderView to view hierarchy
+        self.tableView.tableHeaderView = self.stackedTableHeaderView;
+        [self.stackedTableHeaderView layoutIfNeeded];
+        needsOffsetFix = YES;
+    }
+
+    // set the stackedTableHeaderView frame height to the intrinsic height of the stackView
+    CGRect frame = self.stackView.bounds;
+    self.stackedTableHeaderView.frame = frame;
+    // reset the tableHeaderView to update the size change
+    self.tableView.tableHeaderView = self.stackedTableHeaderView;
+    
+    if (needsOffsetFix) {
+        if (self.tableView.contentOffset.y == 0.0) {
+            CGPoint offset = self.tableView.contentOffset;
+            offset.y = -self.tableView.contentInset.top;
+            self.tableView.contentOffset = offset;
+        }
+    }
+}
+
+- (void)refresh
+{
+    [self.tableView reloadData];
+}
+
+- (void)insertSearchBarIfNeeded
+{
+    if (self.searchBar) {
+        return;
+    }
+    
+    MenuItemSourceTextBar *searchBar = [[MenuItemSourceTextBar alloc] initAsSearchBar];
+    searchBar.translatesAutoresizingMaskIntoConstraints = NO;
+    searchBar.delegate = self;
+    
+    NSAssert(_stackView != nil, @"stackView is nil");
+    [_stackView addArrangedSubview:searchBar];
+    
+    NSLayoutConstraint *heightConstraint = [searchBar.heightAnchor constraintEqualToConstant:44.0];
+    heightConstraint.priority = UILayoutPriorityDefaultHigh;
+    heightConstraint.active = YES;
+    
+    [searchBar setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisVertical];
+    _searchBar = searchBar;
+    
+    __weak MenuItemSourceView *weakSelf = self;
+    {
+        MenuItemSourceTextBarFieldObserver *observer = [[MenuItemSourceTextBarFieldObserver alloc] init];
+        observer.interval = SearchBarFetchRequestUpdateDelay;
+        [observer setOnTextChange:^(NSString *text) {
+            [weakSelf searchBarInputChangeDetectedForLocalResultsUpdateWithText:text];
+        }];
+        [_searchBar addTextObserver:observer];
+    }
+    {
+        MenuItemSourceTextBarFieldObserver *observer = [[MenuItemSourceTextBarFieldObserver alloc] init];
+        observer.interval = SearchBarRemoteServiceUpdateDelay;
+        [observer setOnTextChange:^(NSString *text) {
+            [weakSelf searchBarInputChangeDetectedForRemoteResultsUpdateWithText:text];
+        }];
+        [_searchBar addTextObserver:observer];
+    }
+}
+
+- (BOOL)searchBarInputIsActive
+{
+    return [self.searchBar isFirstResponder] || self.searchBar.textField.text.length > 0;
+}
+
+- (void)searchBarInputChangeDetectedForLocalResultsUpdateWithText:(NSString *)searchText
+{
+    // overrided in subclasses
+}
+
+- (void)searchBarInputChangeDetectedForRemoteResultsUpdateWithText:(NSString *)searchText
+{
+    // overrided in subclasses
+}
+
+- (void)showLoadingSourcesIndicatorIfEmpty
+{
+    if ([self fetchedResultsAreEmpty]) {
+        [self showLoadingSourcesIndicator];
+    }
+}
+
+- (void)showLoadingSourcesIndicator
+{
+    [self.footerView startLoadingIndicatorAnimation];
+}
+
+- (void)hideLoadingSourcesIndicator
+{
+    [self.footerView stopLoadingIndicatorAnimation];
+    [self toggleNoResultsIndiciator];
+}
+
+- (void)showLoadingErrorMessageForResults
+{
+    NSString *text = NSLocalizedString(@"An error occurred loading the results, please try again in a moment.", @"The error message displayed when a user is editing a MenuItem and the results cannot be loaded, such as posts, pages, etc.");
+    [self.footerView toggleMessageWithText:text];
+}
+
+- (BOOL)itemTypeMatchesSourceItemType
+{
+    return [self.item.type isEqualToString:[self sourceItemType]];
+}
+
+- (void)setItemSourceWithContentID:(NSNumber *)contentID name:(NSString *)name
+{
+    MenuItem *item = self.item;
+    if (item.contentID.integerValue == contentID.integerValue && item.type == [self sourceItemType]) {
+        // No update needed.
+        return;
+    }
+    item.contentID = contentID;
+    item.type = [self sourceItemType];
+    if (name.length && [self.delegate sourceViewItemNameCanBeOverridden:self]) {
+        item.name = name;
+    }
+    [self.delegate sourceViewDidUpdateItem:self];
+}
+
+- (NSString *)sourceItemType
+{
+    // overrided in subclasses
+    return nil;
+}
+
+- (void)toggleNoResultsIndiciator
+{
+    if ([self fetchedResultsAreEmpty] && !self.defersFooterViewMessageUpdates) {
+        if (self.searchBarInputIsActive) {
+            [self.footerView toggleMessageWithText:NSLocalizedString(@"No results. Please try a different search.", @"Shown when user is searching for specific Menu item options and no items are available, such as posts, pages, etc.")];
+        } else {
+            [self.footerView toggleMessageWithText:NSLocalizedString(@"Nothing found.", @"Shown when user is loading Menu item options and no items are available, such as posts, pages, etc.")];
+        }
+    } else {
+        [self.footerView toggleMessageWithText:nil];
+    }
+}
+
+#pragma mark - NSFetchedResultsController and subclass methods
+
+- (NSFetchedResultsController *)resultsController
+{
+    NSFetchRequest *fetchRequest = nil;
+    if (!_resultsController && [self managedObjectContext] && (fetchRequest = [self fetchRequest])) {
+        
+        NSFetchedResultsController *resultsController = [[NSFetchedResultsController alloc] initWithFetchRequest:fetchRequest managedObjectContext:[self managedObjectContext] sectionNameKeyPath:[self fetechedResultsControllerSectionNameKeyPath] cacheName:nil];
+        resultsController.delegate = self;
+        _resultsController = resultsController;
+    }
+    
+    return _resultsController;
+}
+
+- (NSManagedObjectContext *)managedObjectContext
+{
+    return self.blog.managedObjectContext;
+}
+
+- (NSFetchRequest *)fetchRequest
+{
+    // overrided in subclasses
+    return nil;
+}
+
+- (NSPredicate *)defaultFetchRequestPredicate
+{
+    // overrided in subclasses if needed
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"blog == %@", [self blog]];
+    return predicate;
+}
+
+- (NSString *)fetechedResultsControllerSectionNameKeyPath
+{
+    // overrided in subclasses
+    return nil;
+}
+
+- (void)performResultsControllerFetchRequest
+{
+    if (!self.resultsController) {
+        return;
+    }
+    NSError *error;
+    if (![self.resultsController performFetch:&error]) {
+        DDLogError(@"Error occurred preforming fetch for MenuItem source of type: %@ error: %@", [self sourceItemType], error);
+    }
+    [self toggleNoResultsIndiciator];
+}
+
+- (BOOL)fetchedResultsAreEmpty
+{
+    return self.resultsController.fetchedObjects.count == 0;
+}
+
+- (void)deselectVisibleSourceCellsIfNeeded
+{
+    NSArray *cells = [self.tableView visibleCells];
+    for (MenuItemSourceCell *cell in cells) {
+        if (![cell isKindOfClass:[MenuItemSourceCell class]]) {
+            continue;
+        }
+        if (cell.sourceSelected) {
+            cell.sourceSelected = NO;
+        }
+    }
+}
+
+#pragma mark - subclass configuration
+
+- (void)configureSourceCell:(MenuItemSourceCell *)cell forIndexPath:(NSIndexPath *)indexPath
+{
+    // overrided in subclasses
+}
+
+- (void)scrollingWillDisplayEndOfTableView:(UITableView *)tableView
+{
+    // overrided in subclasses
+}
+
+#pragma mark - UIScrollView
+
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
+{
+    self.observeUserScrollingForEndOfTableView = YES;
+}
+
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
+{
+    if (!decelerate) {
+        self.observeUserScrollingForEndOfTableView = NO;
+    }
+}
+
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
+{
+    self.observeUserScrollingForEndOfTableView = NO;
+}
+
+#pragma mark - UITableView
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
+{
+    return self.resultsController.sections.count;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+    id <NSFetchedResultsSectionInfo> sectionInfo = [[self.resultsController sections] objectAtIndex:section];
+    return [sectionInfo numberOfObjects];
+}
+
+- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    return 50;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    return UITableViewAutomaticDimension;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayCell:(nonnull UITableViewCell *)cell forRowAtIndexPath:(nonnull NSIndexPath *)indexPath
+{
+    NSInteger numSections = self.resultsController.sections.count;
+    if (indexPath.section == numSections - 1 && self.observeUserScrollingForEndOfTableView) {
+        NSInteger numRowsInSection = [tableView numberOfRowsInSection:indexPath.section];
+        if (indexPath.row == numRowsInSection - 1) {
+            if (cell.frame.origin.y > tableView.bounds.size.height) {
+                self.observeUserScrollingForEndOfTableView = NO;
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    /*  Since we're firing a method as a cell is about to be displayed,
+                     we should dispatch this method async, as any implementation of
+                     the method may trigger additional table updates and on the same cell.
+                     */
+                    [self scrollingWillDisplayEndOfTableView:tableView];
+                });
+            }
+        }
+    }
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    static NSString * const identifier = @"MenuItemSourceCell";
+    MenuItemSourceCell *cell = [tableView dequeueReusableCellWithIdentifier:identifier];
+    if (!cell) {
+        cell = [[MenuItemSourceCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:identifier];
+    }
+    
+    [self configureSourceCell:cell forIndexPath:indexPath];
+    
+    return cell;
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
+{
+    id <NSFetchedResultsSectionInfo> sectionInfo = [[self.resultsController sections] objectAtIndex:section];
+    return [sectionInfo name];
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
+}
+
+#pragma mark - delegate
+
+- (void)tellDelegateDidBeginEditingWithKeyBoard
+{
+    [self.delegate sourceViewDidBeginEditingWithKeyBoard:self];
+}
+
+- (void)tellDelegateDidEndEditingWithKeyBoard
+{
+    [self.delegate sourceViewDidEndEditingWithKeyboard:self];
+}
+
+#pragma mark - MenuItemSourceTextBarDelegate
+
+- (void)sourceTextBarDidBeginEditing:(MenuItemSourceTextBar *)textBar
+{
+    [self tellDelegateDidBeginEditingWithKeyBoard];
+}
+
+- (void)sourceTextBarDidEndEditing:(MenuItemSourceTextBar *)textBar
+{
+    [self tellDelegateDidEndEditingWithKeyBoard];
+}
+
+- (void)sourceTextBar:(MenuItemSourceTextBar *)textBar didUpdateWithText:(NSString *)text
+{
+    // overrided in sublcasses
+}
+
+#pragma mark - NSFetchedResultsControllerDelegate
+
+- (void)controllerDidChangeContent:(NSFetchedResultsController *)controller
+{
+    [self.tableView reloadData];
+    [self toggleNoResultsIndiciator];
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceView.m
@@ -31,16 +31,16 @@ static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
         self.translatesAutoresizingMaskIntoConstraints = NO;
         self.backgroundColor = [UIColor whiteColor];
         
-        [self initTableView];
-        [self initStackedTableHeaderView];
-        [self initStackView];
-        [self initFooterView];
+        [self setupTableView];
+        [self setupStackedTableHeaderView];
+        [self setupStackView];
+        [self setupFooterView];
     }
     
     return self;
 }
 
-- (void)initTableView
+- (void)setupTableView
 {
     UITableView *tableView = [[UITableView alloc] init];
     tableView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -61,7 +61,7 @@ static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
     _tableView = tableView;
 }
 
-- (void)initStackedTableHeaderView
+- (void)setupStackedTableHeaderView
 {
     // setup the tableHeaderView and keep translatesAutoresizingMaskIntoConstraints to default YES
     // this allows the tableView to handle sizing the view as any other tableHeaderView
@@ -69,7 +69,7 @@ static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
     _stackedTableHeaderView = stackedTableHeaderView;
 }
 
-- (void)initStackView
+- (void)setupStackView
 {
     UIStackView *stackView = [[UIStackView alloc] init];
     stackView.translatesAutoresizingMaskIntoConstraints = NO;
@@ -98,7 +98,7 @@ static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
     _stackView = stackView;
 }
 
-- (void)initFooterView
+- (void)setupFooterView
 {
     MenuItemSourceFooterView *footerView = [[MenuItemSourceFooterView alloc] initWithFrame:CGRectMake(0, 0, self.tableView.frame.size.width, 60.0)];
     

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceView.m
@@ -9,6 +9,8 @@
 static NSTimeInterval const SearchBarFetchRequestUpdateDelay = 0.10;
 static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
 
+static CGFloat const SearchBarHeight = 44.0;
+
 @interface MenuItemSourceView () <MenuItemSourceTextBarDelegate>
 
 /**
@@ -164,7 +166,7 @@ static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
     NSAssert(_stackView != nil, @"stackView is nil");
     [_stackView addArrangedSubview:searchBar];
     
-    NSLayoutConstraint *heightConstraint = [searchBar.heightAnchor constraintEqualToConstant:44.0];
+    NSLayoutConstraint *heightConstraint = [searchBar.heightAnchor constraintEqualToConstant:SearchBarHeight];
     heightConstraint.priority = UILayoutPriorityDefaultHigh;
     heightConstraint.active = YES;
     

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceView.m
@@ -197,12 +197,12 @@ static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
 
 - (void)searchBarInputChangeDetectedForLocalResultsUpdateWithText:(NSString *)searchText
 {
-    // overrided in subclasses
+    AssertSubclassMethod();
 }
 
 - (void)searchBarInputChangeDetectedForRemoteResultsUpdateWithText:(NSString *)searchText
 {
-    // overrided in subclasses
+    AssertSubclassMethod();
 }
 
 - (void)showLoadingSourcesIndicatorIfEmpty
@@ -251,7 +251,7 @@ static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
 
 - (NSString *)sourceItemType
 {
-    // overrided in subclasses
+    AssertSubclassMethod();
     return nil;
 }
 
@@ -290,7 +290,7 @@ static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
 
 - (NSFetchRequest *)fetchRequest
 {
-    // overrided in subclasses
+    AssertSubclassMethod();
     return nil;
 }
 
@@ -303,7 +303,7 @@ static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
 
 - (NSString *)fetechedResultsControllerSectionNameKeyPath
 {
-    // overrided in subclasses
+    AssertSubclassMethod();
     return nil;
 }
 
@@ -341,12 +341,12 @@ static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
 
 - (void)configureSourceCell:(MenuItemSourceCell *)cell forIndexPath:(NSIndexPath *)indexPath
 {
-    // overrided in subclasses
+    AssertSubclassMethod();
 }
 
 - (void)scrollingWillDisplayEndOfTableView:(UITableView *)tableView
 {
-    // overrided in subclasses
+    AssertSubclassMethod();
 }
 
 #pragma mark - UIScrollView
@@ -461,7 +461,7 @@ static NSTimeInterval const SearchBarRemoteServiceUpdateDelay = 0.25;
 
 - (void)sourceTextBar:(MenuItemSourceTextBar *)textBar didUpdateWithText:(NSString *)text
 {
-    // overrided in sublcasses
+    AssertSubclassMethod();
 }
 
 #pragma mark - NSFetchedResultsControllerDelegate

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -55,6 +55,15 @@
 		08CC677E1C49B65A00153AD7 /* MenuItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC67791C49B65A00153AD7 /* MenuItem.m */; };
 		08CC677F1C49B65A00153AD7 /* Menu.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC677A1C49B65A00153AD7 /* Menu.m */; };
 		08CC67801C49B65A00153AD7 /* MenuLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 08CC677D1C49B65A00153AD7 /* MenuLocation.m */; };
+		08D3456C1CD8004C00358E8C /* MenuItemSourceCategoryView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D345591CD8004C00358E8C /* MenuItemSourceCategoryView.m */; };
+		08D3456D1CD8004C00358E8C /* MenuItemSourceCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D3455B1CD8004C00358E8C /* MenuItemSourceCell.m */; };
+		08D3456F1CD8004C00358E8C /* MenuItemSourceFooterView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D3455F1CD8004C00358E8C /* MenuItemSourceFooterView.m */; };
+		08D345701CD8004C00358E8C /* MenuItemSourceLinkView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D345611CD8004C00358E8C /* MenuItemSourceLinkView.m */; };
+		08D345711CD8004C00358E8C /* MenuItemSourcePageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D345631CD8004C00358E8C /* MenuItemSourcePageView.m */; };
+		08D345721CD8004C00358E8C /* MenuItemSourcePostAbstractView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D345651CD8004C00358E8C /* MenuItemSourcePostAbstractView.m */; };
+		08D345731CD8004C00358E8C /* MenuItemSourcePostView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D345671CD8004C00358E8C /* MenuItemSourcePostView.m */; };
+		08D345741CD8004C00358E8C /* MenuItemSourceTagView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D345691CD8004C00358E8C /* MenuItemSourceTagView.m */; };
+		08D345751CD8004C00358E8C /* MenuItemSourceView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D3456B1CD8004C00358E8C /* MenuItemSourceView.m */; };
 		08D978551CD2AF7D0054F19A /* Menu+ViewDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */; };
 		08D978561CD2AF7D0054F19A /* MenuItem+ViewDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D9784E1CD2AF7D0054F19A /* MenuItem+ViewDesign.m */; };
 		08D978571CD2AF7D0054F19A /* MenuItemCheckButtonView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D978501CD2AF7D0054F19A /* MenuItemCheckButtonView.m */; };
@@ -912,6 +921,24 @@
 		08CC677B1C49B65A00153AD7 /* Menu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Menu.h; sourceTree = "<group>"; };
 		08CC677C1C49B65A00153AD7 /* MenuLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuLocation.h; sourceTree = "<group>"; };
 		08CC677D1C49B65A00153AD7 /* MenuLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuLocation.m; sourceTree = "<group>"; };
+		08D345581CD8004C00358E8C /* MenuItemSourceCategoryView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemSourceCategoryView.h; sourceTree = "<group>"; };
+		08D345591CD8004C00358E8C /* MenuItemSourceCategoryView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemSourceCategoryView.m; sourceTree = "<group>"; };
+		08D3455A1CD8004C00358E8C /* MenuItemSourceCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemSourceCell.h; sourceTree = "<group>"; };
+		08D3455B1CD8004C00358E8C /* MenuItemSourceCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemSourceCell.m; sourceTree = "<group>"; };
+		08D3455E1CD8004C00358E8C /* MenuItemSourceFooterView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemSourceFooterView.h; sourceTree = "<group>"; };
+		08D3455F1CD8004C00358E8C /* MenuItemSourceFooterView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemSourceFooterView.m; sourceTree = "<group>"; };
+		08D345601CD8004C00358E8C /* MenuItemSourceLinkView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemSourceLinkView.h; sourceTree = "<group>"; };
+		08D345611CD8004C00358E8C /* MenuItemSourceLinkView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemSourceLinkView.m; sourceTree = "<group>"; };
+		08D345621CD8004C00358E8C /* MenuItemSourcePageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemSourcePageView.h; sourceTree = "<group>"; };
+		08D345631CD8004C00358E8C /* MenuItemSourcePageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemSourcePageView.m; sourceTree = "<group>"; };
+		08D345641CD8004C00358E8C /* MenuItemSourcePostAbstractView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemSourcePostAbstractView.h; sourceTree = "<group>"; };
+		08D345651CD8004C00358E8C /* MenuItemSourcePostAbstractView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemSourcePostAbstractView.m; sourceTree = "<group>"; };
+		08D345661CD8004C00358E8C /* MenuItemSourcePostView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemSourcePostView.h; sourceTree = "<group>"; };
+		08D345671CD8004C00358E8C /* MenuItemSourcePostView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemSourcePostView.m; sourceTree = "<group>"; };
+		08D345681CD8004C00358E8C /* MenuItemSourceTagView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemSourceTagView.h; sourceTree = "<group>"; };
+		08D345691CD8004C00358E8C /* MenuItemSourceTagView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemSourceTagView.m; sourceTree = "<group>"; };
+		08D3456A1CD8004C00358E8C /* MenuItemSourceView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemSourceView.h; sourceTree = "<group>"; };
+		08D3456B1CD8004C00358E8C /* MenuItemSourceView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemSourceView.m; sourceTree = "<group>"; };
 		08D4C0E61C76F14E002E5BF6 /* WordPress 47.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 47.xcdatamodel"; sourceTree = "<group>"; };
 		08D9784B1CD2AF7D0054F19A /* Menu+ViewDesign.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Menu+ViewDesign.h"; sourceTree = "<group>"; };
 		08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Menu+ViewDesign.m"; sourceTree = "<group>"; };
@@ -2231,6 +2258,37 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
+		08D345571CD8002A00358E8C /* MenuItemEditing */ = {
+			isa = PBXGroup;
+			children = (
+				08D3456A1CD8004C00358E8C /* MenuItemSourceView.h */,
+				08D3456B1CD8004C00358E8C /* MenuItemSourceView.m */,
+				08D345641CD8004C00358E8C /* MenuItemSourcePostAbstractView.h */,
+				08D345651CD8004C00358E8C /* MenuItemSourcePostAbstractView.m */,
+				08D345621CD8004C00358E8C /* MenuItemSourcePageView.h */,
+				08D345631CD8004C00358E8C /* MenuItemSourcePageView.m */,
+				08D345661CD8004C00358E8C /* MenuItemSourcePostView.h */,
+				08D345671CD8004C00358E8C /* MenuItemSourcePostView.m */,
+				08D345601CD8004C00358E8C /* MenuItemSourceLinkView.h */,
+				08D345611CD8004C00358E8C /* MenuItemSourceLinkView.m */,
+				08D345581CD8004C00358E8C /* MenuItemSourceCategoryView.h */,
+				08D345591CD8004C00358E8C /* MenuItemSourceCategoryView.m */,
+				08D345681CD8004C00358E8C /* MenuItemSourceTagView.h */,
+				08D345691CD8004C00358E8C /* MenuItemSourceTagView.m */,
+				08D3455A1CD8004C00358E8C /* MenuItemSourceCell.h */,
+				08D3455B1CD8004C00358E8C /* MenuItemSourceCell.m */,
+				08D978511CD2AF7D0054F19A /* MenuItemSourceHeaderView.h */,
+				08D978521CD2AF7D0054F19A /* MenuItemSourceHeaderView.m */,
+				08D3455E1CD8004C00358E8C /* MenuItemSourceFooterView.h */,
+				08D3455F1CD8004C00358E8C /* MenuItemSourceFooterView.m */,
+				08D9784F1CD2AF7D0054F19A /* MenuItemCheckButtonView.h */,
+				08D978501CD2AF7D0054F19A /* MenuItemCheckButtonView.m */,
+				08D978531CD2AF7D0054F19A /* MenuItemSourceTextBar.h */,
+				08D978541CD2AF7D0054F19A /* MenuItemSourceTextBar.m */,
+			);
+			name = MenuItemEditing;
+			sourceTree = "<group>";
+		};
 		08D978491CD2AF7D0054F19A /* Menus */ = {
 			isa = PBXGroup;
 			children = (
@@ -2246,12 +2304,7 @@
 				08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */,
 				08D9784D1CD2AF7D0054F19A /* MenuItem+ViewDesign.h */,
 				08D9784E1CD2AF7D0054F19A /* MenuItem+ViewDesign.m */,
-				08D9784F1CD2AF7D0054F19A /* MenuItemCheckButtonView.h */,
-				08D978501CD2AF7D0054F19A /* MenuItemCheckButtonView.m */,
-				08D978511CD2AF7D0054F19A /* MenuItemSourceHeaderView.h */,
-				08D978521CD2AF7D0054F19A /* MenuItemSourceHeaderView.m */,
-				08D978531CD2AF7D0054F19A /* MenuItemSourceTextBar.h */,
-				08D978541CD2AF7D0054F19A /* MenuItemSourceTextBar.m */,
+				08D345571CD8002A00358E8C /* MenuItemEditing */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -5175,6 +5228,7 @@
 				B5772AC41C9C7A070031F97E /* GravatarService.swift in Sources */,
 				5D2C05561AD2F56200A753FE /* NavBarTitleDropdownButton.m in Sources */,
 				E66969DC1B9E55C300EC9C00 /* ReaderTopicToReaderListTopic37to38.swift in Sources */,
+				08D3456D1CD8004C00358E8C /* MenuItemSourceCell.m in Sources */,
 				B5AB733D19901F85005F5044 /* WPNoResultsView+AnimatedBox.m in Sources */,
 				31C9F82E1A2368A2008BB945 /* BlogDetailHeaderView.m in Sources */,
 				FF28B3F11AEB251200E11AAE /* InfoPListTranslator.m in Sources */,
@@ -5233,6 +5287,7 @@
 				83418AAA11C9FA6E00ACF00C /* Comment.m in Sources */,
 				E125443C12BF5A7200D87A0A /* WordPress.xcdatamodeld in Sources */,
 				B574CE111B5D8F8600A84FFD /* WPStyleGuide+AlertView.swift in Sources */,
+				08D345731CD8004C00358E8C /* MenuItemSourcePostView.m in Sources */,
 				E6417BA41CA07E260084050A /* SigninWPComViewController.swift in Sources */,
 				B56A70181B5040B9001D5815 /* SwitchTableViewCell.swift in Sources */,
 				E66969E21B9E67A000EC9C00 /* ReaderTopicToReaderSiteTopic37to38.swift in Sources */,
@@ -5314,6 +5369,7 @@
 				E14B40FF1C58B93F005046F6 /* SettingsCommon.swift in Sources */,
 				B58FD8CE1C7256DF00E5F6A4 /* NotificationsViewController+RowActions.swift in Sources */,
 				0859DCF71CB847F700EB4069 /* RemoteMenuItem.m in Sources */,
+				08D345711CD8004C00358E8C /* MenuItemSourcePageView.m in Sources */,
 				937D9A0F19F83812007B9D5F /* WordPress-22-23.xcmappingmodel in Sources */,
 				5D1D04761B7A50B100CDE646 /* ReaderStreamViewController.swift in Sources */,
 				E6417BA21CA07D910084050A /* Signin2FAViewController.swift in Sources */,
@@ -5321,6 +5377,7 @@
 				B57B92BD1B73B08100DFF00B /* SeparatorsView.swift in Sources */,
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,
 				E127A0F11C43B7CB00085129 /* SiteServiceRemoteREST.m in Sources */,
+				08D3456C1CD8004C00358E8C /* MenuItemSourceCategoryView.m in Sources */,
 				462F4E0A18369F0B0028D2F8 /* BlogDetailsViewController.m in Sources */,
 				593F26611CAB00CA00F14073 /* PostSharingController.swift in Sources */,
 				B55F1AA81C10936600FD04D4 /* BlogSettings+Discussion.swift in Sources */,
@@ -5334,6 +5391,7 @@
 				BE87E1A21BD405790075D45B /* WP3DTouchShortcutHandler.swift in Sources */,
 				FFA9148F1BA6E5170068F8BF /* RotationAwareNavigationViewController.m in Sources */,
 				5D4E30D11AA4B41A000D9904 /* WPStyleGuide+Posts.m in Sources */,
+				08D345751CD8004C00358E8C /* MenuItemSourceView.m in Sources */,
 				5D17530F1A97D2CA0031A082 /* PostCardTableViewCell.m in Sources */,
 				5D7B414819E482C9007D9EC7 /* WPRichTextMediaAttachment.swift in Sources */,
 				E13F23C314FE84600081D9CC /* NSMutableDictionary+Helpers.m in Sources */,
@@ -5383,6 +5441,7 @@
 				E240859C183D82AE002EB0EF /* WPAnimatedBox.m in Sources */,
 				08472A201C727E020040769D /* PostServiceOptions.m in Sources */,
 				852416CF1A12EBDD0030700C /* AppRatingUtility.m in Sources */,
+				08D345741CD8004C00358E8C /* MenuItemSourceTagView.m in Sources */,
 				B5CC05F91962186D00975CAC /* Meta.m in Sources */,
 				E6431DE51C4E892900FD8D90 /* SharingConnectionsViewController.m in Sources */,
 				5D20A6531982D56600463A91 /* FollowedSitesViewController.m in Sources */,
@@ -5497,6 +5556,7 @@
 				E663D1901C65383E0017F109 /* SharingAccountViewController.swift in Sources */,
 				93DEB88219E5BF7100F9546D /* TodayExtensionService.m in Sources */,
 				5DE293C11AD8009E00825DE5 /* PostListFilter.m in Sources */,
+				08D345701CD8004C00358E8C /* MenuItemSourceLinkView.m in Sources */,
 				5D42A3E2175E7452005CFF05 /* ReaderPost.m in Sources */,
 				B587797F19B799D800E57C5A /* UIImageView+Networking.swift in Sources */,
 				FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */,
@@ -5568,6 +5628,7 @@
 				E1A03F48174283E10085D192 /* BlogToJetpackAccount.m in Sources */,
 				B522C4F81B3DA79B00E47B59 /* NotificationSettingsViewController.swift in Sources */,
 				E14B13C31C4E7675009DD68F /* Reachability+Rx.swift in Sources */,
+				08D345721CD8004C00358E8C /* MenuItemSourcePostAbstractView.m in Sources */,
 				B587797C19B799D800E57C5A /* NSParagraphStyle+Helpers.swift in Sources */,
 				5D6C4B121B604190005E3C43 /* RichTextView.swift in Sources */,
 				E148362F1C6DF7D8005ACF53 /* Product.swift in Sources */,
@@ -5586,6 +5647,7 @@
 				5DF738971965FACD00393584 /* RecommendedTopicsViewController.m in Sources */,
 				85D239B11AE5A5FC0074768D /* OnePasswordFacade.m in Sources */,
 				5D1181E71B4D6DEB003F3084 /* WPStyleGuide+Reader.swift in Sources */,
+				08D3456F1CD8004C00358E8C /* MenuItemSourceFooterView.m in Sources */,
 				E66969E01B9E648100EC9C00 /* ReaderTopicToReaderDefaultTopic37to38.swift in Sources */,
 				B5FF3BE71CAD881100C1D597 /* GravatarOverlayView.swift in Sources */,
 				85CE4C201A703CF200780DFE /* NSBundle+VersionNumberHelper.m in Sources */,


### PR DESCRIPTION
Adding a collection of views responsible for handling the loading and selection of different sources a `MenuItem` can point to.

Ultimately, these views live within views not included in this PR: `MenuItemEditingViewController` and `MenuItemSourceContainerView`. I've broken up the PR flow to limit as many lines as possible between reviewers. For the sake of that, this PR focuses only on the source views included that live within the limited red area outlined here:

![simulator screen shot may 2 2016 5 11 11 pm](https://cloud.githubusercontent.com/assets/1873422/14969656/1bc90ecc-1089-11e6-9c50-f8debd563a39.png)

**To test:**

1. Build and run the staging branch `feature/menus-views` to load the complete Menus implementation.
2. Select a .com site with admin rights.
3. Select "Menus" under the site options.
4. Select a `MenuItem` to edit its source, such as "Home", "About", "Blog", etc.
5. Source views are loaded as Pages, Posts, Link, Categories, Tags or Posts using [custom content types](https://jetpack.com/support/custom-content-types/).
6. You can select different types by hitting the header area with the left chevron, which loads the corresponding sources in the correct source view.

![menus_sources](https://cloud.githubusercontent.com/assets/1873422/14970152/73632fde-108c-11e6-8ae2-dc901c0bacd4.gif)

**Pages**

1. Test that pages load as expected for a site.
2. Test that searching loads both local and remote pages.

**Posts**

1. Test that posts load as expected for a site.
2. Test that searching loads both local and remote posts.
3. Test that posts continue loading via paging when scrolling to the bottom for a site with many posts.

**Link**

1. Test that the "LINK ADDRESS (URL)" field accepts text as expected.
2. Test that the "Open new link" checkbox checks and un-checks as expected.

**Categories**

1. Test that the categories load as expected for a site.
2. Ensure the parent/child nesting is as expected for a site.

**Tags**

1. Test that the tags load as expected for a site.
2. Test that searching tags loads both local and remote tags for a site as expected.
3. Test that paging a long list of tags loads as expected for a site.

**Custom Posts**

1. Load some custom post types for a site/theme as noted in https://jetpack.com/support/custom-content-types/
2. Create posts using these types on the site.
3. Load the associated custom type with the app Menus editing.
4. Test that the custom posts load as expected for the site.

Needs review: @aerych (let me know if you'd like me to break this up additionally)