### PR TITLE
People Management: Infinite Scroll

### DIFF
--- a/WordPress/Classes/Networking/PeopleRemote.swift
+++ b/WordPress/Classes/Networking/PeopleRemote.swift
@@ -16,7 +16,7 @@ class PeopleRemote: ServiceRemoteWordPressComREST {
 
     /// Specifies the number of entities to be retrieved on each query.
     ///
-    private let pageSize = 50
+    private let pageSize = 20
 
 
     /// Retrieves the collection of users associated to a given Site.

--- a/WordPress/Classes/Networking/PeopleRemote.swift
+++ b/WordPress/Classes/Networking/PeopleRemote.swift
@@ -52,7 +52,7 @@ class PeopleRemote: ServiceRemoteWordPressComREST {
                 return
             }
 
-            let hasMore = self.peopleFoundFromResponse(response) > offset
+            let hasMore = self.peopleFoundFromResponse(response) > (offset + people.count)
             success(users: people, hasMore: hasMore)
 
         }, failure: { (error, httpResponse) in
@@ -92,7 +92,7 @@ class PeopleRemote: ServiceRemoteWordPressComREST {
                 return
             }
 
-            let hasMore = self.peopleFoundFromResponse(response) > pageNumber * self.pageSize
+            let hasMore = self.peopleFoundFromResponse(response) > (offset + people.count)
             success(followers: people, hasMore: hasMore)
 
         }, failure: { (error, httpResponse) in

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -31,9 +31,10 @@ struct PeopleService {
     ///
     /// - Parameter completion: Closure to be executed on completion.
     ///
-    func refreshUsers(completion: (Bool -> Void)) {
+    func refreshUsers(completion: ((shouldLoadMore: Bool) -> Void)) {
         remote.getUsers(siteID, success: { users, hasMore in
             self.mergeUsers(users)
+            completion(shouldLoadMore: hasMore)
 
         }, failure: { error in
             DDLogSwift.logError(String(error))
@@ -45,9 +46,10 @@ struct PeopleService {
     ///
     /// - Parameter completion: Closure to be executed on completion.
     ///
-    func refreshFollowers(completion: (Bool -> Void)) {
+    func refreshFollowers(completion: ((shouldLoadMore: Bool) -> Void)) {
         remote.getFollowers(siteID, success: { followers, hasMore in
             self.mergeFollowers(followers)
+            completion(shouldLoadMore: hasMore)
 
         }, failure: { error in
             DDLogSwift.logError(String(error))

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -27,43 +27,33 @@ struct PeopleService {
         siteID = dotComID
     }
 
-    /// Refreshes the Users + Followers associated to the current blog.
+    /// Refreshes the Users associated to the current blog.
     ///
     /// - Parameter completion: Closure to be executed on completion.
     ///
-    func refreshPeople(completion: (Bool -> Void)) {
-        let group = dispatch_group_create()
-        var success = true
-
-        // Load Users
-        dispatch_group_enter(group)
+    func refreshUsers(completion: (Bool -> Void)) {
         remote.getUsers(siteID, success: { users, hasMore in
             self.mergeUsers(users)
-            dispatch_group_leave(group)
 
         }, failure: { error in
             DDLogSwift.logError(String(error))
-            success = false
-            dispatch_group_leave(group)
         })
-
-        // Load Followers
-        dispatch_group_enter(group)
-        remote.getFollowers(siteID, success: { followers, hasMore in
-            self.mergeFollowers(followers)
-            dispatch_group_leave(group)
-
-        }, failure: { error in
-            DDLogSwift.logError(String(error))
-            success = false
-            dispatch_group_leave(group)
-        })
-
-        dispatch_group_notify(group, dispatch_get_main_queue()) {
-            completion(success)
-        }
     }
 
+
+    /// Refreshes the Followers associated to the current blog.
+    ///
+    /// - Parameter completion: Closure to be executed on completion.
+    ///
+    func refreshFollowers(completion: (Bool -> Void)) {
+        remote.getFollowers(siteID, success: { followers, hasMore in
+            self.mergeFollowers(followers)
+
+        }, failure: { error in
+            DDLogSwift.logError(String(error))
+        })
+
+    }
 
     /// Updates a given User with the specified role.
     ///

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -29,69 +29,81 @@ struct PeopleService {
 
     /// Refreshes the Users associated to the current blog.
     ///
-    /// - Parameter completion: Closure to be executed on completion.
+    /// - Parameters:
+    ///     - success: Closure to be executed on success.
+    ///     - failure: Closure to be executed on failure.
     ///
-    func refreshUsers(completion: ((shouldLoadMore: Bool) -> Void)) {
+    func refreshUsers(success: ((shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
         remote.getUsers(siteID, success: { users, hasMore in
             // Note:
             // Since we support Infinite Scrolling, on refresh, always purgue and just keep the top N results.
             //
             self.mergePeople(users)
             self.purgePeople(users)
-            completion(shouldLoadMore: hasMore)
+            success(shouldLoadMore: hasMore)
 
         }, failure: { error in
             DDLogSwift.logError(String(error))
+            failure?(error)
         })
     }
 
     /// Refreshes the Followers associated to the current blog.
     ///
-    /// - Parameter completion: Closure to be executed on completion.
+    /// - Parameters:
+    ///     - success: Closure to be executed on success.
+    ///     - failure: Closure to be executed on failure.
     ///
-    func refreshFollowers(completion: ((shouldLoadMore: Bool) -> Void)) {
+    func refreshFollowers(success: ((shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
         remote.getFollowers(siteID, success: { followers, hasMore in
             // Note:
             // Since we support Infinite Scrolling, on refresh, always purgue and just keep the top N results.
             //
             self.mergePeople(followers)
             self.purgePeople(followers)
-            completion(shouldLoadMore: hasMore)
+            success(shouldLoadMore: hasMore)
 
         }, failure: { error in
             DDLogSwift.logError(String(error))
+            failure?(error)
         })
     }
 
     /// Attempts to retrieve more users from the backend.
     ///
-    /// - Parameter completion: Closure to be executed on completion.
+    /// - Parameters:
+    ///     - success: Closure to be executed on success.
+    ///     - failure: Closure to be executed on failure.
     ///
-    func loadMoreUsers(completion: ((shouldLoadMore: Bool) -> Void)) {
+    func loadMoreUsers(success: ((shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
         let users = loadPeople(siteID, type: User.self)
 
         remote.getUsers(siteID, offset: users.count, success: { (users, hasMore) in
             self.mergePeople(users)
-            completion(shouldLoadMore: hasMore)
+            success(shouldLoadMore: hasMore)
 
         }, failure: { error in
             DDLogSwift.logError(String(error))
+            failure?(error)
         })
     }
 
     /// Attempts to retrieve more followers from the backend.
     ///
-    /// - Parameter completion: Closure to be executed on completion.
+    /// - Parameters:
+    ///     - success: Closure to be executed on success.
+    ///     - failure: Closure to be executed on failure.
     ///
-    func loadMoreFollowers(completion: ((shouldLoadMore: Bool) -> Void)) {
+    func loadMoreFollowers(success: ((shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
         let followers = loadPeople(siteID, type: Follower.self)
 
         remote.getFollowers(siteID, offset: followers.count, success: { (followers, hasMore) in
             self.mergePeople(followers)
-            completion(shouldLoadMore: hasMore)
+            success(shouldLoadMore: hasMore)
 
         }, failure: { error in
             DDLogSwift.logError(String(error))
+            failure?(error)
         })
     }
 

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -41,7 +41,6 @@ struct PeopleService {
         })
     }
 
-
     /// Refreshes the Followers associated to the current blog.
     ///
     /// - Parameter completion: Closure to be executed on completion.
@@ -54,8 +53,40 @@ struct PeopleService {
         }, failure: { error in
             DDLogSwift.logError(String(error))
         })
-
     }
+
+    /// Attempts to retrieve more users from the backend.
+    ///
+    /// - Parameter completion: Closure to be executed on completion.
+    ///
+    func loadMoreUsers(completion: ((shouldLoadMore: Bool) -> Void)) {
+        let users = loadPeople(siteID, type: User.self)
+
+        remote.getUsers(siteID, offset: users.count, success: { (users, hasMore) in
+            self.mergeUsers(users)
+            completion(shouldLoadMore: hasMore)
+
+        }, failure: { error in
+            DDLogSwift.logError(String(error))
+        })
+    }
+
+    /// Attempts to retrieve more followers from the backend.
+    ///
+    /// - Parameter completion: Closure to be executed on completion.
+    ///
+    func loadMoreFollowers(completion: ((shouldLoadMore: Bool) -> Void)) {
+        let followers = loadPeople(siteID, type: Follower.self)
+
+        remote.getFollowers(siteID, offset: followers.count, success: { (followers, hasMore) in
+            self.mergeFollowers(followers)
+            completion(shouldLoadMore: hasMore)
+
+        }, failure: { error in
+            DDLogSwift.logError(String(error))
+        })
+    }
+
 
     /// Updates a given User with the specified role.
     ///

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -37,7 +37,7 @@ struct PeopleService {
 
         // Load Users
         dispatch_group_enter(group)
-        remote.getUsers(siteID, success: { users in
+        remote.getUsers(siteID, success: { users, hasMore in
             self.mergeUsers(users)
             dispatch_group_leave(group)
 
@@ -49,7 +49,7 @@ struct PeopleService {
 
         // Load Followers
         dispatch_group_enter(group)
-        remote.getFollowers(siteID, success: { followers in
+        remote.getFollowers(siteID, success: { followers, hasMore in
             self.mergeFollowers(followers)
             dispatch_group_leave(group)
 

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -33,14 +33,14 @@ struct PeopleService {
     ///     - success: Closure to be executed on success.
     ///     - failure: Closure to be executed on failure.
     ///
-    func refreshUsers(success: ((shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
+    func refreshUsers(success: ((retrieved: Int, shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
         remote.getUsers(siteID, success: { users, hasMore in
             // Note:
             // Since we support Infinite Scrolling, on refresh, always purgue and just keep the top N results.
             //
             self.mergePeople(users)
             self.purgePeople(users)
-            success(shouldLoadMore: hasMore)
+            success(retrieved: users.count, shouldLoadMore: hasMore)
 
         }, failure: { error in
             DDLogSwift.logError(String(error))
@@ -54,14 +54,14 @@ struct PeopleService {
     ///     - success: Closure to be executed on success.
     ///     - failure: Closure to be executed on failure.
     ///
-    func refreshFollowers(success: ((shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
+    func refreshFollowers(success: ((retrieved: Int, shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
         remote.getFollowers(siteID, success: { followers, hasMore in
             // Note:
             // Since we support Infinite Scrolling, on refresh, always purgue and just keep the top N results.
             //
             self.mergePeople(followers)
             self.purgePeople(followers)
-            success(shouldLoadMore: hasMore)
+            success(retrieved: followers.count, shouldLoadMore: hasMore)
 
         }, failure: { error in
             DDLogSwift.logError(String(error))
@@ -72,15 +72,14 @@ struct PeopleService {
     /// Attempts to retrieve more users from the backend.
     ///
     /// - Parameters:
+    ///     - offset: Number of records to skip
     ///     - success: Closure to be executed on success.
     ///     - failure: Closure to be executed on failure.
     ///
-    func loadMoreUsers(success: ((shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
-        let users = loadPeople(siteID, type: User.self)
-
-        remote.getUsers(siteID, offset: users.count, success: { (users, hasMore) in
+    func loadMoreUsers(offset: Int, success: ((retrieved: Int, shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
+        remote.getUsers(siteID, offset: offset, success: { (users, hasMore) in
             self.mergePeople(users)
-            success(shouldLoadMore: hasMore)
+            success(retrieved: users.count, shouldLoadMore: hasMore)
 
         }, failure: { error in
             DDLogSwift.logError(String(error))
@@ -91,15 +90,14 @@ struct PeopleService {
     /// Attempts to retrieve more followers from the backend.
     ///
     /// - Parameters:
+    ///     - offset: Number of records to skip
     ///     - success: Closure to be executed on success.
     ///     - failure: Closure to be executed on failure.
     ///
-    func loadMoreFollowers(success: ((shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
-        let followers = loadPeople(siteID, type: Follower.self)
-
-        remote.getFollowers(siteID, offset: followers.count, success: { (followers, hasMore) in
+    func loadMoreFollowers(offset: Int, success: ((retrieved: Int, shouldLoadMore: Bool) -> Void), failure: (ErrorType -> Void)? = nil) {
+        remote.getFollowers(siteID, offset: offset, success: { (followers, hasMore) in
             self.mergePeople(followers)
-            success(shouldLoadMore: hasMore)
+            success(retrieved: followers.count, shouldLoadMore: hasMore)
 
         }, failure: { error in
             DDLogSwift.logError(String(error))

--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -14,14 +14,23 @@
         <scene sceneID="0Jd-lB-cu0">
             <objects>
                 <tableViewController storyboardIdentifier="PeopleViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="5ll-RY-leg" customClass="PeopleViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="86" sectionHeaderHeight="18" sectionFooterHeight="18" id="HU2-1s-xgj">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="86" sectionHeaderHeight="18" sectionFooterHeight="1" id="HU2-1s-xgj">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                        <view key="tableFooterView" contentMode="scaleToFill" id="GlF-16-ak3">
-                            <rect key="frame" x="0.0" y="173.5" width="600" height="0.0"/>
+                        <view key="tableFooterView" contentMode="scaleToFill" id="1wT-dA-R90" userLabel="FooterView">
+                            <rect key="frame" x="0.0" y="136.5" width="600" height="30"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <subviews>
+                                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="L1Z-xm-37g">
+                                    <rect key="frame" x="110" y="5" width="20" height="20"/>
+                                </activityIndicatorView>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstItem="L1Z-xm-37g" firstAttribute="centerY" secondItem="1wT-dA-R90" secondAttribute="centerY" id="FiN-Ec-31A"/>
+                                <constraint firstItem="L1Z-xm-37g" firstAttribute="centerX" secondItem="1wT-dA-R90" secondAttribute="centerX" id="Pjq-i7-5rC"/>
+                            </constraints>
                         </view>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="PeopleCell" rowHeight="86" id="kMD-3K-Yok" customClass="PeopleCell" customModule="WordPress" customModuleProvider="target">
@@ -138,6 +147,8 @@
                         </connections>
                     </refreshControl>
                     <connections>
+                        <outlet property="footerActivityIndicator" destination="L1Z-xm-37g" id="0Hk-Vq-YkI"/>
+                        <outlet property="footerView" destination="1wT-dA-R90" id="hb4-2d-bqw"/>
                         <outlet property="titleButton" destination="qYY-lN-fuq" id="Nre-fZ-kXG"/>
                         <segue destination="Hu7-FD-rJZ" kind="presentation" identifier="invite" modalPresentationStyle="formSheet" id="sCY-hm-WIa"/>
                     </connections>

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -15,7 +15,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
     private var filter = Filter.Users {
         didSet {
             refreshInterface()
-            refreshResults()
+            refreshResultsController()
             refreshPeople()
         }
     }
@@ -154,7 +154,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
         titleButton.setAttributedTitleForTitle(filter.title)
     }
 
-    private func refreshResults() {
+    private func refreshResultsController() {
         resultsController.fetchRequest.predicate = predicate
 
         do {
@@ -179,8 +179,15 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
             return
         }
 
-        service.refreshPeople { [weak self] _ in
+        let completion = { [weak self] (success: Bool) -> Void in
             self?.refreshControl?.endRefreshing()
+        }
+
+        switch filter {
+        case .Followers:
+            service.refreshFollowers(completion)
+        case .Users:
+            service.refreshUsers(completion)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -106,6 +106,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
     public override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         tableView.deselectSelectedRowWithAnimation(true)
+        refreshNoResultsView()
         WPAnalytics.track(.OpenedPeople)
     }
 
@@ -178,10 +179,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
             return
         }
 
-        refreshNoResultsView()
-
         service.refreshPeople { [weak self] _ in
-            self?.refreshNoResultsView()
             self?.refreshControl?.endRefreshing()
         }
     }

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -122,8 +122,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
             personViewController.person = personAtIndexPath(selectedIndexPath)
 
         } else if let navController = segue.destinationViewController as? UINavigationController,
-            let inviteViewController = navController.topViewController as? InvitePersonViewController,
-            let blog = blog
+            let inviteViewController = navController.topViewController as? InvitePersonViewController
         {
             inviteViewController.blog = blog
         }

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -48,9 +48,17 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
 
     /// Navigation Bar Custom Title
     ///
-    @IBOutlet private var titleButton : NavBarTitleDropdownButton!
+    @IBOutlet private var titleButton: NavBarTitleDropdownButton!
 
+    /// TableView Footer
+    ///
+    @IBOutlet private var footerView: UIView!
 
+    /// TableView Footer Activity Indicator
+    ///
+    @IBOutlet private var footerActivityIndicator: UIActivityIndicatorView!
+
+    
 
     // MARK: - UITableView Methods
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -24,6 +24,18 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
     ///
     private let noResultsView = WPNoResultsView()
 
+    /// Indicates whether there are more results that can be retrieved, or not.
+    ///
+    private var shouldLoadMore = false {
+        didSet {
+            if shouldLoadMore {
+                footerActivityIndicator.startAnimating()
+            } else {
+                footerActivityIndicator.stopAnimating()
+            }
+        }
+    }
+
     /// Filter Predicate
     ///
     private var predicate: NSPredicate {
@@ -58,7 +70,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
     ///
     @IBOutlet private var footerActivityIndicator: UIActivityIndicatorView!
 
-    
+
 
     // MARK: - UITableView Methods
 
@@ -187,7 +199,8 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
             return
         }
 
-        let completion = { [weak self] (success: Bool) -> Void in
+        let completion = { [weak self] (shouldLoadMore: Bool) -> Void in
+            self?.shouldLoadMore = shouldLoadMore
             self?.refreshControl?.endRefreshing()
         }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -36,6 +36,10 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
         }
     }
 
+    /// Number of pending-rows that trigger the LoadMore call
+    ///
+    private let refreshRowPadding = 4
+
     /// Filter Predicate
     ///
     private var predicate: NSPredicate {
@@ -97,6 +101,16 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
 
     public override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return hasHorizontallyCompactView() ? CGFloat.min : 0
+    }
+
+    public override func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
+        // Refresh only when we reach the last 3 rows in the last section!
+        let numberOfRowsInSection = self.tableView(tableView, numberOfRowsInSection: indexPath.section)
+        guard shouldLoadMore == true && (indexPath.row + refreshRowPadding) >= numberOfRowsInSection else {
+            return
+        }
+
+        loadMorePeople()
     }
 
 
@@ -209,6 +223,23 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
             service.refreshFollowers(completion)
         case .Users:
             service.refreshUsers(completion)
+        }
+    }
+
+    private func loadMorePeople() {
+        guard let blog = blog, service = PeopleService(blog: blog) else {
+            return
+        }
+
+        let completion = { [weak self] (shouldLoadMore: Bool) -> Void in
+            self?.shouldLoadMore = shouldLoadMore
+        }
+
+        switch filter {
+        case .Followers:
+            service.loadMoreFollowers(completion)
+        case .Users:
+            service.loadMoreUsers(completion)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -40,6 +40,10 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
     ///
     private var isLoadingMore = false
 
+    /// Number of records to skip in the next request
+    ///
+    private var nextRequestOffset = 0
+
     /// Number of pending-rows that trigger the LoadMore call
     ///
     private let refreshRowPadding = 4
@@ -190,6 +194,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
         //
         title = filter.title
         titleButton.setAttributedTitleForTitle(filter.title)
+        shouldLoadMore = false
     }
 
     private func refreshResultsController() {
@@ -217,7 +222,8 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
             return
         }
 
-        let completion = { [weak self] (shouldLoadMore: Bool) -> Void in
+        let completion = { [weak self] (retrieved: Int, shouldLoadMore: Bool) -> Void in
+            self?.nextRequestOffset = retrieved
             self?.shouldLoadMore = shouldLoadMore
             self?.refreshControl?.endRefreshing()
         }
@@ -241,16 +247,17 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
 
         isLoadingMore = true
 
-        let completion = { [weak self] (shouldLoadMore: Bool) -> Void in
+        let success = { [weak self] (retrieved: Int, shouldLoadMore: Bool) -> Void in
+            self?.nextRequestOffset += retrieved
             self?.shouldLoadMore = shouldLoadMore
             self?.isLoadingMore = false
         }
 
         switch filter {
         case .Followers:
-            service.loadMoreFollowers(completion)
+            service.loadMoreFollowers(nextRequestOffset, success: success)
         case .Users:
-            service.loadMoreUsers(completion)
+            service.loadMoreUsers(nextRequestOffset, success: success)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -36,6 +36,10 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
         }
     }
 
+    /// Indicates whether there is a loadMore call in progress, or not.
+    ///
+    private var isLoadingMore = false
+
     /// Number of pending-rows that trigger the LoadMore call
     ///
     private let refreshRowPadding = 4
@@ -231,8 +235,15 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
             return
         }
 
+        guard isLoadingMore == false else {
+            return
+        }
+
+        isLoadingMore = true
+
         let completion = { [weak self] (shouldLoadMore: Bool) -> Void in
             self?.shouldLoadMore = shouldLoadMore
+            self?.isLoadingMore = false
         }
 
         switch filter {


### PR DESCRIPTION
Closes #5502

#### To test:
1. Locally [hack this spot](https://github.com/wordpress-mobile/WordPress-iOS/pull/5508/files#diff-5e2d6556d819df0de802fec9c853008aR19), so that the pageSize is set to 1.
2. Open **My Sites** > **Site A** > **People**
3. Try scrolling all the way down. Switch to Followers, and please, verify it works as well.

Note: Please, make sure that **Site A** has more than 1 User / Follower.

#### Known Issues:
Follower's API lacks a sorting order parameter. I'll file another issue to deal with that, once the API has been enhanced.

--

Needs review: @SergioEstevao 
Sergio, may i bother you with a (hopefully fun) PR?

Thanks in advance!