### PR TITLE
Migrate PushAuthentication Remote to WordPressComRestApi

### DIFF
--- a/WordPress/Classes/Networking/PushAuthenticationServiceRemote.swift
+++ b/WordPress/Classes/Networking/PushAuthenticationServiceRemote.swift
@@ -1,10 +1,9 @@
 import Foundation
-import AFNetworking
 
 /// The purpose of this class is to encapsulate all of the interaction with the REST endpoint,
 /// required to handle WordPress.com 2FA Code Veritication via Push Notifications
 ///
-@objc public class PushAuthenticationServiceRemote : ServiceRemoteREST
+@objc public class PushAuthenticationServiceRemote : ServiceRemoteWordPressComREST
 {
     /// Verifies a WordPress.com Login.
     ///
@@ -15,19 +14,19 @@ import AFNetworking
     ///
     public func authorizeLogin(token: String, success: (() -> ())?, failure: (() -> ())?) {
         let path = "me/two-step/push-authentication"
-        let requestUrl = self.pathForEndpoint(path, withVersion: ServiceRemoteRESTApiVersion_1_1)
+        let requestUrl = self.pathForEndpoint(path, withVersion: .Version_1_1)
 
         let parameters  = [
             "action"        : "authorize_login",
             "push_token"    : token
         ]
 
-        api.POST(requestUrl,
+        wordPressComRestApi.POST(requestUrl,
             parameters: parameters,
-            success: { (operation: AFHTTPRequestOperation, response: AnyObject) -> Void in
+            success: { (response: AnyObject, httpResponse: NSHTTPURLResponse?) -> Void in
                 success?()
             },
-            failure:{ (operation: AFHTTPRequestOperation?, error: NSError) -> Void in
+            failure:{ (error: NSError, httpResponse: NSHTTPURLResponse?) -> Void in
                 failure?()
             })
     }

--- a/WordPress/Classes/Services/PushAuthenticationService.swift
+++ b/WordPress/Classes/Services/PushAuthenticationService.swift
@@ -15,7 +15,7 @@ import Foundation
     ///
     public required override init(managedObjectContext: NSManagedObjectContext) {
         super.init(managedObjectContext: managedObjectContext)
-        self.authenticationServiceRemote = PushAuthenticationServiceRemote(api: apiForRequest())
+        self.authenticationServiceRemote = PushAuthenticationServiceRemote(wordPressComRestApi: apiForRequest())
     }
 
     /// Authorizes a WordPress.com Login Attempt (2FA Protected Accounts)
@@ -41,21 +41,21 @@ import Foundation
 
     /// Helper method to get the WordPress.com REST Api, if any
     ///
-    /// - Returns: WordPressComApi instance.  It can be an anonymous API instance if there are no credentials.
+    /// - Returns: WordPressComRestApi instance.  It can be an anonymous API instance if there are no credentials.
     ///
-    private func apiForRequest() -> WordPressComApi {
+    private func apiForRequest() -> WordPressComRestApi {
 
-        var api : WordPressComApi? = nil
+        var api : WordPressComRestApi? = nil
 
         let accountService = AccountService(managedObjectContext: managedObjectContext)
-        if let unwrappedRestApi = accountService.defaultWordPressComAccount()?.restApi {
+        if let unwrappedRestApi = accountService.defaultWordPressComAccount()?.wordPressComRestApi {
             if unwrappedRestApi.hasCredentials() {
                 api = unwrappedRestApi
             }
         }
 
         if api == nil {
-            api = WordPressComApi.anonymousApi()
+            api = WordPressComRestApi()
         }
 
         return api!

--- a/WordPress/WordPressTest/PushAuthenticationServiceRemoteTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationServiceRemoteTests.swift
@@ -1,17 +1,16 @@
 import Foundation
 import XCTest
-import WordPress
-import AFNetworking
+@testable import WordPress
 
 class PushAuthenticationServiceRemoteTests : XCTestCase {
 
     var pushAuthenticationServiceRemote:PushAuthenticationServiceRemote?
-    var mockRemoteApi:MockWordPressComApi?
+    var mockRemoteApi:MockWordPressComRestApi?
     let token = "token"
     override func setUp() {
         super.setUp()
-        mockRemoteApi = MockWordPressComApi()
-        pushAuthenticationServiceRemote = PushAuthenticationServiceRemote(api: mockRemoteApi)
+        mockRemoteApi = MockWordPressComRestApi()
+        pushAuthenticationServiceRemote = PushAuthenticationServiceRemote(wordPressComRestApi: mockRemoteApi)
     }
 
     func testAuthorizeLoginUsesTheCorrectPath() {
@@ -36,7 +35,7 @@ class PushAuthenticationServiceRemoteTests : XCTestCase {
         pushAuthenticationServiceRemote!.authorizeLogin(token, success: { () -> () in
            successBlockCalled = true
         }, failure: nil)
-        mockRemoteApi?.successBlockPassedIn?(AFHTTPRequestOperation(), [])
+        mockRemoteApi?.successBlockPassedIn?([], NSHTTPURLResponse())
 
         XCTAssertTrue(mockRemoteApi!.postMethodCalled, "Method was not called")
         XCTAssertTrue(successBlockCalled, "Success block not called")
@@ -47,7 +46,7 @@ class PushAuthenticationServiceRemoteTests : XCTestCase {
         pushAuthenticationServiceRemote!.authorizeLogin(token, success: nil, failure: { () -> () in
             failureBlockCalled = true
         })
-        mockRemoteApi?.failureBlockPassedIn?(AFHTTPRequestOperation(), NSError(domain:"UnitTest", code:0, userInfo:nil))
+        mockRemoteApi?.failureBlockPassedIn?(NSError(domain:"UnitTest", code:0, userInfo:nil), NSHTTPURLResponse())
 
         XCTAssertTrue(mockRemoteApi!.postMethodCalled, "Method was not called")
         XCTAssertTrue(failureBlockCalled, "Failure block not called")

--- a/WordPress/WordPressTest/PushAuthenticationServiceTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationServiceTests.swift
@@ -1,12 +1,12 @@
 import Foundation
 import XCTest
-import WordPress
+@testable import WordPress
 
 class PushAuthenticationServiceTests : XCTestCase {
 
     var pushAuthenticationService:PushAuthenticationService?
     var mockPushAuthenticationServiceRemote:MockPushAuthenticationServiceRemote?
-    var mockRemoteApi:MockWordPressComApi?
+    var mockRemoteApi:MockWordPressComRestApi?
     let token = "token"
 
     class MockPushAuthenticationServiceRemote : PushAuthenticationServiceRemote {
@@ -24,8 +24,8 @@ class PushAuthenticationServiceTests : XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockRemoteApi = MockWordPressComApi()
-        mockPushAuthenticationServiceRemote = MockPushAuthenticationServiceRemote(api: mockRemoteApi)
+        mockRemoteApi = MockWordPressComRestApi()
+        mockPushAuthenticationServiceRemote = MockPushAuthenticationServiceRemote(wordPressComRestApi: mockRemoteApi)
         pushAuthenticationService = PushAuthenticationService(managedObjectContext: TestContextManager().mainContext)
         pushAuthenticationService?.authenticationServiceRemote = mockPushAuthenticationServiceRemote
     }


### PR DESCRIPTION
Refs #5245 

To test:
 - Try to log in using a WP.com account on the web that triggers a push authentication
 - Check if all goes well

Needs review: @jleandroperez 

