### PR TITLE
Share Extension: Prevents appending local URL's

### DIFF
--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4.0.20160707.1</string>
+	<string>6.4.0.20160714</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6.4.0.20160707.1</string>
+	<string>6.4.0.20160714</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>org-appextension-feature-password-management</string>

--- a/WordPress/WordPressShareExtension/Info-Alpha.plist
+++ b/WordPress/WordPressShareExtension/Info-Alpha.plist
@@ -33,7 +33,7 @@
 			<key>NSExtensionActivationRule</key>
 			<dict>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<string>1</string>
+				<integer>1</integer>
 				<key>NSExtensionActivationDictionaryVersion</key>
 				<integer>2</integer>
 				<key>NSExtensionActivationSupportsText</key>

--- a/WordPress/WordPressShareExtension/Info-Internal.plist
+++ b/WordPress/WordPressShareExtension/Info-Internal.plist
@@ -33,7 +33,7 @@
 			<key>NSExtensionActivationRule</key>
 			<dict>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<string>1</string>
+				<integer>1</integer>
 				<key>NSExtensionActivationDictionaryVersion</key>
 				<integer>2</integer>
 				<key>NSExtensionActivationSupportsText</key>

--- a/WordPress/WordPressShareExtension/Info-Internal.plist
+++ b/WordPress/WordPressShareExtension/Info-Internal.plist
@@ -21,11 +21,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4.0.20160707.1</string>
+	<string>6.4.0.20160714</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>6.4.0.20160707.1</string>
+	<string>6.4.0.20160714</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WordPress/WordPressShareExtension/Info.plist
+++ b/WordPress/WordPressShareExtension/Info.plist
@@ -39,7 +39,7 @@
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
 				<integer>1</integer>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<string>1</string>
+				<integer>1</integer>
 			</dict>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -214,11 +214,13 @@ private extension ShareViewController
     func loadTextContent() {
         extensionContext?.loadWebsiteUrl { url in
             // Text + New Line + Source
-            let current = self.contentText ?? String()
-            let source  = url?.absoluteString ?? String()
-            let spacing = current.isEmpty ? String() : "\n\n"
+            var payload = self.contentText ?? String()
+            if let sourceURL = url?.absoluteString where url?.fileURL == false {
+                payload += payload.isEmpty ? String() : "\n\n"
+                payload += sourceURL
+            }
 
-            self.textView.text = "\(current)\(spacing)\(source)"
+            self.textView.text = payload
         }
     }
 

--- a/WordPress/WordPressTodayWidget/Info-Internal.plist
+++ b/WordPress/WordPressTodayWidget/Info-Internal.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4.0.20160707.1</string>
+	<string>6.4.0.20160714</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>6.4.0.20160707.1</string>
+	<string>6.4.0.20160714</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>


### PR DESCRIPTION
Fixes #5690

To test:
1. Install Google Photos
2. Attempt to share a Photo

Please, verify that the local URL isn't appended to the Extension Text. Also, please, double check that Sharing from Safari didn't break.

Needs review: @astralbodies 
Thanks in advance Aaron!!
