### PR TITLE
Issue/5583 replace themes searchbar

### DIFF
--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowser.storyboard
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowser.storyboard
@@ -340,11 +340,11 @@
                                         <outlet property="currentThemeName" destination="QqI-lf-7WU" id="qGX-CK-8ey"/>
                                         <outlet property="customizeButton" destination="u2z-nw-Vyc" id="1gk-tM-uLp"/>
                                         <outlet property="detailsButton" destination="6BA-aY-mOt" id="LAT-yo-MX8"/>
-                                        <outlet property="searchBar" destination="QcA-Am-6I5" id="erh-Ff-XFp"/>
-                                        <outlet property="searchTypeButton" destination="gVo-ti-m3S" id="ubO-fe-9XS"/>
+                                        <outlet property="filterBar" destination="QcA-Am-6I5" id="ULL-Kt-Bh8"/>
+                                        <outlet property="filterTypeButton" destination="gVo-ti-m3S" id="1et-xB-Gzn"/>
                                         <outlet property="supportButton" destination="iix-Pu-kKG" id="0Sd-aS-Nyg"/>
-                                        <outletCollection property="searchBarBorders" destination="mCK-BA-lBb" collectionClass="NSMutableArray" id="tib-Ny-Vrf"/>
-                                        <outletCollection property="searchBarBorders" destination="vOP-ZF-qi0" collectionClass="NSMutableArray" id="pzf-Gb-tmO"/>
+                                        <outletCollection property="filterBarBorders" destination="vOP-ZF-qi0" collectionClass="NSMutableArray" id="eHA-ty-vDq"/>
+                                        <outletCollection property="filterBarBorders" destination="mCK-BA-lBb" collectionClass="NSMutableArray" id="iF8-KI-IhN"/>
                                     </connections>
                                 </collectionReusableView>
                                 <collectionReusableView key="sectionFooterView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ThemeBrowserFooterView" id="Mhx-tS-Lea" userLabel="ThemeBrowserFooterView">

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowser.storyboard
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowser.storyboard
@@ -29,13 +29,13 @@
                                 <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="0.0" id="zdl-yg-1wZ">
                                     <size key="itemSize" width="250" height="241"/>
-                                    <size key="headerReferenceSize" width="50" height="162"/>
+                                    <size key="headerReferenceSize" width="50" height="163"/>
                                     <size key="footerReferenceSize" width="50" height="50"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ThemeBrowserCell" id="YzH-tn-GEt" customClass="ThemeBrowserCell" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="162" width="250" height="241"/>
+                                        <rect key="frame" x="0.0" y="163" width="250" height="241"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                             <rect key="frame" x="0.0" y="0.0" width="250" height="241"/>
@@ -135,27 +135,27 @@
                                     </collectionViewCell>
                                 </cells>
                                 <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ThemeBrowserHeaderView" id="47y-8d-jwn" userLabel="ThemeBrowserHeaderView" customClass="ThemeBrowserHeaderView" customModule="WordPress" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="162"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="163"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="4cE-G3-dPY">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="162"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="163"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1gq-o6-8td">
-                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="108"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="109"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mll-1k-nOP" userLabel="Header Divider Line">
-                                                            <rect key="frame" x="16" y="8" width="568" height="92"/>
+                                                            <rect key="frame" x="16" y="8" width="568" height="93"/>
                                                             <color key="backgroundColor" red="0.84705883260000003" green="0.88627451660000001" blue="0.91372549530000002" alpha="1" colorSpace="calibratedRGB"/>
                                                         </view>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="U27-29-c8Q">
-                                                            <rect key="frame" x="0.0" y="0.0" width="600" height="108"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="600" height="109"/>
                                                             <subviews>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jwo-3t-dLB">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="53.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="54"/>
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QqI-lf-7WU">
-                                                                            <rect key="frame" x="15" y="28" width="40" height="17"/>
+                                                                            <rect key="frame" x="15" y="29" width="40" height="17"/>
                                                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                                             <nil key="highlightedColor"/>
@@ -176,16 +176,16 @@
                                                                     </constraints>
                                                                 </view>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="AFz-WC-4n8">
