### PR TITLE
Update and fix error handling for new api class

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -263,15 +263,13 @@
         switch (error.code) {
             case 500:{
                 errorMessage = NSLocalizedString(@"Your site does not support this media file format.", @"Message to show to user when media upload failed because server doesn't support media type");
-                errorCode = WordPressComApiErrorUploadFailedInvalidFileType;
             } break;
             case 401:{
-                errorMessage = NSLocalizedString(@"Your site is out of space for media uploads.", @"Message to show to user when media upload failed because user doesn't have enough space on quota/disk");
-                errorCode = WordPressComApiErrorUploadFailedNotEnoughDiskQuota;
+                errorMessage = NSLocalizedString(@"Your site is out of space for media uploads.", @"Message to show to user when media upload failed because user doesn't have enough space on quota/disk");                
             } break;
         }
         userInfo[NSLocalizedDescriptionKey] = errorMessage;
-        newError = [[NSError alloc] initWithDomain:WordPressComRestApiErrorDomain code:errorCode userInfo:userInfo];
+        newError = [[NSError alloc] initWithDomain:WPXMLRPCFaultErrorDomain code:errorCode userInfo:userInfo];
     }
     return newError;
 }

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -13,8 +13,6 @@
 #import "WordPress-swift.h"
 #import <WordPressApi/WordPressApi.h>
 #import "WPXMLRPCDecoder.h"
-#import "WordPress-Swift.h"
-
 
 @implementation MediaService
 
@@ -258,27 +256,7 @@
 
 - (NSError *)translateMediaUploadError:(NSError *)error {
     NSError *newError = error;
-    if (error.domain == WordPressComApiErrorDomain) {
-        NSString *errorMessage = [error localizedDescription];
-        NSInteger errorCode = error.code;
-        NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
-        switch (error.code) {
-            case WordPressComApiErrorUploadFailed:
-                errorMessage = NSLocalizedString(@"The app couldn't upload this media.", @"Message to show to user when media upload failed by unknow server error");
-                errorCode = WordPressComApiErrorUploadFailed;
-                break;
-            case WordPressComApiErrorUploadFailedInvalidFileType:
-                errorMessage = NSLocalizedString(@"Your site does not support this media file format.", @"Message to show to user when media upload failed because server doesn't support media type");
-                errorCode = WordPressComApiErrorUploadFailedInvalidFileType;
-                break;
-            case WordPressComApiErrorUploadFailedNotEnoughDiskQuota:
-                errorMessage = NSLocalizedString(@"Your site is out of space for media uploads.", @"Message to show to user when media upload failed because user doesn't have enough space on quota/disk");
-                errorCode = WordPressComApiErrorUploadFailedNotEnoughDiskQuota;
-                break;
-        }
-        userInfo[NSLocalizedDescriptionKey] = errorMessage;
-        newError = [[NSError alloc] initWithDomain:WordPressComApiErrorDomain code:errorCode userInfo:userInfo];
-    } else if (error.domain == WPXMLRPCFaultErrorDomain) {
+    if (error.domain == WPXMLRPCFaultErrorDomain) {
         NSString *errorMessage = [error localizedDescription];
         NSInteger errorCode = error.code;
         NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
@@ -293,7 +271,7 @@
             } break;
         }
         userInfo[NSLocalizedDescriptionKey] = errorMessage;
-        newError = [[NSError alloc] initWithDomain:WordPressComApiErrorDomain code:errorCode userInfo:userInfo];
+        newError = [[NSError alloc] initWithDomain:WordPressComRestApiErrorDomain code:errorCode userInfo:userInfo];
     }
     return newError;
 }

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -6,6 +6,7 @@
 #import "SupportViewController.h"
 #import "WordPress-Swift.h"
 #import <WPXMLRPC/WPXMLRPC.h>
+#import "WordPressComApi.h"
 
 NSInteger const SupportButtonIndex = 0;
 NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
@@ -82,6 +83,12 @@ NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
 
             default:
                 break;
