### PR TITLE
Issues/5150 add reader referrer

### DIFF
--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -65,3 +65,8 @@ extern NSInteger const WPOnePasswordGeneratedMaxLength;
 /// Scheme Constants
 ///
 extern NSString *const WPComScheme;
+
+/// Referrer Constants
+///
+extern NSString *const WPComReferrerGaUtmSourceKey;
+extern NSString *const WPComReferrerURL;

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -70,3 +70,8 @@ NSInteger const WPOnePasswordGeneratedMaxLength                     = 50;
 /// Scheme Constants
 ///
 NSString *const WPComScheme = WPCOM_SCHEME;
+
+/// Referrer Constants
+///
+NSString *const WPComReferrerGaUtmSourceKey = @"utm_source";
+NSString *const WPComReferrerURL = @"https://wordpress.com";

--- a/WordPress/Classes/Utility/WPComReferrerUtil.swift
+++ b/WordPress/Classes/Utility/WPComReferrerUtil.swift
@@ -4,7 +4,7 @@ import Foundation
 {
 
     /// Add the utm_source query string param to a URL string.
-    /// If the utm_source already exists the original pathis returned.
+    /// If the utm_source already exists the original path is returned.
     ///
     /// - Parameters:
     ///     - path: A URL string. Can be an absolute or relative URL string.

--- a/WordPress/Classes/Utility/WPComReferrerUtil.swift
+++ b/WordPress/Classes/Utility/WPComReferrerUtil.swift
@@ -3,10 +3,19 @@ import Foundation
 @objc public class WPComReferrerUtil : NSObject
 {
 
+    /// Add the utm_source query string param to a URL string.
+    /// If the utm_source already exists the original pathis returned.
+    ///
+    /// - Parameters:
+    ///     - path: A URL string. Can be an absolute or relative URL string.
+    ///
+    /// - Returns: The path with the utm_source appended, or the original path if it already had a utm_source param.
+    ///
     class func addUtmSourceToURLPath(path: String) -> String {
-        if path.isEmpty {
+        if path.isEmpty || path.containsString(WPComReferrerGaUtmSourceKey) {
             return path
         }
+
         guard let urlencodedReferrer = WPComReferrerURL.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet()) else {
             return path
         }

--- a/WordPress/Classes/Utility/WPComReferrerUtil.swift
+++ b/WordPress/Classes/Utility/WPComReferrerUtil.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+@objc public class WPComReferrerUtil : NSObject
+{
+
+    class func addUtmSourceToURLPath(path: String) -> String {
+        if path.isEmpty {
+            return path
+        }
+        guard let urlencodedReferrer = WPComReferrerURL.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet()) else {
+            return path
+        }
+        let joiner = path.containsString("?") ? "&" : "?"
+        return "\(path)\(joiner)\(WPComReferrerGaUtmSourceKey)=\(urlencodedReferrer)"
+    }
+
+}

--- a/WordPress/Classes/Utility/WPWebViewController.h
+++ b/WordPress/Classes/Utility/WPWebViewController.h
@@ -42,6 +42,11 @@
 @property (nonatomic, assign) BOOL      secureInteraction;
 
 /**
+ *  @brief  When true adds a custom referrer to NSURLRequest.
+ */
+@property (nonatomic, assign) BOOL useCustomReferrer;
+
+/**
  *	@brief		Dismiss modal presentation
  */
 - (IBAction)dismiss;

--- a/WordPress/Classes/Utility/WPWebViewController.h
+++ b/WordPress/Classes/Utility/WPWebViewController.h
@@ -44,7 +44,7 @@
 /**
  *  @brief  When true adds a custom referrer to NSURLRequest.
  */
-@property (nonatomic, assign) BOOL useCustomReferrer;
+@property (nonatomic, assign) BOOL addsWPComReferrer;
 
 /**
  *	@brief		Dismiss modal presentation

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -315,7 +315,7 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
     }
 
     // Append uta_source to shared links when using the custom referrer
-    if (self.useCustomReferrer) {
+    if (self.addsWPComReferrer) {
         permaLink = [WPComReferrerUtil addUtmSourceToURLPath:permaLink];
     }
 
@@ -466,14 +466,14 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
     } else {
         NSURL *loginURL = self.wpLoginURL ?: [self authUrlFromUrl:self.url];
         request = [WPURLRequest requestForAuthenticationWithURL:loginURL
-                                                 redirectURL:self.url
-                                                    username:self.username
-                                                    password:self.password
-                                                 bearerToken:self.authToken
-                                                   userAgent:userAgent];
+                                                    redirectURL:self.url
+                                                       username:self.username
+                                                       password:self.password
+                                                    bearerToken:self.authToken
+                                                      userAgent:userAgent];
     }
 
-    if (self.useCustomReferrer) {
+    if (self.addsWPComReferrer) {
         NSMutableURLRequest *mReq = [request isKindOfClass:[NSMutableURLRequest class]] ? (NSMutableURLRequest *)request : [request mutableCopy];
         [mReq setValue:WPComReferrerURL forHTTPHeaderField:@"Referer"];
         request = mReq;

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -306,12 +306,17 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
 
 - (IBAction)showLinkOptions
 {
-    NSString* permaLink             = [self documentPermalink];
+    NSString *permaLink             = [self documentPermalink];
     NSString *title                 = [self documentTitle];
     NSMutableArray *activityItems   = [NSMutableArray array];
     
     if (title) {
         [activityItems addObject:title];
+    }
+
+    // Append uta_source to shared links when using the custom referrer
+    if (self.useCustomReferrer) {
+        permaLink = [WPComReferrerUtil addUtmSourceToURLPath:permaLink];
     }
 
     [activityItems addObject:[NSURL URLWithString:permaLink]];
@@ -455,17 +460,26 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
 - (NSURLRequest *)newRequestForWebsite
 {
     NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent wordPressUserAgent];
+    NSURLRequest *request;
     if (!self.needsLogin) {
-        return [WPURLRequest requestWithURL:self.url userAgent:userAgent];
+        request = [WPURLRequest requestWithURL:self.url userAgent:userAgent];
+    } else {
+        NSURL *loginURL = self.wpLoginURL ?: [self authUrlFromUrl:self.url];
+        request = [WPURLRequest requestForAuthenticationWithURL:loginURL
+                                                 redirectURL:self.url
+                                                    username:self.username
+                                                    password:self.password
+                                                 bearerToken:self.authToken
+                                                   userAgent:userAgent];
     }
-    
-    NSURL *loginURL = self.wpLoginURL ?: [self authUrlFromUrl:self.url];
-    return [WPURLRequest requestForAuthenticationWithURL:loginURL
-                                             redirectURL:self.url
-                                                username:self.username
-                                                password:self.password
-                                             bearerToken:self.authToken
-                                               userAgent:userAgent];
+
+    if (self.useCustomReferrer) {
+        NSMutableURLRequest *mReq = [request isKindOfClass:[NSMutableURLRequest class]] ? (NSMutableURLRequest *)request : [request mutableCopy];
+        [mReq setValue:WPComReferrerURL forHTTPHeaderField:@"Referer"];
+        request = mReq;
+    }
+
+    return request;
 }
 
 - (NSURL *)authUrlFromUrl:(NSURL *)url

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -104,12 +104,15 @@ import SVProgressHUD
     }
 
     func shareReaderPost(post: ReaderPost, fromView anchorView:UIView, inViewController viewController:UIViewController) {
-
+        var permalink = post.permaLink ?? ""
+        if !permalink.isEmpty {
+            permalink = WPComReferrerUtil.addUtmSourceToURLPath(permalink)
+        }
         sharePost(
             post.titleForDisplay(),
             summary: post.contentPreviewForDisplay(),
             tags: post.tags,
-            link: post.permaLink,
+            link: permalink,
             fromView: anchorView,
             inViewController: viewController)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -104,9 +104,9 @@ import SVProgressHUD
     }
 
     func shareReaderPost(post: ReaderPost, fromView anchorView:UIView, inViewController viewController:UIViewController) {
-        var permalink = post.permaLink ?? ""
-        if !permalink.isEmpty {
-            permalink = WPComReferrerUtil.addUtmSourceToURLPath(permalink)
+        var permalink = post.permaLink
+        if let link = permalink where !link.isEmpty {
+            permalink = WPComReferrerUtil.addUtmSourceToURLPath(link)
         }
         sharePost(
             post.titleForDisplay(),

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1118,6 +1118,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 - (void)commentCell:(UITableViewCell *)cell linkTapped:(NSURL *)url
 {
     WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:url];
+    webViewController.useCustomReferrer = YES;
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];
 }
@@ -1159,6 +1160,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
     }
 
     WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:linkURL];
+    webViewController.useCustomReferrer = YES;
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];
 }
@@ -1172,6 +1174,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
         controller = [[WPImageViewController alloc] initWithImage:imageControl.imageView.image andURL:imageControl.linkURL];
     } else if (imageControl.linkURL) {
         WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:imageControl.linkURL];
+        webViewController.useCustomReferrer = YES;
         controller = [[UINavigationController alloc] initWithRootViewController:webViewController];
     } else {
         controller = [[WPImageViewController alloc] initWithImage:imageControl.imageView.image];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1118,7 +1118,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 - (void)commentCell:(UITableViewCell *)cell linkTapped:(NSURL *)url
 {
     WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:url];
-    webViewController.useCustomReferrer = YES;
+    webViewController.addsWPComReferrer = YES;
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];
 }
@@ -1160,7 +1160,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
     }
 
     WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:linkURL];
-    webViewController.useCustomReferrer = YES;
+    webViewController.addsWPComReferrer = YES;
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];
 }
@@ -1174,7 +1174,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
         controller = [[WPImageViewController alloc] initWithImage:imageControl.imageView.image andURL:imageControl.linkURL];
     } else if (imageControl.linkURL) {
         WPWebViewController *webViewController = [WPWebViewController authenticatedWebViewController:imageControl.linkURL];
-        webViewController.useCustomReferrer = YES;
+        webViewController.addsWPComReferrer = YES;
         controller = [[UINavigationController alloc] initWithRootViewController:webViewController];
     } else {
         controller = [[WPImageViewController alloc] initWithImage:imageControl.imageView.image];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -631,7 +631,7 @@ final public class ReaderDetailViewController : UIViewController
 
     func presentWebViewControllerWithURL(url:NSURL) {
         let controller = WPWebViewController.authenticatedWebViewController(url)
-        controller.useCustomReferrer = true
+        controller.addsWPComReferrer = true
         let navController = UINavigationController(rootViewController: controller)
         presentViewController(navController, animated: true, completion: nil)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -631,6 +631,7 @@ final public class ReaderDetailViewController : UIViewController
 
     func presentWebViewControllerWithURL(url:NSURL) {
         let controller = WPWebViewController.authenticatedWebViewController(url)
+        controller.useCustomReferrer = true
         let navController = UINavigationController(rootViewController: controller)
         presentViewController(navController, animated: true, completion: nil)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -120,6 +120,7 @@ public class ReaderPostMenu
     private class func visitSiteForPost(post:ReaderPost, presentingViewController viewController:UIViewController) {
         let siteURL = NSURL(string: post.blogURL)!
         let controller = WPWebViewController(URL: siteURL)
+        controller.addsWPComReferrer = true
         let navController = UINavigationController(rootViewController: controller)
         viewController.presentViewController(navController, animated: true, completion: nil)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -757,7 +757,7 @@ import WordPressComAnalytics
     private func visitSiteForPost(post:ReaderPost) {
         let siteURL = NSURL(string: post.blogURL)!
         let controller = WPWebViewController(URL: siteURL)
-        controller.useCustomReferrer = true
+        controller.addsWPComReferrer = true
         let navController = UINavigationController(rootViewController: controller)
         presentViewController(navController, animated: true, completion: nil)
     }
@@ -784,7 +784,7 @@ import WordPressComAnalytics
 
         let linkURL = NSURL(string: sourceAttribution.blogURL)
         let controller = WPWebViewController(URL: linkURL)
-        controller.useCustomReferrer = true
+        controller.addsWPComReferrer = true
         let navController = UINavigationController(rootViewController: controller)
         presentViewController(navController, animated: true, completion: nil)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -757,6 +757,7 @@ import WordPressComAnalytics
     private func visitSiteForPost(post:ReaderPost) {
         let siteURL = NSURL(string: post.blogURL)!
         let controller = WPWebViewController(URL: siteURL)
+        controller.useCustomReferrer = true
         let navController = UINavigationController(rootViewController: controller)
         presentViewController(navController, animated: true, completion: nil)
     }
@@ -783,6 +784,7 @@ import WordPressComAnalytics
 
         let linkURL = NSURL(string: sourceAttribution.blogURL)
         let controller = WPWebViewController(URL: linkURL)
+        controller.useCustomReferrer = true
         let navController = UINavigationController(rootViewController: controller)
         presentViewController(navController, animated: true, completion: nil)
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -777,6 +777,7 @@
 		E6B9B8AA1B94E1FE0001B92F /* ReaderPostTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E6B9B8A91B94E1FE0001B92F /* ReaderPostTest.m */; };
 		E6B9B8AF1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B9B8AE1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift */; };
 		E6BDEA731CE4824300682885 /* ReaderSearchTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BDEA721CE4824300682885 /* ReaderSearchTopic.swift */; };
