### PR TITLE
Menus: Cleanup removed menus stat

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '~> 0.9.2'
     pod 'WordPress-iOS-Editor', '1.6.1'
     pod 'WordPressApi', '0.4.0'
-    pod 'WordPressCom-Analytics-iOS', '0.1.13'
+    pod 'WordPressCom-Analytics-iOS', '0.1.14'
     pod 'WordPressCom-Stats-iOS', '0.7.0'
     pod 'wpxmlrpc', '~> 0.8'
     

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -171,7 +171,7 @@ PODS:
   - WordPressApi (0.4.0):
     - AFNetworking (~> 2.6.0)
     - wpxmlrpc (~> 0.8)
-  - WordPressCom-Analytics-iOS (0.1.13)
+  - WordPressCom-Analytics-iOS (0.1.14)
   - WordPressCom-Stats-iOS (0.7.0):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (~> 2.2.0)
@@ -231,7 +231,7 @@ DEPENDENCIES:
   - WordPress-iOS-Editor (= 1.6.1)
   - WordPress-iOS-Shared (= 0.5.9)
   - WordPressApi (= 0.4.0)
-  - WordPressCom-Analytics-iOS (= 0.1.13)
+  - WordPressCom-Analytics-iOS (= 0.1.14)
   - WordPressCom-Stats-iOS (= 0.7.0)
   - WordPressCom-Stats-iOS/Services (= 0.7.0)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.1`)
@@ -296,12 +296,12 @@ SPEC CHECKSUMS:
   WordPress-iOS-Editor: 9daa51cb32ee0c2821045c1035e925eb3c6633ed
   WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
   WordPressApi: 483767025bcdab26429b51bfe5171f17d3d30466
-  WordPressCom-Analytics-iOS: 5daf418f358bf6ae72f14824e7e90c74d95631a6
+  WordPressCom-Analytics-iOS: add1bee7ca8411d666a6d8b8340efde80a3adab8
   WordPressCom-Stats-iOS: d1996675fadd5a2c8548344a40663834898114f3
   WordPressComKit: 6f0c39c3e0af3599cd5244e4ec05192f5e4a7882
   WPMediaPicker: 98356dbf35bfaba0f51aff16d88563babadf24c7
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 114a95bb9b033ca7eb8bdfacff6bf16f9ef7d2e8
+PODFILE CHECKSUM: 642a064ca9c1c758cd3dbff81d26c074775bed86
 
 COCOAPODS: 1.0.0

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -366,9 +366,6 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         case WPAnalyticsStatMenusSavedMenu:
             eventName = @"menus_saved_menu";
             break;
-        case WPAnalyticsStatMenusUpdatedMenuName:
-            eventName = @"menus_updated_menu_name";
-            break;
         case WPAnalyticsStatNotificationsCommentApproved:
             eventName = @"notifications_approved";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -1000,9 +1000,6 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatMenusSavedMenu:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Menus - Menu Saved"];
             break;
-        case WPAnalyticsStatMenusUpdatedMenuName:
-            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Menus - Menu Name Updated"];
-            break;
             
             // to be implemented with the sign in refactor
         case WPAnalyticsStatLoginMagicLinkExited:


### PR DESCRIPTION
Fixes #5434 

Removing the stat `WPAnalyticsStatMenusUpdatedMenuName` altogether as it can't be easily tracked accurately. Will reimplement if a desire to track this change emerges or Menus implementation changes to support it.

Test:
- Build the branch after a pod update, without errors.

Needs review: @jleandroperez can you take a quick peak?
