### PR TITLE
Migrate MenuServiceRemote to user WordPressComRestAPI using NSURLSess…

### DIFF
--- a/WordPress/Classes/Networking/MenusServiceRemote.h
+++ b/WordPress/Classes/Networking/MenusServiceRemote.h
@@ -1,4 +1,4 @@
-#import "ServiceRemoteREST.h"
+#import "ServiceRemoteWordPressComREST.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -29,7 +29,7 @@ typedef void(^MenusServiceRemoteMenuRequestSuccessBlock)(RemoteMenu *menu);
 typedef void(^MenusServiceRemoteMenusRequestSuccessBlock)(NSArray<RemoteMenu *> * _Nullable menus,  NSArray<RemoteMenuLocation *> * _Nullable locations);
 typedef void(^MenusServiceRemoteFailureBlock)(NSError * _Nonnull error);
 
-@interface MenusServiceRemote : ServiceRemoteREST
+@interface MenusServiceRemote : ServiceRemoteWordPressComREST
 
 #pragma mark - Remote queries: Creating and modifying menus
 

--- a/WordPress/Classes/Networking/MenusServiceRemote.m
+++ b/WordPress/Classes/Networking/MenusServiceRemote.m
@@ -4,7 +4,7 @@
 #import "RemoteMenu.h"
 #import "RemoteMenuItem.h"
 #import "RemoteMenuLocation.h"
-#import "WordPressRestApi.h"
+#import "WordPress-Swift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,11 +40,11 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/menus/new", blogId];
     NSString *requestURL = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteRESTApiVersion_1_1];
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.api POST:requestURL
+    [self.wordPressComRestApi POST:requestURL
         parameters:@{MenusRemoteKeyName: menuName}
-           success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+           success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
                void(^responseFailure)() = ^() {
                    NSString *message = NSLocalizedString(@"An error occurred creating the Menu.", @"An error description explaining that a Menu could not be created.");
                    [self handleResponseErrorWithMessage:message url:requestURL failure:failure];
@@ -60,7 +60,7 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
                    menu.name = menuName;
                    success(menu);
                }
-           } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
+           } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
                if (failure) {
                    failure(error);
                }
@@ -81,7 +81,7 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/menus/%@", blogId, menuID];
     NSString *requestURL = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteRESTApiVersion_1_1];
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
     NSMutableDictionary *params = [NSMutableDictionary dictionaryWithCapacity:2];
     if (updatedName.length) {
@@ -98,9 +98,9 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
     // Brent Coursey - 10/1/2015
     [params setObject:menuID forKey:MenusRemoteKeyID];
     
-    [self.api POST:requestURL
+    [self.wordPressComRestApi POST:requestURL
         parameters:params
-           success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+           success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
                void(^responseFailure)() = ^() {
                    NSString *message = NSLocalizedString(@"An error occurred updating the Menu.", @"An error description explaining that a Menu could not be updated.");
                    [self handleResponseErrorWithMessage:message url:requestURL failure:failure];
@@ -117,7 +117,7 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
                if (success) {
                    success(menu);
                }
-           } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
+           } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
                if (failure) {
                    failure(error);
                }
@@ -135,10 +135,10 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/menus/%@/delete", blogId, menuID];
     NSString *requestURL = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteRESTApiVersion_1_1];
-    [self.api POST:requestURL
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    [self.wordPressComRestApi POST:requestURL
         parameters:nil
-           success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+           success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
                void(^responseFailure)() = ^() {
                    NSString *message = NSLocalizedString(@"An error occurred deleting the Menu.", @"An error description explaining that a Menu could not be deleted.");
                    [self handleResponseErrorWithMessage:message url:requestURL failure:failure];
@@ -155,7 +155,7 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
                } else {
                    responseFailure();
                }
-           } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
+           } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
                if (failure) {
                    failure(error);
                }
@@ -173,11 +173,11 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/menus", blogId];
     NSString *requestURL = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteRESTApiVersion_1_1];
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.api GET:requestURL
+    [self.wordPressComRestApi GET:requestURL
        parameters:nil
-          success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+          success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
               if (![responseObject isKindOfClass:[NSDictionary class]]) {
                   NSString *message = NSLocalizedString(@"An error occurred fetching the Menus.", @"An error description explaining that Menus could not be fetched.");
                   [self handleResponseErrorWithMessage:message url:requestURL failure:failure];
@@ -189,7 +189,7 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
                   success(menus, locations);
               }
               
-          } failure:^(AFHTTPRequestOperation * _Nonnull operation, NSError * _Nonnull error) {
+          } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
               if (failure) {
                   failure(error);
               }