+		E6BDEA751CE5176300682885 /* WPComReferrerUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BDEA741CE5176300682885 /* WPComReferrerUtil.swift */; };
 		E6C09B3E1BF0FDEB003074CB /* ReaderCrossPostMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C09B3D1BF0FDEB003074CB /* ReaderCrossPostMeta.swift */; };
 		E6C448571CB091AA00458157 /* SigninKeyboardResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C448561CB091AA00458157 /* SigninKeyboardResponder.swift */; };
 		E6C892D61C601D55007AD612 /* SharingButtonsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C892D51C601D55007AD612 /* SharingButtonsViewController.swift */; };
@@ -2079,6 +2080,7 @@
 		E6B9B8A91B94E1FE0001B92F /* ReaderPostTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReaderPostTest.m; sourceTree = "<group>"; };
 		E6B9B8AE1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderStreamViewControllerTests.swift; sourceTree = "<group>"; };
 		E6BDEA721CE4824300682885 /* ReaderSearchTopic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSearchTopic.swift; sourceTree = "<group>"; };
+		E6BDEA741CE5176300682885 /* WPComReferrerUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPComReferrerUtil.swift; sourceTree = "<group>"; };
 		E6C09B3D1BF0FDEB003074CB /* ReaderCrossPostMeta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReaderCrossPostMeta.swift; path = Classes/Models/ReaderCrossPostMeta.swift; sourceTree = SOURCE_ROOT; };
 		E6C448561CB091AA00458157 /* SigninKeyboardResponder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SigninKeyboardResponder.swift; sourceTree = "<group>"; };
 		E6C892D51C601D55007AD612 /* SharingButtonsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingButtonsViewController.swift; sourceTree = "<group>"; };
@@ -3280,6 +3282,7 @@
 				E1E1AA8C1B7DEDFC001C8645 /* WPMapFilterReduce.m */,
 				E12E6E321C21BA170033C5D0 /* FeatureFlag.swift */,
 				E6B3137C1CCADA8E00ECCAA7 /* OptimizelyHelper.swift */,
