### PR TITLE
Adds unit tests to the Post CoreData entity.

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class WordPressComRestApi;
 @class WPXMLRPCClient;
 
+extern NSString * const BlogEntityName;
 extern NSString * const PostFormatStandard;
 
 typedef NS_ENUM(NSUInteger, BlogFeature) {

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -17,6 +17,7 @@ static NSInteger const ImageSizeMediumHeight = 360;
 static NSInteger const ImageSizeLargeWidth = 640;
 static NSInteger const ImageSizeLargeHeight = 480;
 
+NSString * const BlogEntityName = @"Blog";
 NSString * const PostFormatStandard = @"standard";
 NSString * const ActiveModulesKeyPublicize = @"publicize";
 NSString * const ActiveModulesKeySharingButtons = @"sharedaddy";

--- a/WordPress/Classes/Models/Post.h
+++ b/WordPress/Classes/Models/Post.h
@@ -3,6 +3,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString * const PostEntityName;
 extern NSString * const PostTypeDefaultIdentifier;
 
 @class Coordinate;

--- a/WordPress/Classes/Models/Post.h
+++ b/WordPress/Classes/Models/Post.h
@@ -48,7 +48,7 @@ extern NSString * const PostTypeDefaultIdentifier;
  
  @param categoryNames a `NSArray` with the names of the categories for this post. If a given category name doesn't exist it's ignored.
  */
-- (void)setCategoriesFromNames:(nullable NSArray *)categoryNames;
+- (void)setCategoriesFromNames:(nonnull NSArray *)categoryNames;
 
 #pragma mark - Convenience methods
 

--- a/WordPress/Classes/Models/Post.m
+++ b/WordPress/Classes/Models/Post.m
@@ -8,6 +8,7 @@
 #import "ContextManager.h"
 #import <WordPressShared/NSString+XMLExtensions.h>
 
+NSString * const PostEntityName = @"Post";
 NSString * const PostTypeDefaultIdentifier = @"post";
 
 @interface Post()
@@ -70,7 +71,11 @@ NSString * const PostTypeDefaultIdentifier = @"post";
 
 - (NSString *)categoriesText
 {
-    return [[[self.categories valueForKey:@"categoryName"] allObjects] componentsJoinedByString:@", "];
+    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:PostCategoryNameKey ascending:true];
+    NSArray *sortDescriptors = @[sortDescriptor];
+    NSArray *sortedCategories = [[self.categories allObjects] sortedArrayUsingDescriptors:sortDescriptors];
+
+    return [[sortedCategories valueForKey:PostCategoryNameKey] componentsJoinedByString:@", "];
 }
 
 - (NSString *)postFormatText
@@ -96,7 +101,7 @@ NSString * const PostTypeDefaultIdentifier = @"post";
     NSMutableSet *categories = nil;
 
     for (NSString *categoryName in categoryNames) {
-        NSSet *results = [self.blog.categories filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"categoryName = %@", categoryName]];
+        NSSet *results = [self.blog.categories filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"%K = %@", PostCategoryNameKey, categoryName]];
         if (results && (results.count > 0)) {
             if (categories == nil) {
                 categories = [NSMutableSet setWithSet:results];

--- a/WordPress/Classes/Models/PostCategory.h
+++ b/WordPress/Classes/Models/PostCategory.h
@@ -2,6 +2,8 @@
 #import "Blog.h"
 #import "WordPressAppDelegate.h"
 
+extern NSString * const PostCategoryEntityName;
+extern NSString * const PostCategoryNameKey;
 extern const NSInteger PostCategoryUncategorized;
 
 @interface PostCategory : NSManagedObject

--- a/WordPress/Classes/Models/PostCategory.m
+++ b/WordPress/Classes/Models/PostCategory.m
@@ -1,5 +1,7 @@
 #import "PostCategory.h"
 
+NSString * const PostCategoryEntityName = @"Category";
+NSString * const PostCategoryNameKey = @"categoryName";
 const NSInteger PostCategoryUncategorized = 1;
 
 @implementation PostCategory

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -64,6 +64,7 @@
 #import "PostContentProvider.h"
 #import "Post.h"
 #import "PostCardTableViewCell.h"
+#import "PostCategory.h"
 #import "PostContentProvider.h"
 #import "PostListFilter.h"
 #import "PostListFooterView.h"

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */; };
 		5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */; };
 		594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */ = {isa = PBXBuildFile; fileRef = 594DB2941AB891A200E2E456 /* WPUserAgent.m */; };
+		5960967F1CF7959300848496 /* PostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5960967E1CF7959300848496 /* PostTests.swift */; };
 		596C035E1B84F21D00899EEB /* ThemeBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596C035D1B84F21D00899EEB /* ThemeBrowserViewController.swift */; };
 		596C03601B84F24000899EEB /* ThemeBrowser.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 596C035F1B84F24000899EEB /* ThemeBrowser.storyboard */; };
 		5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */; };
