### PR TITLE
Menus: Resolving Static Analysis Warnings

### DIFF
--- a/WordPress/Classes/Services/MenusService.m
+++ b/WordPress/Classes/Services/MenusService.m
@@ -409,7 +409,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (remoteItem.type) {
         // Override the type_family param based on the type.
         // This is a weird behavior of the API and is not documented.
-        NSString *typeFamily = item.typeFamily;
+        NSString *typeFamily;
         if ([remoteItem.type isEqualToString:MenuItemTypeCustom]) {
             typeFamily = @"custom";
         } else if ([remoteItem.type isEqualToString:MenuItemTypeTag] || [remoteItem.type isEqualToString:MenuItemTypeCategory]){

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -551,7 +551,7 @@ NSInteger const BlogDetailAccountHideViewAdminDay = 7;
 - (void)showMenus
 {
     [WPAppAnalytics track:WPAnalyticsStatMenusAccessed withBlog:self.blog];
-    MenusViewController *viewController = [[MenusViewController alloc] initWithBlog:self.blog];
+    MenusViewController *viewController = [MenusViewController controllerWithBlog:self.blog];
     [self.navigationController pushViewController:viewController
                                          animated:YES];
 }

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.h
@@ -24,7 +24,7 @@ extern NSString * const MenuItemEditingTypeSelectionChangedNotification;
  */
 @property (nonatomic, copy, nullable) void(^onSelectedToCancel)();
 
-- (id)initWithItem:(MenuItem *)item blog:(Blog *)blog;
++ (MenuItemEditingViewController *)itemEditingViewControllerWithItem:(MenuItem *)item blog:(Blog *)blog;
 
 @end
 

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.m
@@ -414,14 +414,12 @@ typedef NS_ENUM(NSUInteger, MenuItemEditingViewControllerContentLayout) {
     CGRect frame = [[notification.userInfo objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
     frame = [self.view.window convertRect:frame toView:self.view];
     
-    CGFloat constraintConstant = self.stackViewBottomConstraint.constant;
-    
+    CGFloat constraintConstant;
     if (frame.origin.y > self.view.frame.size.height) {
         constraintConstant = 0.0;
     } else  {
         constraintConstant = self.view.frame.size.height - frame.origin.y;
     }
-    
     [self.view layoutIfNeeded];
     self.stackViewBottomConstraint.constant = constraintConstant;
     

--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MenusViewController : UIViewController
 
-- (id)initWithBlog:(Blog *)blog;
++ (MenusViewController *)controllerWithBlog:(Blog *)blog;
 
 @end
 

--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -63,7 +63,7 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
 
 - (void)setupWithBlog:(Blog *)blog
 {
-    // using a new child context to keep local changes disacardable
+    // using a new child context to keep local changes discardable
     // using main queue as we still want processing done on the main thread
     NSManagedObjectContext *context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
     context.parentContext = blog.managedObjectContext;

--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -47,35 +47,36 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
 
 @implementation MenusViewController
 
++ (MenusViewController *)controllerWithBlog:(Blog *)blog
+{
+    NSParameterAssert([blog isKindOfClass:[Blog class]]);
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Menus" bundle:nil];
+    MenusViewController *controller = [storyboard instantiateInitialViewController];
+    [controller setupWithBlog:blog];
+    return controller;
+}
+
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (id)initWithBlog:(Blog *)blog
+- (void)setupWithBlog:(Blog *)blog
 {
-    NSParameterAssert([blog isKindOfClass:[Blog class]]);
-    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Menus" bundle:nil];
-    self = [storyboard instantiateInitialViewController];
-    if (self) {
-        
-        // using a new child context to keep local changes disacardable
-        // using main queue as we still want processing done on the main thread
-        NSManagedObjectContext *context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
-        context.parentContext = blog.managedObjectContext;
-        context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
-        
-        // set local blog from local context
-        _blog = [context objectWithID:blog.objectID];
-        
-        // set up the undomanager
-        context.undoManager = [[NSUndoManager alloc] init];
+    // using a new child context to keep local changes disacardable
+    // using main queue as we still want processing done on the main thread
+    NSManagedObjectContext *context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+    context.parentContext = blog.managedObjectContext;
+    context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
 
-        MenusService *service = [[MenusService alloc] initWithManagedObjectContext:context];
-        _menusService = service;
-    }
-    
-    return self;
+    // set local blog from local context
+    _blog = [context objectWithID:blog.objectID];
+
+    // set up the undomanager
+    context.undoManager = [[NSUndoManager alloc] init];
+
+    MenusService *service = [[MenusService alloc] initWithManagedObjectContext:context];
+    _menusService = service;
 }
 
 - (void)viewDidLoad
@@ -485,7 +486,8 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
 
 - (MenuItemEditingViewController *)editingControllerWithItem:(MenuItem *)item
 {
-    MenuItemEditingViewController *controller = [[MenuItemEditingViewController alloc] initWithItem:item blog:self.blog];
+    MenuItemEditingViewController *controller = [MenuItemEditingViewController itemEditingViewControllerWithItem:item
+                                                                                                            blog:self.blog];
     void(^dismiss)() = ^() {
         [self dismissViewControllerAnimated:YES completion:nil];
     };


### PR DESCRIPTION
This PR resolves and improves a couple of warnings from the static analyzer for Menus.

To test:

1. Select a .com site with admin rights.
2. Open Menus from the blog details.
3. Open the MenuItem editing view by selecting an item in the list of items.
4. Ensure the modal editing controller presents.
5. Run the static analyzer on the project and ensure no warnings present.
6. 🏁 

Needs review: @nheagy can I bother you with a review?