### PR TITLE
Menus: MenuItems views for ordering and editing

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern CGFloat const MenuItemsStackableViewDefaultHeight;
 
 @protocol MenuItemDrawingViewDelegate <NSObject>
@@ -17,7 +19,7 @@ extern CGFloat const MenuItemsStackableViewDefaultHeight;
  */
 @interface MenuItemAbstractView : UIView <MenuItemDrawingViewDelegate>
 
-@property (nonatomic, weak) id <MenuItemAbstractViewDelegate> delegate;
+@property (nonatomic, weak, nullable) id <MenuItemAbstractViewDelegate> delegate;
 
 /**
  Content view in which most of the drawing and MenuItem content is setup in.
@@ -67,12 +69,12 @@ extern CGFloat const MenuItemsStackableViewDefaultHeight;
 /**
  Tracker for a stackableView appearing before this view in a stack.
 */
-@property (nonatomic, weak) MenuItemAbstractView *previous;
+@property (nonatomic, weak, nullable) MenuItemAbstractView *previous;
 
 /**
  Tracker for a stackableView appearing after this view in a stack.
  */
-@property (nonatomic, weak) MenuItemAbstractView *next;
+@property (nonatomic, weak, nullable) MenuItemAbstractView *next;
 
 /**
  Add an accessory button to the accessoryStackView.
@@ -108,3 +110,5 @@ extern CGFloat const MenuItemsStackableViewDefaultHeight;
  */
 - (void)itemView:(MenuItemAbstractView *)itemView highlighted:(BOOL)highlighted;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.h
@@ -1,0 +1,110 @@
+#import <UIKit/UIKit.h>
+
+extern CGFloat const MenuItemsStackableViewDefaultHeight;
+
+@protocol MenuItemDrawingViewDelegate <NSObject>
+- (void)drawingViewDrawRect:(CGRect)rect;
+@end
+
+@interface MenuItemDrawingView : UIView
+
+@end
+
+@protocol MenuItemAbstractViewDelegate;
+
+/**
+ An abstract view encapsulating work needed for representing editable MenuItems as found in MenuItemsViewController.
+ */
+@interface MenuItemAbstractView : UIView <MenuItemDrawingViewDelegate>
+
+@property (nonatomic, weak) id <MenuItemAbstractViewDelegate> delegate;
+
+/**
+ Content view in which most of the drawing and MenuItem content is setup in.
+ */
+@property (nonatomic, strong, readonly) MenuItemDrawingView *contentView;
+
+/**
+ The highlighted state.
+ */
+@property (nonatomic, assign) BOOL highlighted;
+
+/**
+ Toggles the drawing as a placeholder (dashed lines while ordering).
+ */
+@property (nonatomic, assign) BOOL isPlaceholder;
+
+/**
+ Toggles the drawing of the line separator.
+ */
+@property (nonatomic, assign) BOOL drawsLineSeparator;
+
+/**
+ The visual indentation for parent/child relationships.
+ */
+@property (nonatomic, assign) NSInteger indentationLevel;
+
+/**
+ The primary stackView.
+ */
+@property (nonatomic, strong, readonly) UIStackView *stackView;
+
+/**
+ The primary textLabel.
+ */
+@property (nonatomic, strong, readonly) UILabel *textLabel;
+
+/**
+ The primary icon imageView.
+ */
+@property (nonatomic, strong, readonly) UIImageView *iconView;
+
+/**
+ Accessory stackView used for secondary views on the right side.
+ */
+@property (nonatomic, strong, readonly) UIStackView *accessoryStackView;
+
+/**
+ Tracker for a stackableView appearing before this view in a stack.
+*/
+@property (nonatomic, weak) MenuItemAbstractView *previous;
+
+/**
+ Tracker for a stackableView appearing after this view in a stack.
+ */
+@property (nonatomic, weak) MenuItemAbstractView *next;
+
+/**
+ Add an accessory button to the accessoryStackView.
+ */
+- (void)addAccessoryButton:(UIButton *)button;
+
+/**
+ Add an accessory button with an image icon to the accessoryStackView.
+ */
+- (UIButton *)addAccessoryButtonIconViewWithImage:(UIImage *)image;
+
+/**
+ The backgroundColor the contentView should use for any highlighted state changes.
+ */
+- (UIColor *)contentViewBackgroundColor;
+
+/**
+ TextColor of the label during any any highlighted state changes.
+ */
+- (UIColor *)textLabelColor;
+
+/**
+ TintColor of the icon during any any highlighted state changes.
+ */
+- (UIColor *)iconTintColor;
+
+@end
+
+@protocol MenuItemAbstractViewDelegate <NSObject>
+
+/**
+ The highlighted state changed for the stackableView.
+ */
+- (void)itemView:(MenuItemAbstractView *)itemView highlighted:(BOOL)highlighted;
+@end

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.m
@@ -318,42 +318,42 @@ CGFloat const MenuItemsStackableViewDefaultHeight = 44.0;
     CGContextSetLineWidth(context, 1.0);
     
     const CGFloat dashLength = 6.0;
-    const CGFloat dashFillPercentage = 60; // fill % of the line with dashes, rest with white space
+    const CGFloat dashFillPercentage = 60; // Fill % of the line with dashes, rest with white space.
     
     CGFloat(^spacingForLineLength)(CGFloat) = ^ CGFloat (CGFloat lineLength) {
-        // calculate the white spacing needed to fill the full line with dashes
+        // Calculate the white spacing needed to fill the full line with dashes
         const CGFloat dashFill = (lineLength * dashFillPercentage) / 100;
-        //// the white spacing is proportionate to amount of space the dashes will take
-        //// uses (dashFill - dashLength) to ensure there is one extra dash to touch the end of the line
+        //// The white spacing is proportionate to amount of space the dashes will take.
+        //// Uses (dashFill - dashLength) to ensure there is one extra dash to touch the end of the line.
         return ((lineLength - dashFill) * dashLength) / (dashFill - dashLength);
     };
     
     const CGFloat pointOffset = 0.5;
