### PR TITLE
Issue/5665 photo goes missing

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -701,7 +701,7 @@ static NSString * const MediaDirectory = @"Media";
                                                                                     error:nil];
 
         for (NSURL *currentURL in contentsOfDir) {
-            NSString *filepath = [currentURL path];
+            NSString *filepath = [[currentURL URLByResolvingSymlinksInPath] path];
             NSString *extension = filepath.pathExtension.lowercaseString;
             if (![mediaExtensions containsObject:extension] ||
                 [pathsToKeep containsObject:filepath]) {


### PR DESCRIPTION
Fixes #5665 

This bug shows up because of  interesting symlinks returned on URL's coming from ```[NSFileManager contentsOfDirectoryAtURL]```. More details here: http://stackoverflow.com/questions/14992834/what-does-the-private-prefix-on-an-ios-file-path-indicate

To test:
 - Check the steps to reproduce on the issue #5665 and make sure that images are not deleted.

Needs review: @aerych 