### PR TITLE
Show images from private sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -329,14 +329,16 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     }
 
     NSURL *url = [post featuredImageURLForDisplay];
+    self.postCardImageView.image = nil; // Clear the image so we know its not stale.
     // if not private create photon url
     if (![post isPrivate]) {
         CGSize imageSize = self.postCardImageView.frame.size;
         url = [PhotonImageURLHelper photonURLWithSize:imageSize forImageURL:url];
+        [self.postCardImageView setImageWithURL:url placeholderImage:nil];
+    } else {
+        NSURLRequest *request = [PrivateSiteURLProtocol requestForPrivateSiteFromURL:url];
+        [self.postCardImageView setImageWithURLRequest:request placeholderImage:nil success:nil failure:nil];
     }
-
-    self.postCardImageView.image = nil; // Clear the image so we know its not stale.
-    [self.postCardImageView setImageWithURL:url placeholderImage:nil];
 }
 
 - (void)configureTitle

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -330,11 +330,11 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
     NSURL *url = [post featuredImageURLForDisplay];
     self.postCardImageView.image = nil; // Clear the image so we know its not stale.
-    // if not private create photon url
     if ([post isPrivate] && [post.blog isHostedAtWPcom]) {
         NSURLRequest *request = [PrivateSiteURLProtocol requestForPrivateSiteFromURL:url];
         [self.postCardImageView setImageWithURLRequest:request placeholderImage:nil success:nil failure:nil];
     } else {
+        // if not private create photon url
         CGSize imageSize = self.postCardImageView.frame.size;
         url = [PhotonImageURLHelper photonURLWithSize:imageSize forImageURL:url];
         [self.postCardImageView setImageWithURL:url placeholderImage:nil];

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -331,13 +331,13 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     NSURL *url = [post featuredImageURLForDisplay];
     self.postCardImageView.image = nil; // Clear the image so we know its not stale.
     // if not private create photon url
-    if (![post isPrivate]) {
+    if ([post isPrivate] && [post.blog isHostedAtWPcom]) {
+        NSURLRequest *request = [PrivateSiteURLProtocol requestForPrivateSiteFromURL:url];
+        [self.postCardImageView setImageWithURLRequest:request placeholderImage:nil success:nil failure:nil];
+    } else {
         CGSize imageSize = self.postCardImageView.frame.size;
         url = [PhotonImageURLHelper photonURLWithSize:imageSize forImageURL:url];
         [self.postCardImageView setImageWithURL:url placeholderImage:nil];
-    } else {
-        NSURLRequest *request = [PrivateSiteURLProtocol requestForPrivateSiteFromURL:url];
-        [self.postCardImageView setImageWithURLRequest:request placeholderImage:nil success:nil failure:nil];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -29,18 +29,6 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
 
     private let animatedBox = WPAnimatedBox()
 
-    // MARK: - Initializers & deinitializers
-
-    deinit {
-        PrivateSiteURLProtocol.unregisterPrivateSiteURLProtocol()
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-
-        PrivateSiteURLProtocol.registerPrivateSiteURLProtocol()
-    }
-
     // MARK: - Convenience constructors
 
     class func controllerWithBlog(blog: Blog) -> PostListViewController {

--- a/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.h
+++ b/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.h
@@ -20,4 +20,6 @@
 + (void)registerPrivateSiteURLProtocol;
 + (void)unregisterPrivateSiteURLProtocol;
 
++ (NSURLRequest *)requestForPrivateSiteFromURL:(NSURL *)url;
+
 @end

--- a/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
+++ b/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
@@ -97,6 +97,18 @@ static NSString *cachedToken;
     return NO;
 }
 
++ (NSURLRequest *)requestForPrivateSiteFromURL:(NSURL *)url
+{
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
+    //make sure the scheme used is https
+    [urlComponents setScheme:@"https"];
+    NSURL *httpsURL = [urlComponents URL];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:httpsURL];
+    NSString *bearerToken = [NSString stringWithFormat:@"Bearer %@", [self bearerToken]];
+    [request addValue:bearerToken forHTTPHeaderField:@"Authorization"];
+    return request;
+}
+
 - (void)startLoading
 {
     NSMutableURLRequest *mRequest = [self.request mutableCopy];

--- a/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
+++ b/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
@@ -21,7 +21,9 @@ static NSString *cachedToken;
 {    
     @synchronized(mutex) {
         if (regcount == 0) {
-            [NSURLProtocol registerClass:[self class]];
+            if (![NSURLProtocol registerClass:[self class]]) {
+                DDLogInfo(@"Unable to register protocol");
+            }
         }
         regcount++;
     }
@@ -31,9 +33,13 @@ static NSString *cachedToken;
 {
     @synchronized(mutex) {
         cachedToken = nil;
-        regcount--;
-        if (regcount == 0) {
-            [NSURLProtocol unregisterClass:[self class]];
+        if (regcount > 0) {
+            regcount--;
+            if (regcount == 0) {
+                [NSURLProtocol unregisterClass:[self class]];
+            }
+        } else {
+            DDLogInfo(@"Detected unbalanced register/unregister private site protocol.");
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
+++ b/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
@@ -22,6 +22,7 @@ static NSString *cachedToken;
     @synchronized(mutex) {
         if (regcount == 0) {
             if (![NSURLProtocol registerClass:[self class]]) {
+                NSAssert(YES, @"Unable to register protocol");
                 DDLogInfo(@"Unable to register protocol");
             }
         }


### PR DESCRIPTION
This PR fixes the loading of images on PostListViewController when the site is private

To test:
 - Login with a private WP.com site
 - Access that site
 - Open the post list
 - Check if the image load correctly.

Needs review: @diegoreymendez 
