### PR TITLE
Fixed invalid feature flag tests.

### DIFF
--- a/WordPress/WordPressTest/FeatureFlagTest.swift
+++ b/WordPress/WordPressTest/FeatureFlagTest.swift
@@ -24,9 +24,10 @@ class FeatureFlagTest: XCTestCase {
 
     func testEnsureDisabledFeaturesInProduction() {
         Build.withCurrent(.AppStore) {
-            expect(FeatureFlag.People.enabled).to(beFalse())
-            expect(FeatureFlag.Plans.enabled).to(beFalse())
-            expect(FeatureFlag.Domains.enabled).to(beFalse())
+            expect(FeatureFlag.ReaderMenu.enabled).to(beFalse())
+            expect(FeatureFlag.People.enabled).to(beTrue())
+            expect(FeatureFlag.MyProfile.enabled).to(beTrue())
+            expect(FeatureFlag.AccountSettings.enabled).to(beTrue())
         }
     }
 


### PR DESCRIPTION
Fixes #5752. Feature flags have changed since the test was written – updated to reflect current state.

To test: check the tests build and pass.

Needs review: @diegoreymendez 

