### PR TITLE
Fix editing of pages

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/EditPageViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/EditPageViewController.m
@@ -9,6 +9,10 @@
 
 @implementation EditPageViewController
 
++ (Class)supportedPostClass {
+    return [Page class];
+}
+
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -200,9 +200,13 @@ EditImageDetailsViewControllerDelegate
     return self;
 }
 
++ (Class)supportedPostClass {
+    return [Post class];
+}
+
 - (instancetype)initWithPost:(AbstractPost *)post
 {
-    NSParameterAssert([post isKindOfClass:[Post class]]);
+    NSParameterAssert([post isKindOfClass:[self.class supportedPostClass]]);
     
     return [self initWithPost:post
                          mode:kWPPostViewControllerModePreview];
@@ -211,7 +215,7 @@ EditImageDetailsViewControllerDelegate
 - (instancetype)initWithPost:(AbstractPost *)post
                         mode:(WPPostViewControllerMode)mode
 {
-    NSParameterAssert([post isKindOfClass:[Post class]]);
+    NSParameterAssert([post isKindOfClass:[self.class supportedPostClass]]);
 
     BOOL changeToEditModeDueToUnsavedChanges = (mode == kWPEditorViewControllerModePreview
                                                 && [post hasUnsavedChanges]);
@@ -1434,7 +1438,7 @@ EditImageDetailsViewControllerDelegate
 
 - (void)discardChanges
 {
-    NSAssert([_post isKindOfClass:[Post class]],
+    NSAssert([_post isKindOfClass:[self.class supportedPostClass]],
              @"The post should exist here.");
 
     NSManagedObjectContext* context = self.post.managedObjectContext;


### PR DESCRIPTION
This PR fixs the editing of pages that was crashing because of assert for Post type on WPPostViewController.

To test:
 - Launch the app
 - Go to Blog->Pages
 - Edit a page
 - Save a page
 - Check if no crash happens

Needs review: @diegoreymendez do you mind have a look on this?