### PR TITLE
Reader: Confirm the search phrase is not empty

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -121,7 +121,7 @@ import Gridicons
     func performSearch() {
         assert(streamController != nil)
 
-        guard let phrase = searchBar.text?.trim() else {
+        guard let phrase = searchBar.text?.trim() where !phrase.isEmpty else {
             return
         }
 


### PR DESCRIPTION
Fixes #5708 

To test: 
Open the reader search screen. 
Try to search for a space, or multiple spaces.  
Confirm a search is not performed when the search phrase is just spaces and there is no crash.

Needs review: @kurzee would you sir?

