### PR TITLE
Does not add the Crashlytics logger for Debug & Internal builds

### DIFF
--- a/WordPress/Classes/Utility/Logging/WPLogger.m
+++ b/WordPress/Classes/Utility/Logging/WPLogger.m
@@ -47,7 +47,7 @@
     [DDLog addLogger:[DDTTYLogger sharedInstance]];
 #endif
     
-#ifndef INTERNAL_BUILD
+#if !defined(INTERNAL_BUILD) && !defined(DEBUG)
     [DDLog addLogger:[WPCrashlyticsLogger sharedInstance]];
 #endif
     


### PR DESCRIPTION
Not sure how it really broke - maybe Crashlytics changed slightly causing the log warnings to show up. This PR changes our initialization slightly to not add the custom Crashlytics logger to our CocoaLumberjack setup when its not an app store build.

**To test:**
1. Launch the app in the simulator or on a device.
2. Verify the console does not mention any errors about CLLog.


Needs review: @kurzee 

