### PR TITLE
Sharing: Switch Publicize service from serviceID to label

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
@@ -24,7 +24,7 @@ import WordPressShared
 
         super.init(style: .Grouped)
 
-        navigationItem.title = publicizeService.serviceID
+        navigationItem.title = publicizeService.label
     }
 
 
@@ -124,7 +124,7 @@ import WordPressShared
         }
 
         var title =  NSLocalizedString("Connecting %@", comment: "Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name")
-        title = NSString(format: title, publicizeService.serviceID) as String
+        title = NSString(format: title, publicizeService.label) as String
 
         let manyAccountFooter = NSLocalizedString("Select the account you would like to authorize. Note that your posts will be automatically shared to the selected account.", comment: "")
         let oneAccountFooter = NSLocalizedString("Confirm this is the account you would like to authorize. Note that your posts will be automatically shared to this account.", comment: "")


### PR DESCRIPTION
Fixes #5543

To test:

1. Open the app
2. Go to a site's dashboard and select Sharing
3. Under Connections select a service to connect
4. Select Connect (or Connect Another Account if you already have a connection)
5. Log in to that sharing service and accept the connection to WordPress
6. On the next screen in the app, confirm that the navigation header and "Connecting" use the sharing service label (e.g. `Google+`) instead of serviceID (e.g. `google_plus`)

Needs review: @aerych 

