### PR TITLE
Adds external keyboard shortcuts for access to the tabs

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -579,6 +579,10 @@ static NSInteger const WPTabBarIconOffset = 5;
 }
 
 - (NSArray<UIKeyCommand *>*)keyCommands {
+    if (self.presentedViewController) {
+        return nil;
+    }
+
     return @[
              [UIKeyCommand keyCommandWithInput:@"N" modifierFlags:UIKeyModifierCommand action:@selector(showPostTab) discoverabilityTitle:NSLocalizedString(@"New Post", @"The accessibility value of the post tab.")],
              [UIKeyCommand keyCommandWithInput:@"1" modifierFlags:UIKeyModifierCommand action:@selector(showMySitesTab) discoverabilityTitle:NSLocalizedString(@"My Sites", @"The accessibility value of the my sites tab.")],

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -571,6 +571,23 @@ static NSInteger const WPTabBarIconOffset = 5;
     }
 }
 
+#pragma mark - UIResponder & Keyboard Helpers
+
+- (BOOL)canBecomeFirstResponder
+{
+    return YES;
+}
+
+- (NSArray<UIKeyCommand *>*)keyCommands {
+    return @[
+             [UIKeyCommand keyCommandWithInput:@"N" modifierFlags:UIKeyModifierCommand action:@selector(showPostTab) discoverabilityTitle:NSLocalizedString(@"New Post", @"The accessibility value of the post tab.")],
+             [UIKeyCommand keyCommandWithInput:@"1" modifierFlags:UIKeyModifierCommand action:@selector(showMySitesTab) discoverabilityTitle:NSLocalizedString(@"My Sites", @"The accessibility value of the my sites tab.")],
+             [UIKeyCommand keyCommandWithInput:@"2" modifierFlags:UIKeyModifierCommand action:@selector(showReaderTab) discoverabilityTitle:NSLocalizedString(@"Reader", @"The accessibility value of the reader tab.")],
+             [UIKeyCommand keyCommandWithInput:@"3" modifierFlags:UIKeyModifierCommand action:@selector(showMeTab) discoverabilityTitle:NSLocalizedString(@"Me", @"The accessibility value of the me tab.")],
+             [UIKeyCommand keyCommandWithInput:@"4" modifierFlags:UIKeyModifierCommand action:@selector(showNotificationsTab) discoverabilityTitle:NSLocalizedString(@"Notifications", @"Notifications tab bar item accessibility label")],
+             ];
+}
+
 #pragma mark - Notification Badge Icon Management
 
 - (void)addNotificationBadgeIcon

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -299,6 +299,11 @@ static NSInteger const WPTabBarIconOffset = 5;
     [self showPostTabWithOptions:nil];
 }
 
+- (void)showMeTab
+{
+    [self showTabForIndex:WPTabMe];
+}
+
 - (void)showNotificationsTab
 {
     [self showTabForIndex:WPTabNotifications];


### PR DESCRIPTION
Closes #5629 

![2016-06-29_07-21-10](https://cloud.githubusercontent.com/assets/373903/16452109/6969d010-3dcc-11e6-8707-5194d10c5f65.png)

*To test:*
1. Launch in physical iPad with external keyboard or simulator with external keyboard turned on under Hardware > Keyboard menu.
2. Hold down the Command key to see the helper window of keyboard shortcuts.
3. Try each of the shortcuts (only works with real device because of simulator conflicts).
4. Make sure keyboard shortcuts don't affect things when a modal window is up (like a new post window).

Needs review: @frosty, @diegoreymendez 
