### PR TITLE
Issue/4683 Site Settings tagline is now a single line field

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -700,10 +700,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         return;
     }
 
-    SettingsMultiTextViewController *siteTaglineViewController = [[SettingsMultiTextViewController alloc] initWithText:self.blog.settings.tagline
+    SettingsTextViewController *siteTaglineViewController = [[SettingsTextViewController alloc] initWithText:self.blog.settings.tagline
                                                                                                            placeholder:NSLocalizedString(@"Explain what this site is about.", @"Placeholder text for the tagline of a site")
-                                                                                                                  hint:NSLocalizedString(@"In a few words, explain what this site is about.",@"Explain what is the purpose of the tagline")
-                                                                                                            isPassword:NO];
+                                                                                                        hint:NSLocalizedString(@"In a few words, explain what this site is about.",@"Explain what is the purpose of the tagline")];
     siteTaglineViewController.title = NSLocalizedString(@"Tagline", @"Title for screen that show tagline editor");
     siteTaglineViewController.onValueChanged = ^(NSString *value) {
         NSString *normalizedTagline = [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];


### PR DESCRIPTION
Fixes #4683. I've changed tagline from using a `SettingsMultiTextViewController` to using a `SettingsTextViewController`.

To test: As per the original issue, edit a site's tagline and ensure that you can't press return to enter newlines.

Needs review: @jleandroperez 
