### PR TITLE
Issue/5599 Modal and popover presentation updates

### DIFF
--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -307,7 +307,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
 
         controller.tableView.scrollEnabled = false
 
-        ForcePopoverPresentationPopoverControllerDelegate.configurePresentationControllerForViewController(controller,
+        ForcePopoverPresenter.configurePresentationControllerForViewController(controller,
                                                                                                            presentingFromView: titleButton)
 
         presentViewController(controller, animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -283,8 +283,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
     }
 
     private func displayModePicker() {
-        let controller              = SettingsSelectionViewController(style: .Grouped)
-        controller.title            = NSLocalizedString("Filters", comment: "Title of the list of People Filters")
+        let controller              = SettingsSelectionViewController(style: .Plain)
         controller.titles           = Filter.allFilters.map { $0.title }
         controller.values           = Filter.allFilters.map { $0.rawValue }
         controller.currentValue     = filter.rawValue
@@ -297,8 +296,10 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
             self?.dismissViewControllerAnimated(true, completion: nil)
         }
 
-        let navController = UINavigationController(rootViewController: controller)
-        presentViewController(navController, animated: true, completion: nil)
+        ForcePopoverPresentationPopoverControllerDelegate.configurePresentationControllerForViewController(controller,
+                                                                                                           presentingFromView: titleButton)
+
+        presentViewController(controller, animated: true, completion: nil)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1049,9 +1049,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
             }
         }
 
-        let navController = UINavigationController(rootViewController: controller)
-
-        displayFilterPopover(navController)
+        displayFilterPopover(controller)
     }
 
     func displayFilterPopover(controller: UIViewController) {
@@ -1061,13 +1059,10 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
             return
         }
 
-        controller.modalPresentationStyle = .Popover
-        presentViewController(controller, animated: true, completion: nil)
+        ForcePopoverPresentationPopoverControllerDelegate.configurePresentationControllerForViewController(controller,
+                                                                                                           presentingFromView: titleView)
 
-        let presentationController = controller.popoverPresentationController
-        presentationController?.permittedArrowDirections = .Any
-        presentationController?.sourceView = titleView
-        presentationController?.sourceRect = titleView.bounds
+        presentViewController(controller, animated: true, completion: nil)
     }
 
     func setFilterWithPostStatus(status: String) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1060,7 +1060,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
             return
         }
 