+				E6BDEA741CE5176300682885 /* WPComReferrerUtil.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -5791,6 +5794,7 @@
 				E149D65019349E69006A843D /* MediaServiceRemoteREST.m in Sources */,
 				176579F71C63A40F0000978E /* PurchaseButton.swift in Sources */,
 				B587798719B799EB00E57C5A /* NotificationBlock+Interface.swift in Sources */,
+				E6BDEA751CE5176300682885 /* WPComReferrerUtil.swift in Sources */,
 				E6A3384C1BB08E3F00371587 /* ReaderGapMarker.m in Sources */,
 				930F09171C7D110E00995926 /* ShareExtensionService.swift in Sources */,
 				E1E1AA8D1B7DEDFC001C8645 /* WPMapFilterReduce.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -778,6 +778,7 @@
 		E6B9B8AF1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B9B8AE1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift */; };
 		E6BDEA731CE4824300682885 /* ReaderSearchTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BDEA721CE4824300682885 /* ReaderSearchTopic.swift */; };
 		E6BDEA751CE5176300682885 /* WPComReferrerUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BDEA741CE5176300682885 /* WPComReferrerUtil.swift */; };
+		E6BDEA771CE5735200682885 /* WPComReferrerUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BDEA761CE5735200682885 /* WPComReferrerUtilTests.swift */; };
 		E6C09B3E1BF0FDEB003074CB /* ReaderCrossPostMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C09B3D1BF0FDEB003074CB /* ReaderCrossPostMeta.swift */; };
 		E6C448571CB091AA00458157 /* SigninKeyboardResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C448561CB091AA00458157 /* SigninKeyboardResponder.swift */; };
 		E6C892D61C601D55007AD612 /* SharingButtonsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C892D51C601D55007AD612 /* SharingButtonsViewController.swift */; };
