### PR TITLE
Post List: Reload tableview instead of visible rows.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -151,10 +151,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
             let width = view.frame.width
 
             tableViewHandler.refreshCachedRowHeightsForWidth(width)
-
-            if let indexPathsForVisibleRows = tableView.indexPathsForVisibleRows {
-                tableView.reloadRowsAtIndexPaths(indexPathsForVisibleRows, withRowAnimation: .None)
-            }
+            tableView.reloadData()
         }
     }
 


### PR DESCRIPTION
We've had a couple of crashes where the cause was reported to be `UITableView internal bug: unable to generate a new section map with old section count: 1 and new section count: 0'`. The exact cause isn't known but it appears that the apps is trying to reload rows in a section that no longer exists.  Rather than reloading visible rows, we can just reload the UITableView to avoid the crash. 

Needs review: @sendhil 

Sample stack trace:

> *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'UITableView internal bug: unable to generate a new section map with old section count: 1 and new section count: 0'

> Last Exception Backtrace:
0   CoreFoundation                       0x0000000182456db0 __exceptionPreprocess + 124
1   libobjc.A.dylib                      0x0000000181abbf80 objc_exception_throw + 52
2   CoreFoundation                       0x0000000182456c80 +[NSException raise:format:arguments:] + 104
3   Foundation                           0x0000000182ddc154 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 108
4   UIKit                                0x00000001877c9318 -[_UITableViewUpdateSupport(Private) _computeSectionUpdates] + 2584
5   UIKit                                0x00000001877c8864 -[_UITableViewUpdateSupport initWithTableView:updateItems:oldRowData:newRowData:oldRowRange:newRowRange:context:] + 500
6   UIKit                                0x00000001877ad0ec -[UITableView _endCellAnimationsWithContext:] + 10800
7   UIKit                                0x00000001877c81d0 -[UITableView _updateRowsAtIndexPaths:updateAction:withRowAnimation:] + 356
8   WordPress                            0x00000001003b9ec0 WordPress.AbstractPostListViewController.viewWillLayoutSubviews () -> () (AbstractPostListViewController.swift:156)
9   WordPress                            0x00000001003b9f1c @objc WordPress.AbstractPostListViewController.viewWillLayoutSubviews () -> () (AbstractPostListViewController.swift:0)
10  UIKit                                0x00000001875b00f4 -[UIView(CALayerDelegate) layoutSublayersOfLayer:] + 412
11  QuartzCore                           0x0000000184f42994 -[CALayer layoutSublayers] + 144
12  QuartzCore                           0x0000000184f3d5d0 CA::Layer::layout_if_needed(CA::Transaction*) + 288
13  UIKit                                0x00000001875c70a4 -[UIView(Hierarchy) layoutBelowIfNeeded] + 920
14  UIKit                                0x0000000187675694 -[UINavigationController _layoutViewController:] + 1192
15  UIKit                                0x000000018767306c -[UINavigationController _layoutTopViewController] + 224
16  UIKit                                0x000000018768bdd8 -[UINavigationController navigationTransitionView:didEndTransition:fromView:toView:] + 724
17  UIKit                                0x000000018768bac4 -[UINavigationTransitionView _notifyDelegateTransitionDidStopWithContext:] + 412
18  UIKit                                0x000000018768b7cc -[UINavigationTransitionView _cleanupTransition] + 740
19  UIKit                                0x00000001875efc28 -[UIViewAnimationState sendDelegateAnimationDidStop:finished:] + 308
20  UIKit                                0x00000001875edea4 +[UIViewAnimationState popAnimationState] + 320
21  UIKit                                0x000000018767f234 -[UINavigationTransitionView transition:fromView:toView:] + 1788
22  UIKit                                0x0000000187674d48 -[UINavigationController _startTransition:fromViewController:toViewController:] + 2692
23  UIKit                                0x0000000187673ef4 -[UINavigationController _startDeferredTransitionIfNeeded:] + 864
24  UIKit                                0x000000018773d8ec -[UINavigationController(StateRestoration) decodeRestorableStateWithCoder:] + 608
25  UIKit                                0x00000001879433f8 -[UIViewController(StateRestoration) _decodeRestorableStateAndReturnContinuationWithCoder:] + 60
26  UIKit                                0x0000000187881770 ___restoreState_block_invoke + 708
27  UIKit                                0x00000001875c35b4 +[UIView(Animation) performWithoutAnimation:] + 76
28  UIKit                                0x0000000187735df8 -[UIApplication(StateRestoration) _restoreApplicationPreservationStateWithSessionIdentifier:beginHandler:completionHandler:] + 5672
29  UIKit                                0x000000018762ad44 -[UIApplication(StateRestoration) _doRestorationIfNecessary] + 240
30  UIKit                                0x000000018762a964 -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] + 304
31  UIKit                                0x000000018785a184 -[UIApplication _callInitializationDelegatesForMainScene:transitionContext:] + 2900
32  UIKit                                0x000000018785e5f0 -[UIApplication _runWithMainScene:transitionContext:completion:] + 1680
33  UIKit                                0x000000018785b764 -[UIApplication workspaceDidEndTransaction:] + 164
34  FrontBoardServices                   0x0000000183df77ac __FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__ + 32
35  FrontBoardServices                   0x0000000183df7618 -[FBSSerialQueue _performNext] + 164
36  FrontBoardServices                   0x0000000183df79c8 -[FBSSerialQueue _performNextFromRunLoopSource] + 52
37  CoreFoundation                       0x000000018240d09c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 20
38  CoreFoundation                       0x000000018240cb30 __CFRunLoopDoSources0 + 536
39  CoreFoundation                       0x000000018240a830 __CFRunLoopRun + 720
40  CoreFoundation                       0x0000000182334c50 CFRunLoopRunSpecific + 380
41  UIKit                                0x000000018762394c -[UIApplication _run] + 456
42  UIKit                                0x000000018761e088 UIApplicationMain + 200
43  WordPress                            0x00000001000738c4 main (main.m:5)
44  ???                                  0x0000000181ed28b8 0x0 + 0
