### PR TITLE
Set user agent on anonymous api object.

### DIFF
--- a/WordPress/Classes/Services/PushAuthenticationService.swift
+++ b/WordPress/Classes/Services/PushAuthenticationService.swift
@@ -55,7 +55,7 @@ import Foundation
         }
 
         if api == nil {
-            api = WordPressComRestApi()
+            api = WordPressComRestApi(oAuthToken: nil, userAgent: WPUserAgent.wordPressUserAgent())
         }
 
         return api!


### PR DESCRIPTION
Refs #5245

To test:
  - When doing a request for push authentication confirmation check is the user agent is being set properly.


Needs review: @jleandroperez 
