### PR TITLE
NotificationDetails: StackViews

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -63,6 +63,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 // Outlets
 @property (nonatomic,   weak) IBOutlet UITableView          *tableView;
 @property (nonatomic,   weak) IBOutlet UIGestureRecognizer  *tableGesturesRecognizer;
+@property (nonatomic,   weak) IBOutlet NSLayoutConstraint   *bottomLayoutConstraint;
 @property (nonatomic, strong) ReplyTextView                 *replyTextView;
 @property (nonatomic, strong) SuggestionsTableView          *suggestionsTableView;
 
@@ -127,7 +128,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(handleKeyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
-    [nc addObserver:self selector:@selector(handleKeyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
+    [nc addObserver:self selector:@selector(handleKeyboardWillShow:) name:UIKeyboardWillHideNotification object:nil];
     
     [self.tableView deselectSelectedRowWithAnimation:YES];
 }
@@ -1357,36 +1358,12 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     // Bottom Inset: Consider the tab bar!
     CGRect viewFrame = self.view.frame;
     CGFloat bottomInset = CGRectGetHeight(kbRect) - (CGRectGetMaxY(kbRect) - CGRectGetHeight(viewFrame));
-    
+
     [UIView beginAnimations:nil context:nil];
     [UIView setAnimationDuration:[userInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue]];
     [UIView setAnimationCurve:[userInfo[UIKeyboardAnimationCurveUserInfoKey] intValue]];
 
-    [self.view updateConstraintWithFirstItem:self.view
-                                  secondItem:self.replyTextView
-                          firstItemAttribute:NSLayoutAttributeBottom
-                         secondItemAttribute:NSLayoutAttributeBottom
-                                    constant:bottomInset];
-    
-    [self.view layoutIfNeeded];
-    
-    [UIView commitAnimations];
-}
-
-- (void)handleKeyboardWillHide:(NSNotification *)notification
-{
-    NSDictionary* userInfo = notification.userInfo;
-    
-    [UIView beginAnimations:nil context:nil];
-    [UIView setAnimationDuration:[userInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue]];
-    [UIView setAnimationCurve:[userInfo[UIKeyboardAnimationCurveUserInfoKey] intValue]];
-    
-    [self.view updateConstraintWithFirstItem:self.view
-                                  secondItem:self.replyTextView
-                          firstItemAttribute:NSLayoutAttributeBottom
-                         secondItemAttribute:NSLayoutAttributeBottom
-                                    constant:0];
-    
+    self.bottomLayoutConstraint.constant = MAX(bottomInset, 0);
     [self.view layoutIfNeeded];
     
     [UIView commitAnimations];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -135,8 +135,7 @@ static NSInteger NotificationSectionCount               = 1;
     [self.replyTextView resignFirstResponder];
     
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-    [nc removeObserver:self name:UIKeyboardWillShowNotification object:nil];
-    [nc removeObserver:self name:UIKeyboardWillHideNotification object:nil];
+    [nc removeObserver:self name:UIKeyboardWillChangeFrameNotification object:nil];
 }
 
 - (void)viewDidLayoutSubviews

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -330,28 +330,13 @@ static NSInteger NotificationSectionCount               = 1;
     self.suggestionsTableView.suggestionsDelegate = self;
     [self.suggestionsTableView setTranslatesAutoresizingMaskIntoConstraints:NO];
     [self.view addSubview:self.suggestionsTableView];
-    
-    // Pin the suggestions view left and right edges to the super view edges
-    NSDictionary *views = @{@"suggestionsview": self.suggestionsTableView };
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[suggestionsview]|"
-                                                                      options:0
-                                                                      metrics:nil
-                                                                        views:views]];
 
