### PR TITLE
Added a 'fling' gesture to WPImageViewController.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -2,18 +2,20 @@
 
 #import <AFNetworking/UIKit+AFNetworking.h>
 #import "WordPressAppDelegate.h"
-
+#import "WordPress-Swift.h"
 
 static CGFloat const MaximumZoomScale = 4.0;
 static CGFloat const MinimumZoomScale = 0.1;
 
-@interface WPImageViewController ()<UIScrollViewDelegate>
+@interface WPImageViewController ()<UIScrollViewDelegate, FlingableViewHandlerDelegate>
 
 @property (nonatomic, assign) BOOL isLoadingImage;
 @property (nonatomic, strong) UIScrollView *scrollView;
 @property (nonatomic, strong) UIImageView *imageView;
 @property (nonatomic, assign) BOOL shouldHideStatusBar;
 @property (nonatomic, strong) UIActivityIndicatorView *activityIndicatorView;
+
+@property (nonatomic) FlingableViewHandler *flingableViewHandler;
 
 @end
 
@@ -69,7 +71,10 @@ static CGFloat const MinimumZoomScale = 0.1;
     [tgr1 setNumberOfTapsRequired:1];
     [tgr1 requireGestureRecognizerToFail:tgr2];
     [self.scrollView addGestureRecognizer:tgr1];
-    
+
+    self.flingableViewHandler = [[FlingableViewHandler alloc] initWithTargetView:self.scrollView];
+    self.flingableViewHandler.delegate = self;
+
     self.activityIndicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhiteLarge];
     self.activityIndicatorView.color = [WPStyleGuide greyDarken30];
     self.activityIndicatorView.hidesWhenStopped = YES;
@@ -215,6 +220,9 @@ static CGFloat const MinimumZoomScale = 0.1;
     }
 
     self.imageView.frame = frame;
+
+    // Only allow the flinging gesture if we're zoomed all the way out
+    self.flingableViewHandler.isActive = (scrollView.zoomScale == scrollView.minimumZoomScale);
 }
 
 #pragma mark - Status bar management
@@ -254,6 +262,24 @@ static CGFloat const MinimumZoomScale = 0.1;
     }
     
     return NO;
