### PR TITLE
Move Push Notification constant out of WordPressComApi class.

### DIFF
--- a/WordPress/Classes/Networking/NotificationsServiceRemote.swift
+++ b/WordPress/Classes/Networking/NotificationsServiceRemote.swift
@@ -8,6 +8,16 @@ import UIDeviceIdentifier
 ///
 public class NotificationsServiceRemote : ServiceRemoteWordPressComREST
 {
+    #if DEBUG
+        static let WordPressComApiPushAppId = "org.wordpress.appstore.dev"
+    #else
+    #if INTERNAL_BUILD
+        static let  WordPressComApiPushAppId = "org.wordpress.internal"
+    #else
+        static let WordPressComApiPushAppId = "org.wordpress.appstore"
+    #endif
+    #endif
+
     /// Designated Initializer. Fails if the remoteApi is nil.
     ///
     /// - Parameter wordPressComRestApi: A Reference to the WordPressComRestApi that should be used to interact with WordPress.com
@@ -83,7 +93,7 @@ public class NotificationsServiceRemote : ServiceRemoteWordPressComREST
         let parameters = [
             "device_token"    : token,
             "device_family"   : "apple",
-            "app_secret_key"  : WordPressComApiPushAppId,
+            "app_secret_key"  : NotificationsServiceRemote.WordPressComApiPushAppId,
             "device_name"     : device.name,
             "device_model"    : UIDeviceHardware.platform(),
             "os_version"      : device.systemVersion,

--- a/WordPress/Classes/Networking/NotificationsServiceRemote.swift
+++ b/WordPress/Classes/Networking/NotificationsServiceRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AFNetworking
 import UIDeviceIdentifier
 
 /// The purpose of this class is to encapsulate all of the interaction with the Notifications REST endpoints.
@@ -8,16 +7,6 @@ import UIDeviceIdentifier
 ///
 public class NotificationsServiceRemote : ServiceRemoteWordPressComREST
 {
-    #if DEBUG
-        static let WordPressComApiPushAppId = "org.wordpress.appstore.dev"
-    #else
-    #if INTERNAL_BUILD
-        static let  WordPressComApiPushAppId = "org.wordpress.internal"
-    #else
-        static let WordPressComApiPushAppId = "org.wordpress.appstore"
-    #endif
-    #endif
-
     /// Designated Initializer. Fails if the remoteApi is nil.
     ///
     /// - Parameter wordPressComRestApi: A Reference to the WordPressComRestApi that should be used to interact with WordPress.com
@@ -93,7 +82,7 @@ public class NotificationsServiceRemote : ServiceRemoteWordPressComREST
         let parameters = [
             "device_token"    : token,
             "device_family"   : "apple",
-            "app_secret_key"  : NotificationsServiceRemote.WordPressComApiPushAppId,
+            "app_secret_key"  : WPPushNotificationAppId,
             "device_name"     : device.name,
             "device_model"    : UIDeviceHardware.platform(),
             "os_version"      : device.systemVersion,

--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -27,6 +27,7 @@ extern NSString *const WPGravatarBaseURL;
 /// Notifications Constants
 ///
 extern NSString *const WPNotificationsBucketName;
+extern NSString *const WPPushNotificationAppId;
 
 /// Keychain + User Defaults Constants
 ///

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -27,7 +27,15 @@ NSString *const WPGravatarBaseURL                                   = @"http://g
 /// Notifications Constants
 ///
 NSString *const WPNotificationsBucketName                           = @"note20";
-
+#ifdef DEBUG
+NSString *const  WPPushNotificationAppId = @"org.wordpress.appstore.dev";
+#else
+#ifdef INTERNAL_BUILD
+NSString *const   WPPushNotificationAppId = @"org.wordpress.internal";
+#else
+NSString *const WPPushNotificationAppId = @"org.wordpress.appstore";
+#endif
+#endif
 /// Keychain Constants
 ///
 #ifdef INTERNAL_BUILD

--- a/WordPress/WordPressApi/WordPressComApi.h
+++ b/WordPress/WordPressApi/WordPressComApi.h
@@ -18,7 +18,6 @@ typedef NS_ENUM(NSUInteger, WordPressComApiError) {
 extern NSString *const WordPressComApiErrorDomain;
 extern NSString *const WordPressComApiErrorCodeKey;
 extern NSString *const WordPressComApiErrorMessageKey;
-extern NSString *const WordPressComApiPushAppId;
 
 @interface WordPressComApi : AFHTTPRequestOperationManager
 @property (nonatomic, readonly, strong) NSString *username;

--- a/WordPress/WordPressApi/WordPressComApi.m
+++ b/WordPress/WordPressApi/WordPressComApi.m
@@ -11,16 +11,6 @@ static NSString *const WordPressComApiOauthBaseUrl = @"https://public-api.wordpr
 NSString *const WordPressComApiNotificationFields = @"id,type,unread,body,subject,timestamp,meta";
 static NSString *const WordPressComApiLoginUrl = @"https://wordpress.com/wp-login.php";
 
-#ifdef DEBUG
-NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore.dev";
-#else
-#ifdef INTERNAL_BUILD
-NSString *const WordPressComApiPushAppId = @"org.wordpress.internal";
-#else
-NSString *const WordPressComApiPushAppId = @"org.wordpress.appstore";
-#endif
-#endif
-
 #define UnfollowedBlogEvent @"UnfollowedBlogEvent"
 
 // AFJSONRequestOperation requires that a URI end with .json in order to match


### PR DESCRIPTION
Refs #5245 

To test:
 - Check if push notifications are getting to the app when events happen in the backend: new comment, new post, etc...

Needs review: @jleandroperez 