-                                                                    <rect key="frame" x="0.0" y="54.5" width="600" height="53.5"/>
+                                                                    <rect key="frame" x="0.0" y="55" width="600" height="54"/>
                                                                     <subviews>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IWG-BN-4Em">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="200" height="53.5"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="200" height="54"/>
                                                                             <subviews>
                                                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-customize" translatesAutoresizingMaskIntoConstraints="NO" id="1xR-MV-xJj">
                                                                                     <rect key="frame" x="91" y="8" width="18" height="18"/>
                                                                                 </imageView>
                                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="u2z-nw-Vyc">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="200" height="53"/>
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="200" height="54"/>
                                                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                     <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="-20"/>
                                                                                     <state key="normal" title="Customize">
@@ -207,13 +207,13 @@
                                                                             </constraints>
                                                                         </view>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JzW-Fm-uZ0">
-                                                                            <rect key="frame" x="200" y="0.0" width="200" height="53.5"/>
+                                                                            <rect key="frame" x="200" y="0.0" width="200" height="54"/>
                                                                             <subviews>
                                                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-details" translatesAutoresizingMaskIntoConstraints="NO" id="ujm-Fw-DZX">
                                                                                     <rect key="frame" x="91" y="8" width="18" height="18"/>
                                                                                 </imageView>
                                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6BA-aY-mOt">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="200" height="53"/>
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="200" height="54"/>
                                                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                     <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="-20"/>
                                                                                     <state key="normal" title="Details">
@@ -235,13 +235,13 @@
                                                                             </constraints>
                                                                         </view>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ufe-0H-S8G">
-                                                                            <rect key="frame" x="400" y="0.0" width="200" height="53.5"/>
+                                                                            <rect key="frame" x="400" y="0.0" width="200" height="54"/>
                                                                             <subviews>
                                                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-support" translatesAutoresizingMaskIntoConstraints="NO" id="xKH-00-3XD">
                                                                                     <rect key="frame" x="91" y="8" width="18" height="18"/>
                                                                                 </imageView>
                                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iix-Pu-kKG">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="200" height="53"/>
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="200" height="54"/>
                                                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                     <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="-20"/>
                                                                                     <state key="normal" title="Support">
@@ -287,7 +287,7 @@
                                                     </variation>
                                                 </view>
                                                 <view contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QcA-Am-6I5">
-                                                    <rect key="frame" x="0.0" y="108" width="600" height="53"/>
+                                                    <rect key="frame" x="0.0" y="109" width="600" height="53"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vOP-ZF-qi0" userLabel="Above Search Line">
                                                             <rect key="frame" x="0.0" y="0.0" width="600" height="1"/>
@@ -317,7 +317,7 @@
                                                     </constraints>
                                                 </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mCK-BA-lBb" userLabel="Below Search Line">
-                                                    <rect key="frame" x="0.0" y="161" width="600" height="1"/>
+                                                    <rect key="frame" x="0.0" y="162" width="600" height="1"/>
                                                     <color key="backgroundColor" red="0.84705883264541626" green="0.88627451658248901" blue="0.91372549533843994" alpha="1" colorSpace="calibratedRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="4dN-RY-rvY"/>
@@ -348,7 +348,7 @@
                                     </connections>
                                 </collectionReusableView>
                                 <collectionReusableView key="sectionFooterView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ThemeBrowserFooterView" id="Mhx-tS-Lea" userLabel="ThemeBrowserFooterView">
-                                    <rect key="frame" x="0.0" y="403" width="600" height="50"/>
+                                    <rect key="frame" x="0.0" y="404" width="600" height="50"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Va9-Te-cqS">

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowser.storyboard
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowser.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="CnL-S6-q9U">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="CnL-S6-q9U">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
@@ -142,17 +142,17 @@
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="162"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1gq-o6-8td">
-                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="107"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="108"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mll-1k-nOP" userLabel="Header Divider Line">
-                                                            <rect key="frame" x="16" y="8" width="568" height="91"/>
+                                                            <rect key="frame" x="16" y="8" width="568" height="92"/>
                                                             <color key="backgroundColor" red="0.84705883260000003" green="0.88627451660000001" blue="0.91372549530000002" alpha="1" colorSpace="calibratedRGB"/>
                                                         </view>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="U27-29-c8Q">
-                                                            <rect key="frame" x="0.0" y="0.0" width="600" height="107"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="600" height="108"/>
                                                             <subviews>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jwo-3t-dLB">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="53"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="53.5"/>
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QqI-lf-7WU">
                                                                             <rect key="frame" x="15" y="28" width="40" height="17"/>