@@ -2081,6 +2082,7 @@
 		E6B9B8AE1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderStreamViewControllerTests.swift; sourceTree = "<group>"; };
 		E6BDEA721CE4824300682885 /* ReaderSearchTopic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSearchTopic.swift; sourceTree = "<group>"; };
 		E6BDEA741CE5176300682885 /* WPComReferrerUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPComReferrerUtil.swift; sourceTree = "<group>"; };
+		E6BDEA761CE5735200682885 /* WPComReferrerUtilTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPComReferrerUtilTests.swift; sourceTree = "<group>"; };
 		E6C09B3D1BF0FDEB003074CB /* ReaderCrossPostMeta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReaderCrossPostMeta.swift; path = Classes/Models/ReaderCrossPostMeta.swift; sourceTree = SOURCE_ROOT; };
 		E6C448561CB091AA00458157 /* SigninKeyboardResponder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SigninKeyboardResponder.swift; sourceTree = "<group>"; };
 		E6C892D51C601D55007AD612 /* SharingButtonsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingButtonsViewController.swift; sourceTree = "<group>"; };
@@ -3172,6 +3174,7 @@
 				E1E1AA8E1B7DF54B001C8645 /* WPMapFilterReduceTest.m */,
 				E19A10C91B010AA0006192B0 /* WPURLRequestTest.m */,
 				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
