### PR TITLE
Issue/5407 - Resolve crash when updating a post.

### DIFF
--- a/WordPress/Classes/Networking/PostServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.m
@@ -133,7 +133,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 
     [self.wordPressComRestApi POST:requestUrl
         parameters:parameters
-           success:^(AFHTTPRequestOperation *operation, id responseObject) {
+           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                RemotePost *post = [self remotePostFromJSONDictionary:responseObject];
                if (success) {
                    success(post);


### PR DESCRIPTION
Fixes #5407 - Looks like a completion block was leftover from the NSURLSession updates.

To test:

1. Repeat the steps in the issue #5407 
2. Ensure a crash does not occur in any update method.


Needs review: @SergioEstevao 

