### PR TITLE
Disables state restoration after updates.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -330,7 +330,20 @@ int ddLogLevel = DDLogLevelInfo;
 
 - (BOOL)application:(UIApplication *)application shouldRestoreApplicationState:(NSCoder *)coder
 {
-    return self.shouldRestoreApplicationState;
+    NSUserDefaults* standardUserDefaults = [NSUserDefaults standardUserDefaults];
+
+    NSString* const lastSavedStateVersionKey = @"lastSavedStateVersionKey";
+    NSString* lastSavedStateVersion = [standardUserDefaults objectForKey:lastSavedStateVersionKey];
+    NSString* currentVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleShortVersionString"];
+    BOOL shouldRestoreApplicationState = NO;
+
+    if (lastSavedStateVersion && [lastSavedStateVersion length] > 0 && [lastSavedStateVersion isEqualToString:currentVersion]) {
+        shouldRestoreApplicationState = self.shouldRestoreApplicationState;;
+    }
+
+    [standardUserDefaults setObject:currentVersion forKey:lastSavedStateVersionKey];
+
+    return shouldRestoreApplicationState;
 }
 
 - (void)application: (UIApplication *)application performActionForShortcutItem:(nonnull UIApplicationShortcutItem *)shortcutItem completionHandler:(nonnull void (^)(BOOL))completionHandler


### PR DESCRIPTION
Fixes #5636 

**What it does:**

This patch effectively disables state restoration on the first launch after the WPiOS App is updated.

**To test:**

1. Run 6.2.
2. Go to the list of posts for a blog.  Background the app, and then stop it in Xcode.  It won't save its state if you manually quit the app in the simulator.
3. Run 5.3.  Make sure it doesn't crash (nor restore state).

**Important note:**

Since this patch stores a new key in `NSUserDefaults`, it's easy to make mistakes during testing.  If you test the above sequence twice, the second time around you'll get the crash, unless you first remove the version info from `NSUserDefaults`.

Needs review: @sendhil 