-    {
-        CGFloat dash[2] = {dashLength, spacingForLineLength(dashRect.size.width)};
-        CGContextSetLineDash(context, 0, dash, 2);
-        
-        const CGFloat leftX = dashRect.origin.x - pointOffset;
-        const CGFloat rightX = dashRect.origin.x + dashRect.size.width + pointOffset;
-        CGContextMoveToPoint(context, leftX, dashRect.origin.y);
-        CGContextAddLineToPoint(context, rightX, dashRect.origin.y);
-        CGContextMoveToPoint(context, leftX, dashRect.origin.y + dashRect.size.height);
-        CGContextAddLineToPoint(context, rightX, dashRect.origin.y + dashRect.size.height);
-        CGContextStrokePath(context);
-        
-    }
-    {
-        CGFloat dash[2] = {dashLength, spacingForLineLength(dashRect.size.height)};
-        CGContextSetLineDash(context, 0, dash, 2);
-        
-        const CGFloat topY = dashRect.origin.y - pointOffset;
-        const CGFloat bottomY = dashRect.origin.y + dashRect.size.height + pointOffset;
-        CGContextMoveToPoint(context, dashRect.origin.x, topY);
-        CGContextAddLineToPoint(context, dashRect.origin.x, bottomY);
-        CGContextMoveToPoint(context, dashRect.origin.x + dashRect.size.width, topY);
-        CGContextAddLineToPoint(context, dashRect.origin.x + dashRect.size.width, bottomY);
-        CGContextStrokePath(context);
-    }
+
+    // Draw the dashed lines.
+    // First draw the horiztonal top and bottom lines, from left to right.
+    CGFloat topBottomDashes[2] = {dashLength, spacingForLineLength(dashRect.size.width)};
+    CGContextSetLineDash(context, 0, topBottomDashes, 2);
+    
+    const CGFloat leftX = dashRect.origin.x - pointOffset;
+    const CGFloat rightX = dashRect.origin.x + dashRect.size.width + pointOffset;
+    CGContextMoveToPoint(context, leftX, dashRect.origin.y);
+    CGContextAddLineToPoint(context, rightX, dashRect.origin.y);
+    CGContextMoveToPoint(context, leftX, dashRect.origin.y + dashRect.size.height);
+    CGContextAddLineToPoint(context, rightX, dashRect.origin.y + dashRect.size.height);
+    CGContextStrokePath(context);
+
+    // Second draw the vertical left and right lines, from top to bottom.
+    CGFloat leftRightDashes[2] = {dashLength, spacingForLineLength(dashRect.size.height)};
+    CGContextSetLineDash(context, 0, leftRightDashes, 2);
+    
+    const CGFloat topY = dashRect.origin.y - pointOffset;
+    const CGFloat bottomY = dashRect.origin.y + dashRect.size.height + pointOffset;
+    CGContextMoveToPoint(context, dashRect.origin.x, topY);
+    CGContextAddLineToPoint(context, dashRect.origin.x, bottomY);
+    CGContextMoveToPoint(context, dashRect.origin.x + dashRect.size.width, topY);
+    CGContextAddLineToPoint(context, dashRect.origin.x + dashRect.size.width, bottomY);
+    CGContextStrokePath(context);
 }
 
 #pragma mark - MenuItemDrawingViewDelegate

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.m
@@ -1,0 +1,379 @@
+#import "MenuItemAbstractView.h"
+#import "WPStyleGuide.h"
+#import "WPFontManager.h"
+#import "MenuItem+ViewDesign.h"
+
+@interface MenuItemDrawingView ()
+
+@property (nonatomic, weak) id <MenuItemDrawingViewDelegate> drawDelegate;
+
+@end
+
+@implementation MenuItemDrawingView
+
+- (void)drawRect:(CGRect)rect
+{
+    [self.drawDelegate drawingViewDrawRect:rect];
+}
+
+@end
+
+CGFloat const MenuItemsStackableViewDefaultHeight = 44.0;
+
+@interface MenuItemAbstractView ()
+
+@property (nonatomic, assign) BOOL showsReorderingOptions;
+@property (nonatomic, weak) NSLayoutConstraint *constraintForLeadingIndentation;
+
+@end
+
+@implementation MenuItemAbstractView
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        
+        self.translatesAutoresizingMaskIntoConstraints = NO;
+        self.backgroundColor = [UIColor whiteColor];
+        
+        _drawsLineSeparator = YES;
+        
+        [self setupContentView];
+        [self setupStackView];
+        [self setupIconView];
+        [self setupTextLabel];
+    }
+    
+    return self;
+}
+
+- (void)setupContentView
+{
+    MenuItemDrawingView *contentView = [[MenuItemDrawingView alloc] init];
+    contentView.drawDelegate = self;
+    contentView.translatesAutoresizingMaskIntoConstraints = NO;
+    contentView.tintColor = [self iconTintColor];
+    contentView.backgroundColor = [UIColor whiteColor];
+    
+    [self addSubview:contentView];
+    _contentView = contentView;
+    
+    NSLayoutConstraint *leadingConstraint = [contentView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor];
+    _constraintForLeadingIndentation = leadingConstraint;
+    leadingConstraint.active = YES;
+    
+    [NSLayoutConstraint activateConstraints:@[
+                                              [contentView.topAnchor constraintEqualToAnchor:self.topAnchor],
+                                              [contentView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+                                              [contentView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor]
+                                              ]];
+}
+
+- (void)setupStackView
+{
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    NSAssert(_contentView != nil, @"contentView is nil");
+    [_contentView addSubview:stackView];
+    
+    [NSLayoutConstraint activateConstraints:@[
+                                              [stackView.topAnchor constraintEqualToAnchor:_contentView.topAnchor],
+                                              [stackView.leadingAnchor constraintEqualToAnchor:_contentView.leadingAnchor],
+                                              [stackView.trailingAnchor constraintEqualToAnchor:_contentView.trailingAnchor],
+                                              [stackView.bottomAnchor constraintEqualToAnchor:_contentView.bottomAnchor]
+                                              ]];
+    
+    UIEdgeInsets margins = UIEdgeInsetsZero;
+    margins.top = 8.0;
+    margins.bottom = 8.0;
+    margins.left = MenusDesignDefaultContentSpacing;
+    margins.right = MenusDesignDefaultContentSpacing;
+    stackView.layoutMargins = margins;
+    stackView.layoutMarginsRelativeArrangement = YES;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.alignment = UIStackViewAlignmentCenter;
+    stackView.spacing = MenusDesignDefaultContentSpacing / 2.0;
+    
+    _stackView = stackView;
+}
+
+- (void)setupIconView
+{
+    UIImageView *iconView = [[UIImageView alloc] init];
+    iconView.translatesAutoresizingMaskIntoConstraints = NO;
+    iconView.contentMode = UIViewContentModeScaleAspectFit;
+    iconView.backgroundColor = [UIColor clearColor];
+    // width and height constraints are (less than or equal to) in case the view is hidden
+    [iconView.widthAnchor constraintLessThanOrEqualToConstant:MenusDesignItemIconSize].active = YES;
+    [iconView.heightAnchor constraintLessThanOrEqualToConstant:MenusDesignItemIconSize].active = YES;
+    iconView.tintColor = [WPStyleGuide grey];
+    _iconView = iconView;
+
+    NSAssert(_stackView != nil, @"stackView is nil");
+    [_stackView addArrangedSubview:iconView];
+}
+
+- (void)setupTextLabel
+{
+    UILabel *label = [[UILabel alloc] init];
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+    label.numberOfLines = 2;
+    label.textColor = [self textLabelColor];
+    label.font = [WPFontManager systemRegularFontOfSize:17.0];
+    label.backgroundColor = [UIColor clearColor];
+    
+    NSAssert(_stackView != nil, @"stackView is nil");
+    [_stackView addArrangedSubview:label];
+    
+    [label setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+    [label setContentCompressionResistancePriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+    
+    _textLabel = label;
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    /* Set the preferredMaxLayoutWidth to give a heads up to the constraint resolver.
+       This speeds things up when hiding views such as the accessoryStackView's arranged views.
+     */
+    self.textLabel.preferredMaxLayoutWidth = self.accessoryStackView.frame.origin.x - self.textLabel.frame.origin.x;
+}
+
+#pragma mark - instance
+
+- (void)setHighlighted:(BOOL)highlighted
+{
+    if (_highlighted != highlighted) {
+        _highlighted = highlighted;
+        
+        self.textLabel.textColor = [self textLabelColor];
+        self.iconView.tintColor = [self iconTintColor];
+        self.contentView.tintColor = [self iconTintColor];
+        self.contentView.backgroundColor = [self contentViewBackgroundColor];
+        [self.contentView setNeedsDisplay];
+        
+        [self.delegate itemView:self highlighted:highlighted];
+    }
+}
+
+- (void)setIsPlaceholder:(BOOL)isPlaceholder
+{
+    if (_isPlaceholder != isPlaceholder) {
+        _isPlaceholder = isPlaceholder;
+        self.contentView.alpha = isPlaceholder ? 0.45 : 1.0;
+        [self setNeedsDisplay];
+        [self.contentView setNeedsDisplay];
+    }
+}
+
+- (void)setDrawsLineSeparator:(BOOL)drawsLineSeparator
+{
+    if (_drawsLineSeparator != drawsLineSeparator) {
+        _drawsLineSeparator = drawsLineSeparator;
+        [self setNeedsDisplay];
+        [self.contentView setNeedsDisplay];
+    }
+}
+
+- (void)setIndentationLevel:(NSInteger)indentationLevel
+{
+    if (_indentationLevel != indentationLevel) {
+        _indentationLevel = indentationLevel;
+        self.constraintForLeadingIndentation.constant = (MenusDesignDefaultContentSpacing * indentationLevel);
+        [self setNeedsDisplay];
+        [self.contentView setNeedsDisplay];
+    }
+}
+
+- (void)addAccessoryButton:(UIButton *)button
+{
+    if (!self.accessoryStackView) {
+        UIStackView *stackView = [[UIStackView alloc] init];
+        stackView.translatesAutoresizingMaskIntoConstraints = NO;
+        stackView.distribution = UIStackViewDistributionFill;
+        [stackView setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
+        [stackView setContentHuggingPriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
+        [self.stackView addArrangedSubview:stackView];
+        _accessoryStackView = stackView;
+    }
+    
+    [self.accessoryStackView addArrangedSubview:button];
+    [self.accessoryStackView setNeedsLayout];
+}
+
+- (UIButton *)addAccessoryButtonIconViewWithImage:(UIImage *)image
+{
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+    button.translatesAutoresizingMaskIntoConstraints = NO;
+    button.backgroundColor = [UIColor clearColor];
+    
+    [button setImage:image forState:UIControlStateNormal];
+    
+    CGFloat padding = 6.0;
+    CGFloat width = MenusDesignItemIconSize + (padding * 2);
+    CGFloat height = MenusDesignItemIconSize + (padding * 2);
+    
+    UIEdgeInsets inset = button.imageEdgeInsets;
+    inset.top = padding;
+    inset.bottom = padding;
+    inset.left = padding;
+    inset.right = padding;
+    button.imageEdgeInsets = inset;
+    
+    NSLayoutConstraint *widthConstraint = [button.widthAnchor constraintEqualToConstant:width];
+    widthConstraint.priority = 999;
+    NSLayoutConstraint *heightConstraint = [button.heightAnchor constraintEqualToConstant:height];
+    heightConstraint.priority = 999;
+    [NSLayoutConstraint activateConstraints:@[
+                                              widthConstraint,
+                                              heightConstraint
+                                              ]];
+    [self addAccessoryButton:button];
+    
+    return button;
+}
+
+- (UIColor *)contentViewBackgroundColor
+{
+    UIColor *color = nil;
+    if (self.highlighted) {
+        color = [WPStyleGuide mediumBlue];
+    } else  {
+        color = [UIColor whiteColor];
+    }
+    
+    return color;
+}
+
+- (UIColor *)textLabelColor
+{
+    UIColor *color = nil;
+    if (self.highlighted) {
+        color = [UIColor whiteColor];
+    } else  {
+        color = [WPStyleGuide darkGrey];
+    }
+    
+    return color;
+}
+
+- (UIColor *)iconTintColor
+{
+    UIColor *color = nil;
+    if (self.highlighted) {
+        color = [UIColor whiteColor];
+    } else  {
+        color = [WPStyleGuide grey];
+    }
+    
+    return color;
+}
+
+#pragma mark - touches
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesBegan:touches withEvent:event];
+    self.highlighted = YES;
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesMoved:touches withEvent:event];
+    self.highlighted = NO;
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesEnded:touches withEvent:event];
+    self.highlighted = NO;
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesCancelled:touches withEvent:event];
+    self.highlighted = NO;
+}
+
+#pragma mark - overrides
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+    [self setNeedsDisplay];
+    [self.contentView setNeedsDisplay];
+}
+
+- (void)drawRect:(CGRect)rect
+{    
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    CGRect dashRect = CGRectInset(self.contentView.frame, 8.0, 8.0);
+    
+    CGContextSetStrokeColorWithColor(context, [[WPStyleGuide mediumBlue] CGColor]);
+    CGContextSetLineWidth(context, 1.0);
+    
+    const CGFloat dashLength = 6.0;
+    const CGFloat dashFillPercentage = 60; // fill % of the line with dashes, rest with white space
+    
+    CGFloat(^spacingForLineLength)(CGFloat) = ^ CGFloat (CGFloat lineLength) {
+        // calculate the white spacing needed to fill the full line with dashes
+        const CGFloat dashFill = (lineLength * dashFillPercentage) / 100;
+        //// the white spacing is proportionate to amount of space the dashes will take
+        //// uses (dashFill - dashLength) to ensure there is one extra dash to touch the end of the line
+        return ((lineLength - dashFill) * dashLength) / (dashFill - dashLength);
+    };
+    
+    const CGFloat pointOffset = 0.5;
+    {
+        CGFloat dash[2] = {dashLength, spacingForLineLength(dashRect.size.width)};
+        CGContextSetLineDash(context, 0, dash, 2);
+        
+        const CGFloat leftX = dashRect.origin.x - pointOffset;
+        const CGFloat rightX = dashRect.origin.x + dashRect.size.width + pointOffset;
+        CGContextMoveToPoint(context, leftX, dashRect.origin.y);
+        CGContextAddLineToPoint(context, rightX, dashRect.origin.y);
+        CGContextMoveToPoint(context, leftX, dashRect.origin.y + dashRect.size.height);
+        CGContextAddLineToPoint(context, rightX, dashRect.origin.y + dashRect.size.height);
+        CGContextStrokePath(context);
+        
+    }
+    {
+        CGFloat dash[2] = {dashLength, spacingForLineLength(dashRect.size.height)};
+        CGContextSetLineDash(context, 0, dash, 2);
+        
+        const CGFloat topY = dashRect.origin.y - pointOffset;
+        const CGFloat bottomY = dashRect.origin.y + dashRect.size.height + pointOffset;
+        CGContextMoveToPoint(context, dashRect.origin.x, topY);
+        CGContextAddLineToPoint(context, dashRect.origin.x, bottomY);
+        CGContextMoveToPoint(context, dashRect.origin.x + dashRect.size.width, topY);
+        CGContextAddLineToPoint(context, dashRect.origin.x + dashRect.size.width, bottomY);
+        CGContextStrokePath(context);
+    }
+}
+
+#pragma mark - MenuItemDrawingViewDelegate
+
+- (void)drawingViewDrawRect:(CGRect)rect
+{
+    if (self.highlighted || !self.drawsLineSeparator) {
+        return;
+    }
+    
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextSetLineWidth(context, MenusDesignStrokeWidth);
+    
+    // draw a line on the bottom
+    CGContextMoveToPoint(context, self.stackView.layoutMargins.left, rect.size.height - (MenusDesignStrokeWidth / 2.0));
+    CGContextAddLineToPoint(context, rect.size.width, rect.size.height - (MenusDesignStrokeWidth / 2.0));
+    
+    UIColor *borderColor = [WPStyleGuide greyLighten20];
+    CGContextSetStrokeColorWithColor(context, [borderColor CGColor]);
+    CGContextStrokePath(context);
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemInsertionView.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemInsertionView.h
@@ -1,5 +1,7 @@
 #import "MenuItemAbstractView.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSUInteger, MenuItemInsertionOrder) {
     MenuItemInsertionOrderAbove = 1,
     MenuItemInsertionOrderBelow,
@@ -13,7 +15,7 @@ typedef NS_ENUM(NSUInteger, MenuItemInsertionOrder) {
  */
 @interface MenuItemInsertionView : MenuItemAbstractView
 
-@property (nonatomic, weak) id <MenuItemAbstractViewDelegate, MenuItemInsertionViewDelegate> delegate;
+@property (nonatomic, weak, nullable) id <MenuItemAbstractViewDelegate, MenuItemInsertionViewDelegate> delegate;
 
 /**
  The type of insertion the view represents.
@@ -30,3 +32,5 @@ typedef NS_ENUM(NSUInteger, MenuItemInsertionOrder) {
 - (void)itemInsertionViewSelected:(MenuItemInsertionView *)insertionView;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemInsertionView.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemInsertionView.h
@@ -1,0 +1,32 @@
+#import "MenuItemAbstractView.h"
+
+typedef NS_ENUM(NSUInteger, MenuItemInsertionOrder) {
+    MenuItemInsertionOrderAbove = 1,
+    MenuItemInsertionOrderBelow,
+    MenuItemInsertionOrderChild
+};
+
+@protocol MenuItemInsertionViewDelegate;
+
+/**
+ An a view encapsulating work for inserting new MenuItems in MenuItemsViewController.
+ */
+@interface MenuItemInsertionView : MenuItemAbstractView
+
+@property (nonatomic, weak) id <MenuItemAbstractViewDelegate, MenuItemInsertionViewDelegate> delegate;
+
+/**
+ The type of insertion the view represents.
+ */
+@property (nonatomic, assign) MenuItemInsertionOrder insertionOrder;
+
+@end
+
+@protocol MenuItemInsertionViewDelegate <MenuItemAbstractViewDelegate>
+
+/**
+ User interaction detected for selecting the insertion.
+ */
+- (void)itemInsertionViewSelected:(MenuItemInsertionView *)insertionView;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemInsertionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemInsertionView.m
@@ -1,0 +1,79 @@
+#import "MenuItemInsertionView.h"
+
+@import Gridicons;
+
+@implementation MenuItemInsertionView
+
+@dynamic delegate;
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+                
+        UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tapGestureRecognized:)];
+        [self.contentView addGestureRecognizer:tap];
+        
+        self.iconView.tintColor = [WPStyleGuide wordPressBlue];
+        self.iconView.image = [Gridicon iconOfType:GridiconTypePlus];
+    }
+    
+    return self;
+}
+
+- (void)setInsertionOrder:(MenuItemInsertionOrder)insertionOrder
+{
+    if (_insertionOrder != insertionOrder) {
+        _insertionOrder = insertionOrder;
+        self.textLabel.text = [self textForOrder:insertionOrder];
+    }
+}
+
+- (NSString *)textForOrder:(MenuItemInsertionOrder)insertionOrder
+{
+    NSString *text;
+    switch (insertionOrder) {
+        case MenuItemInsertionOrderAbove:
+            text = NSLocalizedString(@"Add menu item above", @"");
+            break;
+        case MenuItemInsertionOrderBelow:
+            text = NSLocalizedString(@"Add menu item below", @"");
+            break;
+        case MenuItemInsertionOrderChild:
+            text = NSLocalizedString(@"Add menu item to children", @"");
+            break;
+        default:
+            text = nil;
+            break;
+    }
+    
+    return text;
+}
+
+- (UIColor *)textLabelColor
+{
+    UIColor *color = nil;
+    if (self.highlighted) {
+        color = [super textLabelColor];
+    } else  {
+        color = [WPStyleGuide wordPressBlue];
+    }
+    
+    return color;
+}
+
+#pragma mark - gestures
+
+- (void)tapGestureRecognized:(UITapGestureRecognizer *)tap
+{
+    [self tellDelegateWasSelected];
+}
+
+#pragma mark - delegate helpers
+
+- (void)tellDelegateWasSelected
+{
+    [self.delegate itemInsertionViewSelected:self];
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemView.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemView.h
@@ -1,5 +1,7 @@
 #import "MenuItemAbstractView.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class MenuItem;
 
 @protocol MenuItemViewDelegate;
@@ -9,7 +11,7 @@
  */
 @interface MenuItemView : MenuItemAbstractView
 
-@property (nonatomic, weak) id <MenuItemAbstractViewDelegate, MenuItemViewDelegate> delegate;
+@property (nonatomic, weak, nullable) id <MenuItemAbstractViewDelegate, MenuItemViewDelegate> delegate;
 @property (nonatomic, strong) MenuItem *item;
 
 /**
@@ -52,3 +54,5 @@
 - (void)itemViewCancelButtonPressed:(MenuItemView *)itemView;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemView.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemView.h
@@ -1,0 +1,54 @@
+#import "MenuItemAbstractView.h"
+
+@class MenuItem;
+
+@protocol MenuItemViewDelegate;
+
+/**
+ View that encapsulates the display and editing actions for a MenuItem within MenuItemsViewController.
+ */
+@interface MenuItemView : MenuItemAbstractView
+
+@property (nonatomic, weak) id <MenuItemAbstractViewDelegate, MenuItemViewDelegate> delegate;
+@property (nonatomic, strong) MenuItem *item;
+
+/**
+ Show the add and ordering buttons for the item.
+ */
+@property (nonatomic, assign) BOOL showsEditingButtonOptions;
+
+/**
+ Show the cancel button for cancelling adding new items around the view.
+ */
+@property (nonatomic, assign) BOOL showsCancelButtonOption;
+
+/**
+ Refresh the content based on the item.
+ */
+- (void)refresh;
+
+/**
+ The detectedable region of the view for allowing ordering.
+ */
+- (CGRect)orderingToggleRect;
+
+@end
+
+@protocol MenuItemViewDelegate <NSObject>
+
+/**
+ User interaction detected for selecting the item.
+ */
+- (void)itemViewSelected:(MenuItemView *)itemView;
+
+/**
+ User interaction detected for adding a new item around this view.
+ */
+- (void)itemViewAddButtonPressed:(MenuItemView *)itemView;
+
+/**
+ User interaction detected for cancelling adding a new item around this view.
+ */
+- (void)itemViewCancelButtonPressed:(MenuItemView *)itemView;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemView.m
@@ -1,0 +1,191 @@
+#import "MenuItemView.h"
+#import "MenuItem.h"
+#import "WPStyleGuide.h"
+#import "MenuItem+ViewDesign.h"
+#import "WPFontManager.h"
+
+@import Gridicons;
+
+@interface MenuItemView ()
+
+@property (nonatomic, strong, readonly) UIButton *addButton;
+@property (nonatomic, strong, readonly) UIButton *orderingButton;
+@property (nonatomic, strong, readonly) UIButton *cancelButton;
+@property (nonatomic, assign) CGPoint touchesBeganLocation;
+
+@end
+
+@implementation MenuItemView
+
+@dynamic delegate;
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+
+        [self setupAddButton];
+        [self setupOrderingButton];
+        [self setupCancelButton];
+        
+        self.highlighted = NO;
+    }
+    
+    return self;
+}
+
+- (void)setupAddButton
+{
+    UIButton *button = [self addAccessoryButtonIconViewWithImage:[Gridicon iconOfType:GridiconTypePlus]];
+    [button addTarget:self action:@selector(addButtonPressed) forControlEvents:UIControlEventTouchUpInside];
+    _addButton = button;
+}
+
+- (void)setupOrderingButton
+{
+    UIImage *image = [[UIImage imageNamed:@"menus-move-icon"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    UIButton *button = [self addAccessoryButtonIconViewWithImage:image];
+    button.userInteractionEnabled = NO;
+    _orderingButton = button;
+}
+
+- (void)setupCancelButton
+{
+    UIButton *button = [[UIButton alloc] init];
+    [button addTarget:self action:@selector(cancelButtonPressed) forControlEvents:UIControlEventTouchUpInside];
+    button.titleLabel.font = [WPFontManager systemRegularFontOfSize:16.0];
+    [button setTitle:NSLocalizedString(@"Cancel", @"") forState:UIControlStateNormal];
+    
+    UIEdgeInsets inset = button.contentEdgeInsets;
+    inset.left = 6.0;
+    inset.right = inset.left;
+    button.contentEdgeInsets = inset;
+    button.hidden = YES;
+    
+    [self.accessoryStackView addArrangedSubview:button];
+    [button setContentHuggingPriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
+    [button setContentCompressionResistancePriority:UILayoutPriorityDefaultHigh forAxis:UILayoutConstraintAxisHorizontal];
+    
+    NSLayoutConstraint *heightConstraint = [button.heightAnchor constraintEqualToAnchor:self.accessoryStackView.heightAnchor];
+    heightConstraint.priority = 999;
+    heightConstraint.active = YES;
+    
+    _cancelButton = button;
+}
+
+- (void)setItem:(MenuItem *)item
+{
+    if (_item != item) {
+        _item = item;
+        [self refresh];
+    }
+}
+
+- (void)setHighlighted:(BOOL)highlighted
+{
+    [super setHighlighted:highlighted];
+    
+    if (highlighted) {
+        
+        [self.cancelButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
+        self.addButton.tintColor = [UIColor whiteColor];
+        self.orderingButton.tintColor = [UIColor whiteColor];
+        
+    } else {
+     
+        [self.cancelButton setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
+        self.addButton.tintColor = [WPStyleGuide wordPressBlue];
+        self.orderingButton.tintColor = [WPStyleGuide greyLighten20];
+    }
+}
+
+- (void)refresh
+{
+    self.iconView.image = [MenuItem iconImageForItemType:self.item.type];
+    self.textLabel.text = self.item.name;
+}
+
+- (CGRect)orderingToggleRect
+{
+    return [self convertRect:self.orderingButton.frame fromView:self.orderingButton.superview];
+}
+
+- (void)setShowsEditingButtonOptions:(BOOL)showsEditingButtonOptions
+{
+    if (_showsEditingButtonOptions != showsEditingButtonOptions) {
+        _showsEditingButtonOptions = showsEditingButtonOptions;
+    }
+    self.addButton.hidden = !showsEditingButtonOptions;
+}
+
+- (void)setShowsCancelButtonOption:(BOOL)showsCancelButtonOption
+{
+    if (_showsCancelButtonOption != showsCancelButtonOption) {
+        _showsCancelButtonOption = showsCancelButtonOption;
+    }
+    self.orderingButton.hidden = showsCancelButtonOption;
+    self.cancelButton.hidden = !showsCancelButtonOption;
+}
+
+#pragma mark - buttons
+
+- (void)addButtonPressed
+{
+    [self.delegate itemViewAddButtonPressed:self];
+}
+
+- (void)cancelButtonPressed
+{
+    [self.delegate itemViewCancelButtonPressed:self];
+}
+
+#pragma mark - touches
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesBegan:touches withEvent:event];
+    
+    UITouch *touch = [touches anyObject];
+    self.touchesBeganLocation = [touch locationInView:self];
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesMoved:touches withEvent:event];
+    self.touchesBeganLocation = CGPointZero;
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesEnded:touches withEvent:event];
+    
+    UITouch *touch = [touches anyObject];
+    if (CGPointEqualToPoint(self.touchesBeganLocation, CGPointZero)) {
+        return;
+    }
+    
+    CGPoint endedPoint = [touch locationInView:self];
+    if (CGPointEqualToPoint(endedPoint, CGPointZero)) {
+        return;
+    }
+    
+    if (CGRectContainsPoint(self.bounds, self.touchesBeganLocation) && CGRectContainsPoint(self.bounds, endedPoint)) {
+        
+        CGRect orderingButttonRect = [self convertRect:self.orderingButton.frame fromView:self.orderingButton.superview];
+        if (CGRectContainsPoint(orderingButttonRect, endedPoint)) {
+            // Ignore the selection if the touch ended within the ordering button.
+            return;
+        }
+        [self.delegate itemViewSelected:self];
+    }
+    
+    self.touchesBeganLocation = CGPointZero;
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesCancelled:touches withEvent:event];
+    self.touchesBeganLocation = CGPointZero;
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemsVisualOrderingView.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemsVisualOrderingView.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class MenuItem;
 @class MenuItemView;
 
@@ -10,7 +12,7 @@
  */
 @interface MenuItemsVisualOrderingView : UIView
 
-@property (nonatomic, weak) id <MenuItemsVisualOrderingViewDelegate> delegate;
+@property (nonatomic, weak, nullable) id <MenuItemsVisualOrderingViewDelegate> delegate;
 
 /**
  Set up the view to copy the view's representation in the UI for animating it's ordering.
@@ -38,3 +40,5 @@
 - (void)visualOrderingView:(MenuItemsVisualOrderingView *)visualOrderingView animatingVisualItemViewForOrdering:(MenuItemView *)orderingView;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemsVisualOrderingView.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemsVisualOrderingView.h
@@ -1,0 +1,40 @@
+#import <UIKit/UIKit.h>
+
+@class MenuItem;
+@class MenuItemView;
+
+@protocol MenuItemsVisualOrderingViewDelegate;
+
+/**
+ A view that manages the visual effect of a MenuItemView dragging across the screen for ordering in MenuItemsViewController.
+ */
+@interface MenuItemsVisualOrderingView : UIView
+
+@property (nonatomic, weak) id <MenuItemsVisualOrderingViewDelegate> delegate;
+
+/**
+ Set up the view to copy the view's representation in the UI for animating it's ordering.
+ */
+- (void)setupVisualOrderingWithItemView:(MenuItemView *)itemView;
+
+/**
+ Update the visual itemView with a model change for its MenuItem.
+ */
+- (void)updateForVisualOrderingMenuItemsModelChange;
+
+/**
+ Update the location of the visual itemView according to related touches in a parentView.
+ */
+- (void)updateVisualOrderingWithTouchLocation:(CGPoint)touchLocation vector:(CGPoint)vector;
+
+@end
+
+@protocol MenuItemsVisualOrderingViewDelegate <NSObject>
+@optional
+
+/**
+ The visual orderingView is animating and may require parent view changes to keep the view on screen.
+ */
+- (void)visualOrderingView:(MenuItemsVisualOrderingView *)visualOrderingView animatingVisualItemViewForOrdering:(MenuItemView *)orderingView;
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemsVisualOrderingView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemsVisualOrderingView.m
@@ -1,0 +1,92 @@
+#import "MenuItemsVisualOrderingView.h"
+#import "MenuItemView.h"
+#import "MenuItem.h"
+
+@interface MenuItemsVisualOrderingView ()
+
+@property (nonatomic, assign) CGRect startingOrderedItemViewFrame;
+@property (nonatomic, strong) MenuItemView *itemView;
+@property (nonatomic, strong) MenuItemView *visualOrderingView;
+@property (nonatomic, strong) NSLayoutConstraint *topConstraintForVisualTouchUpdates;
+
+@end
+
+@implementation MenuItemsVisualOrderingView
+
+- (void)setupVisualOrderingWithItemView:(MenuItemView *)itemView
+{
+    self.itemView = itemView;
+    self.startingOrderedItemViewFrame = itemView.frame;
+    
+    [self reloadItemViews];
+}
+
+- (void)updateForVisualOrderingMenuItemsModelChange
+{
+    self.visualOrderingView.indentationLevel = self.itemView.indentationLevel;
+}
+
+- (void)updateVisualOrderingWithTouchLocation:(CGPoint)touchLocation vector:(CGPoint)vector
+{
+    CGFloat constraintConstValue = self.startingOrderedItemViewFrame.origin.y + vector.y;
+    const CGFloat boundsPadding = 20.0;
+    
+    if (constraintConstValue < -boundsPadding) {
+        constraintConstValue = -boundsPadding;
+    } else   {
+
+        const CGFloat maxY = (self.frame.size.height - self.visualOrderingView.frame.size.height) + boundsPadding;
+        if (constraintConstValue > maxY) {
+            constraintConstValue = maxY;
+        }
+    }
+    
+    self.topConstraintForVisualTouchUpdates.constant = constraintConstValue;
+    
+    if ([self.delegate respondsToSelector:@selector(visualOrderingView:animatingVisualItemViewForOrdering:)]) {
+        [self.delegate visualOrderingView:self animatingVisualItemViewForOrdering:self.visualOrderingView];
+    }
+}
+
+#pragma mark - private
+
+- (void)reloadItemViews
+{
+    self.topConstraintForVisualTouchUpdates = nil;
+    
+    [self.visualOrderingView removeFromSuperview];
+    self.visualOrderingView = nil;
+    
+    MenuItem *item = self.itemView.item;
+    
+    CGRect layoutFrame = [self convertRect:self.itemView.frame fromView:self.itemView.superview];
+    MenuItemView *orderingView = [[MenuItemView alloc] init];
+    orderingView.item = item;
+    orderingView.indentationLevel = self.itemView.indentationLevel;
+    orderingView.drawsLineSeparator = NO;
+    orderingView.alpha = 0.65;
+    orderingView.userInteractionEnabled = NO;
+    
+    CALayer *contentLayer = orderingView.contentView.layer;
+    contentLayer.shadowColor = [[UIColor blackColor] CGColor];
+    contentLayer.shadowOpacity = 0.3;
+    contentLayer.shadowRadius = 10.0;
+    contentLayer.shadowOffset = CGSizeMake(0, 0);
+    
+    NSLayoutConstraint *heightConstraint = [orderingView.heightAnchor constraintGreaterThanOrEqualToConstant:MenuItemsStackableViewDefaultHeight];
+    heightConstraint.active = YES;
+    
+    [self addSubview:orderingView];
+    self.visualOrderingView = orderingView;
+    
+    NSLayoutConstraint *topConstraint = [orderingView.topAnchor constraintEqualToAnchor:self.topAnchor];
+    topConstraint.constant = layoutFrame.origin.y;
+    self.topConstraintForVisualTouchUpdates = topConstraint;
+    [NSLayoutConstraint activateConstraints:@[
+                                              topConstraint,
+                                              [orderingView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+                                              [orderingView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor]
+                                              ]];
+}
+
+@end

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -55,6 +55,10 @@
 		082AB9D91C4EEEF4000CA523 /* PostTagService.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9D81C4EEEF4000CA523 /* PostTagService.m */; };
 		082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9DC1C4F035E000CA523 /* PostTag.m */; };
 		08472A201C727E020040769D /* PostServiceOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 08472A1F1C727E020040769D /* PostServiceOptions.m */; };