@@ -176,10 +176,10 @@
                                                                     </constraints>
                                                                 </view>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="AFz-WC-4n8">
-                                                                    <rect key="frame" x="0.0" y="54" width="600" height="53"/>
+                                                                    <rect key="frame" x="0.0" y="54.5" width="600" height="53.5"/>
                                                                     <subviews>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IWG-BN-4Em">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="200" height="53"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="200" height="53.5"/>
                                                                             <subviews>
                                                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-customize" translatesAutoresizingMaskIntoConstraints="NO" id="1xR-MV-xJj">
                                                                                     <rect key="frame" x="91" y="8" width="18" height="18"/>
@@ -207,7 +207,7 @@
                                                                             </constraints>
                                                                         </view>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JzW-Fm-uZ0">
-                                                                            <rect key="frame" x="200" y="0.0" width="200" height="53"/>
+                                                                            <rect key="frame" x="200" y="0.0" width="200" height="53.5"/>
                                                                             <subviews>
                                                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-details" translatesAutoresizingMaskIntoConstraints="NO" id="ujm-Fw-DZX">
                                                                                     <rect key="frame" x="91" y="8" width="18" height="18"/>
@@ -235,7 +235,7 @@
                                                                             </constraints>
                                                                         </view>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ufe-0H-S8G">
-                                                                            <rect key="frame" x="400" y="0.0" width="200" height="53"/>
+                                                                            <rect key="frame" x="400" y="0.0" width="200" height="53.5"/>
                                                                             <subviews>
                                                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-support" translatesAutoresizingMaskIntoConstraints="NO" id="xKH-00-3XD">
                                                                                     <rect key="frame" x="91" y="8" width="18" height="18"/>
@@ -286,45 +286,34 @@
                                                         </mask>
                                                     </variation>
                                                 </view>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vOP-ZF-qi0" userLabel="Above Search Line">
-                                                    <rect key="frame" x="0.0" y="107" width="600" height="1"/>
-                                                    <color key="backgroundColor" red="0.84705883264541626" green="0.88627451658248901" blue="0.91372549533843994" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="1" id="Cy1-Ly-r0w"/>
-                                                    </constraints>
-                                                </view>
                                                 <view contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QcA-Am-6I5">
                                                     <rect key="frame" x="0.0" y="108" width="600" height="53"/>
                                                     <subviews>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="fzn-G2-C1L">
-                                                            <rect key="frame" x="0.0" y="0.0" width="600" height="53"/>
-                                                            <subviews>
-                                                                <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="800" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gVo-ti-m3S">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="104" height="53"/>
-                                                                    <inset key="contentEdgeInsets" minX="15" minY="0.0" maxX="15" maxY="0.0"/>
-                                                                    <state key="normal" title="Button" image="theme-type-chevron"/>
-                                                                    <connections>
-                                                                        <action selector="didTapSearchTypeButton:" destination="47y-8d-jwn" eventType="touchUpInside" id="VDa-tX-HhH"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="85U-8E-CJ7">
-                                                                    <rect key="frame" x="548" y="0.0" width="52" height="53"/>
-                                                                    <inset key="contentEdgeInsets" minX="15" minY="0.0" maxX="15" maxY="0.0"/>
-                                                                    <state key="normal" image="icon-post-search-highlight"/>
-                                                                    <connections>
-                                                                        <action selector="didTapSearchButton:" destination="CnL-S6-q9U" eventType="touchUpInside" id="Way-Mk-5nO"/>
-                                                                    </connections>
-                                                                </button>
-                                                            </subviews>
-                                                        </stackView>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vOP-ZF-qi0" userLabel="Above Search Line">
+                                                            <rect key="frame" x="0.0" y="0.0" width="600" height="1"/>
+                                                            <color key="backgroundColor" red="0.84705883264541626" green="0.88627451658248901" blue="0.91372549533843994" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="1" id="Cy1-Ly-r0w"/>
+                                                            </constraints>
+                                                        </view>
+                                                        <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="800" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gVo-ti-m3S">
+                                                            <rect key="frame" x="0.0" y="0.0" width="104" height="53"/>
+                                                            <inset key="contentEdgeInsets" minX="15" minY="0.0" maxX="15" maxY="0.0"/>
+                                                            <state key="normal" title="Button" image="theme-type-chevron"/>
+                                                            <connections>
+                                                                <action selector="didTapSearchTypeButton:" destination="47y-8d-jwn" eventType="touchUpInside" id="KOw-UF-IYA"/>
+                                                            </connections>
+                                                        </button>
                                                     </subviews>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
