### PR TITLE
Plans: Replaces Support feature text with custom app-specific text

### DIFF
--- a/WordPress/Classes/Networking/PlansFeaturesRemote.swift
+++ b/WordPress/Classes/Networking/PlansFeaturesRemote.swift
@@ -149,5 +149,36 @@ private func mapPlanFeaturesResponse(response: AnyObject) throws -> PlanFeatures
         }
     }
 
-    return features
+    return featuresWithReplacedSupportDescriptions(features)
+}
+
+// We'd like the Support feature for our plans to contain different text (app-specific) to that which the API actually returns.
+// This method finds the relevant features and replaces the text.
+private func featuresWithReplacedSupportDescriptions(features: PlanFeatures) -> PlanFeatures {
+    let freePlanID = 1, premiumPlanID = 1003, businessPlanID = 1008
+
+    let replacementFeatures = [
+        freePlanID: NSLocalizedString("Ask our Happiness Engineers questions in this app, or find answers in our community forum.", comment: "Description of the Support feature of our Free plan"),
+        premiumPlanID: NSLocalizedString("Ask our Happiness Engineers questions in this app anytime you need, or at WordPress.com/help.", comment: "Description of the Support feature of our Premium plan"),
+        businessPlanID: NSLocalizedString("Ask our Happiness Engineers questions in this app anytime you need, or chat with us live at WordPress.com/help.", comment: "Description of the Support feature of our Business plan")
+    ]
+
+    var updatedFeatures: PlanFeatures = [:]
+    for (planID, planFeatures) in features {
+        if !replacementFeatures.keys.contains(planID) {
+            // If it's not one of our target plans, just copy it into the new collection
+            updatedFeatures[planID] = planFeatures
+        } else {
+            // Otherwise, replace the Support feature with our new text
+            updatedFeatures[planID] = planFeatures.map { f in
+                if f.slug == "support" {
+                    return PlanFeature(slug: f.slug, title: f.title, description: replacementFeatures[planID]!, iconURL: f.iconURL)
+                } else {
+                    return f
+                }
+            }
+        }
+    }
+
+    return updatedFeatures
 }


### PR DESCRIPTION
We'd like the Support feature in the Plans details lists to contain different text (app-specific) to that which the API actually returns.

This PR adds a method that finds the relevant features and replaces the text.

To test:

View Plans details, and verify that the text displayed matches the text added in this PR (view the detail of the commit to see the text for each plan).

Needs review: @kwonye 

@rachelmcr Would you mind checking the copy for me? I made a few small tweaks to your original – let me know if you want it any different.