### PR TITLE
People Management: Followers Order

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,6 +5,8 @@ data model as well as any custom migrations.
 
 ## WordPress 50
 
+- @jleandroperez 2016-06-20
+- `Person` added `creationDate` attribute.
 - @jleandroperez 2016-06-21
 - `Person` removed `isFollower` property.
 - `Person` added `kind` Int16 attribute.

--- a/WordPress/Classes/Models/ManagedPerson+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/ManagedPerson+CoreDataProperties.swift
@@ -15,4 +15,5 @@ extension ManagedPerson {
     @NSManaged var username: String
     @NSManaged var isSuperAdmin: Bool
     @NSManaged var kind: Int16
+    @NSManaged var creationDate: NSDate?
 }

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -287,6 +287,7 @@ private extension PeopleService {
     func createManagedPerson<T: Person>(person: T) {
         let managedPerson = NSEntityDescription.insertNewObjectForEntityForName("Person", inManagedObjectContext: context) as! ManagedPerson
         managedPerson.updateWith(person)
+        managedPerson.creationDate = NSDate()
         DDLogSwift.logDebug("Created person \(managedPerson)")
     }
 }

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -51,6 +51,20 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
         return predicate
     }
 
+    /// Sort Descriptor
+    ///
+    private var sortDescriptors: [NSSortDescriptor] {
+        // Note:
+        // Followers must be sorted out by creationDate!
+        //
+        switch filter {
+        case .Followers:
+            return [NSSortDescriptor(key: "creationDate", ascending: true, selector: #selector(NSDate.compare(_:)))]
+        default:
+            return [NSSortDescriptor(key: "displayName", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:)))]
+        }
+    }
+
     /// Core Data Context
     ///
     private lazy var context: NSManagedObjectContext = {
@@ -60,11 +74,11 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
     /// Core Data FRC
     ///
     private lazy var resultsController: NSFetchedResultsController = {
+        // FIXME(@koke, 2015-11-02): my user should be first
         let request = NSFetchRequest(entityName: "Person")
         request.predicate = self.predicate
+        request.sortDescriptors = self.sortDescriptors
 
-        // FIXME(@koke, 2015-11-02): my user should be first
-        request.sortDescriptors = [NSSortDescriptor(key: "displayName", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:)))]
         let frc = NSFetchedResultsController(fetchRequest: request, managedObjectContext: self.context, sectionNameKeyPath: nil, cacheName: nil)
         frc.delegate = self
         return frc
@@ -201,6 +215,7 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
 
     private func refreshResultsController() {
         resultsController.fetchRequest.predicate = predicate
+        resultsController.fetchRequest.sortDescriptors = sortDescriptors
 
         do {
             try resultsController.performFetch()

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -266,11 +266,11 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
 
         switch filter {
         case .Followers:
-            service.loadFollowersPage(nextRequestOffset, success: success)
+            service.loadFollowersPage(offset, success: success)
         case .Users:
-            service.loadUsersPage(nextRequestOffset, success: success)
+            service.loadUsersPage(offset, success: success)
         case .Viewers:
-            service.loadViewersPage(nextRequestOffset, success: success)
+            service.loadViewersPage(offset, success: success)
         }
     }
 

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 50.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 50.xcdatamodel/contents
@@ -393,6 +393,7 @@
     </entity>
     <entity name="Person" representedClassName=".ManagedPerson" syncable="YES">
         <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="creationDate" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="displayName" attributeType="String" syncable="YES"/>
         <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="isSuperAdmin" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
@@ -643,7 +644,7 @@
         <element name="Meta" positionX="9" positionY="153" width="128" height="105"/>
         <element name="Notification" positionX="18" positionY="162" width="128" height="255"/>
         <element name="Page" positionX="0" positionY="0" width="128" height="60"/>
-        <element name="Person" positionX="18" positionY="153" width="128" height="210"/>
+        <element name="Person" positionX="18" positionY="153" width="128" height="30"/>
         <element name="Post" positionX="0" positionY="0" width="128" height="195"/>
         <element name="PostTag" positionX="27" positionY="153" width="128" height="105"/>
         <element name="PostType" positionX="27" positionY="153" width="128" height="105"/>


### PR DESCRIPTION
#### Details:
- Updating Data Model Mark 50 (yet again)
- Person gets a new creationDate attribute
- Followers are now sorted by this attribute

#### Testing:
1. Pick a blog that has a *LOT* of followers (such as automattic.com), and make sure you're an admin
2. Log into your dotcom acocunt
3. Open `My Sites` > `Site` > `People`
4. Tap over the navbar title and select `Followers`
5. Begin scrolling down

Please, note that newly added Followers will always be appended to the list. (Before this patch, since the Sort was being applied over the name, scrolling downwards didn't always append new pages).

Needs Review: @aerych 
Eric, may i bother you with (yet another) review?

Thanks in advance!

cc @oguzkocer / @hypest ("Easiest Hack Ever")