+		0857C2771CE5375F0014AE99 /* MenuItemAbstractView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0857C2701CE5375F0014AE99 /* MenuItemAbstractView.m */; };
+		0857C2781CE5375F0014AE99 /* MenuItemInsertionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0857C2721CE5375F0014AE99 /* MenuItemInsertionView.m */; };
+		0857C2791CE5375F0014AE99 /* MenuItemsVisualOrderingView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0857C2741CE5375F0014AE99 /* MenuItemsVisualOrderingView.m */; };
+		0857C27A1CE5375F0014AE99 /* MenuItemView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0857C2761CE5375F0014AE99 /* MenuItemView.m */; };
 		0859DCF61CB847F700EB4069 /* RemoteMenu.m in Sources */ = {isa = PBXBuildFile; fileRef = 0859DCF11CB847F700EB4069 /* RemoteMenu.m */; };
 		0859DCF71CB847F700EB4069 /* RemoteMenuItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 0859DCF31CB847F700EB4069 /* RemoteMenuItem.m */; };
 		0859DCF81CB847F700EB4069 /* RemoteMenuLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0859DCF51CB847F700EB4069 /* RemoteMenuLocation.m */; };
@@ -973,6 +977,14 @@
 		082AB9DC1C4F035E000CA523 /* PostTag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostTag.m; sourceTree = "<group>"; };
 		08472A1E1C7273FA0040769D /* PostServiceOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PostServiceOptions.h; sourceTree = "<group>"; };
 		08472A1F1C727E020040769D /* PostServiceOptions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostServiceOptions.m; sourceTree = "<group>"; };
+		0857C26F1CE5375F0014AE99 /* MenuItemAbstractView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemAbstractView.h; sourceTree = "<group>"; };
+		0857C2701CE5375F0014AE99 /* MenuItemAbstractView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemAbstractView.m; sourceTree = "<group>"; };
+		0857C2711CE5375F0014AE99 /* MenuItemInsertionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemInsertionView.h; sourceTree = "<group>"; };
+		0857C2721CE5375F0014AE99 /* MenuItemInsertionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemInsertionView.m; sourceTree = "<group>"; };
+		0857C2731CE5375F0014AE99 /* MenuItemsVisualOrderingView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemsVisualOrderingView.h; sourceTree = "<group>"; };
+		0857C2741CE5375F0014AE99 /* MenuItemsVisualOrderingView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemsVisualOrderingView.m; sourceTree = "<group>"; };
+		0857C2751CE5375F0014AE99 /* MenuItemView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemView.h; sourceTree = "<group>"; };
+		0857C2761CE5375F0014AE99 /* MenuItemView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemView.m; sourceTree = "<group>"; };
 		0859DCF01CB847F700EB4069 /* RemoteMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteMenu.h; path = "Remote Objects/RemoteMenu.h"; sourceTree = "<group>"; };
 		0859DCF11CB847F700EB4069 /* RemoteMenu.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteMenu.m; path = "Remote Objects/RemoteMenu.m"; sourceTree = "<group>"; };
 		0859DCF21CB847F700EB4069 /* RemoteMenuItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteMenuItem.h; path = "Remote Objects/RemoteMenuItem.h"; sourceTree = "<group>"; };
@@ -2403,6 +2415,14 @@
 				08D345491CD7F50900358E8C /* MenusSelectionDetailView.m */,
 				08D3454C1CD7F50900358E8C /* MenusSelectionItemView.h */,
 				08D3454D1CD7F50900358E8C /* MenusSelectionItemView.m */,
