### PR TITLE
Menus: MenuItems view controller for ordering and hierarchy editing.

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.h
@@ -1,0 +1,71 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class Menu;
+@class MenuItem;
+
+@protocol MenuItemsViewControllerDelegate;
+
+@interface MenuItemsViewController : UIViewController
+
+@property (nonatomic, weak, nullable) id <MenuItemsViewControllerDelegate> delegate;
+@property (nonatomic, strong, nullable) Menu *menu;
+
+/**
+ Reload the views associated with the Menu's items.
+ */
+- (void)reloadItems;
+
+/**
+ Refresh the views associated with the specific item.
+ */
+- (void)refreshViewWithItem:(MenuItem *)item focus:(BOOL)focusesView;
+
+/**
+ Delete the MenuItem object and remove the view representing the item.
+ */
+- (void)removeItem:(MenuItem *)item;
+
+@end
+
+@protocol MenuItemsViewControllerDelegate <NSObject>
+
+/**
+ User created a new (empty) MenuItem.
+ */
+- (void)itemsViewController:(MenuItemsViewController *)itemsViewController createdNewItemForEditing:(MenuItem *)item;
+
+/**
+ User selected an item for editing it.
+ */
+- (void)itemsViewController:(MenuItemsViewController *)itemsViewController selectedItemForEditing:(MenuItem *)item;
+
+/**
+ User updated the ordering of the Menu's items.
+ */
+- (void)itemsViewController:(MenuItemsViewController *)itemsViewController didUpdateMenuItemsOrdering:(Menu *)menu;
+
+/**
+ User interaction triggered a need for scrolling a view to the center of any parent scrollViews.
+ */
+- (void)itemsViewController:(MenuItemsViewController *)itemsViewController requiresScrollingToCenterView:(UIView *)viewForScrolling;
+
+/**
+ User interaction triggered that may require enabling/disabling scrolling for any parent scrollViews.
+ */
+- (void)itemsViewController:(MenuItemsViewController *)itemsViewController prefersScrollingEnabled:(BOOL)enabled;
+
+/**
+ User interaction triggered that may require an offset update for a rect change of the view within any parent scrollViews.
+ */
+- (void)itemsViewController:(MenuItemsViewController *)itemsViewController prefersAdjustingScrollingOffsetForAnimatingView:(UIView *)view;
+
+/**
+ User interaction triggered a change in a specific view's rect that may require an offset change for any parent scrollViews.
+ */
+- (void)itemsViewAnimatingContentSizeChanges:(MenuItemsViewController *)itemsView focusedRect:(CGRect)focusedRect updatedFocusRect:(CGRect)updatedFocusRect;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
@@ -11,7 +11,7 @@
 #import <WordPressShared/WPDeviceIdentification.h>
 #import "WPGUIConstants.h"
 
-static CGFloat const ItemHoriztonalDragDetectionWidthRation = 0.5;
+static CGFloat const ItemHoriztonalDragDetectionWidthRatio = 0.05;
 static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
 
 @interface MenuItemsViewController () <MenuItemAbstractViewDelegate, MenuItemViewDelegate, MenuItemInsertionViewDelegate, MenuItemsVisualOrderingViewDelegate>
@@ -448,7 +448,7 @@ static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
         //// detect if the user is moving horizontally to the right or left to change the indentation
         
         // first check to see if we should pay attention to touches that might signal a change in indentation
