### PR TITLE
SettingsMultiTextViewController: Correcting width when needed

### DIFF
--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -127,11 +127,12 @@ static CGFloat const SettingsMinHeight = 41.0f;
 
 - (void)adjustCellSize
 {
+    CGFloat widthInUse = CGRectGetWidth(self.textView.frame);
     CGFloat widthAvailable = CGRectGetWidth(self.textViewCell.contentView.bounds) - (2 * SettingsTextPadding.dx);
     CGSize size = [self.textView sizeThatFits:CGSizeMake(widthAvailable, CGFLOAT_MAX)];
     CGFloat height = size.height;
 
-    if (fabs(self.tableView.rowHeight - height) > (self.textView.font.lineHeight * 0.5f))
+    if (fabs(self.tableView.rowHeight - height) > (self.textView.font.lineHeight * 0.5f) || widthInUse != widthAvailable)
     {
         [self.tableView beginUpdates];
         self.textView.frame = CGRectMake(SettingsTextPadding.dx, SettingsTextPadding.dy, widthAvailable, height);


### PR DESCRIPTION
Closes #5526

To test:
1. Log into a dotcom account
2. Open `Me` > `My Profile` > `About`
3. Begin typing a long text.

Note: Please, use an iPhone 6 device (or simulator). This glitch was caused by the initial `View`'s width getting resized, and the textView not getting properly expanded.

Needs review: @astralbodies 
Thanks in advance Aaron!

