### PR TITLE
Fix missing analytics

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -782,6 +782,12 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         case WPAnalyticsStatLoginMagicLinkRequested:
         case WPAnalyticsStatLoginMagicLinkSucceeded:
 
+            // to be implemented
+        case WPAnalyticsStatOpenedPeople:
+        case WPAnalyticsStatOpenedPerson:
+        case WPAnalyticsStatPersonRemoved:
+        case WPAnalyticsStatPersonUpdated:
+
         case WPAnalyticsStatDefaultAccountChanged:
         case WPAnalyticsStatNoStat:
         case WPAnalyticsStatPerformedCoreDataMigrationFixFor45:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -155,6 +155,9 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
     NSDictionary *eventProperties;
     
     switch (stat) {
+        case WPAnalyticsStatABTestStart:
+            eventName = @"abtest_start";
+            break;
         case WPAnalyticsStatAddedSelfHostedSite:
             eventName = @"self_hosted_blog_added";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -962,6 +962,11 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatLoginMagicLinkRequested:
         case WPAnalyticsStatLoginMagicLinkSucceeded:
 
+            // To be implemented
+        case WPAnalyticsStatOpenedPeople:
+        case WPAnalyticsStatOpenedPerson:
+        case WPAnalyticsStatPersonRemoved:
+        case WPAnalyticsStatPersonUpdated:
 
         case WPAnalyticsStatAppUpgraded:
         case WPAnalyticsStatDefaultAccountChanged:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -249,6 +249,9 @@ NSString *const SessionCount = @"session_count";
     WPAnalyticsTrackerMixpanelInstructionsForStat *instructions;
 
     switch (stat) {
+        case WPAnalyticsStatABTestStart:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"AB Test - Started"];
+            break;
         case WPAnalyticsStatApplicationOpened:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Application Opened"];
             [instructions setPeoplePropertyToIncrement:@"Application Opened"];


### PR DESCRIPTION
#5321 updated WordPressCom-Analytics-iOS to 0.1.11, but didn't handle all the new stat values.

I've cherry-picked the A/B test one from #5226, but I'm not sure of the values for the People related stats, so I left those to be implemented.

@jleandroperez I'm merging this right away to fix the broken tests in develop, but please take a look at those People stats when you have a minute and handle them properly