@@ -1153,6 +1154,7 @@
 		5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAppAnalyticsTests.m; sourceTree = "<group>"; };
 		594DB2931AB891A200E2E456 /* WPUserAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUserAgent.h; sourceTree = "<group>"; };
 		594DB2941AB891A200E2E456 /* WPUserAgent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUserAgent.m; sourceTree = "<group>"; };
+		5960967E1CF7959300848496 /* PostTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostTests.swift; sourceTree = "<group>"; };
 		596C035D1B84F21D00899EEB /* ThemeBrowserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserViewController.swift; sourceTree = "<group>"; };
 		596C035F1B84F24000899EEB /* ThemeBrowser.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ThemeBrowser.storyboard; sourceTree = "<group>"; };
 		597421B01CEB6874005D5F38 /* ConfigurablePostView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConfigurablePostView.h; sourceTree = "<group>"; };
@@ -2955,6 +2957,7 @@
 				5D7A577F1AFBFD940097C028 /* BasePostTest.m */,
 				E6B9B8A91B94E1FE0001B92F /* ReaderPostTest.m */,
 				B55F1AA11C107CE200FD04D4 /* BlogSettingsDiscussionTests.swift */,
+				5960967E1CF7959300848496 /* PostTests.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -6218,6 +6221,7 @@
 				852416D21A12ED690030700C /* AppRatingUtilityTests.m in Sources */,
 				598F86AB1B67BD7600550C9C /* ThemeServiceRemoteTests.m in Sources */,
 				E15618FD16DB8677006532C4 /* UIKitTestHelper.m in Sources */,
+				5960967F1CF7959300848496 /* PostTests.swift in Sources */,
 				E124CE721C86D27100F7BA99 /* StoreTests.swift in Sources */,
 				B5744A1E1C3D8FA700A3B8DC /* InteractiveNotificationsHandlerTests.m in Sources */,
 				B5EFB1C91B333C5A007608A3 /* NotificationsServiceTests.swift in Sources */,

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -58,14 +58,6 @@ class PostTests: XCTestCase {
         XCTAssert(categoriesText == "1, 2, 3")
     }
 
