### PR TITLE
Issue/6.3/5245 migrate sharing services to nsurlsession

### DIFF
--- a/WordPress/Classes/Networking/SharingServiceRemote.swift
+++ b/WordPress/Classes/Networking/SharingServiceRemote.swift
@@ -1,12 +1,11 @@
 import Foundation
-import AFNetworking
 import NSObject_SafeExpectations
 
 
 /// SharingServiceRemote is responsible for wrangling the REST API calls related to
 /// publiczice services, publicize connections, and keyring connections.
 ///
-public class SharingServiceRemote : ServiceRemoteREST
+public class SharingServiceRemote : ServiceRemoteWordPressComREST
 {
 
     // MARK: - Helper methods

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -258,7 +258,7 @@ public class SharingService : LocalCoreDataService
                 success?()
             },
             failure: { (error:NSError!) in
-                if let errorCode = error.userInfo[WordPressComApiErrorCodeKey] as? String {
+                if let errorCode = error.userInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String {
                     if errorCode == self.SharingAPIErrorNotFound {
                         // This is a special situation. If the call to disconnect the service returns not_found then the service
                         // has probably already been disconnected and the call was made with stale data.

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -731,10 +731,10 @@ public class SharingService : LocalCoreDataService
     /// - Parameter blog: The blog to use for the rest api.
     ///
     private func remoteForBlog(blog: Blog) -> SharingServiceRemote? {
-        guard let api = blog.restApi() else {
+        guard let api = blog.wordPressComRestApi() else {
             return nil
         }
 
-        return SharingServiceRemote(api: api)
+        return SharingServiceRemote(wordPressComRestApi: api)
     }
 }

--- a/WordPress/WordPressTest/SharingServiceRemoteTests.m
+++ b/WordPress/WordPressTest/SharingServiceRemoteTests.m
@@ -1,10 +1,7 @@
 #import <XCTest/XCTest.h>
-#import <OCMock/OCMock.h>
-
 #import "Blog.h"
-#import "ServiceRemoteREST.h"
-#import "WordPressComApi.h"
 #import "WordPress-Swift.h"
+#import "WordPressTests-Swift.h"
 
 @interface SharingServiceRemoteTests : XCTestCase
 
@@ -17,38 +14,33 @@
 
 - (void)testGetPublicizeServices
 {
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    MockWordPressComRestApi *api = [[MockWordPressComRestApi alloc] initWithOAuthToken:nil userAgent:nil];
     SharingServiceRemote *service = nil;
 
-    NSString *url = @"v1.1/meta/external-services";
-    NSDictionary *params = @{@"type":@"publicize"};
-
-    OCMStub([api GET:[OCMArg isEqual:url]
-          parameters:[OCMArg isEqual:params]
-             success:[OCMArg isNotNil]
-             failure:[OCMArg isNotNil]]);
-
-    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithWordPressComRestApi:api]);
 
     [service getPublicizeServices:^(NSArray *services) {} failure:^(NSError *error) {}];
+
+    XCTAssertTrue([api getMethodCalled], @"Method was not called");
+    XCTAssertEqualObjects([api URLStringPassedIn], @"v1.1/meta/external-services", @"Incorrect URL passed in");
+    NSDictionary * parameters = [api parametersPassedIn];
+    XCTAssertEqualObjects(parameters[@"type"], @"publicize", @"incorrect type parameter");
 }
 
 
 - (void)testGetKeyringServices
 {
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    MockWordPressComRestApi *api = [[MockWordPressComRestApi alloc] initWithOAuthToken:nil userAgent:nil];
     SharingServiceRemote *service = nil;
 
     NSString *url = @"v1.1/me/keyring-connections";
 
-    OCMStub([api GET:[OCMArg isEqual:url]
-          parameters:[OCMArg isNil]
-             success:[OCMArg isNotNil]
-             failure:[OCMArg isNotNil]]);
-
-    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithWordPressComRestApi:api]);
 
     [service getKeyringConnections:^(NSArray *connections) {} failure:^(NSError *error) {}];
+
+    XCTAssertTrue([api getMethodCalled], @"Method was not called");
+    XCTAssertEqualObjects([api URLStringPassedIn], url, @"Incorrect URL passed in");
 }
 
 
@@ -56,21 +48,19 @@
 {
     NSNumber *mockID = @10;
 
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    MockWordPressComRestApi *api = [[MockWordPressComRestApi alloc] initWithOAuthToken:nil userAgent:nil];
     SharingServiceRemote *service = nil;
 
     NSString *url = [NSString stringWithFormat:@"v1.1/sites/%@/publicize-connections", mockID];
 
-    OCMStub([api GET:[OCMArg isEqual:url]
-          parameters:[OCMArg isNil]
-             success:[OCMArg isNotNil]
-             failure:[OCMArg isNotNil]]);
-
-    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithWordPressComRestApi:api]);
 
     [service getPublicizeConnections:mockID
                              success:^(NSArray *connections) {}
                              failure:^(NSError *error) {}];