+}
+
+#pragma mark - FlingableViewHandlerDelegate
+
+- (void)flingableViewHandlerDidBeginRecognizingGesture:(FlingableViewHandler *)handler
+{
+    self.scrollView.multipleTouchEnabled = NO;
+}
+
+- (void)flingableViewHandlerDidEndRecognizingGesture:(FlingableViewHandler *)handler {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self dismissViewControllerAnimated:YES completion:nil];
+    });
+}
+
+- (void)flingableViewHandlerWasCancelled:(FlingableViewHandler *)handler
+{
+    self.scrollView.multipleTouchEnabled = YES;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/System/FlingableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/System/FlingableViewHandler.swift
@@ -94,7 +94,7 @@ class FlingableViewHandler: NSObject {
     private func makeAttachmentBehaviorForRecognizer(recognizer: UIGestureRecognizer, inView view: UIView) -> UIAttachmentBehavior {
         let location = recognizer.locationInView(view)
 
-        let (centerX, centerY) = (view.bounds.width / 2.0, view.bounds.height / 2.0)
+        let (centerX, centerY) = (round(view.bounds.width / 2.0), round(view.bounds.height / 2.0))
         let offset = UIOffset(horizontal: location.x - centerX, vertical: location.y - centerY)
 
         let anchor = recognizer.locationInView(animator.referenceView)

--- a/WordPress/Classes/ViewRelated/System/FlingableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/System/FlingableViewHandler.swift
@@ -1,0 +1,164 @@
+import UIKit
+
+@objc
+protocol FlingableViewHandlerDelegate {
+    optional func flingableViewHandlerDidBeginRecognizingGesture(handler: FlingableViewHandler)
+    optional func flingableViewHandlerDidEndRecognizingGesture(handler: FlingableViewHandler)
+    optional func flingableViewHandlerWasCancelled(handler: FlingableViewHandler)
+}
+
+class FlingableViewHandler: NSObject {
+    /// The velocity at which the target view must be flung before it detaches.
+    // Default value found through trial and error.
+    var escapeVelocity: CGFloat = 1500
+
+    /// The amount of oscillation when the view snaps back to its original position
+    /// Default is 0.8. 0.0 for no oscillation, 1.0 for max.
+    var snapDamping: CGFloat = 0.8
+
+    /// Used to 'slow down' the fling velocity when the user releases their finger
+    /// in horizontally or vertically compact views, otherwise the view feels
+    /// like it's moving far too quickly.
+    var flingVelocityScaleFactorForCompactTraits: CGFloat = 5.0
+
+    var isActive = false {
+        didSet {
+            panGestureRecognizer.enabled = isActive
+        }
+    }
+
+    var delegate: FlingableViewHandlerDelegate?
+
+    private let animator: UIDynamicAnimator
+    private var attachmentBehavior: UIAttachmentBehavior!
+    private var panGestureRecognizer: UIPanGestureRecognizer!
+
+    // Used to restore the target view to its original position if the gesture is cancelled
+    private var initialCenter: CGPoint? = nil
+
+    /// - parameter targetView: The view that can be flung.
+    init(targetView: UIView) {
+        precondition(targetView.superview != nil, "The target view must have a superview!")
+
+        animator = UIDynamicAnimator(referenceView: targetView.superview!)
+
+        super.init()
+
+        panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
+        targetView.addGestureRecognizer(panGestureRecognizer)
+        isActive = true
+    }
+
+    @objc
+    private func handlePanGesture(recognizer: UIPanGestureRecognizer) {
+        guard isActive else { return }
+        guard let view = recognizer.view,
+              let referenceView = animator.referenceView else { return }
+
+        switch recognizer.state {
+        case .Began:
+            delegate?.flingableViewHandlerDidBeginRecognizingGesture?(self)
+
+            animator.removeAllBehaviors()
+
+            // Keep track of the view's initial position so we can restore it later
+            initialCenter = view.center
+
+            attachmentBehavior = makeAttachmentBehaviorForRecognizer(recognizer, inView: view)
+            animator.addBehavior(attachmentBehavior)
+            break
+        case .Changed:
+            let anchor = recognizer.locationInView(referenceView)
+            attachmentBehavior.anchorPoint = anchor
+            break
+        case .Ended, .Cancelled:
+            animator.removeAllBehaviors()
+
+            let magnitude = recognizer.magnitudeInView(referenceView)
+            if magnitude < escapeVelocity {
+                animator.addBehavior(makeSnapBehaviorForView(view))
+
+                delegate?.flingableViewHandlerWasCancelled?(self)
+
+                return
+            }
+
+            let pushBehavior = makePushBehaviorForRecognizer(recognizer, inView: view)
+            animator.addBehavior(pushBehavior)
+            break
+        default:
+            break
+        }
+    }
+
+    private func makeAttachmentBehaviorForRecognizer(recognizer: UIGestureRecognizer, inView view: UIView) -> UIAttachmentBehavior {
+        let location = recognizer.locationInView(view)
+
+        let (centerX, centerY) = (view.bounds.width / 2.0, view.bounds.height / 2.0)
+        let offset = UIOffset(horizontal: location.x - centerX, vertical: location.y - centerY)
+
+        let anchor = recognizer.locationInView(animator.referenceView)
+
+        return UIAttachmentBehavior(item: view,
+                                    offsetFromCenter: offset,
+                                    attachedToAnchor: anchor)
+    }
+
+    private func makeSnapBehaviorForView(view: UIView) -> UISnapBehavior {
+        let snap = UISnapBehavior(item: view, snapToPoint: initialCenter!)
+        snap.damping = snapDamping
+
+        return snap
+    }
+
+    private func makePushBehaviorForRecognizer(recognizer: UIPanGestureRecognizer, inView view: UIView) -> UIPushBehavior {
+        let velocity = recognizer.velocityInView(view)
+        let magnitude = recognizer.magnitudeInView(view)
+
+        let pushBehavior = UIPushBehavior(items: [view], mode: .Instantaneous)
+
+        // Push in the same direction as the user was moving their touch
+        let pushDirection = CGVector(dx: velocity.x, dy: velocity.y)
+        pushBehavior.pushDirection = pushDirection
+
+        // Scale down the magnitude for smaller display sizes
+        let horizontallyCompactTraits = UITraitCollection(horizontalSizeClass: .Compact)
+        let verticallyCompactTraits = UITraitCollection(verticalSizeClass: .Compact)
+
+        if view.traitCollection.containsTraitsInCollection(horizontallyCompactTraits) ||
+            view.traitCollection.containsTraitsInCollection(verticallyCompactTraits) {
+            pushBehavior.magnitude = magnitude / flingVelocityScaleFactorForCompactTraits
+        } else {
+            pushBehavior.magnitude = magnitude
+        }
+
+        // Apply the force at the same offset as the user's touch from the view's center
+        let referenceView = animator.referenceView
+        let location = recognizer.locationInView(referenceView)
+        let center = view.center
+        let offset = UIOffset(horizontal: location.x - center.x, vertical: location.y - center.y)
+        pushBehavior.setTargetOffsetFromCenter(offset , forItem: view)
+
+        // Check for the view leaving the screen
+        pushBehavior.action = { [weak self] in
+            guard let strongSelf = self,
+                  let referenceView = referenceView else { return }
+
+            if !CGRectIntersectsRect(view.frame, referenceView.bounds) {
+                strongSelf.animator.removeAllBehaviors()
+                view.removeFromSuperview()
+
+                strongSelf.delegate?.flingableViewHandlerDidEndRecognizingGesture?(strongSelf)
+            }
+        }
+
+        return pushBehavior
+    }
+}
+
+private extension UIPanGestureRecognizer {
+    func magnitudeInView(view: UIView) -> CGFloat {
+        let velocity = velocityInView(view)
+        return sqrt((velocity.x * velocity.x) + (velocity.y * velocity.y))
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		1724DDC81C60F1200099D273 /* PlanDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1724DDC71C60F1200099D273 /* PlanDetailViewController.swift */; };
 		1724DDCC1C6121D00099D273 /* Plans.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1724DDCB1C6121D00099D273 /* Plans.storyboard */; };
 		172797D91CE5D0CD00CB8057 /* PlansLoadingIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172797D81CE5D0CD00CB8057 /* PlansLoadingIndicatorView.swift */; };
+		171795831D1C65E8002F1EB2 /* FlingableViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171795821D1C65E8002F1EB2 /* FlingableViewHandler.swift */; };
 		173BCE731CEB368A00AE8817 /* DomainsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173BCE721CEB368A00AE8817 /* DomainsListViewController.swift */; };
 		173BCE751CEB369900AE8817 /* Domains.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 173BCE741CEB369900AE8817 /* Domains.storyboard */; };
 		173BCE771CEB3D8200AE8817 /* DomainsServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173BCE761CEB3D8200AE8817 /* DomainsServiceRemote.swift */; };