-                                                        <constraint firstItem="fzn-G2-C1L" firstAttribute="top" secondItem="QcA-Am-6I5" secondAttribute="top" id="1tx-Ok-8mh"/>
-                                                        <constraint firstItem="fzn-G2-C1L" firstAttribute="leading" secondItem="QcA-Am-6I5" secondAttribute="leading" id="8hC-Pa-jR4"/>
+                                                        <constraint firstItem="vOP-ZF-qi0" firstAttribute="leading" secondItem="QcA-Am-6I5" secondAttribute="leading" id="FmJ-BZ-l2a"/>
                                                         <constraint firstAttribute="height" constant="53" id="STF-gH-eRR"/>
-                                                        <constraint firstAttribute="trailing" secondItem="fzn-G2-C1L" secondAttribute="trailing" id="s07-VR-hlE"/>
-                                                        <constraint firstAttribute="bottom" secondItem="fzn-G2-C1L" secondAttribute="bottom" id="w2Y-Kx-Urt"/>
+                                                        <constraint firstItem="gVo-ti-m3S" firstAttribute="leading" secondItem="QcA-Am-6I5" secondAttribute="leading" id="TRA-S7-L1m"/>
+                                                        <constraint firstAttribute="bottom" secondItem="gVo-ti-m3S" secondAttribute="bottom" id="X0e-Hw-ADy"/>
+                                                        <constraint firstAttribute="trailing" secondItem="vOP-ZF-qi0" secondAttribute="trailing" id="iEj-bD-daP"/>
+                                                        <constraint firstItem="vOP-ZF-qi0" firstAttribute="top" secondItem="QcA-Am-6I5" secondAttribute="top" id="iOq-ip-cjc"/>
+                                                        <constraint firstItem="gVo-ti-m3S" firstAttribute="top" secondItem="QcA-Am-6I5" secondAttribute="top" id="jIm-dr-Or2"/>
                                                     </constraints>
                                                 </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mCK-BA-lBb" userLabel="Below Search Line">
@@ -352,11 +341,10 @@
                                         <outlet property="customizeButton" destination="u2z-nw-Vyc" id="1gk-tM-uLp"/>
                                         <outlet property="detailsButton" destination="6BA-aY-mOt" id="LAT-yo-MX8"/>
                                         <outlet property="searchBar" destination="QcA-Am-6I5" id="erh-Ff-XFp"/>
-                                        <outlet property="searchButton" destination="85U-8E-CJ7" id="kU6-YP-GJa"/>
                                         <outlet property="searchTypeButton" destination="gVo-ti-m3S" id="ubO-fe-9XS"/>
                                         <outlet property="supportButton" destination="iix-Pu-kKG" id="0Sd-aS-Nyg"/>
-                                        <outletCollection property="searchBarBorders" destination="vOP-ZF-qi0" collectionClass="NSMutableArray" id="pzf-Gb-tmO"/>
                                         <outletCollection property="searchBarBorders" destination="mCK-BA-lBb" collectionClass="NSMutableArray" id="tib-Ny-Vrf"/>
+                                        <outletCollection property="searchBarBorders" destination="vOP-ZF-qi0" collectionClass="NSMutableArray" id="pzf-Gb-tmO"/>
                                     </connections>
                                 </collectionReusableView>
                                 <collectionReusableView key="sectionFooterView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ThemeBrowserFooterView" id="Mhx-tS-Lea" userLabel="ThemeBrowserFooterView">
@@ -402,7 +390,6 @@
     </scenes>
     <resources>
         <image name="icon-menu-ellipsis" width="24" height="24"/>
-        <image name="icon-post-search-highlight" width="22" height="22"/>
         <image name="theme-customize" width="18" height="18"/>
         <image name="theme-details" width="18" height="18"/>
         <image name="theme-support" width="18" height="18"/>

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
@@ -20,9 +20,9 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
     @IBOutlet weak var customizeButton: UIButton!
     @IBOutlet weak var detailsButton: UIButton!
     @IBOutlet weak var supportButton: UIButton!
