### PR TITLE
Check self-hosted credentials using the WordPressOrgXMLRPCApi class.

### DIFF
--- a/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
+++ b/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
@@ -39,7 +39,21 @@ public class WordPressOrgXMLRPCApi: NSObject
     }
 
     //MARK: - Network requests
+    /**
+     Check if username and password are valid credentials for the xmlrpc endpoint.
 
+     - parameter username: username to check
+     - parameter password: password to check
+     - parameter success:  callback block to be invoked if credentials are valid, the object returned in the block is the options dictionary for the site.
+     - parameter failure:  callback block to be invoked is credentials fail
+     */
+    public func checkCredentials(username: String,
+                                 password: String,
+                                 success: SuccessResponseBlock,
+                                 failure: FailureReponseBlock) {
+        let parameters:[AnyObject] = [0, username, password]
+        callMethod("wp.getOptions", parameters: parameters, success: success, failure: failure)
+    }
     /**
      Executes a XMLRPC call for the method specificied with the arguments provided.
 


### PR DESCRIPTION
Refs #5245 

To test:
 - Add a self-hosted site to the app
 - Go to Blog -> Settings
 - Try to change the password to a invalid one.
 - Check if error message shows up
 - Go to the web and change the password for the site
 - Now in the app try to update the password to the new one.
 - Check if success message shows up.

Needs review: @jleandroperez 
