### PR TITLE
Fixes Site Settings modal in AbstractPostListViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.h
@@ -4,7 +4,6 @@
 
 @interface SiteSettingsViewController : UITableViewController
 
-@property (nonatomic, assign, readwrite) BOOL isCancellable;
 @property (nonatomic, strong,  readonly) Blog *blog;
 
 - (instancetype)initWithBlog:(Blog *)blog;

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -130,7 +130,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     [self.refreshControl addTarget:self action:@selector(refreshTriggered:) forControlEvents:UIControlEventValueChanged];
 
     if (self.isCancellable) {
-        self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel:)];
+        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(cancel:)];
     }
 
     [self refreshData];
@@ -997,14 +997,8 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 
 - (IBAction)cancel:(id)sender
 {
-    if (self.isCancellable) {
-        [self dismissViewControllerAnimated:YES completion:nil];
-    } else {
-        [self.navigationController popToRootViewControllerAnimated:YES];
-    }
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
-
-
 
 #pragma mark - Discussion
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -129,8 +129,9 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     self.refreshControl = [[UIRefreshControl alloc] init];
     [self.refreshControl addTarget:self action:@selector(refreshTriggered:) forControlEvents:UIControlEventValueChanged];
 
-    if (self.isCancellable) {
-        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(cancel:)];
+    BOOL isFirstViewControllerInNavigationStack = self.navigationController.navigationBar.backItem == nil;
+    if (isFirstViewControllerInNavigationStack) {
+        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(dismiss)];
     }
 
     [self refreshData];
@@ -995,7 +996,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     return [self.blog supports:BlogFeatureWPComRESTAPI] && self.blog.isAdmin;
 }
 
-- (IBAction)cancel:(id)sender
+- (IBAction)dismiss
 {
     [self dismissViewControllerAnimated:YES completion:nil];
 }

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -129,6 +129,10 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     self.refreshControl = [[UIRefreshControl alloc] init];
     [self.refreshControl addTarget:self action:@selector(refreshTriggered:) forControlEvents:UIControlEventValueChanged];
 
+    if (self.isCancellable) {
+        self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancel:)];
+    }
+
     [self refreshData];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -658,7 +658,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
         // bad login/pass combination
         let editSiteViewController = SiteSettingsViewController(blog: blog)
-        editSiteViewController.isCancellable = false
+        editSiteViewController.isCancellable = true
 
         let navController = UINavigationController(rootViewController: editSiteViewController)
         navController.navigationBar.translucent = false

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -658,7 +658,6 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
         // bad login/pass combination
         let editSiteViewController = SiteSettingsViewController(blog: blog)
-        editSiteViewController.isCancellable = true
 
         let navController = UINavigationController(rootViewController: editSiteViewController)
         navController.navigationBar.translucent = false

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -655,7 +655,6 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     func promptForPassword() {
         let message = NSLocalizedString("The username or password stored in the app may be out of date. Please re-enter your password in the settings and try again.", comment: "")
-        WPError.showAlertWithTitle(NSLocalizedString("Unable to Connect", comment: ""), message: message)
 
         // bad login/pass combination
         let editSiteViewController = SiteSettingsViewController(blog: blog)
@@ -667,7 +666,9 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         navController.modalTransitionStyle = .CrossDissolve
         navController.modalPresentationStyle = .FormSheet
 
-        presentViewController(navController, animated: true, completion: nil)
+        WPError.showAlertWithTitle(NSLocalizedString("Unable to Connect", comment: ""), message: message, withSupportButton: true) { _ in
+            self.presentViewController(navController, animated: true, completion: nil)
+        }
     }
 
     // MARK: - Searching


### PR DESCRIPTION
Whilst looking through our uses of modals in the app, I realised that `promptForPassword()` in `AbstractPostListViewController` wasn't working correctly. 

I think it must've been written before `UIAlertController`, as it attempted to present an alert and them immediately afterwards present a view controller. Since view-controller based alerts, the alert is already being displayed and the view controller presentation fails.

I've updated the method to present the site settings VC once the alert has been dismissed.

### To test

To trigger the alert, I faked it by adding the following into the end of the `success` block of `syncHelper(_:syncContentWithUserInteraction:success:failure:)`:

```
let error = NSError(domain: WPXMLRPCFaultErrorDomain, code: strongSelf.dynamicType.HTTPErrorCodeForbidden, userInfo: nil)

failure?(error: error)
strongSelf.handleSyncFailure(error)
```

The site settings lacked a Cancel button (in fact, the original code sets `isCancellable` to false), so it couldn't be dismissed. I've updated things to allow the settings VC to be dismissed via a 'Done' button. I thought Done sounded better than Cancel, because if you've made some changes Cancel sounds like it would undo them (but it wouldn't).

Also note that testing this with the above code doesn't trigger the situation in which `SiteSettingsViewController` would normally show the site's username / password fields.

Needs review: @diegoreymendez Would you do the honours as you Swiftified `AbstractPostListViewController`? Thanks!