### PR TITLE
Issue/5080 BlogListViewController now shows all sites when search is activated

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -799,14 +799,15 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
         return [self fetchRequestPredicateForSearch];
     }
 
-    return [NSPredicate predicateWithFormat:@"visible = YES"];
+    return [self fetchRequestPredicateForVisibleBlogs];
 }
 
 - (NSPredicate *)fetchRequestPredicateForSearch
 {
     NSString *searchText = self.searchController.searchBar.text;
     if ([searchText isEmpty]) {
-        return [self fetchRequestPredicateForHideableBlogs];
+         // Don't filter – show all sites
+        return [self fetchRequestPredicateForAllBlogs];
     }
     
     return [NSPredicate predicateWithFormat:@"( settings.name contains[cd] %@ ) OR ( url contains[cd] %@)", searchText, searchText];
@@ -823,6 +824,16 @@ static NSTimeInterval HideAllSitesInterval = 2.0;
     WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
 
     return [NSPredicate predicateWithFormat:@"account != NULL AND account = %@", defaultAccount];
+}
+
+- (NSPredicate *)fetchRequestPredicateForVisibleBlogs
+{
+    return [NSPredicate predicateWithFormat:@"visible = YES"];
+}
+
+- (NSPredicate *)fetchRequestPredicateForAllBlogs
+{
+    return [NSPredicate predicateWithValue:YES];
 }
 
 - (void)updateFetchRequest


### PR DESCRIPTION
Fixes #5080. Please see that issue for full details.

When search was activated, but no search query was entered, we were filtering to show all 'hideable' blogs (this basically means any blogs that belong to the default dotcom account). I've changed this to now simply show all sites. I've also tidied up the predicates we already had a little.

To test:

* Log into a WordPress.com account, and also add a non-dotcom, non-Jetpack site. 
* From the site picker, tap the search icon
* Verify that the site appears in the site list before you enter a search term.
* Verify that you can still see the site when you enter a matching search term, too.

Needs review: @jleandroperez (It looks like you touched this code last, so would you mind doing the honours? Thanks!)