### PR TITLE
Adds nullability info to BasePost.

### DIFF
--- a/WordPress/Classes/Models/BasePost.h
+++ b/WordPress/Classes/Models/BasePost.h
@@ -3,6 +3,8 @@
 #import "DateUtils.h"
 #import "PostContentProvider.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef enum {
     AbstractPostRemoteStatusPushing,    // Uploading post
     AbstractPostRemoteStatusFailed,      // Upload failed
@@ -10,41 +12,41 @@ typedef enum {
     AbstractPostRemoteStatusSync,       // Post uploaded
 } AbstractPostRemoteStatus;
 
-extern NSString * const PostStatusDraft;
-extern NSString * const PostStatusPending;
-extern NSString * const PostStatusPrivate;
-extern NSString * const PostStatusPublish;
-extern NSString * const PostStatusScheduled;
-extern NSString * const PostStatusTrash;
-extern NSString * const PostStatusDeleted;
+extern NSString * _Nonnull const PostStatusDraft;
+extern NSString * _Nonnull const PostStatusPending;
+extern NSString * _Nonnull const PostStatusPrivate;
+extern NSString * _Nonnull const PostStatusPublish;
+extern NSString * _Nonnull const PostStatusScheduled;
+extern NSString * _Nonnull const PostStatusTrash;
+extern NSString * _Nonnull const PostStatusDeleted;
 
 @interface BasePost : NSManagedObject<PostContentProvider>
 
 // Attributes
-@property (nonatomic, strong) NSNumber * postID;
-@property (nonatomic, strong) NSNumber * authorID;
-@property (nonatomic, strong) NSString * author;
-@property (nonatomic, strong) NSString * authorAvatarURL;
-@property (nonatomic, strong) NSDate * date_created_gmt;
-@property (nonatomic, strong) NSString * postTitle;
-@property (nonatomic, strong) NSString * content;
-@property (nonatomic, strong) NSString * status;
-@property (nonatomic, weak, readonly) NSString * statusTitle;
-@property (nonatomic, strong) NSString * password;
-@property (nonatomic, strong) NSString * permaLink;
-@property (nonatomic, strong) NSString * mt_excerpt;
-@property (nonatomic, strong) NSString * mt_text_more;
-@property (nonatomic, strong) NSString * wp_slug;
-@property (nonatomic, strong) NSNumber * remoteStatusNumber;
+@property (nonatomic, strong, nullable) NSNumber * postID;
+@property (nonatomic, strong, nullable) NSNumber * authorID;
+@property (nonatomic, strong, nullable) NSString * author;
+@property (nonatomic, strong, nullable) NSString * authorAvatarURL;
+@property (nonatomic, strong, nullable) NSDate * date_created_gmt;
+@property (nonatomic, strong, nullable) NSString * postTitle;
+@property (nonatomic, strong, nullable) NSString * content;
+@property (nonatomic, strong, nullable) NSString * status;
+@property (nonatomic, weak, readonly, nullable) NSString * statusTitle;
+@property (nonatomic, strong, nullable) NSString * password;
+@property (nonatomic, strong, nullable) NSString * permaLink;
+@property (nonatomic, strong, nullable) NSString * mt_excerpt;
+@property (nonatomic, strong, nullable) NSString * mt_text_more;
+@property (nonatomic, strong, nullable) NSString * wp_slug;
+@property (nonatomic, strong, nullable) NSNumber * remoteStatusNumber;
 @property (nonatomic) AbstractPostRemoteStatus remoteStatus;
-@property (nonatomic, strong) NSNumber * post_thumbnail;
+@property (nonatomic, strong, nullable) NSNumber * post_thumbnail;
 
 // Helpers
 /**
  Cached path of an image from the post to use for display purposes. 
  Not part of the post's canoncial data.
  */
-@property (nonatomic, strong) NSString *pathForDisplayImage;
+@property (nonatomic, strong, nullable) NSString *pathForDisplayImage;
 /**
  BOOL flag if the feature image was changed.
  */
@@ -121,14 +123,16 @@ extern NSString * const PostStatusDeleted;
 - (void)save;
 
 //date conversion
-- (NSDate *)dateCreated;
-- (void)setDateCreated:(NSDate *)localDate;
+- (nullable NSDate *)dateCreated;
+- (void)setDateCreated:(nullable NSDate *)localDate;
 
 //comments
 - (void)findComments;
 
 // Subclass methods
-- (NSString *)remoteStatusText;
-+ (NSString *)titleForRemoteStatus:(NSNumber *)remoteStatus;
+- (nullable NSString *)remoteStatusText;
++ (NSString *)titleForRemoteStatus:(nullable NSNumber *)remoteStatus;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Models/BasePost.h
+++ b/WordPress/Classes/Models/BasePost.h
@@ -12,13 +12,13 @@ typedef enum {
     AbstractPostRemoteStatusSync,       // Post uploaded
 } AbstractPostRemoteStatus;
 
-extern NSString * _Nonnull const PostStatusDraft;
-extern NSString * _Nonnull const PostStatusPending;
-extern NSString * _Nonnull const PostStatusPrivate;
-extern NSString * _Nonnull const PostStatusPublish;
-extern NSString * _Nonnull const PostStatusScheduled;
-extern NSString * _Nonnull const PostStatusTrash;
-extern NSString * _Nonnull const PostStatusDeleted;
+extern NSString * const PostStatusDraft;
+extern NSString * const PostStatusPending;
+extern NSString * const PostStatusPrivate;
+extern NSString * const PostStatusPublish;
+extern NSString * const PostStatusScheduled;
+extern NSString * const PostStatusTrash;
+extern NSString * const PostStatusDeleted;
 
 @interface BasePost : NSManagedObject<PostContentProvider>
 

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -162,7 +162,7 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 }
 
 - (NSString *)remoteStatusText
