### PR TITLE
Add analytics for Plans views

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,8 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '~> 0.9.1'
     pod 'WordPress-iOS-Editor', '1.6.1'
     pod 'WordPressApi', '0.4.0'
-    pod 'WordPressCom-Analytics-iOS', '0.1.11'
+    #pod 'WordPressCom-Analytics-iOS', '0.1.11'
+    pod 'WordPressCom-Analytics-iOS', :branch => 'plans', :git => 'https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git'
     pod 'WordPressCom-Stats-iOS', '0.7.0'
     pod 'wpxmlrpc', '~> 0.8'
     

--- a/Podfile
+++ b/Podfile
@@ -53,8 +53,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '~> 0.9.1'
     pod 'WordPress-iOS-Editor', '1.6.1'
     pod 'WordPressApi', '0.4.0'
-    #pod 'WordPressCom-Analytics-iOS', '0.1.11'
-    pod 'WordPressCom-Analytics-iOS', :branch => 'plans', :git => 'https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git'
+    pod 'WordPressCom-Analytics-iOS', '0.1.12'
     pod 'WordPressCom-Stats-iOS', '0.7.0'
     pod 'wpxmlrpc', '~> 0.8'
     

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -239,7 +239,7 @@ DEPENDENCIES:
   - WordPress-iOS-Editor (= 1.6.1)
   - WordPress-iOS-Shared (= 0.5.9)
   - WordPressApi (= 0.4.0)
-  - WordPressCom-Analytics-iOS (= 0.1.11)
+  - WordPressCom-Analytics-iOS (from `https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git`, branch `plans`)
   - WordPressCom-Stats-iOS (= 0.7.0)
   - WordPressCom-Stats-iOS/Services (= 0.7.0)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.1`)
@@ -253,6 +253,9 @@ EXTERNAL SOURCES:
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
+  WordPressCom-Analytics-iOS:
+    :branch: plans
+    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.1
@@ -264,6 +267,9 @@ CHECKOUT OPTIONS:
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
+  WordPressCom-Analytics-iOS:
+    :commit: 3915ed845335ff81e5f4267801631a6622e947eb
+    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.1
@@ -313,6 +319,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 7dde7576a67a9a494733555a89c9ff8418f5eede
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 3be528f1f8db6da2934fb5a3442bc44e15558671
+PODFILE CHECKSUM: 64f231861cd14576fe78587735e327fd168db5cc
 
 COCOAPODS: 1.0.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -176,7 +176,7 @@ PODS:
   - WordPressApi (0.4.0):
     - AFNetworking (~> 2.6.0)
     - wpxmlrpc (~> 0.8)
-  - WordPressCom-Analytics-iOS (0.1.11)
+  - WordPressCom-Analytics-iOS (0.1.12)
   - WordPressCom-Stats-iOS (0.7.0):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (~> 2.2.0)
@@ -239,7 +239,7 @@ DEPENDENCIES:
   - WordPress-iOS-Editor (= 1.6.1)
   - WordPress-iOS-Shared (= 0.5.9)
   - WordPressApi (= 0.4.0)
-  - WordPressCom-Analytics-iOS (from `https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git`, branch `plans`)
+  - WordPressCom-Analytics-iOS (= 0.1.12)
   - WordPressCom-Stats-iOS (= 0.7.0)
   - WordPressCom-Stats-iOS/Services (= 0.7.0)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.1`)
@@ -253,9 +253,6 @@ EXTERNAL SOURCES:
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPressCom-Analytics-iOS:
-    :branch: plans
-    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.1
@@ -267,9 +264,6 @@ CHECKOUT OPTIONS:
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPressCom-Analytics-iOS:
-    :commit: 3915ed845335ff81e5f4267801631a6622e947eb
-    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.1
@@ -313,12 +307,12 @@ SPEC CHECKSUMS:
   WordPress-iOS-Editor: 9daa51cb32ee0c2821045c1035e925eb3c6633ed
   WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
   WordPressApi: 483767025bcdab26429b51bfe5171f17d3d30466