+				0857C26F1CE5375F0014AE99 /* MenuItemAbstractView.h */,
+				0857C2701CE5375F0014AE99 /* MenuItemAbstractView.m */,
+				0857C2711CE5375F0014AE99 /* MenuItemInsertionView.h */,
+				0857C2721CE5375F0014AE99 /* MenuItemInsertionView.m */,
+				0857C2731CE5375F0014AE99 /* MenuItemsVisualOrderingView.h */,
+				0857C2741CE5375F0014AE99 /* MenuItemsVisualOrderingView.m */,
+				0857C2751CE5375F0014AE99 /* MenuItemView.h */,
+				0857C2761CE5375F0014AE99 /* MenuItemView.m */,
 				08216FB21CDBF96000304BA7 /* MenuItemEditingHeaderView.h */,
 				08216FB31CDBF96000304BA7 /* MenuItemEditingHeaderView.m */,
 				08216FB01CDBF96000304BA7 /* MenuItemEditingFooterView.h */,
@@ -5741,12 +5761,14 @@
 				FA5C740F1C599BA7000B528C /* TableViewHeaderDetailView.swift in Sources */,
 				5D44EB351986D695008B7175 /* ReaderSiteServiceRemote.m in Sources */,
 				E6417BAC1CA07F7F0084050A /* SigninHelpers.swift in Sources */,
