### PR TITLE
Fix button title for scheduled page list

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -581,6 +581,8 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
         let filterType = currentPostListFilter().filterType
 
         switch filterType {
+        case .Scheduled:
+            return NSLocalizedString("Edit Drafts", comment: "Button title, encourages users to schedule a draft page to publish.")
         case .Trashed:
             return ""
         default:

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -581,8 +581,6 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
         let filterType = currentPostListFilter().filterType
 
         switch filterType {
-        case .Scheduled:
-            return NSLocalizedString("Edit Drafts", comment: "Button title, encourages users to schedule a draft page to publish.")
         case .Trashed:
             return ""
         default:
@@ -612,7 +610,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
         case .Draft:
             return NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views drafts in the pages list and there are no pages")
         case .Scheduled:
-            return NSLocalizedString("Would you like to schedule a draft to publish?", comment: "Displayed when the user views scheduled pages in the oages list and there are no pages")
+            return NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views scheduled pages in the pages list and there are no pages")
         case .Trashed:
             return NSLocalizedString("Everything you write is solid gold.", comment: "Displayed when the user views trashed pages in the pages list and there are no pages")
         default:

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -440,12 +440,6 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     @IBAction func didTapNoResultsView(noResultsView: WPNoResultsView) {
         WPAnalytics.track(.PostListNoResultsButtonPressed, withProperties: propertiesForAnalytics())
 
-        if currentPostListFilter().filterType == .Scheduled {
-            let index = indexForFilterWithType(.Draft)
-            setCurrentFilterIndex(index)
-            return
-        }
-
         createPost()
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -648,8 +648,6 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         let filterType = currentPostListFilter().filterType
 
         switch filterType {
-        case .Scheduled:
-            return NSLocalizedString("Edit Drafts", comment: "Button title, encourages users to schedule a draft post to publish.")
         case .Trashed:
             return ""
         default:
@@ -680,7 +678,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         case .Draft:
             return NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views drafts in the posts list and there are no posts")
         case .Scheduled:
-            return NSLocalizedString("Would you like to schedule a draft to publish?", comment: "Displayed when the user views scheduled posts in the posts list and there are no posts")
+            return NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views scheduled posts in the posts list and there are no posts")
         case .Trashed:
             return NSLocalizedString("Everything you write is solid gold.", comment: "Displayed when the user views trashed posts in the posts list and there are no posts")
         default:


### PR DESCRIPTION
Fixes #5557 

To test:

1. Open the app
2. Open a site's Page list
3. In the Page filter, select Scheduled
4. Make sure the page list is empty (publish, move to draft, or trash any scheduled pages so the list is empty)
5. Check to make sure the call to action button says "Edit Drafts" instead of "Start a Page"
6. Tap the "Edit Drafts" button
7. Make sure you end up on the Drafts page list

![simulator screen shot jun 10 2016 10 38 04 pm](https://cloud.githubusercontent.com/assets/8658164/15979469/0ccc5310-2f5c-11e6-9767-e3f4c472d538.png)


Needs review: @diegoreymendez 