-        const BOOL detectedHorizontalOrderingTouches = fabs(vector.x) > (selectedItemView.frame.size.width * ItemHoriztonalDragDetectionWidthRation); // a travel of x% should be considered for updating relationships
+        const BOOL detectedHorizontalOrderingTouches = fabs(vector.x) > (selectedItemView.frame.size.width * ItemHoriztonalDragDetectionWidthRatio); // a travel of x% should be considered for updating relationships
         
         [self.visualOrderingView updateVisualOrderingWithTouchLocation:touchPoint vector:vector];
         

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
@@ -1,0 +1,862 @@
+#import "MenuItemsViewController.h"
+#import "Menu.h"
+#import "MenuItem.h"
+#import "WPStyleGuide.h"
+#import "MenuItemAbstractView.h"
+#import "MenuItemView.h"
+#import "MenuItemInsertionView.h"
+#import "MenuItemsVisualOrderingView.h"
+#import "ContextManager.h"
+#import "Menu+ViewDesign.h"
+
+@interface MenuItemsViewController () <MenuItemAbstractViewDelegate, MenuItemViewDelegate, MenuItemInsertionViewDelegate, MenuItemsVisualOrderingViewDelegate>
+
+@property (nonatomic, strong) IBOutlet UIStackView *stackView;
+
+@property (nonatomic, strong, readonly) NSMutableSet *itemViews;
+@property (nonatomic, strong, readonly) NSMutableSet *insertionViews;
+@property (nonatomic, strong) MenuItemView *itemViewForInsertionToggling;
+@property (nonatomic, assign) BOOL isEditingForItemViewInsertion;
+
+@property (nonatomic, assign) CGPoint touchesBeganLocation;
+@property (nonatomic, assign) CGPoint touchesMovedLocation;
+@property (nonatomic, assign) BOOL showingTouchesOrdering;
+
+@property (nonatomic, assign) BOOL observesOrderingTouches;
+@property (nonatomic, assign) BOOL observesParentChildNestingTouches;
+
+@property (nonatomic, strong) MenuItemView *itemViewForOrdering;
+@property (nonatomic, strong, readonly) MenuItemsVisualOrderingView *visualOrderingView;
+
+@end
+
+@implementation MenuItemsViewController
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    
+    self.view.translatesAutoresizingMaskIntoConstraints = NO;
+    self.view.layer.borderColor = [[WPStyleGuide greyLighten20] CGColor];
+    self.view.layer.borderWidth = MenusDesignStrokeWidth;
+    
+    _itemViews = [NSMutableSet set];
+    _insertionViews = [NSMutableSet setWithCapacity:3];
+    
+    self.touchesBeganLocation = CGPointZero;
+    self.touchesMovedLocation = CGPointZero;
+}
+
+- (void)setMenu:(Menu *)menu
+{
+    if (_menu != menu) {
+        _menu = menu;
+        [self reloadItems];
+    }
+}
+
+- (void)refreshViewWithItem:(MenuItem *)item focus:(BOOL)focusesView
+{
+    MenuItemView *itemView = [self itemViewForItem:item];
+    [itemView refresh];
+    if (focusesView) {
+        [self.delegate itemsViewController:self requiresScrollingToCenterView:itemView];
+    }
+}
+
+- (void)removeItem:(MenuItem *)item
+{
+    // Reassign any children to the parent of the item.
+    BOOL parentChildUpdateNeeded = NO;
+    if (item.children.count) {
+        parentChildUpdateNeeded = YES;
+        NSSet *children = [NSSet setWithSet:item.children];
+        for (MenuItem *child in children) {
+            child.parent = item.parent;
+        }
+    }
+    
+    // Remove the itemView from the stackView.
+    MenuItemView *itemView = [self itemViewForItem:item];
+    [self.stackView removeArrangedSubview:itemView];
+    [itemView removeFromSuperview];
+    [self.itemViews removeObject:itemView];
+    itemView = nil;
+    if (parentChildUpdateNeeded) {
+        [self updateParentChildIndentationForItemViews];
+    }
+    
+    // Remove the item from the context.
+    NSManagedObjectContext *managedObjectContext = item.managedObjectContext;
+    [managedObjectContext deleteObject:item];
+    [managedObjectContext processPendingChanges];
+    [[ContextManager sharedInstance] saveContext:managedObjectContext];
+}
+
+- (void)reloadItems
+{
+    NSArray *arrangedViews = [NSArray arrayWithArray:self.stackView.arrangedSubviews];
+    for (MenuItemAbstractView *stackableView in arrangedViews) {
+        [self.stackView removeArrangedSubview:stackableView];
+        [stackableView removeFromSuperview];
+    }
+    
+    [self.itemViews removeAllObjects];
+    [self.insertionViews removeAllObjects];
+    
+    self.isEditingForItemViewInsertion = NO;
+    self.itemViewForInsertionToggling = nil;
+    
+    for (MenuItem *item in self.menu.items) {
+        [self addNewItemViewWithItem:item];
+    }
+}
+
+- (MenuItemView *)addNewItemViewWithItem:(MenuItem *)item
+{
+    MenuItemView *itemView = [[MenuItemView alloc] init];
+    itemView.delegate = self;
+    itemView.item = item;
+    itemView.indentationLevel = 0;
+    
+    NSLayoutConstraint *heightConstraint = [itemView.heightAnchor constraintGreaterThanOrEqualToConstant:MenuItemsStackableViewDefaultHeight];
+    heightConstraint.active = YES;
+    [self.itemViews addObject:itemView];
+    [self.stackView addArrangedSubview:itemView];
+    [itemView.widthAnchor constraintEqualToAnchor:self.view.widthAnchor].active = YES;
+    
+    MenuItem *parentItem = item.parent;
+    while (parentItem) {
+        itemView.indentationLevel++;
+        parentItem = parentItem.parent;
+    }
+    
+    return itemView;
+}
+
+- (void)updateParentChildIndentationForItemViews
+{
+    for (UIView *arrangedView in self.stackView.arrangedSubviews) {
+        if (![arrangedView isKindOfClass:[MenuItemView class]]) {
+            continue;
+        }
+        
+        MenuItemView *itemView = (MenuItemView *)arrangedView;
+        itemView.indentationLevel = 0;
+        
+        MenuItem *parentItem = itemView.item.parent;
+        while (parentItem) {
+            itemView.indentationLevel++;
+            parentItem = parentItem.parent;
+        }
+    }
+}
+
+- (MenuItemInsertionView *)addNewInsertionViewWithOrder:(MenuItemInsertionOrder)insertionOrder forItemView:(MenuItemView *)itemView
+{
+    NSInteger index = [self.stackView.arrangedSubviews indexOfObject:itemView];
+    MenuItemInsertionView *insertionView = [[MenuItemInsertionView alloc] init];
+    insertionView.delegate = self;
+    insertionView.insertionOrder = insertionOrder;
+    
+    switch (insertionOrder) {
+        case MenuItemInsertionOrderAbove:
+            insertionView.indentationLevel = itemView.indentationLevel;
+            break;
+        case MenuItemInsertionOrderBelow:
+            insertionView.indentationLevel = itemView.indentationLevel;
+            index++;
+            break;
+        case MenuItemInsertionOrderChild:
+            insertionView.indentationLevel = itemView.indentationLevel + 1;
+            index += 2;
+            break;
+    }
+    
+    NSLayoutConstraint *heightConstraint = [insertionView.heightAnchor constraintEqualToConstant:MenuItemsStackableViewDefaultHeight];
+    heightConstraint.priority = UILayoutPriorityDefaultHigh;
+    heightConstraint.active = YES;
+    
+    [self.insertionViews addObject:insertionView];
+    [self.stackView insertArrangedSubview:insertionView atIndex:index];
+    
+    [insertionView.widthAnchor constraintEqualToAnchor:self.stackView.widthAnchor].active = YES;
+    
+    return insertionView;
+}
+
+- (void)insertInsertionItemViewsAroundItemView:(MenuItemView *)toggledItemView
+{
+    if (self.isEditingForItemViewInsertion) {
+        [self removeItemInsertionViews:NO];
+    }
+    
+    self.isEditingForItemViewInsertion = YES;
+    
+    self.itemViewForInsertionToggling = toggledItemView;
+    toggledItemView.showsCancelButtonOption = YES;
+    toggledItemView.showsEditingButtonOptions = NO;
+    
+    [self addNewInsertionViewWithOrder:MenuItemInsertionOrderAbove forItemView:toggledItemView];
+    [self addNewInsertionViewWithOrder:MenuItemInsertionOrderBelow forItemView:toggledItemView];
+    [self addNewInsertionViewWithOrder:MenuItemInsertionOrderChild forItemView:toggledItemView];
+}
+
+- (void)insertItemInsertionViewsAroundItemView:(MenuItemView *)toggledItemView animated:(BOOL)animated
+{
+    BOOL wasEditing = self.isEditingForItemViewInsertion;
+
+    CGRect previousRect = toggledItemView.frame;
+    CGRect updatedRect = toggledItemView.frame;
+    
+    [self insertInsertionItemViewsAroundItemView:toggledItemView];
+    
+    if (!animated) {
+        return;
+    }
+    
+    // since we are adding content above the toggledItemView, the toggledItemView (focus) will move downwards with the updated content size
+    updatedRect.origin.y += MenuItemsStackableViewDefaultHeight;
+    
+    for (MenuItemInsertionView *insertionView in self.insertionViews) {
+        insertionView.hidden = YES;
+        insertionView.alpha = 0.0;
+    }
+    [UIView animateWithDuration:0.3 animations:^{
+        
+        for (MenuItemInsertionView *insertionView in self.insertionViews) {
+            insertionView.hidden = NO;
+            insertionView.alpha = 1.0;
+        }
+        // inform the delegate to handle this content change based on the rect we are focused on
+        // a delegate will likely scroll the content with the size change
+        if (!wasEditing) {
+            [self.delegate itemsViewAnimatingContentSizeChanges:self focusedRect:previousRect updatedFocusRect:updatedRect];
+        }
+        
+    } completion:^(BOOL finished) {
+        
+        
+    }];
+}
+
+- (void)removeItemInsertionViews
+{
+    for (MenuItemInsertionView *insertionView in self.insertionViews) {
+        [self.stackView removeArrangedSubview:insertionView];
+        [insertionView removeFromSuperview];
+    }
+    
+    [self.insertionViews removeAllObjects];
+    self.itemViewForInsertionToggling = nil;
+}
+
+- (void)removeItemInsertionViews:(BOOL)animated
+{
+    self.isEditingForItemViewInsertion = NO;
+    self.itemViewForInsertionToggling.showsCancelButtonOption = NO;
+    self.itemViewForInsertionToggling.showsEditingButtonOptions = YES;
+    
+    if (!animated) {
+        [self removeItemInsertionViews];
+        return;
+    }
+    
+    CGRect previousRect = self.itemViewForInsertionToggling.frame;
+    CGRect updatedRect = previousRect;
+    // since we are removing content above the toggledItemView, the toggledItemView (focus) will move upwards with the updated content size
+    updatedRect.origin.y -= MenuItemsStackableViewDefaultHeight;
+    
+    [UIView animateWithDuration:0.3 delay:0.0 options:0 animations:^{
+        
+        for (MenuItemInsertionView *insertionView in self.insertionViews) {
+            insertionView.hidden = YES;
+            insertionView.alpha = 0.0;
+        }
+        
+        // inform the delegate to handle this content change based on the rect we are focused on
+        // a delegate will likely scroll the content with the size change
+        [self.delegate itemsViewAnimatingContentSizeChanges:self focusedRect:previousRect updatedFocusRect:updatedRect];
+        
+    } completion:^(BOOL finished) {
+        
+        [self removeItemInsertionViews];
+    }];
+}
+
+- (MenuItemView *)itemViewForItem:(MenuItem *)item
+{
+    MenuItemView *itemView = nil;
+    for (MenuItemView *arrangedItemView in self.itemViews) {
+        if (arrangedItemView.item == item) {
+            itemView = arrangedItemView;
+            break;
+        }
+    }
+    return itemView;
+}
+
+#pragma mark - touches
+
+- (void)resetTouchesMovedObservationVectorX
+{
+    CGPoint reset = CGPointZero;
+    reset.x = self.touchesMovedLocation.x;
+    reset.y = self.touchesBeganLocation.y;
+    self.touchesBeganLocation = reset;
+}
+
+- (void)resetTouchesMovedObservationVectorY
+{
+    CGPoint reset = CGPointZero;
+    reset.y = self.touchesMovedLocation.y;
+    reset.x = self.touchesBeganLocation.x;
+    self.touchesBeganLocation = reset;
+}
+
+- (void)updateWithTouchesStarted:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    CGPoint location = [[touches anyObject] locationInView:self.view];
+
+    self.touchesBeganLocation = location;
+    
+    if (self.isEditingForItemViewInsertion) {
+        return;
+    }
+    
+    for (MenuItemView *itemView in self.itemViews) {
+        if (CGRectContainsPoint(itemView.frame, [[touches anyObject] locationInView:itemView.superview])) {
+            self.observesParentChildNestingTouches = YES;
+        } else {
+            continue;
+        }
+        if (CGRectContainsPoint([itemView orderingToggleRect], [[touches anyObject] locationInView:itemView])) {
+            self.observesOrderingTouches = YES;
+        }
+        if (self.observesParentChildNestingTouches || self.observesOrderingTouches) {
+            [self beginOrdering:itemView];
+            break;
+        }
+    }
+}
+
+- (void)updateWithTouchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    CGPoint location = [[touches anyObject] locationInView:self.view];
+    
+    CGPoint startLocation = self.touchesBeganLocation;
+    
+    self.touchesMovedLocation = location;
+    CGPoint vector = CGPointZero;
+    vector.x = location.x - startLocation.x;
+    vector.y = location.y - startLocation.y;
+    
+    if (self.isEditingForItemViewInsertion || !(self.observesOrderingTouches || self.observesParentChildNestingTouches)) {
+        return;
+    }
+    
+    if (self.observesOrderingTouches) {
+        // Only show ordering visual for ordering, not for parent/child nesting.
+        [self showOrdering];
+    }
+    [self orderingTouchesMoved:touches withEvent:event vector:vector];
+}
+
+- (void)updateWithTouchesStopped:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    self.observesOrderingTouches = NO;
+    self.observesParentChildNestingTouches = NO;
+    self.touchesBeganLocation = CGPointZero;
+    self.touchesMovedLocation = CGPointZero;
+    [self endReordering];
+}
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesBegan:touches withEvent:event];
+    [self updateWithTouchesStarted:touches withEvent:event];
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesMoved:touches withEvent:event];
+    [self updateWithTouchesMoved:touches withEvent:event];
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesEnded:touches withEvent:event];
+    [self updateWithTouchesStopped:touches withEvent:event];
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesCancelled:touches withEvent:event];
+    [self updateWithTouchesStopped:touches withEvent:event];
+}
+
+#pragma mark - ordering
+
+- (void)beginOrdering:(MenuItemView *)orderingView
+{
+    self.itemViewForOrdering = orderingView;
+    [self prepareVisualOrderingViewWithItemView:orderingView];
+}
+
+- (void)showOrdering
+{
+    if (!self.showingTouchesOrdering) {
+        self.showingTouchesOrdering = YES;
+        [self showVisualOrderingView];
+        [self toggleOrderingPlaceHolder:YES forItemViewsWithSelectedItemView:self.itemViewForOrdering];
+    }
+}
+
+- (void)hideOrdering
+{
+    self.showingTouchesOrdering = NO;
+    [self toggleOrderingPlaceHolder:NO forItemViewsWithSelectedItemView:self.itemViewForOrdering];
+    [self hideVisualOrderingView];
+}
+
+- (void)endReordering
+{
+    // cleanup
+    
+    [self hideOrdering];
+    self.itemViewForOrdering = nil;
+    [self.delegate itemsViewController:self prefersScrollingEnabled:YES];
+}
+
+- (void)orderingTouchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event vector:(CGPoint)vector
+{
+    if (!self.itemViewForOrdering) {
+        return;
+    }
+    
+    const CGPoint touchPoint = [[touches anyObject] locationInView:self.view];
+    MenuItemView *selectedItemView = self.itemViewForOrdering;
+    MenuItem *selectedItem = selectedItemView.item;
+    BOOL modelUpdated = NO;
+
+    if (self.observesParentChildNestingTouches) {
+        //// horiztonal indentation detection (child relationships)
+        //// detect if the user is moving horizontally to the right or left to change the indentation
+        
+        // first check to see if we should pay attention to touches that might signal a change in indentation
+        const BOOL detectedHorizontalOrderingTouches = fabs(vector.x) > ((selectedItemView.frame.size.width * 5.0) / 100); // a travel of x% should be considered for updating relationships
+        
+        [self.visualOrderingView updateVisualOrderingWithTouchLocation:touchPoint vector:vector];
+        
+        if (detectedHorizontalOrderingTouches) {
+            
+            NSOrderedSet *orderedItems = self.menu.items;
+            NSUInteger selectedItemIndex = [orderedItems indexOfObject:selectedItem];
+            
+            // check if not first item in order
+            if (selectedItemIndex > 0) {
+                // detect the child/parent relationship changes and update the model
+                if (vector.x > 0) {
+                    // trying to make a child
+                    MenuItem *previousItem = [orderedItems objectAtIndex:selectedItemIndex - 1];
+                    MenuItem *parent = previousItem;
+                    MenuItem *newParent = nil;
+                    while (parent) {
+                        if (parent == selectedItem.parent) {
+                            break;
+                        }
+                        newParent = parent;
+                        parent = parent.parent;
+                    }
+                    
+                    if (newParent) {
+                        selectedItem.parent = newParent;
+                        modelUpdated = YES;
+                    }
+                    
+                } else  {
+                    if (selectedItem.parent) {
+                        
+                        MenuItem *lastChildItem = [selectedItem.parent lastDescendantInOrderedItems:orderedItems];
+                        // only the lastChildItem can move up the tree, otherwise it would break the visual child/parent relationship
+                        if (selectedItem == lastChildItem) {
+                            // try to move up the parent tree
+                            MenuItem *parent = selectedItem.parent.parent;
+                            selectedItem.parent = parent;
+                            modelUpdated = YES;
+                        }
+                    }
+                }
+            }
+            
+            // reset the vector to observe the next delta of interest
+            [self resetTouchesMovedObservationVectorX];
+        }
+    }
+    
+    if (self.observesOrderingTouches) {
+        [self.delegate itemsViewController:self prefersScrollingEnabled:NO];
+        
+        //// vertical ordering detection (order of the items in the menu)
+        if (!CGRectContainsPoint(selectedItemView.frame, touchPoint)) {
+            
+            //// if the touch is over a different item, detect which item to replace the ordering with
+            
+            for (MenuItemView *itemView in self.itemViews) {
+                // enumerate the itemViews lists since we don't care about other views in the stackView.arrangedSubviews list
+                if (itemView == selectedItemView) {
+                    continue;
+                }
+                // detect if the touch within a padded inset of an itemView under the touchPoint
+                const CGRect orderingDetectionRect = CGRectInset(itemView.frame, 10.0, 10.0);
+                if (CGRectContainsPoint(orderingDetectionRect, touchPoint)) {
+                    
+                    // reorder the model if needed or available
+                    BOOL orderingUpdate = [self handleOrderingTouchForItemView:selectedItemView withOtherItemView:itemView touchLocation:touchPoint];
+                    if (orderingUpdate) {
+                        modelUpdated = YES;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    
+    // update the views based on the model changes
+    if (modelUpdated) {
+        [self updateParentChildIndentationForItemViews];
+        [self.visualOrderingView updateForVisualOrderingMenuItemsModelChange];
+        [self.delegate itemsViewController:self didUpdateMenuItemsOrdering:self.menu];
+    }
+}
+
+- (BOOL)handleOrderingTouchForItemView:(MenuItemView *)itemView withOtherItemView:(MenuItemView *)otherItemView touchLocation:(CGPoint)touchLocation
+{
+    // ordering may may reflect the user wanting to move an item to before or after otherItem
+    // ordering may reflect the user wanting to move an item to be a child of the parent of otherItem
+    // ordering may reflect the user wanting to move an item out of a child stack, or up the parent tree to the next parent
+    
+    if (itemView == otherItemView) {
+        return NO;
+    }
+    
+    MenuItem *item = itemView.item;
+    MenuItem *otherItem = otherItemView.item;
+
+    // can't order a ancestor within a descendant
+    if ([otherItem isDescendantOfItem:item]) {
+        return NO;
+    }
+    
+    BOOL updated = NO;
+    
+    NSMutableOrderedSet *orderedItems = [NSMutableOrderedSet orderedSetWithOrderedSet:self.menu.items];
+    
+    const BOOL itemIsOrderedBeforeOtherItem = [orderedItems indexOfObject:item] < [orderedItems indexOfObject:otherItem];
+    
+    const BOOL orderingTouchesBeforeOtherItem = touchLocation.y < CGRectGetMidY(otherItemView.frame);
+    const BOOL orderingTouchesAfterOtherItem = !orderingTouchesBeforeOtherItem; // using additional BOOL for readability
+    
+    void (^moveItemAndDescendantsOrderingWithOtherItem)(BOOL) = ^ (BOOL afterOtherItem) {
+        
+        // get the item and its descendants
+        NSMutableArray *movingItems = [NSMutableArray array];
+        for (NSUInteger i = [orderedItems indexOfObject:item]; i < orderedItems.count; i++) {
+            MenuItem *orderedItem = [orderedItems objectAtIndex:i];
+            if (orderedItem != item && ![orderedItem isDescendantOfItem:item]) {
+                break;
+            }
+            [movingItems addObject:orderedItem];
+        }
+        
+        [orderedItems removeObjectsInArray:movingItems];
+        
+        // insert the items in new position
+        NSUInteger otherItemIndex = [orderedItems indexOfObject:otherItem];
+        NSUInteger insertionIndex = afterOtherItem ? otherItemIndex + 1 : otherItemIndex;
+        
+        [orderedItems insertObjects:movingItems atIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(insertionIndex, movingItems.count)]];
+    };
+    
+    if (itemIsOrderedBeforeOtherItem) {
+        // descending in ordering
+        
+        if (orderingTouchesBeforeOtherItem) {
+            // trying to move up the parent tree
+            
+            if (item.parent != otherItem.parent) {
+                if ([self nextAvailableItemForOrderingAfterItem:item] == otherItem) {
+                    // take the parent of the otherItem, or nil
+                    item.parent = otherItem.parent;
+                    updated = YES;
+                }
+            }
+            
+        } else  if (orderingTouchesAfterOtherItem) {
+            // trying to order the item after the otherItem
+            
+            if (otherItem.children.count) {
+                // if ordering after a parent, we need to become a child
+                item.parent = otherItem;
+            } else  {
+                // assuming the item will take the parent of the otherItem's parent, or nil
+                item.parent = otherItem.parent;
+            }
+            
+            moveItemAndDescendantsOrderingWithOtherItem(YES);
+            
+            updated = YES;
+        }
+        
+    } else  {
+        // ascending in ordering
+        
+        if (orderingTouchesBeforeOtherItem) {
+            // trying to order the item before the otherItem
+            
+            // assuming the item will become the parent of the otherItem's parent, or nil
+            item.parent = otherItem.parent;
+            
+            moveItemAndDescendantsOrderingWithOtherItem(NO);
+            
+            updated = YES;
+            
+        } else  if (orderingTouchesAfterOtherItem) {
+            // trying to become a child of the otherItem's parent
+            
+            if (item.parent != otherItem.parent) {
+                
+                // can't become a child of the otherItem's parent, if already a child of otherItem
+                if (item.parent != otherItem) {
+                    if ([self nextAvailableItemForOrderingBeforeItem:item] == otherItem) {
+                        // become the parent of the otherItem's parent, or nil
+                        item.parent = otherItem.parent;
+                        updated = YES;
+                    }
+                }
+            }
+        }
+    }
+    
+    if (updated) {
+        
+        // update the stackView arrangedSubviews ordering to reflect the ordering in orderedItems
+        [self.stackView sendSubviewToBack:otherItemView];
+        [self orderingAnimationWithBlock:^{
+            for (NSUInteger i = 0; i < orderedItems.count; i++) {
+                
+                MenuItem *item = [orderedItems objectAtIndex:i];
+                MenuItemView *itemView = [self itemViewForItem:item];
+                [self.stackView insertArrangedSubview:itemView atIndex:i];
+            }
+        }];
+        
+        self.menu.items = orderedItems;
+        [self.delegate itemsViewController:self didUpdateMenuItemsOrdering:self.menu];
+    }
+    
+    return updated;
+}
+
+- (MenuItem *)nextAvailableItemForOrderingAfterItem:(MenuItem *)item
+{
+    MenuItem *availableItem = nil;
+    NSUInteger itemIndex = [self.menu.items indexOfObject:item];
+    
+    for (NSUInteger i = itemIndex + 1; itemIndex < self.menu.items.count; i++) {
+        
+        MenuItem *anItem = [self.menu.items objectAtIndex:i];
+        if (![anItem isDescendantOfItem:item]) {
+            availableItem = anItem;
+            break;
+        }
+    }
+    
+    return availableItem;
+}
+
+- (MenuItem *)nextAvailableItemForOrderingBeforeItem:(MenuItem *)item
+{
+    NSUInteger itemIndex = [self.menu.items indexOfObject:item];
+    if (itemIndex == 0) {
+        return nil;
+    }
+    
+    MenuItem *availableItem = [self.menu.items objectAtIndex:itemIndex - 1];
+    return availableItem;
+}
+
+- (void)toggleOrderingPlaceHolder:(BOOL)showsPlaceholder forItemViewsWithSelectedItemView:(MenuItemView *)selectedItemView
+{
+    selectedItemView.isPlaceholder = showsPlaceholder;
+    
+    if (!selectedItemView.item.children.count) {
+        return;
+    }
+    
+    // find any descendant MenuItemViews that should also be set as a placeholder or not
+    NSArray *arrangedViews = self.stackView.arrangedSubviews;
+    
+    NSUInteger itemViewIndex = [arrangedViews indexOfObject:selectedItemView];
+    for (NSUInteger i = itemViewIndex + 1; i < arrangedViews.count; i++) {
+        UIView *view = [arrangedViews objectAtIndex:i];
+        if ([view isKindOfClass:[MenuItemView class]]) {
+            MenuItemView *itemView = (MenuItemView *)view;
+            if ([itemView.item isDescendantOfItem:selectedItemView.item]) {
+                itemView.isPlaceholder = showsPlaceholder;
+            }
+        }
+    }
+}
+
+- (void)orderingAnimationWithBlock:(void(^)())block
+{
+    [UIView animateWithDuration:0.10 animations:^{
+        block();
+    } completion:nil];
+}
+
+- (void)prepareVisualOrderingViewWithItemView:(MenuItemView *)selectedItemView
+{
+    MenuItemsVisualOrderingView *orderingView = self.visualOrderingView;
+    if (!orderingView) {
+        orderingView = [[MenuItemsVisualOrderingView alloc] initWithFrame:self.stackView.bounds];
+        orderingView.delegate = self;
+        orderingView.translatesAutoresizingMaskIntoConstraints = NO;
+        orderingView.backgroundColor = [UIColor clearColor];
+        orderingView.userInteractionEnabled = NO;
+        orderingView.hidden = YES;
+        
+        [self.view addSubview:orderingView];
+        [NSLayoutConstraint activateConstraints:@[
+                                                  [orderingView.topAnchor constraintEqualToAnchor:self.stackView.topAnchor],
+                                                  [orderingView.leadingAnchor constraintEqualToAnchor:self.stackView.leadingAnchor],
+                                                  [orderingView.trailingAnchor constraintEqualToAnchor:self.stackView.trailingAnchor],
+                                                  [orderingView.bottomAnchor constraintEqualToAnchor:self.stackView.bottomAnchor]
+                                                  ]];
+        _visualOrderingView = orderingView;
+    }
+    
+    [self.visualOrderingView setupVisualOrderingWithItemView:selectedItemView];
+}
+
+- (void)showVisualOrderingView
+{
+    self.visualOrderingView.hidden = NO;
+}
+
+- (void)hideVisualOrderingView
+{
+    self.visualOrderingView.hidden = YES;
+}
+
+#pragma mark - MenuItemsVisualOrderingViewDelegate
+
+- (void)visualOrderingView:(MenuItemsVisualOrderingView *)visualOrderingView animatingVisualItemViewForOrdering:(MenuItemView *)orderingView
+{
+    [self.delegate itemsViewController:self prefersAdjustingScrollingOffsetForAnimatingView:orderingView];
+}
+
+#pragma mark - MenuItemViewDelegate
+
+- (void)itemView:(MenuItemAbstractView *)itemView highlighted:(BOOL)highlighted
+{
+    // Toggle drawing the line separator on the previous view in the stackView.
+    // Otherwise the drawn line stacks oddling against the highlighted drawing.
+    NSUInteger indexOfView = [self.stackView.arrangedSubviews indexOfObject:itemView];
+    if (indexOfView != NSNotFound && indexOfView > 0) {
+        MenuItemAbstractView *view = [self.stackView.arrangedSubviews objectAtIndex:indexOfView - 1];
+        if ([view isKindOfClass:[MenuItemAbstractView class]]) {
+            view.drawsLineSeparator = !highlighted;
+        }
+    }
+}
+
+- (void)itemViewSelected:(MenuItemView *)itemView
+{
+    [self.delegate itemsViewController:self selectedItemForEditing:itemView.item];
+}
+
+- (void)itemViewAddButtonPressed:(MenuItemView *)itemView
+{
+    [self insertItemInsertionViewsAroundItemView:itemView animated:YES];
+}
+
+- (void)itemViewCancelButtonPressed:(MenuItemView *)itemView
+{
+    [self removeItemInsertionViews:YES];
+}
+
+#pragma mark - MenuItemInsertionViewDelegate
+
+- (void)itemInsertionViewSelected:(MenuItemInsertionView *)insertionView
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        
+        // Dispatch a bit later since we are about to swap out views.
+        // Any layout or drawing related to the seleciton made need to complete before removing the insertionView.
+        
+        MenuItem *toggledItem = self.itemViewForInsertionToggling.item;
+        
+        // Create a new item.
+        MenuItem *newItem = [NSEntityDescription insertNewObjectForEntityForName:[MenuItem entityName] inManagedObjectContext:self.menu.managedObjectContext];
+        newItem.name = [MenuItem defaultItemNameLocalized];
+        newItem.type = MenuItemTypePage;
+        
+        // Insert the new item into the menu's ordered items.
+        BOOL requiresOffsetInsertionOrder = NO;
+        NSMutableOrderedSet *orderedItems = [NSMutableOrderedSet orderedSetWithOrderedSet:self.menu.items];
+        switch (insertionView.insertionOrder) {
+                
+            case MenuItemInsertionOrderAbove:
+                [orderedItems insertObject:newItem atIndex:[orderedItems indexOfObject:toggledItem]];
+                newItem.parent = toggledItem.parent;
+                break;
+                
+            case MenuItemInsertionOrderBelow:
+            {
+                if (toggledItem.children.count) {
+                    // Find the last child and insert below it.
+                    MenuItem *lastChild = [toggledItem lastDescendantInOrderedItems:orderedItems];
+                    [orderedItems insertObject:newItem atIndex:[orderedItems indexOfObject:lastChild] + 1];
+                    requiresOffsetInsertionOrder = YES;
+                } else {
+                    [orderedItems insertObject:newItem atIndex:[orderedItems indexOfObject:toggledItem] + 1];
+                }
+                newItem.parent = toggledItem.parent;
+                break;
+            }
+                
+            case MenuItemInsertionOrderChild:
+                [orderedItems insertObject:newItem atIndex:[orderedItems indexOfObject:toggledItem] + 1];
+                newItem.parent = toggledItem;
+                break;
+        }
+        
+        // Update the menu items.
+        self.menu.items = orderedItems;
+        
+        // Go ahead and save the context with the new item, we can delete later if needed.
+        [[ContextManager sharedInstance] saveContextAndWait:self.menu.managedObjectContext];
+        
+        // Add and replace the insertionView with a new itemView.
+        MenuItemView *newItemView = [self addNewItemViewWithItem:newItem];
+        if (requiresOffsetInsertionOrder) {
+            // Need to find the correct index for the new itemView.
+            MenuItem *previousItem = [orderedItems objectAtIndex:[orderedItems indexOfObject:newItem] - 1];
+            MenuItemView *previousItemView = [self itemViewForItem:previousItem];
+            [self.stackView insertArrangedSubview:newItemView atIndex:[self.stackView.arrangedSubviews indexOfObject:previousItemView] + 1];
+        } else {
+            // Easily swap out the insertionView with the new itemView.
+            [self.stackView insertArrangedSubview:newItemView atIndex:[self.stackView.arrangedSubviews indexOfObject:insertionView]];
+            [self.stackView removeArrangedSubview:insertionView];
+            [insertionView removeFromSuperview];
+        }
+        [self removeItemInsertionViews:YES];
+        
+        // Inform the delegate to begin editing the new item.
+        [self.delegate itemsViewController:self createdNewItemForEditing:newItem];
+    });
+}
+
+@end

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
@@ -9,6 +9,10 @@
 #import "ContextManager.h"
 #import "Menu+ViewDesign.h"
 #import <WordPressShared/WPDeviceIdentification.h>
+#import "WPGUIConstants.h"
+
+static CGFloat const ItemHoriztonalDragDetectionWidthRation = 0.5;
+static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
 
 @interface MenuItemsViewController () <MenuItemAbstractViewDelegate, MenuItemViewDelegate, MenuItemInsertionViewDelegate, MenuItemsVisualOrderingViewDelegate>
 
@@ -224,13 +228,13 @@
     
     for (MenuItemInsertionView *insertionView in self.insertionViews) {
         insertionView.hidden = YES;
-        insertionView.alpha = 0.0;
+        insertionView.alpha = WPAlphaZero;
     }
-    [UIView animateWithDuration:0.3 animations:^{
+    [UIView animateWithDuration:WPAnimationDurationDefault animations:^{
         
         for (MenuItemInsertionView *insertionView in self.insertionViews) {
             insertionView.hidden = NO;
-            insertionView.alpha = 1.0;
+            insertionView.alpha = WPAlphaFull;
         }
         // inform the delegate to handle this content change based on the rect we are focused on
         // a delegate will likely scroll the content with the size change
@@ -238,10 +242,7 @@
             [self.delegate itemsViewAnimatingContentSizeChanges:self focusedRect:previousRect updatedFocusRect:updatedRect];
         }
         
-    } completion:^(BOOL finished) {
-        
-        
-    }];
+    } completion:nil];
 }
 
 - (void)removeItemInsertionViews
