### PR TITLE
Issue/5015: Replaces all instances of 'disapprove' with 'unapprove'.

### DIFF
--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -10,7 +10,7 @@ extern NSString * const CommentUploadFailedNotification;
 
 extern NSString * const CommentStatusPending;
 extern NSString * const CommentStatusApproved;
-extern NSString * const CommentStatusDisapproved;
+extern NSString * const CommentStatusUnapproved;
 extern NSString * const CommentStatusSpam;
 // Draft status is for comments that have not yet been successfully published
 // we can use this status to restore comment replies that the user has written

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -11,7 +11,7 @@ NSString * const CommentUploadFailedNotification = @"CommentUploadFailed";
 
 NSString * const CommentStatusPending = @"hold";
 NSString * const CommentStatusApproved = @"approve";
-NSString * const CommentStatusDisapproved = @"trash";
+NSString * const CommentStatusUnapproved = @"trash";
 NSString * const CommentStatusSpam = @"spam";
 
 // draft is used for comments that have been composed but not succesfully uploaded yet

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -696,7 +696,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 /**
     Note:
     The main reason why it's a very good idea *not* to reuse NoteBlockHeaderTableViewCell, just to display the
-    gravatar, is because we're implementing a custom behavior whenever the user approves/ disapproves the comment.
+    gravatar, is because we're implementing a custom behavior whenever the user approves/ unapproves the comment.
     
     -   Font colors are updated.
     -   A left separator is displayed.

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -176,7 +176,7 @@ import WordPressShared.WPStyleGuide
     private let approveNormalTitle      = NSLocalizedString("Approve",  comment: "Approve a comment")
     private let approveSelectedTitle    = NSLocalizedString("Approved", comment: "Unapprove a comment")
     private let approveNormalHint       = NSLocalizedString("Approves the comment",  comment: "Approves a comment. Spoken Hint.")
-    private let approveSelectedHint     = NSLocalizedString("Disapproves the comment", comment: "Unapproves a comment. Spoken Hint.")
+    private let approveSelectedHint     = NSLocalizedString("Unapproves the comment", comment: "Unapproves a comment. Spoken Hint.")
 
     // MARK: - IBOutlets
     @IBOutlet private var actionsView   : UIStackView!


### PR DESCRIPTION
Fixes #5015. I've replaced all instances of 'disapprove' with 'unapprove'.

Needs review: @jleandroperez 
Tagging you because it affects notifications :) Thanks!