### PR TITLE
Person: Adds linkedUserID

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -3,11 +3,12 @@
 This file documents changes in the data model. Please explain any changes to the
 data model as well as any custom migrations.
 
-## WordPress 49 (@jleandroperez 2016-05-04)
-- `Person` added Int32 `linkedUserID`.
+## WordPress 49
 
-## WordPress 49 (@jleandroperez 2016-04-22)
-- `Blog` added transformable `capabilities`.
+- @jleandroperez 2016-05-04
+ - `Person` added Int32 `linkedUserID`.
+- @jleandroperez 2016-04-22
+ - `Blog` added transformable `capabilities`.
 
 ## WordPress 48 
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -3,6 +3,9 @@
 This file documents changes in the data model. Please explain any changes to the
 data model as well as any custom migrations.
 
+## WordPress 49 (@jleandroperez 2016-05-04)
+- `Person` added Int32 `linkedUserID`.
+
 ## WordPress 49 (@jleandroperez 2016-04-22)
 - `Blog` added transformable `capabilities`.
 

--- a/WordPress/Classes/Models/Person.swift
+++ b/WordPress/Classes/Models/Person.swift
@@ -103,6 +103,10 @@ func <(lhs: Person.Role, rhs: Person.Role) -> Bool {
 }
 
 class ManagedPerson: NSManagedObject {
+    
+}
+
+extension ManagedPerson {
     @NSManaged var avatarURL: String?
     @NSManaged var displayName: String
     @NSManaged var firstName: String?
@@ -113,9 +117,10 @@ class ManagedPerson: NSManagedObject {
     @NSManaged var linkedUserID: Int32
     @NSManaged var username: String
     @NSManaged var isSuperAdmin: Bool
-
     @NSManaged var blog: Blog
+}
 
+extension ManagedPerson {
     func updateWith(person: Person) {
         avatarURL = person.avatarURL?.absoluteString
         displayName = person.displayName

--- a/WordPress/Classes/Models/Person.swift
+++ b/WordPress/Classes/Models/Person.swift
@@ -12,6 +12,7 @@ struct Person {
     let displayName: String
     let role: Role
     let siteID: Int
+    let linkedUserID: Int
     let avatarURL: NSURL?
     let isSuperAdmin: Bool
     
@@ -109,6 +110,7 @@ class ManagedPerson: NSManagedObject {
     @NSManaged var role: String
     @NSManaged var siteID: Int32
     @NSManaged var userID: Int32
+    @NSManaged var linkedUserID: Int32
     @NSManaged var username: String
     @NSManaged var isSuperAdmin: Bool
 
@@ -122,6 +124,7 @@ class ManagedPerson: NSManagedObject {
         role = String(person.role)
         siteID = Int32(person.siteID)
         userID = Int32(person.ID)
+        linkedUserID = Int32(person.linkedUserID)
         username = person.username
         isSuperAdmin = person.isSuperAdmin
     }
@@ -136,6 +139,7 @@ extension Person {
         displayName = managedPerson.displayName
         role = Role(string: managedPerson.role)
         siteID = Int(managedPerson.siteID)
+        linkedUserID = Int(managedPerson.linkedUserID)
         avatarURL = managedPerson.avatarURL.flatMap { NSURL(string: $0) }
         isSuperAdmin = managedPerson.isSuperAdmin
     }
@@ -161,6 +165,7 @@ func ==(lhs: Person, rhs: Person) -> Bool {
         && lhs.displayName == rhs.displayName
         && lhs.role == rhs.role
         && lhs.siteID == rhs.siteID
+        && lhs.linkedUserID == rhs.linkedUserID
         && lhs.avatarURL == rhs.avatarURL
         && lhs.isSuperAdmin == rhs.isSuperAdmin
 }

--- a/WordPress/Classes/Networking/PeopleRemote.swift
+++ b/WordPress/Classes/Networking/PeopleRemote.swift
@@ -6,7 +6,7 @@ class PeopleRemote: ServiceRemoteREST {
         let path = pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_1)
         let parameters = [
             "number": 50,
-            "fields": "ID, nice_name, first_name, last_name, name, avatar_URL, roles, is_super_admin",
+            "fields": "ID, nice_name, first_name, last_name, name, avatar_URL, roles, is_super_admin, linked_user_ID",
         ]
 
         api.GET(path,
@@ -51,6 +51,7 @@ class PeopleRemote: ServiceRemoteREST {
                 .flatMap { NSURL(string: $0)}
                 .flatMap { Gravatar($0)?.canonicalURL }
             let isSuperAdmin = user["is_super_admin"] as? Bool ?? false
+            let linkedUserID = user["linked_user_ID"] as? Int ?? ID
             let roles = user["roles"] as? [String]
 
             let role = roles?.map({
@@ -58,7 +59,7 @@ class PeopleRemote: ServiceRemoteREST {
                 return Person.Role(string: role)
             }).sort().first ?? .Unsupported
 
-            return Person(ID: ID, username: username, firstName: firstName, lastName: lastName, displayName: displayName, role: role, siteID: siteID, avatarURL: avatarURL, isSuperAdmin: isSuperAdmin)
+            return Person(ID: ID, username: username, firstName: firstName, lastName: lastName, displayName: displayName, role: role, siteID: siteID, linkedUserID: linkedUserID, avatarURL: avatarURL, isSuperAdmin: isSuperAdmin)
         }
 
         let errorCount = people.reduce(0) { (sum, person) -> Int in

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 49.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 49.xcdatamodel/contents
@@ -388,6 +388,7 @@
         <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="isSuperAdmin" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="linkedUserID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="role" attributeType="String" syncable="YES"/>
         <attribute name="siteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="userID" attributeType="Integer 32" syncable="YES"/>
@@ -624,7 +625,7 @@
         <element name="Meta" positionX="9" positionY="153" width="128" height="105"/>
         <element name="Notification" positionX="18" positionY="162" width="128" height="255"/>
         <element name="Page" positionX="0" positionY="0" width="128" height="60"/>
-        <element name="Person" positionX="18" positionY="153" width="128" height="180"/>
+        <element name="Person" positionX="18" positionY="153" width="128" height="195"/>
         <element name="Post" positionX="0" positionY="0" width="128" height="195"/>
         <element name="PostTag" positionX="27" positionY="153" width="128" height="105"/>
         <element name="PostType" positionX="27" positionY="153" width="128" height="105"/>


### PR DESCRIPTION
#### Details:
In this PR we're adding the `linkedUserID` field (returned by WordPress.com for Jetpack users, linked to a WordPress.com user).

This is required to properly handle the "Self hosted + Jetpack" scenario, in Issue #5175.

I'm adding the extra field to the Data Model Mark 49, since it is still in Develop, and didn't make it's way thru 6.2

Needs Review: @astralbodies 
Thanks in advance Aaron!
