### PR TITLE
People Management: Viewers Data Model

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,6 +5,9 @@ data model as well as any custom migrations.
 
 ## WordPress 50
 
+- @jleandroperez 2016-06-21
+- `Person` removed `isFollower` property.
+- `Person` added `kind` Int16 attribute.
 - @aerych 2016-05-26
 - Added `ReaderSearchSuggestion` entity. Represents a search in the reader.
 - @aerych 2016-05-31

--- a/WordPress/Classes/Models/ManagedPerson+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/ManagedPerson+CoreDataProperties.swift
@@ -14,5 +14,5 @@ extension ManagedPerson {
     @NSManaged var linkedUserID: Int64
     @NSManaged var username: String
     @NSManaged var isSuperAdmin: Bool
-    @NSManaged var isFollower: Bool
+    @NSManaged var kind: Int16
 }

--- a/WordPress/Classes/Models/ManagedPerson.swift
+++ b/WordPress/Classes/Models/ManagedPerson.swift
@@ -5,7 +5,7 @@ import CoreData
 //
 class ManagedPerson: NSManagedObject {
 
-    func updateWith(person: Person) {
+    func updateWith<T : Person>(person: T) {
         avatarURL = person.avatarURL?.absoluteString
         displayName = person.displayName
         firstName = person.firstName
@@ -16,14 +16,15 @@ class ManagedPerson: NSManagedObject {
         linkedUserID = Int64(person.linkedUserID)
         username = person.username
         isSuperAdmin = person.isSuperAdmin
-        isFollower = person.dynamicType.isFollower
+        kind = Int16(person.dynamicType.kind.rawValue)
     }
 
     func toUnmanaged() -> Person {
-        if isFollower {
+        switch Int(kind) {
+        case PersonKind.User.rawValue:
+            return User(managedPerson: self)
+        default:
             return Follower(managedPerson: self)
         }
-
-        return User(managedPerson: self)
     }
 }

--- a/WordPress/Classes/Models/Person.swift
+++ b/WordPress/Classes/Models/Person.swift
@@ -19,6 +19,10 @@ protocol Person {
     var isSuperAdmin: Bool { get }
     var fullName: String { get }
 
+    /// Static Properties
+    ///
+    static var kind: PersonKind { get }
+
     /// Initializers
     ///
     init(ID: Int,
@@ -47,6 +51,13 @@ enum Role: String, Comparable, Equatable, CustomStringConvertible {
     case Unsupported    = "unsupported"
 }
 
+// MARK: - Specifies all of the possible Person Types that might exist.
+//
+enum PersonKind: Int {
+    case User           = 0
+    case Follower       = 1
+}
+
 // MARK: - Defines a Blog's User
 //
 struct User: Person {
@@ -60,6 +71,7 @@ struct User: Person {
     let linkedUserID: Int
     let avatarURL: NSURL?
     let isSuperAdmin: Bool
+    static let kind = PersonKind.User
 }
 
 // MARK: - Defines a Blog's Follower
@@ -75,6 +87,7 @@ struct Follower: Person {
     let linkedUserID: Int
     let avatarURL: NSURL?
     let isSuperAdmin: Bool
+    static let kind = PersonKind.Follower
 }
 
 // MARK: - Extensions
@@ -86,10 +99,6 @@ extension Person {
         let separator = (first.isEmpty == false && last.isEmpty == false) ? " " : ""
 
         return "\(first)\(separator)\(last)"
-    }
-
-    static var isFollower: Bool {
-        return self == Follower.self
     }
 }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -47,8 +47,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
     /// Filter Predicate
     ///
     private var predicate: NSPredicate {
-        let follower = self.filter == .Followers
-        let predicate = NSPredicate(format: "siteID = %@ AND isFollower = %@", self.blog!.dotComID!, follower)
+        let predicate = NSPredicate(format: "siteID = %@ AND kind = %@", blog!.dotComID!, NSNumber(integer: filter.personKind.rawValue))
         return predicate
     }
 
@@ -343,7 +342,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
 
 
 
-    // MARK: - Private Structs
+    // MARK: - Private Enums
 
     private enum Filter : String {
         case Users      = "team"
@@ -358,11 +357,17 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
             }
         }
 
+        var personKind: PersonKind {
+            switch self {
+            case .Users:
+                return .User
+            case .Followers:
+                return .Follower
+            }
+        }
+
         static let allFilters = [Filter.Users, .Followers]
     }
-
-
-    // MARK: - Constants
 
     private enum RestorationKeys {
         static let blog = "peopleBlogRestorationKey"

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 50.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 50.xcdatamodel/contents
@@ -395,8 +395,8 @@
         <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="displayName" attributeType="String" syncable="YES"/>
         <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="isFollower" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="isSuperAdmin" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
+        <attribute name="kind" optional="YES" attributeType="Integer 16" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="linkedUserID" optional="YES" attributeType="Integer 64" defaultValueString="0" syncable="YES"/>
         <attribute name="role" attributeType="String" syncable="YES"/>
@@ -655,6 +655,7 @@
         <element name="ReaderGapMarker" positionX="18" positionY="153" width="128" height="45"/>
         <element name="ReaderListTopic" positionX="45" positionY="189" width="128" height="135"/>
         <element name="ReaderPost" positionX="0" positionY="0" width="128" height="630"/>
+        <element name="ReaderSearchSuggestion" positionX="36" positionY="162" width="128" height="75"/>
         <element name="ReaderSearchTopic" positionX="27" positionY="153" width="128" height="45"/>
         <element name="ReaderSite" positionX="9" positionY="153" width="128" height="163"/>
         <element name="ReaderSiteTopic" positionX="36" positionY="180" width="128" height="195"/>
@@ -662,6 +663,5 @@
         <element name="SharingButton" positionX="27" positionY="153" width="128" height="165"/>
         <element name="SourcePostAttribution" positionX="9" positionY="153" width="128" height="225"/>
         <element name="Theme" positionX="9" positionY="153" width="128" height="330"/>
-        <element name="ReaderSearchSuggestion" positionX="36" positionY="162" width="128" height="75"/>
     </elements>
 </model>


### PR DESCRIPTION
#### Details:
This PR doesn't really add new functionality. Several minor changes were introduced, as a requirement to implement the  `Site Viewers` feature.

- `Person` Core Data entity looses the `isFollower` attribute, and gains the `kind` attribute
- PeopleService / Person / PeopleViewController got updated accordingly.

Please, log into a WordPress.com and:
- Open `My Sites` > `Site`
- Verify that the People tab works as expected (view Users / Followers, send an invitation).

@aerych may i bother you with a (hopefully brief) PR?
Thanks in advance sir!

Ref. #5585
