### PR TITLE
Stop hiding the status bar on post and page edit.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -795,7 +795,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
         let post = apost.hasRevision() ? apost.revision : apost
 
-        let controller = PostPreviewViewController(post: post, shouldHideStatusBar: false)
+        let controller = PostPreviewViewController(post: post)
         controller.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(controller, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.h
@@ -3,6 +3,6 @@
 
 @interface PostPreviewViewController : UIViewController <UIWebViewDelegate>
 
-- (instancetype)initWithPost:(AbstractPost *)aPost shouldHideStatusBar:(BOOL)shouldHideStatusBar;
+- (instancetype)initWithPost:(AbstractPost *)aPost;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -16,7 +16,6 @@
 @property (nonatomic, strong) UIView *loadingView;
 @property (nonatomic, strong) NSMutableData *receivedData;
 @property (nonatomic, strong) AbstractPost *apost;
-@property (nonatomic, assign) BOOL *shouldHideStatusBar;
 @property (nonatomic, strong) UIBarButtonItem *shareBarButtonItem;
 
 @end
@@ -32,13 +31,12 @@
     self.webView.delegate = nil;
 }
 
-- (instancetype)initWithPost:(AbstractPost *)aPost shouldHideStatusBar:(BOOL)shouldHideStatusBar
+- (instancetype)initWithPost:(AbstractPost *)aPost
 {
     self = [super init];
     if (self) {
         self.apost = aPost;
         self.navigationItem.title = NSLocalizedString(@"Preview", @"Post Editor / Preview screen title.");
-        self.shouldHideStatusBar = shouldHideStatusBar;
     }
     return self;
 }
@@ -352,14 +350,6 @@
 {
     NSArray *comps = [surString componentsSeparatedByString:@"\n"];
     return [comps componentsJoinedByString:@"<br>"];
-}
-
-#pragma mark - Status bar management
-
-- (BOOL)prefersStatusBarHidden
-{
-    // Do not hide status bar on iPad
-    return (self.shouldHideStatusBar && !IS_IPAD);
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
@@ -3,7 +3,7 @@
 
 @interface PostSettingsViewController : UITableViewController
 
-- (instancetype)initWithPost:(AbstractPost *)aPost shouldHideStatusBar:(BOOL)shouldHideStatusBar;
+- (instancetype)initWithPost:(AbstractPost *)aPost;
 - (void)endEditingAction:(id)sender;
 
 @property (nonatomic, strong, readonly) AbstractPost *apost;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -60,7 +60,6 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 @property (nonatomic, strong) UIImage *featuredImage;
 @property (nonatomic, strong) PublishDatePickerView *datePicker;
 @property (assign) BOOL *textFieldDidHaveFocusBeforeOrientationChange;
-@property (nonatomic, assign) BOOL *shouldHideStatusBar;
 @property (nonatomic, assign) BOOL *isUploadingMedia;
 @property (nonatomic, strong) NSProgress *featuredImageProgress;
 @property (nonatomic, strong) WPAndDeviceMediaLibraryDataSource *mediaDataSource;
@@ -91,12 +90,11 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     [self removePostPropertiesObserver];
 }
 
-- (instancetype)initWithPost:(AbstractPost *)aPost shouldHideStatusBar:(BOOL)shouldHideStatusBar
+- (instancetype)initWithPost:(AbstractPost *)aPost
 {
     self = [super initWithStyle:UITableViewStyleGrouped];
     if (self) {
         self.apost = aPost;
-        _shouldHideStatusBar = shouldHideStatusBar;
     }
     return self;
 }
@@ -1227,14 +1225,6 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
 - (void)mediaPickerControllerDidCancel:(WPMediaPickerViewController *)picker {
     [self.navigationController dismissViewControllerAnimated:YES completion:nil];
-}
-
-#pragma mark - Status bar management
-
-- (BOOL)prefersStatusBarHidden
-{
-    // Do not hide the status bar on iPad
-    return self.shouldHideStatusBar && !IS_IPAD;
 }
 
 #pragma mark - PostCategoriesViewControllerDelegate

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -357,7 +357,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 - (void)showSettings
 {
     Post *post = (Post *)self.post;
-    UIViewController *vc = [[[self classForSettingsViewController] alloc] initWithPost:post shouldHideStatusBar:NO];
+    UIViewController *vc = [[[self classForSettingsViewController] alloc] initWithPost:post];
     UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Back", nil) style:UIBarButtonItemStylePlain target:nil action:nil];
     self.navigationItem.backBarButtonItem = backButton;
     [self.navigationController pushViewController:vc animated:YES];
@@ -365,7 +365,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)showPreview
 {
-    PostPreviewViewController *vc = [[PostPreviewViewController alloc] initWithPost:self.post shouldHideStatusBar:NO];
+    PostPreviewViewController *vc = [[PostPreviewViewController alloc] initWithPost:self.post];
     UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Back", nil) style:UIBarButtonItemStylePlain target:nil action:nil];
     self.navigationItem.backBarButtonItem = backButton;
     [self.navigationController pushViewController:vc animated:YES];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -818,7 +818,7 @@ EditImageDetailsViewControllerDelegate
 - (void)showSettings
 {
     Post *post = (Post *)self.post;
-    PostSettingsViewController *vc = [[[self classForSettingsViewController] alloc] initWithPost:post shouldHideStatusBar:YES];
+    PostSettingsViewController *vc = [[[self classForSettingsViewController] alloc] initWithPost:post];
 	vc.hidesBottomBarWhenPushed = YES;
     [self.navigationController pushViewController:vc animated:YES];
 }
@@ -830,7 +830,7 @@ EditImageDetailsViewControllerDelegate
         return;
     }
     
-    PostPreviewViewController *vc = [[PostPreviewViewController alloc] initWithPost:self.post shouldHideStatusBar:self.isEditing];
+    PostPreviewViewController *vc = [[PostPreviewViewController alloc] initWithPost:self.post];
 	vc.hidesBottomBarWhenPushed = YES;
     [self.navigationController pushViewController:vc animated:YES];
 }
@@ -2223,18 +2223,6 @@ EditImageDetailsViewControllerDelegate
 
 
 #pragma mark - Status bar management
-
-- (BOOL)prefersStatusBarHidden
-{
-    /**
-     Never hide for the iPad. 
-     Always hide on the iPhone except when user is not editing
-     */
-    if (IS_IPAD || !self.isEditing) {
-        return NO;
-    }
-    return YES;
-}
 
 - (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
 {


### PR DESCRIPTION
Fixes #5377

This PR makes the status bar visible again while editing a post. The gains of extra space or small compared to the ability of seeing the status bar information.

 It also fixes the bug above when the status has special states like hotspot or in call connections.

To test:
 - Start or Edit an existing post
 - Check if the status is present
 - Click on post settings and post preview and check if all works correctly.
 - Check the same on pages
 - Check the same using the legacy editor.

Needs review: @aerych 

@bummytime do you want also to have look?
