### PR TITLE
Updates Person data-types

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -8,6 +8,7 @@ data model as well as any custom migrations.
 - @jleandroperez 2016-05-13
 - `Person` updated `siteID` to Int64.
 - `Person` updated `userID` to Int64.
+- `Person` added Boolean `isFollower`.
 - @aerych 2016-05-12
 - Added `ReaderSearchTopic` entity. Represents a search in the reader.
 - @jleandroperez 2016-05-04

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,10 +5,13 @@ data model as well as any custom migrations.
 
 ## WordPress 49
 
+- @jleandroperez 2016-05-13
+- `Person` updated `siteID` to Int64.
+- `Person` updated `userID` to Int64.
 - @aerych 2016-05-12
 - Added `ReaderSearchTopic` entity. Represents a search in the reader.
 - @jleandroperez 2016-05-04
- - `Person` added Int32 `linkedUserID`.
+ - `Person` added Int64 `linkedUserID`.
 - @jleandroperez 2016-04-22
  - `Blog` added transformable `capabilities`.
 

--- a/WordPress/Classes/Models/ManagedPerson+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/ManagedPerson+CoreDataProperties.swift
@@ -9,9 +9,9 @@ extension ManagedPerson {
     @NSManaged var firstName: String?
     @NSManaged var lastName: String?
     @NSManaged var role: String
-    @NSManaged var siteID: Int32
-    @NSManaged var userID: Int32
-    @NSManaged var linkedUserID: Int32
+    @NSManaged var siteID: Int64
+    @NSManaged var userID: Int64
+    @NSManaged var linkedUserID: Int64
     @NSManaged var username: String
     @NSManaged var isSuperAdmin: Bool
     @NSManaged var blog: Blog

--- a/WordPress/Classes/Models/ManagedPerson+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/ManagedPerson+CoreDataProperties.swift
@@ -14,5 +14,6 @@ extension ManagedPerson {
     @NSManaged var linkedUserID: Int64
     @NSManaged var username: String
     @NSManaged var isSuperAdmin: Bool
+    @NSManaged var isFollower: Bool
     @NSManaged var blog: Blog
 }

--- a/WordPress/Classes/Models/ManagedPerson.swift
+++ b/WordPress/Classes/Models/ManagedPerson.swift
@@ -11,9 +11,9 @@ class ManagedPerson: NSManagedObject {
         firstName = person.firstName
         lastName = person.lastName
         role = String(person.role)
-        siteID = Int32(person.siteID)
-        userID = Int32(person.ID)
-        linkedUserID = Int32(person.linkedUserID)
+        siteID = Int64(person.siteID)
+        userID = Int64(person.ID)
+        linkedUserID = Int64(person.linkedUserID)
         username = person.username
         isSuperAdmin = person.isSuperAdmin
     }

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 49.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 49.xcdatamodel/contents
@@ -388,10 +388,10 @@
         <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="isSuperAdmin" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="linkedUserID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="linkedUserID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <attribute name="role" attributeType="String" syncable="YES"/>
-        <attribute name="siteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
-        <attribute name="userID" attributeType="Integer 32" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
+        <attribute name="userID" attributeType="Integer 64" syncable="YES"/>
         <attribute name="username" attributeType="String" syncable="YES"/>
     </entity>
     <entity name="Post" representedClassName="Post" parentEntity="AbstractPost">
@@ -638,12 +638,12 @@
         <element name="ReaderGapMarker" positionX="18" positionY="153" width="128" height="45"/>
         <element name="ReaderListTopic" positionX="45" positionY="189" width="128" height="135"/>
         <element name="ReaderPost" positionX="0" positionY="0" width="128" height="600"/>
+        <element name="ReaderSearchTopic" positionX="27" positionY="153" width="128" height="45"/>
         <element name="ReaderSite" positionX="9" positionY="153" width="128" height="163"/>
         <element name="ReaderSiteTopic" positionX="36" positionY="180" width="128" height="195"/>
         <element name="ReaderTagTopic" positionX="27" positionY="171" width="128" height="90"/>
         <element name="SharingButton" positionX="27" positionY="153" width="128" height="165"/>
         <element name="SourcePostAttribution" positionX="9" positionY="153" width="128" height="225"/>
         <element name="Theme" positionX="9" positionY="153" width="128" height="330"/>
-        <element name="ReaderSearchTopic" positionX="27" positionY="153" width="128" height="45"/>
     </elements>
 </model>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 49.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 49.xcdatamodel/contents
@@ -386,6 +386,7 @@
         <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="displayName" attributeType="String" syncable="YES"/>
         <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isFollower" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="isSuperAdmin" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="linkedUserID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
@@ -626,7 +627,7 @@
         <element name="Meta" positionX="9" positionY="153" width="128" height="105"/>
         <element name="Notification" positionX="18" positionY="162" width="128" height="255"/>
         <element name="Page" positionX="0" positionY="0" width="128" height="60"/>
-        <element name="Person" positionX="18" positionY="153" width="128" height="195"/>
+        <element name="Person" positionX="18" positionY="153" width="128" height="210"/>
         <element name="Post" positionX="0" positionY="0" width="128" height="195"/>
         <element name="PostTag" positionX="27" positionY="153" width="128" height="105"/>
         <element name="PostType" positionX="27" positionY="153" width="128" height="105"/>


### PR DESCRIPTION
Closes #5322

#### Testing: With the App!
1. If your cocoapods setup has (RVM?) please install `release/6.2` on your device, normally
2. If not, you may hack it, as i did:
2.1. In develop, temporarily set the data model to Mark 48
2.2. Comment [this line](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/Services/BlogService.m#L593) so it doesn't crash.
2.3. Run the app, and log into your account
3. Install this branch on top

As a result, the app should not get logged out.

#### Unit Tests:
Please, run `CoreDataMigrationTests.testMigrate48to49DoesntLoosePersonEntities` and verify it doesn't break.

Needs review: @astralbodies 
cc @aerych 
