### PR TITLE
Reader: Check siteID to determine if topic is external.

### DIFF
--- a/WordPress/Classes/Models/ReaderSiteTopic.swift
+++ b/WordPress/Classes/Models/ReaderSiteTopic.swift
@@ -20,7 +20,7 @@ import Foundation
 
     public var isExternal: Bool {
         get {
-            return (feedID.integerValue > 0)
+            return siteID.integerValue == 0
         }
     }
 }


### PR DESCRIPTION
Fixes #5730 

To test:
#### Scenario 1
Browse posts for a tag. 
Tap the header of one of the posts in the list to preview that site. 
Tap the following button in the site header to follow and unfollow the site. Confirm there are no crashes. 
#### Scenario 2
In the new reader Menu, ap the Manage button next to Followed Sites.
Tap on one of the sites in the list to preview it. 
Unfollow and refollow the site. Confirm their are no crashes. 
#### Scenario 3
Back on the Manage Sites list, follow a wpcom site and a remote feed via the search bar. 
Confirm they are followed correctly and there are no crashes. 
#### Scenario 4
Swipe to delete the two sites you just added. 
Confirm they are removed correctly and there are no crashes. 

Needs review: @nheagy would you mind taking this one? 

