### PR TITLE
Remove WordPressApi pod.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -49,7 +49,6 @@ abstract_target 'WordPress_Base' do
     pod 'Simperium', '0.8.15'
     pod 'WPMediaPicker', '~> 0.9.2'
     pod 'WordPress-iOS-Editor', '1.6.3'
-    pod 'WordPressApi', '0.4.0'
     pod 'WordPressCom-Analytics-iOS', '0.1.15'
     pod 'WordPressCom-Stats-iOS', '0.7.0'
     pod 'wpxmlrpc', '~> 0.8'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -167,9 +167,6 @@ PODS:
     - WordPressCom-Analytics-iOS (~> 0.1.0)
   - WordPress-iOS-Shared (0.5.9):
     - CocoaLumberjack (~> 2.2.0)
-  - WordPressApi (0.4.0):
-    - AFNetworking (~> 2.6.0)
-    - wpxmlrpc (~> 0.8)
   - WordPressCom-Analytics-iOS (0.1.15)
   - WordPressCom-Stats-iOS (0.7.0):
     - AFNetworking (~> 2.6.0)
@@ -228,7 +225,6 @@ DEPENDENCIES:
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
   - WordPress-iOS-Editor (= 1.6.3)
   - WordPress-iOS-Shared (= 0.5.9)
-  - WordPressApi (= 0.4.0)
   - WordPressCom-Analytics-iOS (= 0.1.15)
   - WordPressCom-Stats-iOS (= 0.7.0)
   - WordPressCom-Stats-iOS/Services (= 0.7.0)
@@ -292,13 +288,12 @@ SPEC CHECKSUMS:
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
   WordPress-iOS-Editor: 42bf4c2466d47da5f4ba7dc15073075948d83bbc
   WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
-  WordPressApi: 483767025bcdab26429b51bfe5171f17d3d30466
   WordPressCom-Analytics-iOS: e1a7111255e98561c4b5a33ef4baa75a68e0d5d3
   WordPressCom-Stats-iOS: d1996675fadd5a2c8548344a40663834898114f3
   WordPressComKit: 6f0c39c3e0af3599cd5244e4ec05192f5e4a7882
   WPMediaPicker: 98356dbf35bfaba0f51aff16d88563babadf24c7
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 1655143c7756aab12e84e5c10aec7726563240cf
+PODFILE CHECKSUM: 8860300b5b827da76001431938288032ee4b0a8d
 
 COCOAPODS: 1.0.1

--- a/WordPress/Classes/Networking/MediaServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteREST.m
@@ -1,7 +1,6 @@
 #import "MediaServiceRemoteREST.h"
 #import "RemoteMedia.h"
 #import "NSDate+WordPressJSON.h"
-#import <WordPressApi/WordPressApi.h>
 #import "WordPress-Swift.h"
 
 const NSInteger WPRestErrorCodeMediaNew = 10;
@@ -144,7 +143,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
             NSError * error = nil;
             if (errorList.count > 0){
                 NSDictionary * errorDictionary = @{NSLocalizedDescriptionKey: errorList[0]};
-                error = [NSError errorWithDomain:WordPressRestApiErrorDomain code:WPRestErrorCodeMediaNew userInfo:errorDictionary];
+                error = [NSError errorWithDomain:WordPressComRestApiErrorDomain code:WordPressComRestApiErrorUploadFailed userInfo:errorDictionary];
             }
             if (failure) {
                 failure(error);

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -22,8 +22,6 @@
 #import "RemotePostType.h"
 #import "PostType.h"
 
-#import <WordPressApi/WordPressApi.h>
-
 NSString *const LastUsedBlogURLDefaultsKey = @"LastUsedBlogURLDefaultsKey";
 NSString *const EditPostViewControllerLastUsedBlogURLOldKey = @"EditPostViewControllerLastUsedBlogURL";
 NSString *const WPComGetFeatures = @"wpcom.getFeatures";

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -11,7 +11,6 @@
 #import "UIImage+Resize.h"
 #import <MobileCoreServices/MobileCoreServices.h>
 #import "WordPress-swift.h"
-#import <WordPressApi/WordPressApi.h>
 #import "WPXMLRPCDecoder.h"
 
 @implementation MediaService

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -11,7 +11,6 @@
 #import "RemoteReaderTopic.h"
 #import "WordPress-Swift.h"
 #import "WPAccount.h"
-#import <WordPressApi/WordPressApi.h>
 
 NSString * const ReaderTopicDidChangeViaUserInteractionNotification = @"ReaderTopicDidChangeViaUserInteractionNotification";
 NSString * const ReaderTopicDidChangeNotification = @"ReaderTopicDidChangeNotification";

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -10,7 +10,6 @@
 #import <Simperium/Simperium.h>
 #import <SVProgressHUD/SVProgressHUD.h>
 #import <UIDeviceIdentifier/UIDeviceHardware.h>
-#import <WordPressApi/WordPressApi.h>
 #import <WordPress_AppbotX/ABX.h>
 #import <WordPressShared/UIImage+Util.h>
 
@@ -178,10 +177,6 @@ int ddLogLevel = DDLogLevelInfo;
     BOOL returnValue = NO;
 
     if ([self.hockey handleOpenURL:url options:options]) {
-        returnValue = YES;
-    }
-
-    if ([WordPressApi handleOpenURL:url]) {
         returnValue = YES;
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import WordPressApi
 import WordPressComAnalytics
 import WordPressShared
 import wpxmlrpc


### PR DESCRIPTION
Refs #5245 
 
Final step to remove WordPressApi pod from the app

To test:
  - Compile the app and check if no warning related to WordPressApi show
  - Test the app with a WP.com and  self-hosted site.


Needs review: @astralbodies 
