### PR TITLE
Notifications + Swift Mk 5: Simperium

### DIFF
--- a/WordPress/Classes/Extensions/NSFetchedResultsController+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSFetchedResultsController+Helpers.swift
@@ -5,7 +5,7 @@ extension NSFetchedResultsController
 {
     /// Returns whether an indexPath represents the last row in it's section, or not
     ///
-    func isLastRowInSection(indexPath: NSIndexPath) -> Bool {
+    func isLastIndexPathInSection(indexPath: NSIndexPath) -> Bool {
         guard let sections = sections else {
             return false
         }

--- a/WordPress/Classes/Extensions/NSFetchedResultsController+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSFetchedResultsController+Helpers.swift
@@ -3,6 +3,21 @@ import Foundation
 
 extension NSFetchedResultsController
 {
+    /// Returns whether an indexPath represents the last row in it's section, or not
+    ///
+    func isLastRowInSection(indexPath: NSIndexPath) -> Bool {
+        guard let sections = sections else {
+            return false
+        }
+
+        guard indexPath.section < sections.count else {
+            return false
+        }
+
+        return indexPath.row == sections[indexPath.section].numberOfObjects - 1
+    }
+
+
     /// Returns an object of the specified type. Nil if the indexPath is out of bounds.
     ///
     func objectOfType<T : NSManagedObject>(type: T.Type, atIndexPath indexPath: NSIndexPath) -> T? {

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -50,6 +50,7 @@
 #import "NavbarTitleDropdownButton.h"
 #import "NotificationsViewController.h"
 #import "NotificationsViewController+Internal.h"
+#import "Meta.h"
 #import "Notification.h"
 #import "Notification+Internals.h"
 #import "NSString+Helpers.h"

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -50,6 +50,7 @@
 #import "NavbarTitleDropdownButton.h"
 #import "NotificationsViewController.h"
 #import "NotificationsViewController+Internal.h"
+#import "NotificationDetailsViewController.h"
 #import "Meta.h"
 #import "Notification.h"
 #import "Notification+Internals.h"

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -443,6 +443,30 @@ extension NotificationsViewController: SPBucketDelegate
 
 
 
+// MARK: - Sync'ing Helpers
+//
+extension NotificationsViewController
+{
+    func resetApplicationBadge() {
+        UIApplication.sharedApplication().applicationIconBadgeNumber = 0
+    }
+
+    func updateLastSeenTime() {
+        guard let note = tableViewHandler.resultsController.fetchedObjects?.first as? Notification else {
+            return
+        }
+
+        let bucketName = Meta.classNameWithoutNamespaces()
+        guard let metadata = simperium.bucketForName(bucketName).objectForKey(bucketName.lowercaseString) as? Meta else {
+            return
+        }
+
+        metadata.last_seen = NSNumber(double: note.timestampAsDate.timeIntervalSince1970)
+        simperium.save()
+    }
+}
+
+
 
 // MARK: - Tracking
 //
@@ -526,6 +550,11 @@ private extension NotificationsViewController
         case Comment                = 2
         case Follow                 = 3
         case Like                   = 4
+    }
+
+    enum Syncing {
+        static let pushMaxWait      = NSTimeInterval(1)
+        static let syncTimeoutKey   = "network_status"
     }
 
     enum RatingSettings {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -236,7 +236,7 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
         // after a DB OP. This loop has been measured in the order of milliseconds (iPad Mini)
         for indexPath in tableView.indexPathsForVisibleRows ?? [] {
             let cell = tableView.cellForRowAtIndexPath(indexPath) as! NoteTableViewCell
-            cell.showsBottomSeparator = isRowLastRowForSection(indexPath)
+            cell.showsBottomSeparator = isRowLastRowForSection(indexPath) == false
         }
 
         // Update NoResults View

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -441,6 +441,25 @@ extension NotificationsViewController: SPBucketDelegate
     }
 }
 
+
+
+
+// MARK: - Tracking
+//
+extension NotificationsViewController
+{
+    func trackAppeared() {
+        WPAnalytics.track(.OpenedNotificationsList)
+    }
+
+    func trackSyncTimeout() {
+        let properties = [Syncing.syncTimeoutKey : simperium.networkStatus]
+        WPAnalytics.track(.NotificationsMissingSyncWarning, withProperties: properties)
+    }
+
+}
+
+
 // MARK: - ABXPromptViewDelegate Methods
 //
 extension NotificationsViewController: ABXPromptViewDelegate

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -468,7 +468,7 @@ extension NotificationsViewController: SPBucketDelegate
         }
 
         // If needed, show the details only if NotificationPushMaxWait hasn't elapsed
-        if pushNotificationID == key {
+        if let waitingNoteID = pushNotificationID where waitingNoteID == key {
             if abs(pushNotificationDate.timeIntervalSinceNow) <= Syncing.pushMaxWait {
                 showDetailsForNotificationWithID(key)
             }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -464,6 +464,20 @@ extension NotificationsViewController
         metadata.last_seen = NSNumber(double: note.timestampAsDate.timeIntervalSince1970)
         simperium.save()
     }
+
+    func startSyncTimeoutTimer() {
+        // Don't proceed if we're not even connected
+        guard WordPressAppDelegate.sharedInstance().connectionAvailable else {
+            return
+        }
+
+        stopSyncTimeoutTimer()
+        performSelector(#selector(trackSyncTimeout), withObject:nil, afterDelay: Syncing.syncTimeout)
+    }
+
+    func stopSyncTimeoutTimer() {
+        NSObject.cancelPreviousPerformRequestsWithTarget(self, selector: #selector(trackSyncTimeout), object: nil)
+    }
 }
 
 
@@ -477,10 +491,9 @@ extension NotificationsViewController
     }
 
     func trackSyncTimeout() {
-        let properties = [Syncing.syncTimeoutKey : simperium.networkStatus]
+        let properties = [Syncing.networkStatusKey : simperium.networkStatus]
         WPAnalytics.track(.NotificationsMissingSyncWarning, withProperties: properties)
     }
-
 }
 
 
@@ -554,7 +567,8 @@ private extension NotificationsViewController
 
     enum Syncing {
         static let pushMaxWait      = NSTimeInterval(1)
-        static let syncTimeoutKey   = "network_status"
+        static let syncTimeout      = NSTimeInterval(10)
+        static let networkStatusKey = "network_status"
     }
 
     enum RatingSettings {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -257,7 +257,7 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
         }
 
         let isMarkedForDeletion     = isNoteMarkedForDeletion(note.objectID)
-        let isLastRow               = tableViewHandler.resultsController.isLastRowInSection(indexPath)
+        let isLastRow               = tableViewHandler.resultsController.isLastIndexPathInSection(indexPath)
 
         cell.attributedSubject      = note.subjectBlock()?.attributedSubjectText()
         cell.attributedSnippet      = note.snippetBlock()?.attributedSnippetText()
@@ -288,8 +288,8 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
         // after a DB OP. This loop has been measured in the order of milliseconds (iPad Mini)
         for indexPath in tableView.indexPathsForVisibleRows ?? [] {
             let cell = tableView.cellForRowAtIndexPath(indexPath) as! NoteTableViewCell
-            let isLastRow = tableViewHandler.resultsController.isLastRowInSection(indexPath)
-            cell.showsBottomSeparator = isLastRow == false
+            let isLastRow = tableViewHandler.resultsController.isLastIndexPathInSection(indexPath)
+            cell.showsBottomSeparator = !isLastRow
         }
 
         // Update NoResults View

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -534,7 +534,7 @@ extension NotificationsViewController
         pushNotificationID = nil
         pushNotificationDate = nil
 
-        let properties = [Stats.networkStatusKey : simperium.networkStatus]
+        let properties = [Stats.networkStatusKey: simperium.networkStatus]
         WPAnalytics.track(.NotificationsMissingSyncWarning, withProperties: properties)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -205,7 +205,7 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
         }
 
         let isMarkedForDeletion     = isNoteMarkedForDeletion(note.objectID)
-        let isLastRow               = isRowLastRowForSection(indexPath)
+        let isLastRow               = tableViewHandler.resultsController.isLastRowInSection(indexPath)
 
         cell.attributedSubject      = note.subjectBlock()?.attributedSubjectText()
         cell.attributedSnippet      = note.snippetBlock()?.attributedSnippetText()
@@ -236,7 +236,8 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
         // after a DB OP. This loop has been measured in the order of milliseconds (iPad Mini)
         for indexPath in tableView.indexPathsForVisibleRows ?? [] {
             let cell = tableView.cellForRowAtIndexPath(indexPath) as! NoteTableViewCell
-            cell.showsBottomSeparator = isRowLastRowForSection(indexPath) == false
+            let isLastRow = tableViewHandler.resultsController.isLastRowInSection(indexPath)
+            cell.showsBottomSeparator = isLastRow == false
         }
 
         // Update NoResults View

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
@@ -27,6 +27,7 @@
 @property (nonatomic, strong) NSMutableSet                  *notificationIdsBeingDeleted;
 
 - (void)reloadResultsController;
+- (void)stopSyncTimeoutTimer;
 
 - (void)cancelDeletionForNoteWithID:(NSManagedObjectID *)noteObjectID;
 - (BOOL)isNoteMarkedForDeletion:(NSManagedObjectID *)noteObjectID;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
@@ -28,8 +28,6 @@
 
 - (void)reloadResultsController;
 
-- (BOOL)isRowLastRowForSection:(NSIndexPath *)indexPath;
-
 - (void)cancelDeletionForNoteWithID:(NSManagedObjectID *)noteObjectID;
 - (BOOL)isNoteMarkedForDeletion:(NSManagedObjectID *)noteObjectID;
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
@@ -31,6 +31,4 @@
 - (void)cancelDeletionForNoteWithID:(NSManagedObjectID *)noteObjectID;
 - (BOOL)isNoteMarkedForDeletion:(NSManagedObjectID *)noteObjectID;
 
-- (id <SPBucketDelegate>)simperiumBucketDelegate;
-
 @end

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Internal.h
@@ -27,7 +27,6 @@
 @property (nonatomic, strong) NSMutableSet                  *notificationIdsBeingDeleted;
 
 - (void)reloadResultsController;
-- (void)stopSyncTimeoutTimer;
 
 - (void)cancelDeletionForNoteWithID:(NSManagedObjectID *)noteObjectID;
 - (BOOL)isNoteMarkedForDeletion:(NSManagedObjectID *)noteObjectID;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.h
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.h
@@ -17,18 +17,6 @@
 @interface NotificationsViewController : UITableViewController
 
 /**
- *  @brief      This instance will push the Details View associated with a given Notification ID.
- *  @details    If the Notification is unavailable at the point in which this call is executed, we'll hold for
- *              the time interval specified by the `NotificationsSyncTimeout` constant.
- *              Whenever the notification is sync'ed, if the timeout hasn't yet elapsed, we'll proceed pushing
- *              the details view. Otherwise, the event will be discarded.
- *
- *  @param      notificationID      The simperiumKey of the Notification that should be rendered onscreen.
- */
-
-- (void)showDetailsForNoteWithID:(NSString *)notificationID;
-
-/**
  *  @brief      Will display an Undelete button on top of a given notification.
  *  @details    On timeout, the destructive action (received via parameter) will be exeuted, and the notification
  *              will (supposedly) get deleted.

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -34,7 +34,6 @@
 
 static NSTimeInterval const NotificationPushMaxWait     = 1;
 static CGFloat const NoteEstimatedHeight                = 70;
-static NSTimeInterval NotificationsSyncTimeout          = 10;
 static NSTimeInterval NotificationsUndoTimeout          = 4;
 
 
@@ -202,22 +201,7 @@ static NSTimeInterval NotificationsUndoTimeout          = 4;
     }
 }
 
-- (void)startSyncTimeoutTimer
-{
-    // Don't proceed if we're not even connected
-    BOOL isConnected = [[WordPressAppDelegate sharedInstance] connectionAvailable];
-    if (!isConnected) {
-        return;
-    }
-    
-    [self stopSyncTimeoutTimer];
-    [self performSelector:@selector(trackSyncTimeout) withObject:nil afterDelay:NotificationsSyncTimeout];
-}
 
-- (void)stopSyncTimeoutTimer
-{
-    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(trackSyncTimeout) object:nil];
-}
 
 
 #pragma mark - Helper methods

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -179,31 +179,6 @@ static NSTimeInterval NotificationsUndoTimeout          = 4;
 }
 
 
-#pragma mark - Public Methods
-
-- (void)showDetailsForNoteWithID:(NSString *)notificationID
-{
-    Simperium *simperium        = [[WordPressAppDelegate sharedInstance] simperium];
-    SPBucket *notesBucket       = [simperium bucketForName:self.entityName];
-    Notification *notification  = [notesBucket objectForKey:notificationID];
-    
-    if (notification) {
-        DDLogInfo(@"Pushing Notification Details for: [%@]", notificationID);
-        
-        [self showDetailsForNotification:notification];
-    } else {
-        DDLogInfo(@"Notification Details for [%@] cannot be pushed right now. Waiting %f secs", notificationID, NotificationPushMaxWait);
-        
-        self.pushNotificationID     = notificationID;
-        self.pushNotificationDate   = [NSDate date];
-        
-        [self startSyncTimeoutTimer];
-    }
-}
-
-
-
-
 #pragma mark - Helper methods
 
 - (void)reloadResultsControllerIfNeeded
@@ -310,31 +285,6 @@ static NSTimeInterval NotificationsUndoTimeout          = 4;
 - (BOOL)isNoteMarkedForDeletion:(NSManagedObjectID *)noteObjectID
 {
     return [self.notificationDeletionBlocks objectForKey:noteObjectID] != nil;
-}
-
-
-#pragma mark - Segue Helpers
-
-- (void)showDetailsForNotification:(Notification *)note
-{
-    [WPAnalytics track:WPAnalyticsStatOpenedNotificationDetails withProperties:@{ @"notification_type" : note.type ?: @"unknown"}];
-    
-    // Mark as Read, if needed
-    if(!note.read.boolValue) {
-        note.read = @(1);
-        [[ContextManager sharedInstance] saveContext:note.managedObjectContext];
-    }
-    
-    // Failsafe: Don't push nested!
-    if (self.navigationController.visibleViewController != self) {
-        [self.navigationController popToRootViewControllerAnimated:NO];
-    }
-    
-    if (note.isMatcher && note.metaPostID && note.metaSiteID) {
-        [self performSegueWithIdentifier:[ReaderDetailViewController classNameWithoutNamespaces] sender:note];
-    } else {
-        [self performSegueWithIdentifier:NSStringFromClass([NotificationDetailsViewController class]) sender:note];
-    }
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -36,17 +36,6 @@ static NSTimeInterval const NotificationPushMaxWait     = 1;
 static CGFloat const NoteEstimatedHeight                = 70;
 static NSTimeInterval NotificationsSyncTimeout          = 10;
 static NSTimeInterval NotificationsUndoTimeout          = 4;
-static NSString const *NotificationsNetworkStatusKey    = @"network_status";
-
-typedef NS_ENUM(NSUInteger, NotificationFilter)
-{
-    NotificationFilterNone,
-    NotificationFilterUnread,
-    NotificationFilterComment,
-    NotificationFilterFollow,
-    NotificationFilterLike
-};
-
 
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -202,9 +202,6 @@ static NSTimeInterval NotificationsUndoTimeout          = 4;
     }
 }
 
-
-#pragma mark - Stats Helpers
-
 - (void)startSyncTimeoutTimer
 {
     // Don't proceed if we're not even connected
@@ -224,29 +221,6 @@ static NSTimeInterval NotificationsUndoTimeout          = 4;
 
 
 #pragma mark - Helper methods
-
-- (void)resetApplicationBadge
-{
-    [UIApplication sharedApplication].applicationIconBadgeNumber = 0;
-}
-
-- (void)updateLastSeenTime
-{
-    Notification *note      = [self.tableViewHandler.resultsController.fetchedObjects firstObject];
-    if (!note) {
-        return;
-    }
-
-    NSString *bucketName    = NSStringFromClass([Meta class]);
-    Simperium *simperium    = [[WordPressAppDelegate sharedInstance] simperium];
-    Meta *metadata          = [[simperium bucketForName:bucketName] objectForKey:bucketName.lowercaseString];
-    if (!metadata) {
-        return;
-    }
-
-    metadata.last_seen      = @(note.timestampAsDate.timeIntervalSince1970);
-    [simperium save];
-}
 
 - (void)reloadResultsControllerIfNeeded
 {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -48,14 +48,6 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 };
 
 
-#pragma mark ====================================================================================
-#pragma mark Protocols
-#pragma mark ====================================================================================
-
-@interface NotificationsViewController (Protocols) <SPBucketDelegate>
-
-@end
-
 
 
 #pragma mark ====================================================================================
@@ -156,42 +148,6 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 {
     [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
     [self.tableViewHandler clearCachedRowHeights];
-}
-
-
-#pragma mark - SPBucketDelegate Methods
-
-- (void)bucket:(SPBucket *)bucket didChangeObjectForKey:(NSString *)key forChangeType:(SPBucketChangeType)changeType memberNames:(NSArray *)memberNames
-{
-    UIApplication *application = [UIApplication sharedApplication];
-    
-    // Did the user tap on a push notification?
-    if (changeType == SPBucketChangeInsert && [self.pushNotificationID isEqualToString:key]) {
-
-        // Show the details only if NotificationPushMaxWait hasn't elapsed
-        if (ABS(self.pushNotificationDate.timeIntervalSinceNow) <= NotificationPushMaxWait) {
-            [self showDetailsForNoteWithID:key];
-        }
-        
-        // Stop the sync timeout: we've got activity!
-        [self stopSyncTimeoutTimer];
-        
-        // Cleanup
-        self.pushNotificationID     = nil;
-        self.pushNotificationDate   = nil;
-    }
-    
-    // Mark as read immediately if:
-    //  -   We're onscreen
-    //  -   The app is in Foreground
-    //
-    // We need to make sure that the app is in FG, since this method might get called during a Background Fetch OS event,
-    // which would cause the badge to get reset on its own.
-    //
-    if (changeType == SPBucketChangeInsert && self.isViewOnScreen && application.applicationState == UIApplicationStateActive) {
-        [self resetApplicationBadge];
-        [self updateLastSeenTime];
-    }
 }
 
 
@@ -557,21 +513,6 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
         ReaderDetailViewController *readerViewController = segue.destinationViewController;
         [readerViewController setupWithPostID:note.metaPostID siteID:note.metaSiteID];
     }
-}
-
-
-#pragma mark - Swift Migration Helpers
-
-// Note:
-// Since not all of the ObjC methods are being exposed to Swift, these helpers are added temporarily,
-// just as a workaround during the Swift migration.
-//
-// TODO: Nuke them. JLP 06.30.2016
-//
-
-- (id <SPBucketDelegate>)simperiumBucketDelegate
-{
-    return self;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -97,19 +97,19 @@ static NSTimeInterval NotificationsUndoTimeout          = 4;
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    
+
+    // Tracking
+    [WPAnalytics track:WPAnalyticsStatOpenedNotificationsList];
+
     // Manually deselect the selected row. This is required due to a bug in iOS7 / iOS8
     [self.tableView deselectSelectedRowWithAnimation:YES];
     
     // While we're onscreen, please, update rows with animations
     self.tableViewHandler.updateRowAnimation = UITableViewRowAnimationFade;
-    
-    // Tracking
-    [self trackAppeared];
-    [self updateLastSeenTime];
-    
+
     // Notifications
     [self hookApplicationStateNotes];
+    [self updateLastSeenTime];
     [self resetApplicationBadge];
 
     // Refresh the UI

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -222,14 +222,6 @@ static NSTimeInterval NotificationsUndoTimeout          = 4;
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(trackSyncTimeout) object:nil];
 }
 
-- (void)trackSyncTimeout
-{
-    Simperium *simperium = [[WordPressAppDelegate sharedInstance] simperium];
-    NSDictionary *properties = @{ NotificationsNetworkStatusKey : simperium.networkStatus };
-    
-    [WPAnalytics track:WPAnalyticsStatNotificationsMissingSyncWarning withProperties:properties];
-}
-
 
 #pragma mark - Helper methods
 
@@ -309,11 +301,6 @@ static NSTimeInterval NotificationsUndoTimeout          = 4;
     if (indexPath) {
         [self.tableView reloadRowsAtIndexPaths:@[ indexPath ] withRowAnimation:UITableViewRowAnimationFade];
     }
-}
-
-- (void)trackAppeared
-{
-    [WPAnalytics track:WPAnalyticsStatOpenedNotificationsList];
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -32,7 +32,6 @@
 #pragma mark Constants
 #pragma mark ====================================================================================
 
-static NSTimeInterval const NotificationPushMaxWait     = 1;
 static CGFloat const NoteEstimatedHeight                = 70;
 static NSTimeInterval NotificationsUndoTimeout          = 4;
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -170,7 +170,7 @@ static NSTimeInterval NotificationsUndoTimeout          = 4;
 
 - (void)handleApplicationWillResignActiveNote:(NSNotification *)note
 {
-    [self stopSyncTimeoutTimer];
+    [self stopWaitingForNotification];
 }
 
 - (void)handleDefaultAccountChangedNote:(NSNotification *)note

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -366,17 +366,6 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     }
 }
 
-- (BOOL)isRowLastRowForSection:(NSIndexPath *)indexPath
-{
-    // Failsafe!
-    if (indexPath.section >= self.tableViewHandler.resultsController.sections.count) {
-        return false;
-    }
-    
-    id<NSFetchedResultsSectionInfo> sectionInfo = [self.tableViewHandler.resultsController.sections objectAtIndex:indexPath.section];
-    return indexPath.row == (sectionInfo.numberOfObjects - 1);
-}
-
 - (void)trackAppeared
 {
     [WPAnalytics track:WPAnalyticsStatOpenedNotificationsList];

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -509,7 +509,7 @@ static NSInteger const WPTabBarIconOffset = 5;
 - (void)showNotificationsTabForNoteWithID:(NSString *)notificationID
 {
     [self showTabForIndex:WPTabNotifications];
-    [self.notificationsViewController showDetailsForNoteWithID:notificationID];
+    [self.notificationsViewController showDetailsForNotificationWithID:notificationID];
 }
 
 - (BOOL)isNavigatingMySitesTab


### PR DESCRIPTION
#### Details:
This PR adds no new functionality. We'll gradually migrate all of the Notifications-Y code over to Swift.
Once it's ready, we'll address code improvements / technical debt.

Reference #5613

--

#### Scenario A: Regular Notification
1. Receive a regular Notification (you may click like over any of your own posts)
2. Launch the app and open the Notifications tab
3. Press over the new notification row

As a result, the notification details should be onscreen.

#### Scenario B: Automatcher
1. Receive a matcher notification (mention on a post)
2. Launch the app and open the Notifications tab
3. Press over the Matcher notification

As a result, the reader should be onscreen.

#### Scenario C: While Onscreen
1. Launch the app and open the Notifications screen
2. Receive a new notification

As a result, the badge should get immediately reset.

#### Scenario D: Background
1. Receive a push notification while the app is in BG
2. Tap over the note to open the details

As a result, the details should become onscreen, after a while

#### Scenario E: Timeout
1. Hack [this spot](https://github.com/wordpress-mobile/WordPress-iOS/blob/issue/notifications-swiftification-mark5/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift#L620) and lower the timeout to, say, 0.1 seconds
2. Receive a push notification while the app is in BG
3. Immediately press on it

As a result, the app should launch, and the notifications list should be onscreen. However, the Details shouldn't show up.


Needs review: @astralbodies 
Aaron, may i bother you with a (hopefully fun) review?

Thanks in advance!
