### PR TITLE
Make WordPressComServiceRemote use WordPressComRestApi

### DIFF
--- a/WordPress/Classes/Networking/WordPressComServiceRemote.h
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.h
@@ -1,4 +1,4 @@
-#import "ServiceRemoteREST.h"
+#import "ServiceRemoteWordPressComREST.h"
 
 typedef NS_ENUM(NSUInteger, WordPressComServiceBlogVisibility) {
     WordPressComServiceBlogVisibilityPublic = 0,
@@ -13,7 +13,7 @@ typedef void(^WordPressComServiceFailureBlock)(NSError *error);
  *  @class      WordPressComServiceRemote
  *  @brief      Encapsulates exclusive WordPress.com services.
  */
-@interface WordPressComServiceRemote : ServiceRemoteREST
+@interface WordPressComServiceRemote : ServiceRemoteWordPressComREST
 
 /**
  *  @brief      Creates a WordPress.com account with the specified parameters.

--- a/WordPress/Classes/Services/SignupService.swift
+++ b/WordPress/Classes/Services/SignupService.swift
@@ -104,7 +104,7 @@ public class SignupService : LocalCoreDataService
         let currentLanguage = WordPressComLanguageDatabase().deviceLanguageIdNumber()
         let languageId = currentLanguage.stringValue
 
-        let remote = WordPressComServiceRemote(api: WordPressComApi.anonymousApi())
+        let remote = WordPressComServiceRemote(wordPressComRestApi: self.anonymousApi())
         remote.validateWPComBlogWithUrl(params.url,
                                         andBlogTitle: params.title,
                                         andLanguageId: languageId,
@@ -129,7 +129,7 @@ public class SignupService : LocalCoreDataService
                                    failure: SignupFailureBlock) {
 
         status(status: .CreatingUser)
-        let remote = WordPressComServiceRemote(api: WordPressComApi.anonymousApi())
+        let remote = WordPressComServiceRemote(wordPressComRestApi: self.anonymousApi())
         remote.createWPComAccountWithEmail(params.email,
                                             andUsername: params.username,
                                             andPassword: params.password,
@@ -200,7 +200,7 @@ public class SignupService : LocalCoreDataService
                                     success: (blog: Blog) -> Void,
                                     failure: SignupFailureBlock) {
 
-        guard let api = account.restApi else {
+        guard let api = account.wordPressComRestApi else {
             DDLogSwift.logError("Failed to get the REST API from the account.")
             assertionFailure()
 
@@ -213,7 +213,7 @@ public class SignupService : LocalCoreDataService
         let languageId = currentLanguage.stringValue
 
         status(status: .CreatingBlog)
-        let remote = WordPressComServiceRemote(api: api)
+        let remote = WordPressComServiceRemote(wordPressComRestApi: api)
         remote.createWPComBlogWithUrl(params.url,
                                         andBlogTitle: params.title,
                                         andLanguageId: languageId,
@@ -329,6 +329,9 @@ public class SignupService : LocalCoreDataService
 
     // MARK: Private Instance Methods
 
+    func anonymousApi() -> WordPressComRestApi {
+        return WordPressComRestApi(userAgent:WPUserAgent.wordPressUserAgent())
+    }
 
     /// An internal struct for conveniently sharing params between the different
     /// sign up steps.

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -139,7 +139,7 @@
 #import "WPSearchControllerConfigurator.h"
 #import "WPWalkthroughTextField.h"
 #import "WPUserAgent.h"
-
+#import "WordPressComServiceRemote.h"
 // Pods
 
 #import <FormatterKit/FormatterKit-umbrella.h>

--- a/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
@@ -427,7 +427,7 @@ static UIEdgeInsets const CreateBlogCancelButtonPaddingPad  = {1.0, 13.0, 0.0, 0
 
 - (void)displayRemoteError:(NSError *)error
 {
-    NSString *errorMessage = [error.userInfo objectForKey:WordPressComApiErrorMessageKey];
+    NSString *errorMessage = [error.userInfo objectForKey:WordPressComRestApi.ErrorKeyErrorMessage];
     [self showError:errorMessage];
 }
 
@@ -529,8 +529,8 @@ static UIEdgeInsets const CreateBlogCancelButtonPaddingPad  = {1.0, 13.0, 0.0, 0
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
         AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
         
-        WordPressComApi *api = [[accountService defaultWordPressComAccount] restApi];
-        WordPressComServiceRemote *service = [[WordPressComServiceRemote alloc] initWithApi:api];
+        WordPressComRestApi *api = [[accountService defaultWordPressComAccount] wordPressComRestApi];
+        WordPressComServiceRemote *service = [[WordPressComServiceRemote alloc] initWithWordPressComRestApi:api];
         
         [service createWPComBlogWithUrl:[self getSiteAddressWithoutWordPressDotCom]
                            andBlogTitle:_siteTitleField.text

--- a/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/NUX/CreateAccountAndBlogViewController.m
@@ -660,7 +660,7 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
 
 - (void)displayRemoteError:(NSError *)error
 {
-    NSString *errorMessage = [error.userInfo objectForKey:WordPressComApiErrorMessageKey];
+    NSString *errorMessage = [error.userInfo objectForKey:WordPressComRestApi.ErrorKeyErrorMessage];
     [self showError:errorMessage];
 }
 
@@ -759,6 +759,10 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
     [_createAccountButton showActivityIndicator:authenticating];
 }
 
+- (WordPressComRestApi *)anonymousApi {
+    return [[WordPressComRestApi alloc] initWithOAuthToken:nil userAgent:[WPUserAgent wordPressUserAgent]];
+}
+
 - (void)createUserAndSite
 {
     if (_authenticating) {
@@ -782,8 +786,8 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
 
         NSString *languageId = [_currentLanguageId stringValue];
         
-        WordPressComApi *api = [WordPressComApi anonymousApi];
-        WordPressComServiceRemote *service = [[WordPressComServiceRemote alloc] initWithApi:api];
+        WordPressComRestApi *api = [self anonymousApi];
+        WordPressComServiceRemote *service = [[WordPressComServiceRemote alloc] initWithWordPressComRestApi:api];
         
         [service validateWPComBlogWithUrl:[self getSiteAddressWithoutWordPressDotCom]
                              andBlogTitle:[self generateSiteTitleFromUsername:_usernameField.text]
@@ -804,8 +808,8 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
             [self displayRemoteError:error];
         };
         
-        WordPressComApi *api = [WordPressComApi anonymousApi];
-        WordPressComServiceRemote *service = [[WordPressComServiceRemote alloc] initWithApi:api];
+        WordPressComRestApi *api = [self anonymousApi];
+        WordPressComServiceRemote *service = [[WordPressComServiceRemote alloc] initWithWordPressComRestApi:api];
         
         [service createWPComAccountWithEmail:_emailField.text
                                  andUsername:_usernameField.text
@@ -883,8 +887,8 @@ static UIEdgeInsets const CreateAccountAndBlogHelpButtonPaddingPad  = {1.0, 0.0,
 
         NSString *languageId = [_currentLanguageId stringValue];
         
-        WordPressComApi *api = [_account restApi];
-        WordPressComServiceRemote *service = [[WordPressComServiceRemote alloc] initWithApi:api];
+        WordPressComRestApi *api = [_account wordPressComRestApi];
+        WordPressComServiceRemote *service = [[WordPressComServiceRemote alloc] initWithWordPressComRestApi:api];
         
         [service createWPComBlogWithUrl:[self getSiteAddressWithoutWordPressDotCom]
                            andBlogTitle:[self generateSiteTitleFromUsername:_usernameField.text]

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -823,6 +823,8 @@
 		FF27169F1CAAF5060006E2D4 /* WordPressTestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF27169E1CAAF5060006E2D4 /* WordPressTestCredentials.swift */; };
 		FF2716A11CABC7D40006E2D4 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2716A01CABC7D40006E2D4 /* XCTest+Extensions.swift */; };
 		FF28B3F11AEB251200E11AAE /* InfoPListTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = FF28B3F01AEB251200E11AAE /* InfoPListTranslator.m */; };
