### PR TITLE
Plans: load localized copy from the API

### DIFF
--- a/WordPress/Classes/Networking/PlansFeaturesRemote.swift
+++ b/WordPress/Classes/Networking/PlansFeaturesRemote.swift
@@ -7,7 +7,11 @@ class PlanFeaturesRemote: ServiceRemoteREST {
     }
 
     private var cacheDate: NSDate?
-    private let cacheFilename = "plan-features.json"
+    private let languageDatabase = WordPressComLanguageDatabase()
+    private var cacheFilename: String {
+        let locale = languageDatabase.deviceLanguage.slug
+        return "plan-features-\(locale).json"
+    }
 
     func getPlanFeatures(success: PlanFeatures -> Void, failure: ErrorType -> Void) {
         // First we'll try and return plan features from memory, then check our disk cache,
@@ -79,9 +83,11 @@ class PlanFeaturesRemote: ServiceRemoteREST {
     private func fetchPlanFeatures(success: PlanFeatures -> Void, failure: ErrorType -> Void) {
         let endpoint = "plans/features"
         let path = pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_2)
+        let locale = languageDatabase.deviceLanguage.slug
+        let parameters = ["locale": locale]
 
         api.GET(path,
-                parameters: nil,
+                parameters: parameters,
                 success: {
                     [weak self] requestOperation, response in
                     do {

--- a/WordPress/Classes/Networking/PlansRemote.swift
+++ b/WordPress/Classes/Networking/PlansRemote.swift
@@ -12,9 +12,11 @@ class PlansRemote: ServiceRemoteREST {
     func getPlansForSite(siteID: Int, success: SitePlans -> Void, failure: ErrorType -> Void) {
         let endpoint = "sites/\(siteID)/plans"
         let path = pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_2)
+        let locale = WordPressComLanguageDatabase().deviceLanguage.slug
+        let parameters = ["locale": locale]
 
         api.GET(path,
-            parameters: nil,
+            parameters: parameters,
             success: {
                 _, response in
                 do {

--- a/WordPress/Classes/Utility/Languages.swift
+++ b/WordPress/Classes/Utility/Languages.swift
@@ -52,7 +52,7 @@ class WordPressComLanguageDatabase : NSObject
     ///
     func nameForLanguageWithId(languageId: Int) -> String {
         for language in all {
-            if language.languageId == languageId {
+            if language.id == languageId {
                 return language.name
             }
         }
@@ -63,8 +63,11 @@ class WordPressComLanguageDatabase : NSObject
     /// Returns the current device language as the corresponding WordPress.com language ID.
     /// If the language is not supported, it returns 1 (English).
     ///
-    func deviceLanguageId() -> NSNumber {
-        return deviceLanguage.languageId
+    /// This is a wrapper for Objective-C, Swift code should use deviceLanguage directly.
+    ///
+    @objc(deviceLanguageId)
+    func deviceLanguageIdNumber() -> NSNumber {
+        return deviceLanguage.id
     }
 
     /// Returns the current device language as the corresponding WordPress.com language.
@@ -103,8 +106,8 @@ class WordPressComLanguageDatabase : NSObject
     {
         /// Language Unique Identifier
         ///
-        let languageId : NSNumber
-        
+        let id : Int
+
         /// Human readable Language name
         ///
         let name : String
@@ -124,17 +127,17 @@ class WordPressComLanguageDatabase : NSObject
         /// Designated initializer. Will fail if any of the required properties is missing
         ///
         init?(dict : NSDictionary) {
-            guard let unwrappedLanguageId = dict.numberForKey(Keys.identifier)?.integerValue,
+            guard let unwrappedId = dict.numberForKey(Keys.identifier)?.integerValue,
                         unwrappedSlug = dict.stringForKey(Keys.slug),
                         unwrappedName = dict.stringForKey(Keys.name) else
             {
-                languageId = Int.min
+                id = Int.min
                 name = String()
                 slug = String()
                 return nil
             }
             
-            languageId = unwrappedLanguageId
+            id = unwrappedId
             name = unwrappedName
             slug = unwrappedSlug
         }

--- a/WordPress/Classes/Utility/Languages.swift
+++ b/WordPress/Classes/Utility/Languages.swift
@@ -64,14 +64,20 @@ class WordPressComLanguageDatabase : NSObject
     /// If the language is not supported, it returns 1 (English).
     ///
     func deviceLanguageId() -> NSNumber {
+        return deviceLanguage.languageId
+    }
+
+    /// Returns the current device language as the corresponding WordPress.com language.
+    /// If the language is not supported, it returns English.
+    ///
+    var deviceLanguage: Language {
         let variants = LanguageTagVariants(string: deviceLanguageCode)
         for variant in variants {
             if let match = self.languageWithSlug(variant) {
-                return match.languageId
+                return match
             }
         }
-
-        return 1
+        return languageWithSlug("en")!
     }
 
     /// Searches for a WordPress.com language that matches a language tag.

--- a/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
@@ -106,7 +106,7 @@ public class LanguageViewController : UITableViewController
         let languages   = languageDatabase.grouped
         let titles      = languages.map { $0.map { $0.name } }
         let subtitles   = languages.map { $0.map { $0.description } }
-        let values      = languages.map { $0.map { $0.languageId } } as [[NSObject]]
+        let values      = languages.map { $0.map { $0.id } } as [[NSObject]]
         
         // Setup ListPickerViewController
         let listViewController = SettingsListPickerViewController(headers: headers, titles: titles, subtitles: subtitles, values: values)

--- a/WordPress/WordPressTest/LanguagesTests.swift
+++ b/WordPress/WordPressTest/LanguagesTests.swift
@@ -26,7 +26,7 @@ class LanguagesTests: XCTestCase
         let languages = WordPressComLanguageDatabase()
         
         for language in languages.popular {
-            let filtered = languages.all.filter { $0.languageId == language.languageId }
+            let filtered = languages.all.filter { $0.id == language.id }
             XCTAssert(filtered.count == 1)
         }
     }
@@ -41,74 +41,74 @@ class LanguagesTests: XCTestCase
         XCTAssert(spanish == "Español")
     }
 
-    func testDeviceLanguageIdReturnsValueForSpanish() {
+    func testDeviceLanguageReturnsValueForSpanish() {
         let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("es")
 
-        XCTAssertEqual(languages.deviceLanguageId(), es)
+        XCTAssertEqual(languages.deviceLanguage.id, es)
     }
 
-    func testDeviceLanguageIdReturnsValueForSpanishSpainLowercase() {
+    func testDeviceLanguageReturnsValueForSpanishSpainLowercase() {
         let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("es-es")
 
-        XCTAssertEqual(languages.deviceLanguageId(), es)
+        XCTAssertEqual(languages.deviceLanguage.id, es)
     }
 
-    func testDeviceLanguageIdReturnsValueForSpanishSpain() {
+    func testDeviceLanguageReturnsValueForSpanishSpain() {
         let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("es-ES")
 
-        XCTAssertEqual(languages.deviceLanguageId(), es)
+        XCTAssertEqual(languages.deviceLanguage.id, es)
     }
 
-    func testDeviceLanguageIdReturnsEnglishForUnknownLanguage() {
+    func testDeviceLanguageReturnsEnglishForUnknownLanguage() {
         let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("not-a-language")
 
-        XCTAssertEqual(languages.deviceLanguageId(), en)
+        XCTAssertEqual(languages.deviceLanguage.id, en)
     }
 
-    func testDeviceLanguageIdReturnsValueForSpanishSpainExtra() {
+    func testDeviceLanguageReturnsValueForSpanishSpainExtra() {
         let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("es-ES-extra")
 
-        XCTAssertEqual(languages.deviceLanguageId(), es)
+        XCTAssertEqual(languages.deviceLanguage.id, es)
     }
 
-    func testDeviceLanguageIdReturnsValueForSpanishNO() {
+    func testDeviceLanguageReturnsValueForSpanishNO() {
         let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("es-NO")
 
-        XCTAssertEqual(languages.deviceLanguageId(), es)
+        XCTAssertEqual(languages.deviceLanguage.id, es)
     }
 
-    func testDeviceLanguageIdReturnsZhCNForZhHans() {
+    func testDeviceLanguageReturnsZhCNForZhHans() {
         let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("zh-Hans")
 
-        XCTAssertEqual(languages.deviceLanguageId(), zhCN)
+        XCTAssertEqual(languages.deviceLanguage.id, zhCN)
     }
 
-    func testDeviceLanguageIdReturnsZhTWForZhHant() {
+    func testDeviceLanguageReturnsZhTWForZhHant() {
         let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("zh-Hant")
 
-        XCTAssertEqual(languages.deviceLanguageId(), zhTW)
+        XCTAssertEqual(languages.deviceLanguage.id, zhTW)
     }
 
-    func testDeviceLanguageIdReturnsZhCNForZhHansES() {
+    func testDeviceLanguageReturnsZhCNForZhHansES() {
         let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("zh-Hans-ES")
 
-        XCTAssertEqual(languages.deviceLanguageId(), zhCN)
+        XCTAssertEqual(languages.deviceLanguage.id, zhCN)
     }
 
-    func testDeviceLanguageIdReturnsZhTWForZhHantES() {
+    func testDeviceLanguageReturnsZhTWForZhHantES() {
         let languages = WordPressComLanguageDatabase()
         languages._overrideDeviceLanguageCode("zh-Hant-ES")
 
-        XCTAssertEqual(languages.deviceLanguageId(), zhTW)
+        XCTAssertEqual(languages.deviceLanguage.id, zhTW)
     }
 
 


### PR DESCRIPTION
To test: visit plans with a non-English language/region, make sure the content is localized.

I've included a few changes to `Languages` here to avoid postponing this PR even more (previously on Languages: #5246, #5251, #5252)

Needs review: @frosty 
