### PR TITLE
Check the arguments instead of the ivars on ServiceRemoteXMLRPC init

### DIFF
--- a/WordPress/Classes/Networking/ServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/ServiceRemoteXMLRPC.m
@@ -14,7 +14,9 @@
 - (id)initWithApi:(WPXMLRPCClient *)api username:(NSString *)username password:(NSString *)password
 {
     NSParameterAssert(api != nil);
-    if (_username == nil || _password == nil) {
+    NSParameterAssert(username != nil);
+    NSParameterAssert(password != nil);
+    if (username == nil || password == nil) {
         return nil;
     }
 


### PR DESCRIPTION

Needs review: @koke 

