### PR TITLE
Update Media Library Data Source

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,7 +47,7 @@ abstract_target 'WordPress_Base' do
     pod 'NSObject-SafeExpectations', '0.0.2'
     pod 'NSURL+IDN', '0.3'
     pod 'Simperium', '0.8.15'
-    pod 'WPMediaPicker', '~> 0.10.0'
+    pod 'WPMediaPicker', '~> 0.10.1'
     pod 'WordPress-iOS-Editor', '1.7.1'
     pod 'WordPressCom-Analytics-iOS', '0.1.15'
     pod 'WordPressCom-Stats-iOS', '0.7.4'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -185,7 +185,7 @@ PODS:
     - WordPressCom-Stats-iOS/Services
   - WordPressComKit (0.0.4):
     - Alamofire (~> 3.0)
-  - WPMediaPicker (0.10.0)
+  - WPMediaPicker (0.10.1)
   - wpxmlrpc (0.8.2)
 
 DEPENDENCIES:
@@ -223,7 +223,7 @@ DEPENDENCIES:
   - WordPressCom-Stats-iOS (= 0.7.4)
   - WordPressCom-Stats-iOS/Services (= 0.7.4)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.4`)
-  - WPMediaPicker (~> 0.10.0)
+  - WPMediaPicker (~> 0.10.1)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -285,9 +285,9 @@ SPEC CHECKSUMS:
   WordPressCom-Analytics-iOS: e1a7111255e98561c4b5a33ef4baa75a68e0d5d3
   WordPressCom-Stats-iOS: 87b64bc36015e90789fec4abdb931af87c6e4cfe
   WordPressComKit: 0742c47e5b55bff0e6d26d40db9e010404675a73
-  WPMediaPicker: 8ec6e21020447461dcb19d2f524e4b2e7f7a8a78
+  WPMediaPicker: 645ecc2435293cc898c76180f3994358a68cae20
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: df640b096b347a1477d40861401f3f93aef5ad81
+PODFILE CHECKSUM: 4462bd43cdbe9229af61e7b952dd38430915b973
 
 COCOAPODS: 1.0.1

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -5,17 +5,23 @@
 #import "ContextManager.h"
 #import "WordPress-swift.h"
 
-@interface  MediaLibraryPickerDataSource()
+@interface  MediaLibraryPickerDataSource() <NSFetchedResultsControllerDelegate>
 
 @property (nonatomic, strong) MediaLibraryGroup *mediaGroup;
 @property (nonatomic, strong) Blog *blog;
 @property (nonatomic, strong) AbstractPost *post;
 @property (nonatomic, assign) WPMediaType filter;
 @property (nonatomic, assign) BOOL ascendingOrdering;
-@property (nonatomic, strong) NSArray *media;
 @property (nonatomic, strong) NSMutableDictionary *observers;
 @property (nonatomic, strong) MediaService *mediaService;
+@property (nonatomic, strong) NSFetchedResultsController *fetchController;
 @property (nonatomic, strong) id groupObserverHandler;
+#pragma mark - change trackers
+@property (nonatomic, strong) NSMutableIndexSet *mediaRemoved;
+@property (nonatomic, strong) NSMutableIndexSet *mediaInserted;
+@property (nonatomic, strong) NSMutableIndexSet *mediaChanged;
+@property (nonatomic, strong) NSMutableArray *mediaMoved;
+
 @end
 
 @implementation MediaLibraryPickerDataSource
@@ -37,6 +43,12 @@
         NSManagedObjectContext *backgroundContext = [[ContextManager sharedInstance] newDerivedContext];
         _mediaService = [[MediaService alloc] initWithManagedObjectContext:backgroundContext];
         _observers = [NSMutableDictionary dictionary];
+
+        _mediaRemoved = [[NSMutableIndexSet alloc] init];
+        _mediaInserted = [[NSMutableIndexSet alloc] init];
+        _mediaChanged = [[NSMutableIndexSet alloc] init];
+        _mediaMoved = [[NSMutableArray alloc] init];
+
     }
     return self;
 }
@@ -56,10 +68,15 @@
     return [self initWithBlog:nil];
 }
 
+#pragma mark - WPMediaCollectionDataSource
 
 -(NSInteger)numberOfAssets
 {
-    return [self.media count];
+    if ([[self.fetchController sections] count] > 0) {
+        id <NSFetchedResultsSectionInfo> sectionInfo = [[self.fetchController sections] objectAtIndex:0];
+        return [sectionInfo numberOfObjects];
+    } else
+        return 0;
 }
 
 -(NSInteger)numberOfGroups
@@ -83,44 +100,31 @@
     return self.mediaGroup;
 }
 
--(void)loadDataWithSuccess:(WPMediaSuccessBlock)successBlock failure:(WPMediaFailureBlock)failureBlock
+- (void)loadDataWithSuccess:(WPMediaSuccessBlock)successBlock failure:(WPMediaFailureBlock)failureBlock
 {
-    NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
-    [mainContext performBlock:^{
-        NSString *entityName = NSStringFromClass([Media class]);
-        NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
-        request.predicate = [[self class] predicateForFilter:self.filter blog:self.blog];
-        NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:self.ascendingOrdering];
-        request.sortDescriptors = @[sortDescriptor];
+    // let's check if we already have fetched results before
+    if (self.fetchController.fetchedObjects == nil) {
         NSError *error;
-        self.media = [mainContext executeFetchRequest:request error:&error];
-    }];
-    [self.mediaService syncMediaLibraryForBlog:self.blog success:^{
-        NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
-        [mainContext performBlock:^{
-            NSString *entityName = NSStringFromClass([Media class]);
-            NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
-            request.predicate = [[self class] predicateForFilter:self.filter blog:self.blog];
-            NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:self.ascendingOrdering];
-            request.sortDescriptors = @[sortDescriptor];
-            NSError *error;
-            self.media = [mainContext executeFetchRequest:request error:&error];
-            if (self.media == nil && error) {
-                DDLogVerbose(@"Error fecthing media: %@", [error localizedDescription]);
-                if (failureBlock) {
-                    failureBlock(error);
-                }
-                return;
+        if (![self.fetchController performFetch:&error]) {
+            if (failureBlock) {
+                failureBlock(error);
             }
-            if (successBlock) {
-                successBlock();
-            }
-        }];
-    } failure:^(NSError *error) {
-        if (failureBlock) {
-            failureBlock(error);
+            return;
         }
-    }];
+    }
+    BOOL localResultsAvailable = NO;
+    if (self.fetchController.fetchedObjects.count > 0) {
+        localResultsAvailable = YES;
+        if (successBlock) {
+            successBlock();
+        }
+    }
+    // try to sync from the server
+    [self.mediaService syncMediaLibraryForBlog:self.blog success:^{
+        if (!localResultsAvailable && successBlock) {
+            successBlock();
+        }
+    } failure:failureBlock];
 }
 
 - (void)notifyObserversWithIncrementalChanges:(BOOL)incrementalChanges removed:(NSIndexSet *)removed inserted:(NSIndexSet *)inserted changed:(NSIndexSet *)changed moved:(NSArray<id<WPMediaMove>> *)moved
@@ -220,7 +224,7 @@
 
 -(id<WPMediaAsset>)mediaAtIndex:(NSInteger)index
 {
-    return self.media[index];
+    return [self.fetchController objectAtIndexPath:[NSIndexPath indexPathForRow:index inSection:0]];
 }
 
 -(id<WPMediaAsset>)mediaWithIdentifier:(NSString *)identifier
@@ -244,23 +248,99 @@
     return media;
 }
 
+#pragma mark - NSFetchedResultsController helpers
+
 + (NSPredicate *)predicateForFilter:(WPMediaType)filter blog:(Blog *)blog
 {
-    NSPredicate *predicate;
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", @"blog", blog];
+    NSPredicate *mediaPredicate = [NSPredicate predicateWithValue:YES];
     switch (filter) {
         case WPMediaTypeImage: {
-            predicate = [NSPredicate predicateWithFormat:@"mediaTypeString = %@ && blog = %@",  @"image", blog];
+            mediaPredicate = [NSPredicate predicateWithFormat:@"mediaTypeString == %@", [Media stringFromMediaType:MediaTypeImage]];
         } break;
         case WPMediaTypeVideo: {
-            predicate = [NSPredicate predicateWithFormat:@"mediaTypeString = %@ && blog = %@", @"video", blog];
+            mediaPredicate = [NSPredicate predicateWithFormat:@"mediaTypeString == %@", [Media stringFromMediaType:MediaTypeVideo]];
         } break;
         case WPMediaTypeVideoOrImage: {
-            predicate = [NSPredicate predicateWithFormat:@"(mediaTypeString = %@ || mediaTypeString = %@)  && blog = %@", @"image", @"video", blog];
+            mediaPredicate = [NSPredicate predicateWithFormat:@"(mediaTypeString == %@ || mediaTypeString == %@)", [Media stringFromMediaType:MediaTypeImage], [Media stringFromMediaType:MediaTypeVideo]];
         } break;
         default:
             break;
     };
-    return predicate;
+    return [NSCompoundPredicate andPredicateWithSubpredicates:
+            @[predicate, mediaPredicate]];
+}
+
+- (NSFetchedResultsController *)fetchController
+{
+    if (_fetchController) {
+        return _fetchController;
+    }
+
+    NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
+    NSString *entityName = NSStringFromClass([Media class]);
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:entityName];
+    fetchRequest.predicate = [[self class] predicateForFilter:self.filter blog:self.blog];
+    NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:self.ascendingOrdering];
+    fetchRequest.sortDescriptors = @[sortDescriptor];
+
+    _fetchController = [[NSFetchedResultsController alloc]
+                            initWithFetchRequest:fetchRequest
+                            managedObjectContext:mainContext
+                            sectionNameKeyPath:nil
+                            cacheName:nil];
+    _fetchController.delegate = self;
+
+    return _fetchController;
+}
+
+#pragma mark - NSFetchedResultsControllerDelegate
+
+- (void)controllerWillChangeContent:(NSFetchedResultsController *)controller {
+    [self.mediaRemoved removeAllIndexes];
+    [self.mediaInserted removeAllIndexes];
+    [self.mediaChanged removeAllIndexes];
+    [self.mediaMoved removeAllObjects];
+}
+
+
+- (void)controller:(NSFetchedResultsController *)controller didChangeSection:(id <NSFetchedResultsSectionInfo>)sectionInfo
+           atIndex:(NSUInteger)sectionIndex forChangeType:(NSFetchedResultsChangeType)type {
+    //This shouldn't be called because we don't have sections.
+}
+
+
+- (void)controller:(NSFetchedResultsController *)controller didChangeObject:(id)anObject
+       atIndexPath:(NSIndexPath *)indexPath forChangeType:(NSFetchedResultsChangeType)type
+      newIndexPath:(NSIndexPath *)newIndexPath
+{
+    switch(type) {
+
+        case NSFetchedResultsChangeInsert:
+            [self.mediaInserted addIndex:newIndexPath.row];
+        break;
+        case NSFetchedResultsChangeDelete:
+            [self.mediaRemoved addIndex:indexPath.row];
+        break;
+        case NSFetchedResultsChangeUpdate:
+            [self.mediaChanged addIndex:indexPath.row];
+        break;
+
+        case NSFetchedResultsChangeMove: {
+            WPIndexMove *mediaMove = [[WPIndexMove alloc] init:indexPath.row to:newIndexPath.row];
+            [self.mediaMoved addObject:mediaMove];
+        }
+        break;
+    }
+}
+
+
+- (void)controllerDidChangeContent:(NSFetchedResultsController *)controller {
+    [self notifyObserversWithIncrementalChanges:YES
+                                        removed:self.mediaRemoved
+                                       inserted:self.mediaInserted
+                                        changed:self.mediaChanged
+                                          moved:self.mediaMoved];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -306,7 +306,7 @@
 
 - (void)controller:(NSFetchedResultsController *)controller didChangeSection:(id <NSFetchedResultsSectionInfo>)sectionInfo
            atIndex:(NSUInteger)sectionIndex forChangeType:(NSFetchedResultsChangeType)type {
-    //This shouldn't be called because we don't have sections.
+    //This shouldn't be called because we don't have changes to sections.
 }
 
 


### PR DESCRIPTION
Update the media library data source to use a NSFetchedResultsController.
This allows improved changed notification and also allow to show media immediately instead of waiting for the server sync.

To test:
 - Create a new post
 - Tap on add media
 - Select the media library
 - If it's the first access it should sync from the server and then show the results
 - If not the first access it should show results immediately and eventually update from server results.
 - On the media library you also need to test the adding a new image using the camera. 

Needs review: @frosty 