### PR TITLE
Refactor WPUserAgent

### DIFF
--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -139,7 +139,7 @@ static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.word
 {
     if (!_wordPressComRestApi && self.authToken.length > 0) {
         _wordPressComRestApi = [[WordPressComRestApi alloc] initWithOAuthToken:self.authToken
-                                                                     userAgent: [[WPUserAgent new] wordPressUserAgent]];
+                                                                     userAgent: [WPUserAgent wordPressUserAgent]];
     }
     return _wordPressComRestApi;
 

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -75,7 +75,6 @@ int ddLogLevel = DDLogLevelInfo;
 @property (nonatomic, strong, readwrite) HockeyManager                  *hockey;
 @property (nonatomic, assign, readwrite) UIBackgroundTaskIdentifier     bgTask;
 @property (nonatomic, assign, readwrite) BOOL                           connectionAvailable;
-@property (nonatomic, strong, readwrite) WPUserAgent                    *userAgent;
 @property (nonatomic, assign, readwrite) BOOL                           shouldRestoreApplicationState;
 @property (nonatomic, assign) UIApplicationShortcutItem                 *launchedShortcutItem;
 
@@ -373,8 +372,7 @@ int ddLogLevel = DDLogLevelInfo;
     
     // Networking setup
     [[AFNetworkActivityIndicatorManager sharedManager] setEnabled:YES];
-    self.userAgent = [[WPUserAgent alloc] init];
-    [self.userAgent useWordPressUserAgentInUIWebViews];
+    [WPUserAgent useWordPressUserAgentInUIWebViews];
     [self setupSingleSignOn];
 
     // WORKAROUND: Preload the Merriweather regular font to ensure it is not overridden

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerWPCom.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerWPCom.m
@@ -31,7 +31,7 @@
 {
     int x = arc4random();
     NSString *statsURL = [NSString stringWithFormat:@"%@%@%@%@%d" , WPMobileReaderURL, @"&template=stats&stats_name=", statName, @"&rnd=", x];
-    NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent wordPressUserAgent];
+    NSString *userAgent = [WPUserAgent wordPressUserAgent];
     
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:statsURL]];
     [request setValue:userAgent forHTTPHeaderField:@"User-Agent"];

--- a/WordPress/Classes/Utility/WPUserAgent.h
+++ b/WordPress/Classes/Utility/WPUserAgent.h
@@ -7,13 +7,18 @@
 @interface WPUserAgent : NSObject
 
 /**
+ *  @brief      Default User-Agent header.
+ */
++ (NSString *)defaultUserAgent;
+
+/**
  *  @brief      WordPress custom User-Agent header.
  */
-@property (nonatomic, strong, readonly) NSString *wordPressUserAgent;
++ (NSString *)wordPressUserAgent;
 
 /**
  *  @brief      Sets User-Agent header of all UIWebViews to be the WordPress one.
  */
-- (void)useWordPressUserAgentInUIWebViews;
++ (void)useWordPressUserAgentInUIWebViews;
 
 @end

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -2,51 +2,34 @@
 
 static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
 
-@interface WPUserAgent ()
-
-// Default UA to append "wp-iphone/<version>" to
-- (NSString *)defaultUserAgent;
-
-@property (nonatomic, strong, readwrite) NSString *wordPressUserAgent;
-
-@end
-
 @implementation WPUserAgent
 
-- (instancetype)init
++ (NSString *)defaultUserAgent
 {
-    self = [super init];
-    if (self) {
-        // Cleanup unused NSUserDefaults keys from older WPUserAgent implementation
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"DefaultUserAgent"];
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"AppUserAgent"];
-    }
-    return self;
+    static NSString * _defaultUserAgent;
+    static dispatch_once_t _onceToken;
+    dispatch_once(&_onceToken, ^{
+        if ([[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent] != nil){
+            NSLog(@"To get the real default nothing should be already be set here");
+        }
+        if ([NSThread isMainThread]){
+            _defaultUserAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+        } else {
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                _defaultUserAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+            });
+        }
+    });
+    NSAssert(_defaultUserAgent != nil, @"User agent shouldn't be nil");
+    NSAssert([_defaultUserAgent length] > 0, @"User agent shouldn't be empty");
+
+    return _defaultUserAgent;
 }
 