+		FF34EEA91CF473F600F8B38D /* WordPressComServiceRemoteRestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF34EEA81CF473F600F8B38D /* WordPressComServiceRemoteRestTests.swift */; };
+		FF34EEAB1CF480F100F8B38D /* WordPressComRestApiFailThrottled.json in Resources */ = {isa = PBXBuildFile; fileRef = FF34EEAA1CF480F100F8B38D /* WordPressComRestApiFailThrottled.json */; };
 		FF3DD6BE19F2B6B3003A52CB /* RemoteMedia.m in Sources */ = {isa = PBXBuildFile; fileRef = FF3DD6BD19F2B6B3003A52CB /* RemoteMedia.m */; };
 		FF4258501BA092EE00580C68 /* RelatedPostsSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FF42584F1BA092EE00580C68 /* RelatedPostsSettingsViewController.m */; };
 		FF619DD51C75246900903B65 /* CLPlacemark+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF619DD41C75246900903B65 /* CLPlacemark+Formatting.swift */; };
@@ -2151,6 +2153,8 @@
 		FF2716A01CABC7D40006E2D4 /* XCTest+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTest+Extensions.swift"; sourceTree = "<group>"; };
 		FF28B3EF1AEB251200E11AAE /* InfoPListTranslator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InfoPListTranslator.h; sourceTree = "<group>"; };
 		FF28B3F01AEB251200E11AAE /* InfoPListTranslator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InfoPListTranslator.m; sourceTree = "<group>"; };
+		FF34EEA81CF473F600F8B38D /* WordPressComServiceRemoteRestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressComServiceRemoteRestTests.swift; sourceTree = "<group>"; };
+		FF34EEAA1CF480F100F8B38D /* WordPressComRestApiFailThrottled.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = WordPressComRestApiFailThrottled.json; sourceTree = "<group>"; };
 		FF3DD6BD19F2B6B3003A52CB /* RemoteMedia.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteMedia.m; path = "Remote Objects/RemoteMedia.m"; sourceTree = "<group>"; };
 		FF3DD6BF19F2B77A003A52CB /* RemoteMedia.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RemoteMedia.h; path = "Remote Objects/RemoteMedia.h"; sourceTree = "<group>"; };
 		FF42584E1BA092EE00580C68 /* RelatedPostsSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RelatedPostsSettingsViewController.h; sourceTree = "<group>"; };
@@ -2756,6 +2760,7 @@
 				59E2AAE71B20E3EA0051DC06 /* ServiceRemoteRESTTests.m */,
 				08A2AD741CCEBDBD00E84454 /* TaxonomyServiceRemoteRESTTests.m */,
 				598F86AA1B67BD7600550C9C /* ThemeServiceRemoteTests.m */,