-        ForcePopoverPresentationPopoverControllerDelegate.configurePresentationControllerForViewController(controller,
+        ForcePopoverPresenter.configurePresentationControllerForViewController(controller,
                                                                                                            presentingFromView: titleView)
 
         presentViewController(controller, animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
@@ -27,7 +27,7 @@ static const CGFloat CategoryCellIndentation = 16.0;
             currentSelection:(NSArray *)originalSelection
                selectionMode:(CategoriesSelectionMode)selectionMode
 {
-    self = [super initWithStyle:UITableViewStylePlain];
+    self = [super initWithStyle:UITableViewStyleGrouped];
     if (self) {
         _selectionMode = selectionMode;
         _blog = blog;
@@ -87,7 +87,11 @@ static const CGFloat CategoryCellIndentation = 16.0;
 {
     WPAddPostCategoryViewController *addCategoryViewController = [[WPAddPostCategoryViewController alloc] initWithBlog:self.blog];
     addCategoryViewController.delegate = self;
-    [self presentViewController:[[UINavigationController alloc] initWithRootViewController:addCategoryViewController]
+
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:addCategoryViewController];
+    navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
+
+    [self presentViewController:navigationController
                        animated:YES
                      completion:nil];
 }

--- a/WordPress/Classes/ViewRelated/Post/Geolocation/PostGeolocationViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Geolocation/PostGeolocationViewController.m
@@ -62,7 +62,7 @@ typedef NS_ENUM(NSInteger, SearchResultsSection) {
 {
     [super viewWillLayoutSubviews];
     self.searchBarTop.hidden = !self.navigationController.navigationBarHidden;
-    self.searchBarTop.frame = [[UIApplication sharedApplication] statusBarFrame];
+    self.searchBarTop.frame = CGRectMake(0.0, 0.0, self.view.frame.size.width, [self.topLayoutGuide length]);
     self.searchBar.frame = CGRectMake(0.0, [self.topLayoutGuide length]-1, self.view.frame.size.width, 44.0);
     self.tableView.frame = CGRectMake(0.0, CGRectGetMaxY(self.searchBar.frame), self.view.frame.size.width, self.view.frame.size.height-CGRectGetMaxY(self.searchBar.frame));
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -975,6 +975,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 {
     PostGeolocationViewController *controller = [[PostGeolocationViewController alloc] initWithPost:self.post locationService:self.locationService];
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:controller];
+    navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
     [self presentViewController:navigationController animated:YES completion:nil];
 }
 
@@ -1003,6 +1004,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     picker.delegate = self;
     picker.allowMultipleSelection = NO;
     picker.showMostRecentFirst = YES;
+    picker.modalPresentationStyle = UIModalPresentationFormSheet;
     [self presentViewController:picker animated:YES completion:nil];
 }
 

--- a/WordPress/Classes/ViewRelated/System/ForcePopoverPresentationPopoverControllerDelegate.swift
+++ b/WordPress/Classes/ViewRelated/System/ForcePopoverPresentationPopoverControllerDelegate.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+/// This delegate forces popover presentation even on iPhone / in compact size classes
+class ForcePopoverPresentationPopoverControllerDelegate: NSObject, UIPopoverPresentationControllerDelegate {
+    static let delegate = ForcePopoverPresentationPopoverControllerDelegate()
+
+    private static let verticalPadding: CGFloat = 10
+
+    /// Configures a view controller to use a popover presentation style
+    static func configurePresentationControllerForViewController(controller: UIViewController, presentingFromView sourceView: UIView) {
+        controller.modalPresentationStyle = .Popover
+
+        let presentationController = controller.popoverPresentationController
+        presentationController?.permittedArrowDirections = .Any
+        presentationController?.sourceView = sourceView
+
+        // Outset the source rect vertically to push the popover up / down a little
+        // when displayed. Otherwise, when presented from a navigation controller
+        // the top of the popover lines up perfectly with the bottom of the
+        // navigation controller and looks a little odd
+        presentationController?.sourceRect = CGRectInset(sourceView.bounds, 0, -verticalPadding)
+        presentationController?.delegate = ForcePopoverPresentationPopoverControllerDelegate.delegate
+
+        controller.view.sizeToFit()
+    }
+
+    func adaptivePresentationStyleForPresentationController(controller: UIPresentationController) -> UIModalPresentationStyle {
+        return .None
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/ForcePopoverPresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/ForcePopoverPresenter.swift
@@ -1,8 +1,8 @@
 import UIKit
 
 /// This delegate forces popover presentation even on iPhone / in compact size classes
-class ForcePopoverPresentationPopoverControllerDelegate: NSObject, UIPopoverPresentationControllerDelegate {
-    static let delegate = ForcePopoverPresentationPopoverControllerDelegate()
+class ForcePopoverPresenter: NSObject, UIPopoverPresentationControllerDelegate {
+    static let presenter = ForcePopoverPresenter()
 
     private static let verticalPadding: CGFloat = 10
 
@@ -19,7 +19,7 @@ class ForcePopoverPresentationPopoverControllerDelegate: NSObject, UIPopoverPres
         // the top of the popover lines up perfectly with the bottom of the
         // navigation controller and looks a little odd
         presentationController?.sourceRect = CGRectInset(sourceView.bounds, 0, -verticalPadding)
-        presentationController?.delegate = ForcePopoverPresentationPopoverControllerDelegate.delegate
+        presentationController?.delegate = ForcePopoverPresenter.presenter
 
         controller.view.sizeToFit()
     }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
@@ -12,6 +12,8 @@ NSString * const SettingsSelectionHintsKey = @"Hints";
 NSString * const SettingsSelectionDefaultValueKey = @"DefaultValue";
 NSString * const SettingsSelectionCurrentValueKey = @"CurrentValue";
 
+CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
+
 @interface SettingsSelectionViewController ()
 @property (nonatomic, strong) WPTableViewSectionHeaderFooterView *hintView;
 @end
@@ -61,6 +63,17 @@ NSString * const SettingsSelectionCurrentValueKey = @"CurrentValue";
 
     [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
+}
+
+- (CGSize)preferredContentSize
+{
+    CGSize size = [super preferredContentSize];
+
+    if (self.tableView.style == UITableViewStylePlain) {
+        size.height = [self.titles count] * SettingsSelectionDefaultTableViewCellHeight;
+    }
+
+    return size;
 }
 
 - (void)configureCancelButton

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -103,7 +103,7 @@
 		173BCE751CEB369900AE8817 /* Domains.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 173BCE741CEB369900AE8817 /* Domains.storyboard */; };
 		173BCE771CEB3D8200AE8817 /* DomainsServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173BCE761CEB3D8200AE8817 /* DomainsServiceRemote.swift */; };
 		173BCE791CEB780800AE8817 /* Domain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173BCE781CEB780800AE8817 /* Domain.swift */; };
-		1746D7771D2165AE00B11D77 /* ForcePopoverPresentationPopoverControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1746D7761D2165AE00B11D77 /* ForcePopoverPresentationPopoverControllerDelegate.swift */; };
+		1746D7771D2165AE00B11D77 /* ForcePopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */; };
 		1751E5911CE0E552000CA08D /* KeyValueDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */; };
 		1751E5931CE23801000CA08D /* NSAttributedString+StyledHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */; };
 		176579F71C63A40F0000978E /* PurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176579F61C63A40F0000978E /* PurchaseButton.swift */; };