+				E6BDEA761CE5735200682885 /* WPComReferrerUtilTests.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -6112,6 +6115,7 @@
 				59B48B621B99E132008EBB84 /* JSONLoader.swift in Sources */,
 				9363113F19FA996700B0C739 /* AccountServiceTests.swift in Sources */,
 				591CFB061B28A960009E61B3 /* AccountServiceRemoteRESTTests.m in Sources */,
+				E6BDEA771CE5735200682885 /* WPComReferrerUtilTests.swift in Sources */,
 				F1564E5B18946087009F8F97 /* NSStringHelpersTest.m in Sources */,
 				08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */,
 				93EF094C19ED533500C89770 /* ContextManagerTests.swift in Sources */,

--- a/WordPress/WordPressTest/WPComReferrerUtilTests.swift
+++ b/WordPress/WordPressTest/WPComReferrerUtilTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import XCTest
+@testable import WordPress
+
+class WPComReferrerUtilTests: XCTestCase {
+
+    func testAddUtmSourceToURLPath() {
+        let utmSource = "utm_source=https://wordpress.com"
+
+        // Test a regular path
+        var path = "/url/path"
+        var newPath = WPComReferrerUtil.addUtmSourceToURLPath(path)
+        var match = "\(path)?\(utmSource)"
+        XCTAssert(newPath == match, "The utm_source was not added correctly")
+
+        // Test an existing query
+        path = "/url/path?existing=param"
+        newPath = WPComReferrerUtil.addUtmSourceToURLPath(path)
+        match = "\(path)&\(utmSource)"
+        XCTAssert(newPath == match, "The utm_source was not added correctly")
+
+        // Test an existing utm_source
+        path = "/url/path?existing=param&utm_source=foo"
+        newPath = WPComReferrerUtil.addUtmSourceToURLPath(path)
+        XCTAssert(newPath == path, "A string with an existing utm source should not be changed.")
+    }
+
+}


### PR DESCRIPTION
Closes #5150
This PR Adds a custom referrer to links opened by the reader and adds a custom query parameter to links shared from the reader. I'm not 100% happy with the names of the constants so suggestions are welcome.  

To test:
### Test 1:
Open the reader and view a post detail. 
Click a link in the post content.
Inspect from within the app or use a tool like Charles proxy to confirm that a referrer header is added to the URL request coming from the in-app web view. 

### Test 2: 
Repeat Test 1 with links in reader comments.

### Test 3
Repeat Test 1 in the post list by choosing the "view site" option from a post card's menu.

### Test 4
Share a link from the post list by choosing the "share" option from a post card's menu. 
Choose to share to safari. 
Confirm the URL opened in safari contains a utm_source parameter in its query string.

### Test 5
Repeat Test 4 by sharing a post from the post detail. 

Needs review: @kurzee, would you be game for a review?