@@ -271,13 +272,12 @@
     // since we are removing content above the toggledItemView, the toggledItemView (focus) will move upwards with the updated content size
     updatedRect.origin.y -= MenuItemsStackableViewDefaultHeight;
     
-    [UIView animateWithDuration:0.3 delay:0.0 options:0 animations:^{
+    [UIView animateWithDuration:WPAnimationDurationDefault delay:0.0 options:0 animations:^{
         
         for (MenuItemInsertionView *insertionView in self.insertionViews) {
             insertionView.hidden = YES;
-            insertionView.alpha = 0.0;
+            insertionView.alpha = WPAlphaZero;
         }
-        
         // inform the delegate to handle this content change based on the rect we are focused on
         // a delegate will likely scroll the content with the size change
         [self.delegate itemsViewAnimatingContentSizeChanges:self focusedRect:previousRect updatedFocusRect:updatedRect];
@@ -448,7 +448,7 @@
         //// detect if the user is moving horizontally to the right or left to change the indentation
         
         // first check to see if we should pay attention to touches that might signal a change in indentation
-        const BOOL detectedHorizontalOrderingTouches = fabs(vector.x) > ((selectedItemView.frame.size.width * 5.0) / 100); // a travel of x% should be considered for updating relationships
+        const BOOL detectedHorizontalOrderingTouches = fabs(vector.x) > (selectedItemView.frame.size.width * ItemHoriztonalDragDetectionWidthRation); // a travel of x% should be considered for updating relationships
         
         [self.visualOrderingView updateVisualOrderingWithTouchLocation:touchPoint vector:vector];
         
@@ -512,7 +512,7 @@
                     continue;
                 }
                 // detect if the touch within a padded inset of an itemView under the touchPoint
-                const CGRect orderingDetectionRect = CGRectInset(itemView.frame, 10.0, 10.0);
+                const CGRect orderingDetectionRect = CGRectInset(itemView.frame, ItemOrderingTouchesDetectionInset, ItemOrderingTouchesDetectionInset);
                 if (CGRectContainsPoint(orderingDetectionRect, touchPoint)) {
                     
                     // reorder the model if needed or available

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
@@ -8,6 +8,7 @@
 #import "MenuItemsVisualOrderingView.h"
 #import "ContextManager.h"
 #import "Menu+ViewDesign.h"
+#import <WordPressShared/WPDeviceIdentification.h>
 
 @interface MenuItemsViewController () <MenuItemAbstractViewDelegate, MenuItemViewDelegate, MenuItemInsertionViewDelegate, MenuItemsVisualOrderingViewDelegate>
 
@@ -39,6 +40,9 @@
     self.view.translatesAutoresizingMaskIntoConstraints = NO;
     self.view.layer.borderColor = [[WPStyleGuide greyLighten20] CGColor];
     self.view.layer.borderWidth = MenusDesignStrokeWidth;
+    if (![WPDeviceIdentification isRetina]) {
+        self.view.layer.borderWidth = MenusDesignStrokeWidth * 2;
+    }
     
     _itemViews = [NSMutableSet set];
     _insertionViews = [NSMutableSet setWithCapacity:3];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		08216FD31CDBF96000304BA7 /* MenuItemTagsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 08216FC31CDBF96000304BA7 /* MenuItemTagsViewController.m */; };
 		08216FD41CDBF96000304BA7 /* MenuItemTypeSelectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08216FC51CDBF96000304BA7 /* MenuItemTypeSelectionView.m */; };
 		08216FD51CDBF96000304BA7 /* MenuItemTypeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 08216FC71CDBF96000304BA7 /* MenuItemTypeViewController.m */; };
+		082635BB1CEA69280088030C /* MenuItemsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 082635BA1CEA69280088030C /* MenuItemsViewController.m */; };
 		082AB9D61C4EEA72000CA523 /* RemotePostTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9D51C4EEA72000CA523 /* RemotePostTag.m */; };
 		082AB9D91C4EEEF4000CA523 /* PostTagService.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9D81C4EEEF4000CA523 /* PostTagService.m */; };
 		082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9DC1C4F035E000CA523 /* PostTag.m */; };
