### PR TITLE
Don't show notification pop up immediately after first open

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -382,10 +382,6 @@ int ddLogLevel = DDLogLevelInfo;
     [WPFontManager merriweatherRegularFontOfSize:16.0];
 
     [self customizeAppearance];
-
-    // Notifications
-    [[PushNotificationsManager sharedInstance] registerForRemoteNotifications];
-    [[InteractiveNotificationsHandler sharedInstance] registerForUserNotifications];
     
     // Deferred tasks to speed up app launch
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -202,6 +202,10 @@ typedef NS_ENUM(NSInteger, SettingsSectionFeedbackRows)
 {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults setBool:YES forKey:UserDefaultsHelpshiftWasUsed];
+    
+    // Notifications
+    [[PushNotificationsManager sharedInstance] registerForRemoteNotifications];
+    [[InteractiveNotificationsHandler sharedInstance] registerForUserNotifications];
 
     NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
     AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];


### PR DESCRIPTION
Fixes #1802

To test:

Testing on the simulator is the easiest. To enable notifications in the simulator, you'll have to apply this patch: https://cloudup.com/c7zsRYsoQ88

(Restart simulator contents and settings every time before each step)

1. Open app and notice there is no notification pop up
2. Open app, click info button on the top right, and select "Contact Us". A Notification pop up should appear.
3. Open app, log in to a WordPress.com site and after successful log in, the notification pop up will show.
4. Open app, log in to a self-hosted site. Connect Jetpack and the notification pop up will show.

Needs review: @frosty 