### PR TITLE
Reader: Fixes comment UI glitch after locking/unlocking screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
+++ b/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
@@ -449,6 +449,9 @@ static const UIEdgeInsets ReplyAndLikeButtonEdgeInsets = {0.0f, 4.0f, 0.0f, -4.0
 
 - (void)configureContentView
 {
+    // Set the content to an empty string first. This "resets" the text layout
+    // and helps clear up some artifacting and drawing errors in certain edge cases.
+    self.textContentView.content = @"";
     self.textContentView.privateContent = [self.contentProvider isPrivateContent];
     self.textContentView.content = [self sanitizedContentStringForDisplay:[self.contentProvider contentForDisplay]];
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -125,8 +125,8 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 
     if (!CGSizeEqualToSize(self.previousViewGeometry, CGSizeZero)) {
         if (! CGSizeEqualToSize(self.previousViewGeometry, self.view.frame.size)) {
-            // Refresh cached row heights based on the new width
-            [self.tableViewHandler refreshCachedRowHeightsForWidth:CGRectGetWidth(self.view.frame)];
+            // Clear cached heights and refresh
+            [self.tableViewHandler clearCachedRowHeights];
             [self.tableView reloadData];
         }
     }
@@ -210,7 +210,7 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 
     CGFloat width = CGRectGetWidth(self.view.frame);
     [self updateCellsAndRefreshMediaForWidth:width];
-    [self.tableView reloadRowsAtIndexPaths:[self.tableView indexPathsForVisibleRows] withRowAnimation:UITableViewRowAnimationNone];
+    [self.tableView reloadData];
 }
 
 
@@ -483,16 +483,11 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
     [self updateCachedMediaCellLayoutForWidth:width];
 
     // Resize cells in the media cell cache
-    // No need to refresh on iPad when using a fixed width.
     for (NSString *key in [self.mediaCellCache allKeys]) {
         ReaderCommentCell *cell = [self.mediaCellCache objectForKey:key];
-        NSIndexPath *indexPath = [self indexPathForCommentWithID:[key numericValue]];
-
         [cell refreshMediaLayout];
-        [self.tableViewHandler invalidateCachedRowHeightAtIndexPath:indexPath];
     }
-
-    [self.tableViewHandler refreshCachedRowHeightsForWidth:width];
+    [self.tableViewHandler clearCachedRowHeights];
 }
 
 - (void)updateCellForLayoutWidthConstraint:(CGFloat)width

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -167,12 +167,6 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
 
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 
-    // Avoid refreshing cells when there is no need.
-    if (![UIDevice isPad] && WPTableViewFixedWidth > CGRectGetWidth(self.tableView.frame)) {
-        // Refresh cached row heights based on the new width
-        [self updateCellsAndRefreshMediaForWidth:size.width];
-    }
-
     [coordinator animateAlongsideTransition:nil completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
         NSIndexPath *selectedIndexPath = [self.tableView indexPathForSelectedRow];
         // Make sure a selected comment is visible after rotating, and that the replyTextView is still the first responder.
@@ -180,20 +174,10 @@ static NSString *CommentLayoutCellIdentifier = @"CommentLayoutCellIdentifier";
             [self.replyTextView becomeFirstResponder];
             [self.tableView selectRowAtIndexPath:selectedIndexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
         }
-        
+        [self updateCellsAndRefreshMediaForWidth:size.width];
+        [self.tableView reloadData];
         [self refreshNoResultsView];
     }];
-}
-
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
-{
-    [super traitCollectionDidChange:previousTraitCollection];
-
-    [self.view layoutIfNeeded];
-
-    CGFloat width = CGRectGetWidth(self.view.frame);
-    [self updateCellsAndRefreshMediaForWidth:width];
-    [self.tableView reloadData];
 }
 
 


### PR DESCRIPTION
Fixes #5650.  

To test:
Repeat the following tests with a list of comments of various size containing links, images, and/or other embedded content.   Note that it is expected to see some layout artifacts in the iOS simulator, but not on a device.

Scenario 1:  iPhone
Load a comment list. Scroll the list and confirm that comments are rendered correctly.
Change device orientation. Confirm that comments are correctly resized and render correctly.

Scenario 2: iPad
Load a comment list. Scroll the list and confirm that comments are rendered correctly.
Change device orientation. Confirm that comments are correctly resized and render correctly.

Scenario 3: iPad
Load a comment list. Scroll the list and confirm that comments are rendered correctly.
Lock the screen then unlock the screen. 
Confirm that comments continue to be rendered correctly.

Scenario 4: iPad Air 2
Load a comment list.
Background the app.
Launch Safari. 
Swipe from the side to bring up the multitasking menu and select the WPiOS app.
Confirm that comments render correctly. 
Adjust the size of the split screen. 
Confirm that comments render correctly.

Needs review: @jleandroperez would you please?