@@ -1088,7 +1088,7 @@
 		173BCE741CEB369900AE8817 /* Domains.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Domains.storyboard; sourceTree = "<group>"; };
 		173BCE761CEB3D8200AE8817 /* DomainsServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsServiceRemote.swift; sourceTree = "<group>"; };
 		173BCE781CEB780800AE8817 /* Domain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Domain.swift; sourceTree = "<group>"; };
-		1746D7761D2165AE00B11D77 /* ForcePopoverPresentationPopoverControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForcePopoverPresentationPopoverControllerDelegate.swift; sourceTree = "<group>"; };
+		1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForcePopoverPresenter.swift; sourceTree = "<group>"; };
 		1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueDatabase.swift; sourceTree = "<group>"; };
 		1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+StyledHTML.swift"; sourceTree = "<group>"; };
 		176579F61C63A40F0000978E /* PurchaseButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseButton.swift; sourceTree = "<group>"; };
@@ -3404,7 +3404,7 @@
 				FFA9148E1BA6E5170068F8BF /* RotationAwareNavigationViewController.m */,
 				E1DD4CCA1CAE41B800C3863E /* PagedViewController.swift */,
 				E1DD4CCC1CAE41C800C3863E /* PagedViewController.xib */,
-				1746D7761D2165AE00B11D77 /* ForcePopoverPresentationPopoverControllerDelegate.swift */,
+				1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */,
 				171795821D1C65E8002F1EB2 /* FlingableViewHandler.swift */,
 			);
 			path = System;
@@ -5991,7 +5991,7 @@
 				5D8CBC471A6F47880081F4AE /* EditImageDetailsViewController.m in Sources */,
 				E1A6DBE219DC7D140071AC1E /* PostServiceRemoteXMLRPC.m in Sources */,
 				B5A9B7C31BFA6F3100FC30A5 /* NSString+Helpers.swift in Sources */,