@@ -971,6 +972,8 @@
 		08216FC51CDBF96000304BA7 /* MenuItemTypeSelectionView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemTypeSelectionView.m; sourceTree = "<group>"; };
 		08216FC61CDBF96000304BA7 /* MenuItemTypeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemTypeViewController.h; sourceTree = "<group>"; };
 		08216FC71CDBF96000304BA7 /* MenuItemTypeViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemTypeViewController.m; sourceTree = "<group>"; };
+		082635B91CEA69280088030C /* MenuItemsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemsViewController.h; sourceTree = "<group>"; };
+		082635BA1CEA69280088030C /* MenuItemsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemsViewController.m; sourceTree = "<group>"; };
 		082AB9D41C4EEA72000CA523 /* RemotePostTag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemotePostTag.h; sourceTree = "<group>"; };
 		082AB9D51C4EEA72000CA523 /* RemotePostTag.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RemotePostTag.m; sourceTree = "<group>"; };
 		082AB9D71C4EEEF4000CA523 /* PostTagService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostTagService.h; sourceTree = "<group>"; };
@@ -2384,6 +2387,8 @@
 		089F087F1CE25D30009909F2 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				082635B91CEA69280088030C /* MenuItemsViewController.h */,
+				082635BA1CEA69280088030C /* MenuItemsViewController.m */,
 				08216FA81CDBF95100304BA7 /* MenuItemEditingViewController.h */,
 				08216FA91CDBF95100304BA7 /* MenuItemEditingViewController.m */,
 				08216FC61CDBF96000304BA7 /* MenuItemTypeViewController.h */,
