### PR TITLE
Lookback: Update 6.3 Podfile to Lookback 1.3.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -26,7 +26,7 @@ abstract_target 'WordPress_Base' do
     pod 'FormatterKit', '~> 1.8.1'
     pod 'Helpshift', '~> 5.5.1'
     pod 'HockeySDK', '~> 3.8.0', :configurations => ['Release-Internal', 'Release-Alpha']
-    pod 'Lookback', '1.1.4', :configurations => ['Release-Internal', 'Release-Alpha']
+    pod 'Lookback', '1.3.0', :configurations => ['Release-Internal', 'Release-Alpha']
     pod 'MRProgress', '~>0.7.0'
     pod 'Mixpanel', '2.9.4'
     pod 'Optimizely-iOS-SDK', '~> 1.4.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -85,7 +85,7 @@ PODS:
   - HockeySDK (3.8.6):
     - HockeySDK/AllFeaturesLib (= 3.8.6)
   - HockeySDK/AllFeaturesLib (3.8.6)
-  - Lookback (1.1.4):
+  - Lookback (1.3.0):
     - PDKTZipArchive
   - Mixpanel (2.9.4):
     - Mixpanel/Mixpanel (= 2.9.4)
@@ -216,7 +216,7 @@ DEPENDENCIES:
   - Gridicons (= 0.2)
   - Helpshift (~> 5.5.1)
   - HockeySDK (~> 3.8.0)
-  - Lookback (= 1.1.4)
+  - Lookback (= 1.3.0)
   - Mixpanel (= 2.9.4)
   - MRProgress (~> 0.7.0)
   - Nimble (~> 4.0.0)
@@ -284,7 +284,7 @@ SPEC CHECKSUMS:
   Gridicons: 5c33065054b19e56a47d252b52e321746b97a414
   Helpshift: 1b89b3632bf46af10d2c9d9f448e64a0ccf667ec
   HockeySDK: ab68303eec6680f6b539de65d747742dd276e934
-  Lookback: 9ab9027ff246d2dc5ce34be483f70e4a6718280b
+  Lookback: e126cf9ea6e916cba0b9105eafea701741789e4c
   Mixpanel: 80d2ca9bb38ae91c1044d738e80fe448377ac89f
   MRProgress: 1cb0051b678be4a2ef4881414cd316768fc70028
   Nimble: 0f3c8b8b084cda391209c3c5efbb48bedeeb920a
@@ -313,6 +313,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 7dde7576a67a9a494733555a89c9ff8418f5eede
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 67953a044beb3d2e46a24c07d3ccce0eba775b60
+PODFILE CHECKSUM: ad10c58fd6488c2e0aa230159673ae170c199824
 
 COCOAPODS: 1.0.0


### PR DESCRIPTION
Fixes #5500 

Updating the Lookback pod to `1.3.0` to try and resolve launch crashes seen by @rachelmcr.

Merging this into the 6.3 branch so the upcoming internal builds include this update for testing.

To test:
- Checkout and update the pods for this branch.
- Test build the WordPress Internal target to your device.
- Ensure no build errors or warnings occur.
- Run the Lookback app on your Mac.
- Ensure Lookback runs as expected.

Needs review: @sendhil  