### PR TITLE
Pages: preload when on wifi

### DIFF
--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -5,10 +5,16 @@
 @class Blog, Post, Page, AbstractPost;
 @class RemotePost;
 
+typedef NS_ENUM(NSInteger, PostServiceType) {
+    PostServiceTypePost,
+    PostServiceTypePage,
+    PostServiceTypeAny
+};
+/*
 extern NSString * const PostServiceTypePost;
 extern NSString * const PostServiceTypePage;
 extern NSString * const PostServiceTypeAny;
-
+*/
 extern const NSUInteger PostServiceDefaultNumberToSync;
 
 typedef void(^PostServiceSyncSuccess)(NSArray<AbstractPost *> *posts);
@@ -21,6 +27,8 @@ typedef void(^PostServiceSyncFailure)(NSError *error);
 
 + (Post *)createDraftPostInMainContextForBlog:(Blog *)blog;
 + (Page *)createDraftPageInMainContextForBlog:(Blog *)blog;
+
++ (NSString *)keyForType:(PostServiceType)postType;
 
 - (AbstractPost *)findPostWithID:(NSNumber *)postID inBlog:(Blog *)blog;
 
@@ -48,7 +56,7 @@ typedef void(^PostServiceSyncFailure)(NSError *error);
  @param success A success block
  @param failure A failure block
  */
-- (void)syncPostsOfType:(NSString *)postType
+- (void)syncPostsOfType:(PostServiceType)postType
                 forBlog:(Blog *)blog
                 success:(PostServiceSyncSuccess)success
                 failure:(PostServiceSyncFailure)failure;
@@ -65,7 +73,7 @@ typedef void(^PostServiceSyncFailure)(NSError *error);
  @param success A success block
  @param failure A failure block
  */
-- (void)syncPostsOfType:(NSString *)postType
+- (void)syncPostsOfType:(PostServiceType)postType
             withOptions:(PostServiceSyncOptions *)options
                 forBlog:(Blog *)blog
                 success:(PostServiceSyncSuccess)success
@@ -109,7 +117,6 @@ typedef void(^PostServiceSyncFailure)(NSError *error);
 - (void)trashPost:(AbstractPost *)post
           success:(void (^)())success
           failure:(void (^)(NSError *error))failure;