+        }
+    } else if ([error.domain isEqualToString:WordPressComApiErrorDomain]) {
+        DDLogError(@"wp.com API error: %@: %@", [error.userInfo objectForKey:WordPressComApiErrorCodeKey], [error localizedDescription]);
+        if (error.code == WordPressComApiErrorInvalidToken || error.code == WordPressComApiErrorAuthorizationRequired) {
+            [SigninHelpers showSigninForWPComFixingAuthToken];
+            return;
         }
     } else if ([error.domain isEqualToString:WordPressComRestApiErrorDomain]) {
         DDLogError(@"wp.com API error: %@: %@", error.userInfo[WordPressComRestApi.ErrorKeyErrorCode],

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -1,6 +1,5 @@
 #import "WPError.h"
 #import "WordPressAppDelegate.h"
-#import "WordPressComApi.h"
 #import "WPAccount.h"
 #import "NSString+XMLExtensions.h"
 #import "NSString+Helpers.h"
@@ -39,7 +38,9 @@ NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
     NSString *message = nil;
     NSString *customTitle = nil;
 
-    if ([error.domain isEqual:AFURLRequestSerializationErrorDomain] || [error.domain isEqual:AFURLResponseSerializationErrorDomain]) {
+    if ([error.domain isEqual:AFURLRequestSerializationErrorDomain] ||
+        [error.domain isEqual:AFURLResponseSerializationErrorDomain])
+    {
         NSHTTPURLResponse *response = (NSHTTPURLResponse *)[error.userInfo objectForKey:AFNetworkingOperationFailingURLResponseErrorKey];
         switch (error.code) {
             case NSURLErrorBadServerResponse:
@@ -82,9 +83,10 @@ NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
             default:
                 break;
         }
-    } else if ([error.domain isEqualToString:WordPressComApiErrorDomain]) {
-        DDLogError(@"wp.com API error: %@: %@", [error.userInfo objectForKey:WordPressComApiErrorCodeKey], [error localizedDescription]);
-        if (error.code == WordPressComApiErrorInvalidToken || error.code == WordPressComApiErrorAuthorizationRequired) {
+    } else if ([error.domain isEqualToString:WordPressComRestApiErrorDomain]) {
+        DDLogError(@"wp.com API error: %@: %@", error.userInfo[WordPressComRestApi.ErrorKeyErrorCode],
+                   [error localizedDescription]);
+        if (error.code == WordPressComRestApiErrorInvalidToken || error.code == WordPressComRestApiErrorAuthorizationRequired) {
             [SigninHelpers showSigninForWPComFixingAuthToken];
             return;
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -859,6 +859,7 @@
 		FFB8DCA91CE3248400D4D1B7 /* ServiceRemoteWordPressComREST.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB8DCA61CE3248400D4D1B7 /* ServiceRemoteWordPressComREST.m */; };
 		FFB8DCAA1CE3248400D4D1B7 /* SiteServiceRemoteWordPressComREST.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB8DCA81CE3248400D4D1B7 /* SiteServiceRemoteWordPressComREST.m */; };
 		FFB8DCAB1CE3271F00D4D1B7 /* WordPressComRestApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB8DCA31CE320F200D4D1B7 /* WordPressComRestApi.swift */; };
+		FFC347461CF87B1B00B07952 /* WordPressComRestApiMultipleErrors.json in Resources */ = {isa = PBXBuildFile; fileRef = FFC347451CF87B1B00B07952 /* WordPressComRestApiMultipleErrors.json */; };
 		FFC6ADD41B56F295002F3C84 /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC6ADD21B56F295002F3C84 /* AboutViewController.swift */; };
 		FFC6ADD51B56F295002F3C84 /* AboutViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FFC6ADD31B56F295002F3C84 /* AboutViewController.xib */; };
 		FFC6ADDA1B56F366002F3C84 /* LocalCoreDataService.m in Sources */ = {isa = PBXBuildFile; fileRef = FFC6ADD91B56F366002F3C84 /* LocalCoreDataService.m */; };
@@ -2207,6 +2208,7 @@
 		FFB8DCA61CE3248400D4D1B7 /* ServiceRemoteWordPressComREST.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ServiceRemoteWordPressComREST.m; sourceTree = "<group>"; };
 		FFB8DCA71CE3248400D4D1B7 /* SiteServiceRemoteWordPressComREST.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SiteServiceRemoteWordPressComREST.h; sourceTree = "<group>"; };
 		FFB8DCA81CE3248400D4D1B7 /* SiteServiceRemoteWordPressComREST.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SiteServiceRemoteWordPressComREST.m; sourceTree = "<group>"; };
+		FFC347451CF87B1B00B07952 /* WordPressComRestApiMultipleErrors.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = WordPressComRestApiMultipleErrors.json; sourceTree = "<group>"; };
 		FFC6ADD21B56F295002F3C84 /* AboutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
 		FFC6ADD31B56F295002F3C84 /* AboutViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AboutViewController.xib; sourceTree = "<group>"; };
 		FFC6ADD91B56F366002F3C84 /* LocalCoreDataService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LocalCoreDataService.m; sourceTree = "<group>"; };
@@ -4468,6 +4470,7 @@
 			isa = PBXGroup;
 			children = (
 				FFB8DC971CE320C700D4D1B7 /* WordPressComRestApiFailInvalidInput.json */,
+				FFC347451CF87B1B00B07952 /* WordPressComRestApiMultipleErrors.json */,
 				FF34EEAA1CF480F100F8B38D /* WordPressComRestApiFailThrottled.json */,
 				FFB8DC981CE320C700D4D1B7 /* WordPressComRestApiFailInvalidJSON.json */,
 				FFB8DC991CE320C700D4D1B7 /* WordPressComRestApiFailRequestInvalidToken.json */,
@@ -5163,6 +5166,7 @@
 				E1E4CE0F1774563F00430844 /* misteryman.jpg in Resources */,
 				855408881A6F106800DDBD79 /* app-review-prompt-notifications-disabled.json in Resources */,
 				FF9839AD1CD3F82300E85258 /* WordPressOAuthClientWrongPasswordFail.json in Resources */,
+				FFC347461CF87B1B00B07952 /* WordPressComRestApiMultipleErrors.json in Resources */,
 				59F9C1591B9DD3D600885CC1 /* get-purchased-themes-v1.1.json in Resources */,
 				8554088A1A6F107D00DDBD79 /* app-review-prompt-global-disable.json in Resources */,
 				B5AEEC7A1ACACFDA008BF2A4 /* notifications-like.json in Resources */,

--- a/WordPress/WordPressApi/WordPressComRestApi.swift
+++ b/WordPress/WordPressApi/WordPressComRestApi.swift
@@ -261,13 +261,16 @@ final class WordPressComRestAPIResponseSerializer: AFJSONResponseSerializer
             userInfo = originalError.userInfo
         }
 
