### PR TITLE
Fix media upload progress reporting.

### DIFF
--- a/WordPress/Classes/Networking/MediaServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteREST.m
@@ -128,7 +128,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     }
     NSURL *url = [[NSURL alloc] initFileURLWithPath:path];
     FilePart *filePart = [[FilePart alloc] initWithParameterName:@"media[]" url:url filename:filename mimeType:type];
-    NSProgress *localProgress = [self.wordPressComRestApi multipartPOST:requestUrl
+    __block NSProgress *localProgress = [self.wordPressComRestApi multipartPOST:requestUrl
                                                     parameters:parameters
                                                      fileParts:@[filePart]
                                                        success:^(id  _Nonnull responseObject, NSHTTPURLResponse * _Nullable httpResponse) {
@@ -153,6 +153,8 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
         }
         
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+        localProgress.totalUnitCount = 0;
+        localProgress.completedUnitCount = 0;
         DDLogDebug(@"Error uploading file: %@", [error localizedDescription]);
         if (failure) {
             failure(error);

--- a/WordPress/WordPressApi/WordPressComRestApi.swift
+++ b/WordPress/WordPressApi/WordPressComRestApi.swift
@@ -206,7 +206,10 @@ public class WordPressComRestApi: NSObject
         progress?.cancellationHandler = {
             task.cancel()
         }
-
+        if let sizeString = request.allHTTPHeaderFields?["Content-Length"],
+           let size = Int64(sizeString) {
+            progress?.totalUnitCount = size
+        }
         return progress
     }
 


### PR DESCRIPTION
Refs #5245 

Because of the REST Api updates media progress reporting and media error reporting where not working correctly. When a media upload failed the editor still thought the media upload was still in progress and needed to be canceled explicitly.
This PR needs to be **tested on a device,** because the simulator has a bug that doesn't report progress correctly on streamed file uploads.

To test:
 - Login with WP.com account
 - Create a new Post on the editor
 - Add a image or video
 - Check if progress is being reported correctly.
 - Add another media
 - In the middle of the upload cut the network connection
 - Check if failure report is done correctly and the top progress bar is updated correctly.

Needs review: @jleandroperez 