-{
+{    
     return [BasePost titleForRemoteStatus:self.remoteStatusNumber];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -776,15 +776,17 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
                 return
             }
             
-            // If the post was restored, see if it appears in the current filter.
-            // If not, prompt the user to let it know under which filter it appears.
-            let filter = strongSelf.filterThatDisplaysPostsWithStatus(apost.status)
-            
-            if filter == strongSelf.currentPostListFilter() {
-                return
+            if let postStatus = apost.status {
+                // If the post was restored, see if it appears in the current filter.
+                // If not, prompt the user to let it know under which filter it appears.
+                let filter = strongSelf.filterThatDisplaysPostsWithStatus(postStatus)
+                
+                if filter == strongSelf.currentPostListFilter() {
+                    return
+                }
+                
+                strongSelf.promptThatPostRestoredToFilter(filter)
             }
-            
-            strongSelf.promptThatPostRestoredToFilter(filter)
         }) { [weak self] (error: NSError!) in
             
             guard let strongSelf = self else {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -471,7 +471,9 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         
         postViewController.onClose = { [weak self] (viewController, changesSaved) in
             if changesSaved {
-                self?.setFilterWithPostStatus(viewController.post.status)
+                if let postStatus = viewController.post.status {
+                    self?.setFilterWithPostStatus(postStatus)
+                }
             }
             
             viewController.presentingViewController?.dismissViewControllerAnimated(true, completion: nil)
@@ -518,7 +520,9 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
             postViewController.onClose = {[weak self] viewController, changesSaved in
                 
                 if changesSaved {
-                    self?.setFilterWithPostStatus(viewController.post.status)
+                    if let postStatus = viewController.post.status {
+                        self?.setFilterWithPostStatus(postStatus)
+                    }
                 }
                 
                 viewController.navigationController?.popViewControllerAnimated(true)

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -38,7 +38,7 @@ import SVProgressHUD
         return controller
     }
     
-    func sharePost(title: String, summary: String, tags: String, link: String, fromBarButtonItem anchorBarButtonItem:UIBarButtonItem, inViewController viewController:UIViewController) {
+    func sharePost(title: String, summary: String, tags: String, link: String?, fromBarButtonItem anchorBarButtonItem:UIBarButtonItem, inViewController viewController:UIViewController) {
         let controller = shareController(
             title,
             summary: summary,
@@ -59,7 +59,7 @@ import SVProgressHUD
         }
     }
     
-    func sharePost(title: String, summary: String, tags: String, link: String, fromView anchorView:UIView, inViewController viewController:UIViewController) {
+    func sharePost(title: String, summary: String, tags: String, link: String?, fromView anchorView:UIView, inViewController viewController:UIViewController) {
         let controller = shareController(
             title,
             summary: summary,

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -439,7 +439,9 @@ final public class ReaderDetailViewController : UIViewController
     private func configureByLine() {
         // Avatar
         let placeholder = UIImage(named: "gravatar")
-        if let url = NSURL(string: post!.authorAvatarURL) {
+        
+        if let avatarURLString = post?.authorAvatarURL,
+            let url = NSURL(string: avatarURLString) {
             avatarImageView.setImageWithURL(url, placeholderImage: placeholder)
         }
 
@@ -837,8 +839,10 @@ extension ReaderDetailViewController : WPRichTextViewDelegate
     public func richTextView(richTextView: WPRichTextView, didReceiveLinkAction linkURL: NSURL) {
         var url = linkURL
         if url.host != nil {
-            let postURL = NSURL(string: post!.permaLink)
-            url = NSURL(string: linkURL.absoluteString, relativeToURL: postURL)!
+            if let postURLString = post?.permaLink {
+                let postURL = NSURL(string: postURLString)
+                url = NSURL(string: linkURL.absoluteString, relativeToURL: postURL)!
+            }
         }
         presentWebViewControllerWithURL(url)
     }


### PR DESCRIPTION
### Description:

Fixes a crash that was caused by posts with no status set.  If you create a draft post and crash the app you can easily cause this scenario to trigger.

### Details:

This PR improves `BasePost` by adding nullability info, meaning any Swift code using this class will know which properties, parameters and return values are optionals and which are not - thus forcing our Swift code to unwrap any optionals we may be dealing with.

At some point it'd be interesting to migrate `BasePost` to Swift and make sure a post cannot exist without a status being set, but for the time being this fix should do.

### Testing:

**Test 1:**
1. Create a post, write some content.
2. Crash the editor.
3. Relaunch the app and interact with the draft.  Make sure the post list does not crash.

**Test 2:**
1. Create a post, and save it as draft.
2. Make sure the filter is set to "Draft" in the post list, after exiting the editor.

**Test 3:**
1. Edit a post saved as draft.
2. Publish it.
3. Make sure the filter is set to "Publish" in the post list, after exiting the editor.

**Test 4:**
I'm not entirely sure how to test the changes in the reader... was hoping you could come up with proper tests @aerych.  Let me know if you need me to dig deeper.

Needs review: @aerych 
