### PR TITLE
Update the WPMediaPicker to version 0.10.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,7 +47,7 @@ abstract_target 'WordPress_Base' do
     pod 'NSObject-SafeExpectations', '0.0.2'
     pod 'NSURL+IDN', '0.3'
     pod 'Simperium', '0.8.15'
-    pod 'WPMediaPicker', '~> 0.9.2'
+    pod 'WPMediaPicker', '~> 0.10.0'
     pod 'WordPress-iOS-Editor', '1.7.1'
     pod 'WordPressCom-Analytics-iOS', '0.1.15'
     pod 'WordPressCom-Stats-iOS', '0.7.4'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -185,7 +185,7 @@ PODS:
     - WordPressCom-Stats-iOS/Services
   - WordPressComKit (0.0.4):
     - Alamofire (~> 3.0)
-  - WPMediaPicker (0.9.2)
+  - WPMediaPicker (0.10.0)
   - wpxmlrpc (0.8.2)
 
 DEPENDENCIES:
@@ -223,7 +223,7 @@ DEPENDENCIES:
   - WordPressCom-Stats-iOS (= 0.7.4)
   - WordPressCom-Stats-iOS/Services (= 0.7.4)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.4`)
-  - WPMediaPicker (~> 0.9.2)
+  - WPMediaPicker (~> 0.10.0)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -285,9 +285,9 @@ SPEC CHECKSUMS:
   WordPressCom-Analytics-iOS: e1a7111255e98561c4b5a33ef4baa75a68e0d5d3
   WordPressCom-Stats-iOS: 87b64bc36015e90789fec4abdb931af87c6e4cfe
   WordPressComKit: 0742c47e5b55bff0e6d26d40db9e010404675a73
-  WPMediaPicker: 98356dbf35bfaba0f51aff16d88563babadf24c7
+  WPMediaPicker: 8ec6e21020447461dcb19d2f524e4b2e7f7a8a78
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: baa47bc285158d18e8761c191d1e68427e319449
+PODFILE CHECKSUM: df640b096b347a1477d40861401f3f93aef5ad81
 
 COCOAPODS: 1.0.1

--- a/WordPress/Classes/Models/Media.h
+++ b/WordPress/Classes/Models/Media.h
@@ -64,6 +64,7 @@ typedef NS_ENUM(NSUInteger, MediaOrientation) {
 
 
 - (void)mediaTypeFromUrl:(NSString *)ext;
++ (NSString *)stringFromMediaType:(MediaType)mediaType;
 
 - (void)remove;
 - (void)save;

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -72,18 +72,23 @@
 
 - (void)setMediaType:(MediaType)mediaType
 {
+    self.mediaTypeString = [[self class] stringFromMediaType:mediaType];    
+}
+
++ (NSString *)stringFromMediaType:(MediaType)mediaType
+{
     switch (mediaType) {
         case MediaTypeImage:
-            self.mediaTypeString = @"image";
+            return @"image";
             break;
         case MediaTypeVideo:
-            self.mediaTypeString = @"video";
+            return @"video";
             break;
         case MediaTypePowerpoint:
-            self.mediaTypeString = @"powerpoint";
+            return @"powerpoint";
             break;
         case MediaTypeDocument:
-            self.mediaTypeString = @"document";
+            return @"document";
             break;
     }
 }

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -113,15 +113,13 @@
                   success:(void (^)(UIImage *image))success
                   failure:(void (^)(NSError *error))failure;
 /**
- *  Get number of items in media library
+ *  Get the number of items in a blog media library that are of a certain type.
  *
- *  @param blog    from where to count the media items
- *  @param success a block that will be invoked when the media is retrieved
- *  @param failure a block that will be invoked if an error happens returnin the associated error object with the details.
+ *  @param blog from what blog to count the media items.
+ *  @param mediaTypes set of media type values to be considered in the counting.
  */
-- (void)getMediaLibraryCountForBlog:(Blog *)blog
-                            success:(void (^)(NSInteger))success
-                            failure:(void (^)(NSError *error))failure;
+- (NSInteger)getMediaLibraryCountForBlog:(Blog *)blog
+                           forMediaTypes:(NSSet *)mediaTypes;
 
 #pragma mark - Media cleanup
 

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -441,23 +441,35 @@
     }];
 }
 
-- (void)getMediaLibraryCountForBlog:(Blog *)blog
-                            success:(void (^)(NSInteger))success
-                            failure:(void (^)(NSError *error))failure
+- (NSInteger)getMediaLibraryCountForBlog:(Blog *)blog
+                           forMediaTypes:(NSSet *)mediaTypes
 {
-    id<MediaServiceRemote> remote = [self remoteForBlog:blog];
-    [remote getMediaLibraryCountWithSuccess:^(NSInteger count) {
-                               if (success) {
-                                   success(count);
-                               }
-                           }
-                           failure:^(NSError *error) {
-                               if (failure) {
-                                   [self.managedObjectContext performBlock:^{
-                                       failure(error);
-                                   }];
-                               }
-                           }];
+    NSString *entityName = NSStringFromClass([Media class]);
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
+    request.predicate = [self predicateForMediaTypes:mediaTypes blog:blog];
+    NSError *error;
+    NSArray *mediaAssets = [self.managedObjectContext executeFetchRequest:request error:&error];
+    return mediaAssets.count;
+}
+
+- (NSPredicate *)predicateForMediaTypes:(NSSet *)mediaTypes blog:(Blog *)blog
+{
+    NSMutableArray * filters = [NSMutableArray array];
+    [mediaTypes enumerateObjectsUsingBlock:^(NSNumber *obj, BOOL *stop){
+        MediaType filter = (MediaType)[obj intValue];
+        NSString *filterString = [Media stringFromMediaType:filter];
+        [filters addObject:[NSString stringWithFormat:@"mediaTypeString == \"%@\"", filterString]];
+    }];
+
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"blog == %@", blog];
+    if (filters.count > 0) {
+        NSString *mediaFilters = [filters componentsJoinedByString:@" || "];
+        NSPredicate *mediaPredicate = [NSPredicate predicateWithFormat:mediaFilters];
+        predicate = [NSCompoundPredicate andPredicateWithSubpredicates:
+                     @[predicate, mediaPredicate]];
+    }
+
+    return predicate;
 }
 
 #pragma mark - Private


### PR DESCRIPTION
This PR updates the WPMediaPicker to version 0.10.0.

As a consequence the MediaLibrary data source needed to be update in order to report correct media count depending of the filter that are active on the Media Picker.

To test:
 - Start a new post.
 - Tap to add new media.
 - Tap on the collection/group selector on the media picker
 - Check if the count for media on the Media Library is updated correctly with the number element inside
 - Cancel the picker
 - Go to Post settings and tap on Featured Image
 - Check if the picker here shows the correct count for the Media Library, it should ignore any videos on the library.

Needs review: @frosty 