### PR TITLE
Migrate TaxonomyService to use WordPressComRestAPI class.

### DIFF
--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.h
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "TaxonomyServiceRemote.h"
-#import "SiteServiceRemoteREST.h"
+#import "SiteServiceRemoteWordPressComREST.h"
 
-@interface TaxonomyServiceRemoteREST : SiteServiceRemoteREST <TaxonomyServiceRemote>
+@interface TaxonomyServiceRemoteREST : SiteServiceRemoteWordPressComREST <TaxonomyServiceRemote>
 
 @end

--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
@@ -1,5 +1,5 @@
 #import "TaxonomyServiceRemoteREST.h"
-#import "WordPressComApi.h"
+#import "WordPress-Swift.h"
 #import "RemotePostCategory.h"
 #import "RemotePostTag.h"
 #import "RemoteTaxonomyPaging.h"
@@ -143,16 +143,16 @@ static NSString * const TaxonomyRESTPageParameter = @"page";
     NSString *path = [NSString stringWithFormat:@"sites/%@/%@/new?context=edit", self.siteID, typeIdentifier];
     NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteRESTApiVersion_1_1];
     
-    [self.api POST:requestUrl
+    [self.wordPressComRestApi POST:requestUrl
         parameters:parameters
-           success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+           success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
                if (![responseObject isKindOfClass:[NSDictionary class]]) {
                    NSString *message = [NSString stringWithFormat:@"Invalid response creating taxonomy of type: %@", typeIdentifier];
                    [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
                    return;
                }
                success(responseObject);
-           } failure:^(AFHTTPRequestOperation * _Nullable operation, NSError * _Nonnull error) {
+           } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
                if (failure) {
                    failure(error);
                }
@@ -168,16 +168,16 @@ static NSString * const TaxonomyRESTPageParameter = @"page";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteRESTApiVersion_1_1];
     
-    [self.api GET:requestUrl
+    [self.wordPressComRestApi GET:requestUrl
        parameters:parameters
-          success:^(AFHTTPRequestOperation * _Nonnull operation, id  _Nonnull responseObject) {
+          success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
               if (![responseObject isKindOfClass:[NSDictionary class]]) {
                   NSString *message = [NSString stringWithFormat:@"Invalid response requesting taxonomy of type: %@", typeIdentifier];
                   [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
                   return;
               }
               success(responseObject);
-          } failure:^(AFHTTPRequestOperation * _Nullable operation, NSError * _Nonnull error) {
+          } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
               if (failure) {
                   failure(error);
               }

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -249,8 +249,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<TaxonomyServiceRemote>)remoteForBlog:(Blog *)blog {
     if ([blog supports:BlogFeatureWPComRESTAPI]) {
-        if (blog.restApi) {
-            return [[TaxonomyServiceRemoteREST alloc] initWithApi:blog.restApi siteID:blog.dotComID];
+        if (blog.wordPressComRestApi) {
+            return [[TaxonomyServiceRemoteREST alloc] initWithWordPressComRestApi:blog.wordPressComRestApi siteID:blog.dotComID];
         }
     } else if (blog.api) {
         return [[TaxonomyServiceRemoteXMLRPC alloc] initWithApi:blog.api username:blog.username password:blog.password];

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -102,8 +102,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<TaxonomyServiceRemote>)remoteForBlog:(Blog *)blog {
     if ([blog supports:BlogFeatureWPComRESTAPI]) {
-        if (blog.restApi) {
-            return [[TaxonomyServiceRemoteREST alloc] initWithApi:blog.restApi siteID:blog.dotComID];
+        if (blog.wordPressComRestApi) {
+            return [[TaxonomyServiceRemoteREST alloc] initWithWordPressComRestApi:blog.wordPressComRestApi siteID:blog.dotComID];
         }
     } else if (blog.api) {
         return [[TaxonomyServiceRemoteXMLRPC alloc] initWithApi:blog.api username:blog.username password:blog.password];

--- a/WordPress/WordPressTest/TaxonomyServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/TaxonomyServiceRemoteRESTTests.m
@@ -1,7 +1,7 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 #import "Blog.h"
-#import "WordPressComApi.h"
+#import "WordPress-Swift.h"
 #import "TaxonomyServiceRemoteREST.h"
 #import "RemotePostCategory.h"
 #import "RemotePostTag.h"
@@ -22,11 +22,11 @@
     Blog *blog = OCMStrictClassMock([Blog class]);
     OCMStub([blog dotComID]).andReturn(@10);
     
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
-    OCMStub([blog restApi]).andReturn(api);
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
+    OCMStub([blog wordPressComRestApi]).andReturn(api);
     
     TaxonomyServiceRemoteREST *service = nil;
-    XCTAssertNoThrow(service = [[TaxonomyServiceRemoteREST alloc] initWithApi:blog.restApi siteID:blog.dotComID]);
+    XCTAssertNoThrow(service = [[TaxonomyServiceRemoteREST alloc] initWithWordPressComRestApi:blog.wordPressComRestApi siteID:blog.dotComID]);
     
     self.service = service;
 }
@@ -57,7 +57,7 @@
         return ([parameters isKindOfClass:[NSDictionary class]] && [[parameters objectForKey:@"name"] isEqualToString:category.name]);
     };
     
-    WordPressComApi *api = self.service.api;
+    WordPressComRestApi *api = self.service.wordPressComRestApi;
     OCMStub([api POST:[OCMArg isEqual:url]
            parameters:[OCMArg checkWithBlock:parametersCheckBlock]
               success:[OCMArg isNotNil]
@@ -72,7 +72,7 @@
 {
     NSString *url = [self GETtaxonomyURLWithType:@"categories"];
     
-    WordPressComApi *api = self.service.api;
+    WordPressComRestApi *api = self.service.wordPressComRestApi;
     OCMStub([api GET:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
               success:[OCMArg isNotNil]
@@ -115,7 +115,7 @@
         return YES;
     };
     
-    WordPressComApi *api = self.service.api;
+    WordPressComRestApi *api = self.service.wordPressComRestApi;
     OCMStub([api GET:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
@@ -141,7 +141,7 @@
         return YES;
     };
     
-    WordPressComApi *api = self.service.api;
+    WordPressComRestApi *api = self.service.wordPressComRestApi;
     OCMStub([api GET:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
@@ -164,8 +164,8 @@
     BOOL (^parametersCheckBlock)(id obj) = ^BOOL(NSDictionary *parameters) {
         return ([parameters isKindOfClass:[NSDictionary class]] && [[parameters objectForKey:@"name"] isEqualToString:tag.name]);
     };
-    
-    WordPressComApi *api = self.service.api;
+
+    WordPressComRestApi *api = self.service.wordPressComRestApi;
     OCMStub([api POST:[OCMArg isEqual:url]
            parameters:[OCMArg checkWithBlock:parametersCheckBlock]
               success:[OCMArg isNotNil]
@@ -180,7 +180,7 @@
 {
     NSString *url = [self GETtaxonomyURLWithType:@"tags"];
     
-    WordPressComApi *api = self.service.api;
+    WordPressComRestApi *api = self.service.wordPressComRestApi;
     OCMStub([api GET:[OCMArg isEqual:url]
           parameters:[OCMArg isNil]
              success:[OCMArg isNotNil]
@@ -223,7 +223,7 @@
         return YES;
     };
     
-    WordPressComApi *api = self.service.api;
+    WordPressComRestApi *api = self.service.wordPressComRestApi;
     OCMStub([api GET:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
@@ -249,7 +249,7 @@
         return YES;
     };
     
-    WordPressComApi *api = self.service.api;
+    WordPressComRestApi *api = self.service.wordPressComRestApi;
     OCMStub([api GET:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]


### PR DESCRIPTION
Refs #5245 

To test:
 - Login in the app using a WP.com account
 - Create a new Post or Edit one.
 - Go to Post Settings and change category and tags
 - Add new categories
 - Go to blog settings and check if list of categories shows correctly

Needs review: @kurzee 

