### PR TITLE
Adds nullability info to Blog.h.

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -3,6 +3,8 @@
 #import <CoreData/CoreData.h>
 #import "JetpackState.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class BlogSettings;
 @class WPAccount;
 @class WordPressComApi;
@@ -54,53 +56,53 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 
 @interface Blog : NSManagedObject
 
-@property (nonatomic, strong, readwrite) NSNumber *blogID __deprecated_msg("Use dotComID instead");
-@property (nonatomic, strong, readwrite) NSNumber *dotComID;
-@property (nonatomic, strong, readwrite) NSString *xmlrpc;
-@property (nonatomic, strong, readwrite) NSString *apiKey;
-@property (nonatomic, strong, readwrite) NSNumber *hasOlderPosts;
-@property (nonatomic, strong, readwrite) NSNumber *hasOlderPages;
-@property (nonatomic, strong, readwrite) NSSet *posts;
-@property (nonatomic, strong, readwrite) NSSet *categories;
-@property (nonatomic, strong, readwrite) NSSet *tags;
-@property (nonatomic, strong, readwrite) NSSet *comments;
-@property (nonatomic, strong, readwrite) NSSet *connections;
-@property (nonatomic, strong, readwrite) NSSet *themes;
-@property (nonatomic, strong, readwrite) NSSet *media;
-@property (nonatomic, strong, readwrite) NSOrderedSet *menus;
-@property (nonatomic, strong, readwrite) NSOrderedSet *menuLocations;
-@property (nonatomic, strong, readwrite) NSString *currentThemeId;
+@property (nonatomic, strong, readwrite, nullable) NSNumber *blogID __deprecated_msg("Use dotComID instead");
+@property (nonatomic, strong, readwrite, nullable) NSNumber *dotComID;
+@property (nonatomic, strong, readwrite, nullable) NSString *xmlrpc;
+@property (nonatomic, strong, readwrite, nullable) NSString *apiKey;
+@property (nonatomic, strong, readwrite, nullable) NSNumber *hasOlderPosts;
+@property (nonatomic, strong, readwrite, nullable) NSNumber *hasOlderPages;
+@property (nonatomic, strong, readwrite, nullable) NSSet *posts;
+@property (nonatomic, strong, readwrite, nullable) NSSet *categories;
+@property (nonatomic, strong, readwrite, nullable) NSSet *tags;
+@property (nonatomic, strong, readwrite, nullable) NSSet *comments;
+@property (nonatomic, strong, readwrite, nullable) NSSet *connections;
+@property (nonatomic, strong, readwrite, nullable) NSSet *themes;
+@property (nonatomic, strong, readwrite, nullable) NSSet *media;
+@property (nonatomic, strong, readwrite, nullable) NSOrderedSet *menus;
+@property (nonatomic, strong, readwrite, nullable) NSOrderedSet *menuLocations;
+@property (nonatomic, strong, readwrite, nullable) NSString *currentThemeId;
 @property (nonatomic, assign, readwrite) BOOL isSyncingPosts;
 @property (nonatomic, assign, readwrite) BOOL isSyncingPages;
 @property (nonatomic, assign, readwrite) BOOL isSyncingMedia;
-@property (nonatomic, strong, readwrite) NSDate *lastPostsSync;
-@property (nonatomic, strong, readwrite) NSDate *lastPagesSync;
-@property (nonatomic, strong, readwrite) NSDate *lastCommentsSync;
-@property (nonatomic, strong, readwrite) NSDate *lastStatsSync;
-@property (nonatomic, strong, readwrite) NSString *lastUpdateWarning;
+@property (nonatomic, strong, readwrite, nullable) NSDate *lastPostsSync;
+@property (nonatomic, strong, readwrite, nullable) NSDate *lastPagesSync;
+@property (nonatomic, strong, readwrite, nullable) NSDate *lastCommentsSync;
+@property (nonatomic, strong, readwrite, nullable) NSDate *lastStatsSync;
+@property (nonatomic, strong, readwrite, nullable) NSString *lastUpdateWarning;
 @property (nonatomic, assign, readwrite) BOOL visible;
