### PR TITLE
Prevents settings multi shrink

### DIFF
--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -3,7 +3,8 @@
 #import "WPTableViewCell.h"
 #import "WPTableViewSectionHeaderFooterView.h"
 
-static CGFloat const HorizontalMargin = 10.0f;
+static CGVector const SettingsTextPadding = {11.0f, 3.0f};
+static CGFloat const SettingsMinHeight = 41.0f;
 
 @interface SettingsMultiTextViewController() <UITextViewDelegate>
 
@@ -66,7 +67,7 @@ static CGFloat const HorizontalMargin = 10.0f;
     }
     _textViewCell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
     _textViewCell.selectionStyle = UITableViewCellSelectionStyleNone;
-    self.textView = [[UITextView alloc] initWithFrame:CGRectInset(self.textViewCell.bounds, HorizontalMargin, 0)];
+    self.textView = [[UITextView alloc] initWithFrame:CGRectInset(self.textViewCell.bounds, SettingsTextPadding.dx, SettingsTextPadding.dy)];
     self.textView.text = self.text;
     self.textView.returnKeyType = UIReturnKeyDefault;
     self.textView.keyboardType = UIKeyboardTypeDefault;
@@ -130,13 +131,15 @@ static CGFloat const HorizontalMargin = 10.0f;
 
 - (void)adjustCellSize
 {
-    CGFloat widthAvailable = self.textViewCell.contentView.bounds.size.width - ( 2 * HorizontalMargin);
+    CGFloat widthAvailable = CGRectGetWidth(self.textViewCell.contentView.bounds) - (2 * SettingsTextPadding.dx);
     CGSize size = [self.textView sizeThatFits:CGSizeMake(widthAvailable, CGFLOAT_MAX)];
-    if (fabs(self.tableView.rowHeight - size.height) > (self.textView.font.lineHeight/2))
+    CGFloat height = size.height;
+
+    if (fabs(self.tableView.rowHeight - height) > (self.textView.font.lineHeight * 0.5f))
     {
         [self.tableView beginUpdates];
-        self.textView.frame = CGRectMake(HorizontalMargin, 0, widthAvailable, size.height);
-        self.tableView.rowHeight = size.height;
+        self.textView.frame = CGRectMake(SettingsTextPadding.dx, SettingsTextPadding.dy, widthAvailable, height);
+        self.tableView.rowHeight = MAX(height, SettingsMinHeight) + SettingsTextPadding.dy;
         [self.tableView endUpdates];
     }
 }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -92,12 +92,12 @@ static CGFloat const SettingsMinHeight = 41.0f;
     return _hintView;
 }
 
-- (void)viewDidDisappear:(BOOL)animated
+- (void)viewWillDisappear:(BOOL)animated
 {
     if (self.onValueChanged) {
         self.onValueChanged(self.textView.text);
     }
-    [super viewDidDisappear:animated];
+    [super viewWillDisappear:animated];
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView


### PR DESCRIPTION
### Scenario:
1. Launch WPiOS and log into a dotcom account
2. Open `Me` > `My Profile`
3. Tap over `About Me`

Note that the TextView shouldn't shrink anymore, as soon as the view appears (which is the behavior we have in `develop`

Plus: To prevent UI weirdness in the caller, the callback block will now be executed on `viewWillDisappear`.

Needs review: @SergioEstevao 
Thanks in advance!
