### PR TITLE
Fixing Restoration Crash

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -498,8 +498,7 @@ NSInteger const BlogDetailAccountHideViewAdminDay = 7;
 - (void)showPeople
 {
     // TODO(@koke, 2015-11-02): add analytics
-    PeopleViewController *controller = [[UIStoryboard storyboardWithName:@"People" bundle:nil] instantiateInitialViewController];
-    controller.blog = self.blog;
+    PeopleViewController *controller = [PeopleViewController controllerWithBlog:self.blog];
     [self.navigationController pushViewController:controller animated:YES];
 }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -117,12 +117,9 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
         guard let blogID = coder.decodeObjectForKey(RestorationKeys.blog) as? String,
             let objectURL = NSURL(string: blogID),
             let objectID = context.persistentStoreCoordinator?.managedObjectIDForURIRepresentation(objectURL),
-            let restoredBlog = try? context.existingObjectWithID(objectID) else
+            let restoredBlog = try? context.existingObjectWithID(objectID) as? Blog,
+            let blog = restoredBlog else
         {
-            return nil
-        }
-        
-        guard let blog = restoredBlog as? Blog else {
             return nil
         }
         

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -117,8 +117,8 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
         guard let blogID = coder.decodeObjectForKey(RestorationKeys.blog) as? String,
             let objectURL = NSURL(string: blogID),
             let objectID = context.persistentStoreCoordinator?.managedObjectIDForURIRepresentation(objectURL),
-            let restoredBlog = try? context.existingObjectWithID(objectID) as? Blog,
-            let blog = restoredBlog else
+            let restoredBlog = try? context.existingObjectWithID(objectID),
+            let blog = restoredBlog  as? Blog else
         {
             return nil
         }


### PR DESCRIPTION
Fixes #5289

To test:
1. Log into a Dotcom account
2. Open `My Sites` > `Site` > People
3. Press the home button
4. Kill the app
5. Relaunch the app

As a result, the User's list should be onscreen. And of course, the app shouldn't crash.

Needs review: @frosty 
Thanks in advance James!
