### PR TITLE
Migrate Domain Services to WordPressComRestApi.

### DIFF
--- a/WordPress/Classes/Networking/DomainsServiceRemote.swift
+++ b/WordPress/Classes/Networking/DomainsServiceRemote.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-class DomainsServiceRemote: ServiceRemoteREST {
+class DomainsServiceRemote: ServiceRemoteWordPressComREST {
     enum Error: ErrorType {
         case DecodeError
     }
 
     func getDomainsForSite(siteID: Int, success: [Domain] -> Void, failure: ErrorType -> Void) {
         let endpoint = "sites/\(siteID)/domains"
-        let path = pathForEndpoint(endpoint, withVersion: ServiceRemoteRESTApiVersion_1_1)
+        let path = pathForEndpoint(endpoint, withVersion: .Version_1_1)
 
-        api.GET(path,
+        wordPressComRestApi.GET(path,
                 parameters: nil,
                 success: {
-                    _, response in
+                    response, _ in
                     do {
                         try success(mapDomainsResponse(response))
                     } catch {
@@ -20,7 +20,7 @@ class DomainsServiceRemote: ServiceRemoteREST {
                         failure(error)
                     }
             }, failure: {
-                _, error in
+                error, _ in
                 failure(error)
         })
     }

--- a/WordPress/Classes/Services/DomainsService.swift
+++ b/WordPress/Classes/Services/DomainsService.swift
@@ -110,6 +110,6 @@ struct DomainsService {
 
 extension DomainsService {
     init(managedObjectContext context: NSManagedObjectContext, account: WPAccount) {
-        self.init(managedObjectContext: context, remote: DomainsServiceRemote(api: account.restApi))
+        self.init(managedObjectContext: context, remote: DomainsServiceRemote(wordPressComRestApi: account.wordPressComRestApi))
     }
 }

--- a/WordPress/WordPressTest/DomainsServiceTests.swift
+++ b/WordPress/WordPressTest/DomainsServiceTests.swift
@@ -17,8 +17,8 @@ class DomainsServiceTests : XCTestCase
     override func setUp() {
         super.setUp()
 
-        let api = WordPressComApi(OAuthToken: "")
-        remote = DomainsServiceRemote(api: api)
+        let api = WordPressComRestApi(oAuthToken: "")
+        remote = DomainsServiceRemote(wordPressComRestApi: api)
         context = TestContextManager().mainContext
         testBlog = makeTestBlog()
     }


### PR DESCRIPTION
Refs #5245 

To test:
 - Login with a WP.com account.
 - Test domain pages on Blog->Domains
 - Run unit tests

Needs review: @frosty 

