### PR TITLE
Resize images for private blogs.

### DIFF
--- a/WordPress/Classes/Utility/WPImageURLHelper.swift
+++ b/WordPress/Classes/Utility/WPImageURLHelper.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Helper class to create a WordPress URL for downloading images with size parameters.
+public class WPImageURLHelper: NSObject
+{
+    /**
+     Adds to the provided url width and height parameters to allow the image to be resized on the server
+
+     - parameter size: the required size for the image
+     - parameter url:  the original url for the image
+
+     - returns: an URL with the added query parameters.
+
+     - note: If there is any problem with the original URL parsing, the original URL is returned with no changes.
+     */
+    public class func imageURLWithSize(size: CGSize, forImageURL url:NSURL) -> NSURL {
+        guard let urlComponents = NSURLComponents(URL: url, resolvingAgainstBaseURL: true) else {
+            return url
+        }
+        var newQueryItems = [NSURLQueryItem]()
+        if let queryItems = urlComponents.queryItems {
+            for queryItem in queryItems {
+                if queryItem.name != "w" && queryItem.name != "h" {
+                    newQueryItems.append(queryItem)
+                }
+            }
+        }
+        let height = size.height
+        let width = size.width
+        if height != 0 {
+            let heightItem = NSURLQueryItem(name:"h", value:"\(height)")
+            newQueryItems.append(heightItem)
+        }
+
+        if width != 0 {
+            let widthItem = NSURLQueryItem(name:"w", value:"\(width)")
+            newQueryItems.append(widthItem)
+        }
+
+        urlComponents.queryItems = newQueryItems
+        guard let resultURL = urlComponents.URL else {
+            return url
+        }
+        return resultURL
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -330,16 +330,17 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
     NSURL *url = [post featuredImageURLForDisplay];
     self.postCardImageView.image = nil; // Clear the image so we know its not stale.
+    CGFloat desiredWidth = [UIApplication  sharedApplication].keyWindow.frame.size.width;
+    CGFloat desiredHeight = self.postCardImageViewHeightConstraint.constant;
+    CGSize imageSize = CGSizeMake(desiredWidth, desiredHeight);
     if ([post isPrivate] && [post.blog isHostedAtWPcom]) {
-        CGSize imageSize = self.postCardImageView.frame.size;
         CGFloat scale = [[UIScreen mainScreen] scale];
-        CGSize scaledSize = CGSizeMake(imageSize.width * scale, imageSize.height * scale);
+        CGSize scaledSize = CGSizeMake(desiredWidth * scale, desiredHeight * scale);
         url = [WPImageURLHelper imageURLWithSize:scaledSize forImageURL:url];
         NSURLRequest *request = [PrivateSiteURLProtocol requestForPrivateSiteFromURL:url];
         [self.postCardImageView setImageWithURLRequest:request placeholderImage:nil success:nil failure:nil];
     } else {
         // if not private create photon url
-        CGSize imageSize = self.postCardImageView.frame.size;
         url = [PhotonImageURLHelper photonURLWithSize:imageSize forImageURL:url];
         [self.postCardImageView setImageWithURL:url placeholderImage:nil];
     }

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -331,6 +331,10 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     NSURL *url = [post featuredImageURLForDisplay];
     self.postCardImageView.image = nil; // Clear the image so we know its not stale.
     if ([post isPrivate] && [post.blog isHostedAtWPcom]) {
+        CGSize imageSize = self.postCardImageView.frame.size;
+        CGFloat scale = [[UIScreen mainScreen] scale];
+        CGSize scaledSize = CGSizeMake(imageSize.width * scale, imageSize.height * scale);
+        url = [WPImageURLHelper imageURLWithSize:scaledSize forImageURL:url];
         NSURLRequest *request = [PrivateSiteURLProtocol requestForPrivateSiteFromURL:url];
         [self.postCardImageView setImageWithURLRequest:request placeholderImage:nil success:nil failure:nil];
     } else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -316,7 +316,8 @@ import WordPressShared
                 // momentarily visible.
                 featuredImageView.image = nil
                 var url = featuredImageURL
-                let size = CGSize(width:featuredMediaView.frame.width, height:featuredMediaHeightConstraintConstant)
+                let desiredWidth = UIApplication.sharedApplication().keyWindow?.frame.size.width ?? self.featuredMediaView.frame.width
+                let size = CGSize(width:desiredWidth, height:featuredMediaHeightConstraintConstant)
                 if !(contentProvider!.isPrivate()) {
                     url = PhotonImageURLHelper.photonURLWithSize(size, forImageURL: url)
                     featuredImageView.setImageWithURL(url, placeholderImage:nil)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -316,13 +316,16 @@ import WordPressShared
                 // momentarily visible.
                 featuredImageView.image = nil
                 var url = featuredImageURL
+                let size = CGSize(width:featuredMediaView.frame.width, height:featuredMediaHeightConstraintConstant)
                 if !(contentProvider!.isPrivate()) {
-                    let size = CGSize(width:featuredMediaView.frame.width, height:featuredMediaHeightConstraintConstant)
                     url = PhotonImageURLHelper.photonURLWithSize(size, forImageURL: url)
                     featuredImageView.setImageWithURL(url, placeholderImage:nil)
 
                 } else if (url.host != nil) && url.host!.hasSuffix("wordpress.com") {
                     // private wpcom image needs special handling.
+                    let scale = UIScreen.mainScreen().scale
+                    let scaledSize = CGSize(width:size.width * scale, height: size.height * scale)
+                    url = WPImageURLHelper.imageURLWithSize(scaledSize, forImageURL: url)
                     let request = requestForURL(url)
                     featuredImageView.setImageWithURLRequest(request, placeholderImage: nil, success: nil, failure: nil)
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -871,6 +871,7 @@
 		FFA0B7D71CAC1F9F00533B9D /* MainNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA0B7D61CAC1F9F00533B9D /* MainNavigationTests.swift */; };
 		FFA162311CB7031A00E2E110 /* AppSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA162301CB7031A00E2E110 /* AppSettingsViewController.swift */; };
 		FFA9148F1BA6E5170068F8BF /* RotationAwareNavigationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FFA9148E1BA6E5170068F8BF /* RotationAwareNavigationViewController.m */; };
+		FFB0DEAA1D38061B00DD4A50 /* WPImageURLHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB0DEA91D38061B00DD4A50 /* WPImageURLHelper.swift */; };
 		FFB1FA9E1BF0EB840090C761 /* UIImage+Exporters.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1FA9D1BF0EB840090C761 /* UIImage+Exporters.swift */; };
 		FFB1FAA01BF0EC4E0090C761 /* PHAsset+Exporters.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1FA9F1BF0EC4E0090C761 /* PHAsset+Exporters.swift */; };
 		FFB7B8201A0012E80032E723 /* ApiCredentials.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB7B81D1A0012E80032E723 /* ApiCredentials.m */; };
