### PR TITLE
Allow edit of post setting while images are being uploaded.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -818,11 +818,6 @@ EditImageDetailsViewControllerDelegate
 
 - (void)showSettings
 {
-    if ([self isMediaUploading]) {
-        [self showMediaUploadingAlert];
-        return;
-    }
-    
     Post *post = (Post *)self.post;
     PostSettingsViewController *vc = [[[self classForSettingsViewController] alloc] initWithPost:post shouldHideStatusBar:YES];
 	vc.hidesBottomBarWhenPushed = YES;


### PR DESCRIPTION
This PR allows user to edit post settings while media uploads are being done. This will allow user to be more productive while the wait for media uploads to finish.

To test:
 - Start or edit a post
 - Add media to it
 - Click on the settings icon,
 - Edit settings
 - Close settings screen
 - See if image upload continues normally
 - Do the same but spend enough time on settings to allow the upload to finish while on settings
 - Go back to the editor and check if everything went ok.

Needs review: @bummytime  
