### PR TITLE
Account Settings: Improving Update Email UX

### DIFF
--- a/WordPress/Classes/Models/AccountSettings.swift
+++ b/WordPress/Classes/Models/AccountSettings.swift
@@ -34,6 +34,7 @@ extension AccountSettings {
     }
     
     var emailForDisplay : String {
-        return emailPendingAddress?.nonEmptyString() ?? email
+        let pendingEmail = emailPendingAddress?.nonEmptyString() ?? email        
+        return emailPendingChange ? pendingEmail : email
     }
 }

--- a/WordPress/Classes/Models/ManagedAccountSettings.swift
+++ b/WordPress/Classes/Models/ManagedAccountSettings.swift
@@ -39,11 +39,12 @@ class ManagedAccountSettings: NSManagedObject {
             self.displayName = value
         case .AboutMe(let value):
             self.aboutMe = value
-        case .EmailPendingAddress(let value):
+        case .Email(let value):
             self.emailPendingAddress = value
-            self.emailPendingChange = (value != nil)
-        case .EmailPendingChange(let value):
-            self.emailPendingChange = value
+            self.emailPendingChange = true
+        case .EmailRevertPendingChange:
+            self.emailPendingAddress = nil
+            self.emailPendingChange = false
         case .PrimarySite(let value):
             self.primarySiteID = value
         case .WebAddress(let value):
@@ -65,10 +66,10 @@ class ManagedAccountSettings: NSManagedObject {
             return .DisplayName(self.displayName)
         case .AboutMe(_):
             return .AboutMe(self.aboutMe)
-        case .EmailPendingAddress(_):
-            return .EmailPendingAddress(nil)
-        case .EmailPendingChange(_):
-            return .EmailPendingChange(self.emailPendingChange)
+        case .Email(_):
+            return .EmailRevertPendingChange
+        case .EmailRevertPendingChange(_):
+            return .Email(self.emailPendingAddress ?? String())
         case .PrimarySite(_):
             return .PrimarySite(self.primarySiteID.integerValue)
         case .WebAddress(_):
@@ -84,8 +85,8 @@ enum AccountSettingsChange {
     case LastName(String)
     case DisplayName(String)
     case AboutMe(String)
-    case EmailPendingAddress(String?)
-    case EmailPendingChange(Bool)
+    case Email(String)
+    case EmailRevertPendingChange
     case PrimarySite(Int)
     case WebAddress(String)
     case Language(String)
@@ -100,10 +101,10 @@ enum AccountSettingsChange {
             return value
         case .AboutMe(let value):
             return value
-        case .EmailPendingAddress(let value):
-            return value ?? String()
-        case .EmailPendingChange(let value):
-            return String(value)
+        case .Email(let value):
+            return value
+        case .EmailRevertPendingChange:
+            return String(false)
         case .PrimarySite(let value):
             return String(value)
         case .WebAddress(let value):

--- a/WordPress/Classes/Models/ManagedAccountSettings.swift
+++ b/WordPress/Classes/Models/ManagedAccountSettings.swift
@@ -39,8 +39,9 @@ class ManagedAccountSettings: NSManagedObject {
             self.displayName = value
         case .AboutMe(let value):
             self.aboutMe = value
-        case .Email(let value):
-            self.email = value
+        case .EmailPendingAddress(let value):
+            self.emailPendingAddress = value
+            self.emailPendingChange = (value != nil)
         case .EmailPendingChange(let value):
             self.emailPendingChange = value
         case .PrimarySite(let value):
@@ -64,8 +65,8 @@ class ManagedAccountSettings: NSManagedObject {
             return .DisplayName(self.displayName)
         case .AboutMe(_):
             return .AboutMe(self.aboutMe)
-        case .Email(_):
-            return .Email(self.email)
+        case .EmailPendingAddress(_):
+            return .EmailPendingAddress(nil)
         case .EmailPendingChange(_):
             return .EmailPendingChange(self.emailPendingChange)
         case .PrimarySite(_):
@@ -83,7 +84,7 @@ enum AccountSettingsChange {
     case LastName(String)
     case DisplayName(String)
     case AboutMe(String)
-    case Email(String)
+    case EmailPendingAddress(String?)
     case EmailPendingChange(Bool)
     case PrimarySite(Int)
     case WebAddress(String)
@@ -99,8 +100,8 @@ enum AccountSettingsChange {
             return value
         case .AboutMe(let value):
             return value
-        case .Email(let value):
-            return value
+        case .EmailPendingAddress(let value):
+            return value ?? String()
         case .EmailPendingChange(let value):
             return String(value)
         case .PrimarySite(let value):

--- a/WordPress/Classes/Networking/AccountSettingsRemote.swift
+++ b/WordPress/Classes/Networking/AccountSettingsRemote.swift
@@ -149,7 +149,7 @@ class AccountSettingsRemote: ServiceRemoteREST {
             return "display_name"
         case .AboutMe(_):
             return "description"
-        case .Email(_):
+        case .EmailPendingAddress(_):
             return "user_email"
         case .EmailPendingChange(_):
             return "user_email_change_pending"

--- a/WordPress/Classes/Networking/AccountSettingsRemote.swift
+++ b/WordPress/Classes/Networking/AccountSettingsRemote.swift
@@ -149,9 +149,9 @@ class AccountSettingsRemote: ServiceRemoteREST {
             return "display_name"
         case .AboutMe(_):
             return "description"
-        case .EmailPendingAddress(_):
+        case .Email(_):
             return "user_email"
-        case .EmailPendingChange(_):
+        case .EmailRevertPendingChange(_):
             return "user_email_change_pending"
         case .PrimarySite(_):
             return "primary_site_ID"

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -107,7 +107,7 @@ private struct AccountSettingsController: SettingsController {
             let editableRow = row as! EditableTextRow
             let hint = NSLocalizedString("Will not be publicly displayed.", comment: "Help text when editing email address")
             let changeType = { rawValue in
-                return AccountSettingsChange.EmailPendingAddress(rawValue)
+                return AccountSettingsChange.Email(rawValue)
             }
             
             let settingsViewController =  self.controllerForEditableText(editableRow,
@@ -119,8 +119,7 @@ private struct AccountSettingsController: SettingsController {
             settingsViewController.displaysActionButton = settings?.emailPendingChange ?? false
             settingsViewController.actionText = NSLocalizedString("Revert Pending Change", comment: "Cancels a pending Email Change")
             settingsViewController.onActionPress = {
-                let change = AccountSettingsChange.EmailPendingChange(false)
-                service.saveChange(change)
+                service.saveChange(.EmailRevertPendingChange)
             }
             
             return settingsViewController

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -105,13 +105,9 @@ private struct AccountSettingsController: SettingsController {
     func editEmailAddress(settings: AccountSettings?, service: AccountSettingsService) -> ImmuTableRow -> SettingsTextViewController {
         return { row in
             let editableRow = row as! EditableTextRow
-            let hint = NSLocalizedString("Will not be publicly displayed.", comment: "Help text when editing email address")
-            let changeType = { rawValue in
-                return AccountSettingsChange.Email(rawValue)
-            }
-            
+            let hint = NSLocalizedString("Will not be publicly displayed.", comment: "Help text when editing email address")            
             let settingsViewController =  self.controllerForEditableText(editableRow,
-                                                                         changeType: changeType,
+                                                                         changeType: AccountSettingsChange.Email,
                                                                          hint: hint,
                                                                          service: service)
             settingsViewController.mode = .Email

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -106,8 +106,12 @@ private struct AccountSettingsController: SettingsController {
         return { row in
             let editableRow = row as! EditableTextRow
             let hint = NSLocalizedString("Will not be publicly displayed.", comment: "Help text when editing email address")
+            let changeType = { rawValue in
+                return AccountSettingsChange.EmailPendingAddress(rawValue)
+            }
+            
             let settingsViewController =  self.controllerForEditableText(editableRow,
-                                                                         changeType: AccountSettingsChange.Email,
+                                                                         changeType: changeType,
                                                                          hint: hint,
                                                                          service: service)
             settingsViewController.mode = .Email


### PR DESCRIPTION
Fixes #5185

To test:
1. Log into a WordPress.com account
2. Tap over `Me` > `Account Settings`
3. Edit your email

As a result, the *Account Settings* interface should display, immediately, the new email, along with the top notice (indicating that there's a pending change).

Needs review: @koke 
May i bother you with a review sir?

Thanks in advance!
