### PR TITLE
Reader: Improve scrolling experience. Keeps bars hidden when tapping to stop scroll

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -866,7 +866,12 @@ extension ReaderDetailViewController : UIScrollViewDelegate
         if y > scrollView.contentOffset.y && y > threshold {
             setBarsHidden(true)
         } else {
-            setBarsHidden(false)
+            // Velocity will be 0,0 if the user taps to stop an in progress scroll.
+            // If the bars are already visible its fine but if the bars are hidden
+            // we don't want to jar the user by having them reappear.
+            if !CGPointEqualToPoint(velocity, CGPointZero) {
+                setBarsHidden(false)
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #5285 

To test: Repeat the steps described in the issue. Confirm that stopping the scroll 

Needs review: @diegoreymendez, would you be so kind?