-@property (nonatomic, weak, readwrite) NSNumber *isActivated;
-@property (nonatomic, strong, readwrite) NSDictionary *options;
-@property (nonatomic, strong, readwrite) NSSet *postTypes;
-@property (nonatomic, strong, readwrite) NSDictionary *postFormats;
-@property (nonatomic, strong, readwrite) WPAccount *account;
-@property (nonatomic, strong, readwrite) WPAccount *jetpackAccount;
-@property (nonatomic, strong, readwrite) WPAccount *accountForDefaultBlog;
+@property (nonatomic, weak, readwrite, nullable) NSNumber *isActivated;
+@property (nonatomic, strong, readwrite, nullable) NSDictionary *options;
+@property (nonatomic, strong, readwrite, nullable) NSSet *postTypes;
+@property (nonatomic, strong, readwrite, nullable) NSDictionary *postFormats;
+@property (nonatomic, strong, readwrite, nullable) WPAccount *account;
+@property (nonatomic, strong, readwrite, nullable) WPAccount *jetpackAccount;
+@property (nonatomic, strong, readwrite, nullable) WPAccount *accountForDefaultBlog;
 @property (nonatomic, assign, readwrite) BOOL videoPressEnabled;
 @property (nonatomic, assign, readwrite) BOOL isMultiAuthor;
 @property (nonatomic, assign, readwrite) BOOL isHostedAtWPcom;
-@property (nonatomic, strong, readwrite) NSString *icon;
+@property (nonatomic, strong, readwrite, nullable) NSString *icon;
 @property (nonatomic, assign, readwrite) SiteVisibility siteVisibility;
-@property (nonatomic, strong, readwrite) NSNumber *planID;
-@property (nonatomic, strong, readwrite) NSSet *sharingButtons;
-@property (nonatomic, strong, readwrite) NSDictionary *capabilities;
+@property (nonatomic, strong, readwrite, nullable) NSNumber *planID;
+@property (nonatomic, strong, readwrite, nullable) NSSet *sharingButtons;
+@property (nonatomic, strong, readwrite, nullable) NSDictionary *capabilities;
 
 
 /**
  *  @details    Maps to a BlogSettings instance, which contains a collection of the available preferences, 
  *              and their values.
  */
-@property (nonatomic, strong, readwrite) BlogSettings *settings;
+@property (nonatomic, strong, readwrite, nullable) BlogSettings *settings;
 
 /**
  *  @details    Flags whether the current user is an admin on the blog.
@@ -112,23 +114,23 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
  *
  *  @warn       For WordPress.com or Jetpack Managed sites this will be nil. Use usernameForSite instead
  */
-@property (nonatomic, strong, readwrite) NSString       *username;
-@property (nonatomic, strong, readwrite) NSString       *password;
+@property (nonatomic, strong, readwrite, nullable) NSString       *username;
+@property (nonatomic, strong, readwrite, nullable) NSString       *password;
 
 
 // Readonly Properties
-@property (nonatomic,   weak,  readonly) NSArray *sortedPostFormatNames;
-@property (nonatomic,   weak,  readonly) NSArray *sortedPostFormats;
-@property (nonatomic, strong,  readonly) WPXMLRPCClient *api;
-@property (nonatomic,   weak,  readonly) NSString       *version;
-@property (nonatomic, strong,  readonly) NSString       *authToken;
-@property (nonatomic, strong,  readonly) NSSet *allowedFileTypes;
-@property (nonatomic, copy, readonly) NSString *usernameForSite;
+@property (nonatomic,   weak,  readonly, nullable) NSArray *sortedPostFormatNames;
+@property (nonatomic,   weak,  readonly, nullable) NSArray *sortedPostFormats;
+@property (nonatomic, strong,  readonly, nullable) WPXMLRPCClient *api;
+@property (nonatomic,   weak,  readonly, nullable) NSString       *version;
+@property (nonatomic, strong,  readonly, nullable) NSString       *authToken;
+@property (nonatomic, strong,  readonly, nullable) NSSet *allowedFileTypes;
+@property (nonatomic, copy, readonly, nullable) NSString *usernameForSite;
 
 /**
  *  @details    Contains the Jetpack state. Returns nil if the blog options haven't been downloaded yet
  */
-@property (nonatomic, strong,  readonly) JetpackState *jetpack;
+@property (nonatomic, strong,  readonly, nullable) JetpackState *jetpack;
 
 
 /**
@@ -137,18 +139,18 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 
 // User to display the blog url to the user (IDN decoded, no http:)
 // wp.koke.me/sub
-@property (weak, readonly) NSString *displayURL;
+@property (weak, readonly, nullable) NSString *displayURL;
 // alias of displayURL
 // kept for compatibilty, used as a key to store passwords
-@property (weak, readonly) NSString *hostURL;
-@property (weak, readonly) NSString *homeURL;
+@property (weak, readonly, nullable) NSString *hostURL;
+@property (weak, readonly, nullable) NSString *homeURL;
 // http://wp.koke.me/sub
-@property (nonatomic, strong) NSString *url;
+@property (nonatomic, strong, nullable) NSString *url;
 // Used for reachability checks (IDN encoded)
 // wp.koke.me
-@property (weak, readonly) NSString *hostname;
+@property (weak, readonly, nullable) NSString *hostname;
 
-@property (weak, readonly) NSString *defaultPostFormatText;
+@property (weak, readonly, nullable) NSString *defaultPostFormatText;
 
 #pragma mark - Blog information
 - (BOOL)isPrivate;
@@ -190,6 +192,16 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
  
  @return a WordPressComApi object if available
  */
