### PR TITLE
Issue/5319 dont try to enforce method overriding

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -591,19 +591,16 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
         }
 
         let filterType = currentPostListFilter().filterType
-        var message : String
 
         switch filterType {
         case .Draft:
-            message = NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views drafts in the pages list and there are no pages")
+            return NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views drafts in the pages list and there are no pages")
         case .Scheduled:
-            message = NSLocalizedString("Would you like to schedule a draft to publish?", comment: "Displayed when the user views scheduled pages in the oages list and there are no pages")
+            return NSLocalizedString("Would you like to schedule a draft to publish?", comment: "Displayed when the user views scheduled pages in the oages list and there are no pages")
         case .Trashed:
-            message = NSLocalizedString("Everything you write is solid gold.", comment: "Displayed when the user views trashed pages in the pages list and there are no pages")
+            return NSLocalizedString("Everything you write is solid gold.", comment: "Displayed when the user views trashed pages in the pages list and there are no pages")
         default:
-            message = NSLocalizedString("Would you like to publish your first page?", comment: "Displayed when the user views published pages in the pages list and there are no pages")
+            return NSLocalizedString("Would you like to publish your first page?", comment: "Displayed when the user views published pages in the pages list and there are no pages")
         }
-
-        return message
     }
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -63,7 +63,9 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     // MARK: - UIViewController
 
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        super.noResultsCustomizer = self
+        super.refreshNoResultsView = { [weak self] noResultsView in
+            self?.handleRefreshNoResultsView(noResultsView)
+        }
         super.tableViewController = (segue.destinationViewController as! UITableViewController)
     }
 
@@ -536,13 +538,10 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
             restorePost(apost)
         }
     }
-}
 
