### PR TITLE
Menus: Fix memory retain issue for default menus

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -327,16 +327,18 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
         self.itemsLoadingLabel.hidden = NO;
         
         __weak __typeof__(self) weakSelf = self;
+        __weak __typeof__(menu) weakMenu = menu;
+
         void(^successBlock)(NSArray<MenuItem *> *) = ^(NSArray<MenuItem *> *defaultItems) {
             weakSelf.itemsLoadingLabel.hidden = YES;
             
-            BOOL menuEqualToSelectedMenu = weakSelf.selectedMenuLocation.menu == menu;
+            BOOL menuEqualToSelectedMenu = weakSelf.selectedMenuLocation.menu == weakMenu;
             if (defaultItems.count) {
                 NSOrderedSet *items = [NSOrderedSet orderedSetWithArray:defaultItems];
-                menu.items = items;
+                weakMenu.items = items;
                 if (menuEqualToSelectedMenu) {
                     weakSelf.itemsViewController.menu = nil;
-                    weakSelf.itemsViewController.menu = menu;
+                    weakSelf.itemsViewController.menu = weakMenu;
                 }
             } else {
                 if (menuEqualToSelectedMenu) {


### PR DESCRIPTION
A `Menu` object was being strongly referenced during the processing of default `MenuItems` for a site. This `Menu` object should instead be weakly referenced as the user may leave the Menus view before this process finishes and the Menu object, while valid in memory, is no longer a valid CoreData object, causing a crash.

To test:
- I couldn't actually reproduce this, @jleandroperez can you retest as when you found it?
- Regardless, this should be fixed by casting a `weak` reference.

Needs review: @jleandroperez can you take a peak, whenever you have a chance? No rush, thanks for finding this one!