--- a/WordPress/Classes/Services/MenusService.m
+++ b/WordPress/Classes/Services/MenusService.m
@@ -32,11 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
     NSParameterAssert([blog isKindOfClass:[Blog class]]);
     NSAssert([self blogSupportsMenusCustomization:blog], @"Do not call this method on unsupported blogs, check with blogSupportsMenusCustomization first.");
 
-    if (blog.restApi == nil) {
+    if (blog.wordPressComRestApi == nil) {
         return;
     }
 
-    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithApi:blog.restApi];
+    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithWordPressComRestApi:blog.wordPressComRestApi];
     [remote getMenusForBlog:blog
                     success:^(NSArray<RemoteMenu *> * _Nullable remoteMenus, NSArray<RemoteMenuLocation *> * _Nullable remoteLocations) {
         
@@ -92,11 +92,11 @@ NS_ASSUME_NONNULL_BEGIN
     NSParameterAssert([blog isKindOfClass:[Blog class]]);
     NSAssert([self blogSupportsMenusCustomization:blog], @"Do not call this method on unsupported blogs, check with blogSupportsMenusCustomization first.");
     
-    if (blog.restApi == nil) {
+    if (blog.wordPressComRestApi == nil) {
         return;
     }
 
-    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithApi:blog.restApi];
+    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithWordPressComRestApi:blog.wordPressComRestApi];
     [remote createMenuWithName:menuName
                           blog:blog
                        success:^(RemoteMenu * _Nonnull remoteMenu) {
@@ -118,7 +118,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSParameterAssert([menu isKindOfClass:[Menu class]]);
     NSAssert([self blogSupportsMenusCustomization:blog], @"Do not call this method on unsupported blogs, check with blogSupportsMenusCustomization first.");
     
-    if (blog.restApi == nil) {
+    if (blog.wordPressComRestApi == nil) {
         return;
     }
 
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
         remoteItems = [self remoteItemsFromMenuItems:menu.items];
     }
     
-    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithApi:blog.restApi];
+    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithWordPressComRestApi:blog.wordPressComRestApi];
     [remote updateMenuForID:menu.menuID
                        blog:blog
                    withName:menu.name
@@ -172,7 +172,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSParameterAssert([menu isKindOfClass:[Menu class]]);
     NSAssert([self blogSupportsMenusCustomization:blog], @"Do not call this method on unsupported blogs, check with blogSupportsMenusCustomization first.");
     
-    if (blog.restApi == nil) {
+    if (blog.wordPressComRestApi == nil) {
         return;
     }
 
@@ -193,7 +193,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
     
-    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithApi:blog.restApi];
+    MenusServiceRemote *remote = [[MenusServiceRemote alloc] initWithWordPressComRestApi:blog.wordPressComRestApi];
     [remote deleteMenuForID:menu.menuID
                        blog:blog
                     success:completeMenuDeletion

--- a/WordPress/WordPressTest/MenusServiceRemoteTests.m
+++ b/WordPress/WordPressTest/MenusServiceRemoteTests.m
@@ -4,7 +4,7 @@
 #import "ContextManager.h"
 #import "MenusServiceRemote.h"
 #import "TestContextManager.h"
-#import "WordPressComApi.h"
+#import "WordPress-Swift.h"
 #import "RemoteMenu.h"
 
 @interface MenusServicRemoteTests : XCTestCase
@@ -18,7 +18,7 @@
     Blog *blog = OCMStrictClassMock([Blog class]);
     OCMStub([blog dotComID]).andReturn(@10);
     
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     MenusServiceRemote *service = nil;
     
     RemoteMenu *menu = OCMClassMock([RemoteMenu class]);
@@ -39,7 +39,7 @@
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithWordPressComRestApi:api]);
     
     [service createMenuWithName:name
                            blog:blog
@@ -52,7 +52,7 @@
     Blog *blog = OCMStrictClassMock([Blog class]);
     OCMStub([blog dotComID]).andReturn(@10);
     
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     MenusServiceRemote *service = nil;
     
     RemoteMenu *menu = OCMClassMock([RemoteMenu class]);
@@ -66,7 +66,7 @@
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithWordPressComRestApi:api]);
 
     [service updateMenuForID:menu.menuID
                         blog:blog
@@ -82,7 +82,7 @@
     Blog *blog = OCMStrictClassMock([Blog class]);
     OCMStub([blog dotComID]).andReturn(@10);
     
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     MenusServiceRemote *service = nil;
     
     RemoteMenu *menu = OCMClassMock([RemoteMenu class]);
@@ -96,7 +96,7 @@
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithWordPressComRestApi:api]);
     
     [service deleteMenuForID:menu.menuID
                         blog:blog
@@ -109,7 +109,7 @@
     Blog *blog = OCMStrictClassMock([Blog class]);
     OCMStub([blog dotComID]).andReturn(@10);
     
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     MenusServiceRemote *service = nil;
     
     NSString* url = [NSString stringWithFormat:@"v1.1/sites/%@/menus", [blog dotComID]];
@@ -119,7 +119,7 @@
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
     
-    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[MenusServiceRemote alloc] initWithWordPressComRestApi:api]);
     
     [service getMenusForBlog:blog
                      success:^(NSArray<RemoteMenu *> *menus, NSArray<RemoteMenuLocation *> *locations) {}

--- a/WordPress/WordPressTest/MenusServiceTests.m
+++ b/WordPress/WordPressTest/MenusServiceTests.m
@@ -2,7 +2,7 @@
 #import <XCTest/XCTest.h>
 #import "MenusService.h"
 #import "Blog.h"
-#import "WordPressComApi.h"
+#import "WordPress-Swift.h"
 #import "Menu.h"
 #import "MenuLocation.h"
 #import "MenuItem.h"
@@ -71,11 +71,11 @@
 
 - (void)testThatWordPressBlogSupportsMenusServices
 {
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     
     Blog *blog = OCMStrictClassMock([Blog class]);
     
-    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog wordPressComRestApi]).andReturn(api);
     OCMStub([blog dotComID]).andReturn(@1);
     OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
     