-    @IBOutlet var searchBarBorders: [UIView]!
-    @IBOutlet weak var searchBar: UIView!
-    @IBOutlet weak var searchTypeButton: UIButton!
+    @IBOutlet var filterBarBorders: [UIView]!
+    @IBOutlet weak var filterBar: UIView!
+    @IBOutlet weak var filterTypeButton: UIButton!
 
     // MARK: - Properties
 
@@ -31,9 +31,9 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
             currentThemeName.text = theme?.name
         }
     }
-    private var searchType: ThemeType = .All {
+    private var filterType: ThemeType = .All {
         didSet {
-            Styles.styleSearchTypeButton(searchTypeButton, title: searchType.title)
+            Styles.styleSearchTypeButton(filterTypeButton, title: filterType.title)
         }
     }
     public weak var presenter: ThemePresenter? {
@@ -42,9 +42,9 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
                 theme = presenter.currentTheme()
 
                 if ThemeType.mayPurchase {
-                    searchType = presenter.searchType
+                    filterType = presenter.filterType
                 } else {
-                    searchBar.hidden = true
+                    filterBar.hidden = true
                 }
             }
         }
@@ -55,7 +55,7 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
     override public func awakeFromNib() {
         super.awakeFromNib()
 
-        let buttons = [customizeButton, detailsButton, supportButton, searchTypeButton]
+        let buttons = [customizeButton, detailsButton, supportButton, filterTypeButton]
         buttons.forEach { $0.exclusiveTouch = true }
 
         applyStyles()
@@ -75,8 +75,8 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
         let currentThemeButtons = [customizeButton, detailsButton, supportButton]
         currentThemeButtons.forEach { Styles.styleCurrentThemeButton($0) }
 
-        searchBar.backgroundColor = Styles.searchBarBackgroundColor
-        searchBarBorders.forEach { $0.backgroundColor = Styles.searchBarBorderColor }
+        filterBar.backgroundColor = Styles.searchBarBackgroundColor
+        filterBarBorders.forEach { $0.backgroundColor = Styles.searchBarBorderColor }
     }
 
     private func setTextForLabels() {
@@ -106,13 +106,13 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
         presenter?.presentSupportForTheme(theme)
     }
 
-    private func updateSearchType(type: ThemeType) {
-        guard type != self.searchType else {
+    private func updateFilterType(type: ThemeType) {
+        guard type != filterType else {
             return
         }
 
-        self.searchType = type
-        self.presenter?.searchType = type
+        filterType = type
+        presenter?.filterType = type
     }
 
     @IBAction func didTapSearchTypeButton(sender: UIButton) {
@@ -123,14 +123,14 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
             alertController.addActionWithTitle(type.title,
                 style: .Default,
                 handler: { [weak self] (action: UIAlertAction) in
-                    self?.updateSearchType(type)
+                    self?.updateFilterType(type)
             })
         }
 
         alertController.modalPresentationStyle = .Popover
         if let popover = alertController.popoverPresentationController {
-            popover.sourceView = searchTypeButton
-            popover.sourceRect = searchTypeButton.bounds
+            popover.sourceView = filterTypeButton
+            popover.sourceRect = filterTypeButton.bounds
             popover.permittedArrowDirections = .Any
             popover.canOverlapSourceViewRect = true
         }

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
@@ -22,7 +22,6 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
     @IBOutlet weak var supportButton: UIButton!
     @IBOutlet var searchBarBorders: [UIView]!
     @IBOutlet weak var searchBar: UIView!
-    @IBOutlet weak var searchButton: UIButton!
     @IBOutlet weak var searchTypeButton: UIButton!
 
     // MARK: - Properties
@@ -45,7 +44,7 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
                 if ThemeType.mayPurchase {
                     searchType = presenter.searchType
                 } else {
-                    searchTypeButton.hidden = true
+                    searchBar.hidden = true
                 }
             }
         }
