### PR TITLE
Issue/5421 Login errors now announce their titles when VoiceOver is active

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
@@ -104,7 +104,11 @@ class SigninErrorViewController : UIViewController
     func presentFromController(controller: UIViewController) {
         controller.providesPresentationContextTransitionStyle = true
         controller.definesPresentationContext = true
-        controller.presentViewController(self, animated: false, completion: nil)
+        controller.presentViewController(self, animated: false, completion: {
+            if (UIAccessibilityIsVoiceOverRunning()) {
+                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, self.titleLabel)
+            }
+        })
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/WPWalkthroughOverlayView.m
+++ b/WordPress/Classes/ViewRelated/NUX/WPWalkthroughOverlayView.m
@@ -34,6 +34,9 @@ CGFloat const WPWalkthroughGrayOverlayMaxLabelWidth = 289.0;
     self = [super initWithFrame:frame];
     if (self) {
         _overlayMode = WPWalkthroughGrayOverlayViewOverlayModePrimaryButton;
+
+        self.accessibilityViewIsModal = YES;
+
         [self configureBackgroundColor];
         [self addViewElements];
         [self addGestureRecognizer];
@@ -172,6 +175,15 @@ CGFloat const WPWalkthroughGrayOverlayMaxLabelWidth = 289.0;
     CGFloat heightFromBottomLabel = _viewHeight - CGRectGetMinY(_bottomLabel.frame) - CGRectGetHeight(_bottomLabel.frame);
     NSArray *viewsToCenter = @[_logo, _title, _description];
     [WPNUXUtility centerViews:viewsToCenter withStartingView:_logo andEndingView:_description forHeight:(_viewHeight-heightFromBottomLabel)];
+}
+
+- (void)didMoveToSuperview
+{
+    [super didMoveToSuperview];
+
+    if (UIAccessibilityIsVoiceOverRunning()) {
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, _title);
+    }
 }
 
 - (void)dismiss


### PR DESCRIPTION
Fixes #5421

I've updated both the old and new login flow errors so that they'll announce their titles (and that a layout change has taken place) if Voiceover is active. So, if you enter incorrect login details, the error overlay should appear and Voiceover should read and focus the "Sorry, we can't log you in" label. 

Additionally, I've told UIAccessibility to treat `WPWalkthroughOverlayView` as a modal view, so that you're no longer to tap through to elements underneath it.

To test:

Please see original issue for testing steps. Make sure you test each of the following scenarios for displaying the error:

* New and old login flows
* With the keyboard visible, select the Done button
* With the keyboard visible, select the Sign In button
* With the keyboard hidden, select the Sign In button

Needs review: @aerych