### PR TITLE
Reader: Fixes breaking constraints when multitasking on the iPad.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,6 +10,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ysV-mc-MQ9" id="VTN-SK-j2Y">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="63.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lwd-Kl-XE5">
@@ -33,7 +33,7 @@
                             <constraint firstAttribute="bottom" secondItem="rJY-ty-wZw" secondAttribute="bottom" id="fDp-e1-tf7"/>
                             <constraint firstItem="rJY-ty-wZw" firstAttribute="leading" secondItem="KcP-7c-oak" secondAttribute="leading" constant="14" id="ttN-d9-8Ad"/>
                             <constraint firstItem="rJY-ty-wZw" firstAttribute="top" secondItem="KcP-7c-oak" secondAttribute="top" id="uhg-5N-UUi"/>
-                            <constraint firstAttribute="width" constant="600" id="veg-0O-Jpa"/>
+                            <constraint firstAttribute="width" priority="900" constant="600" id="veg-0O-Jpa"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -18,7 +18,6 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5pB-wb-r4Y">
                                 <rect key="frame" x="0.0" y="8" width="320" height="48"/>
-                                <animations/>
                                 <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aMb-Gb-gWp">
@@ -26,7 +25,6 @@
                                 <subviews>
                                     <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="odD-xS-y0M">
                                         <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
-                                        <animations/>
                                         <gestureRecognizers/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="32" id="MAk-f1-wxx"/>
@@ -35,7 +33,6 @@
                                     </imageView>
                                     <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="HKf-84-9ay" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="12" y="12" width="24" height="24"/>
-                                        <animations/>
                                         <gestureRecognizers/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="24" id="IxI-83-hD0"/>
@@ -44,13 +41,11 @@
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u3R-Xf-UYr">
                                         <rect key="frame" x="42" y="0.0" width="246" height="17"/>
-                                        <animations/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <animations/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <gestureRecognizers/>
                                 <constraints>
@@ -65,7 +60,6 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <animations/>
                         <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="5pB-wb-r4Y" firstAttribute="leading" secondItem="Wqw-Gu-5jd" secondAttribute="leading" id="1mR-8q-8m8"/>
@@ -74,7 +68,7 @@
                             <constraint firstItem="5pB-wb-r4Y" firstAttribute="top" secondItem="Wqw-Gu-5jd" secondAttribute="top" constant="8" id="H4E-fW-Oib"/>
                             <constraint firstAttribute="bottom" secondItem="5pB-wb-r4Y" secondAttribute="bottom" constant="8" id="SFB-Cd-DLa"/>
                             <constraint firstAttribute="trailing" secondItem="5pB-wb-r4Y" secondAttribute="trailing" id="aSj-nA-n8O"/>
-                            <constraint firstAttribute="width" constant="600" id="dqo-df-thU"/>
+                            <constraint firstAttribute="width" priority="900" constant="600" id="dqo-df-thU"/>
                             <constraint firstItem="aMb-Gb-gWp" firstAttribute="top" secondItem="Wqw-Gu-5jd" secondAttribute="top" constant="16" id="epM-bd-P7k"/>
                             <constraint firstItem="aMb-Gb-gWp" firstAttribute="leading" secondItem="Wqw-Gu-5jd" secondAttribute="leading" constant="16" id="qQY-I7-eZS"/>
                         </constraints>
@@ -90,7 +84,6 @@
                         </variation>
                     </view>
                 </subviews>
-                <animations/>
                 <constraints>
                     <constraint firstItem="Wqw-Gu-5jd" firstAttribute="centerX" secondItem="5qn-1n-3Ik" secondAttribute="centerX" id="KDV-ou-sc0"/>
                     <constraint firstItem="Wqw-Gu-5jd" firstAttribute="top" secondItem="5qn-1n-3Ik" secondAttribute="top" id="KUc-I4-IEJ"/>
