### PR TITLE
NoticeAnimator: Preserving OriginY on Layout

### DIFF
--- a/WordPress/Classes/Utility/NoticeAnimator.swift
+++ b/WordPress/Classes/Utility/NoticeAnimator.swift
@@ -73,7 +73,8 @@ class NoticeAnimator: Animator {
 
     // MARK: - Public Methods
     func layout() {
-        var targetFrame = targetView.bounds
+        var targetFrame = noticeLabel.frame
+        targetFrame.size.width = targetView.bounds.width
         targetFrame.size.height = heightForMessage(message)
         noticeLabel.frame = targetFrame
     }


### PR DESCRIPTION
#### Details:
NoticeView's *Y Position* was being reset each time the view was laid out. In a specific scenario, this was causing a weird UI glitch (Detailed below).

#### To test:
1. Log into a dotcom account using **Device A**
2. Open **Me** > **Account Settings** > **Email**
3. Change your Email address
4.The Notice should show up on top
5 Hit back. You should see the **Me** screen
6. Using **Device B** (or just a web browser!) revert the email change
7. On **Device A** open again the **Account Settings** screen

As a result, the Notice should animate in / out, without any weird side effect.


Needs review: @koke 
Thanks in advance!

