### PR TITLE
Fix layout of date picker for the iPad.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -823,8 +823,8 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         frame.size.width = WPTableViewFixedWidth;
     } else {
         frame.size.width = CGRectGetWidth(self.tableView.bounds);
-        self.datePicker.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     }
+    self.datePicker.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     self.datePicker.frame = frame;
 
     NSUInteger sec = [self.sections indexOfObject:[NSNumber numberWithInteger:PostSettingsSectionMeta]];

--- a/WordPress/Classes/ViewRelated/Post/WPPickerView.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPickerView.m
@@ -1,7 +1,6 @@
 #import "WPPickerView.h"
 
 static NSInteger WPPickerToolBarHeight = 44.0f;
-static NSInteger WPPickerStartingWidth = 320.0f;
 
 @interface WPPickerView ()<UIPickerViewDataSource, UIPickerViewDelegate>
 
@@ -51,9 +50,9 @@ static NSInteger WPPickerStartingWidth = 320.0f;
     [self configureToolbar];
 
     UIView *picker = [self viewForPicker];
-    picker.frame = CGRectMake(0.0f, CGRectGetMaxY(self.toolbar.frame), WPPickerStartingWidth, CGRectGetHeight(picker.frame));
+    picker.frame = CGRectMake(0.0f, CGRectGetMaxY(self.toolbar.frame), CGRectGetWidth(picker.frame), CGRectGetHeight(picker.frame));
 
-    self.frame = CGRectMake(0.0f, 0.0f, WPPickerStartingWidth, CGRectGetMaxY(picker.frame));
+    self.frame = CGRectMake(0.0f, 0.0f, CGRectGetWidth(picker.frame), CGRectGetMaxY(picker.frame));
 
     [self addSubview:picker];
     [self addSubview:self.toolbar];
@@ -61,8 +60,8 @@ static NSInteger WPPickerStartingWidth = 320.0f;
 
 - (void)configureToolbar
 {
-    self.toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0.0f, 0.0f, WPPickerStartingWidth, WPPickerToolBarHeight)];
-    self.toolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    self.toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0.0f, 0.0f, CGRectGetWidth(self.frame), WPPickerToolBarHeight)];
+    self.toolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin;
 
     UIBarButtonItem *spacer = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
     UIBarButtonItem *leftSpacer = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
@@ -160,7 +159,7 @@ static NSInteger WPPickerStartingWidth = 320.0f;
 - (UIDatePicker *)datePickerView
 {
     if (!_datePickerView) {
-        UIDatePicker *picker = [[UIDatePicker alloc] init];
+        UIDatePicker *picker = [[UIDatePicker alloc] init];        
         picker.autoresizingMask = UIViewAutoresizingFlexibleWidth;
         picker.datePickerMode = UIDatePickerModeDateAndTime;
         picker.date = self.startingDate;


### PR DESCRIPTION
Fixes #5473 

To test:
 - Open the app on a iPad
 - Create or edit a post
 - Go to Post Settings
 - Edit the publish date of the post
 - Check if the layout of the picker and toolbar are done correctly on multiple orientations and multitasking modes.



Needs review: @diegoreymendez 

