### PR TITLE
Removes whitespace flagged by the linter.

### DIFF
--- a/WordPress/Classes/Services/SignupService.swift
+++ b/WordPress/Classes/Services/SignupService.swift
@@ -33,8 +33,8 @@ public class SignupService : LocalCoreDataService
     private let URLKey = "url"
 
 
-    /// Starts the process of creating a new blog and wpcom account for the user. 
-    /// 
+    /// Starts the process of creating a new blog and wpcom account for the user.
+    ///
     /// - Parameters:
     ///     - url: The url for the new wpcom site
     ///     - blogTitle: The title of the blog
@@ -57,8 +57,8 @@ public class SignupService : LocalCoreDataService
         // Organize parameters into a struct for easy sharing
         let params = SignupParams(url: url, title: blogTitle, email: emailAddress, username: username, password: password)
 
-        // Create call back blocks for the various methods we'll call to create the user account and blog. 
-        // Each success block calls the next step in the process. 
+        // Create call back blocks for the various methods we'll call to create the user account and blog.
+        // Each success block calls the next step in the process.
         // NOTE: The steps below are constructed in reverse order.
 
         let createWPComBlogSuccessBlock = { (blog: Blog) in
@@ -89,8 +89,8 @@ public class SignupService : LocalCoreDataService
 
     /// Validates that the blog can be created and is not already taken.
     ///
-    /// - Paramaters: 
-    ///     - params: Account and blog information with which to sign up the user. 
+    /// - Paramaters:
+    ///     - params: Account and blog information with which to sign up the user.
     ///     - status: The status callback
     ///     - success: A success calback
     ///     - failure: A failure callback
@@ -233,7 +233,7 @@ public class SignupService : LocalCoreDataService
                                             }
 
                                             guard let blog = self.createBlogFromBlogOptions(blogOptions, failure: failure) else {
-                                                // No need to call the failure block here. It will be called from 
+                                                // No need to call the failure block here. It will be called from
                                                 // `createBlogFromBlogOptions` if needed.
                                                 return
                                             }
@@ -272,7 +272,7 @@ public class SignupService : LocalCoreDataService
     /// failure block if the blog can not be created.
     ///
     /// - Parameters:
-    ///     - blogOptions: A dictionary of blog options. 
+    ///     - blogOptions: A dictionary of blog options.
     ///     - failure: A failure block.
     ///
     /// - Returns: A blog or nil.
@@ -330,7 +330,7 @@ public class SignupService : LocalCoreDataService
     // MARK: Private Instance Methods
 
 
-    /// An internal struct for conveniently sharing params between the different 
+    /// An internal struct for conveniently sharing params between the different
     /// sign up steps.
     ///
     struct SignupParams {

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -29,7 +29,7 @@ import WordPressComAnalytics
     // Helper used by the app delegate
     class func showSigninFromPresenter(presenter: UIViewController, animated: Bool, thenEditor: Bool) {
         if useNewSigninFlow() {
-            let controller = SigninEmailViewController.controller();
+            let controller = SigninEmailViewController.controller()
             controller.dismissBlock = {(cancelled) in
                 // Show the editor if requested, and we weren't cancelled.
                 if !cancelled && thenEditor {
@@ -65,7 +65,7 @@ import WordPressComAnalytics
     // Helper used by the MeViewController
     class func showSigninForJustWPComFromPresenter(presenter: UIViewController) {
         if useNewSigninFlow() {
-            let controller = SigninEmailViewController.controller();
+            let controller = SigninEmailViewController.controller()
             controller.restrictSigninToWPCom = true
 
             let navController = NUXNavigationController(rootViewController: controller)
@@ -286,7 +286,7 @@ import WordPressComAnalytics
     }
 
 
-    /// Checks whether credentials have been populated. 
+    /// Checks whether credentials have been populated.
     /// Note: that loginFields.emailAddress is not checked. Use loginFields.username instead.
     ///
     /// - Parameter loginFields: An instance of LoginFields to check

--- a/WordPress/Classes/ViewRelated/NUX/SigninKeyboardResponder.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninKeyboardResponder.swift
@@ -47,8 +47,8 @@ extension SigninKeyboardResponder where Self: NUXAbstractViewController
     }
 
 
-    /// Returns the vertical offset to apply to the sign in form. 
-    /// 
+    /// Returns the vertical offset to apply to the sign in form.
+    ///
     /// - Returns: DefaultSigninFormVerticalOffset unless a conforming controller provides its own implementation.
     ///
     func signinFormVerticalOffset() -> CGFloat {

--- a/WordPress/Classes/ViewRelated/NUX/SigninWPComViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninWPComViewController.swift
@@ -219,7 +219,7 @@ import WordPressShared
     }
 
 
-    /// Shows a prompt to the user regarding a reserved username. 
+    /// Shows a prompt to the user regarding a reserved username.
     ///
     /// - Parameters:
     ///     - username: The username that was entered.

--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -309,7 +309,7 @@ import WordPressShared
 
 
     /// Because the signup form is larger than the average sign in form and has
-    /// a header, we want to tweak the vertical offset a bit rather than use 
+    /// a header, we want to tweak the vertical offset a bit rather than use
     /// the default.
     /// However, on a small screen we remove some UI elements so return the default size.
     ///
@@ -359,7 +359,7 @@ import WordPressShared
 
     /// Display a status message for the specified SignupStatus
     ///
-    /// - Paramaters: 
+    /// - Paramaters:
     ///     - status: SignupStatus
     ///
     func displayLoginMessageForStatus(status: SignupStatus) {
@@ -450,13 +450,13 @@ import WordPressShared
 
 
     // MARK: - Keyboard Notifications
-    
-    
+
+
     func handleKeyboardWillShow(notification: NSNotification) {
         keyboardWillShow(notification)
     }
-    
-    
+
+
     func handleKeyboardWillHide(notification: NSNotification) {
         keyboardWillHide(notification)
     }
@@ -497,7 +497,7 @@ extension SignupViewController: UITextFieldDelegate {
         if textField != usernameField || userDefinedSiteAddress {
             return
         }
-        // If the user has not customized the site name, then let it match the 
+        // If the user has not customized the site name, then let it match the
         // username they chose.
         loginFields.siteUrl = loginFields.username
         siteURLField.text = loginFields.username


### PR DESCRIPTION
(also semicolons) 

No trailing space shall escape our linter's wrath. 

Needs review: @diegoreymendez 