### PR TITLE
SettingsMultiTextViewController: Correcting width when needed - Release 6.3 Backport

### DIFF
--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -3,6 +3,7 @@
 #import "WPTableViewCell.h"
 #import "WPTableViewSectionHeaderFooterView.h"
 
+static CGVector const SettingsTextPadding = {11.0f, 3.0f};
 static CGFloat const HorizontalMargin = 10.0f;
 
 @interface SettingsMultiTextViewController() <UITextViewDelegate>

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -130,9 +130,12 @@ static CGFloat const HorizontalMargin = 10.0f;
 
 - (void)adjustCellSize
 {
-    CGFloat widthAvailable = self.textViewCell.contentView.bounds.size.width - ( 2 * HorizontalMargin);
+    CGFloat widthInUse = CGRectGetWidth(self.textView.frame);
+    CGFloat widthAvailable = CGRectGetWidth(self.textViewCell.contentView.bounds) - (2 * SettingsTextPadding.dx);
     CGSize size = [self.textView sizeThatFits:CGSizeMake(widthAvailable, CGFLOAT_MAX)];
-    if (fabs(self.tableView.rowHeight - size.height) > (self.textView.font.lineHeight/2))
+    CGFloat height = size.height;
+
+    if (fabs(self.tableView.rowHeight - height) > (self.textView.font.lineHeight * 0.5f) || widthInUse != widthAvailable)
     {
         [self.tableView beginUpdates];
         self.textView.frame = CGRectMake(HorizontalMargin, 0, widthAvailable, size.height);


### PR DESCRIPTION
Backporting PR #5531 for Release 6.3

#### To test:
1. Log into a dotcom account
2. Open Me > My Profile > About
3. Begin typing a long text.

Note: Please, use an iPhone 6 device (or simulator). This glitch was caused by the initial View's width getting resized, and the textView not getting properly expanded.

Needs review: @astralbodies 
Thanks in advance!