### PR TITLE
Signin: Fixes a UI glitch described in #5747

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
@@ -36,13 +36,6 @@ class SigninErrorViewController : UIViewController
     }
 
 
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-
-        modalPresentationStyle = .OverFullScreen
-    }
-
-
     override func viewDidLoad() {
         super.viewDidLoad()
 


### PR DESCRIPTION
Fixes #5747 
This glitch feels like a framework bug but I can't say for sure.  When the SigninErrorViewController's presentationStyle is set to OverFullScreen, the presenting controller displays a back button arrow that lingers after the error vc is dismissed.  Strictly speaking we don't need to set the presentationStyle as the full screen is covered by default, so removing the custom init *mostly* fixes the glitch.  I say mostly because a keen eye might spot the back button arrow momentarily becoming visible as the error vc is presented.  However when the vc is dismissed the arrow is no longer there. 

To test: 
Be already signed into the app and try to add a new self-hosted site. You can just enter `a` for the username, password, and URL and you'll see the error screen. 
Dismiss the error screen and confirm that the back button arrow is not visible. 

Needs review: @diegoreymendez would you be game to review this one? 
