### PR TITLE
Use oAuthToken directly from the mainAccount instead of the restAPI.

### DIFF
--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -13,7 +13,7 @@ public class GravatarService
     ///
     public init?(context: NSManagedObjectContext) {
         let mainAccount = AccountService(managedObjectContext: context).defaultWordPressComAccount()
-        accountToken    = mainAccount?.restApi.authToken
+        accountToken    = mainAccount?.authToken
         accountEmail    = mainAccount?.email
 
         guard accountEmail?.isEmpty == false && accountToken?.isEmpty == false else {

--- a/WordPress/Classes/Utility/WPTableImageSource.m
+++ b/WordPress/Classes/Utility/WPTableImageSource.m
@@ -116,7 +116,7 @@ static const NSInteger WPTableImageSourceMinPhotonQuality = 1;
         AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
         WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
         [[WPImageSource sharedSource] downloadImageForURL:url
-                                                authToken:[[defaultAccount restApi] authToken]
+                                                authToken:[defaultAccount authToken]
                                               withSuccess:successBlock
                                                   failure:failureBlock];
     } else {


### PR DESCRIPTION
Refs #5245 

To test:
 - Login with WP.com account
 - Test if uploading a gravar image works correctly on the Me section
 - Check if images on tables like comments, show correctly.

Needs review: @koke 