### PR TITLE
Reader: Show fewer suggestions for smaller heights.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
@@ -32,8 +32,22 @@ class ReaderSearchSuggestionsViewController : UIViewController
     var tableViewHandler: WPTableViewHandler!
     var delegate: ReaderSearchSuggestionsDelegate?
     let cellIdentifier = "CellIdentifier"
-    let maxTableViewRows = 5
     let rowAndButtonHeight = CGFloat(44.0)
+    var maxTableViewRows:Int {
+        let height = UIApplication.sharedApplication().keyWindow?.frame.size.height ?? 0
+        if height == 320 {
+            // iPhone 4s, 5, 5s, in landscape orientation
+            return 1
+        } else if height <= 480 {
+            // iPhone 4s in portrait orientation
+            return 2
+        } else if height <= 568 {
+            // iPhone 5, 5s in portrait orientation
+            return 4
+        }
+        // Everything else
+        return 5
+    }
 
 
     /// A convenience method for instantiating the controller from the storyboard.
@@ -70,6 +84,13 @@ class ReaderSearchSuggestionsViewController : UIViewController
         borderImageView.image = UIImage(color: WPStyleGuide.greyLighten10(), havingSize: CGSize(width: stackView.frame.width, height: 1))
 
         updateHeightConstraint()
+    }
+
+
+    override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animateAlongsideTransition({ (_) in
+            self.updateHeightConstraint()
+            }, completion: nil)
     }
 
 


### PR DESCRIPTION
Fixes #5679 

To test: 
Prepare by searching for at least five different topics beginning with the same letter. 
For each platform, confirm that the clear button is always visible.
- [x] iPhone 4s:  Should show 2 options in portrait orientation, 1 option in landscape
- [x] iPhone 5/5s: Should show 4 options in portrait orientation, 1 option in landscape
- [x] iPhone 6/6s: Should show 5 options in portrait orientation, 2 options in landscape
- [x] iPad (any): Should show 5 options always.

Needs review: @bummytime  