@@ -1082,6 +1083,7 @@
 		1724DDC71C60F1200099D273 /* PlanDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanDetailViewController.swift; sourceTree = "<group>"; };
 		1724DDCB1C6121D00099D273 /* Plans.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Plans.storyboard; sourceTree = "<group>"; };
 		172797D81CE5D0CD00CB8057 /* PlansLoadingIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlansLoadingIndicatorView.swift; sourceTree = "<group>"; };
+		171795821D1C65E8002F1EB2 /* FlingableViewHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlingableViewHandler.swift; sourceTree = "<group>"; };
 		173BCE721CEB368A00AE8817 /* DomainsListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsListViewController.swift; sourceTree = "<group>"; };
 		173BCE741CEB369900AE8817 /* Domains.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Domains.storyboard; sourceTree = "<group>"; };
 		173BCE761CEB3D8200AE8817 /* DomainsServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsServiceRemote.swift; sourceTree = "<group>"; };
@@ -3405,6 +3407,7 @@
 				FFA9148E1BA6E5170068F8BF /* RotationAwareNavigationViewController.m */,
 				E1DD4CCA1CAE41B800C3863E /* PagedViewController.swift */,
 				E1DD4CCC1CAE41C800C3863E /* PagedViewController.xib */,
+				171795821D1C65E8002F1EB2 /* FlingableViewHandler.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -6039,6 +6042,7 @@
 				082AB9D91C4EEEF4000CA523 /* PostTagService.m in Sources */,
 				E62079E11CF7A61200F5CD46 /* ReaderSearchSuggestionService.swift in Sources */,
 				E1249B4619408D0F0035E895 /* CommentServiceRemoteXMLRPC.m in Sources */,
+				171795831D1C65E8002F1EB2 /* FlingableViewHandler.swift in Sources */,
 				FF3EAE9B1D0036E300CC4939 /* WordPressOrgXMLRPCApi.swift in Sources */,
 				85AD6AEF173CCFDC002CB896 /* WPNUXSecondaryButton.m in Sources */,
 				FFC6ADDD1B56F3D2002F3C84 /* ThemeServiceRemote.m in Sources */,


### PR DESCRIPTION
Adds a 'fling' to dismiss gesture to `WPImageViewController`, like Slack and Tweetbot. 

### To test

* View an image full screen anywhere that `WPImageViewController` is used. Images in the Reader are probably easiest.
* Check that you can still zoom and pan the image. 
* When you're zoomed out you should be able to drag the image. If you fling it hard enough, it'll fly offscreen and be dismissed.
* Check when the app is viewed at different sizes. I changed the velocity slightly at regular vs compact sizes, as it felt a little fast when viewed Regular.
* Let me know if you think it 'feels' right! Compare to Slack and Tweetbot perhaps.

Needs review: @jleandroperez