+
+    XCTAssertTrue([api getMethodCalled], @"Method was not called");
+    XCTAssertEqualObjects([api URLStringPassedIn], url, @"Incorrect URL passed in");
 }
 
 
@@ -78,24 +68,20 @@
 {
     NSNumber *mockID = @10;
 
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    MockWordPressComRestApi *api = [[MockWordPressComRestApi alloc] initWithOAuthToken:nil userAgent:nil];
     SharingServiceRemote *service = nil;
 
     NSString *url = [NSString stringWithFormat:@"v1.1/sites/%@/publicize-connections/new", mockID];
 
-    OCMStub([api POST:[OCMArg isEqual:url]
-           parameters:[OCMArg isNotNil]
-              success:[OCMArg isNotNil]
-              failure:[OCMArg isNotNil]]);
-
-    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithWordPressComRestApi:api]);
 
     [service createPublicizeConnection:mockID
                    keyringConnectionID:mockID
                         externalUserID:nil
                                success:^(RemotePublicizeConnection *remotePubConn) {}
                                failure:^(NSError *error) {}];
-
+    XCTAssertTrue([api postMethodCalled], @"Method was not called");
+    XCTAssertEqualObjects([api URLStringPassedIn], url, @"Incorrect URL passed in");
 }
 
 
@@ -103,19 +89,17 @@
 {
     NSNumber *mockID = @10;
 
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    MockWordPressComRestApi *api = [[MockWordPressComRestApi alloc] initWithOAuthToken:nil userAgent:nil];
     SharingServiceRemote *service = nil;
 
     NSString *url = [NSString stringWithFormat:@"v1.1/sites/%@/publicize-connections/%@/delete", mockID, mockID];
 
-    OCMStub([api POST:[OCMArg isEqual:url]
-           parameters:[OCMArg isNil]
-              success:[OCMArg isNotNil]
-              failure:[OCMArg isNotNil]]);
-
-    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithWordPressComRestApi:api]);
 
     [service deletePublicizeConnection:mockID connectionID:mockID success:^{} failure:^(NSError *error) {}];
+
+    XCTAssertTrue([api postMethodCalled], @"Method was not called");
+    XCTAssertEqualObjects([api URLStringPassedIn], url, @"Incorrect URL passed in");
 }
 
 
@@ -124,21 +108,19 @@
 {
     NSNumber *mockID = @10;
 
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    MockWordPressComRestApi *api = [[MockWordPressComRestApi alloc] initWithOAuthToken:nil userAgent:nil];
     SharingServiceRemote *service = nil;
 
     NSString *url = [NSString stringWithFormat:@"v1.1/sites/%@/sharing-buttons", mockID];
 
-    OCMStub([api GET:[OCMArg isEqual:url]
-          parameters:[OCMArg isNil]
-             success:[OCMArg isNotNil]
-             failure:[OCMArg isNotNil]]);
-
-    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithWordPressComRestApi:api]);
 
     [service getSharingButtonsForSite:mockID
                              success:^(NSArray *buttons) {}
                               failure:^(NSError *error) {}];
+
+    XCTAssertTrue([api getMethodCalled], @"Method was not called");
+    XCTAssertEqualObjects([api URLStringPassedIn], url, @"Incorrect URL passed in");
 }
 
 
@@ -146,23 +128,21 @@
 {
     NSNumber *mockID = @10;
 
-    WordPressComApi *api = OCMStrictClassMock([WordPressComApi class]);
+    MockWordPressComRestApi *api = [[MockWordPressComRestApi alloc] initWithOAuthToken:nil userAgent:nil];
     SharingServiceRemote *service = nil;
 
     NSString *url = [NSString stringWithFormat:@"v1.1/sites/%@/sharing-buttons", mockID];
     NSArray *buttons = [NSArray array];
 
-    OCMStub([api POST:[OCMArg isEqual:url]
-           parameters:[OCMArg isNotNil]
-              success:[OCMArg isNotNil]
-              failure:[OCMArg isNotNil]]);
-
-    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithApi:api]);
+    XCTAssertNoThrow(service = [[SharingServiceRemote alloc] initWithWordPressComRestApi:api]);
 
     [service updateSharingButtonsForSite:mockID
                           sharingButtons:buttons
                                  success:^(NSArray *buttons){}
                                  failure:^(NSError *error) {}];
+
+    XCTAssertTrue([api postMethodCalled], @"Method was not called");
+    XCTAssertEqualObjects([api URLStringPassedIn], url, @"Incorrect URL passed in");
 }
 
 


### PR DESCRIPTION
Refs #5245 

To test:
 - Login with a WP.com account
 - Go To Blog->Sharing
 - Test if connections show correctly
 - Try to connect to services and see if it works correctly
 - Delete connections after and check if they work.

Needs review: @aerych 