### PR TITLE
Remove Single Sign On code.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -364,7 +364,6 @@ int ddLogLevel = DDLogLevelInfo;
     // Networking setup
     [[AFNetworkActivityIndicatorManager sharedManager] setEnabled:YES];
     [WPUserAgent useWordPressUserAgentInUIWebViews];
-    [self setupSingleSignOn];
 
     // WORKAROUND: Preload the Merriweather regular font to ensure it is not overridden
     // by any of the Merriweather varients.  Size is arbitrary.
@@ -658,17 +657,6 @@ int ddLogLevel = DDLogLevelInfo;
 
 #pragma mark - Networking setup
 
-- (void)setupSingleSignOn
-{
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-    WPComOAuthController *oAuthController = [WPComOAuthController sharedController];
-    
-    [oAuthController setWordPressComUsername:defaultAccount.username];
-    [oAuthController setWordPressComAuthToken:defaultAccount.authToken];
-}
-
 - (void)setupReachability
 {
     // Setup Reachability
@@ -931,7 +919,6 @@ int ddLogLevel = DDLogLevelInfo;
     
     [self create3DTouchShortcutItems];
     [self toggleExtraDebuggingIfNeeded];
-    [self setupSingleSignOn];
     
     [WPAnalytics track:WPAnalyticsStatDefaultAccountChanged];
 }


### PR DESCRIPTION
Refs #5245 

To test:
 - Sign in the app with a WP.com account.
 - Log out
 - Sign in with another account.


Needs review: @jleandroperez 