-    func testSetCategoriesFromNamesWithANilInputParam() {
-        let post = newTestPost()
-
-        post.setCategoriesFromNames(nil)
-
-        XCTAssert(post.categories?.count == 0)
-    }
-
     func testSetCategoriesFromNamesWithTwoCategories() {
         let blog = newTestBlog()
         let post = newTestPost()

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import XCTest
+
+@testable import WordPress
+
+class PostTests: XCTestCase {
+
+    private let context: NSManagedObjectContext = {
+        let context = NSManagedObjectContext(concurrencyType: .MainQueueConcurrencyType)
+        context.parentContext = TestContextManager.sharedInstance().mainContext
+
+        return context
+    }()
+
+    private func newTestBlog() -> Blog {
+        return NSEntityDescription.insertNewObjectForEntityForName(BlogEntityName, inManagedObjectContext: context) as! Blog
+    }
+
+    private func newTestPost() -> Post {
+        return NSEntityDescription.insertNewObjectForEntityForName(PostEntityName, inManagedObjectContext: context) as! Post
+    }
+
+    private func newTestPostCategory() -> PostCategory {
+        return NSEntityDescription.insertNewObjectForEntityForName(PostCategoryEntityName, inManagedObjectContext: context) as! PostCategory
+    }
+
+    private func newTestPostCategory(name: String) -> PostCategory {
+        let category = newTestPostCategory()
+        category.categoryName = name
+
+        return category
+    }
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        context.rollback()
+        super.tearDown()
+    }
+
+    func testThatNoCategoriesReturnEmptyStringWhenCallingCategoriesText() {
+        let post = newTestPost()
+        let categoriesText = post.categoriesText()
+
+        XCTAssert(categoriesText == "")
+    }
+
+    func testThatSomeCategoriesReturnAListWhenCallingCategoriesText() {
+
+        let post = newTestPost()
+
+        post.categories = Set<PostCategory>(arrayLiteral: newTestPostCategory("1"), newTestPostCategory("2"), newTestPostCategory("3"))
+
+        let categoriesText = post.categoriesText()
+
+        XCTAssert(categoriesText == "1, 2, 3")
+    }
+
+    func testSetCategoriesFromNamesWithANilInputParam() {
+        let post = newTestPost()
+
+        post.setCategoriesFromNames(nil)
+
+        XCTAssert(post.categories?.count == 0)
+    }
+
+    func testSetCategoriesFromNamesWithTwoCategories() {
+        let blog = newTestBlog()
+        let post = newTestPost()
+
+        let category1 = newTestPostCategory("One")
+        let category2 = newTestPostCategory("Two")
+        let category3 = newTestPostCategory("Three")
+
+        blog.categories = Set<PostCategory>(arrayLiteral: category1, category2, category3)
+
+        post.blog = blog
+        post.setCategoriesFromNames(["One", "Three"])
+
+        let postCategories = post.categories as! Set<PostCategory>
+        XCTAssert(postCategories.count == 2)
+        XCTAssert(postCategories.contains(category1))
+        XCTAssert(!postCategories.contains(category2))
+        XCTAssert(postCategories.contains(category3))
+    }
+
+    func testThatSettingNilLikeCountReturnsZeroNumberOfLikes() {
+        let post = newTestPost()
+
+        post.likeCount = nil
+
+        XCTAssert(post.numberOfLikes() == 0)
+    }
+
+    func testThatSettingLikeCountAffectsNumberOfLikes() {
+        let post = newTestPost()
+
+        post.likeCount = 2
+
+        XCTAssert(post.numberOfLikes() == 2)
+    }
+
+    func testThatSettingNilCommentCountReturnsZeroNumberOfComments() {
+        let post = newTestPost()
+
+        post.commentCount = nil
+
+        XCTAssert(post.numberOfComments() == 0)
+    }
+
+    func testThatSettingCommentCountAffectsNumberOfComments() {
+        let post = newTestPost()
+
+        post.commentCount = 2
+
+        XCTAssert(post.numberOfComments() == 2)
+    }
+
+    func testThatAddCategoriesWorks() {
+        let post = newTestPost()
+        let testCategories = Set<PostCategory>(arrayLiteral: newTestPostCategory("1"), newTestPostCategory("2"), newTestPostCategory("3"))
+
+        post.addCategories(testCategories)
+
+        guard let postCategories = post.categories else {
+            XCTFail("post.categories should not be nil here.")
+            return
+        }
+
+        XCTAssert(postCategories.count == testCategories.count)
+
+        for testCategory in testCategories {
+            XCTAssert(postCategories.contains(testCategory))
+        }
+    }
+
+    func testThatAddCategoriesObjectWorks() {
+        let post = newTestPost()
+        let testCategory = newTestPostCategory("1")
+
+        post.addCategoriesObject(testCategory)
+
+        guard let postCategories = post.categories else {
+            XCTFail("post.categories should not be nil here.")
+            return
+        }
+
+        XCTAssert(postCategories.count == 1)
+        XCTAssert(postCategories.contains(testCategory))
+    }
+
+    func testThatRemoveCategoriesWorks() {
+        let post = newTestPost()
+        let testCategories = Set<PostCategory>(arrayLiteral: newTestPostCategory("1"), newTestPostCategory("2"), newTestPostCategory("3"))
+
+        post.categories = testCategories
+        XCTAssert(post.categories?.count != 0 && post.categories?.count == testCategories.count)
+
+        post.removeCategories(testCategories)
+        XCTAssert(post.categories?.count == 0)
+    }
+
+    func testThatRemoveCategoriesObjectWorks() {
+        let post = newTestPost()
+        let testCategory = newTestPostCategory("1")
+
+        post.categories = Set<PostCategory>(arrayLiteral: testCategory)
+        XCTAssert(post.categories?.count == 1)
+
+        post.removeCategoriesObject(testCategory)
+        XCTAssert(post.categories?.count == 0)
+    }
+
+}

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -51,7 +51,7 @@ class PostTests: XCTestCase {
 
         let post = newTestPost()
 
-        post.categories = Set<PostCategory>(arrayLiteral: newTestPostCategory("1"), newTestPostCategory("2"), newTestPostCategory("3"))
+        post.categories = [newTestPostCategory("1"), newTestPostCategory("2"), newTestPostCategory("3")]
 
         let categoriesText = post.categoriesText()
 
@@ -66,7 +66,7 @@ class PostTests: XCTestCase {
         let category2 = newTestPostCategory("Two")
         let category3 = newTestPostCategory("Three")
 
-        blog.categories = Set<PostCategory>(arrayLiteral: category1, category2, category3)
+        blog.categories = [category1, category2, category3]
 
         post.blog = blog
         post.setCategoriesFromNames(["One", "Three"])
@@ -112,7 +112,7 @@ class PostTests: XCTestCase {
 
     func testThatAddCategoriesWorks() {
         let post = newTestPost()
-        let testCategories = Set<PostCategory>(arrayLiteral: newTestPostCategory("1"), newTestPostCategory("2"), newTestPostCategory("3"))
+        let testCategories = Set([newTestPostCategory("1"), newTestPostCategory("2"), newTestPostCategory("3")])
 
         post.addCategories(testCategories)
 


### PR DESCRIPTION
Adds unit tests for the Post CoreData entity.

### Details:

The reason why I'm introducing these unit tests (aside from them being a good thing to have), is that I'm planning to use them to check that the [upcoming migration](https://github.com/wordpress-mobile/WordPress-iOS/pull/5453) of `Post` to Swift does not introduce any regressions.

### Scope:

- Complete unit testing all public interfaces of `Post`.
- Modified `categoriesText` to always return the same result given the same input (by ordering the categories alphabetically).  Otherwise it would be impossible to properly test it.
- Added a few entity name constants, to cleanup the code a bit.

### Testing:

Test 1:
- Run the unit tests and make sure they all succeed.

Test 2:
- Run the app.
- Edit a post with categories.
- Go to the post settings.
- Make sure the post categories are ordered alphabetically now, and that they are correctly showing up.

Needs review: @SergioEstevao 
