### PR TITLE
PlanDetail: Fixes a visual glitch when PurchaseButton animates.

### DIFF
--- a/WordPress/Classes/ViewRelated/Plans/PurchaseButton.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PurchaseButton.swift
@@ -41,6 +41,13 @@ class PurchaseButton: RoundedButton {
                     self.cornerRadius = self.bounds.height / 2
                     self.titleLabel?.alpha = 0
 
+                    // Ask the superview to layout if necessary, because the 
+                    // button has changed size. This is required otherwise
+                    // we were seeing an animation glitch where the superview's
+                    // constraints weren't animating correctly to contain the 
+                    // button as it changed size.
+                    // See https://github.com/wordpress-mobile/WordPress-iOS/pull/5361
+                    // for more info.
                     self.superview?.layoutIfNeeded()
                     }, completion:  { finished in
                         self.activityIndicatorView.startAnimating()
@@ -55,6 +62,7 @@ class PurchaseButton: RoundedButton {
                     self.cornerRadius = self._cornerRadius
                     self.borderWidth = 1
 
+                    // See comment above
                     self.superview?.layoutIfNeeded()
                     }, completion:  { finished in
                         self.titleLabel?.alpha = 1

--- a/WordPress/Classes/ViewRelated/Plans/PurchaseButton.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PurchaseButton.swift
@@ -41,7 +41,7 @@ class PurchaseButton: RoundedButton {
                     self.cornerRadius = self.bounds.height / 2
                     self.titleLabel?.alpha = 0
 
-                    self.layoutIfNeeded()
+                    self.superview?.layoutIfNeeded()
                     }, completion:  { finished in
                         self.activityIndicatorView.startAnimating()
                         self.borderWidth = 0
@@ -55,7 +55,7 @@ class PurchaseButton: RoundedButton {
                     self.cornerRadius = self._cornerRadius
                     self.borderWidth = 1
 
-                    self.layoutIfNeeded()
+                    self.superview?.layoutIfNeeded()
                     }, completion:  { finished in
                         self.titleLabel?.alpha = 1
                 })


### PR DESCRIPTION
This PR fixes an issue where the purchase button doesn't animate correctly when entering / exiting the selected state. Before (green highlight just to help debugging):

![purchase-broken](https://cloud.githubusercontent.com/assets/4780/15208496/c219970a-1823-11e6-9b21-1742ba2c77d6.gif)

After:

![purchase-fixed](https://cloud.githubusercontent.com/assets/4780/15208498/c4da98ae-1823-11e6-878f-b59142e00260.gif)

The PR simply changes the animation to tell the button's superview to layout if necessary (which in turn will layout the button), instead of just the button itself. Prior to this, I tried calling `invalidatesIntrinsicContentSize`, but that didn't do the trick. Asking the superview to layout feels a little dirty perhaps, but I've seen other situations in the past where it's been necessary too. I spent a while trying different ways to resolve this issue, and eventually figured that spending much extra looking for another solution wasn't worth it for such a relatively small issue. 

Needs review: @koke 