### PR TITLE
Notifications + Swift Mk 4: NoResults View

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -251,7 +251,7 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
 extension NotificationsViewController
 {
     func showFiltersSegmentedControlIfApplicable() {
-        guard tableHeaderView.alpha != WPAlphaZero && shouldDisplayFilters == true else {
+        guard tableHeaderView.alpha == WPAlphaZero && shouldDisplayFilters == true else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -297,7 +297,6 @@ extension NotificationsViewController
 
         // Refresh its properties: The user may have signed into WordPress.com
         noResultsView.titleText     = noResultsTitleText
-        noResultsView.titleText     = noResultsTitleText
         noResultsView.messageText   = noResultsMessageText
         noResultsView.accessoryView = noResultsAccessoryView
         noResultsView.buttonTitle   = noResultsButtonText

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
@@ -29,7 +29,6 @@
 - (void)reloadResultsController;
 
 - (BOOL)isRowLastRowForSection:(NSIndexPath *)indexPath;
-- (void)showNoResultsViewIfNeeded;
 
 - (void)cancelDeletionForNoteWithID:(NSManagedObjectID *)noteObjectID;
 - (BOOL)isNoteMarkedForDeletion:(NSManagedObjectID *)noteObjectID;


### PR DESCRIPTION
#### Details:
We're slowly rewriting the entire Notifications stack in Swift, and relying on Swift Extensions to just... port code over (instead of a full massive rewrite).

This time we're moving over the NoResults handling code.
Outlining below few testing scenarios, thanks!!

Reference #5613

#### Scenario A: Launching Empty Notifications List
1. Log into a dotcom account that has no notifications
2. Tap over the Notifications tab

Verify that the legend `No notifications yet` shows up onscreen, and the Filters segmented control isn't visible.

#### Scenario B: Switch from Empty to Non Empty
1. Log into a dotcom account that has no notifications
2. Tap over the Notifications tab
3. Receive a notification

Please, verify that the Empty Notifications legend is removed, and the Filters shows up.

#### Scenario C: Launching a Non-Empty Notifications List
1. Fresh install the app
2. Log into a dotcom account, with a non-empty notifications list
3. Open the Notifications tab

Please, press over the different Notifications filters, and verify that the Empty list text shows up as expected (for any of the filters that don't really have notifications).

#### Scenario D: Jetpack
1. Fresh install the app
2. Log into a Self Hosted blog without Jetpack wired (DM me if you need a testing blog please!)
3. Tap over the Notifications tab bar

Please, verify that the Empty Notifications text displays the Jetpack logo. Tap it, and verify that a WebView (with more information) shows up.

Needs review: @frosty 
Sir, may i bother you with a review?

Thanks in advance!!!
