### PR TITLE
Migrate Plans Remote to WordPressComRestApi

### DIFF
--- a/WordPress/Classes/Networking/PlansFeaturesRemote.swift
+++ b/WordPress/Classes/Networking/PlansFeaturesRemote.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class PlanFeaturesRemote: ServiceRemoteREST {
+class PlanFeaturesRemote: ServiceRemoteWordPressComREST {
 
     enum Error: ErrorType {
         case DecodeError
@@ -82,23 +82,23 @@ class PlanFeaturesRemote: ServiceRemoteREST {
 
     private func fetchPlanFeatures(success: PlanFeatures -> Void, failure: ErrorType -> Void) {
         let endpoint = "plans/features"
-        let path = pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_2)
+        let path = pathForEndpoint(endpoint, withVersion: .Version_1_2)
         let locale = languageDatabase.deviceLanguage.slug
         let parameters = ["locale": locale]
 
-        api.GET(path,
+        wordPressComRestApi.GET(path,
                 parameters: parameters,
                 success: {
-                    [weak self] requestOperation, response in
+                    [weak self] response, httpResponse in
                     do {
                         let planFeatures = try mapPlanFeaturesResponse(response)
-                        self?.cacheResponseData(requestOperation.responseData)
+                        self?.cacheResponseObject(response)
                         success(planFeatures)
                     } catch {
                         failure(error)
                     }
             }, failure: {
-                _, error in
+                error, _ in
                 failure(error)
         })
     }
@@ -109,8 +109,9 @@ class PlanFeaturesRemote: ServiceRemoteREST {
         return cacheDirectory.URLByAppendingPathComponent(cacheFilename)
     }
 
-    private func cacheResponseData(responseData: NSData?) {
-        guard let responseData = responseData else { return }
+    private func cacheResponseObject(responseObject: AnyObject) {
+        let data = try? NSJSONSerialization.dataWithJSONObject(responseObject, options: NSJSONWritingOptions())
+        guard let responseData = data else { return }
         guard let cacheFileURL = cacheFileURL else { return }
 
         responseData.writeToURL(cacheFileURL, atomically: true)

--- a/WordPress/Classes/Networking/PlansFeaturesRemote.swift
+++ b/WordPress/Classes/Networking/PlansFeaturesRemote.swift
@@ -89,10 +89,10 @@ class PlanFeaturesRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.GET(path,
                 parameters: parameters,
                 success: {
-                    [weak self] response, httpResponse in
+                    [weak self] responseObject, _ in
                     do {
-                        let planFeatures = try mapPlanFeaturesResponse(response)
-                        self?.cacheResponseObject(response)
+                        let planFeatures = try mapPlanFeaturesResponse(responseObject)
+                        self?.cacheResponseObject(responseObject)
                         success(planFeatures)
                     } catch {
                         failure(error)

--- a/WordPress/Classes/Networking/PlansRemote.swift
+++ b/WordPress/Classes/Networking/PlansRemote.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class PlansRemote: ServiceRemoteREST {
+class PlansRemote: ServiceRemoteWordPressComREST {
     typealias SitePlans = (activePlan: Plan, availablePlans: [Plan])
     enum Error: ErrorType {
         case DecodeError
@@ -11,14 +11,14 @@ class PlansRemote: ServiceRemoteREST {
 
     func getPlansForSite(siteID: Int, success: SitePlans -> Void, failure: ErrorType -> Void) {
         let endpoint = "sites/\(siteID)/plans"
-        let path = pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_2)
+        let path = pathForEndpoint(endpoint, withVersion: .Version_1_2)
         let locale = WordPressComLanguageDatabase().deviceLanguage.slug
         let parameters = ["locale": locale]
 
-        api.GET(path,
+        wordPressComRestApi.GET(path,
             parameters: parameters,
             success: {
-                _, response in
+                response, _ in
                 do {
                     try success(mapPlansResponse(response))
                 } catch {
@@ -28,7 +28,7 @@ class PlansRemote: ServiceRemoteREST {
                     failure(error)
                 }
             }, failure: {
-                _, error in
+                error, _ in
                 failure(error)
         })
     }

--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -55,12 +55,12 @@ extension PlanService {
             return nil
         }
 
-        guard let api = account.restApi else {
+        guard let api = account.wordPressComRestApi else {
             return nil
         }
 
-        self.remote = PlansRemote(api: api)
-        self.featuresRemote = PlanFeaturesRemote(api: api)
+        self.remote = PlansRemote(wordPressComRestApi: api)
+        self.featuresRemote = PlanFeaturesRemote(wordPressComRestApi: api)
     }
 }
 
@@ -86,12 +86,12 @@ struct PlanStorage {
 
 extension PlanService {
     init?(blog: Blog, store: S) {
-        guard let api = blog.restApi() else {
+        guard let api = blog.wordPressComRestApi() else {
             return nil
         }
 
-        let remote = PlansRemote(api: api)
-        let featuresRemote = PlanFeaturesRemote(api: api)
+        let remote = PlansRemote(wordPressComRestApi: api)
+        let featuresRemote = PlanFeaturesRemote(wordPressComRestApi: api)
 
         self.init(store: store, remote: remote, featuresRemote: featuresRemote)
     }


### PR DESCRIPTION
Refs #5245 

To test:
 - Login with a WP.com account
- Access the option blog->plans and check if plans show correctly
- Put the app offline
- Go to plans again and see if the cache works.

Needs review: @koke 

