### PR TITLE
Adds "WordPress" to the title of the share extension UI.

### DIFF
--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -33,6 +33,7 @@ class ShareViewController: SLComposeServiceViewController {
     override func viewDidLoad() {
         // Tracker
         tracks.wpcomUsername = wpcomUsername
+        title = NSLocalizedString("WordPress", comment: "Application title")
 
         // TextView
         loadTextViewContent()


### PR DESCRIPTION
Fixes #5283 

To test:
1. Launch the share extension.
2. Verify window title is present.


Needs review: @jleandroperez 

