### PR TITLE
Fixing Crash after SignUp

### DIFF
--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -36,17 +36,17 @@ static NSString * const RemoteBlogRelatedPostsEnabledKey                    = @"
 static NSString * const RemoteBlogRelatedPostsShowHeadlineKey               = @"jetpack_relatedposts_show_headline";
 static NSString * const RemoteBlogRelatedPostsShowThumbnailsKey             = @"jetpack_relatedposts_show_thumbnails";
 
-static NSString * const RemoteBlogSharingButtonStyle = @"sharing_button_style";
-static NSString * const RemoteBlogSharingLabel = @"sharing_label";
-static NSString * const RemoteBlogSharingTwitterName = @"twitter_via";
-static NSString * const RemoteBlogSharingCommentLikesEnabled = @"jetpack_comment_likes_enabled";
-static NSString * const RemoteBlogSharingDisabledLikes = @"disabled_likes";
-static NSString * const RemoteBlogSharingDisabledReblogs = @"disabled_reblogs";
+static NSString * const RemoteBlogSharingButtonStyle                        = @"sharing_button_style";
+static NSString * const RemoteBlogSharingLabel                              = @"sharing_label";
+static NSString * const RemoteBlogSharingTwitterName                        = @"twitter_via";
+static NSString * const RemoteBlogSharingCommentLikesEnabled                = @"jetpack_comment_likes_enabled";
+static NSString * const RemoteBlogSharingDisabledLikes                      = @"disabled_likes";
+static NSString * const RemoteBlogSharingDisabledReblogs                    = @"disabled_reblogs";
 
-static NSString * const RemotePostTypesKey = @"post_types";
-static NSString * const RemotePostTypeNameKey = @"name";
-static NSString * const RemotePostTypeLabelKey = @"label";
-static NSString * const RemotePostTypeQueryableKey = @"api_queryable";
+static NSString * const RemotePostTypesKey                                  = @"post_types";
+static NSString * const RemotePostTypeNameKey                               = @"name";
+static NSString * const RemotePostTypeLabelKey                              = @"label";
+static NSString * const RemotePostTypeQueryableKey                          = @"api_queryable";
 
 #pragma mark - Keys used for Update Calls
 // Note: Only god knows why these don't match the "Parsing Keys"

--- a/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
@@ -491,11 +491,7 @@ static UIEdgeInsets const CreateBlogCancelButtonPaddingPad  = {1.0, 13.0, 0.0, 0
             [WPAnalytics track:WPAnalyticsStatCreatedAccount];
             [operation didSucceed];
             
-            NSMutableDictionary *blogOptions = [[responseDictionary dictionaryForKey:@"blog_details"] mutableCopy];
-            if ([blogOptions objectForKey:@"blogname"]) {
-                [blogOptions setObject:[blogOptions objectForKey:@"blogname"] forKey:@"blogName"];
-                [blogOptions removeObjectForKey:@"blogname"];
-            }
+            NSDictionary *blogOptions = [responseDictionary dictionaryForKey:@"blog_details"];
             
             NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
             AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
@@ -509,7 +505,7 @@ static UIEdgeInsets const CreateBlogCancelButtonPaddingPad  = {1.0, 13.0, 0.0, 0
             }
             blog.dotComID = [blogOptions numberForKey:@"blogid"];
             blog.url = blogOptions[@"url"];
-            blog.settings.name = [blogOptions[@"blogname"] stringByDecodingXMLCharacters];
+            blog.settings.name = [[blogOptions stringForKey:@"blogname"] stringByDecodingXMLCharacters];
             defaultAccount.defaultBlog = blog;
             
             [[ContextManager sharedInstance] saveContext:context];

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -852,11 +852,7 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
             [WPAnalytics track:WPAnalyticsStatCreatedAccount];
             [operation didSucceed];
 
-            NSMutableDictionary *blogOptions = [[responseDictionary dictionaryForKey:@"blog_details"] mutableCopy];
-            if ([blogOptions objectForKey:@"blogname"]) {
-                [blogOptions setObject:[blogOptions objectForKey:@"blogname"] forKey:@"blogName"];
-                [blogOptions removeObjectForKey:@"blogname"];
-            }
+            NSDictionary *blogOptions = [responseDictionary dictionaryForKey:@"blog_details"];
 
             NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
             AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
@@ -870,7 +866,7 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
             }
             blog.dotComID = [blogOptions numberForKey:@"blogid"];
             blog.url = blogOptions[@"url"];
-            blog.settings.name = [blogOptions[@"blogname"] stringByDecodingXMLCharacters];
+            blog.settings.name = [[blogOptions stringForKey:@"blogname"] stringByDecodingXMLCharacters];
             defaultAccount.defaultBlog = blog;
 
             [[ContextManager sharedInstance] saveContext:context];


### PR DESCRIPTION
Fixes #5347

To test:
1. If you are logged in, disconnect from WordPress.com
2. Select Create Account
3. Enter valid details to create a new account and submit them

As a result the app should no longer crash. Both, the Widget and Share Extension should be properly wired.

Needs review: @astralbodies 

