### PR TITLE
Issue/5223: Fixes issue with ellipsis in title of tag previews in Reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -72,6 +72,9 @@ import WordPressComAnalytics
     private var tagSlug:String? {
         didSet {
             if tagSlug != nil {
+                // Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/5223
+                title = tagSlug
+
                 fetchTagTopic()
             }
         }


### PR DESCRIPTION
Fixes #5223. 

To test:

* Tap a tag in the Reader to preview it. As the view controller is pushed on, you shouldn't see the title being truncated.

Before:

![ellipsis](https://cloud.githubusercontent.com/assets/4780/15750319/44b83018-28e6-11e6-8777-ce74c7ec10bf.gif)

After:

![ellipsis2](https://cloud.githubusercontent.com/assets/4780/15750359/78df9188-28e6-11e6-83e0-540490e9159e.gif)

Needs review: @aerych 