@@ -111,7 +104,6 @@
                     </mask>
                 </variation>
             </tableViewCellContentView>
-            <animations/>
             <connections>
                 <outlet property="avatarImageView" destination="HKf-84-9ay" id="tZr-P9-JcR"/>
                 <outlet property="blavatarImageView" destination="odD-xS-y0M" id="pyw-35-X8J"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -63,6 +62,7 @@
                             <constraint firstItem="kzd-gs-nwM" firstAttribute="width" secondItem="Iu5-0g-eH5" secondAttribute="width" constant="4" id="4kB-se-exN"/>
                             <constraint firstItem="kzd-gs-nwM" firstAttribute="centerY" secondItem="mwJ-ag-abH" secondAttribute="centerY" id="50a-Ga-DXU"/>
                             <constraint firstItem="mwJ-ag-abH" firstAttribute="centerY" secondItem="NEV-Mu-ne8" secondAttribute="centerY" id="9GB-lS-8tE"/>
+                            <constraint firstAttribute="width" priority="900" constant="600" id="Fio-tK-HrZ"/>
                             <constraint firstItem="mwJ-ag-abH" firstAttribute="centerX" secondItem="NEV-Mu-ne8" secondAttribute="centerX" id="K6x-SS-1Sk"/>
                             <constraint firstItem="7AJ-lZ-zT3" firstAttribute="centerX" secondItem="NEV-Mu-ne8" secondAttribute="centerX" id="Kh7-xU-0dq"/>
                             <constraint firstItem="kzd-gs-nwM" firstAttribute="height" secondItem="mwJ-ag-abH" secondAttribute="height" id="LRu-tc-Xnt"/>
@@ -75,8 +75,14 @@
                             <constraint firstItem="Iu5-0g-eH5" firstAttribute="centerX" secondItem="srv-7s-DDa" secondAttribute="centerX" id="ubh-zN-r4p"/>
                             <constraint firstItem="Iu5-0g-eH5" firstAttribute="centerY" secondItem="srv-7s-DDa" secondAttribute="centerY" id="wLv-K0-f1H"/>
                         </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="Fio-tK-HrZ"/>
+                            </mask>
+                        </variation>
                         <variation key="heightClass=regular-widthClass=regular">
                             <mask key="constraints">
+                                <include reference="Fio-tK-HrZ"/>
                                 <exclude reference="qqo-cg-4OR"/>
                                 <exclude reference="tYd-7j-19d"/>
                             </mask>
@@ -87,21 +93,18 @@
                     <constraint firstItem="NEV-Mu-ne8" firstAttribute="centerX" secondItem="RWc-RJ-5IV" secondAttribute="centerX" id="DDH-v3-nGs"/>
                     <constraint firstItem="NEV-Mu-ne8" firstAttribute="leading" secondItem="RWc-RJ-5IV" secondAttribute="leading" id="FFx-yP-3wf"/>
                     <constraint firstAttribute="bottom" secondItem="NEV-Mu-ne8" secondAttribute="bottom" id="azr-K6-fut"/>
-                    <constraint firstItem="NEV-Mu-ne8" firstAttribute="width" secondItem="RWc-RJ-5IV" secondAttribute="width" constant="600" id="dVF-3Q-CdG"/>
                     <constraint firstAttribute="trailing" secondItem="NEV-Mu-ne8" secondAttribute="trailing" id="jJd-RR-6mH"/>
                     <constraint firstItem="NEV-Mu-ne8" firstAttribute="top" secondItem="RWc-RJ-5IV" secondAttribute="top" id="w7G-La-9lf"/>
                 </constraints>
                 <variation key="default">
                     <mask key="constraints">
                         <exclude reference="DDH-v3-nGs"/>
-                        <exclude reference="dVF-3Q-CdG"/>
                     </mask>
                 </variation>
                 <variation key="heightClass=regular-widthClass=regular">
                     <mask key="constraints">
                         <include reference="DDH-v3-nGs"/>
                         <exclude reference="FFx-yP-3wf"/>
