### PR TITLE
Fix search controller layout on ipad compact mode

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Search/WPSearchControllerConfigurator.h
+++ b/WordPress/Classes/ViewRelated/System/Search/WPSearchControllerConfigurator.h
@@ -1,7 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "WPSearchController.h"
 
-extern const CGFloat SearchBarWidth;
 extern const CGFloat SearchBariPadWidth;
 extern const CGFloat SearchWrapperViewMinHeight;
 extern const NSTimeInterval SearchBarAnimationDuration;

--- a/WordPress/Classes/ViewRelated/System/Search/WPSearchControllerConfigurator.m
+++ b/WordPress/Classes/ViewRelated/System/Search/WPSearchControllerConfigurator.m
@@ -79,30 +79,16 @@ const NSTimeInterval SearchBarAnimationDuration = 0.2; // seconds
     UISearchBar *searchBar = self.searchController.searchBar;
     [self.searchWrapperView addSubview:searchBar];
     
-    NSDictionary *views = NSDictionaryOfVariableBindings(searchBar);
-    NSDictionary *metrics = @{@"searchbarWidth":@(SearchBariPadWidth)};
     if ([UIDevice isPad]) {
-        [self.searchWrapperView addConstraint:[NSLayoutConstraint constraintWithItem:searchBar
-                                                                           attribute:NSLayoutAttributeCenterX
-                                                                           relatedBy:NSLayoutRelationEqual
-                                                                              toItem:self.searchWrapperView
-                                                                           attribute:NSLayoutAttributeCenterX
-                                                                          multiplier:1.0
-                                                                            constant:0.0]];
-        [self.searchWrapperView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"[searchBar(searchbarWidth)]"
-                                                                                       options:0
-                                                                                       metrics:metrics
-                                                                                         views:views]];
+        [searchBar.centerXAnchor constraintEqualToAnchor:self.searchWrapperView.centerXAnchor].active = YES;
+        NSLayoutConstraint *sizeConstraint = [searchBar.widthAnchor constraintEqualToConstant:SearchBariPadWidth];
+        sizeConstraint.priority = UILayoutPriorityDefaultLow;
+        sizeConstraint.active = YES;
+        [searchBar.widthAnchor constraintLessThanOrEqualToAnchor:self.searchWrapperView.widthAnchor multiplier:1].active = YES;
     } else {
-        [self.searchWrapperView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|[searchBar]|"
-                                                                                       options:0
-                                                                                       metrics:metrics
-                                                                                         views:views]];
+        [searchBar.widthAnchor constraintEqualToAnchor:self.searchWrapperView.widthAnchor multiplier:1].active = YES;
     }
-    [self.searchWrapperView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[searchBar]|"
-                                                                                   options:0
-                                                                                   metrics:metrics
-                                                                                     views:views]];
+    [searchBar.bottomAnchor constraintEqualToAnchor:self.searchWrapperView.bottomAnchor].active = YES;
 }
 
 - (void)configureSearchWrapper

--- a/WordPress/Classes/ViewRelated/System/Search/WPSearchControllerConfigurator.m
+++ b/WordPress/Classes/ViewRelated/System/Search/WPSearchControllerConfigurator.m
@@ -52,20 +52,7 @@ const NSTimeInterval SearchBarAnimationDuration = 0.2; // seconds
     self.searchBar.barStyle = UIBarStyleBlack;
     self.searchBar.barTintColor = [WPStyleGuide wordPressBlue];
     self.searchBar.showsCancelButton = YES;
-    
-    // IMPORTANT: Without this the app crashes for iOS < 7.1.  Not needed for iOS >= 7.1.
-    // This is not very well documented but basically UISearchBar didn't conform to protocol
-    // UITextInputTraits until 7.1, which is the reason why this is crashing.
-    //
-    // A hackish alternative is available for earlier versions of iOS although I don't think this
-    // is worth the effort as we'll be dropping support soon (plus hackish solutions are bad):
-    // http://stackoverflow.com/questions/20065487/uitextinputtraits-is-not-working-in-ios7
-    //
-    // This means the return button will read "Search" for iOS < 7.1 instead of "Done".  No biggie.
-    //
-    if ([self.searchBar respondsToSelector:@selector(setReturnKeyType:)]) {
-        self.searchBar.returnKeyType = UIReturnKeyDone;
-    }
+    self.searchBar.returnKeyType = UIReturnKeyDone;
     
     [self.searchBar setImage:[UIImage imageNamed:@"icon-clear-searchfield"] forSearchBarIcon:UISearchBarIconClear state:UIControlStateNormal];
     [self.searchBar setImage:[UIImage imageNamed:@"icon-post-list-search"] forSearchBarIcon:UISearchBarIconSearch state:UIControlStateNormal];

--- a/WordPress/Classes/ViewRelated/System/Search/WPSearchControllerConfigurator.m
+++ b/WordPress/Classes/ViewRelated/System/Search/WPSearchControllerConfigurator.m
@@ -1,7 +1,6 @@
 #import "WPSearchControllerConfigurator.h"
 #import "WordPress-Swift.h"
 
-const CGFloat SearchBarWidth = 280.0;
 const CGFloat SearchBariPadWidth = 600.0;
 const CGFloat SearchWrapperViewMinHeight = 44.0;
 const NSTimeInterval SearchBarAnimationDuration = 0.2; // seconds


### PR DESCRIPTION
Fixes #5481 

To test:
 - Start the app on an iPad device or simulator
 - Go to Blog List and/or Post List
 - Tap on the Search icon
 - Activate the multi-task mode on the iPad
 - Test on all multitask mode and  rotations to see if the search bar is kept inside the screen.
 - Run the same tests on a iPhone simulator or device

Needs review: @aerych 