### PR TITLE
Adding rake install to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ cache:
 notifications:
   email: true
 install:
-- rake dependencies
+- bundle install --path vendor/bundle
+- bundle exec rake dependencies
 script:
 - rake test
 env:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,6 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.0.1)
-  rake
   xcpretty-travis-formatter
 
 BUNDLED WITH


### PR DESCRIPTION
Fixes `rake`-related build errors that have been appearing today on `develop` (and earlier on other branches)

To test: if the Travis build below is happy, then this should be a success.

Needs review: @astralbodies you know rake/gem/builder stuff right?