-  WordPressCom-Analytics-iOS: a844ac791b2627dbb64ba62090654f43dd2abc1c
+  WordPressCom-Analytics-iOS: 11a459d7bd4f188a8c24e85e9190da26dfbddc0e
   WordPressCom-Stats-iOS: d1996675fadd5a2c8548344a40663834898114f3
   WordPressComKit: 6f0c39c3e0af3599cd5244e4ec05192f5e4a7882
   WPMediaPicker: 7dde7576a67a9a494733555a89c9ff8418f5eede
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 64f231861cd14576fe78587735e327fd168db5cc
+PODFILE CHECKSUM: 8d2d17cde35dc61af4bb99265343c9d40387c0eb
 
 COCOAPODS: 1.0.0

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -406,8 +406,8 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
             eventProperties = @{ TracksEventPropertyMenuItemKey : @"pages" };
             break;
         case WPAnalyticsStatOpenedPlans:
-            eventName = @"plans_view";
-            eventProperties = @{ TracksEventPropertyMenuItemKey : @"pages" };
+            eventName = @"site_menu_opened";
+            eventProperties = @{ TracksEventPropertyMenuItemKey : @"plans" };
             break;
         case WPAnalyticsStatOpenedPlansComparison:
             eventName = @"plans_compare";

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -405,6 +405,13 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
             eventName = @"site_menu_opened";
             eventProperties = @{ TracksEventPropertyMenuItemKey : @"pages" };
             break;
+        case WPAnalyticsStatOpenedPlans:
+            eventName = @"plans_view";
+            eventProperties = @{ TracksEventPropertyMenuItemKey : @"pages" };
+            break;
+        case WPAnalyticsStatOpenedPlansComparison:
+            eventName = @"plans_compare";
+            break;
         case WPAnalyticsStatOpenedPosts:
             eventName = @"site_menu_opened";
             eventProperties = @{ TracksEventPropertyMenuItemKey : @"posts" };

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -658,6 +658,12 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatOpenedNotificationSettingDetails:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Notification Settings - Accessed Details"];
             break;
+        case WPAnalyticsStatOpenedPlans:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Site Menu - Opened Plans"];
+            break;
+        case WPAnalyticsStatOpenedPlansComparison:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Plans - Opened Comparison"];
+            break;
         case WPAnalyticsStatOpenedSharingManagement:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Site Menu - Opened Sharing Management"];
             break;

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -504,7 +504,7 @@ NSInteger const BlogDetailAccountHideViewAdminDay = 7;
 
 - (void)showPlans
 {
-    // TODO(@koke, 2016-01-28): add analytics
+    [WPAppAnalytics track:WPAnalyticsStatOpenedPlans];
     PlanListViewController *controller = [[PlanListViewController alloc] initWithBlog:self.blog];
     [self.navigationController pushViewController:controller animated:YES];
 }

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
@@ -100,6 +100,7 @@ enum PlanListViewModel {
 
     func controllerForPlanDetails(sitePricedPlans: SitePricedPlans, initialPlan: Plan, planService: PlanService<StoreKitStore>) -> ImmuTableRowControllerGenerator {
         return { row in
+            WPAppAnalytics.track(.OpenedPlansComparison)
             let planVC = PlanComparisonViewController(sitePricedPlans: sitePricedPlans, initialPlan: initialPlan, service: planService)
             let navigationVC = RotationAwareNavigationViewController(rootViewController: planVC)
             navigationVC.modalPresentationStyle = .FormSheet


### PR DESCRIPTION
I only track views to the plans list and plans comparison. We'll add more purchase stats when it's actually implemented.

I've pointed the analytics pod to a branch so we can review it before bumping the version. Before merging, we'd need to release a new analytics version

Changes to the analytics pod are here: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS/compare/plans

Needs review: @frosty 
