### PR TITLE
Posts: Sort drafts by last modified date.

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -340,7 +340,12 @@
 
 - (NSString *)dateStringForDisplay
 {
-    if ([self shouldPublishImmediately]) {
+    if ([self isDraft] || [self.status isEqualToString:PostStatusPending]) {
+        NSString *shortDate = [[self dateModified] shortString];
+        NSString *lastModified = NSLocalizedString(@"last-modified",@"A label for a post's last-modified date.");
+        return [NSString stringWithFormat:@"%@ (%@)", shortDate, lastModified];
+
+    } else if ([self shouldPublishImmediately]) {
         return NSLocalizedString(@"Publish Immediately",@"A short phrase indicating a post is due to be immedately published.");
     }
     return [[self dateCreated] shortString];

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -327,8 +327,10 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
         let sortDescriptorLocal = NSSortDescriptor(key: "metaIsLocal", ascending: false)
         let sortDescriptorImmediately = NSSortDescriptor(key: "metaPublishImmediately", ascending: false)
+        if currentPostListFilter().filterType == .Draft {
+            return [sortDescriptorLocal, NSSortDescriptor(key: "dateModified", ascending: ascending)]
+        }
         let sortDescriptorDate = NSSortDescriptor(key: "date_created_gmt", ascending: ascending)
-
         return [sortDescriptorLocal, sortDescriptorImmediately, sortDescriptorDate]
     }
 


### PR DESCRIPTION
Closes #5522 

To test: Check that draft posts are sorted by date last modified, and show the correct date when compared with wp-admin and calypso.
Confirm that published, scheduled, and trashed posts continue to be sorted by date published. 

Needs review: @bummytime 