-extension PageListViewController : AbstractPostListNoResultsViewCustomizer {
+    // MARK: - Refreshing noResultsView
 
-    // MARK: - AbstractPostListNoResultsViewCustomizer
-
-    func refreshView(noResultsView: WPNoResultsView) {
+    func handleRefreshNoResultsView(noResultsView: WPNoResultsView) {
         noResultsView.titleText = noResultsTitle()
         noResultsView.messageText = noResultsMessage()
         noResultsView.accessoryView = noResultsAccessoryView()

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -100,7 +100,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-        configureNoResultsView()
+        refreshNoResultsView()
     }
 
     override func viewDidAppear(animated: Bool) {
@@ -213,7 +213,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         tableView.tableFooterView = postListFooterView
     }
 
-    private func configureNoResultsView() {
+    private func refreshNoResultsView() {
         guard isViewLoaded() == true else {
             return
         }
@@ -387,7 +387,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         tableViewHandler.refreshCachedRowHeightsForWidth(width)
 
         tableView.reloadData()
-        configureNoResultsView()
+        refreshNoResultsView()
     }
 
     func resetTableViewContentOffset() {
@@ -411,7 +411,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         // After any change, make sure that the no results view is properly
         // configured.
 
-        configureNoResultsView()
+        refreshNoResultsView()
     }
 
     func tableView(tableView: UITableView!, willDisplayCell cell: UITableViewCell!, forRowAtIndexPath indexPath: NSIndexPath!) {
@@ -479,14 +479,14 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         let appDelegate = WordPressAppDelegate.sharedInstance()
 
         if appDelegate.connectionAvailable == false {
-            configureNoResultsView()
+            refreshNoResultsView()
             return
         }
 
         if let lastSynced = lastSyncDate()
             where abs(lastSynced.timeIntervalSinceNow) <= self.dynamicType.postsControllerRefreshInterval {
 
-            configureNoResultsView()
+            refreshNoResultsView()
         } else {
             // Update in the background
             syncItemsWithUserInteraction(false)
@@ -495,7 +495,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     func syncItemsWithUserInteraction(userInteraction: Bool) {
         syncHelper.syncContentWithUserInteraction(userInteraction)
-        configureNoResultsView()
+        refreshNoResultsView()
     }
 
     func updateFilter(filter: PostListFilter, withSyncedPosts posts:[AbstractPost], syncOptions options: PostServiceSyncOptions) {
@@ -632,7 +632,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
             // It will be redisplayed if necessary.
 
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(100 * NSEC_PER_MSEC)), dispatch_get_main_queue(), { [weak self] in
-                self?.configureNoResultsView()
+                self?.refreshNoResultsView()
             })
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -4,11 +4,6 @@ import WordPressComAnalytics
 import WordPressShared
 import wpxmlrpc
 
-protocol AbstractPostListNoResultsViewCustomizer {
-
-    func refreshView(noResultsView: WPNoResultsView)
-}
-
 class AbstractPostListViewController : UIViewController, WPContentSyncHelperDelegate, WPNoResultsViewDelegate, WPSearchControllerDelegate, WPSearchResultsUpdating, WPTableViewHandlerDelegate {
 
     typealias WPNoResultsView = WordPressShared.WPNoResultsView
@@ -27,7 +22,11 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     private static let defaultHeightForFooterView = CGFloat(44.0)
 
     var blog : Blog!
-    var noResultsCustomizer : AbstractPostListNoResultsViewCustomizer!
+
+    /// This closure will be executed whenever the noResultsView must be visually refreshed.  It's up
+    /// to the subclass to define this property.
+    ///
+    var refreshNoResultsView : ((WPNoResultsView) -> ())!
     var tableViewController : UITableViewController!
 
     var tableView : UITableView {
@@ -285,10 +284,10 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     }
 
     private func showNoResultsView() {
-        precondition(noResultsCustomizer != nil)
+        precondition(refreshNoResultsView != nil)
 
         postListFooterView.hidden = true
-        noResultsCustomizer.refreshView(noResultsView)
+        refreshNoResultsView(noResultsView)
 
         // Only add and animate no results view if it isn't already
         // in the table view

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -213,7 +213,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         tableView.tableFooterView = postListFooterView
     }
 
-    func configureNoResultsView() {
+    private func configureNoResultsView() {
         guard isViewLoaded() == true else {
             return
         }
@@ -631,7 +631,9 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
             // To compensate, call configureNoResultsView after a short delay.
             // It will be redisplayed if necessary.
 
-            performSelector(#selector(configureNoResultsView), withObject: self, afterDelay: 0.1)
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(100 * NSEC_PER_MSEC)), dispatch_get_main_queue(), { [weak self] in
+                self?.configureNoResultsView()
+            })
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -680,21 +680,15 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         }
 
         let filterType = currentPostListFilter().filterType
-        var title: String
 
         switch filterType {
         case .Scheduled:
-            title = NSLocalizedString("Edit Drafts", comment: "Button title, encourages users to schedule a draft post to publish.")
-            break
+            return NSLocalizedString("Edit Drafts", comment: "Button title, encourages users to schedule a draft post to publish.")
         case .Trashed:
-            title = ""
-            break
+            return ""
         default:
-            title = NSLocalizedString("Start a Post", comment: "Button title, encourages users to create their first post on their blog.")
-            break
+            return NSLocalizedString("Start a Post", comment: "Button title, encourages users to create their first post on their blog.")
         }
-
-        return title
     }
 
     func noResultsTitle() -> String {
@@ -715,23 +709,16 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         }
 
         let filterType = currentPostListFilter().filterType
-        var message: String
 
         switch filterType {
         case .Draft:
-            message = NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views drafts in the posts list and there are no posts")
-            break
+            return NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views drafts in the posts list and there are no posts")
         case .Scheduled:
-            message = NSLocalizedString("Would you like to schedule a draft to publish?", comment: "Displayed when the user views scheduled posts in the posts list and there are no posts")
-            break
+            return NSLocalizedString("Would you like to schedule a draft to publish?", comment: "Displayed when the user views scheduled posts in the posts list and there are no posts")
         case .Trashed:
-            message = NSLocalizedString("Everything you write is solid gold.", comment: "Displayed when the user views trashed posts in the posts list and there are no posts")
-            break
+            return NSLocalizedString("Everything you write is solid gold.", comment: "Displayed when the user views trashed posts in the posts list and there are no posts")
         default:
-            message = NSLocalizedString("Would you like to publish your first post?", comment: "Displayed when the user views published posts in the posts list and there are no posts")
-            break
+            return NSLocalizedString("Would you like to publish your first post?", comment: "Displayed when the user views published posts in the posts list and there are no posts")
         }
-
-        return message
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -88,7 +88,9 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
 
         precondition(segue.destinationViewController is UITableViewController)
 
-        super.noResultsCustomizer = self
+        super.refreshNoResultsView = { [weak self] noResultsView in
+            self?.handleRefreshNoResultsView(noResultsView)
+        }
         super.tableViewController = (segue.destinationViewController as! UITableViewController)
     }
 
@@ -651,15 +653,10 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
 
         restorePost(apost)
     }
-}
 
-// MARK: - AbstractPostListNoResultsViewCustomizer
+    // MARK: - Refreshing noResultsView
 
-extension PostListViewController : AbstractPostListNoResultsViewCustomizer {
-
-    // MARK: - AbstractPostListNoResultsViewCustomizer
-
-    func refreshView(noResultsView: WPNoResultsView) {
+    private func handleRefreshNoResultsView(noResultsView: WPNoResultsView) {
         noResultsView.titleText = noResultsTitle()
         noResultsView.messageText = noResultsMessage()
         noResultsView.accessoryView = noResultsAccessoryView()

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -16,8 +16,6 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
     static private let currentPostListStatusFilterKey = "CurrentPostListStatusFilterKey"
     static private let currentPostAuthorFilterKey = "CurrentPostAuthorFilterKey"
 
-    // TODO: low cap on first char!
-
     static private let statsCacheInterval = NSTimeInterval(300) // 5 minutes
     static private let postCardEstimatedRowHeight = CGFloat(100.0)
     static private let postCardRestoreCellRowHeight = CGFloat(54.0)
@@ -27,7 +25,11 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
     @IBOutlet private var imageCellForLayout: PostCardTableViewCell!
     @IBOutlet private weak var authorFilterSegmentedControl: UISegmentedControl!
 
-    // MARK: Initializers & deinitializers
+    // MARK: - GUI
+
+    private let animatedBox = WPAnimatedBox()
+
+    // MARK: - Initializers & deinitializers
 
     deinit {
         PrivateSiteURLProtocol.unregisterPrivateSiteURLProtocol()
@@ -85,6 +87,8 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
 
         precondition(segue.destinationViewController is UITableViewController)
+
+        super.noResultsCustomizer = self
         super.tableViewController = (segue.destinationViewController as! UITableViewController)
     }
 
@@ -152,18 +156,6 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         tableView.registerNib(postCardRestoreCellNib, forCellReuseIdentifier: self.dynamicType.postCardRestoreCellIdentifier)
     }
 
-    override func noResultsTitleText() -> String {
-        if syncHelper.isSyncing == true {
-            return NSLocalizedString("Fetching posts...", comment: "A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new posts.")
-        }
-
-        let filter = currentPostListFilter()
-        let titles = noResultsTitles()
-        let title = titles[filter.filterType]
-
-        return title ?? ""
-    }
-
     private func noResultsTitles() -> [PostListStatusFilter:String] {
         if isSearching() {
             return noResultsTitlesWhenSearching()
@@ -195,55 +187,6 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
                 .Scheduled: scheduled,
                 .Trashed: trashed,
                 .Published: published]
-    }
-
-    override func noResultsMessageText() -> String {
-        if syncHelper.isSyncing == true || isSearching() {
-            return ""
-        }
-
-        let filterType = currentPostListFilter().filterType
-        var message: String
-
-        switch filterType {
-        case .Draft:
-            message = NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views drafts in the posts list and there are no posts")
-            break
-        case .Scheduled:
-            message = NSLocalizedString("Would you like to schedule a draft to publish?", comment: "Displayed when the user views scheduled posts in the posts list and there are no posts")
-            break
-        case .Trashed:
-            message = NSLocalizedString("Everything you write is solid gold.", comment: "Displayed when the user views trashed posts in the posts list and there are no posts")
-            break
-        default:
-            message = NSLocalizedString("Would you like to publish your first post?", comment: "Displayed when the user views published posts in the posts list and there are no posts")
-            break
-        }
-
-        return message
-    }
-
-    override func noResultsButtonText() -> String? {
-        if syncHelper.isSyncing == true || isSearching() {
-            return nil
-        }
-
-        let filterType = currentPostListFilter().filterType
-        var title: String
-
-        switch filterType {
-        case .Scheduled:
-            title = NSLocalizedString("Edit Drafts", comment: "Button title, encourages users to schedule a draft post to publish.")
-            break
-        case .Trashed:
-            title = ""
-            break
-        default:
-            title = NSLocalizedString("Start a Post", comment: "Button title, encourages users to create their first post on their blog.")
-            break
-        }
-
-        return title
     }
 
     override func configureAuthorFilter() {
@@ -707,5 +650,91 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         }
 
         restorePost(apost)
+    }
+}
+
+// MARK: - AbstractPostListNoResultsViewCustomizer
+
+extension PostListViewController : AbstractPostListNoResultsViewCustomizer {
+
+    // MARK: - AbstractPostListNoResultsViewCustomizer
+
+    func refreshView(noResultsView: WPNoResultsView) {
+        noResultsView.titleText = noResultsTitle()
+        noResultsView.messageText = noResultsMessage()
+        noResultsView.accessoryView = noResultsAccessoryView()
+        noResultsView.buttonTitle = noResultsButtonTitle()
+    }
+
+    // MARK: - NoResultsView Customizer helpers
+
+    private func noResultsAccessoryView() -> UIView {
+        if syncHelper.isSyncing {
+            animatedBox.animateAfterDelay(0.1)
+            return animatedBox
+        }
+
+        return UIImageView(image: UIImage(named: "illustration-posts"))
+    }
+
+    func noResultsButtonTitle() -> String {
+        if syncHelper.isSyncing == true || isSearching() {
+            return ""
+        }
+
+        let filterType = currentPostListFilter().filterType
+        var title: String
+
+        switch filterType {
+        case .Scheduled:
+            title = NSLocalizedString("Edit Drafts", comment: "Button title, encourages users to schedule a draft post to publish.")
+            break
+        case .Trashed:
+            title = ""
+            break
+        default:
+            title = NSLocalizedString("Start a Post", comment: "Button title, encourages users to create their first post on their blog.")
+            break
+        }
+
+        return title
+    }
+
+    func noResultsTitle() -> String {
+        if syncHelper.isSyncing == true {
+            return NSLocalizedString("Fetching posts...", comment: "A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new posts.")
+        }
+
+        let filter = currentPostListFilter()
+        let titles = noResultsTitles()
+        let title = titles[filter.filterType]
+
+        return title ?? ""
+    }
+
+    func noResultsMessage() -> String {
+        if syncHelper.isSyncing == true || isSearching() {
+            return ""
+        }
+
+        let filterType = currentPostListFilter().filterType
+        var message: String
+
+        switch filterType {
+        case .Draft:
+            message = NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views drafts in the posts list and there are no posts")
+            break
+        case .Scheduled:
+            message = NSLocalizedString("Would you like to schedule a draft to publish?", comment: "Displayed when the user views scheduled posts in the posts list and there are no posts")
+            break
+        case .Trashed:
+            message = NSLocalizedString("Everything you write is solid gold.", comment: "Displayed when the user views trashed posts in the posts list and there are no posts")
+            break
+        default:
+            message = NSLocalizedString("Would you like to publish your first post?", comment: "Displayed when the user views published posts in the posts list and there are no posts")
+            break
+        }
+
+        return message
     }
 }


### PR DESCRIPTION
Fixes #5319.

### Details:

Refreshing the noResultsView is now handled through a block.  This isn't the cleanest solution in the world.  We should seriously refactor `AbstractPostListViewController` and divide it into components instead.

For now this solution should be better than what we previously had.

### Testing:

Run the app.
Go to both pages and posts.
Switch to every tab.
Do a search.
Pull down to refresh.

Needs review: @jleandroperez 