-    // Pin the suggestions view top to the super view top
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[suggestionsview]"
-                                                                      options:0
-                                                                      metrics:nil
-                                                                        views:views]];
-    
-    // Pin the suggestions view bottom to the top of the reply box
-    [self.view addConstraint:[NSLayoutConstraint constraintWithItem:self.suggestionsTableView
-                                                         attribute:NSLayoutAttributeBottom
-                                                         relatedBy:NSLayoutRelationEqual
-                                                            toItem:self.replyTextView
-                                                         attribute:NSLayoutAttributeTop
-                                                        multiplier:1
-                                                          constant:0]];
+    [NSLayoutConstraint activateConstraints:@[
+        [self.suggestionsTableView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [self.suggestionsTableView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [self.suggestionsTableView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [self.suggestionsTableView.bottomAnchor constraintEqualToAnchor:self.replyTextView.topAnchor]
+    ]];
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -379,6 +379,9 @@ static NSInteger NotificationSectionCount               = 1;
     self.topLayoutConstraint.active = !shouldCenterVertically;
     self.bottomLayoutConstraint.active = !shouldCenterVertically;
     self.centerLayoutConstraint.active = shouldCenterVertically;
+
+    // Lock Scrolling for Badge Notifications
+    self.tableView.scrollEnabled = !shouldCenterVertically;
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -67,7 +67,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 @property (nonatomic, strong) SuggestionsTableView          *suggestionsTableView;
 
 // Table Helpers
-@property (nonatomic, strong) NSDictionary                  *layoutCellMap;
+@property (nonatomic, strong) NSDictionary                  *layoutIdentifierMap;
 @property (nonatomic, strong) NSDictionary                  *reuseIdentifierMap;
 @property (nonatomic, strong) NSArray                       *blockGroups;
 
@@ -252,24 +252,23 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 #pragma mark - Autolayout Helpers
 
-- (NSDictionary *)layoutCellMap
+- (NSDictionary *)layoutIdentifierMap
 {
-    if (_layoutCellMap) {
-        return _layoutCellMap;
+    if (_layoutIdentifierMap) {
+        return _layoutIdentifierMap;
     }
     
-    UITableView *tableView  = self.tableView;
-    _layoutCellMap = @{
-        @(NoteBlockGroupTypeHeader)    : [tableView dequeueReusableCellWithIdentifier:NoteBlockHeaderTableViewCell.layoutIdentifier],
-        @(NoteBlockGroupTypeFooter)    : [tableView dequeueReusableCellWithIdentifier:NoteBlockTextTableViewCell.layoutIdentifier],
-        @(NoteBlockGroupTypeText)      : [tableView dequeueReusableCellWithIdentifier:NoteBlockTextTableViewCell.layoutIdentifier],
-        @(NoteBlockGroupTypeComment)   : [tableView dequeueReusableCellWithIdentifier:NoteBlockCommentTableViewCell.layoutIdentifier],
-        @(NoteBlockGroupTypeActions)   : [tableView dequeueReusableCellWithIdentifier:NoteBlockActionsTableViewCell.layoutIdentifier],
-        @(NoteBlockGroupTypeImage)     : [tableView dequeueReusableCellWithIdentifier:NoteBlockImageTableViewCell.layoutIdentifier],
-        @(NoteBlockGroupTypeUser)      : [tableView dequeueReusableCellWithIdentifier:NoteBlockUserTableViewCell.layoutIdentifier]
+    _layoutIdentifierMap = @{
+        @(NoteBlockGroupTypeHeader)    : NoteBlockHeaderTableViewCell.layoutIdentifier,
+        @(NoteBlockGroupTypeFooter)    : NoteBlockTextTableViewCell.layoutIdentifier,
+        @(NoteBlockGroupTypeText)      : NoteBlockTextTableViewCell.layoutIdentifier,
+        @(NoteBlockGroupTypeComment)   : NoteBlockCommentTableViewCell.layoutIdentifier,
+        @(NoteBlockGroupTypeActions)   : NoteBlockActionsTableViewCell.layoutIdentifier,
+        @(NoteBlockGroupTypeImage)     : NoteBlockImageTableViewCell.layoutIdentifier,
+        @(NoteBlockGroupTypeUser)      : NoteBlockUserTableViewCell.layoutIdentifier
     };
     
-    return _layoutCellMap;
+    return _layoutIdentifierMap;
 }
 
 - (NSDictionary *)reuseIdentifierMap
@@ -478,7 +477,8 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     NotificationBlockGroup *blockGroup      = [self blockGroupForIndexPath:indexPath];
-    NoteBlockTableViewCell *tableViewCell   = self.layoutCellMap[@(blockGroup.type)] ?: self.layoutCellMap[@(NoteBlockGroupTypeText)];
+    NSString *layoutIdentifier              = self.layoutIdentifierMap[@(blockGroup.type)] ?: self.layoutIdentifierMap[@(NoteBlockGroupTypeText)];
+    NoteBlockTableViewCell *tableViewCell   = [tableView dequeueReusableCellWithIdentifier:layoutIdentifier];
 
     [self downloadAndResizeMedia:indexPath blockGroup:blockGroup];
     [self setupCell:tableViewCell blockGroup:blockGroup];
@@ -785,7 +785,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 {
     NotificationBlock *textBlock    = blockGroup.blocks.firstObject;
     NSAssert(textBlock, @"Missing Text Block for Notification %@", self.note.simperiumKey);
-    
+
     // Merge the Attachments with their ranges: [NSRange: UIImage]
     NSDictionary *mediaMap          = [self.mediaDownloader imagesForUrls:textBlock.imageUrls];
     NSDictionary *mediaRanges       = [textBlock buildRangesToImagesMap:mediaMap];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -43,9 +43,6 @@
 #pragma mark Constants
 #pragma mark ==========================================================================================
 
-static UIEdgeInsets NotificationTableInsetsPhone        = {0.0f,  0.0f, 20.0f, 0.0f};
-static UIEdgeInsets NotificationTableInsetsPad          = {40.0f, 0.0f, 20.0f, 0.0f};
-
 static NSTimeInterval NotificationFiveMinutes           = 60 * 5;
 static NSInteger NotificationSectionCount               = 1;
 
@@ -61,8 +58,11 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 @interface NotificationDetailsViewController () <ReplyTextViewDelegate, SuggestionsTableViewDelegate>
 
 // Outlets
+@property (nonatomic,   weak) IBOutlet UIStackView          *stackView;
 @property (nonatomic,   weak) IBOutlet UITableView          *tableView;
 @property (nonatomic,   weak) IBOutlet UIGestureRecognizer  *tableGesturesRecognizer;
+@property (nonatomic,   weak) IBOutlet NSLayoutConstraint   *topLayoutConstraint;
+@property (nonatomic,   weak) IBOutlet NSLayoutConstraint   *centerLayoutConstraint;
 @property (nonatomic,   weak) IBOutlet NSLayoutConstraint   *bottomLayoutConstraint;
 @property (nonatomic, strong) ReplyTextView                 *replyTextView;
 @property (nonatomic, strong) SuggestionsTableView          *suggestionsTableView;
@@ -118,7 +118,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     [self setupTableView];
     [self setupMediaDownloader];
     [self setupNotificationListeners];
-    
+
     [AppRatingUtility incrementSignificantEventForSection:@"notifications"];
 }
 
@@ -315,10 +315,7 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
     replyTextView.delegate                  = self;
     self.replyTextView                      = replyTextView;
 
-    // Attach the ReplyTextView at the very bottom
-    [self.view addSubview:self.replyTextView];
-    [self.view pinSubviewAtBottom:self.replyTextView];
-    [self.view pinSubview:self.tableView aboveSubview:self.replyTextView];
+    [self.stackView addArrangedSubview:replyTextView];
 
     // Attach suggestionsView
     [self attachSuggestionsViewIfNeeded];
@@ -396,19 +393,12 @@ static NSString *NotificationsCommentIdKey              = @"NotificationsComment
 
 - (void)adjustTableViewInsetsIfNeeded
 {
-    BOOL isiPadFullScreen = [WPDeviceIdentification isiPad] && [self.traitCollection containsTraitsInCollection:[UITraitCollection traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassRegular]];
-    UIEdgeInsets contentInset = isiPadFullScreen ? NotificationTableInsetsPad : NotificationTableInsetsPhone;
-    
     // Badge Notifications should be centered, and display no cell separators
-    if (self.note.isBadge) {
-        // Center only if the container view is big enough!
-        if (self.view.frame.size.height > self.tableView.contentSize.height) {
-            CGFloat offsetY = (self.view.frame.size.height - self.tableView.contentSize.height) * 0.5f;
-            contentInset    = UIEdgeInsetsMake(offsetY, 0, 0, 0);
-        }
-    }
-    
-    self.tableView.contentInset = contentInset;
+    BOOL shouldCenterVertically = self.note.isBadge;
+
+    self.topLayoutConstraint.active = !shouldCenterVertically;
+    self.bottomLayoutConstraint.active = !shouldCenterVertically;
+    self.centerLayoutConstraint.active = shouldCenterVertically;
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -123,8 +123,7 @@ static NSInteger NotificationSectionCount               = 1;
     [super viewWillAppear:animated];
     
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-    [nc addObserver:self selector:@selector(handleKeyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
-    [nc addObserver:self selector:@selector(handleKeyboardWillShow:) name:UIKeyboardWillHideNotification object:nil];
+    [nc addObserver:self selector:@selector(handleKeyboardWillChangeFrame:) name:UIKeyboardWillChangeFrameNotification object:nil];
     
     [self.tableView deselectSelectedRowWithAnimation:YES];
 }
@@ -1276,7 +1275,7 @@ static NSInteger NotificationSectionCount               = 1;
     }
 }
 
-- (void)handleKeyboardWillShow:(NSNotification *)notification
+- (void)handleKeyboardWillChangeFrame:(NSNotification *)notification
 {
     NSDictionary* userInfo = notification.userInfo;
     

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -54,12 +54,12 @@ static NSInteger NotificationSectionCount               = 1;
 @interface NotificationDetailsViewController () <ReplyTextViewDelegate, SuggestionsTableViewDelegate>
 
 // Outlets
-@property (nonatomic,   weak) IBOutlet UIStackView          *stackView;
-@property (nonatomic,   weak) IBOutlet UITableView          *tableView;
-@property (nonatomic,   weak) IBOutlet UIGestureRecognizer  *tableGesturesRecognizer;
-@property (nonatomic,   weak) IBOutlet NSLayoutConstraint   *topLayoutConstraint;
-@property (nonatomic,   weak) IBOutlet NSLayoutConstraint   *centerLayoutConstraint;
-@property (nonatomic,   weak) IBOutlet NSLayoutConstraint   *bottomLayoutConstraint;
+@property (nonatomic, strong) IBOutlet UIStackView          *stackView;
+@property (nonatomic, strong) IBOutlet UITableView          *tableView;
+@property (nonatomic, strong) IBOutlet UIGestureRecognizer  *tableGesturesRecognizer;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint   *topLayoutConstraint;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint   *centerLayoutConstraint;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint   *bottomLayoutConstraint;
 @property (nonatomic, strong) ReplyTextView                 *replyTextView;
 @property (nonatomic, strong) SuggestionsTableView          *suggestionsTableView;
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -36,6 +36,7 @@
 #import "NSString+Helpers.h"
 
 #import "WPAppAnalytics.h"
+#import "WPDeviceIdentification.h"
 
 
 
@@ -285,7 +286,7 @@ static NSInteger NotificationSectionCount               = 1;
 - (void)attachReplyViewIfNeeded
 {
     // iPad: We've got a different UI!
-    if ([UIDevice isPad]) {
+    if ([WPDeviceIdentification isiPad]) {
         return;
     }
     

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -452,10 +452,12 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
     }
     
     if (note.isMatcher && note.metaPostID && note.metaSiteID) {
-        [self performSegueWithIdentifier:[ReaderDetailViewController classNameWithoutNamespaces] sender:note];
-    } else {
-        [self performSegueWithIdentifier:NSStringFromClass([NotificationDetailsViewController class]) sender:note];
+        ReaderDetailViewController *readerViewController = [ReaderDetailViewController controllerWithPostID:note.metaPostID siteID:note.metaSiteID];
+        [self.navigationController pushViewController:readerViewController animated:YES];
+        return;
     }
+
+    [self performSegueWithIdentifier:NSStringFromClass([NotificationDetailsViewController class]) sender:note];
 }
 
 
@@ -553,7 +555,6 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
 {
     NSString *detailsSegueID        = NSStringFromClass([NotificationDetailsViewController class]);
-    NSString *readerSegueID         = [ReaderDetailViewController classNameWithoutNamespaces];
     Notification *note              = sender;
     __weak __typeof(self) weakSelf  = self;
     
@@ -563,10 +564,6 @@ typedef NS_ENUM(NSUInteger, NotificationFilter)
         detailsViewController.onDeletionRequestCallback = ^(NotificationDeletionActionBlock onUndoTimeout){
             [weakSelf showUndeleteForNoteWithID:note.objectID onTimeout:onUndoTimeout];
         };
-        
-    } else if([segue.identifier isEqualToString:readerSegueID]) {
-        ReaderDetailViewController *readerViewController = segue.destinationViewController;
-        [readerViewController setupWithPostID:note.metaPostID siteID:note.metaSiteID];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -24,7 +24,6 @@
                         <outlet property="ratingsView" destination="ZnY-3K-upT" id="lUG-fd-Stc"/>
                         <outlet property="tableHeaderView" destination="Uvo-9e-l6I" id="dxx-mK-msp"/>
                         <segue destination="veA-Pg-QAw" kind="show" identifier="NotificationDetailsViewController" id="7uj-uJ-yZ8"/>
-                        <segue destination="6Ef-w3-Us2" kind="show" identifier="ReaderDetailViewController" id="zp4-jZ-apm"/>
                     </connections>
                 </tableViewController>
                 <view contentMode="scaleToFill" id="Uvo-9e-l6I" userLabel="Header View">
@@ -100,34 +99,6 @@
             </objects>
             <point key="canvasLocation" x="700" y="-1061"/>
         </scene>
-        <!--ReaderDetailViewController-->
-        <scene sceneID="7zN-ZI-iQe">
-            <objects>
-                <viewControllerPlaceholder storyboardName="Reader" bundleIdentifier="WordPress" referencedIdentifier="ReaderDetailViewController" id="6Ef-w3-Us2" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Bfo-xf-Dnl" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2749.5" y="-1817"/>
-        </scene>
-        <!--Reader Comments View Controller-->
-        <scene sceneID="RLS-eH-qVH">
-            <objects>
-                <viewController id="kOE-dH-qnb" customClass="ReaderCommentsViewController" sceneMemberID="viewController">
-                    <navigationItem key="navigationItem" id="eaw-kn-CXc"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="59U-6R-KoD" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2949" y="-1279"/>
-        </scene>
-        <!--WebView-->
-        <scene sceneID="1zS-D4-F1Z">
-            <objects>
-                <viewController id="Bbj-DX-KQ7" userLabel="WebView" customClass="WPWebViewController" sceneMemberID="viewController">
-                    <navigationItem key="navigationItem" id="Ggf-4b-Gwr"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="fEj-cd-uMn" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2949.375" y="-587.32394366197184"/>
-        </scene>
         <!--Notification Details-->
         <scene sceneID="0B7-mU-JSs">
             <objects>
@@ -174,10 +145,6 @@
                         <outlet property="tableGesturesRecognizer" destination="a20-Yr-RdT" id="Ap0-WK-Z2n"/>
                         <outlet property="tableView" destination="Dcn-Il-AtN" id="Mjf-q7-Lkn"/>
                         <outlet property="topLayoutConstraint" destination="wB2-hr-QKf" id="6lI-hD-BmZ"/>
-                        <segue destination="8p8-88-FGK" kind="show" identifier="StatsViewController" id="EAn-K1-ofm"/>
-                        <segue destination="Bbj-DX-KQ7" kind="show" identifier="WPWebViewController" id="ygK-a3-WEJ"/>
-                        <segue destination="kOE-dH-qnb" kind="show" identifier="ReaderCommentsViewController" id="Puk-pn-rGi"/>
-                        <segue destination="6Ef-w3-Us2" kind="show" identifier="ReaderDetailViewController" id="WHD-nZ-mNK"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jzQ-hT-Ajt" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -188,20 +155,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="1734.375" y="-634.85915492957747"/>
-        </scene>
-        <!--StatsView-->
-        <scene sceneID="iWL-VB-TOS">
-            <objects>
-                <viewController id="8p8-88-FGK" userLabel="StatsView" customClass="StatsViewController" sceneMemberID="viewController">
-                    <navigationItem key="navigationItem" id="Emb-tQ-YvX"/>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="KeQ-Nv-SGg" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2949.375" y="148.94366197183098"/>
+            <point key="canvasLocation" x="1446" y="-1061"/>
         </scene>
     </scenes>
-    <inferredMetricsTieBreakers>
-        <segue reference="WHD-nZ-mNK"/>
-    </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -114,7 +114,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="t2r-NP-ili">
                                 <rect key="frame" x="0.0" y="20" width="600" height="580"/>
                                 <subviews>
-                                    <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Dcn-Il-AtN" customClass="MyTableView">
+                                    <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Dcn-Il-AtN" customClass="IntrinsicTableView" customModule="WordPress">
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="580"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <gestureRecognizers/>

--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -140,30 +140,40 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Dcn-Il-AtN">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <gestureRecognizers/>
-                                <inset key="separatorInset" minX="12" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                <connections>
-                                    <outlet property="dataSource" destination="veA-Pg-QAw" id="VzN-sT-2Co"/>
-                                    <outlet property="delegate" destination="veA-Pg-QAw" id="s6c-EK-4wV"/>
-                                    <outletCollection property="gestureRecognizers" destination="a20-Yr-RdT" appends="YES" id="9kS-tn-Ero"/>
-                                </connections>
-                            </tableView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="t2r-NP-ili">
+                                <rect key="frame" x="0.0" y="20" width="600" height="580"/>
+                                <subviews>
+                                    <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Dcn-Il-AtN" customClass="MyTableView">
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="580"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <gestureRecognizers/>
+                                        <inset key="separatorInset" minX="12" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        <connections>
+                                            <outlet property="dataSource" destination="veA-Pg-QAw" id="VzN-sT-2Co"/>
+                                            <outlet property="delegate" destination="veA-Pg-QAw" id="s6c-EK-4wV"/>
+                                            <outletCollection property="gestureRecognizers" destination="a20-Yr-RdT" appends="YES" id="9kS-tn-Ero"/>
+                                        </connections>
+                                    </tableView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="6LW-NS-qSh" firstAttribute="top" secondItem="Dcn-Il-AtN" secondAttribute="bottom" priority="250" id="9mt-16-fFT"/>
-                            <constraint firstItem="Dcn-Il-AtN" firstAttribute="leading" secondItem="lvM-1n-Dgf" secondAttribute="leading" id="EDd-eL-C3N"/>
-                            <constraint firstItem="Dcn-Il-AtN" firstAttribute="top" secondItem="lvM-1n-Dgf" secondAttribute="top" id="VrG-Fy-A84"/>
-                            <constraint firstAttribute="trailing" secondItem="Dcn-Il-AtN" secondAttribute="trailing" id="eJA-A9-B0Q"/>
+                            <constraint firstItem="6LW-NS-qSh" firstAttribute="top" secondItem="t2r-NP-ili" secondAttribute="bottom" id="Em4-Ll-jHx"/>
+                            <constraint firstItem="t2r-NP-ili" firstAttribute="leading" secondItem="lvM-1n-Dgf" secondAttribute="leading" id="V4D-fq-INq"/>
+                            <constraint firstAttribute="trailing" secondItem="t2r-NP-ili" secondAttribute="trailing" id="bEY-FT-8cX"/>
+                            <constraint firstItem="t2r-NP-ili" firstAttribute="centerY" secondItem="lvM-1n-Dgf" secondAttribute="centerY" priority="750" id="qQ1-lE-W83"/>
+                            <constraint firstItem="t2r-NP-ili" firstAttribute="top" secondItem="8gl-SX-x5I" secondAttribute="bottom" id="wB2-hr-QKf"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="gVZ-cy-2mc"/>
                     <connections>
+                        <outlet property="bottomLayoutConstraint" destination="Em4-Ll-jHx" id="hyF-0f-xzw"/>
+                        <outlet property="centerLayoutConstraint" destination="qQ1-lE-W83" id="1rf-8U-syD"/>
+                        <outlet property="stackView" destination="t2r-NP-ili" id="JMP-dt-hBu"/>
                         <outlet property="tableGesturesRecognizer" destination="a20-Yr-RdT" id="Ap0-WK-Z2n"/>
                         <outlet property="tableView" destination="Dcn-Il-AtN" id="Mjf-q7-Lkn"/>
+                        <outlet property="topLayoutConstraint" destination="wB2-hr-QKf" id="6lI-hD-BmZ"/>
                         <segue destination="8p8-88-FGK" kind="show" identifier="StatsViewController" id="EAn-K1-ofm"/>
                         <segue destination="Bbj-DX-KQ7" kind="show" identifier="WPWebViewController" id="ygK-a3-WEJ"/>
                         <segue destination="kOE-dH-qnb" kind="show" identifier="ReaderCommentsViewController" id="Puk-pn-rGi"/>
@@ -192,6 +202,6 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="zp4-jZ-apm"/>
+        <segue reference="WHD-nZ-mNK"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
@@ -5,7 +5,7 @@ import Foundation
 /// This TableView subclass allows us to use UIStackView along with TableViews. Intrinsic Content Size
 /// will be automatically calculated, based on the Table's Content Size.
 ///
-/// Ref.: 
+/// Ref.:
 ///     -   https://developer.apple.com/library/ios/technotes/tn2154/_index.html#//apple_ref/doc/uid/DTS40013309
 ///     -   http://stackoverflow.com/questions/17334478/uitableview-within-uiscrollview-using-autolayout
 ///

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+
+
+/// This TableView subclass allows us to use UIStackView along with TableViews. Intrinsic Content Size
+/// will be automatically calculated, based on the Table's Content Size.
+///
+/// Ref.: 
+///     -   https://developer.apple.com/library/ios/technotes/tn2154/_index.html#//apple_ref/doc/uid/DTS40013309
+///     -   http://stackoverflow.com/questions/17334478/uitableview-within-uiscrollview-using-autolayout
+///
+class IntrinsicTableView: UITableView
+{
+    override func intrinsicContentSize() -> CGSize {
+        return CGSizeMake(UIViewNoIntrinsicMetric, contentSize.height)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
@@ -11,7 +11,14 @@ import Foundation
 ///
 class IntrinsicTableView: UITableView
 {
+    override var contentSize:CGSize {
+        didSet {
+            self.invalidateIntrinsicContentSize()
+        }
+    }
+
     override func intrinsicContentSize() -> CGSize {
+        layoutIfNeeded()
         return CGSizeMake(UIViewNoIntrinsicMetric, contentSize.height)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockImageTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockImageTableViewCell.swift
@@ -12,18 +12,12 @@ import WordPressShared.WPStyleGuide
 
     // MARK: - Public Methods
     public func downloadImageWithURL(url: NSURL?) {
-        if url == imageURL {
-            return
-        }
-
         let success = { (image: UIImage) in
             self.blockImageView.image = image
             self.blockImageView.displayWithSpringAnimation()
         }
 
         blockImageView.downloadImage(url, placeholderImage: nil, success: success, failure: nil)
-
-        imageURL = url
     }
 
     // MARK: - View Methods
@@ -34,9 +28,6 @@ import WordPressShared.WPStyleGuide
 
     // MARK: - Helpers
     private typealias Styles = WPStyleGuide.Notifications
-
-    // MARK: - Private
-    private var imageURL: NSURL?
 
     // MARK: - IBOutlets
     @IBOutlet weak var blockImageView: UIImageView!

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 		B53AD9BF1BE9584B009AB87E /* SettingsSelectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B53AD9BE1BE9584A009AB87E /* SettingsSelectionViewController.m */; };
 		B53B02B31CAC3AAC003190A0 /* GravatarPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B02B21CAC3AAC003190A0 /* GravatarPickerViewController.swift */; };
 		B53FDF6D19B8C336000723B6 /* UIScreen+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53FDF6C19B8C336000723B6 /* UIScreen+Helpers.swift */; };
+		B54075D41D3D7D5B0095C318 /* IntrinsicTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54075D31D3D7D5B0095C318 /* IntrinsicTableView.swift */; };
 		B54106901B6FE38400C880D0 /* WPWebViewController+Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = B541068F1B6FE38400C880D0 /* WPWebViewController+Auth.swift */; };
 		B541276B1C0F7D610015CA80 /* SettingsMultiTextViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B541276A1C0F7D610015CA80 /* SettingsMultiTextViewController.m */; };
 		B5416CF51C171D7100006DD8 /* PushNotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5416CF41C171D7100006DD8 /* PushNotificationsManager.swift */; };
@@ -1664,6 +1665,7 @@
 		B53AD9BE1BE9584A009AB87E /* SettingsSelectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SettingsSelectionViewController.m; sourceTree = "<group>"; };
 		B53B02B21CAC3AAC003190A0 /* GravatarPickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarPickerViewController.swift; sourceTree = "<group>"; };
 		B53FDF6C19B8C336000723B6 /* UIScreen+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIScreen+Helpers.swift"; sourceTree = "<group>"; };
+		B54075D31D3D7D5B0095C318 /* IntrinsicTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntrinsicTableView.swift; sourceTree = "<group>"; };
 		B541068F1B6FE38400C880D0 /* WPWebViewController+Auth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPWebViewController+Auth.swift"; sourceTree = "<group>"; };
 		B54127691C0F7D610015CA80 /* SettingsMultiTextViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SettingsMultiTextViewController.h; sourceTree = "<group>"; };
 		B541276A1C0F7D610015CA80 /* SettingsMultiTextViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SettingsMultiTextViewController.m; sourceTree = "<group>"; };
@@ -4074,6 +4076,7 @@
 			isa = PBXGroup;
 			children = (
 				B54E1DF31A0A7BBF00807537 /* NotificationMediaDownloader.swift */,
+				B54075D31D3D7D5B0095C318 /* IntrinsicTableView.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -6101,6 +6104,7 @@
 				5D42A3E2175E7452005CFF05 /* ReaderPost.m in Sources */,
 				B587797F19B799D800E57C5A /* UIImageView+Networking.swift in Sources */,
 				FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */,
+				B54075D41D3D7D5B0095C318 /* IntrinsicTableView.swift in Sources */,
 				E1B289DB19F7AF7000DB0707 /* RemoteBlog.m in Sources */,
 				E1A6DBDA19DC7D080071AC1E /* RemotePostCategory.m in Sources */,
 				599738401B87AD2600EC1C30 /* WordPressComServiceRemote.m in Sources */,


### PR DESCRIPTION
#### Details:
This PR addresses technical debt in NotificationDetailsViewController. Specifically:
- UIStackView has been implemented, to easily handle scenarios in which ReplyTextView has to be attached.
- The new leading/trailing Anchor's API has been wired
- Since i was around... cleaned up old Storyboard Segues that weren't used, and shifted over to code for transitions that don't have, as a destination, a VC that lives within Notifications.storyboard.
- Implemented IntrinsicTableView, to simplify "Vertically Centered" layouts, such as the ones used by Badge Notifications

Ref. #5613

--

#### Scenario: Automattcher Segue
1. Log into a dotcom account
2. Open the Notifications List, and press over an automattcher notification

Please, verify that the Reader shows up onscreen

#### Scenario: Comments Segue
1. Open a "Mention in a comment notification"
2. Verify that the Notification Details are onscreen
3. Press over the header

Please, verify that the Comments show up onscreen.

#### Scenario: Comments Segue
1. Open a `New Likes` Notification
2. Press over the header (first row!)

Please, verify that the ReaderPost is onscreen


#### Scenario: Badge Notifications
1. Open a Badge Notification: Stats Surge, First Post, *random* achievement

Please, verify that the interface effectively aligns the UI at the center. The image should show up with an animation.

**Note:** please, check this one on both, iPhone + iPad Devices
**Note II:** please, verify that the verticalScroll gets effectively disabled, in this particular scenario.

#### Scenario: ReplyTextView
1. Open a comment notification (such as a reply)
2. Verify that the ReplyTextView shows up at the bottom of the table
3. Press over the field

Verify that the Reply field gets animated / repositioned. Please, press over the background, and verify that the field gets dismissed.

**Note:** The replyTextField will only be visible on iPhone devices. I'll be iterating over this in other PR's, it should, instead, show up when the horizontal space is compressed!.


-- 

Needs review: @kurzee 
Sir, may i bother you with a review?

Thanks in advance for testing (+ for the patience!!)