-
 
 /**
  Moves the specified post out of the trash bin.

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -205,7 +205,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     // Configure and reload table data when appearing to ensure pending comment count is updated
     [self configureTableViewData];
     [self.tableView reloadData];
-    [self preloadStats];
+    [self preloadBlogData];
 }
 
 - (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
@@ -514,17 +514,45 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 #pragma mark - Private methods
 
-- (void)preloadStats
+
+- (void)preloadBlogData
 {
-    NSString *oauthToken = self.blog.authToken;
     WordPressAppDelegate *appDelegate = [WordPressAppDelegate sharedInstance];
     BOOL isOnWifi = [appDelegate.internetReachability isReachableViaWiFi];
     
-    if (isOnWifi && oauthToken) { // only preload on wifi
+    // only preload on wifi
+    if (isOnWifi) {
+        [self preloadStats];
+        [self preloadPosts];
+    }
+}
+
+- (void)preloadStats
+{
+    NSString *oauthToken = self.blog.authToken;
+    
+    if (oauthToken) {
         self.statsService = [[WPStatsService alloc] initWithSiteId:self.blog.siteID siteTimeZone:[self.blogService timeZoneForBlog:self.blog] oauth2Token:oauthToken andCacheExpirationInterval:5 * 60];
         [self.statsService retrieveInsightsStatsWithAllTimeStatsCompletionHandler:nil insightsCompletionHandler:nil todaySummaryCompletionHandler:nil latestPostSummaryCompletionHandler:nil commentsAuthorCompletionHandler:nil commentsPostsCompletionHandler:nil tagsCategoriesCompletionHandler:nil followersDotComCompletionHandler:nil followersEmailCompletionHandler:nil publicizeCompletionHandler:nil streakCompletionHandler:nil progressBlock:nil andOverallCompletionHandler:nil];
     }
+}
+
+- (void)preloadPosts
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    PostService *postService = [[PostService alloc] initWithManagedObjectContext:context];
     
+    PostServiceSyncOptions *options = [PostServiceSyncOptions new];
+    //options.statuses = filter.statuses
+    options.authorID = nil; //author // blog.account?.userID
+    // options.number = numberOfPostsPerSync()
+    options.purgesLocalSync = YES;
+    
+    NSLog(@"Preloading posts for %@", self.blog.hostname);
+    
+    [postService syncPostsOfType:PostServiceTypePost withOptions:options forBlog:self.blog success:^(NSArray<AbstractPost *> *posts) {
+        NSLog(@"Found %d posts", posts.count);
+    } failure:nil];
 }
 
 - (void)showComments

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -548,11 +548,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     options.authorID = [PostListViewController authorIDFilterForBlog:self.blog];
     options.purgesLocalSync = YES;
     
-    NSLog(@"Preloading posts for %@", self.blog.hostname);
-    
-    [postService syncPostsOfType:PostServiceTypePost withOptions:options forBlog:self.blog success:^(NSArray<AbstractPost *> *posts) {
-        NSLog(@"Found %d posts", posts.count);
-    } failure:nil];
+    [postService syncPostsOfType:PostServiceTypePost withOptions:options forBlog:self.blog success:nil failure:nil];
 }
 
 - (void)showComments

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -544,7 +544,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     
     PostServiceSyncOptions *options = [PostServiceSyncOptions new];
     //options.statuses = filter.statuses
-    options.authorID = nil; //author // blog.account?.userID
+    options.authorID = [PostListViewController authorIDFilterForBlog:self.blog];
     // options.number = numberOfPostsPerSync()
     options.purgesLocalSync = YES;
     

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -524,6 +524,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if (isOnWifi) {
         [self preloadStats];
         [self preloadPosts];
+        [self preloadPages];
     }
 }
 
@@ -549,6 +550,20 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     options.purgesLocalSync = YES;
     
     [postService syncPostsOfType:PostServiceTypePost withOptions:options forBlog:self.blog success:nil failure:nil];
+}
+
+- (void)preloadPages
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    PostService *postService = [[PostService alloc] initWithManagedObjectContext:context];
+    PostListFilter *filter = [PageListViewController currentPostListFilter];
+
+    PostServiceSyncOptions *options = [PostServiceSyncOptions new];
+    options.statuses = filter.statuses;
+    options.authorID = [PageListViewController authorIDFilterForBlog:self.blog];
+    options.purgesLocalSync = YES;
+
+    [postService syncPostsOfType:PostServiceTypePage withOptions:options forBlog:self.blog success:nil failure:nil];
 }
 
 - (void)showComments

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -541,11 +541,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     PostService *postService = [[PostService alloc] initWithManagedObjectContext:context];
+    PostListFilter *filter = [PostListViewController currentPostListFilter];
     
     PostServiceSyncOptions *options = [PostServiceSyncOptions new];
-    //options.statuses = filter.statuses
+    options.statuses = filter.statuses;
     options.authorID = [PostListViewController authorIDFilterForBlog:self.blog];
-    // options.number = numberOfPostsPerSync()
     options.purgesLocalSync = YES;
     
     NSLog(@"Preloading posts for %@", self.blog.hostname);

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -542,11 +542,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     PostService *postService = [[PostService alloc] initWithManagedObjectContext:context];
-    PostListFilter *filter = [PostListViewController currentPostListFilter];
+    PostListFilterSettings *filterSettings = [[PostListFilterSettings alloc] initWithBlog:self.blog postType:PostServiceTypePost];
+    PostListFilter *filter = [filterSettings currentPostListFilter];
     
     PostServiceSyncOptions *options = [PostServiceSyncOptions new];
     options.statuses = filter.statuses;
-    options.authorID = [PostListViewController authorIDFilterForBlog:self.blog];
+    options.authorID = [filterSettings authorIDFilter];
     options.purgesLocalSync = YES;
     
     [postService syncPostsOfType:PostServiceTypePost withOptions:options forBlog:self.blog success:nil failure:nil];
@@ -556,11 +557,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     PostService *postService = [[PostService alloc] initWithManagedObjectContext:context];
-    PostListFilter *filter = [PageListViewController currentPostListFilter];
+    PostListFilterSettings *filterSettings = [[PostListFilterSettings alloc] initWithBlog:self.blog postType:PostServiceTypePage];
+    PostListFilter *filter = [filterSettings currentPostListFilter];
 
     PostServiceSyncOptions *options = [PostServiceSyncOptions new];
     options.statuses = filter.statuses;
-    options.authorID = [PageListViewController authorIDFilterForBlog:self.blog];
+    options.authorID = [filterSettings authorIDFilter];
     options.purgesLocalSync = YES;
 
     [postService syncPostsOfType:PostServiceTypePage withOptions:options forBlog:self.blog success:nil failure:nil];

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -408,8 +408,8 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
 
     // MARK: - Filter Related
 
-    override func keyForCurrentListStatusFilter() -> String {
-        return self.dynamicType.currentPageListStatusFilterKey
+    override class func keyForCurrentListStatusFilter() -> String {
+        return currentPageListStatusFilterKey
     }
 
     // MARK: - Cell Action Handling

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -140,8 +140,8 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
 
     // MARK: - Sync Methods
 
-    override internal func postTypeToSync() -> String {
-        return PostServiceTypePage
+    override internal func postTypeToSync() -> PostServiceType {
+        return PostServiceType.Page
     }
 
     override internal func lastSyncDate() -> NSDate? {
@@ -186,7 +186,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
         }
 
         let searchText = currentSearchTerm()
-        let filterPredicate = currentPostListFilter().predicateForFetchRequest
+        let filterPredicate = self.filterSettings.currentPostListFilter().predicateForFetchRequest
 
         // If we have recently trashed posts, create an OR predicate to find posts matching the filter,
         // or posts that were recently deleted.
@@ -310,7 +310,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     private func cellIdentifierForPage(page: Page) -> String {
         var identifier : String
 
-        if recentlyTrashedPostObjectIDs.contains(page.objectID) == true && currentPostListFilter().filterType != .Trashed {
+        if recentlyTrashedPostObjectIDs.contains(page.objectID) == true && self.filterSettings.currentPostListFilter().filterType != .Trashed {
             identifier = self.dynamicType.restorePageCellIdentifier
         } else {
             identifier = self.dynamicType.pageCellIdentifier
@@ -408,8 +408,8 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
 
     // MARK: - Filter Related
 
-    override class func keyForCurrentListStatusFilter() -> String {
-        return currentPageListStatusFilterKey
+    override func keyForCurrentListStatusFilter() -> String {
+        return self.dynamicType.currentPageListStatusFilterKey
     }
 
     // MARK: - Cell Action Handling
@@ -427,7 +427,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .ActionSheet)
         alertController.addCancelActionWithTitle(cancelButtonTitle, handler: nil)
 
-        let filter = currentPostListFilter().filterType
+        let filter = self.filterSettings.currentPostListFilter().filterType
 
         if filter == .Trashed {
             alertController.addActionWithTitle(publishButtonTitle, style: .Default, handler: { [weak self] (action) in
@@ -572,7 +572,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
             return ""
         }
 
-        let filterType = currentPostListFilter().filterType
+        let filterType = self.filterSettings.currentPostListFilter().filterType
 
         switch filterType {
         case .Trashed:
@@ -587,7 +587,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
             return NSLocalizedString("Fetching pages...", comment: "A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new pages.")
         }
 
-        let filter = currentPostListFilter()
+        let filter = self.filterSettings.currentPostListFilter()
         let titles = noResultsTitles()
         let title = titles[filter.filterType]
         return title ?? ""
@@ -598,7 +598,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
             return ""
         }
 
-        let filterType = currentPostListFilter().filterType
+        let filterType = self.filterSettings.currentPostListFilter().filterType
 
         switch filterType {
         case .Draft:

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -920,8 +920,12 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     // MARK: - Filter Related
 
-    func canFilterByAuthor() -> Bool {
-        return blog.isHostedAtWPcom && blog.isMultiAuthor && blogUserID() != nil
+    class func canFilterByAuthor(blog blog:Blog) -> Bool {
+        return blog.isHostedAtWPcom && blog.isMultiAuthor && blog.account?.userID != nil
+    }
+
+    class func authorIDFilter(forBlog blog:Blog) -> NSNumber? {
+        return currentPostAuthorFilter(forBlog:blog) == .Mine ? blog.account?.userID : nil
     }
 
     func shouldShowOnlyMyPosts() -> Bool {
@@ -929,8 +933,12 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         return filter == .Mine
     }
 
-    func currentPostAuthorFilter() -> PostAuthorFilter {
+    class func currentPostAuthorFilter(forBlog blog:Blog) -> PostAuthorFilter {
         return .Everyone
+    }
+
+    func currentPostAuthorFilter() -> PostAuthorFilter {
+        return self.dynamicType.currentPostAuthorFilter(forBlog:blog)
     }
 
     func setCurrentPostAuthorFilter(filter: PostAuthorFilter) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -925,7 +925,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     }
 
     class func authorIDFilter(forBlog blog:Blog) -> NSNumber? {
-        return currentPostAuthorFilter(forBlog:blog) == .Mine ? blog.account?.userID : nil
+        return currentPostAuthorFilter(blog:blog) == .Mine ? blog.account?.userID : nil
     }
 
     func shouldShowOnlyMyPosts() -> Bool {
@@ -933,12 +933,12 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         return filter == .Mine
     }
 
-    class func currentPostAuthorFilter(forBlog blog:Blog) -> PostAuthorFilter {
+    class func currentPostAuthorFilter(blog blog:Blog) -> PostAuthorFilter {
         return .Everyone
     }
 
     func currentPostAuthorFilter() -> PostAuthorFilter {
-        return self.dynamicType.currentPostAuthorFilter(forBlog:blog)
+        return self.dynamicType.currentPostAuthorFilter(blog:blog)
     }
 
     func setCurrentPostAuthorFilter(filter: PostAuthorFilter) {
@@ -964,7 +964,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     }
     
     class func currentPostListFilter() -> PostListFilter {
-        return PostListFilter.postListFilters()[currentFilterIndex()]
+        return availablePostListFilters()[currentFilterIndex()]
     }
 
     func filterThatDisplaysPostsWithStatus(postStatus: String) -> PostListFilter {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -7,11 +7,6 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     typealias WPNoResultsView = WordPressShared.WPNoResultsView
 
-    enum PostAuthorFilter : UInt {
-        case Mine = 0
-        case Everyone = 1
-    }
-
     private static let postsControllerRefreshInterval = NSTimeInterval(300)
     private static let HTTPErrorCodeForbidden = Int(403)
     private static let postsFetchRequestBatchSize = Int(10)
@@ -70,6 +65,10 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         return noResultsView
     }()
 
+    lazy var filterSettings : PostListFilterSettings = {
+        return PostListFilterSettings(blog:self.blog, postType:self.postTypeToSync())
+    }()
+
 
     var postListFooterView : PostListFooterView!
 
@@ -83,7 +82,6 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     @IBOutlet var searchWrapperViewHeightConstraint : NSLayoutConstraint!
 
     var searchController : WPSearchController! // Stand-in for UISearchController
-    private var allPostListFilters:[PostListFilter]?
     var recentlyTrashedPostObjectIDs = [NSManagedObjectID]() // IDs of trashed posts. Cleared on refresh or when filter changes.
 
     private var needsRefreshCachedCellHeightsBeforeLayout = false
@@ -279,8 +277,8 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     func propertiesForAnalytics() -> [String:AnyObject] {
         var properties = [String:AnyObject]()
 
-        properties["type"] = postTypeToSync()
-        properties["filter"] = currentPostListFilter().title
+        properties["type"] = PostService.keyForType(postTypeToSync())
+        properties["filter"] = filterSettings.currentPostListFilter().title
 
         if let dotComID = blog.dotComID {
             properties[WPAppAnalyticsKeyBlogID] = dotComID
@@ -336,11 +334,11 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     func sortDescriptorsForFetchRequest() -> [NSSortDescriptor] {
         // Ascending only for scheduled posts/pages.
-        let ascending = currentPostListFilter().filterType == .Scheduled
+        let ascending = filterSettings.currentPostListFilter().filterType == .Scheduled
 
         let sortDescriptorLocal = NSSortDescriptor(key: "metaIsLocal", ascending: false)
         let sortDescriptorImmediately = NSSortDescriptor(key: "metaPublishImmediately", ascending: false)
-        if currentPostListFilter().filterType == .Draft {
+        if filterSettings.currentPostListFilter().filterType == .Draft {
             return [sortDescriptorLocal, NSSortDescriptor(key: "dateModified", ascending: ascending)]
         }
         let sortDescriptorDate = NSSortDescriptor(key: "date_created_gmt", ascending: ascending)
@@ -355,7 +353,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         let fetchRequest = tableViewHandler.resultsController.fetchRequest
 
         // Set the predicate based on filtering by the oldestPostDate and not searching.
-        let filter = currentPostListFilter()
+        let filter = filterSettings.currentPostListFilter()
 
         if let oldestPostDate = filter.oldestPostDate where !isSearching() {
 
@@ -428,7 +426,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
             && indexPath.row + self.dynamicType.postsLoadMoreThreshold >= tableView.numberOfRowsInSection(indexPath.section) {
 
             // Only 3 rows till the end of table
-            if currentPostListFilter().hasMore {
+            if filterSettings.currentPostListFilter().hasMore {
                 syncHelper.syncMoreContent()
             }
         }
@@ -516,9 +514,9 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     // MARK: - WPContentSyncHelperDelegate
 
-    func postTypeToSync() -> String {
+    internal func postTypeToSync() -> PostServiceType {
         // Subclasses should override.
-        return PostServiceTypeAny
+        return PostServiceType.Any
     }
 
     func lastSyncDate() -> NSDate? {
@@ -528,12 +526,11 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     func syncHelper(syncHelper: WPContentSyncHelper, syncContentWithUserInteraction userInteraction: Bool, success: ((hasMore: Bool) -> ())?, failure: ((error: NSError) -> ())?) {
 
         if recentlyTrashedPostObjectIDs.count > 0 {
-            recentlyTrashedPostObjectIDs.removeAll()
-            updateAndPerformFetchRequestRefreshingResults()
+            refreshAndReload()
         }
 
-        let filter = currentPostListFilter()
-        let author = shouldShowOnlyMyPosts() ? blogUserID() : nil
+        let filter = filterSettings.currentPostListFilter()
+        let author = filterSettings.shouldShowOnlyMyPosts() ? blogUserID() : nil
 
         let postService = PostService(managedObjectContext: managedObjectContext())
 
@@ -585,8 +582,8 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         WPAnalytics.track(.PostListLoadedMore, withProperties: propertiesForAnalytics())
         postListFooterView.showSpinner(true)
 
-        let filter = currentPostListFilter()
-        let author = shouldShowOnlyMyPosts() ? blogUserID() : nil
+        let filter = filterSettings.currentPostListFilter()
+        let author = filterSettings.shouldShowOnlyMyPosts() ? blogUserID() : nil
 
         let postService = PostService(managedObjectContext: managedObjectContext())
 
@@ -700,7 +697,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         tableViewHandler.clearCachedRowHeights()
         tableView.reloadData()
 
-        let filter = currentPostListFilter()
+        let filter = filterSettings.currentPostListFilter()
         if filter.hasMore && tableViewHandler.resultsController.fetchedObjects?.count == 0 {
             // If the filter detects there are more posts, but there are none that match the current search
             // hide the no results view while the upcoming syncPostsMatchingSearchText() may in fact load results.
@@ -734,14 +731,14 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         guard let searchText = searchController.searchBar.text where !searchText.isEmpty() else {
             return
         }
-        let filter = currentPostListFilter()
+        let filter = filterSettings.currentPostListFilter()
         guard filter.hasMore else {
             return
         }
 
         postsSyncWithSearchDidBegin()
 
-        let author = shouldShowOnlyMyPosts() ? blogUserID() : nil
+        let author = filterSettings.shouldShowOnlyMyPosts() ? blogUserID() : nil
         let postService = PostService(managedObjectContext: managedObjectContext())
         let options = PostServiceSyncOptions()
         options.statuses = filter.statuses
@@ -873,9 +870,9 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
             if let postStatus = apost.status {
                 // If the post was restored, see if it appears in the current filter.
                 // If not, prompt the user to let it know under which filter it appears.
-                let filter = strongSelf.filterThatDisplaysPostsWithStatus(postStatus)
+                let filter = strongSelf.filterSettings.filterThatDisplaysPostsWithStatus(postStatus)
 
-                if filter.filterType == strongSelf.currentPostListFilter().filterType {
+                if filter.filterType == strongSelf.filterSettings.currentPostListFilter().filterType {
                     return
                 }
 
@@ -918,146 +915,45 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         return blog.account?.userID
     }
 
-    // MARK: - Filter Related
-
-    class func canFilterByAuthor(blog blog:Blog) -> Bool {
-        return blog.isHostedAtWPcom && blog.isMultiAuthor && blog.account?.userID != nil
-    }
-
-    class func authorIDFilter(forBlog blog:Blog) -> NSNumber? {
-        return currentPostAuthorFilter(blog:blog) == .Mine ? blog.account?.userID : nil
-    }
-
-    func shouldShowOnlyMyPosts() -> Bool {
-        let filter = currentPostAuthorFilter()
-        return filter == .Mine
-    }
-
-    class func currentPostAuthorFilter(blog blog:Blog) -> PostAuthorFilter {
-        return .Everyone
-    }
-
-    func currentPostAuthorFilter() -> PostAuthorFilter {
-        return self.dynamicType.currentPostAuthorFilter(blog:blog)
-    }
-
-    func setCurrentPostAuthorFilter(filter: PostAuthorFilter) {
-        // Noop. The default implementation is read only.
-        // Subclasses may override the getter and setter for their own filter storage.
-    }
-
-    class func availablePostListFilters() -> [PostListFilter] {
-        return PostListFilter.postListFilters()
-    }
-    
-    func availablePostListFilters() -> [PostListFilter] {
-
-        if allPostListFilters == nil {
-            allPostListFilters = PostListFilter.postListFilters()
-        }
-
-        return allPostListFilters!
-    }
-
-    func currentPostListFilter() -> PostListFilter {
-        return availablePostListFilters()[self.dynamicType.currentFilterIndex()]
-    }
-    
-    class func currentPostListFilter() -> PostListFilter {
-        return availablePostListFilters()[currentFilterIndex()]
-    }
-
-    func filterThatDisplaysPostsWithStatus(postStatus: String) -> PostListFilter {
-        let index = indexOfFilterThatDisplaysPostsWithStatus(postStatus)
-        return availablePostListFilters()[index]
-    }
-
-    func indexOfFilterThatDisplaysPostsWithStatus(postStatus: String) -> Int {
-        var index = 0
-        var found = false
-
-        for (idx, filter) in availablePostListFilters().enumerate() {
-            if filter.statuses.contains(postStatus) {
-                found = true
-                index = idx
-                break
-            }
-        }
-
-        if !found {
-            // The draft filter is the catch all by convention.
-            index = indexForFilterWithType(.Draft)
-        }
-
-        return index
-    }
-
-    func indexForFilterWithType(filterType: PostListFilter.Status) -> Int {
-        if let index = availablePostListFilters().indexOf({ (filter: PostListFilter) -> Bool in
-            return filter.filterType == filterType
-        }) {
-            return index
-        } else {
-            return NSNotFound
-        }
-    }
-
-    class func keyForCurrentListStatusFilter() -> String {
-        fatalError("You should implement this method in the subclass")
-    }
-
-    class func currentFilterIndex() -> Int {
-
-        let userDefaults = NSUserDefaults.standardUserDefaults()
-
-        if let filter = userDefaults.objectForKey(keyForCurrentListStatusFilter()) as? Int
-            where filter < availablePostListFilters().count {
-
-            return filter
-        } else {
-            return 0 // first item is the default
-        }
-     }
-
-    func setCurrentFilterIndex(newIndex: Int) {
-        let index = self.dynamicType.currentFilterIndex()
-
-        guard newIndex != index else {
-            return
-        }
-
-        WPAnalytics.track(.PostListStatusFilterChanged, withProperties: propertiesForAnalytics())
-        NSUserDefaults.standardUserDefaults().setObject(newIndex, forKey: self.dynamicType.keyForCurrentListStatusFilter())
-        NSUserDefaults.resetStandardUserDefaults()
-
+    func refreshAndReload() {
         recentlyTrashedPostObjectIDs.removeAll()
         updateFilterTitle()
         resetTableViewContentOffset()
         updateAndPerformFetchRequestRefreshingResults()
     }
 
+    func keyForCurrentListStatusFilter() -> String {
+        fatalError("You should implement this method in the subclass")
+    }
+
     func updateFilterTitle() {
-        filterButton.setAttributedTitleForTitle(currentPostListFilter().title)
+        filterButton.setAttributedTitleForTitle(filterSettings.currentPostListFilter().title)
     }
 
     func displayFilters() {
-        let titles = availablePostListFilters().map { (filter: PostListFilter) -> String in
+        let availableFilters = filterSettings.availablePostListFilters()
+
+        let titles = availableFilters.map { (filter: PostListFilter) -> String in
             return filter.title
         }
 
-        let dict = [SettingsSelectionDefaultValueKey: availablePostListFilters()[0],
+        let dict = [SettingsSelectionDefaultValueKey: availableFilters[0],
                     SettingsSelectionTitleKey: NSLocalizedString("Filters", comment: "Title of the list of post status filters."),
                     SettingsSelectionTitlesKey: titles,
-                    SettingsSelectionValuesKey: availablePostListFilters(),
-                    SettingsSelectionCurrentValueKey: currentPostListFilter()]
+                    SettingsSelectionValuesKey: availableFilters,
+                    SettingsSelectionCurrentValueKey: filterSettings.currentPostListFilter()]
 
         let controller = SettingsSelectionViewController(style: .Plain, andDictionary: dict as [NSObject : AnyObject])
         controller.onItemSelected = { [weak self] (selectedValue: AnyObject!) -> () in
             if let strongSelf = self,
-                let index = strongSelf.availablePostListFilters().indexOf(selectedValue as! PostListFilter) {
+                let index = strongSelf.filterSettings.availablePostListFilters().indexOf(selectedValue as! PostListFilter) {
 
-                strongSelf.setCurrentFilterIndex(index)
+                strongSelf.filterSettings.setCurrentFilterIndex(index)
                 strongSelf.dismissViewControllerAnimated(true, completion: nil)
+
+                strongSelf.refreshAndReload()
+
+                WPAnalytics.track(.PostListStatusFilterChanged, withProperties: strongSelf.propertiesForAnalytics())
             }
         }
 
@@ -1076,11 +972,6 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         ForcePopoverPresenter.configurePresentationControllerForViewController(controller, presentingFromView: titleView)
 
         presentViewController(controller, animated: true, completion: nil)
-    }
-
-    func setFilterWithPostStatus(status: String) {
-        let index = indexOfFilterThatDisplaysPostsWithStatus(status)
-        setCurrentFilterIndex(index)
     }
 
     // MARK: - Search Controller Delegate Methods

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1067,8 +1067,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
             return
         }
 
-        ForcePopoverPresenter.configurePresentationControllerForViewController(controller,
-                                                                                                           presentingFromView: titleView)
+        ForcePopoverPresenter.configurePresentationControllerForViewController(controller, presentingFromView: titleView)
 
         presentViewController(controller, animated: true, completion: nil)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+@objc class PostListFilterSettings: NSObject {
+    private static let currentPostAuthorFilterKey = "CurrentPostAuthorFilterKey"
+    private static let currentPageListStatusFilterKey = "CurrentPageListStatusFilterKey"
+    private static let currentPostListStatusFilterKey = "CurrentPostListStatusFilterKey"
+
+    let blog:Blog
+    let postType:PostServiceType
+    private var allPostListFilters:[PostListFilter]?
+
+    enum AuthorFilter : UInt {
+        case Mine = 0
+        case Everyone = 1
+    }
+
+    init(blog:Blog, postType:PostServiceType) {
+        self.blog = blog
+        self.postType = postType
+    }
+
+    func canFilterByAuthor() -> Bool {
+        if postType == .Post
+        {
+            return blog.isHostedAtWPcom && blog.isMultiAuthor && blog.account?.userID != nil
+        }
+        return false
+    }
+
+    func authorIDFilter() -> NSNumber? {
+        return currentPostAuthorFilter() == .Mine ? blog.account?.userID : nil
+    }
+
+    func shouldShowOnlyMyPosts() -> Bool {
+        let filter = currentPostAuthorFilter()
+        return filter == .Mine
+    }
+
+    func currentPostAuthorFilter() -> AuthorFilter {
+        if !canFilterByAuthor() {
+            return .Everyone
+        }
+
+        if let filter = NSUserDefaults.standardUserDefaults().objectForKey(self.dynamicType.currentPostAuthorFilterKey) {
+            if filter.unsignedIntegerValue == AuthorFilter.Everyone.rawValue {
+                return .Everyone
+            }
+        }
+
+        return .Mine
+    }
+
+    func setCurrentPostAuthorFilter(filter: AuthorFilter) {
+        guard filter != currentPostAuthorFilter() else {
+            return
+        }
+
+        NSUserDefaults.standardUserDefaults().setObject(filter.rawValue, forKey: self.dynamicType.currentPostAuthorFilterKey)
+        NSUserDefaults.resetStandardUserDefaults()
+    }
+
+    func availablePostListFilters() -> [PostListFilter] {
+
+        if allPostListFilters == nil {
+            allPostListFilters = PostListFilter.postListFilters()
+        }
+
+        return allPostListFilters!
+    }
+
+    func currentPostListFilter() -> PostListFilter {
+        return availablePostListFilters()[currentFilterIndex()]
+    }
+
+    func filterThatDisplaysPostsWithStatus(postStatus: String) -> PostListFilter {
+        let index = indexOfFilterThatDisplaysPostsWithStatus(postStatus)
+        return availablePostListFilters()[index]
+    }
+
+    func indexOfFilterThatDisplaysPostsWithStatus(postStatus: String) -> Int {
+        var index = 0
+        var found = false
+
+        for (idx, filter) in availablePostListFilters().enumerate() {
+            if filter.statuses.contains(postStatus) {
+                found = true
+                index = idx
+                break
+            }
+        }
+
+        if !found {
+            // The draft filter is the catch all by convention.
+            index = indexForFilterWithType(.Draft)
+        }
+
+        return index
+    }
+
+    func indexForFilterWithType(filterType: PostListFilter.Status) -> Int {
+        if let index = availablePostListFilters().indexOf({ (filter: PostListFilter) -> Bool in
+            return filter.filterType == filterType
+        }) {
+            return index
+        } else {
+            return NSNotFound
+        }
+    }
+
+    func keyForCurrentListStatusFilter() -> String {
+        switch postType {
+        case .Page:
+            return self.dynamicType.currentPageListStatusFilterKey
+        case .Post:
+            return self.dynamicType.currentPageListStatusFilterKey
+        default:
+            return ""
+        }
+    }
+
+    func currentFilterIndex() -> Int {
+
+        let userDefaults = NSUserDefaults.standardUserDefaults()
+
+        if let filter = userDefaults.objectForKey(keyForCurrentListStatusFilter()) as? Int
+            where filter < availablePostListFilters().count {
+
+            return filter
+        } else {
+            return 0 // first item is the default
+        }
+    }
+
+    func setCurrentFilterIndex(newIndex: Int) {
+        let index = self.currentFilterIndex()
+
+        guard newIndex != index else {
+            return
+        }
+
+        NSUserDefaults.standardUserDefaults().setObject(newIndex, forKey: self.keyForCurrentListStatusFilter())
+        NSUserDefaults.resetStandardUserDefaults()
+    }
+
+    func setFilterWithPostStatus(status: String) {
+        let index = indexOfFilterThatDisplaysPostsWithStatus(status)
+        self.setCurrentFilterIndex(index)
+
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -553,7 +553,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
 
     // MARK: - Filter Related
 
-    override class func currentPostAuthorFilter(forBlog blog:Blog) -> PostAuthorFilter {
+    override class func currentPostAuthorFilter(blog blog:Blog) -> PostAuthorFilter {
         if !canFilterByAuthor(blog:blog) {
             // No REST API, so we have to use XMLRPC and can't filter results by author.
             return .Everyone

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -584,8 +584,8 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         syncItemsWithUserInteraction(false)
     }
 
-    override func keyForCurrentListStatusFilter() -> String {
-        return self.dynamicType.currentPostListStatusFilterKey
+    override class func keyForCurrentListStatusFilter() -> String {
+        return currentPostListStatusFilterKey
     }
 
     // MARK: - InteractivePostViewDelegate

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -202,7 +202,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
 
         authorsFilterView?.backgroundColor = WPStyleGuide.lightGrey()
 
-        if !canFilterByAuthor() {
+        if !self.dynamicType.canFilterByAuthor(blog:self.blog) {
             authorsFilterViewHeightConstraint?.constant = 0
             authorFilterSegmentedControl.hidden = true
         }
@@ -553,13 +553,13 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
 
     // MARK: - Filter Related
 
-    override func currentPostAuthorFilter() -> PostAuthorFilter {
-        if !canFilterByAuthor() {
+    override class func currentPostAuthorFilter(forBlog blog:Blog) -> PostAuthorFilter {
+        if !canFilterByAuthor(blog:blog) {
             // No REST API, so we have to use XMLRPC and can't filter results by author.
             return .Everyone
         }
 
-        if let filter = NSUserDefaults.standardUserDefaults().objectForKey(self.dynamicType.currentPostAuthorFilterKey) {
+        if let filter = NSUserDefaults.standardUserDefaults().objectForKey(self.currentPostAuthorFilterKey) {
             if filter.unsignedIntegerValue == PostAuthorFilter.Everyone.rawValue {
                 return .Everyone
             }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		37022D931981C19000F322B7 /* VerticallyStackedButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 37022D901981BF9200F322B7 /* VerticallyStackedButton.m */; };
 		374CB16215B93C0800DD0EBC /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 374CB16115B93C0800DD0EBC /* AudioToolbox.framework */; };
 		37EAAF4D1A11799A006D6306 /* CircularImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EAAF4C1A11799A006D6306 /* CircularImageView.swift */; };
