### PR TITLE
Person: Trailing whitespace violation 🚔

### DIFF
--- a/WordPress/Classes/Models/Person.swift
+++ b/WordPress/Classes/Models/Person.swift
@@ -199,7 +199,7 @@ extension Role {
         // Note: Incoming Hack
         // ====
         //
-        // Apologies about this. When a site is Private, the *Viewer* doesn't really exist, but instead, 
+        // Apologies about this. When a site is Private, the *Viewer* doesn't really exist, but instead,
         // it's treated, backend side, as a follower.
         //
         switch self {


### PR DESCRIPTION
🚔 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚔

Fixes trailing whitespace violation in `Person.swift`.

<img width="343" alt="screen shot 2016-06-28 at 5 50 57 pm" src="https://cloud.githubusercontent.com/assets/1873422/16435046/ef506492-3d58-11e6-8107-bcb689104565.png">


Needs review: @jleandroperez 

