### PR TITLE
Disables state restoration after updates.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -330,7 +330,20 @@ int ddLogLevel = DDLogLevelInfo;
 
 - (BOOL)application:(UIApplication *)application shouldRestoreApplicationState:(NSCoder *)coder
 {
-    return self.shouldRestoreApplicationState;
+    NSUserDefaults* standardUserDefaults = [NSUserDefaults standardUserDefaults];
+
+    NSString* const lastSavedStateVersionKey = @"lastSavedStateVersionKey";
+    NSString* lastSavedStateVersion = [standardUserDefaults objectForKey:lastSavedStateVersionKey];
+    NSString* currentVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleShortVersionString"];
+    BOOL shouldRestoreApplicationState = NO;
+
+    if (lastSavedStateVersion && [lastSavedStateVersion length] > 0 && [lastSavedStateVersion isEqualToString:currentVersion]) {
+        shouldRestoreApplicationState = self.shouldRestoreApplicationState;;
+    }
+
+    [standardUserDefaults setObject:currentVersion forKey:lastSavedStateVersionKey];
+
+    return shouldRestoreApplicationState;
 }
 
 - (void)application: (UIApplication *)application performActionForShortcutItem:(nonnull UIApplicationShortcutItem *)shortcutItem completionHandler:(nonnull void (^)(BOOL))completionHandler


### PR DESCRIPTION
Parallel to https://github.com/wordpress-mobile/WordPress-iOS/pull/5736 just targetting `release/6.3.1`