### PR TITLE
Switch to media library if no permission is given to access the devic…

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -125,7 +125,18 @@
 - (void)loadDataWithSuccess:(WPMediaSuccessBlock)successBlock
                     failure:(WPMediaFailureBlock)failureBlock
 {
-    [self.currentDataSource loadDataWithSuccess:successBlock failure:failureBlock];
+    [self.currentDataSource loadDataWithSuccess:successBlock failure:^(NSError *error) {
+        if ([error.domain isEqualToString:WPMediaPickerErrorDomain] && error.code == WPMediaErrorCodePermissionsFailed) {
+            if (self.currentDataSource == self.deviceLibraryDataSource) {                
+                self.currentDataSource = self.mediaLibraryDataSource;
+                [self loadDataWithSuccess:successBlock failure:failureBlock];
+                return;
+            }
+        }
+        if (failureBlock) {
+            failureBlock(error);
+        }
+    }];
 }
 
 - (void)addImage:(UIImage *)image metadata:(NSDictionary *)metadata completionBlock:(WPMediaAddedBlock)completionBlock


### PR DESCRIPTION
Fixes #5261 

To test:
 - Block the access to the photo library for the WordPress app
 - Create a new post on the app
 - Try to add a media object
 - Check if the WordPress media library shows up even if you don't access to the device library.



Needs review: @aerych 