### PR TITLE
Login: Removing duplicate WPAnalyticsStatLoginFailed stat

### DIFF
--- a/WordPress/Classes/Services/LoginFacade.m
+++ b/WordPress/Classes/Services/LoginFacade.m
@@ -64,8 +64,6 @@
             [self.delegate needsMultifactorCode];
         }
     } failure:^(NSError *error) {
-        NSDictionary *properties = @{ @"multifactor" : @(loginFields.shouldDisplayMultifactor) };
-        [WPAnalytics track:WPAnalyticsStatLoginFailed withProperties:properties];
         [WPAppAnalytics track:WPAnalyticsStatLoginFailed error:error];
         if ([self.delegate respondsToSelector:@selector(displayRemoteError:)]) {
             [self.delegate displayRemoteError:error];


### PR DESCRIPTION
Based on an increase in stats seen for the `WPAnalyticsStatLoginFailed` "**Failed Login**" stat, it appears there was a duplicate call leftover from a recent refactor in https://github.com/wordpress-mobile/WordPress-iOS/commit/5cf56bba58ab

Needs review: @SergioEstevao, can you take a quick peak? It looks like your changes in https://github.com/wordpress-mobile/WordPress-iOS/commit/5cf56bba58ab missed a deletion.

Thanks for spotting @maxme  🕵