### PR TITLE
Share Extension: Minor Cleanup

### DIFF
--- a/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
+++ b/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
@@ -37,7 +37,7 @@ extension NSExtensionContext {
         case PublicImage    = "public.image"
     }
 
-    /// Loads the First Item with the specified identifier, and returns its value asynchronously.
+    /// Loads the First Item with the specified identifier, and returns its value asynchronously on the main thread.
     ///
     private func loadItemOfType<T>(type: T.Type, identifier: Identifier, completion: (T? -> Void)) {
         guard let itemProvider = firstItemProviderConformingToTypeIdentifier(identifier) else {
@@ -46,8 +46,10 @@ extension NSExtensionContext {
         }
 
         itemProvider.loadItemForTypeIdentifier(identifier.rawValue, options: nil) { (item, error) in
-            let targetItem = item as? T
-            completion(targetItem)
+            dispatch_async(dispatch_get_main_queue()) {
+                let targetItem = item as? T
+                completion(targetItem)
+            }
         }
     }
 

--- a/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
+++ b/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
@@ -4,32 +4,65 @@ import Foundation
 ///
 extension NSExtensionContext {
 
+    // MARK: - Public
+
+    /// Attempts to load the Website URL, and returns, asynchronously, the result.
+    ///
     func loadWebsiteUrl(completion: (NSURL? -> Void)) {
-        let publicUrlIdentifier = "public.url"
+        loadItemOfType(NSURL.self, identifier: Identifier.PublicURL, completion: completion)
+    }
 
-        guard let item = inputItems.first as? NSExtensionItem,
-            let itemProviders = item.attachments as? [NSItemProvider] else
-        {
-            completion(nil)
-            return
-        }
-
-        let urlItemProviders = itemProviders.filter { (itemProvider) in
-            return itemProvider.hasItemConformingToTypeIdentifier(publicUrlIdentifier)
-        }
-
-        guard let urlItemProvider = urlItemProviders.first else {
-            completion(nil)
-            return
-        }
-
-        urlItemProvider.loadItemForTypeIdentifier(publicUrlIdentifier, options: nil) { (url, error) in
-            guard let theURL = url as? NSURL else {
+    /// Attempts to load the Image Attachment, and returns, asynchronously, the result.
+    ///
+    func loadImageAttachment(completion: (UIImage? -> Void)) {
+        loadItemOfType(NSURL.self, identifier: Identifier.PublicImage) { url in
+            guard let targetURL = url, let rawImage = NSData(contentsOfURL: targetURL) else {
                 completion(nil)
                 return
             }
 
-            completion(theURL)
+            let image = UIImage(data: rawImage)
+            completion(image)
         }
+    }
+
+
+
+    // MARK: - Private
+
+    /// Extension Item Identifiers
+    ///
+    private enum Identifier : String {
+        case PublicURL      = "public.url"
+        case PublicImage    = "public.image"
+    }
+
+    /// Loads the First Item with the specified identifier, and returns its value asynchronously.
+    ///
+    private func loadItemOfType<T>(type: T.Type, identifier: Identifier, completion: (T? -> Void)) {
+        guard let itemProvider = firstItemProviderConformingToTypeIdentifier(identifier) else {
+            completion(nil)
+            return
+        }
+
+        itemProvider.loadItemForTypeIdentifier(identifier.rawValue, options: nil) { (item, error) in
+            let targetItem = item as? T
+            completion(targetItem)
+        }
+    }
+
+    /// Returns the first NSItemProvider available, that matches with a given identifier.
+    ///
+    private func firstItemProviderConformingToTypeIdentifier(identifier: Identifier) -> NSItemProvider? {
+        guard let item = inputItems.first as? NSExtensionItem,
+            let itemProviders = item.attachments as? [NSItemProvider] else {
+            return nil
+        }
+
+        let filteredItemProviders = itemProviders.filter { itemProvider in
+            return itemProvider.hasItemConformingToTypeIdentifier(identifier.rawValue)
+        }
+
+        return filteredItemProviders.first
     }
 }

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -79,7 +79,7 @@ class ShareViewController: SLComposeServiceViewController {
 
         let service = PostService(configuration: configuration)
         let linkified = contentText.stringWithAnchoredLinks()
-        let (subject, body) = splitContentTextIntoSubjectAndBody(linkified)
+        let (subject, body) = linkified.splitContentTextIntoSubjectAndBody()
 
         service.createPost(siteID: selectedSiteID, status: postStatus, title: subject, body: body) {
             (post, error) in
@@ -169,13 +169,4 @@ class ShareViewController: SLComposeServiceViewController {
     private let postStatuses = [
         "draft" : NSLocalizedString("Draft", comment: "Draft post status"),
         "publish" : NSLocalizedString("Publish", comment: "Publish post status")]
-
-    private func splitContentTextIntoSubjectAndBody(contentText: String) -> (subject: String, body: String) {
-        let fullText = contentText
-        let indexOfFirstNewline = fullText.rangeOfCharacterFromSet(NSCharacterSet.newlineCharacterSet())
-        let firstLineOfText = indexOfFirstNewline != nil ? fullText.substringToIndex(indexOfFirstNewline!.startIndex) : fullText
-        let restOfText = indexOfFirstNewline != nil ? fullText.substringFromIndex(indexOfFirstNewline!.endIndex) : ""
-
-        return (firstLineOfText, restOfText)
-    }
 }

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -6,6 +6,7 @@ import WordPressComKit
 class ShareViewController: SLComposeServiceViewController {
 
     // MARK: - Private Properties
+
     private lazy var wpcomUsername: String? = {
         ShareExtensionService.retrieveShareExtensionUsername()
     }()
@@ -28,8 +29,16 @@ class ShareViewController: SLComposeServiceViewController {
 
     private lazy var postStatus = "publish"
 
+    // TODO: This should eventually be moved into WordPressComKit
+    private let postStatuses = [
+        "draft"     : NSLocalizedString("Draft", comment: "Draft post status"),
+        "publish"   : NSLocalizedString("Publish", comment: "Publish post status")
+    ]
+
+
 
     // MARK: - UIViewController Methods
+
     override func viewDidLoad() {
         // Tracker
         tracks.wpcomUsername = wpcomUsername
@@ -48,7 +57,8 @@ class ShareViewController: SLComposeServiceViewController {
 
 
 
-    // MARK: - Overriden Methods
+    // MARK: - SLComposeService Overriden Methods
+
     override func loadPreviewView() -> UIView! {
         // Hides Composer Thumbnail Preview.
         return UIView()
@@ -108,11 +118,16 @@ class ShareViewController: SLComposeServiceViewController {
 
         return [blogPickerItem, statusPickerItem]
     }
+}
 
 
 
-    // MARK: - Private Helpers
-    private func dismissIfNeeded() {
+
+/// ShareViewController Extension: Encapsulates all of the Action Helpers.
+///
+private extension ShareViewController
+{
+    func dismissIfNeeded() {
         guard oauth2Token == nil else {
             return
         }
@@ -130,7 +145,7 @@ class ShareViewController: SLComposeServiceViewController {
         presentViewController(alertController, animated: true, completion: nil)
     }
 
-    private func displaySitePicker() {
+    func displaySitePicker() {
         let pickerViewController = SitePickerViewController()
         pickerViewController.onChange = { (siteId, description) in
             self.selectedSiteID = siteId
@@ -142,7 +157,7 @@ class ShareViewController: SLComposeServiceViewController {
         pushConfigurationViewController(pickerViewController)
     }
 
-    private func displayStatusPicker() {
+    func displayStatusPicker() {
         let pickerViewController = PostStatusPickerViewController(statuses: postStatuses)
         pickerViewController.onChange = { (status, description) in
             self.postStatus = status
@@ -151,7 +166,13 @@ class ShareViewController: SLComposeServiceViewController {
 
         pushConfigurationViewController(pickerViewController)
     }
+}
 
+
+/// ShareViewController Extension: Encapsulates private helpers
+///
+private extension ShareViewController
+{
     private func loadTextViewContent() {
         extensionContext?.loadWebsiteUrl { url in
             dispatch_async(dispatch_get_main_queue()) {
@@ -163,10 +184,4 @@ class ShareViewController: SLComposeServiceViewController {
             }
         }
     }
-
-
-    // TODO: This should eventually be moved into WordPressComKit
-    private let postStatuses = [
-        "draft" : NSLocalizedString("Draft", comment: "Draft post status"),
-        "publish" : NSLocalizedString("Publish", comment: "Publish post status")]
 }

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -169,19 +169,18 @@ private extension ShareViewController
 }
 
 
+
 /// ShareViewController Extension: Encapsulates private helpers
 ///
 private extension ShareViewController
 {
     private func loadTextViewContent() {
         extensionContext?.loadWebsiteUrl { url in
-            dispatch_async(dispatch_get_main_queue()) {
-                let current = self.contentText ?? String()
-                let source  = url?.absoluteString ?? String()
-                let spacing = current.isEmpty ? String() : "\n\n"
+            let current = self.contentText ?? String()
+            let source  = url?.absoluteString ?? String()
+            let spacing = current.isEmpty ? String() : "\n\n"
 
-                self.textView.text = "\(current)\(spacing)\(source)"
-            }
+            self.textView.text = "\(current)\(spacing)\(source)"
         }
     }
 }

--- a/WordPress/WordPressShareExtension/String+Extensions.swift
+++ b/WordPress/WordPressShareExtension/String+Extensions.swift
@@ -5,6 +5,8 @@ import Social
 ///
 extension String
 {
+    /// Returns a String with <A>nchored links
+    ///
     func stringWithAnchoredLinks() -> String {
         guard let output = (self as NSString).mutableCopy() as? NSMutableString,
                 let detector = try? NSDataDetector(types: NSTextCheckingType.Link.rawValue) else
@@ -29,5 +31,16 @@ extension String
         }
 
         return output as String
+    }
+
+
+    /// Returns a tuple containing the First Line + Body of the text
+    ///
+    func splitContentTextIntoSubjectAndBody() -> (subject: String, body: String) {
+        let indexOfFirstNewline = rangeOfCharacterFromSet(NSCharacterSet.newlineCharacterSet())
+        let firstLineOfText = indexOfFirstNewline != nil ? substringToIndex(indexOfFirstNewline!.startIndex) : self
+        let restOfText = indexOfFirstNewline != nil ? substringFromIndex(indexOfFirstNewline!.endIndex) : ""
+
+        return (firstLineOfText, restOfText)
     }
 }


### PR DESCRIPTION
#### Notes:
- `ShareViewController` code has been split in different sections, by means of private extensions.
- `NSExtensionContext` Extension has been generalized, internally, and a new helper to extract images has been added.
- String-specific helper moved to its own extension

#### To test:
This PR doesn't add extra code, it's just a reorganization. This came as a spin off while working on #4910, and thought it'd be healthier to ship it on its own.

Please, verify that the extension works as expected (sanity check).

Needs review: @astralbodies 
Thanks in advance!