+				FF34EEA81CF473F600F8B38D /* WordPressComServiceRemoteRestTests.swift */,
 			);
 			name = "Remote Services";
 			sourceTree = "<group>";
@@ -4446,6 +4451,7 @@
 			isa = PBXGroup;
 			children = (
 				FFB8DC971CE320C700D4D1B7 /* WordPressComRestApiFailInvalidInput.json */,
+				FF34EEAA1CF480F100F8B38D /* WordPressComRestApiFailThrottled.json */,
 				FFB8DC981CE320C700D4D1B7 /* WordPressComRestApiFailInvalidJSON.json */,
 				FFB8DC991CE320C700D4D1B7 /* WordPressComRestApiFailRequestInvalidToken.json */,
 				FFB8DC9A1CE320C700D4D1B7 /* WordPressComRestApiFailUnauthorized.json */,
@@ -5149,6 +5155,7 @@
 				855408861A6F105700DDBD79 /* app-review-prompt-all-enabled.json in Resources */,
 				E131CB5616CACF1E004B0314 /* get-user-blogs_has-blog.json in Resources */,
 				FFB8DC9E1CE320C700D4D1B7 /* WordPressComRestApiFailRequestInvalidToken.json in Resources */,
+				FF34EEAB1CF480F100F8B38D /* WordPressComRestApiFailThrottled.json in Resources */,
 				59F9C1571B9DCE4E00885CC1 /* get-single-theme-v1.1.json in Resources */,
 				FFB8DC9C1CE320C700D4D1B7 /* WordPressComRestApiFailInvalidInput.json in Resources */,
 				B5EFB1D11B33630C007608A3 /* notifications-settings.json in Resources */,
@@ -6155,6 +6162,7 @@
 				B5744A1E1C3D8FA700A3B8DC /* InteractiveNotificationsHandlerTests.m in Sources */,
 				B5EFB1C91B333C5A007608A3 /* NotificationsServiceTests.swift in Sources */,
 				B5AEEC721ACACF2F008BF2A4 /* NotificationTests.m in Sources */,
+				FF34EEA91CF473F600F8B38D /* WordPressComServiceRemoteRestTests.swift in Sources */,
 				BE1071FF1BC75FFA00906AFF /* WPStyleGuide+BlogTests.swift in Sources */,
 				85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */,
 				93D86B981C691E71003D8E3E /* LocalCoreDataServiceTests.m in Sources */,

--- a/WordPress/WordPressTest/Test Data/WordPressComRestApiFailThrottled.json
+++ b/WordPress/WordPressTest/Test Data/WordPressComRestApiFailThrottled.json
@@ -1,0 +1,3 @@
+<html>
+Limit reached
+</html>

--- a/WordPress/WordPressTest/WordPressComServiceRemoteRestTests.swift
+++ b/WordPress/WordPressTest/WordPressComServiceRemoteRestTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import WordPress
+import OHHTTPStubs
+
+class WordPressComServiceRemoteRestTests: XCTestCase {
+
+    let wordPressComRestApi = "https://public-api.wordpress.com/rest/"
+    let wordPressUsersNewEndpoint = "v1.1/users/new"
+    let wordPressSitesNewEndpoint = "v1.1/sites/new"
+
+    var service: WordPressComServiceRemote!
+    var api: WordPressComRestApi!
+
+    override func setUp() {
+        super.setUp()
+
+        api = WordPressComRestApi()
+        service = WordPressComServiceRemote(wordPressComRestApi:api)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        service = nil
+        api = nil
+        OHHTTPStubs.removeAllStubs()
+    }
+
+    private func isRestAPIUsersNewRequest() -> OHHTTPStubsTestBlock {
+        return { request in
+            return request.URL?.absoluteString == self.wordPressComRestApi + self.wordPressUsersNewEndpoint
+        }
+    }
+
+    private func isRestAPISitesNewRequest() -> OHHTTPStubsTestBlock {
+        return { request in
+            return request.URL?.absoluteString == self.wordPressComRestApi + self.wordPressSitesNewEndpoint
+        }
+    }
+
+    func testThrottledFailureCall() {
+        stub(isRestAPIUsersNewRequest()) { request in
+            let stubPath = OHPathForFile("WordPressComRestApiFailThrottled.json", self.dynamicType)
+            return fixture(stubPath!, status:500, headers: ["Content-Type":"application/html"])
+        }
+
+        let expectation = self.expectationWithDescription("One callback should be invoked")
+        service.createWPComAccountWithEmail("fakeEmail",
+                                            andUsername:"fakeUsername",
+                                            andPassword:"fakePassword",
+                                            success: { (responseObject) in
+                                                expectation.fulfill()
+                                                XCTFail("This call should fail")
+            }, failure: { (error) in
+                expectation.fulfill()
+                XCTAssert(error.domain == String(reflecting:WordPressComRestApiError.self), "The error should a WordPressComRestApiError")
+                XCTAssert(error.code == Int(WordPressComRestApiError.TooManyRequests.rawValue), "The error code should be invalid token")
+        })
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
+
+}


### PR DESCRIPTION
Refs #5245 

To test:
 - Create a new wp.com account, by testing success scenarios and failure scenarios:
  - Repeated email
  - Invalid username
  - Invalid email
  - Insecure password
- Create a new wp.com site,  by testing success scenarios and failure scenarios:
 - Used site name
 - Site name is too short

Needs review: @koke 
