### PR TITLE
Issue/5041 Displays different Support footer text if Helpshift is enabled.

### DIFF
--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -424,7 +424,11 @@ typedef NS_ENUM(NSInteger, SettingsSectionFeedbackRows)
 - (NSString *)titleForFooterInSection:(NSInteger)section
 {
     if (section == SettingsSectionFAQForums) {
-        return NSLocalizedString(@"Visit the Help Center to get answers to common questions, or visit the Forums to ask new ones.", @"");
+        if ([HelpshiftUtils isHelpshiftEnabled]) {
+            return NSLocalizedString(@"Visit the Help Center to get answers to common questions, or contact us for more help.", @"Support screen footer text displayed when Helpshift is enabled.");
+        } else {
+            return NSLocalizedString(@"Visit the Help Center to get answers to common questions, or visit the Forums to ask new ones.", @"Support screen footer text displayed when Helpshift is disabled.");
+        }
     } else if (section == SettingsSectionSettings) {
         return NSLocalizedString(@"The Extra Debug feature includes additional information in activity logs, and can help us troubleshoot issues with the app.", @"");
     }


### PR DESCRIPTION
Fixes #5041. See issue for full details.

To test: View the Support screen with Helpshift both enabled and disabled. When disabled, the Forums should be referenced, and when enabled, 'contact us' should be referenced.

Needs review: @aerych 