-- (NSString *)defaultUserAgent
++ (NSString *)wordPressUserAgent
 {
-    // Temporarily unset "UserAgent" from registered user defaults so that we
-    // always get the default value, independently from what's currently set as
-    // User-Agent
-    NSDictionary *originalRegisteredDefaults = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSRegistrationDomain];
-
-    NSMutableDictionary *tempRegisteredDefaults = [NSMutableDictionary dictionaryWithDictionary:originalRegisteredDefaults];
-    [tempRegisteredDefaults removeObjectForKey:WPUserAgentKeyUserAgent];
-    [[NSUserDefaults standardUserDefaults] registerDefaults:tempRegisteredDefaults];
-    
-    NSString *defaultUserAgent = [[[UIWebView alloc] init] stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
-    NSAssert(defaultUserAgent != nil, @"User agent shouldn't be nil");
-    NSAssert([defaultUserAgent length] > 0, @"User agent shouldn't be empty");
-    
-    [[NSUserDefaults standardUserDefaults] registerDefaults:originalRegisteredDefaults];
-    
-    return defaultUserAgent;
-}
-
-- (NSString *)wordPressUserAgent
-{
-    if (! _wordPressUserAgent) {
+    static NSString * _wordPressUserAgent;
+    if (_wordPressUserAgent == nil) {
         NSString *defaultUA = [self defaultUserAgent];
         NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
         _wordPressUserAgent = [NSString stringWithFormat:@"%@ wp-iphone/%@", defaultUA, appVersion];
@@ -55,8 +38,12 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     return _wordPressUserAgent;
 }
 
-- (void)useWordPressUserAgentInUIWebViews
++ (void)useWordPressUserAgentInUIWebViews
 {
+    // Cleanup unused NSUserDefaults keys from older WPUserAgent implementation
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"DefaultUserAgent"];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"AppUserAgent"];
+
     NSString *userAgent = [self wordPressUserAgent];
 
     NSParameterAssert([userAgent isKindOfClass:[NSString class]]);

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -459,7 +459,7 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
 
 - (NSURLRequest *)newRequestForWebsite
 {
-    NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent wordPressUserAgent];
+    NSString *userAgent = [WPUserAgent wordPressUserAgent];
     NSURLRequest *request;
     if (!self.needsLogin) {
         request = [WPURLRequest requestWithURL:self.url userAgent:userAgent];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -162,7 +162,7 @@ import WordPressComAnalytics
             NSString(format:"t=%d", arc4random())
         ]
 
-        let userAgent = WordPressAppDelegate.sharedInstance().userAgent.wordPressUserAgent
+        let userAgent = WPUserAgent.wordPressUserAgent()
         let path  = NSString(format: "%@?%@", pixel, params.componentsJoinedByString("&")) as String
         let url = NSURL(string: path)
 

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -80,7 +80,7 @@ NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
 		
         [self setAuthorizationHeaderWithToken:_authToken];
 		
-        NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent wordPressUserAgent];
+        NSString *userAgent = [WPUserAgent wordPressUserAgent];
 		[self.requestSerializer setValue:userAgent forHTTPHeaderField:@"User-Agent"];
 	}
 	
@@ -250,7 +250,7 @@ constructingBodyWithBlock:block
         DDLogVerbose(@"Initializing anonymous API");
         _anonymousApi = [[self alloc] initWithBaseURL:[NSURL URLWithString:WordPressComApiClientEndpointURL] ];
 
-        NSString *userAgent = [[WordPressAppDelegate sharedInstance].userAgent wordPressUserAgent];
+        NSString *userAgent = [WPUserAgent wordPressUserAgent];
 		[_anonymousApi.requestSerializer setValue:userAgent forHTTPHeaderField:@"User-Agent"];
     });
 

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -68,4 +68,13 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     });
 }
 
+- (void)testThatRegistarDefaultJustAdds {
+    NSDictionary * registrationDomain = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSRegistrationDomain];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{WPUserAgentKeyUserAgent: @(0)}];
+    NSDictionary * changedRegistrationDomain = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSRegistrationDomain];
+
+    XCTAssertTrue((registrationDomain.count == changedRegistrationDomain.count) || ((registrationDomain.count +1) == changedRegistrationDomain.count), "It should add or reset");
+}
+
+
 @end

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -9,47 +9,6 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
 
 @implementation WPUserAgentTests
 