-				1746D7771D2165AE00B11D77 /* ForcePopoverPresentationPopoverControllerDelegate.swift in Sources */,
+				1746D7771D2165AE00B11D77 /* ForcePopoverPresenter.swift in Sources */,
 				5D6C4B081B603E03005E3C43 /* WPContentSyncHelper.swift in Sources */,
 				85D239AF1AE5A5FC0074768D /* HelpshiftEnabledFacade.m in Sources */,
 				E6A2158E1D10627500DE5270 /* ReaderMenuViewModel.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		173BCE751CEB369900AE8817 /* Domains.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 173BCE741CEB369900AE8817 /* Domains.storyboard */; };
 		173BCE771CEB3D8200AE8817 /* DomainsServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173BCE761CEB3D8200AE8817 /* DomainsServiceRemote.swift */; };
 		173BCE791CEB780800AE8817 /* Domain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173BCE781CEB780800AE8817 /* Domain.swift */; };
+		1746D7771D2165AE00B11D77 /* ForcePopoverPresentationPopoverControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1746D7761D2165AE00B11D77 /* ForcePopoverPresentationPopoverControllerDelegate.swift */; };
 		1751E5911CE0E552000CA08D /* KeyValueDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */; };
 		1751E5931CE23801000CA08D /* NSAttributedString+StyledHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */; };
 		176579F71C63A40F0000978E /* PurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176579F61C63A40F0000978E /* PurchaseButton.swift */; };
@@ -1085,6 +1086,7 @@
 		173BCE741CEB369900AE8817 /* Domains.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Domains.storyboard; sourceTree = "<group>"; };
 		173BCE761CEB3D8200AE8817 /* DomainsServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsServiceRemote.swift; sourceTree = "<group>"; };
 		173BCE781CEB780800AE8817 /* Domain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Domain.swift; sourceTree = "<group>"; };
+		1746D7761D2165AE00B11D77 /* ForcePopoverPresentationPopoverControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForcePopoverPresentationPopoverControllerDelegate.swift; sourceTree = "<group>"; };
 		1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueDatabase.swift; sourceTree = "<group>"; };
 		1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+StyledHTML.swift"; sourceTree = "<group>"; };
 		176579F61C63A40F0000978E /* PurchaseButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseButton.swift; sourceTree = "<group>"; };
@@ -3400,6 +3402,7 @@
 				FFA9148E1BA6E5170068F8BF /* RotationAwareNavigationViewController.m */,
 				E1DD4CCA1CAE41B800C3863E /* PagedViewController.swift */,
 				E1DD4CCC1CAE41C800C3863E /* PagedViewController.xib */,
+				1746D7761D2165AE00B11D77 /* ForcePopoverPresentationPopoverControllerDelegate.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -5985,6 +5988,7 @@
 				5D8CBC471A6F47880081F4AE /* EditImageDetailsViewController.m in Sources */,
 				E1A6DBE219DC7D140071AC1E /* PostServiceRemoteXMLRPC.m in Sources */,
 				B5A9B7C31BFA6F3100FC30A5 /* NSString+Helpers.swift in Sources */,
+				1746D7771D2165AE00B11D77 /* ForcePopoverPresentationPopoverControllerDelegate.swift in Sources */,
 				5D6C4B081B603E03005E3C43 /* WPContentSyncHelper.swift in Sources */,
 				85D239AF1AE5A5FC0074768D /* HelpshiftEnabledFacade.m in Sources */,
 				E6A2158E1D10627500DE5270 /* ReaderMenuViewModel.swift in Sources */,


### PR DESCRIPTION
Refs #5599. 

This picks off some of the low-hanging fruit listed in the above issue around some more appropriate uses of modals and popovers on iPad.

### To test

Check the following:

* People and Posts filter dropdowns from the navigation bar are popovers on all devices (and no longer include a navigation bar – fixes #3748).
* Adding a category (either from Post Settings > Categories or from Site Settings > Default Category) should now present a form sheet modal on iPad (full screen on phone)
* Adding a featured image and a location to a post (in post settings) should now use form sheet modals on iPad.

Needs review: @kurzee 