@@ -90,11 +90,11 @@
 
 - (void)testThatWordPressBlogDoesNotSupportMenusServices
 {
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     
     Blog *blog = OCMStrictClassMock([Blog class]);
     
-    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog wordPressComRestApi]).andReturn(api);
     OCMStub([blog dotComID]).andReturn(@1);
     OCMStub([blog supports:BlogFeatureMenus]).andReturn(NO);
     
@@ -109,11 +109,11 @@
 
 - (void)testThatSyncMenusForBlogWorks
 {
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     
     Blog *blog = OCMStrictClassMock([Blog class]);
     
-    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog wordPressComRestApi]).andReturn(api);
     OCMStub([blog dotComID]).andReturn(@1);
     OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
     
@@ -134,11 +134,11 @@
 
 - (void)testThatCreateMenuWithNameWorks
 {
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     
     Blog *blog = OCMStrictClassMock([Blog class]);
     
-    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog wordPressComRestApi]).andReturn(api);
     OCMStub([blog dotComID]).andReturn(@1);
     OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
     
@@ -166,11 +166,11 @@
 
 - (void)testThatUpdateMenuWorks
 {
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     
     Blog *blog = OCMStrictClassMock([Blog class]);
     
-    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog wordPressComRestApi]).andReturn(api);
     OCMStub([blog dotComID]).andReturn(@1);
     OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
     
@@ -217,11 +217,11 @@
 
 - (void)testThatDeleteMenuWithIdWorks
 {
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     
     Blog *blog = OCMStrictClassMock([Blog class]);
     
-    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog wordPressComRestApi]).andReturn(api);
     OCMStub([blog dotComID]).andReturn(@1);
     OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
     
@@ -247,11 +247,11 @@
 
 - (void)testThatDeleteMenuWithoutIdWorks
 {
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     
     Blog *blog = OCMStrictClassMock([Blog class]);
     
-    OCMStub([blog restApi]).andReturn(api);
+    OCMStub([blog wordPressComRestApi]).andReturn(api);
     OCMStub([blog dotComID]).andReturn(@1);
     OCMStub([blog supports:BlogFeatureMenus]).andReturn(YES);
     


### PR DESCRIPTION
Refs #5245 

To test:
 - Login with a WP.com account
 - Access the new menu functionality
 - Test the menu actions

Needs review: @kurzee, I think you may need to activate the feature or merge it your Menu dev branch in order to test this. Tell me if you need any help. 