### PR TITLE
Share Extension: Prevents appending local URL's

### DIFF
--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -214,11 +214,13 @@ private extension ShareViewController
     func loadTextContent() {
         extensionContext?.loadWebsiteUrl { url in
             // Text + New Line + Source
-            let current = self.contentText ?? String()
-            let source  = url?.absoluteString ?? String()
-            let spacing = current.isEmpty ? String() : "\n\n"
+            var payload = self.contentText ?? String()
+            if let sourceURL = url?.absoluteString where url?.fileURL == false {
+                payload += payload.isEmpty ? String() : "\n\n"
+                payload += sourceURL
+            }
 
-            self.textView.text = "\(current)\(spacing)\(source)"
+            self.textView.text = payload
         }
     }
 


### PR DESCRIPTION
Fixes #5690

To test:
1. Install Google Photos
2. Attempt to share a Photo

Please, verify that the local URL isn't appended to the Extension Text. Also, please, double check that Sharing from Safari didn't break.

Needs review: @astralbodies 
Thanks in advance Aaron!!
