### PR TITLE
Added nullability info to Page and Post.

### DIFF
--- a/WordPress/Classes/Models/Page.h
+++ b/WordPress/Classes/Models/Page.h
@@ -1,9 +1,13 @@
 #import <Foundation/Foundation.h>
 #import "AbstractPost.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface Page : AbstractPost
 
-@property (nonatomic, strong) NSNumber * parentID;
+@property (nonatomic, strong, nullable) NSNumber * parentID;
 - (NSString *)sectionIdentifier;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Models/Post.h
+++ b/WordPress/Classes/Models/Post.h
@@ -1,6 +1,8 @@
 #import <CoreData/CoreData.h>
 #import "AbstractPost.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString * const PostTypeDefaultIdentifier;
 
 @class Coordinate;
@@ -10,26 +12,26 @@ extern NSString * const PostTypeDefaultIdentifier;
 ///-------------------------------
 /// @name Specific Post properties
 ///-------------------------------
-@property (nonatomic, strong) NSNumber *commentCount;
-@property (nonatomic, strong) NSNumber *likeCount;
-@property (nonatomic, strong) Coordinate *geolocation;
-@property (nonatomic, strong) NSString *tags;
-@property (nonatomic, strong) NSString *postType;
-@property (nonatomic, strong) NSString *postFormat;
-@property (nonatomic, strong) NSString *postFormatText;
-@property (nonatomic, strong) NSSet *categories;
+@property (nonatomic, strong, nullable) NSNumber *commentCount;
+@property (nonatomic, strong, nullable) NSNumber *likeCount;
+@property (nonatomic, strong, nullable) Coordinate *geolocation;
+@property (nonatomic, strong, nullable) NSString *tags;
+@property (nonatomic, strong, nullable) NSString *postType;
+@property (nonatomic, strong, nullable) NSString *postFormat;
+@property (nonatomic, strong, nullable) NSString *postFormatText;
+@property (nonatomic, strong, nullable) NSSet *categories;
 
 // We shouldn't need to store this, but if we don't send IDs on edits
 // custom fields get duplicated and stop working
-@property (nonatomic, retain) NSString *latitudeID;
-@property (nonatomic, retain) NSString *longitudeID;
-@property (nonatomic, retain) NSString *publicID;
+@property (nonatomic, retain, nullable) NSString *latitudeID;
+@property (nonatomic, retain, nullable) NSString *longitudeID;
+@property (nonatomic, retain, nullable) NSString *publicID;
 
 /**
  A tag for specific post workflows. Only QuickPhoto for now.
  Used for usage stats only.
  */
-@property (nonatomic, strong) NSString *specialType;
+@property (nonatomic, strong, nullable) NSString *specialType;
 
 ///---------------------
 /// @name Helper methods
@@ -45,7 +47,7 @@ extern NSString * const PostTypeDefaultIdentifier;
  
  @param categoryNames a `NSArray` with the names of the categories for this post. If a given category name doesn't exist it's ignored.
  */
-- (void)setCategoriesFromNames:(NSArray *)categoryNames;
+- (void)setCategoriesFromNames:(nullable NSArray *)categoryNames;
 
 #pragma mark - Convenience methods
 
@@ -64,3 +66,5 @@ extern NSString * const PostTypeDefaultIdentifier;
 - (void)removeCategories:(NSSet *)values;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -38,7 +38,7 @@ import SVProgressHUD
         return controller
     }
 
-    func sharePost(title: String, summary: String, tags: String, link: String?, fromBarButtonItem anchorBarButtonItem:UIBarButtonItem, inViewController viewController:UIViewController) {
+    func sharePost(title: String, summary: String, tags: String?, link: String?, fromBarButtonItem anchorBarButtonItem:UIBarButtonItem, inViewController viewController:UIViewController) {
         let controller = shareController(
             title,
             summary: summary,
@@ -59,7 +59,7 @@ import SVProgressHUD
         }
     }
 
-    func sharePost(title: String, summary: String, tags: String, link: String?, fromView anchorView:UIView, inViewController viewController:UIViewController) {
+    func sharePost(title: String, summary: String, tags: String?, link: String?, fromView anchorView:UIView, inViewController viewController:UIViewController) {
         let controller = shareController(
             title,
             summary: summary,


### PR DESCRIPTION
Adds nullability information to `Page` and `Post`.

**To test:**
1. Make sure the app builds.
2. Make sure the tests build and run properly.
3. Go to the list of posts for a blog and interact with posts: search, filter, create, edit, view, view stats, trash, restore, delete.
4. Go to the list of pages for a blog and interact with posts: search, filter, create, edit, view, view stats, trash, restore, delete.

Needs review: @aerych 