+				0857C2771CE5375F0014AE99 /* MenuItemAbstractView.m in Sources */,
 				5DB4683B18A2E718004A89A9 /* LocationService.m in Sources */,
 				590E873B1CB8205700D1B734 /* PostListViewController.swift in Sources */,
 				E15644EB1CE0E4C500D96E64 /* FeatureItemRow.swift in Sources */,
 				E1D04D7E19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m in Sources */,
 				E1249B4B1940AECC0035E895 /* CommentServiceRemoteREST.m in Sources */,
 				E1266D2D1BBE8B9A00FCB6B6 /* Gravatar.swift in Sources */,
+				0857C2791CE5375F0014AE99 /* MenuItemsVisualOrderingView.m in Sources */,
 				E240859C183D82AE002EB0EF /* WPAnimatedBox.m in Sources */,
 				08472A201C727E020040769D /* PostServiceOptions.m in Sources */,
 				852416CF1A12EBDD0030700C /* AppRatingUtility.m in Sources */,
@@ -5822,6 +5844,7 @@
 				3101866B1A373B01008F7DF6 /* WPTabBarController.m in Sources */,
 				85E105861731A597001071A3 /* WPWalkthroughOverlayView.m in Sources */,
 				85B125461B0294F6008A3D95 /* UIAlertControllerProxy.m in Sources */,
