### PR TITLE
Make cell selection style None.

### DIFF
--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -177,6 +177,7 @@ struct MediaSizeRow: ImmuTableRow {
         cell.title = title
         cell.value = value
         cell.onChange = onChange
+        cell.selectionStyle = .None
 
         (cell.minValue, cell.maxValue) = MediaSettings().allowedImageSizeRange
     }


### PR DESCRIPTION
Fixes #5260 

To test:

 - Go to Me -> App Settings
 - Tap on Max Image Upload Size
 - Check that cell is not selected.

Needs review: @aerych 

