### PR TITLE
Migrate NotificationServiceRemote to use WordPressComRestAPI class th…

### DIFF
--- a/WordPress/Classes/Networking/NotificationsServiceRemote.swift
+++ b/WordPress/Classes/Networking/NotificationsServiceRemote.swift
@@ -6,15 +6,15 @@ import UIDeviceIdentifier
 /// Note that Notification Sync'ing itself is handled via Simperium, and here we'll deal mostly with the
 /// Settings / Push Notifications API.
 ///
-public class NotificationsServiceRemote : ServiceRemoteREST
+public class NotificationsServiceRemote : ServiceRemoteWordPressComREST
 {
     /// Designated Initializer. Fails if the remoteApi is nil.
     ///
-    /// - Parameter remoteApi: A Reference to the WordPressComApi that should be used to interact with WordPress.com
+    /// - Parameter wordPressComRestApi: A Reference to the WordPressComRestApi that should be used to interact with WordPress.com
     ///
-    public override init?(api: WordPressComApi!) {
-        super.init(api: api)
-        if api == nil {
+    public override init?(wordPressComRestApi: WordPressComRestApi!) {
+        super.init(wordPressComRestApi: wordPressComRestApi)
+        if wordPressComRestApi == nil {
             return nil
         }
     }
@@ -29,15 +29,15 @@ public class NotificationsServiceRemote : ServiceRemoteREST
     ///
     public func getAllSettings(deviceId: String, success: ([RemoteNotificationSettings] -> Void)?, failure: (NSError! -> Void)?) {
         let path = String(format: "me/notifications/settings/?device_id=%@", deviceId)
-        let requestUrl = self.pathForEndpoint(path, withVersion: ServiceRemoteRESTApiVersion_1_1)
+        let requestUrl = self.pathForEndpoint(path, withVersion: ._1_1)
 
-        api.GET(requestUrl,
+        wordPressComRestApi.GET(requestUrl,
             parameters: nil,
-            success: { (operation: AFHTTPRequestOperation, response: AnyObject) -> Void in
+            success: { (response: AnyObject, httpResponse: NSHTTPURLResponse?) -> Void in
                 let settings = RemoteNotificationSettings.fromDictionary(response as? NSDictionary)
                 success?(settings)
             },
-            failure: { (operation: AFHTTPRequestOperation?, error: NSError) -> Void in
+            failure: { (error: NSError, httpResponse: NSHTTPURLResponse?) -> Void in
                 failure?(error)
             })
     }
@@ -52,16 +52,16 @@ public class NotificationsServiceRemote : ServiceRemoteREST
     ///
     public func updateSettings(settings: [String: AnyObject], success: (() -> ())?, failure: (NSError! -> Void)?) {
         let path = String(format: "me/notifications/settings/")
-        let requestUrl = self.pathForEndpoint(path, withVersion: ServiceRemoteRESTApiVersion_1_1)
+        let requestUrl = self.pathForEndpoint(path, withVersion: ._1_1)
 
-        let parameters = settings as NSDictionary
+        let parameters = settings
 
-        api.POST(requestUrl,
+        wordPressComRestApi.POST(requestUrl,
             parameters: parameters,
-            success: { (operation: AFHTTPRequestOperation, response: AnyObject) -> Void in
+            success: { (response: AnyObject, httpResponse: NSHTTPURLResponse?) -> Void in
                 success?()
             },
-            failure: { (operation: AFHTTPRequestOperation?, error: NSError) -> Void in
+            failure: { (error: NSError, httpResponse: NSHTTPURLResponse?) -> Void in
                 failure?(error)
             })
     }
@@ -77,7 +77,7 @@ public class NotificationsServiceRemote : ServiceRemoteREST
     ///
     public func registerDeviceForPushNotifications(token: String, success: ((deviceId: String) -> ())?, failure: (NSError -> Void)?) {
         let endpoint = "devices/new"
-        let requestUrl = pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_1)
+        let requestUrl = pathForEndpoint(endpoint, withVersion: ._1_1)
 
         let device = UIDevice.currentDevice()
         let parameters = [
@@ -91,9 +91,9 @@ public class NotificationsServiceRemote : ServiceRemoteREST
             "device_uuid"     : device.wordPressIdentifier()
         ]
 
-        api.POST(requestUrl,
+        wordPressComRestApi.POST(requestUrl,
             parameters: parameters,
-            success: { (operation: AFHTTPRequestOperation, response: AnyObject) -> Void in
+            success: { (response: AnyObject, httpResponse: NSHTTPURLResponse?) -> Void in
                 if let responseDict = response as? NSDictionary,
                     let rawDeviceId = responseDict.objectForKey("ID")
                 {
@@ -107,7 +107,7 @@ public class NotificationsServiceRemote : ServiceRemoteREST
                     failure?(outerError)
                 }
             },
-            failure: { (operation: AFHTTPRequestOperation?, error: NSError) -> Void in
+            failure: { (error: NSError, httpResponse: NSHTTPURLResponse?) -> Void in
                 failure?(error)
             })
     }
@@ -122,15 +122,14 @@ public class NotificationsServiceRemote : ServiceRemoteREST
     ///
     public func unregisterDeviceForPushNotifications(deviceId: String, success: (() -> ())?, failure: (NSError -> Void)?) {
         let endpoint = String(format: "devices/%@/delete", deviceId)
-        let requestUrl = pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_1)
+        let requestUrl = pathForEndpoint(endpoint, withVersion: ._1_1)
 
-        api.POST(requestUrl,
+        wordPressComRestApi.POST(requestUrl,
             parameters: nil,
-            cancellable: false,
-            success: { (operation: AFHTTPRequestOperation!, response: AnyObject!) -> Void in
+            success: { (response: AnyObject!, httpResponse: NSHTTPURLResponse?) -> Void in
                 success?()
             },
-            failure: { (operation: AFHTTPRequestOperation!, error: NSError!) -> Void in
+            failure: { (error: NSError, httpResponse: NSHTTPURLResponse?) -> Void in
                 failure?(error)
             })
     }

--- a/WordPress/Classes/Services/NotificationsService.swift
+++ b/WordPress/Classes/Services/NotificationsService.swift
@@ -17,7 +17,7 @@ public class NotificationsService : LocalCoreDataService
     public override init(managedObjectContext context: NSManagedObjectContext) {
         super.init(managedObjectContext: context)
 
-        if let restApi = AccountService(managedObjectContext: context).defaultWordPressComAccount()?.restApi {
+        if let restApi = AccountService(managedObjectContext: context).defaultWordPressComAccount()?.wordPressComRestApi {
             remoteApi = restApi.hasCredentials() ? restApi : nil
         }
     }
@@ -26,11 +26,11 @@ public class NotificationsService : LocalCoreDataService
     ///
     /// - Parameters:
     ///     - managedObjectContext: A Reference to the MOC that should be used to interact with the Core Data Stack.
-    ///     - wordPressComApi: The WordPressComApi that should be used.
+    ///     - wordPressComRestApi: The WordPressComRestApi that should be used.
     ///
-    public convenience init(managedObjectContext context: NSManagedObjectContext, wordPressComApi: WordPressComApi) {
+    public convenience init(managedObjectContext context: NSManagedObjectContext, wordPressComRestApi: WordPressComRestApi) {
         self.init(managedObjectContext: context)
-        self.remoteApi = wordPressComApi
+        self.remoteApi = wordPressComRestApi
     }
 
 
@@ -253,12 +253,12 @@ public class NotificationsService : LocalCoreDataService
 
 
     // MARK: - Private Properties
-    private var remoteApi : WordPressComApi?
+    private var remoteApi : WordPressComRestApi?
 
 
     // MARK: - Private Computed Properties
     private var notificationsServiceRemote : NotificationsServiceRemote? {
-        return NotificationsServiceRemote(api: remoteApi)
+        return NotificationsServiceRemote(wordPressComRestApi: remoteApi)
     }
 
     private var blogService : BlogService {

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -82,6 +82,7 @@
 #import "RotationAwareNavigationViewController.h"
 
 #import "ServiceRemoteREST.h"
+#import "ServiceRemoteWordPressComREST.h"
 #import "SettingsSelectionViewController.h"
 #import "SettingsMultiTextViewController.h"
 #import "SettingTableViewCell.h"

--- a/WordPress/WordPressApi/WordPressComRestApi.swift
+++ b/WordPress/WordPressApi/WordPressComRestApi.swift
@@ -204,6 +204,13 @@ public final class WordPressComRestApi: NSObject
 
         return progress
     }
+
+    public func hasCredentials() -> Bool {
+        guard let authToken = oAuthToken else {
+            return false
+        }
+        return !(authToken.isEmpty)
+    }
 }
 
 /// FilePart represents the infomartion needed to encode a file on a multipart form request

--- a/WordPress/WordPressTest/NotificationsServiceTests.swift
+++ b/WordPress/WordPressTest/NotificationsServiceTests.swift
@@ -9,7 +9,7 @@ class NotificationsServiceTests : XCTestCase
 
     // MARK: - Properties
     var contextManager      : TestContextManager!
-    var remoteApi           : WordPressComApi!
+    var remoteApi           : WordPressComRestApi!
     var service             : NotificationsService!
 
     // MARK: - Constants
@@ -25,8 +25,9 @@ class NotificationsServiceTests : XCTestCase
         super.setUp()
 
         contextManager      = TestContextManager()
-        remoteApi           = WordPressComApi.anonymousApi()
-        service             = NotificationsService(managedObjectContext: contextManager.mainContext, wordPressComApi: remoteApi)
+        remoteApi           = WordPressComRestApi(oAuthToken: nil, userAgent: nil)
+        service             = NotificationsService(managedObjectContext: contextManager.mainContext,
+                                                   wordPressComRestApi: remoteApi)
 
         stub({ request in
             return request.URL?.absoluteString.rangeOfString(self.settingsEndpoint) != nil


### PR DESCRIPTION
Refs #5245 

To test: Login in the app using a WordPress.Com account
 - Go to the Me -> Notification Settings
 - Change the notification settings for blogs and see if all goes well and values are reflected on the server

Needs review: @jleandroperez , thanks in advance.