### PR TITLE
Fixes some compilation errors in release builds.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -243,11 +243,11 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     }
     
     func noResultsTitleText() -> String {
-        assert(false, "You should implement this method in the subclass")
+        fatalError("You should implement this method in the subclass")
     }
     
     func noResultsMessageText() -> String {
-        assert(false, "You should implement this method in the subclass")
+        fatalError("You should implement this method in the subclass")
     }
     
     func noResultsAccessoryView() -> UIView {
@@ -263,11 +263,11 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     }
     
     func noResultsButtonText() -> String? {
-        assert(false, "You should implement this method in the subclass")
+        fatalError("You should implement this method in the subclass")
     }
     
     func configureAuthorFilter() {
-        assert(false, "You should implement this method in the subclass")
+        fatalError("You should implement this method in the subclass")
     }
     
     func configureSearchController() {
@@ -316,7 +316,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     // MARK: TableViewHandler Delegate Methods
     
     func entityName() -> String {
-        assert(false, "You should implement this method in the subclass")
+        fatalError("You should implement this method in the subclass")
     }
     
     func managedObjectContext() -> NSManagedObjectContext {
@@ -401,7 +401,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     }
     
     func predicateForFetchRequest() -> NSPredicate {
-        assert(false, "You should implement this method in the subclass")
+        fatalError("You should implement this method in the subclass")
     }
     
     // MARK: - Table View Handling
@@ -917,7 +917,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     }
     
     func keyForCurrentListStatusFilter() -> String {
-        assert(false, "You should implement this method in the subclass")
+        fatalError("You should implement this method in the subclass")
     }
     
     func currentFilterIndex() -> Int {


### PR DESCRIPTION
Fixes the build errors we're getting in release builds.

This is a temporary fix to make sure we can keep building the app.  A better fix will be provided by [this issue I opened](https://github.com/wordpress-mobile/WordPress-iOS/issues/5319).

Test 1:
Build the app in both debug and release make sure it works as expected.

Test 2:
Run the app, go to the list of posts / pages for a blog... interact... make sure it doesn't break.

Needs review: @koke 
