### PR TITLE
Actually use xcpretty-travis-formatter

### DIFF
--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -99,4 +99,3 @@ fi
 
 eval $CMD
 
-echo

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -99,3 +99,4 @@ fi
 
 eval $CMD
 
+echo

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -31,7 +31,7 @@ function clean_build() {
 }
 
 function pretty_travis() {
-  xcpretty -c
+  xcpretty -f `xcpretty-travis-formatter`
 }
 
 function rawlog() {


### PR DESCRIPTION
We're installing `xcpretty-travis-formatter` but not really using it in our build script

If you look at the [build](https://travis-ci.org/wordpress-mobile/WordPress-iOS/builds/128018694), the build step is collapsed. The test step isn't but it's also cut before it's finished, which is a different issue.

Needs review: @SergioEstevao 
