### PR TITLE
Removed an unnecessary log message.

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -91,8 +91,12 @@ NSString *const SessionCount = @"session_count";
 - (void)track:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties
 {
     WPAnalyticsTrackerMixpanelInstructionsForStat *instructions = [self instructionsForStat:stat];
+
     if (instructions == nil) {
-        DDLogInfo(@"No instructions, do nothing");
+        // Getting no instructions back means the tracker doesn't want to handle a specific event,
+        // so we can simply return.  This is intentional and allowed.
+        // - Diego Rey Mendez, 12 May 2016
+        //
         return;
     }
 


### PR DESCRIPTION
Fixes #5259.

### Details:

Events can be no-op for certain trackers.  This is allowed and perfectly fine.  I've removed the log message that was coming up since it's not really adding useful information, and looked a bit like a warning / error to the reader.

### Test:

Run the app and make sure the "No instructions, do nothing" log message doesn't come up anymore.

### Review:

Needs review: @astralbodies 
