### PR TITLE
Signin: Handle a wpcom credentials and site from self-hosted vc.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/NUXSubmitButton.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXSubmitButton.swift
@@ -8,6 +8,13 @@ let NUXSubmitButtonDisabledAlpha = CGFloat(0.25)
 ///
 @objc class NUXSubmitButton : UIButton
 {
+    var isAnimating: Bool {
+        get {
+            return activityIndicator.isAnimating()
+        }
+    }
+
+
     let activityIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView(activityIndicatorStyle: .White)
         indicator.hidesWhenStopped = true

--- a/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
@@ -4,9 +4,8 @@ import WordPressShared
 /// Provides a form and functionality to sign-in and add an existing self-hosted 
 /// site to the app.
 ///
-@objc class SigninSelfHostedViewController : NUXAbstractViewController, SigninKeyboardResponder
+@objc class SigninSelfHostedViewController : NUXAbstractViewController, SigninKeyboardResponder, SigninWPComSyncHandler
 {
-
     @IBOutlet weak var usernameField: WPWalkthroughTextField!
     @IBOutlet weak var passwordField: WPWalkthroughTextField!
     @IBOutlet weak var siteURLField: WPWalkthroughTextField!
@@ -95,12 +94,23 @@ import WordPressShared
     }
 
 
+    /// Displays the specified text in the status label.
+    ///
+    /// - Parameters:
+    ///     - message: The text to display in the label.
+    ///
+    func configureStatusLabel(message: String) {
+        statusLabel.text = message
+    }
+
+
     /// Configures the appearance and state of the forgot password button.
     ///
     func configureForgotPasswordButton() {
         var status = ""
-        if statusLabel.text != nil {
-            status = statusLabel.text!
+
+        if let text = statusLabel.text {
+            status = text
         }
 
         forgotPasswordButton.hidden = loginFields.siteUrl.isEmpty || !status.isEmpty
@@ -126,7 +136,7 @@ import WordPressShared
     /// - Parameters:
     ///     - loading: True if the form should be configured to a "loading" state.
     ///
-    func configureLoading(loading: Bool) {
+    func configureViewLoading(loading: Bool) {
         usernameField.enabled = !loading
         passwordField.enabled = !loading
         siteURLField.enabled = !loading
@@ -149,6 +159,14 @@ import WordPressShared
 
 
     // MARK: - Instance Methods
+
+
+    ///
+    ///
+    func updateSafariCredentialsIfNeeded() {
+        // Noop.  Required by the SigninWPComSyncHandler protocol but the self-hosted 
+        // controller's implementation does not use safari saved credentials.
+    }
 
 
     /// Validates what is entered in the various form fields and, if valid,
@@ -175,7 +193,7 @@ import WordPressShared
             return
         }
 
-        configureLoading(true)
+        configureViewLoading(true)
         
         loginFacade.signInWithLoginFields(loginFields)
     }
@@ -249,25 +267,42 @@ import WordPressShared
 
 extension SigninSelfHostedViewController: LoginFacadeDelegate {
 
+    func finishedLoginWithUsername(username: String!, authToken: String!, requiredMultifactorCode: Bool) {
+        syncWPCom(username, authToken: authToken, requiredMultifactor: requiredMultifactorCode)
+    }
+
+
     func finishedLoginWithUsername(username: String!, password: String!, xmlrpc: String!, options: [NSObject : AnyObject]!) {
         displayLoginMessage("")
         BlogSyncFacade().syncBlogWithUsername(username, password: password, xmlrpc: xmlrpc, options: options) { [weak self] in
-            self?.configureLoading(false)
+            self?.configureViewLoading(false)
             self?.dismiss()
         }
     }
 
 
     func displayLoginMessage(message: String!) {
-        statusLabel.text = message
+        configureStatusLabel(message)
         configureForgotPasswordButton()
     }
 
 
     func displayRemoteError(error: NSError!) {
         displayLoginMessage("")
-        configureLoading(false)
+        configureViewLoading(false)
         displayError(error)
+    }
+
+
+    func needsMultifactorCode() {
+        configureStatusLabel("")
+        configureViewLoading(false)
+
+        WPAppAnalytics.track(.TwoFactorCodeRequested)
+        // Credentials were good but a 2fa code is needed.
+        loginFields.shouldDisplayMultifactor = true // technically not needed
+        let controller = Signin2FAViewController.controller(loginFields)
+        navigationController?.pushViewController(controller, animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
@@ -107,13 +107,7 @@ import WordPressShared
     /// Configures the appearance and state of the forgot password button.
     ///
     func configureForgotPasswordButton() {
-        var status = ""
-
-        if let text = statusLabel.text {
-            status = text
-        }
-
-        forgotPasswordButton.hidden = loginFields.siteUrl.isEmpty || !status.isEmpty
+        forgotPasswordButton.hidden = loginFields.siteUrl.isEmpty || submitButton.isAnimating
     }
 
 
@@ -142,6 +136,7 @@ import WordPressShared
         siteURLField.enabled = !loading
 
         configureSubmitButton(animating: loading)
+        configureForgotPasswordButton()
         navigationItem.hidesBackButton = loading
     }
 


### PR DESCRIPTION
Fixes #5269 
Adds support for LoginFacade's wpcom delegate method, and SigninWPComSyncHandler. 

To test: 
Switch to the self-hosted controller and try to login to a wpcom site. 
Also try with credentials that have 2fa enabled.  Ensure that the 2fa screen is presented and you can login correctly. 

Needs review: @koke 