@@ -56,7 +55,7 @@ public class ThemeBrowserHeaderView: UICollectionReusableView
     override public func awakeFromNib() {
         super.awakeFromNib()
 
-        let buttons = [customizeButton, detailsButton, supportButton, searchButton, searchTypeButton]
+        let buttons = [customizeButton, detailsButton, supportButton, searchTypeButton]
         buttons.forEach { $0.exclusiveTouch = true }
 
         applyStyles()

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -46,7 +46,7 @@ public enum ThemeType
  */
 public protocol ThemePresenter: class
 {
-    var searchType: ThemeType { get set }
+    var filterType: ThemeType { get set }
 
     var screenshotWidth: Int { get }
 
@@ -124,9 +124,9 @@ public protocol ThemePresenter: class
         return !suspendedSearch.trim().isEmpty
     }
 
-    public var searchType: ThemeType = ThemeType.mayPurchase ? .All : .Free {
+    public var filterType: ThemeType = ThemeType.mayPurchase ? .All : .Free {
         didSet {
-            if searchType != oldValue {
+            if filterType != oldValue {
                 fetchThemes()
                 reloadThemes()
             }
@@ -630,7 +630,7 @@ public protocol ThemePresenter: class
     private func browsePredicate() -> NSPredicate? {
         let blogPredicate = NSPredicate(format: "blog == %@", self.blog)
 
-        let subpredicates = [blogPredicate, searchNamePredicate(), searchType.predicate].flatMap { $0 }
+        let subpredicates = [blogPredicate, searchNamePredicate(), filterType.predicate].flatMap { $0 }
         switch subpredicates.count {
         case 1:
             return subpredicates[0]

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -76,6 +76,8 @@ public protocol ThemePresenter: class
     @IBOutlet weak var searchWrapperView: UIView!
     @IBOutlet weak var searchWrapperViewHeightConstraint: NSLayoutConstraint!
 
+    private var searchButton: UIBarButtonItem!
+
     /**
      *  @brief      The FRC this VC will use to display filtered content.
      */
@@ -216,9 +218,18 @@ public protocol ThemePresenter: class
         sections = themesCount == 0 ? [.Themes] : [.Info, .Themes]
 
         configureSearchController()
+        configureSearchButton()
 
         updateActiveTheme()
         setupSyncHelper()
+    }
+
+    private func configureSearchButton() {
+        searchButton = UIBarButtonItem(image: UIImage.init(named: "icon-post-search"),
+                                       style: .Plain,
+                                       target: self,
+                                       action: #selector(didTapSearchButton))
+        navigationItem.rightBarButtonItem = searchButton
     }
 
     private func configureSearchController() {
@@ -508,7 +519,7 @@ public protocol ThemePresenter: class
             return CGSize.zero
         }
         let horizontallyCompact = traitCollection.horizontalSizeClass == .Compact
-        let height = Styles.headerHeight(horizontallyCompact)
+        let height = Styles.headerHeight(horizontallyCompact, includingSearchBar: ThemeType.mayPurchase)
 
         return CGSize(width: 0, height: height)
     }
@@ -538,7 +549,7 @@ public protocol ThemePresenter: class
 
     // MARK: - Search support
 
-    @IBAction func didTapSearchButton(sender: UIButton) {
+    @objc func didTapSearchButton(sender: UIButton) {
         WPAppAnalytics.track(.ThemesAccessedSearch, withBlog: self.blog)
         beginSearchFor("", animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
+++ b/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
@@ -69,8 +69,11 @@ extension WPStyleGuide
         public static let currentBarSeparator: CGFloat = 1
         public static let searchBarHeight: CGFloat = 53
 
-        public static func headerHeight(horizontallyCompact: Bool) -> CGFloat {
-            var headerHeight = searchBarHeight + (currentBarSeparator * 2)
+        public static func headerHeight(horizontallyCompact: Bool, includingSearchBar: Bool) -> CGFloat {
+            var headerHeight = (currentBarSeparator * 2)
+            if (includingSearchBar) {
+                headerHeight += searchBarHeight
+            }
             if (horizontallyCompact) {
                 headerHeight += (currentBarLineHeight * 2) + currentBarSeparator
             } else {


### PR DESCRIPTION
Fixes #5539

This PR resolves the blank space in themes that used to hold both search and the drop down for selecting free/premium/all. The dropdown was hidden and no longer seen/available leaving an empty search area which has now been moved to a search icon button item in the top-right. Additionally, a few methods were renamed to account for the space being about filtering rather than searching.

Note: The original space and dropdown is available in code, in case we ever bring it back, but hardcoded as disabled and without the search button.

To test:

1. Open Themes on a .com site with admin rights.
2. Hit the search icon in the top right, the search bar should display as normal, in the header.
3. 🏁 

Needs review: @nheagy can you take a look?