@@ -5979,6 +5984,7 @@
 				B518E1651CCAA19200ADFE75 /* Blog+Capabilities.swift in Sources */,
 				B57F010E1CB6931900B761B3 /* UIImageView+Gravatar.swift in Sources */,
 				08216FC91CDBF96000304BA7 /* MenuItemCategoriesViewController.m in Sources */,
+				082635BB1CEA69280088030C /* MenuItemsViewController.m in Sources */,
 				E1A03F48174283E10085D192 /* BlogToJetpackAccount.m in Sources */,
 				B522C4F81B3DA79B00E47B59 /* NotificationSettingsViewController.swift in Sources */,
 				E14B13C31C4E7675009DD68F /* Reachability+Rx.swift in Sources */,


### PR DESCRIPTION
Continuing with the Menus merge by adding the `MenuItemsViewController` and its `UIStackView` goodness. (Menus has been broken up over several PRs to lessen the load for review.)

![simulator screen shot may 16 2016 3 54 54 pm](https://cloud.githubusercontent.com/assets/1873422/15303700/af531412-1b7e-11e6-86ab-3080a018bb41.png)

The `MenuItemsViewController` is embedded as a child view controller within the primary `MenusViewController`, which is un-merged and seen in the staging branch `feature/menus-views`.

`MenuItemsViewController` is responsible for encapsulating the ordering and hierarchy of `MenuItems` built as `MenuItemViews` within a `UIStackView`. Ordering is handled via monitored touch events that check for the ability of a `MenuItem` to order itself under/over another `MenuItem` based on the ordering and hierarchy rules for WordPress Menus.

The view controller itself can be tested and run on a device/simulator via the staging branch `feature/menus-views`.

**To test:**

- Build and run the staging branch `feature/menus-views`.
- Select a site for a WP.com account with admin privileges.
- Select "Menus" from the Personalize section.

**Ordering:** 

- [x] Reorder Menu items by dragging and dropping the right side ordering indicator.
- [x] Save the results and check the site to ensure the ordering change is reflected.

**Parent/Children**

- [x] Drag left or right to create a child relationship for an item.
- [x] Save changes to see they are updated on the site.
- [x] Drag left and right on a parent item to ensure its children follow.
- [x] Save changes to see they are updated on the site.
- [x] Change the ordering of a parent item with children to ensure the children follow.
- [x] Save changes to see they are updated on the site.

**Add new items**

- [x] Select the + button to add new items. Once an option to add above, below or as a child is selected, hit the "OK" button the modal screen to enable it.
- [x] Add an item above, save the change and ensure the item is added above as expected on the site.
- [x] Add an item below, save the change and ensure the item is added above as expected on the site.
- [x] Add an item as a child, save the change and ensure the item is added above as expected on the site.

**Discarding**

- [x] Make ordering/parent/child changes and select the "Discard" button from the top. Ensure the changes are discarded and show the original setup.

Needs review: @jleandroperez can I request you for code review and testing fine sir? 💪💃 Let me know if I'm crazy 🔪 .