-/**
- *  @brief      Returns default UA for this device.
- *  @details    This method is duplicated on purpose since we want to make sure that any change to
- *              the WP UA in the app makes this test show an error unless updated.  This way we
- *              ensure the change is intentional.
- *              Also, the method temporarily unsets "UserAgent" from registered
- *              user defaults so that we always get the default value,
- *              independently from what's currently set as User-Agent.
- */
-- (NSString *)defaultUserAgent
-{
-    NSDictionary *originalRegisteredDefaults = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSRegistrationDomain];
-    
-    NSMutableDictionary *tempRegisteredDefaults = [NSMutableDictionary dictionaryWithDictionary:originalRegisteredDefaults];
-    [tempRegisteredDefaults removeObjectForKey:WPUserAgentKeyUserAgent];
-    [[NSUserDefaults standardUserDefaults] registerDefaults:tempRegisteredDefaults];
-    
-    NSString *userAgent = [self currentUserAgentFromUIWebView];
-    XCTAssertNotNil(userAgent, @"User agent shouldn't be nil");
-    XCTAssertTrue([userAgent length] > 0, @"User agent shouldn't be empty");
-    
-    [[NSUserDefaults standardUserDefaults] registerDefaults:originalRegisteredDefaults];
-    
-    return userAgent;
-}
-
-/**
- *  @brief      Calculates the wordpress UA for this device.
- *  @details    This method is duplicated on purpose since we want to make sure that any change to
- *              the WP UA in the app makes this test show an error unless updated.  This way we
- *              ensure the change is intentional.
- */
-- (NSString *)wordPressUserAgent
-{
-    NSString *defaultUA = [self defaultUserAgent];
-    NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
-    NSString *userAgent = [NSString stringWithFormat:@"%@ wp-iphone/%@", defaultUA, appVersion];
-    
-    return userAgent;
-}
-
 - (NSString *)currentUserAgentFromUserDefaults
 {
     return [[NSUserDefaults standardUserDefaults] objectForKey:WPUserAgentKeyUserAgent];
@@ -62,28 +21,24 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
 
 - (void)testWordPressUserAgent
 {
-    NSString *wordPressUA = [self wordPressUserAgent];
-    WPUserAgent *userAgent = nil;
-    
-    XCTAssertNoThrow(userAgent = [[WPUserAgent alloc] init]);
-    XCTAssertTrue([userAgent isKindOfClass:[WPUserAgent class]]);
-    
-    XCTAssertTrue([[self wordPressUserAgent] isEqualToString:wordPressUA]);
+    NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+    NSString *customAgent = [NSString stringWithFormat:@"wp-iphone/%@", appVersion];
+
+    XCTAssertTrue([[WPUserAgent wordPressUserAgent] containsString:customAgent]);
 }
 
 - (void)testUseWordPressUserAgentInUIWebViews
 {
-    NSString *defaultUA = [self defaultUserAgent];
-    NSString *wordPressUA = [self wordPressUserAgent];
-    WPUserAgent *userAgent = nil;
-    
-    XCTAssertNoThrow(userAgent = [[WPUserAgent alloc] init]);
-    XCTAssertTrue([userAgent isKindOfClass:[WPUserAgent class]]);
-    
+    NSString *defaultUA = [WPUserAgent defaultUserAgent];
+    NSString *wordPressUA = [WPUserAgent wordPressUserAgent];
+
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:WPUserAgentKeyUserAgent];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{WPUserAgentKeyUserAgent: defaultUA}];
+
     XCTAssertTrue([[self currentUserAgentFromUserDefaults] isEqualToString:defaultUA]);
     XCTAssertTrue([[self currentUserAgentFromUIWebView] isEqualToString:defaultUA]);
-    
-    [userAgent useWordPressUserAgentInUIWebViews];
+
+    [WPUserAgent useWordPressUserAgentInUIWebViews];
     
     XCTAssertTrue([[self currentUserAgentFromUserDefaults] isEqualToString:wordPressUA]);
     XCTAssertTrue([[self currentUserAgentFromUIWebView] isEqualToString:wordPressUA]);

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -44,4 +44,28 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     XCTAssertTrue([[self currentUserAgentFromUIWebView] isEqualToString:wordPressUA]);
 }
 
+- (void)testThatOriginalRemovalOfWPUseKeyUserAgentDoesntWork {
+    // get the original user agent
+    NSString *originalUserAgent = [self currentUserAgentFromUIWebView];
+    NSLog(@"OriginalUserAgent: %@", originalUserAgent);
+    // set a new one
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{WPUserAgentKeyUserAgent:@"new user agent"}];
+    NSString *changedUserAgent = [self currentUserAgentFromUIWebView];
+    NSLog(@"changedUserAgent: %@", changedUserAgent);
+
+    // try to remove it using old method
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{}];
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:WPUserAgentKeyUserAgent];
+    NSString *shouldBeOriginal = [self currentUserAgentFromUIWebView];
+    NSLog(@"shouldBeOriginal: %@", shouldBeOriginal);
+    XCTAssertNotEqualObjects(originalUserAgent, shouldBeOriginal, "This agent should be the same");
+}
+
+- (void)testThatCallingFromAnotherThreadWorks {
+    // get the original user agent
+    dispatch_sync(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        XCTAssertNoThrow([WPUserAgent wordPressUserAgent], @"Being called from out of main thread should work");
+    });
+}
+
 @end


### PR DESCRIPTION
Refactor WPUserAgent to use static methods that are thread safe and invoked once.

To test: 
 - Run unit tests see if they are correct.
 - Run the app on the simulator using a Charles or similar program and see if the user agent is correct.

Needs review: @koke, @astralbodies and @aerych mind to have a look?