### PR TITLE
Sharing: Fixes cell margins in sharing button mgt vc.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -89,6 +89,7 @@ import WordPressShared
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
         tableView.setEditing(true, animated: false)
         tableView.allowsSelectionDuringEditing = true
+        tableView.cellLayoutMarginsFollowReadableWidth = false
     }
 
 


### PR DESCRIPTION
Fixes #5487

To test:
View the sharing button management view controller on an iPad Pro and confirm that the rows are correctly laid out. 

Needs review: @SergioEstevao 

