### PR TITLE
Menus: Resolve ordering issue when updating Menu items.

### DIFF
--- a/WordPress/Classes/Services/MenusService.m
+++ b/WordPress/Classes/Services/MenusService.m
@@ -403,6 +403,7 @@ NS_ASSUME_NONNULL_BEGIN
     remoteItem.urlStr = item.urlStr;
     
     if (item.children.count) {
+        // Find the children of the item and them to remoteItem.children.
         NSMutableArray *children = [NSMutableArray arrayWithCapacity:item.children.count];
         for (MenuItem *anItem in items) {
             if (!anItem.parent) {

--- a/WordPress/Classes/Services/MenusService.m
+++ b/WordPress/Classes/Services/MenusService.m
@@ -283,7 +283,6 @@ NS_ASSUME_NONNULL_BEGIN
     item.menu = menu;
     
     if (remoteMenuItem.children) {
-        
         for (RemoteMenuItem *childRemoteItem in remoteMenuItem.children) {
             MenuItem *childItem = [self addMenuItemFromRemoteMenuItem:childRemoteItem forMenu:menu];
             childItem.parent = item;
@@ -366,14 +365,14 @@ NS_ASSUME_NONNULL_BEGIN
             continue;
         }
         // Children of item will be added as remoteItem.children.
-        RemoteMenuItem *remoteItem = [self remoteItemFromItem:item];
+        RemoteMenuItem *remoteItem = [self remoteItemFromItem:item withItems:menuItems];
         [remoteItems addObject:remoteItem];
     }
     
     return [NSArray arrayWithArray:remoteItems];
 }
 
-- (RemoteMenuItem *)remoteItemFromItem:(MenuItem *)item
+- (RemoteMenuItem *)remoteItemFromItem:(MenuItem *)item withItems:(NSOrderedSet<MenuItem *> *)items
 {
     RemoteMenuItem *remoteItem = [[RemoteMenuItem alloc] init];
     remoteItem.itemID = item.itemID;
@@ -404,11 +403,16 @@ NS_ASSUME_NONNULL_BEGIN
     remoteItem.urlStr = item.urlStr;
     
     if (item.children.count) {
-        NSMutableArray *childRemoteItems = [NSMutableArray arrayWithCapacity:item.children.count];
-        for (MenuItem *childItem in item.children) {
-            [childRemoteItems addObject:[self remoteItemFromItem:childItem]];
+        NSMutableArray *children = [NSMutableArray arrayWithCapacity:item.children.count];
+        for (MenuItem *anItem in items) {
+            if (!anItem.parent) {
+                continue;
+            }
+            if (anItem.parent == item) {
+                [children addObject:[self remoteItemFromItem:anItem withItems:items]];
+            }
+            remoteItem.children = children;
         }
-        remoteItem.children = childRemoteItems;
     }
     
     return remoteItem;


### PR DESCRIPTION
Quick rewrite of setting up the `MenuItemRemote` objects for pushing to the remote in the correct order. Previously this was written in a way that lost any ordering for items that were children of another item.

To test:

![simulator screen shot jun 9 2016 2 10 18 pm](https://cloud.githubusercontent.com/assets/1873422/15942901/145bcbb2-2e4c-11e6-97ff-6f8797fb1cf2.png)

1. Open Menus for a .com site with admin rights.
2. Reorder items that are children of another item or create multiple children if needed. (For example, reorder items above as About, Contact, Home.)
3. Save the changes.
4. Check the site that the ordering is correctly updated for the menu.

Needs review: @jleandroperez would you mind reviewing fine sir? 🎩 