-                        <include reference="dVF-3Q-CdG"/>
                         <exclude reference="jJd-RR-6mH"/>
                     </mask>
                 </variation>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -51,7 +50,7 @@
                         <constraint firstItem="Q3K-e0-BuO" firstAttribute="top" secondItem="iWB-Uw-beb" secondAttribute="top" constant="16" id="bis-26-ZXw"/>
                         <constraint firstItem="Q3K-e0-BuO" firstAttribute="leading" secondItem="iWB-Uw-beb" secondAttribute="leading" constant="16" id="eb7-Vx-b0S"/>
                         <constraint firstItem="uk5-Xp-lih" firstAttribute="leading" secondItem="Q3K-e0-BuO" secondAttribute="trailing" constant="10" id="rzx-Qx-G0r"/>
-                        <constraint firstAttribute="width" constant="600" id="sv8-De-gMf"/>
+                        <constraint firstAttribute="width" priority="900" constant="600" id="sv8-De-gMf"/>
                     </constraints>
                     <variation key="default">
                         <mask key="constraints">

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -120,7 +119,7 @@
                     <color key="backgroundColor" red="0.84313725490196079" green="0.8901960784313725" blue="0.92156862745098034" alpha="1" colorSpace="calibratedRGB"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="SEx-10-HwS" secondAttribute="trailing" id="2Q6-h3-yIF"/>
-                        <constraint firstAttribute="width" constant="600" id="9dU-Qi-t1D"/>
+                        <constraint firstAttribute="width" priority="900" constant="600" id="9dU-Qi-t1D"/>
                         <constraint firstAttribute="bottom" secondItem="vwc-uc-Njz" secondAttribute="bottom" id="EhK-Ob-vd9"/>
                         <constraint firstAttribute="trailing" secondItem="vwc-uc-Njz" secondAttribute="trailing" id="GEG-Bw-P4t"/>
                         <constraint firstItem="SEx-10-HwS" firstAttribute="leading" secondItem="Lbk-Jq-qTd" secondAttribute="leading" id="TEC-MX-Y6t"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -50,7 +49,7 @@
                         <constraint firstItem="S0E-MM-cCj" firstAttribute="leading" secondItem="f85-bJ-w04" secondAttribute="trailing" constant="10" id="HuJ-aH-u17"/>
                         <constraint firstItem="S0E-MM-cCj" firstAttribute="centerY" secondItem="OeG-5o-P7K" secondAttribute="centerY" id="YW1-md-OXP"/>
                         <constraint firstItem="OeG-5o-P7K" firstAttribute="top" secondItem="w2t-P4-qyc" secondAttribute="top" constant="16" id="aQr-XY-0Oo"/>
-                        <constraint firstAttribute="width" constant="600" id="dGy-0v-2gt"/>
+                        <constraint firstAttribute="width" priority="900" constant="600" id="dGy-0v-2gt"/>
                         <constraint firstAttribute="trailing" secondItem="S0E-MM-cCj" secondAttribute="trailing" constant="16" id="lEy-BK-56k"/>
                         <constraint firstItem="OeG-5o-P7K" firstAttribute="centerY" secondItem="f85-bJ-w04" secondAttribute="centerY" id="pyz-dc-YRO"/>
                         <constraint firstItem="f85-bJ-w04" firstAttribute="leading" secondItem="OeG-5o-P7K" secondAttribute="trailing" constant="10" id="sDv-w7-oIb"/>


### PR DESCRIPTION
Fixes #5660 
It looks like the culprit was a required constraint for our iPad width implemented in a few different xibs (cards and headers). This PR lowers the priority so we shouldn't see it breaking anymore.

To test:
Repeat the steps described in the issue and confirm that there are no longer warnings about breaking constraints. 

Needs review: @jleandroperez 
