### PR TITLE
Disables payments through StoreKit.

### DIFF
--- a/WordPress/Classes/Services/Store.swift
+++ b/WordPress/Classes/Services/Store.swift
@@ -262,7 +262,9 @@ class StoreKitStore: Store {
     }
 
     var canMakePayments: Bool {
-        return SKPaymentQueue.canMakePayments()
+        // Payments are currently disabled. If this is reverted in the future,
+        // simply return the result of SKPaymentQueue.canMakePayments()
+        return false
     }
 }
 


### PR DESCRIPTION
This PR should _actually_ remove the purchase buttons from Plans, like, for real this time.

Please ensure you test against sites that are already on both Free and Premium plans. I think we might have missed this last time because we may have only checked on Premium (which wouldn't show purchase buttons anyway).

Needs review: @kwonye 
