### PR TITLE
Fix travis cache on 6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ xcode_scheme: WordPress
 xcode_sdk: iphonesimulator
 cache:
 - cocoapods: true
+- bundler: false
 - directories:
   - vendor
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
 - bundler: false
 - directories:
   - vendor
+  - .bundle
 notifications:
   email: true
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ xcode_workspace: WordPress.xcworkspace
 xcode_scheme: WordPress
 xcode_sdk: iphonesimulator
 cache:
-- bundler
 - cocoapods
+- directories:
+  - vendor
 notifications:
   email: true
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ xcode_workspace: WordPress.xcworkspace
 xcode_scheme: WordPress
 xcode_sdk: iphonesimulator
 cache:
-- cocoapods
+- cocoapods: true
 - directories:
   - vendor
 notifications:

--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,7 @@ namespace :dependencies do
       unless check_manifest(lockfile, manifest)
         Rake::Task["dependencies:bundle:install"].invoke
       else
+        sh "bundle env"
         puts "lockfile: #{lockfile}"
         sh "cat #{lockfile}"
         puts "manifest: #{manifest}"

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,13 @@ namespace :dependencies do
     task :check do
       unless check_manifest(lockfile, manifest)
         Rake::Task["dependencies:bundle:install"].invoke
+      else
+        puts "lockfile: #{lockfile}"
+        sh "cat #{lockfile}"
+        puts "manifest: #{manifest}"
+        sh "cat #{manifest}"
+        puts "Cache contents"
+        sh "find vendor"
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -24,8 +24,10 @@ namespace :dependencies do
     end
 
     task :install do
-      sh "bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}"
-      FileUtils.cp(lockfile, manifest)
+      fold("install.bundler") do
+        sh "bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}"
+        FileUtils.cp(lockfile, manifest)
+      end
     end
     CLOBBER << "vendor/bundle"
     CLOBBER << ".bundle"

--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,7 @@ namespace :dependencies do
         sh "cat #{manifest}"
         puts "Cache contents"
         sh "find vendor"
+        sh "bundle exec xcpretty --version"
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -20,15 +20,6 @@ namespace :dependencies do
     task :check do
       unless check_manifest(lockfile, manifest) and File.exist?('.bundle/config')
         Rake::Task["dependencies:bundle:install"].invoke
-      else
-        sh "bundle env"
-        puts "lockfile: #{lockfile}"
-        sh "cat #{lockfile}"
-        puts "manifest: #{manifest}"
-        sh "cat #{manifest}"
-        puts "Cache contents"
-        sh "find vendor"
-        sh "bundle exec xcpretty --version"
       end
     end
 

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ namespace :dependencies do
     manifest = 'vendor/bundle/Manifest.lock'
 
     task :check do
-      unless check_manifest(lockfile, manifest)
+      unless check_manifest(lockfile, manifest) and File.exist?('.bundle/config')
         Rake::Task["dependencies:bundle:install"].invoke
       else
         sh "bundle env"


### PR DESCRIPTION
This should fix the issues with Travis caches and the new build system. From what I found, we're installing gems to a custom path (`vendor/bundle`). We provide this path on `bundle install`, but not on every other `bundle exec` call. This is usually fine as the config is cached in `.bundle/config`, but that's not added to git and wasn't included in the cache.

This PR adds that config file to the cache, and will run `bundle install` again if it's missing.

Needs review: @SergioEstevao 
