### PR TITLE
Issue/5726: Plan list cells not deselecting after modal dismiss

### DIFF
--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -120,7 +120,7 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
         footerTapAction?()
     }
 
-    // MARK: - ImmuTablePresenter 
+    // MARK: - ImmuTablePresenter
 
     func present(controllerGenerator: ImmuTableRowControllerGenerator) -> ImmuTableAction {
         return {

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -119,6 +119,18 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
     func footerTapped() {
         footerTapAction?()
     }
+
+    // MARK: - ImmuTablePresenter 
+
+    func present(controllerGenerator: ImmuTableRowControllerGenerator) -> ImmuTableAction {
+        return {
+            [unowned self] in
+            let controller = controllerGenerator($0)
+            self.presentViewController(controller, animated: true, completion: { _ in
+                self.tableView.deselectSelectedRowWithAnimation(true)
+            })
+        }
+    }
 }
 
 // MARK: - WPNoResultsViewDelegate

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -127,7 +127,12 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
             [unowned self] in
             let controller = controllerGenerator($0)
             self.presentViewController(controller, animated: true, completion: { _ in
-                self.tableView.deselectSelectedRowWithAnimation(true)
+                // When the detail view is displayed as a modal on iPad, we don't receive
+                // view did/will appear/disappear. Because of this, the selected row in the list
+                // is never deselected. So we'll do it manually.
+                if UIDevice.isPad() {
+                    self.tableView.deselectSelectedRowWithAnimation(true)
+                }
             })
         }
     }


### PR DESCRIPTION
Fixes #5726 

See original issue for description of issue. I've fixed the issue by deselecting the row when the modal is presented, as there's no simple way to tell when the modal is dismissed (`viewWill/DidAppear` doesn't get called) – we'd have to implement a delegate or somesuch which seems like overkill.

Needs review: @kurzee 