@@ -2238,6 +2239,7 @@
 		FFA40D4D1CB3EDD5001CB1FB /* WordPress 48.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 48.xcdatamodel"; sourceTree = "<group>"; };
 		FFA9148D1BA6E5170068F8BF /* RotationAwareNavigationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RotationAwareNavigationViewController.h; sourceTree = "<group>"; };
 		FFA9148E1BA6E5170068F8BF /* RotationAwareNavigationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RotationAwareNavigationViewController.m; sourceTree = "<group>"; };
+		FFB0DEA91D38061B00DD4A50 /* WPImageURLHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPImageURLHelper.swift; sourceTree = "<group>"; };
 		FFB1FA9D1BF0EB840090C761 /* UIImage+Exporters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Exporters.swift"; sourceTree = "<group>"; };
 		FFB1FA9F1BF0EC4E0090C761 /* PHAsset+Exporters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PHAsset+Exporters.swift"; sourceTree = "<group>"; };
 		FFB7B81D1A0012E80032E723 /* ApiCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ApiCredentials.m; sourceTree = "<group>"; };
@@ -3408,6 +3410,7 @@
 				E1E1AA8B1B7DEDFC001C8645 /* WPMapFilterReduce.h */,
 				E1E1AA8C1B7DEDFC001C8645 /* WPMapFilterReduce.m */,
 				E12E6E321C21BA170033C5D0 /* FeatureFlag.swift */,
+				FFB0DEA91D38061B00DD4A50 /* WPImageURLHelper.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -6071,6 +6074,7 @@
 				B5772AC91C9C859D0031F97E /* GravatarServiceRemote.swift in Sources */,
 				E61084C11B9B47BA008050C5 /* ReaderSiteTopic.swift in Sources */,
 				5DAE40AD19EC70930011A0AE /* ReaderPostHeaderView.m in Sources */,
+				FFB0DEAA1D38061B00DD4A50 /* WPImageURLHelper.swift in Sources */,
 				E6C448571CB091AA00458157 /* SigninKeyboardResponder.swift in Sources */,
 				74BB6F1A19AE7B9400FB7829 /* WPLegacyEditPageViewController.m in Sources */,
 				B580E4791AEA91000091A094 /* UIViewController+Helpers.swift in Sources */,


### PR DESCRIPTION
Fixes #5720 

To test:

 - Login with WP.com
 - Select a blog that is private
 - Look at the post list
 - Check if images are downloading correctly.
 - Add the same site to the reader
 - Check post from that site and see if images show correctly.

Needs review: @aerych 
