### PR TITLE
Issue/5570 – Fixes iOS 10 crash on launch

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -629,7 +629,12 @@ static NSInteger const WPTabBarIconOffset = 5;
     // In this method, we determine the UITabBarController's last button frame.
     // It's proven to be effective in *all* of the available devices to date, even in multitasking mode.
     // Even better, we don't even need one constant per device.
-    // *If* this ever breaks, worst case scenario, we'll notice the assertion below (and of course, we'll fix it!).
+    //
+    // On iOS 10, the first time this viewcontroller's view is laid out the tab bar buttons have
+    // a zero origin, so this method can't choose a frame. On subsequent layout passes, the
+    // buttons seem to have a correct frame, so this method still works for now.
+    // (When this viewcontroller's view is first created, `viewDidLayoutSubviews` is called twice -
+    // The second time has the correct frame).
     //
     CGRect lastButtonRect = CGRectZero;
     
@@ -641,7 +646,6 @@ static NSInteger const WPTabBarIconOffset = 5;
         }
     }
     
-    NSAssert(!CGRectEqualToRect(lastButtonRect, CGRectZero), @"Couldn't determine the last TabBarButton Frame");
     return lastButtonRect;
 }
 


### PR DESCRIPTION
Fixes #5570. 

iOS 10 was seeing a crash on launch. Checking the console, I found:

```
Jan  1 01:02:34 Jamess-iPad WordPress(Foundation)[484] <Notice>: *** Assertion failure in -[WPTabBarController lastTabBarButtonFrame], /Users/sendhil/Projects/WordPress/WordPress-Release/WordPress/Classes/ViewRelated/System/WPTabBarController.m:644
```

I then added some extra debugging to `[WPTabBarController lastTabBarButtonFrame]` to see what was going on. On both iOS 9 and iOS 10, this method is called twice when the tab bar is laying out its views (via `viewDidLayoutSubviews`). 

On iOS 9, the frames of the tab bar's subviews are correct both times. 
On iOS 10, the frames have a zero origin the first time round. This means that the method can't find an appropriate frame for the notifications cell, triggering an assertion.

I've removed the assert, as the frames returned are fine the second time the method gets called. Worst case, we'd have `CGRectZero` returned and the notifications bubble won't be visible (but in reality, we do get a frame before everything's visible anyway).

### To test

This one's a little tricky. You need to run the app built with the iOS 9 SDK on an iOS 10 device. I was able to do this by first symlinking Xcode 8's device support directory for iOS 10 into Xcode 7:

```
sudo ln -s /Applications/Xcode-beta.app/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport/10.0\ \(14A5261u\) /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport/10.0\ \(14A5261u\)
```

You might need to restart Xcode, but then you should find that you can build onto your iOS 10 device from Xcode 7. You may also need to have first plugged the device into Xcode 8.

* Try running `release/6.3` on the device it should crash on launch.
* Try running this branch. It should run without crashing.

Needs review: @jleandroperez 