-- (WordPressComApi *)restApi;
+- (nullable WordPressComApi *)restApi;
+
+/**
+ Call this method to obtain a WPComAccount associated with this blog, be it the jetpack or
+ non-jetpack.
+ 
+ @return The associated account.
+ */
+- (nullable WPAccount *)wpComAccount;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -657,4 +657,11 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
     return optionValue;
 }
 
+#pragma mark - Account info
+
+- (nullable WPAccount *)wpComAccount
+{
+    return self.account ? self.account : self.jetpackAccount;
+}
+
 @end

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -63,10 +63,16 @@ public class SharingService : LocalCoreDataService
     ///
     public func syncPublicizeConnectionsForBlog(blog: Blog, success: (() -> Void)?, failure: (NSError! -> Void)?) {
         let blogObjectID = blog.objectID
+        
+        guard let dotComID = blog.dotComID else {
+            preconditionFailure("Expected a dotComID.")
+        }
+        
         guard let remote = remoteForBlog(blog) else {
             return
         }
-        remote.getPublicizeConnections(blog.dotComID, success: {(remoteConnections:[RemotePublicizeConnection]) in
+        
+        remote.getPublicizeConnections(dotComID, success: {(remoteConnections:[RemotePublicizeConnection]) in
 
             // Process the results
             self.mergePublicizeConnectionsForBlog(blogObjectID, remoteConnections: remoteConnections, onComplete: success)
@@ -93,11 +99,17 @@ public class SharingService : LocalCoreDataService
         success: (PublicizeConnection -> Void)?,
         failure: (NSError! -> Void)?)
     {
-        let blogObjectID = blog.objectID
         guard let remote = remoteForBlog(blog) else {
             return
         }
-        let dotComID = blog.dotComID
+        
+        guard let dotComID = blog.dotComID else {
+            assertionFailure("Expected a dotComID")
+            return
+        }
+        
+        let blogObjectID = blog.objectID
+        
         remote.createPublicizeConnection(dotComID,
             keyringConnectionID: keyring.keyringID,
             externalUserID: externalUserID,
@@ -546,12 +558,18 @@ public class SharingService : LocalCoreDataService
     ///     - failure: An optional failure block accepting an `NSError` parameter.
     ///
     public func syncSharingButtonsForBlog(blog: Blog, success: (() -> Void)?, failure: (NSError! -> Void)?) {
-        let blogObjectID = blog.objectID
         guard let remote = remoteForBlog(blog) else {
             return
         }
+        
+        guard let dotComID = blog.dotComID else {
+            assertionFailure("Expected a dotComID")
+            return
+        }
+        
+        let blogObjectID = blog.objectID
 
-        remote.getSharingButtonsForSite(blog.dotComID,
+        remote.getSharingButtonsForSite(dotComID,
             success: { (remoteButtons:[RemoteSharingButton]) in
                 self.mergeSharingButtonsForBlog(blogObjectID, remoteSharingButtons: remoteButtons, onComplete: success)
             },
@@ -570,12 +588,18 @@ public class SharingService : LocalCoreDataService
     ///     - failure: An optional failure block accepting an `NSError` parameter.
     ///
     public func updateSharingButtonsForBlog(blog: Blog, sharingButtons: [SharingButton], success: (() -> Void)?, failure: (NSError! -> Void)?) {
-
-        let blogObjectID = blog.objectID
         guard let remote = remoteForBlog(blog) else {
             return
         }
-        remote.updateSharingButtonsForSite(blog.dotComID,
+        
+        guard let dotComID = blog.dotComID else {
+            assertionFailure("Expected a dotComID")
+            return
+        }
+        
+        let blogObjectID = blog.objectID
+        
+        remote.updateSharingButtonsForSite(dotComID,
             sharingButtons: remoteShareButtonsFromShareButtons(sharingButtons),
             success: { (remoteButtons:[RemoteSharingButton]) in
                 self.mergeSharingButtonsForBlog(blogObjectID, remoteSharingButtons: remoteButtons, onComplete: success)

--- a/WordPress/Classes/Services/SiteManagementService.swift
+++ b/WordPress/Classes/Services/SiteManagementService.swift
@@ -27,7 +27,13 @@ public class SiteManagementService : LocalCoreDataService
         guard let remote = siteManagementServiceRemoteForBlog(blog) else {
             return
         }
-        remote.deleteSite(blog.dotComID,
+        
+        guard let dotComID = blog.dotComID else {
+            assertionFailure("Expected a dotComID.")
+            return
+        }
+        
+        remote.deleteSite(dotComID,
             success: {
                 self.managedObjectContext.performBlock {
                     let blogService = BlogService(managedObjectContext: self.managedObjectContext)
@@ -56,7 +62,13 @@ public class SiteManagementService : LocalCoreDataService
         guard let remote = siteManagementServiceRemoteForBlog(blog) else {
             return
         }
-        remote.exportContent(blog.dotComID,
+        
+        guard let dotComID = blog.dotComID else {
+            assertionFailure("Expected a dotComID.")
+            return
+        }
+        
+        remote.exportContent(dotComID,
             success: {
                 success?()
             },
@@ -76,7 +88,13 @@ public class SiteManagementService : LocalCoreDataService
         guard let remote = siteManagementServiceRemoteForBlog(blog) else {
             return
         }
-        remote.getActivePurchases(blog.dotComID,
+        
+        guard let dotComID = blog.dotComID else {
+            assertionFailure("Expected a dotComID.")
+            return
+        }
+        
+        remote.getActivePurchases(dotComID,
             success: { purchases in
                 success?(purchases)
             },

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -601,7 +601,12 @@ public class DiscussionSettingsViewController : UITableViewController
     
     // MARK: - Computed Properties
     private var settings : BlogSettings {
-        return blog.settings
+        
+        guard let settings = blog.settings else {
+            preconditionFailure("Failed to obtain the blog settings.")
+        }
+        
+        return settings
     }
     
     // MARK: - Typealiases

--- a/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
@@ -87,9 +87,14 @@ public class LanguageViewController : UITableViewController
     
     // MARK: - Private Methods
     private func configureTableViewCell(cell: UITableViewCell) {
-        let languageId = blog.settings.languageID.integerValue
         cell.textLabel?.text = NSLocalizedString("Language", comment: "Language of the current blog")
-        cell.detailTextLabel?.text = languageDatabase.nameForLanguageWithId(languageId)
+        
+        if let languageId = blog.settings?.languageID.integerValue {
+            cell.detailTextLabel?.text = languageDatabase.nameForLanguageWithId(languageId)
+        } else {
+            cell.detailTextLabel?.text = NSLocalizedString("Unknown",
+                                                           comment: "Shown in the language selection cell when we can't figure out the blog's configured language.")
+        }
     }
     
     private func pressedLanguageRow() {
@@ -107,7 +112,7 @@ public class LanguageViewController : UITableViewController
         // Setup ListPickerViewController
         let listViewController = SettingsListPickerViewController(headers: headers, titles: titles, subtitles: subtitles, values: values)
         listViewController.title = NSLocalizedString("Site Language", comment: "Title for the Language Picker View")
-        listViewController.selectedValue = blog.settings.languageID
+        listViewController.selectedValue = blog.settings?.languageID
         listViewController.onChange = { [weak self] (selected: AnyObject) in
             guard let newLanguageID = selected as? NSNumber else {
                 return

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -146,7 +146,7 @@ import WordPressShared
         row.configureCell = {[unowned self] (cell: UITableViewCell) in
             cell.editingAccessoryType = .DisclosureIndicator
             cell.textLabel?.text = self.labelTitle
-            cell.detailTextLabel?.text = self.blog.settings.sharingLabel
+            cell.detailTextLabel?.text = self.blog.settings?.sharingLabel
         }
         section.rows = [row]
         return section

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteSettingsViewController+SiteManagement.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteSettingsViewController+SiteManagement.swift
@@ -10,19 +10,22 @@ public extension SiteSettingsViewController
     ///
     public func confirmExportContent() {
         tableView.deselectSelectedRowWithAnimation(true)
-
-        WPAppAnalytics.track(.SiteSettingsExportSiteAccessed, withBlog: self.blog)
-        presentViewController(confirmExportController(), animated: true, completion: nil)
+        
+        if let email = blog.wpComAccount()?.email {
+            WPAppAnalytics.track(.SiteSettingsExportSiteAccessed, withBlog: self.blog)
+            presentViewController(confirmExportController(email), animated: true, completion: nil)
+        }
     }
 
     /// Creates confirmation alert for Export Content
     ///
     /// - Returns: UIAlertController
     ///
-    private func confirmExportController() -> UIAlertController {
+    private func confirmExportController(email: String) -> UIAlertController {
+        
         let confirmTitle = NSLocalizedString("Export Your Content", comment: "Title of Export Content confirmation alert")
         let messageFormat = NSLocalizedString("Your posts, pages, and settings will be mailed to you at %@.", comment: "Message of Export Content confirmation alert; substitution is user's email address")
-        let message = String(format: messageFormat, blog.account.email)
+        let message = String(format: messageFormat, email)
         let alertController = UIAlertController(title: confirmTitle, message: message, preferredStyle: .Alert)
         
         let cancelTitle = NSLocalizedString("Cancel", comment: "Alert dismissal title")

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
@@ -92,10 +92,13 @@ public class StartOverViewController: UITableViewController
 
         WPAppAnalytics.track(.SiteSettingsStartOverContactSupportClicked, withBlog: blog)
         if HelpshiftUtils.isHelpshiftEnabled() {
-            setupHelpshift(blog.account)
             
-            let metadata = helpshiftMetadata(blog)
-            HelpshiftSupport.showConversation(self, withOptions: metadata)
+            if let account = blog.wpComAccount() {
+                setupHelpshift(account)
+                
+                let metadata = helpshiftMetadata(blog)
+                HelpshiftSupport.showConversation(self, withOptions: metadata)
+            }
         } else {
             if let contact = NSURL(string: "https://support.wordpress.com/contact/") {
                 UIApplication.sharedApplication().openURL(contact)

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -8,8 +8,13 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
     public var blog: Blog?
     
     private lazy var resultsController: NSFetchedResultsController = {
+        
+        guard let dotComID = self.blog?.dotComID else {
+            preconditionFailure("Failed to obtain a dotComID.")
+        }
+        
         let request = NSFetchRequest(entityName: "Person")
-        request.predicate = NSPredicate(format: "siteID = %@", self.blog!.dotComID)
+        request.predicate = NSPredicate(format: "siteID = %@", dotComID)
         // FIXME(@koke, 2015-11-02): my user should be first
         request.sortDescriptors = [NSSortDescriptor(key: "displayName", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:)))]
         let context = ContextManager.sharedInstance().mainContext

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -244,11 +244,16 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
     static let restorationIdentifier = "PlanList"
 
     convenience init?(blog: Blog) {
-        precondition(blog.dotComID != nil)
+        
+        guard let dotComID = blog.dotComID else {
+            preconditionFailure("Expected a dotComID.")
+        }
+        
         guard let service = PlanService(blog: blog, store: StoreKitStore()) else {
             return nil
         }
-        self.init(siteID: Int(blog.dotComID), service: service)
+        
+        self.init(siteID: Int(dotComID), service: service)
     }
 
     let siteID: Int


### PR DESCRIPTION
### Description:

Adds nullability information to `Blog.h`, in order to make sure that we're correctly treating access to its properties and methods.

### Details:

When accessing Objective-C properties, parameters and return values that don't have nullability information available from Swift code, Xcode assumes those methods and properties to be IUOs.  In fact we can treat them as both optionals or non-optionals and Xcode will not give any warning to us about their usage.

This is dangerous, and this PR aims to provide Xcode with more information so that it will treat these properties, params and return values as either optionals or non-optionals.

### What's inside the scope of this PR:

- Adding appropriate nullability information for all methods and properties in `Blog.h`.
- Reviewing our previous code to make any force-unwrapping **explicit**, thus raising awareness of spots were we need to improve our code.
- Reviewers should make sure there are no logic changes in the code.  At all.

### What's NOT inside the scope of this PR:

- Fixing the now-explicit force-unwrap calls with proper unwrapping:  there are several reason why I'm leaving this out of this PR purposedly:
    - This PR is not really adding those force-unwrap calls, just making them explicit.
    - The amount of force-unwrap calls make it risky to try and fix everything in this PR.  The new code is no worse than the old code... in fact it's better since now we know we're force-unwrapping.
    - The fix may not be the same for all the cases we have.  We may find mechanisms to make some of these properties and methods non-optional, and some others will need regular unwrapping.  Handling each case atomically is the best option.

### Changes:

- Added nullability info to `Blog.h`.  All properties were marked `nullable`, while methods were analyzed case-by-case.
- Added explicit force-unwrapping were necessary.

### Test:

- Make sure that there are no logic changes in the code.
- Make sure all previously implicit force-unwraps are now explicit.
- Build the app, make sure it builds and run.
- Run the unit tests.

Needs review: @SergioEstevao 
