### PR TITLE
Featured image improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
@@ -26,8 +26,6 @@
     if (self) {
         self.title = NSLocalizedString(@"Featured Image", @"Title for the Featured Image view");
         self.post = post;
-        self.extendedLayoutIncludesOpaqueBars = YES;
-        self.automaticallyAdjustsScrollViewInsets = NO;
     }
     return self;
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1027,7 +1027,8 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         }
         width = width - (PostFeaturedImageCellMargin * 2); // left and right cell margins
         CGFloat height = ceilf(width * 0.66);
-        CGSize imageSize = CGSizeMake(width, height);
+        CGFloat scale = [[UIScreen mainScreen] scale];
+        CGSize imageSize = CGSizeMake(width * scale, height * scale);
         
         [self.imageSource fetchImageForURL:url
                                   withSize:imageSize

--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -221,8 +221,14 @@ static CGFloat const MinimumZoomScale = 0.1;
 
     self.imageView.frame = frame;
 
-    // Only allow the flinging gesture if we're zoomed all the way out
-    self.flingableViewHandler.isActive = (scrollView.zoomScale == scrollView.minimumZoomScale);
+    [self updateFlingableViewHandlerActiveState];
+}
+
+- (void)updateFlingableViewHandlerActiveState
+{
+    BOOL isScrollViewZoomedOut = (self.scrollView.zoomScale == self.scrollView.minimumZoomScale);
+
+    self.flingableViewHandler.isActive = isScrollViewZoomedOut;
 }
 
 #pragma mark - Status bar management


### PR DESCRIPTION
Whilst updating our use of modal view controllers, I found a couple of small issues around featured images, which I've fixed here.

* When previewing a featured image, the image was being overlapped by the navigation bar. I've disabled extended layout so this no longer happens.
* The featured image preview in post settings was pixellated. It now takes into account the screen scale so should be retina quality.

### To test

* Create a new post
* Open the Post Settings
* Tap Featured Image and add a new featured image.
* Wait for it to upload and the full thumbnail to be generated.
* Check that the thumbnail isn't pixellated.
* Tap the thumbnail to view the image.
* Check that the image fits correctly in the area below the navigation bar, and check that you can zoom and pan around it correctly.
* Check that you can 'fling' to dismiss the image.

Needs review: @jleandroperez 