### PR TITLE
PostCardTableViewCell and RestorePostTableViewCell now use Post objects.

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -32,6 +32,9 @@
 - (void)updateRevision;
 - (BOOL)isRevision;
 - (BOOL)isOriginal;
+
+/// Returns the latest revision of a post.
+///
 - (AbstractPost *)latest;
 - (void)cloneFrom:(AbstractPost *)source;
 - (BOOL)hasSiteSpecificChanges;

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -32,6 +32,7 @@
 - (void)updateRevision;
 - (BOOL)isRevision;
 - (BOOL)isOriginal;
+- (AbstractPost *)latest;
 - (void)cloneFrom:(AbstractPost *)source;
 - (BOOL)hasSiteSpecificChanges;
 - (BOOL)hasPhoto;

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -153,6 +153,11 @@
     return ([self original] == nil);
 }
 
+- (AbstractPost *)latest
+{
+    return [self hasRevision] ? [[self revision] latest] : self;
+}
+
 - (AbstractPost *)revision
 {
     return [self primitiveValueForKey:@"revision"];

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -155,6 +155,11 @@
 
 - (AbstractPost *)latest
 {
+    // Even though we currently only support 1 revision per-post, we have plans to support multiple
+    // revisions in the future.  That's the reason why we call `[[self revision] latest]` below.
+    //
+    //  - Diego Rey Mendez, May 19, 2016
+    //
     return [self hasRevision] ? [[self revision] latest] : self;
 }
 

--- a/WordPress/Classes/ViewRelated/Post/ConfigurablePostView.h
+++ b/WordPress/Classes/ViewRelated/Post/ConfigurablePostView.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "InteractivePostViewDelegate.h"
 
-@class AbstractPost;
+@class Post;
 
 /// Protocol that any view representing a post can implement.
 ///
@@ -12,7 +12,7 @@
 /// - Parameters:
 ///     - post: the post to visually represent.
 ///
-- (void)configureWithPost:(nonnull AbstractPost*)post;
+- (void)configureWithPost:(nonnull Post*)post;
 
 /// Same as `configureWithPost:` but only for the purpose of layout.
 ///
@@ -21,7 +21,7 @@
 ///     - layoutOnly: `true` if the configure call is meant for layout purposes only.
 ///             if set to `false`, this should behave exactly like `configureWithPost:`.
 ///
-- (void)configureWithPost:(nonnull AbstractPost*)post
+- (void)configureWithPost:(nonnull Post*)post
             forLayoutOnly:(BOOL)layoutOnly;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -1,7 +1,7 @@
 #import "PostCardTableViewCell.h"
 #import <AFNetworking/UIKit+AFNetworking.h>
-#import "BasePost.h"
 #import "PhotonImageURLHelper.h"
+#import "Post.h"
 #import "PostCardActionBar.h"
 #import "PostCardActionBarItem.h"
 #import "UIImageView+Gravatar.h"
@@ -54,7 +54,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *postCardImageViewHeightConstraint;
 
 @property (nonatomic, weak) id<InteractivePostViewDelegate> delegate;
-@property (nonatomic, strong) AbstractPost *post;
+@property (nonatomic, strong) Post *post;
 @property (nonatomic) CGFloat headerViewHeight;
 @property (nonatomic) CGFloat headerViewLowerMargin;
 @property (nonatomic) CGFloat titleViewLowerMargin;
@@ -257,12 +257,12 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 #pragma mark - ConfigurablePostView
 
-- (void)configureWithPost:(AbstractPost *)post
+- (void)configureWithPost:(Post *)post
 {
     [self configureWithPost:post forLayoutOnly:NO];
 }
 
-- (void)configureWithPost:(nonnull AbstractPost *)post
+- (void)configureWithPost:(nonnull Post *)post
             forLayoutOnly:(BOOL)layoutOnly
 {
     self.configureForLayoutOnly = layoutOnly;
@@ -417,14 +417,14 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     [self resetMetaButton:self.metaButtonLeft];
 
     NSMutableArray *mButtons = [NSMutableArray arrayWithObjects:self.metaButtonLeft, self.metaButtonRight, nil];
-    if ([(Post *)(self.post) numberOfComments] > 0) {
+    if ([self.post numberOfComments] > 0) {
         UIButton *button = [mButtons lastObject];
         [mButtons removeLastObject];
         NSString *title = [NSString stringWithFormat:@"%d", [(Post *)(self.post) numberOfComments]];
         [self configureMetaButton:button withTitle:title andImage:[UIImage imageNamed:@"icon-postmeta-comment"]];
     }
 
-    if ([(Post *)(self.post) numberOfLikes] > 0) {
+    if ([self.post numberOfLikes] > 0) {
         UIButton *button = [mButtons lastObject];
         [mButtons removeLastObject];
         NSString *title = [NSString stringWithFormat:@"%d", [(Post *)(self.post) numberOfLikes]];

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -170,11 +170,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     self.innerContentView.backgroundColor = backgroundColor;
 }
 
-- (AbstractPost *)postOrRevision
-{
-    return [self.post hasRevision] ? [self.post revision] : self.post;
-}
-
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated
 {
     BOOL previouslyHighlighted = self.highlighted;
@@ -328,7 +323,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
         return;
     }
 
-    AbstractPost *post = [self postOrRevision];
+    AbstractPost *post = [self.post latest];
 
     if (![post featuredImageURLForDisplay]) {
         self.postCardImageView.image = nil;
@@ -347,7 +342,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (void)configureTitle
 {
-    AbstractPost *post = [self postOrRevision];
+    AbstractPost *post = [self.post latest];
     NSString *str = [post titleForDisplay] ?: [NSString string];
     self.titleLabel.attributedText = [[NSAttributedString alloc] initWithString:str attributes:[WPStyleGuide postCardTitleAttributes]];
     self.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
@@ -356,7 +351,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (void)configureSnippet
 {
-    AbstractPost *post = [self postOrRevision];
+    AbstractPost *post = [self.post latest];
     NSString *str = [post contentPreviewForDisplay] ?: [NSString string];
     self.snippetLabel.attributedText = [[NSAttributedString alloc] initWithString:str attributes:[WPStyleGuide postCardSnippetAttributes]];
     self.snippetLabel.lineBreakMode = NSLineBreakByTruncatingTail;
@@ -365,7 +360,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (void)configureDate
 {
-    AbstractPost *post = [self postOrRevision];
+    AbstractPost *post = [self.post latest];
     self.dateLabel.text = [post dateStringForDisplay];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.m
@@ -1,5 +1,6 @@
 #import "RestorePostTableViewCell.h"
 #import "InteractivePostViewDelegate.h"
+#import "Post.h"
 #import "WPStyleGuide+Posts.h"
 
 @interface RestorePostTableViewCell()
@@ -62,12 +63,12 @@
 
 #pragma mark - ConfigurablePostView
 
-- (void)configureWithPost:(AbstractPost *)post
+- (void)configureWithPost:(Post *)post
 {
     self.post = post;
 }
 
-- (void)configureWithPost:(AbstractPost *)post
+- (void)configureWithPost:(Post *)post
             forLayoutOnly:(BOOL)layoutOnly
 {
     [self configureWithPost:post];


### PR DESCRIPTION
Fixes #5396.

**To test:**
1. Build the code, make sure it doesn't fail.
2. Run the unit tests, make sure they don't fail.
3. Run the app, go to the list of posts for a blog and interact with it: create, edit, view, view stats, trash, restore posts.

Needs review: @frosty