+				0857C27A1CE5375F0014AE99 /* MenuItemView.m in Sources */,
 				B587797B19B799D800E57C5A /* NSIndexPath+Swift.swift in Sources */,
 				85EC44D41739826A00686604 /* CreateAccountAndBlogViewController.m in Sources */,
 				FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */,
@@ -5991,6 +6014,7 @@
 				5D839AAB187F0D8000811F4A /* PostGeolocationCell.m in Sources */,
 				5D732F971AE84E3C00CD89E7 /* PostListFooterView.m in Sources */,
 				A2DC5B1A1953451B009584C3 /* WPNUXHelpBadgeLabel.m in Sources */,
+				0857C2781CE5375F0014AE99 /* MenuItemInsertionView.m in Sources */,
 				B532D4EA199D4357006E4DF6 /* NoteBlockHeaderTableViewCell.swift in Sources */,
 				59E2AAE31B2096BF0051DC06 /* ServiceRemoteREST.m in Sources */,
 				E6417BA01CA07D540084050A /* SigninSelfHostedViewController.swift in Sources */,


### PR DESCRIPTION
Adding a collection of views responsible for handling the display, selection, ordering, and editing of MenuItems.

![simulator screen shot may 12 2016 5 19 34 pm](https://cloud.githubusercontent.com/assets/1873422/15232281/d0c8ab28-1865-11e6-8cee-348cea35f87e.png)

These views are managed by the `MenuItemsViewController` currently in the Menus staging branch `feature/menus-views`. In order to break down the review, this PR is primarily a code review as testing will occur with the upcoming PR for the `MenuItemsViewController` code itself.

For context build and run `feature/menus-views`.

@diegoreymendez can I kindly request a code review from you fine sir? 🕵