-        var errorObject = responseObject
-        if let errorArray = responseObject as? [AnyObject] where errorArray.count > 0 {
-            errorObject = errorArray.first
+        guard let responseDictionary = responseObject as? [String:AnyObject] else {
+            return responseObject
         }
-        guard let responseDictionary = errorObject as? [String:AnyObject],
-            let errorCode = responseDictionary["error"] as? String,
-            let errorDescription = responseDictionary["message"] as? String
+        var errorDictionary:AnyObject? = responseDictionary
+        if let errorArray = responseDictionary["errors"] as? [AnyObject] where errorArray.count > 0 {
+            errorDictionary = errorArray.first
+        }
+        guard let errorEntry = errorDictionary as? [String:AnyObject],
+            let errorCode = errorEntry["error"] as? String,
+            let errorDescription = errorEntry["message"] as? String
             else {
                 return responseObject
         }

--- a/WordPress/WordPressTest/Test Data/WordPressComRestApiMultipleErrors.json
+++ b/WordPress/WordPressTest/Test Data/WordPressComRestApiMultipleErrors.json
@@ -1,0 +1,8 @@
+{
+    "errors":[
+        {
+            "message": "No media provided in input.",
+            "error": "upload_error"
+        }
+    ]
+}

--- a/WordPress/WordPressTest/WordPressAPI/WordPressComRestApiTests.swift
+++ b/WordPress/WordPressTest/WordPressAPI/WordPressComRestApiTests.swift
@@ -121,5 +121,22 @@ class WordPressComRestApiTests: XCTestCase {
         self.waitForExpectationsWithTimeout(2, handler: nil)
     }
 
+    func testMultipleErrorsFailedCall() {
+        stub(isRestAPIMediaNewRequest()) { request in
+            let stubPath = OHPathForFile("WordPressComRestApiMultipleErrors.json", self.dynamicType)
+            return fixture(stubPath!, status:403, headers: ["Content-Type":"application/json"])
+        }
+        let expectation = self.expectationWithDescription("One callback should be invoked")
+        let api = WordPressComRestApi(oAuthToken:"fakeToken")
+        api.POST(wordPressMediaNewEndpoint, parameters:nil, success: { (responseObject: AnyObject, httpResponse: NSHTTPURLResponse?) in
+            expectation.fulfill()
+            XCTFail("This call should fail")
+            }, failure: { (error, httpResponse) in
+                expectation.fulfill()
+                XCTAssert(error.domain == String(reflecting:WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+                XCTAssert(error.code == Int(WordPressComRestApiError.UploadFailed.rawValue), "The error code should be AuthorizationRequired")
+        })
+        self.waitForExpectationsWithTimeout(2, handler: nil)
+    }
 
 }


### PR DESCRIPTION
Refs #5245 

Test 1:
 - Login to WP.com account
 - Go to blog list
 - Go to server and invalidate password and token for that user
 - Try to do a refresh and check if the correct error message/dialog shows up

Test 2:
 - Login with WP.com account
 - Reduce the maximum file size or disk quota for media for that user on the server to 1Mb
 - Try to upload a media file and see if a proper error message shows up.

Needs review: @koke 