### PR TITLE
Reader: Disable refresh for search topics.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -524,6 +524,17 @@ import WordPressComAnalytics
         // Enable the view now that we have a topic.
         view.userInteractionEnabled = true
 
+        if let topic = readerTopic, properties = topicPropertyForStats() {
+            ReaderHelpers.trackLoadedTopic(topic, withProperties: properties)
+
+            // Disable pull to refresh for search topics.
+            // Searches are a snap shot in time, and ephemeral. There should be no
+            // need to refresh.
+            if ReaderHelpers.isTopicSearchTopic(topic) {
+                tableViewController.refreshControl = nil
+            }
+        }
+
         // Rather than repeatedly creating a service to check if the user is logged in, cache it here.
         let service = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
         let account = service.defaultWordPressComAccount()
@@ -555,10 +566,6 @@ import WordPressComAnalytics
                 selector: #selector(ReaderStreamViewController.handleBlockSiteNotification(_:)),
                 name: ReaderPostMenu.BlockSiteNotification,
                 object: nil)
-        }
-
-        if let topic = readerTopic, properties = topicPropertyForStats() {
-            ReaderHelpers.trackLoadedTopic(topic, withProperties: properties)
         }
     }
 


### PR DESCRIPTION
The new Search feature was never intended to support pull-to-refresh but somehow pull-to-refresh was left enabled when the feature merged.  This PR disables it.

To test:
Perform a search in the reader. 
Try to perform a pull to refresh action. 
The refresh control should not appear and a new sync should not occur.

Load any other topic in the reader.
Confirm that pull to refresh continues to function.

Needs review: @diegoreymendez 

