### PR TITLE
Issues/signup mixpanel ab test

### DIFF
--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -43,6 +43,7 @@
 #import "Media.h"
 #import "MediaService.h"
 #import "MeHeaderView.h"
+#import "MixpanelTweaks.h"
 
 #import "NavbarTitleDropdownButton.h"
 #import "NotificationsViewController.h"

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -126,7 +126,11 @@ int ddLogLevel = DDLogLevelInfo;
 {
     DDLogVerbose(@"didFinishLaunchingWithOptions state: %d", application.applicationState);
     [self.window makeKeyAndVisible];
-    [self showWelcomeScreenIfNeededAnimated:NO];
+    // TODO: Proxy this call to a handler.
+    // Show a placeholder vc.
+    // Use the callback for loaded variants but set a time out.
+    [SigninHelpers loadABTestThenShowSigninController];
+//    [self showWelcomeScreenIfNeededAnimated:NO];
     [self setupLookback];
     [self setupAppbotX];
     [self setupStoreKit];
@@ -357,7 +361,7 @@ int ddLogLevel = DDLogLevelInfo;
     
     // Analytics
     [self configureAnalytics];
-    
+
     // Start Simperium
     [self loginSimperium];
     
@@ -505,7 +509,7 @@ int ddLogLevel = DDLogLevelInfo;
 
 - (void)showWelcomeScreenIfNeededAnimated:(BOOL)animated
 {
-    if (self.isWelcomeScreenVisible || !([self noSelfHostedBlogs] && [self noWordPressDotComAccount])) {
+    if ([self isWelcomeScreenVisible] || !([self noSelfHostedBlogs] && [self noWordPressDotComAccount])) {
         return;
     }
     
@@ -531,6 +535,10 @@ int ddLogLevel = DDLogLevelInfo;
     UINavigationController *presentedViewController = (UINavigationController *)self.window.rootViewController.presentedViewController;
     if (![presentedViewController isKindOfClass:[UINavigationController class]]) {
         return NO;
+    }
+
+    if ([presentedViewController isKindOfClass:[NUXNavigationController class]]) {
+        return YES;
     }
 
     // TODO: Remember to change this when switching to the new signin feature. (Aerych 2016.4.20)

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -125,11 +125,11 @@ int ddLogLevel = DDLogLevelInfo;
 {
     DDLogVerbose(@"didFinishLaunchingWithOptions state: %d", application.applicationState);
     [self.window makeKeyAndVisible];
-    // TODO: Proxy this call to a handler.
-    // Show a placeholder vc.
-    // Use the callback for loaded variants but set a time out.
-    [SigninHelpers loadABTestThenShowSigninController];
-//    [self showWelcomeScreenIfNeededAnimated:NO];
+
+    [self showWelcomeScreenABTestIfNeeded];
+
+    // TODO: Restore this method when the NUX A/B test is over. - aerych, 2016-06-28
+    // [self showWelcomeScreenIfNeededAnimated:NO];
     [self setupLookback];
     [self setupAppbotX];
     [self setupStoreKit];
@@ -500,6 +500,16 @@ int ddLogLevel = DDLogLevelInfo;
 - (BOOL)isLoggedIn
 {
     return !([self noSelfHostedBlogs] && [self noWordPressDotComAccount]);
+}
+
+// Only call this method when launching the app. At any other time the signin screen
+// should be shown by calling `showWelcomeScreenIfNeededAnimated:`
+- (void)showWelcomeScreenABTestIfNeeded
+{
+    if ([self isWelcomeScreenVisible] || !([self noSelfHostedBlogs] && [self noWordPressDotComAccount])) {
+        return;
+    }
+    [SigninHelpers loadABTestThenShowSigninController];
 }
 
 - (void)showWelcomeScreenIfNeededAnimated:(BOOL)animated

--- a/WordPress/Classes/Utility/Analytics/MixpanelTweaks.h
+++ b/WordPress/Classes/Utility/Analytics/MixpanelTweaks.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface MixpanelTweaks : NSObject
+
++ (BOOL)NUXMagicLinksEnabled;
+
+@end

--- a/WordPress/Classes/Utility/Analytics/MixpanelTweaks.m
+++ b/WordPress/Classes/Utility/Analytics/MixpanelTweaks.m
@@ -1,0 +1,11 @@
+#import "MixpanelTweaks.h"
+#import <Mixpanel/MPTweakInline.h>
+
+@implementation MixpanelTweaks
+
++ (BOOL)NUXMagicLinksEnabled
+{
+    return MPTweakValue(@"NUX_MAGICLINKS_ENABLED", NO);
+}
+
+@end

--- a/WordPress/Classes/Utility/Analytics/MixpanelTweaks.m
+++ b/WordPress/Classes/Utility/Analytics/MixpanelTweaks.m
@@ -1,5 +1,5 @@
 #import "MixpanelTweaks.h"
-#import <Mixpanel/MPTweakInline.h>
+#import "Mixpanel/MPTweakInline.h"
 
 @implementation MixpanelTweaks
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -9,7 +9,7 @@ import Mixpanel
 @objc class SigninHelpers: NSObject
 {
     private static let AuthenticationEmailKey = "AuthenticationEmailKey"
-
+    private static let JoinABTestTimeoutInSeconds: NSTimeInterval = 2
 
     // MARK: - AB test related methods
 
@@ -22,7 +22,7 @@ import Mixpanel
     ///
     class func loadABTestThenShowSigninController() {
         guard let rootController = WordPressAppDelegate.sharedInstance().window.rootViewController else {
-            assertionFailure("Oh where oh where could my rootviewcontroller have gone?")
+            assertionFailure("Missing a rootViewController.")
             return
         }
 
@@ -45,7 +45,7 @@ import Mixpanel
             SigninHelpers.showSigninControllerForABTest()
         }
 
-        NSTimer.scheduledTimerWithTimeInterval(2, target: SigninHelpers.self, selector: #selector(SigninHelpers.showSigninControllerForABTest), userInfo: nil, repeats: false)
+        NSTimer.scheduledTimerWithTimeInterval(JoinABTestTimeoutInSeconds, target: SigninHelpers.self, selector: #selector(SigninHelpers.showSigninControllerForABTest), userInfo: nil, repeats: false)
     }
 
 
@@ -55,7 +55,7 @@ import Mixpanel
     ///
     class func showSigninControllerForABTest() {
         guard let rootController = WordPressAppDelegate.sharedInstance().window.rootViewController else {
-            assertionFailure(" Oh where oh where could he be?")
+            assertionFailure("Missing a rootViewController.")
             return
         }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -774,6 +774,7 @@
 		E64ECA4D1CE62041000188A0 /* ReaderSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64ECA4C1CE62041000188A0 /* ReaderSearchViewController.swift */; };
 		E65219F91B8D10C2000B1217 /* ReaderBlockedSiteCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65219F81B8D10C2000B1217 /* ReaderBlockedSiteCell.xib */; };
 		E65219FB1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65219FA1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift */; };
+		E65D31841D21D03C004E6F46 /* MixpanelTweaks.m in Sources */ = {isa = PBXBuildFile; fileRef = E65D31831D21D03C004E6F46 /* MixpanelTweaks.m */; };
 		E663D1901C65383E0017F109 /* SharingAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E663D18F1C65383E0017F109 /* SharingAccountViewController.swift */; };
 		E66969C81B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66969C71B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift */; };
 		E66969CA1B9E0C4F00EC9C00 /* ReaderTopicServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E66969C91B9E0C4F00EC9C00 /* ReaderTopicServiceRemoteTests.m */; };
@@ -2106,6 +2107,8 @@
 		E64ECA4C1CE62041000188A0 /* ReaderSearchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSearchViewController.swift; sourceTree = "<group>"; };
 		E65219F81B8D10C2000B1217 /* ReaderBlockedSiteCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderBlockedSiteCell.xib; sourceTree = "<group>"; };
 		E65219FA1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderBlockedSiteCell.swift; sourceTree = "<group>"; };
+		E65D31821D21D03C004E6F46 /* MixpanelTweaks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MixpanelTweaks.h; sourceTree = "<group>"; };
+		E65D31831D21D03C004E6F46 /* MixpanelTweaks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MixpanelTweaks.m; sourceTree = "<group>"; };
 		E663D18F1C65383E0017F109 /* SharingAccountViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingAccountViewController.swift; sourceTree = "<group>"; };
 		E66969C71B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderTopicServiceTest.swift; sourceTree = "<group>"; };
 		E66969C91B9E0C4F00EC9C00 /* ReaderTopicServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReaderTopicServiceRemoteTests.m; sourceTree = "<group>"; };
@@ -3442,6 +3445,8 @@
 				5948AD0D1AB734F2006E8882 /* WPAppAnalytics.m */,
 				85D790A71AE5BF1F0033AE83 /* MixpanelProxy.h */,
 				85D790A81AE5BF1F0033AE83 /* MixpanelProxy.m */,
+				E65D31821D21D03C004E6F46 /* MixpanelTweaks.h */,
+				E65D31831D21D03C004E6F46 /* MixpanelTweaks.m */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -5895,6 +5900,7 @@
 				5D4E30D11AA4B41A000D9904 /* WPStyleGuide+Posts.m in Sources */,
 				5D17530F1A97D2CA0031A082 /* PostCardTableViewCell.m in Sources */,
 				5D7B414819E482C9007D9EC7 /* WPRichTextMediaAttachment.swift in Sources */,
+				E65D31841D21D03C004E6F46 /* MixpanelTweaks.m in Sources */,
 				E13F23C314FE84600081D9CC /* NSMutableDictionary+Helpers.m in Sources */,
 				59E1D46E1CEF77B500126697 /* Page.swift in Sources */,
 				5DF8D26119E82B1000A2CD95 /* ReaderCommentsViewController.m in Sources */,


### PR DESCRIPTION
This PR implements A/B testing of our new sign in and magic link flow courtesy of Mixpanel. 
A/B testing sign in is a bit challenging in that we need to fetch Mixpanel's testing data *before* know which test variant to show.  Since we've found it isn't great to block the UI (a la Optimizely) this PR takes a different approach.  When the app launches and will show the sign in flow:
- create and display our own version of the loading screen to mask the tab controller while we wait.
- request to join mixpanel experiments with a callback to show the correct flow.
- set a timer that will show the default flow if mixpanel does not respond within 2 secs. 
- shows either the default or the new sign in flow depending on

Faking the loading screen while we wait on Mixpanel to update seemed a somewhat cheesy but safe way to effectively "block" the UI.  That said, I'm definitely open to other ideas.

To Test:
The a/b test is configured for develop builds.  Make sure you're app credentials includes the correct mixpanel development api token before proceeding.  *REMEMBER to recreate the test for beta and production builds.

- Remove the app from the simulator. 
- Build and launch the app.
- Confirm that you do not see a UI glitch when presenting the fake launch screen or either of the sign in variants. The transition should be abrupt but seamless.
- Repeat the steps a few times and confirm that you see both the old and new sign in flows. 

I suspect we'll need to follow up with some additional analytics to indicate which sign in flow was shown unless there is some wizardry already in mixpanel that would let us do that. @sendhil maybe you could chime in here? 

Needs review: @kwonye 