+		43AB7C5E1D3E70510066CB6A /* PostListFilterSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */; };
 		45C73C25113C36F70024D0D2 /* MainWindow-iPad.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45C73C24113C36F70024D0D2 /* MainWindow-iPad.xib */; };
 		462F4E0A18369F0B0028D2F8 /* BlogDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 462F4E0718369F0B0028D2F8 /* BlogDetailsViewController.m */; };
 		4645AFC51961E1FB005F7509 /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4645AFC41961E1FB005F7509 /* AppImages.xcassets */; };
@@ -1148,6 +1149,7 @@
 		374CB16115B93C0800DD0EBC /* AudioToolbox.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		37EAAF4C1A11799A006D6306 /* CircularImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircularImageView.swift; sourceTree = "<group>"; };
 		3C7F96E2BF4BDB333ABE0B89 /* Pods-WordPressTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.debug.xcconfig"; sourceTree = "<group>"; };
+		43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostListFilterSettings.swift; sourceTree = "<group>"; };
 		45C73C24113C36F70024D0D2 /* MainWindow-iPad.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = "MainWindow-iPad.xib"; path = "Resources-iPad/MainWindow-iPad.xib"; sourceTree = "<group>"; };
 		462F4E0618369F0B0028D2F8 /* BlogDetailsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogDetailsViewController.h; sourceTree = "<group>"; };
 		462F4E0718369F0B0028D2F8 /* BlogDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BlogDetailsViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -2911,6 +2913,7 @@
 			isa = PBXGroup;
 			children = (
 				595CB3751D2317D50082C7E9 /* PostListFilter.swift */,
+				43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -6137,6 +6140,7 @@
 				E1F8E1231B0B411E0073E628 /* JetpackService.m in Sources */,
 				5DA3EE161925090A00294E0B /* MediaService.m in Sources */,
 				E65219FB1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift in Sources */,
+				43AB7C5E1D3E70510066CB6A /* PostListFilterSettings.swift in Sources */,
 				E64E17661CA8518800BE7744 /* NUXSubmitButton.swift in Sources */,
 				B5EEDB971C91F10400676B2B /* Blog+Interface.swift in Sources */,
 				5D839AA8187F0D6B00811F4A /* PostFeaturedImageCell.m in Sources */,


### PR DESCRIPTION
Fixes #5537

To test:
1. While on wifi, go to a site's Blog Posts screen. The data should be preloaded after selecting the site, and take no time to show the latest posts on the Blog Post screen.
2. While on 3G or LTE, there should be no preloading. Any new posts will only appear after going to the Blog Posts screen.

_This was branched from #5655_

Needs review: @diegoreymendez want to do both?