### PR TITLE
Readability, Part 1: RIP WPTableViewSectionHeaderFooterView

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ use_frameworks!
 platform :ios, '9.0'
 
 abstract_target 'WordPress_Base' do
-  pod 'WordPress-iOS-Shared', '0.5.9'
+  pod 'WordPress-iOS-Shared', '0.6.0'
   ## This pod is only being included to support the share extension ATM - https://github.com/wordpress-mobile/WordPress-iOS/issues/5081
   pod 'WordPressComKit', :git => 'https://github.com/Automattic/WordPressComKit.git', :tag => '0.0.4'
 

--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '~> 0.10.1'
     pod 'WordPress-iOS-Editor', '1.8'
     pod 'WordPressCom-Analytics-iOS', '0.1.16'
-    pod 'WordPressCom-Stats-iOS', '0.7.4'
+    pod 'WordPressCom-Stats-iOS', '0.7.6'
     pod 'wpxmlrpc', '~> 0.8'
     
     target :WordPressTest do
@@ -69,7 +69,7 @@ abstract_target 'WordPress_Base' do
   end
 
   target 'WordPressTodayWidget' do
-    pod 'WordPressCom-Stats-iOS/Services', '0.7.4'
+    pod 'WordPressCom-Stats-iOS/Services', '0.7.6'
   end
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -159,28 +159,28 @@ PODS:
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
-  - WordPress-iOS-Shared (0.5.9):
+  - WordPress-iOS-Shared (0.6.0):
     - CocoaLumberjack (~> 2.2.0)
   - WordPressCom-Analytics-iOS (0.1.16)
-  - WordPressCom-Stats-iOS (0.7.4):
+  - WordPressCom-Stats-iOS (0.7.6):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.3)
+    - WordPress-iOS-Shared (~> 0.6.0)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-    - WordPressCom-Stats-iOS/Services (= 0.7.4)
-    - WordPressCom-Stats-iOS/UI (= 0.7.4)
-  - WordPressCom-Stats-iOS/Services (0.7.4):
+    - WordPressCom-Stats-iOS/Services (= 0.7.6)
+    - WordPressCom-Stats-iOS/UI (= 0.7.6)
+  - WordPressCom-Stats-iOS/Services (0.7.6):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.3)
+    - WordPress-iOS-Shared (~> 0.6.0)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-  - WordPressCom-Stats-iOS/UI (0.7.4):
+  - WordPressCom-Stats-iOS/UI (0.7.6):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.3)
+    - WordPress-iOS-Shared (~> 0.6.0)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
     - WordPressCom-Stats-iOS/Services
   - WordPressComKit (0.0.4):
@@ -218,10 +218,10 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
   - WordPress-iOS-Editor (= 1.8)
-  - WordPress-iOS-Shared (= 0.5.9)
+  - WordPress-iOS-Shared (= 0.6.0)
   - WordPressCom-Analytics-iOS (= 0.1.16)
-  - WordPressCom-Stats-iOS (= 0.7.4)
-  - WordPressCom-Stats-iOS/Services (= 0.7.4)
+  - WordPressCom-Stats-iOS (= 0.7.6)
+  - WordPressCom-Stats-iOS/Services (= 0.7.6)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.4`)
   - WPMediaPicker (~> 0.10.1)
   - wpxmlrpc (~> 0.8)
@@ -281,13 +281,13 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
   WordPress-iOS-Editor: 50a09646fb62af3efdbb56d13ff656272a079066
-  WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
+  WordPress-iOS-Shared: f799334b41f3af509ccb76d7970f8c74a7716f14
   WordPressCom-Analytics-iOS: 46cbb47a84670f3b8548c8617da939c6b74cfda8
-  WordPressCom-Stats-iOS: 87b64bc36015e90789fec4abdb931af87c6e4cfe
+  WordPressCom-Stats-iOS: 2689a457fd18268d36266fca76e96dd13e4af991
   WordPressComKit: 0742c47e5b55bff0e6d26d40db9e010404675a73
   WPMediaPicker: 645ecc2435293cc898c76180f3994358a68cae20
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 0c6445565ade8440c8db5ab17792a08637b27e4f
+PODFILE CHECKSUM: 76c709696c126ed5a9bb5045e8ac5135e4e76ca5
 
 COCOAPODS: 1.0.1

--- a/WordPress/Classes/Utility/ImmuTable+WordPress.swift
+++ b/WordPress/Classes/Utility/ImmuTable+WordPress.swift
@@ -1,46 +1,16 @@
 import WordPressShared
 
-/// Until https://github.com/wordpress-mobile/WordPress-iOS/pull/4591 is fixed, we
-/// need to use the custom WPTableViewSectionHeaderFooterView.
-///
 /// This lives as an extension on a separate file because it's specific to our UI
 /// implementation and shouldn't be in a generic ImmuTable that we might eventually
 /// release as a standalone library.
 ///
 extension ImmuTableViewHandler {
-    public func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if let title = self.tableView(tableView, titleForHeaderInSection: section) {
-            return WPTableViewSectionHeaderFooterView.heightForHeader(title, width: tableView.frame.width)
-        } else {
-            return UITableViewAutomaticDimension
-        }
+
+    public func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
-    public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let title = self.tableView(tableView, titleForHeaderInSection: section) else {
-            return nil
-        }
-
-        let view = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        view.title = title
-        return view
-    }
-
-    public func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        if let title = self.tableView(tableView, titleForFooterInSection: section) {
-            return WPTableViewSectionHeaderFooterView.heightForFooter(title, width: tableView.frame.width)
-        } else {
-            return UITableViewAutomaticDimension
-        }
-    }
-
-    public func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        guard let title = self.tableView(tableView, titleForFooterInSection: section) else {
-            return nil
-        }
-
-        let view = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        view.title = title
-        return view
+    public func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 }

--- a/WordPress/Classes/Utility/WPTableViewHandler.h
+++ b/WordPress/Classes/Utility/WPTableViewHandler.h
@@ -39,6 +39,8 @@
 - (CGFloat)tableView:(nonnull UITableView *)tableView heightForHeaderInSection:(NSInteger)section;
 - (nullable UIView *)tableView:(nonnull UITableView *)tableView viewForFooterInSection:(NSInteger)section;
 - (CGFloat)tableView:(nonnull UITableView *)tableView heightForFooterInSection:(NSInteger)section;
+- (void)tableView:(nonnull UITableView *)tableView willDisplayHeaderView:(nonnull UIView *)view forSection:(NSInteger)section;
+- (void)tableView:(nonnull UITableView *)tableView willDisplayFooterView:(nonnull UIView *)view forSection:(NSInteger)section;
 
 #pragma mark - Editing table rows
 
@@ -63,7 +65,8 @@
 
 - (nonnull UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(nonnull NSIndexPath *)indexPath;
 
-- (nullable NSString *)titleForHeaderInSection:(NSInteger)section;
+- (nullable NSString *)tableView:(nonnull UITableView *)tableView titleForHeaderInSection:(NSInteger)section;
+- (nullable NSString *)tableView:(nonnull UITableView *)tableView titleForFooterInSection:(NSInteger)section;
 
 #pragma mark - Inserting or deleting table rows
 
@@ -95,7 +98,6 @@
 @property (nonatomic) UITableViewRowAnimation sectionRowAnimation;
 
 - (nonnull instancetype)initWithTableView:(nonnull UITableView *)tableView;
-- (void)updateTitleForSection:(NSUInteger)section;
 - (void)clearCachedRowHeights;
 - (void)refreshCachedRowHeightsForWidth:(CGFloat)width;
 - (void)invalidateCachedRowHeightAtIndexPath:(nonnull NSIndexPath *)indexPath;

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -57,12 +57,6 @@ static CGFloat const DefaultCellHeight = 44.0;
 
 #pragma mark - Public Methods
 
-- (void)updateTitleForSection:(NSUInteger)section
-{
-    WPTableViewSectionHeaderFooterView *sectionHeaderView = (WPTableViewSectionHeaderFooterView *)[self tableView:self.tableView viewForHeaderInSection:section];
-    sectionHeaderView.title = [self titleForHeaderInSection:section];
-}
-
 - (void)clearCachedRowHeights
 {
     [self.cachedRowHeights removeAllObjects];
@@ -281,14 +275,6 @@ static CGFloat const DefaultCellHeight = 44.0;
     return nil;
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
-{
-    if ([self.delegate respondsToSelector:@selector(titleForHeaderInSection:)]) {
-        return [self.delegate titleForHeaderInSection:section];
-    }
-    return nil;
-}
-
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {
     if ([self.delegate respondsToSelector:@selector(tableView:canEditRowAtIndexPath:)]) {
@@ -429,54 +415,6 @@ static CGFloat const DefaultCellHeight = 44.0;
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    if ([self.delegate respondsToSelector:@selector(tableView:viewForHeaderInSection:)]) {
-        return [self.delegate tableView:tableView viewForHeaderInSection:section];
-    }
-
-    WPTableViewSectionHeaderFooterView *header;
-    if ([self.sectionHeaders count] > section) {
-        header = [self.sectionHeaders objectAtIndex:section];
-    } else {
-        header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-        [self.sectionHeaders addObject:header];
-    }
-
-    header.title = [self titleForHeaderInSection:section];
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    if ([self.delegate respondsToSelector:@selector(tableView:heightForHeaderInSection:)]) {
-        return [self.delegate tableView:tableView heightForHeaderInSection:section];
-    }
-
-    NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.tableView.bounds)];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    if ([self.delegate respondsToSelector:@selector(tableView:heightForFooterInSection:)]) {
-        return [self.delegate tableView:tableView heightForFooterInSection:section];
-    }
-
-    // Remove footer height for all but last section
-    return section == [[self.resultsController sections] count] - 1 ? UITableViewAutomaticDimension : 1.0;
-}
-
-
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
-{
-    if ([self.delegate respondsToSelector:@selector(tableView:viewForFooterInSection:)]) {
-        return [self.delegate tableView:tableView viewForFooterInSection:section];
-    }
-
-    return nil;
-}
-
 - (void)tableView:(UITableView *)tableView didEndDisplayingCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
     if ([self.delegate respondsToSelector:@selector(tableView:didEndDisplayingCell:forRowAtIndexPath:)]) {
@@ -484,6 +422,55 @@ static CGFloat const DefaultCellHeight = 44.0;
     }
 }
 
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:viewForHeaderInSection:)]) {
+        return [self.delegate tableView:tableView viewForHeaderInSection:section];
+    }
+    return nil;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:heightForHeaderInSection:)]) {
+        return [self.delegate tableView:tableView heightForHeaderInSection:section];
+    }
+    return UITableViewAutomaticDimension;
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:viewForFooterInSection:)]) {
+        return [self.delegate tableView:tableView viewForFooterInSection:section];
+    }
+    return nil;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:heightForFooterInSection:)]) {
+        return [self.delegate tableView:tableView heightForFooterInSection:section];
+    }
+    return UITableViewAutomaticDimension;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:willDisplayHeaderView:forSection:)]) {
+        [self.delegate tableView:tableView willDisplayHeaderView:view forSection:section];
+    } else {
+        [WPStyleGuide configureTableViewSectionHeader:view];
+    }
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:willDisplayFooterView:forSection:)]) {
+        [self.delegate tableView:tableView willDisplayFooterView:view forSection:section];
+    } else {
+        [WPStyleGuide configureTableViewSectionFooter:view];
+    }
+}
 
 #pragma mark - TableView Datasource Methods
 
@@ -505,10 +492,20 @@ static CGFloat const DefaultCellHeight = 44.0;
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
+    if ([self.delegate respondsToSelector:@selector(tableView:titleForHeaderInSection:)]) {
+        return [self.delegate tableView:tableView titleForHeaderInSection:section];
+    }
     id <NSFetchedResultsSectionInfo> sectionInfo = [[self.resultsController sections] objectAtIndex:section];
     return [sectionInfo name];
 }
 
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:titleForFooterInSection:)]) {
+        return [self.delegate tableView:tableView titleForFooterInSection:section];
+    }
+    return nil;
+}
 
 #pragma mark - UIScrollViewDelegate Methods
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -480,28 +480,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     return WPTableViewDefaultRowHeight;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     BlogDetailsSection *detailSection = [self.tableSections objectAtIndex:section];
     return detailSection.title;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 #pragma mark - Private methods

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -128,10 +128,7 @@ public class DiscussionSettingsViewController : UITableViewController
     }
 
     public override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        guard let headerText = sections[section].headerText else {
-            return nil
-        }
-        return headerText
+        return sections[section].headerText
     }
 
     public override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
@@ -139,10 +136,7 @@ public class DiscussionSettingsViewController : UITableViewController
     }
 
     public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        guard let footerText = sections[section].footerText else {
-            return nil
-        }
-        return footerText
+        return sections[section].footerText
     }
 
     public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -127,40 +127,26 @@ public class DiscussionSettingsViewController : UITableViewController
         return cell
     }
 
-    public override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard let headerText = sections[section].headerText else {
-            return CGFloat.min
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForHeader(headerText, width: tableView.bounds.width)
-    }
-
-    public override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard let headerText = sections[section].headerText else {
             return nil
         }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        footerView.title = headerText
-        return footerView
+        return headerText
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        guard let footerText = sections[section].footerText else {
-            return 0
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForFooter(footerText, width: tableView.bounds.width)
+    public override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard let footerText = sections[section].footerText else {
             return nil
         }
+        return footerText
+    }
 
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title = footerText
-        return footerView
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
@@ -65,17 +65,13 @@ public class LanguageViewController : UITableViewController
         return cell!
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return WPTableViewSectionHeaderFooterView.heightForFooter(footerText, width: view.bounds.width)
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return footerText
     }
 
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        let headerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        headerView.title = footerText
-        return headerView
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
-
-
 
     // MARK: - UITableViewDelegate Methods
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {

--- a/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
@@ -99,82 +99,34 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
     return 0;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            WPTableViewSectionHeaderFooterView *headerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-            return headerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            WPTableViewSectionHeaderFooterView *headerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-            headerView.title = NSLocalizedString(@"Preview", @"Section title for related posts section preview");
-            return headerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
+        case RelatedPostsSettingsSectionPreview:
+            return NSLocalizedString(@"Preview", @"Section title for related posts section preview");
+        default:
+            return nil;
     }
-    return nil;
-
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil
-                                                                                                                           style:WPTableViewSectionStyleFooter];
-            footerView.title = NSLocalizedString(@"Related Posts displays relevant content from your site below your posts", @"Information of what related post are and how they are presented");
-            return footerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil
-                                                                                                                           style:WPTableViewSectionStyleFooter];
-            return footerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
-    }
-    return nil;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            return [WPTableViewSectionHeaderFooterView heightForHeader:@"" width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            return [WPTableViewSectionHeaderFooterView heightForHeader:NSLocalizedString(@"Preview", @"Section title for related posts section preview") width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
+        case RelatedPostsSettingsSectionOptions:
+            return NSLocalizedString(@"Related Posts displays relevant content from your site below your posts", @"Information of what related post are and how they are presented");;
+        default:
+            return nil;
     }
-    return 0;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
 {
-    switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            return [WPTableViewSectionHeaderFooterView heightForFooter:NSLocalizedString(@"Related Posts displays relevant content from your site below your posts.", @"Information of what related post are and how they are presented.")
-                                                                 width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            return [WPTableViewSectionHeaderFooterView heightForFooter:@"" width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
-    }
-    return 0;
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -820,12 +820,10 @@ import WordPressShared
 
 
     override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-        // We only actual editing (ordering) with sections that canSort and are not toggled in the UI activating/deactivating.
+        // Since we want to be able to order particular rows, let's only allow editing for those specific rows.
+        // Note: We have to allow editing because UITableView will only give us the ordering accessory while editing is toggled.
         let section = sections[indexPath.section]
-        if section.canSort && !section.editing && indexPath.row > 0 {
-            return true
-        }
-        return false
+        return section.canSort && !section.editing && indexPath.row > 0
     }
 
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -795,20 +795,8 @@ import WordPressShared
     }
 
 
-    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let title = self.tableView(tableView, titleForHeaderInSection: section) else {
-            return nil
-        }
-
-        let headerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        headerView.title = title
-        return headerView
-    }
-
-
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        let title = self.tableView(tableView, titleForHeaderInSection: section)
-        return WPTableViewSectionHeaderFooterView.heightForHeader(title, width: view.bounds.width)
+    override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
 
@@ -817,20 +805,8 @@ import WordPressShared
     }
 
 
-    override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        guard let title = self.tableView(tableView, titleForFooterInSection: section) else {
-            return nil
-        }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title = title
-        return footerView
-    }
-
-
-    override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        let title = self.tableView(tableView, titleForFooterInSection: section)
-        return WPTableViewSectionHeaderFooterView.heightForFooter(title, width: view.bounds.width)
+    override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 
@@ -840,6 +816,16 @@ import WordPressShared
             tableView.deselectRowAtIndexPath(indexPath, animated: true)
         }
         row.action?()
+    }
+
+
+    override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        // We only actual editing (ordering) with sections that canSort and are not toggled in the UI activating/deactivating.
+        let section = sections[indexPath.section]
+        if section.canSort && !section.editing && indexPath.row > 0 {
+            return true
+        }
+        return false
     }
 
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -98,12 +98,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return 1;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSString *title;
@@ -113,20 +107,12 @@ static NSString *const CellIdentifier = @"CellIdentifier";
         NSString *format = NSLocalizedString(@"Publicize to %@", @"Title. `Publicize` is used as a verb here but `Share` (verb) would also work here. The `%@` is a placeholder for the service name.");
         title = [NSString stringWithFormat:format, self.publicizeService.label];
     }
-
     return title;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
@@ -134,21 +120,13 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     if ([self hasConnectedAccounts] && section == 0) {
         return nil;
     }
-
     NSString *title = NSLocalizedString(@"Connect to automatically share your blog posts to %@", @"Instructional text appearing below a `Connect` button. The `%@` is a placeholder for the name of a third-party sharing service.");
     return [NSString stringWithFormat:title, self.publicizeService.label];
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForFooterInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *footer = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    footer.title = title;
-    return footer;
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -74,12 +74,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return 2;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     if (section == 0) {
@@ -89,16 +83,9 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
@@ -113,16 +100,9 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForFooterInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *footer = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    footer.title = title;
-    return footer;
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -83,12 +83,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return count;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     switch (section) {
@@ -101,16 +95,9 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
@@ -121,16 +108,9 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForFooterInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *footer = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    footer.title = title;
-    return footer;
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -539,9 +539,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSInteger settingsSection = [self.tableSections[section] integerValue];
-    NSString *title = [self titleForHeaderInSection:settingsSection];
-
-    return title.length > 0 ? title : nil;
+    return [self titleForHeaderInSection:settingsSection];
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -536,29 +536,22 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 
 #pragma mark - UITableViewDelegate
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSInteger settingsSection = [self.tableSections[section] integerValue];
     NSString *title = [self titleForHeaderInSection:settingsSection];
-    if (title.length == 0) {
-        return [UIView new];
-    }
-    
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
+
+    return title.length > 0 ? title : nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     return WPTableViewDefaultRowHeight;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSInteger settingsSection = [self.tableSections[section] integerValue];
-    NSString *title = [self titleForHeaderInSection:settingsSection];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (NSString *)titleForHeaderInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
@@ -148,26 +148,12 @@ class DomainsListViewController: UITableViewController, ImmuTablePresenter {
         return tableView.rowHeight
     }
 
-    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        if let title = self.tableView(tableView, titleForHeaderInSection: section) where !title.isEmpty {
-            let header = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-            header.title = title
-            return header
-        } else {
-            return nil
-        }
-    }
-
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if let headerView = self.tableView(tableView, viewForHeaderInSection: section) as? WPTableViewSectionHeaderFooterView {
-            return WPTableViewSectionHeaderFooterView.heightForHeader(headerView.title, width: CGRectGetWidth(view.bounds))
-        } else {
-            return 0
-        }
-    }
-
     override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return viewModel.sections[section].headerText
+    }
+
+    override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
@@ -9,7 +9,6 @@ public class AboutViewController : UITableViewController
         super.viewDidLoad()
 
         setupNavigationItem()
-        setupTableViewFooter()
         setupTableView()
         setupDismissButtonIfNeeded()
     }
@@ -40,16 +39,6 @@ public class AboutViewController : UITableViewController
         tableView.contentInset      = WPTableViewContentInsets
 
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-    }
-
-    private func setupTableViewFooter() {
-        let calendar                = NSCalendar.currentCalendar()
-        let year                    = calendar.components(.Year, fromDate: NSDate()).year
-
-        let footerView              = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title            = NSLocalizedString("© \(year) Automattic, Inc.", comment: "About View's Footer Text")
-        footerView.titleAlignment   = .Center
-        self.footerView             = footerView
     }
 
     private func setupDismissButtonIfNeeded() {
@@ -101,22 +90,18 @@ public class AboutViewController : UITableViewController
         return cell!
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        let isLastSection = section == (rows.count - 1)
-        if isLastSection == false || footerView == nil {
-            return CGFloat.min
-        }
-
-        let height = WPTableViewSectionHeaderFooterView.heightForFooter(footerView!.title, width: view.frame.width)
-        return height + footerBottomPadding
-    }
-
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if section != (rows.count - 1) {
             return nil
         }
+        return footerTitleText
+    }
 
-        return footerView
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
+        if let footerView = view as? UITableViewHeaderFooterView {
+            footerView.textLabel?.textAlignment = .Center
+        }
     }
 
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
@@ -175,8 +160,14 @@ public class AboutViewController : UITableViewController
     private let iconBottomPadding   = CGFloat(30)
     private let footerBottomPadding = CGFloat(12)
 
+
+
     // MARK: - Private Properties
-    private var footerView : WPTableViewSectionHeaderFooterView!
+    private lazy var footerTitleText: String = {
+        let calendar = NSCalendar.currentCalendar()
+        let year = calendar.components(.Year, fromDate: NSDate()).year
+        return NSLocalizedString("© \(year) Automattic, Inc.", comment: "About View's Footer Text")
+    }()
 
     private var rows : [[Row]] {
         let appsBlogHostname = NSURL(string: WPAutomatticAppsBlogURL)?.host ?? String()

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -151,42 +151,27 @@ public class NotificationSettingDetailsViewController : UITableViewController
         return cell!
     }
 
-    public override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard section == firstSectionIndex else {
-            return 0
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForHeader(siteName, width: view.bounds.width)
-    }
-
-    public override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard section == firstSectionIndex else {
             return nil
         }
-
-        let headerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        headerView.title    = siteName
-        return headerView
+        return siteName
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        guard let footerText = sections[section].footerText else {
-            return CGFloat.min
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForFooter(footerText, width: view.bounds.width)
+    public override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard let footerText = sections[section].footerText else {
             return nil
         }
-
-        let footerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title    = footerText
-        return footerView
+        return footerText
     }
 
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
+    }
 
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         tableView.deselectSelectedRowWithAnimation(true)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -163,10 +163,7 @@ public class NotificationSettingDetailsViewController : UITableViewController
     }
 
     public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        guard let footerText = sections[section].footerText else {
-            return nil
-        }
-        return footerText
+        return sections[section].footerText
     }
 
     public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -107,16 +107,12 @@ public class NotificationSettingStreamsViewController : UITableViewController
         return cell!
     }
 
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        let headerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        headerView.title = footerForStream(streamAtSection(section))
-        return headerView
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return footerForStream(streamAtSection(section))
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        let title = footerForStream(streamAtSection(section))
-        let width = view.frame.width
-        return WPTableViewSectionHeaderFooterView.heightForFooter(title, width: width)
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -161,53 +161,32 @@ public class NotificationSettingsViewController : UIViewController
         return isBlogSection && isNotPagination ? blogRowHeight : WPTableViewDefaultRowHeight
     }
 
-    public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    public func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         // Hide when the section is empty!
         if isSectionEmpty(section) {
             return nil
         }
 
         let theSection      = Section(rawValue: section)!
-        let footerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        footerView.title    = theSection.headerText()
-        return footerView
+        return theSection.headerText()
     }
 
-    public func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        // Hide when the section is empty!
-        if isSectionEmpty(section) {
-            return CGFloat.min
-        }
-
-        let theSection      = Section(rawValue: section)!
-        let width           = view.frame.width
-        return WPTableViewSectionHeaderFooterView.heightForHeader(theSection.headerText(), width: width)
+    public func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
-    public func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         // Hide when the section is empty!
         if isSectionEmpty(section) {
             return nil
         }
 
         let theSection      = Section(rawValue: section)!
-        let footerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title    = theSection.footerText()
-
-        return footerView
+        return theSection.footerText()
     }
 
-    public func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        // Hide when the section is empty!
-        if isSectionEmpty(section) {
-            return CGFloat.min
-        }
-
-        let section         = Section(rawValue: section)!
-        let padding         = section.footerPadding()
-        let height          = WPTableViewSectionHeaderFooterView.heightForFooter(section.footerText(), width: view.frame.width)
-
-        return height + padding
+    public func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -108,22 +108,15 @@ class InvitePersonViewController : UITableViewController {
 
     // MARK: - UITableView Methods
 
-    override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        guard section == lastSectionIndex else {
-            return CGFloat.min
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForFooter(lastSectionFooterText, width: view.bounds.width)
-    }
-
-    override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard section == lastSectionIndex else {
             return nil
         }
+        return lastSectionFooterText
+    }
 
-        let headerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        headerView.title = lastSectionFooterText
-        return headerView
+    override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -291,21 +291,7 @@ extension PlanDetailViewController: UITableViewDataSource, UITableViewDelegate {
         return tableViewModel.sections[section].headerText
     }
 
-    func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        if let title = self.tableView(tableView, titleForHeaderInSection: section) where !title.isEmpty {
-            let header = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-            header.title = title
-            return header
-        } else {
-            return nil
-        }
-    }
-
-    func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if let headerView = self.tableView(tableView, viewForHeaderInSection: section) as? WPTableViewSectionHeaderFooterView {
-            return WPTableViewSectionHeaderFooterView.heightForHeader(headerView.title, width: CGRectGetWidth(view.bounds))
-        } else {
-            return 0
-        }
+    func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 }

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -9,36 +9,7 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
         didSet {
             handler.viewModel = viewModel.tableViewModelWithPresenter(self, planService: service)
             updateNoResults()
-            updateFooterView()
         }
-    }
-
-    func updateFooterView() {
-        let footerViewModel = viewModel.tableFooterViewModelWithPresenter(self)
-
-        tableView.tableFooterView = tableFooterViewWithViewModel(footerViewModel)
-    }
-
-    private var footerTapAction: (() -> Void)?
-    private func tableFooterViewWithViewModel(viewModel: (title: String, action: () -> Void)?) -> UIView? {
-        guard let viewModel = viewModel else { return nil }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: "ToSFooterView", style: .Footer)
-
-        let title = viewModel.title
-        footerView.title = title
-        footerView.frame.size.height = WPTableViewSectionHeaderFooterView.heightForFooter(title, width: footerView.bounds.width)
-
-        // Don't add a recognizer if we already have one
-        let recognizers = footerView.gestureRecognizers
-        if recognizers == nil || recognizers?.count == 0 {
-            footerTapAction = viewModel.action
-
-            let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(footerTapped))
-            footerView.addGestureRecognizer(tapRecognizer)
-        }
-
-        return footerView
     }
 
     private let noResultsView = WPNoResultsView()
@@ -114,10 +85,6 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
                 self.viewModel = .Error(String(error))
             }
         )
-    }
-
-    func footerTapped() {
-        footerTapAction?()
     }
 
     // MARK: - ImmuTablePresenter

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
@@ -89,7 +89,8 @@ enum PlanListViewModel {
             return ImmuTable(sections: [
                 ImmuTableSection(
                     headerText: NSLocalizedString("WordPress.com Plans", comment: "Title for the Plans list header"),
-                    rows: rows)
+                    rows: rows,
+                    footerText: NSLocalizedString("Manage your plan at WordPress.com/plans", comment: "Footer for Plans list"))
                 ])
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
 
 + (instancetype)controllerForDetails:(WPImageMeta *)details forPost:(AbstractPost *)post
 {
-    EditImageDetailsViewController *controller = [EditImageDetailsViewController new];
+    EditImageDetailsViewController *controller = [[EditImageDetailsViewController alloc] initWithStyle:UITableViewStyleGrouped];
     controller.imageDetails = details;
     controller.post = post;
     return controller;
@@ -258,7 +258,7 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
     return 0;
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSInteger sec = [[self.sections objectAtIndex:section] integerValue];
     if (sec == ImageDetailsSectionDetails) {
@@ -267,31 +267,12 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
     } else if (sec == ImageDetailsSectionDisplay) {
         return NSLocalizedString(@"Web Display Settings", @"The title of the option group for editing an image's size, alignment, etc. on the image details screen.");
     }
-
-    return @"";
+    return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = [self titleForHeaderInSection:section];
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    if (section == 0) {
-        return WPTableViewTopMargin;
-    }
-
-    NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    // Remove extra padding caused by section footers in grouped table views
-    return 1.0f;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -401,7 +401,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     return 0;
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSInteger sec = [[self.sections objectAtIndex:section] integerValue];
     if (sec == PostSettingsSectionTaxonomy) {
@@ -418,41 +418,23 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
     } else if (sec == PostSettingsSectionGeolocation) {
         return NSLocalizedString(@"Location", @"Label for the geolocation feature (tagging posts by their physical location).");
-
+        
     }
-    return @"";
+    return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = [self titleForHeaderInSection:section];
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    if (IS_IPAD && section == 0) {
-        return WPTableViewTopMargin;
-    }
-
-    NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    // Remove extra padding caused by section footers in grouped table views
-    return 1.0f;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    CGFloat width = IS_IPAD ? WPTableViewFixedWidth : CGRectGetWidth(self.tableView.frame);
+    CGFloat width = CGRectGetWidth(self.tableView.frame);
     NSInteger sectionId = [[self.sections objectAtIndex:indexPath.section] integerValue];
 
     if (sectionId == PostSettingsSectionGeolocation && self.post.geolocation != nil) {
-        return ceilf(width * 0.75f);
+        return ceilf(width * 0.50f);
     }
 
     if (sectionId == PostSettingsSectionFeaturedImage) {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -43,6 +43,7 @@ typedef NS_ENUM(NSInteger, PostSettingsRow) {
 
 static CGFloat CellHeight = 44.0f;
 static NSInteger RowIndexForDatePicker = 0;
+static CGFloat LocationCellHeightToWidthAspectRatio = 0.5f;
 
 static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCellIdentifier";
 static NSString *const TableViewProgressCellIdentifier = @"TableViewProgressCellIdentifier";
@@ -434,7 +435,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     NSInteger sectionId = [[self.sections objectAtIndex:indexPath.section] integerValue];
 
     if (sectionId == PostSettingsSectionGeolocation && self.post.geolocation != nil) {
-        return ceilf(width * 0.50f);
+        return ceilf(width * LocationCellHeightToWidthAspectRatio);
     }
 
     if (sectionId == PostSettingsSectionFeaturedImage) {

--- a/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
@@ -204,19 +204,16 @@ static CGFloat const FollowSitesRowHeight = 54.0;
     return NSLocalizedString(@"Unfollow", @"Label of the table view cell's delete button, when unfollowing a site.");
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     if ([[self.tableViewHandler.resultsController fetchedObjects] count] > 0) {
         return NSLocalizedString(@"Sites", @"Section title for sites the user has followed.");
     }
-    // Return an space instead of empty string or nil to preserve the section
-    // header's height if all items are removed and then one added back.
-    return @" ";
+    return nil;
 }
 
 - (void)tableViewDidChangeContent:(UITableView *)tableView
 {
-    [self.tableViewHandler updateTitleForSection:0];
     [self configureNoResultsView];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -300,15 +300,13 @@ extension ReaderFollowedSitesViewController : WPTableViewHandlerDelegate
         return 54.0
     }
 
-
-    func titleForHeaderInSection(section: Int) -> String? {
+    func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         let count = tableViewHandler.resultsController.fetchedObjects?.count ?? 0
         if count > 0 {
             return NSLocalizedString("Sites", comment: "Section title for sites the user has followed.")
         }
-        return " "
+        return nil
     }
-
 
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         guard let site = tableViewHandler.resultsController.objectAtIndexPath(indexPath) as? ReaderSiteTopic else {
@@ -340,7 +338,6 @@ extension ReaderFollowedSitesViewController : WPTableViewHandlerDelegate
 
     func tableViewDidChangeContent(tableView: UITableView) {
         configureNoResultsView()
-        tableViewHandler.updateTitleForSection(0)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -262,20 +262,13 @@ import WordPressShared
         return viewModel.numberOfItemsInSection(section)
     }
 
-
-    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let title = viewModel.titleForSection(section)
-        let header = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        header.title = title
-        return header
+    override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return viewModel.titleForSection(section)
     }
 
-
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        let title = viewModel.titleForSection(section)
-        return WPTableViewSectionHeaderFooterView.heightForHeader(title, width: view.frame.width)
+    override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
-
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let menuItem = viewModel.menuItemAtIndexPath(indexPath)

--- a/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
@@ -168,7 +168,7 @@
     }
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     id <NSFetchedResultsSectionInfo> sectionInfo = [self.tableViewHandler.resultsController.sections objectAtIndex:section];
 
@@ -180,7 +180,8 @@
         return NSLocalizedString(@"Tags", @"Section title for reader tags you can browse");
     }
 
-    return nil;}
+    return nil;
+}
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {

--- a/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
@@ -182,7 +182,7 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:ReaderTopicDidChangeViaUserInteractionNotification object:nil];
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     id <NSFetchedResultsSectionInfo> sectionInfo = [self.tableViewHandler.resultsController.sections objectAtIndex:section];
 

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
@@ -109,30 +109,7 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
     return cell;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self titleForHeaderInSection:section];
-    if (!title) {
-        return nil;
-    }
-    
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self titleForHeaderInSection:section];
-    if (!title) {
-        // Fix: Prevents extra spacing when dealing with empty footers
-        return CGFLOAT_MIN;
-    }
-    
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     if (section == 0) {
         return NSLocalizedString(@"Log Files By Created Date", @"");
@@ -140,25 +117,22 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    header.title = [self titleForFooterInSection:section];
-    return header;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    NSString *title = [self titleForFooterInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForFooter:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (NSString *)titleForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     if (section == 0) {
         return NSLocalizedString(@"Up to seven days worth of logs are saved.", @"Help text shown below the list of debug logs.");
     }
     return nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 #pragma mark - Table view delegate

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -326,28 +326,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
-{
-    NSString *title = [self titleForFooterInSection:section];
-    if (!title) {
-        return nil;
-    }
-    
-    WPTableViewSectionHeaderFooterView *footer = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    footer.title = title;
-    return footer;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    NSString *title = [self titleForFooterInSection:section];
-    if (!title) {
-        return UITableViewAutomaticDimension;
-    }
-    return [WPTableViewSectionHeaderFooterView heightForFooter:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (NSString *)titleForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     if (section == SettingsSectionFAQForums) {
         if ([HelpshiftUtils isHelpshiftEnabled]) {
@@ -359,6 +338,11 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
         return NSLocalizedString(@"The Extra Debug feature includes additional information in activity logs, and can help us troubleshoot issues with the app.", @"");
     }
     return nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 #pragma mark - Table view delegate

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
@@ -99,25 +99,15 @@ public class SettingsListEditorViewController : UITableViewController
         return cell
     }
 
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard let unwrappedFooterText = footerText else {
             return nil
         }
-
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title = unwrappedFooterText
-
-        return footerView
+        return unwrappedFooterText
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        guard let unwrappedFooterText = footerText else {
-            return CGFloat.min
-        }
-
-        let height = WPTableViewSectionHeaderFooterView.heightForFooter(unwrappedFooterText, width: view.frame.width)
-        return height
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
@@ -100,10 +100,7 @@ public class SettingsListEditorViewController : UITableViewController
     }
 
     public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        guard let unwrappedFooterText = footerText else {
-            return nil
-        }
-        return unwrappedFooterText
+        return footerText
     }
 
     public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListPickerViewController.swift
@@ -102,10 +102,7 @@ class SettingsListPickerViewController<T:Equatable> : UITableViewController
     }
 
     override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        guard let text = headers?[section] else {
-            return nil
-        }
-        return text
+        return headers?[section]
     }
 
     override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
@@ -113,10 +110,7 @@ class SettingsListPickerViewController<T:Equatable> : UITableViewController
     }
 
     override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        guard let text = footers?[section] else {
-            return nil
-        }
-        return text
+        return footers?[section]
     }
 
     override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListPickerViewController.swift
@@ -101,42 +101,26 @@ class SettingsListPickerViewController<T:Equatable> : UITableViewController
         return cell!
     }
 
-    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard let text = headers?[section] else {
             return nil
         }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        footerView.title = text
-
-        return footerView
+        return text
     }
 
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard let text = headers?[section] else {
-            return 0
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForHeader(text, width: view.frame.width)
+    override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
-    override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard let text = footers?[section] else {
             return nil
         }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title = text
-
-        return footerView
+        return text
     }
 
-    override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        guard let text = footers?[section] else {
-            return 0
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForFooter(text, width: view.frame.width)
+    override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -10,7 +10,6 @@ static CGFloat const SettingsMinHeight = 41.0f;
 
 @property (nonatomic, strong) UITableViewCell *textViewCell;
 @property (nonatomic, strong) UITextView *textView;
-@property (nonatomic, strong) UIView *hintView;
 
 @end
 
@@ -77,17 +76,6 @@ static CGFloat const SettingsMinHeight = 41.0f;
     return _textViewCell;
 }
 
-- (UIView *)hintView
-{
-    if (_hintView) {
-        return _hintView;
-    }
-    WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    [footerView setTitle:_hint];
-    _hintView = footerView;
-    return _hintView;
-}
-
 - (void)viewWillDisappear:(BOOL)animated
 {
     if (self.onValueChanged) {
@@ -115,9 +103,14 @@ static CGFloat const SettingsMinHeight = 41.0f;
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    return self.hintView;
+    return self.hint;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (void)textViewDidChange:(UITextView *)textView

--- a/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
@@ -94,24 +94,16 @@ public class SettingsPickerViewController : UITableViewController
         return cell
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        if section != sectionWithFooter || pickerHint == nil {
-            return 0
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForFooter(pickerHint!, width: tableView.bounds.width)
-    }
-
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if section != sectionWithFooter || pickerHint == nil {
             return nil
         }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title = pickerHint!
-        return footerView
+        return pickerHint!
     }
 
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
+    }
 
 
     // MARK: - Cell Setup Helpers

--- a/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
@@ -14,10 +14,6 @@ NSString * const SettingsSelectionCurrentValueKey = @"CurrentValue";
 
 CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
 
-@interface SettingsSelectionViewController ()
-@property (nonatomic, strong) WPTableViewSectionHeaderFooterView *hintView;
-@end
-
 @implementation SettingsSelectionViewController
 
 /**
@@ -95,22 +91,6 @@ CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
     }
 }
 
-- (UIView *)hintView
-{
-    if (!self.hints) {
-        return nil;
-    }
-    
-    if (!_hintView) {
-        _hintView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    }
-    
-    NSUInteger position = [self.values indexOfObject:self.currentValue];
-    _hintView.title = (position != NSNotFound) ? self.hints[position] : [NSString string];
-
-    return _hintView;
-}
-
 #pragma mark - Table view data source
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
@@ -157,9 +137,15 @@ CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    return self.hintView;
+    NSUInteger position = [self.values indexOfObject:self.currentValue];
+    return (position != NSNotFound) ? self.hints[position] : nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (void)dismiss

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -23,7 +23,6 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
 @property (nonatomic, strong) WPTableViewCell   *textFieldCell;
 @property (nonatomic, strong) WPTableViewCell   *actionCell;
 @property (nonatomic, strong) UITextField       *textField;
-@property (nonatomic, strong) UIView            *hintView;
 @property (nonatomic, assign) BOOL              doneButtonEnabled;
 @property (nonatomic, assign) BOOL              shouldNotifyValue;
 @end
@@ -220,18 +219,6 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     return _textField;
 }
 
-- (UIView *)hintView
-{
-    if (_hintView) {
-        return _hintView;
-    }
-    
-    WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    [footerView setTitle:_hint];
-    _hintView = footerView;
-    return _hintView;
-}
-
 
 #pragma mark - UITableViewDelegate
 
@@ -254,9 +241,17 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     return self.actionCell;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    return (section == SettingsTextSectionsTextfield) ? self.hintView : nil;
+    if (section != SettingsTextSectionsTextfield) {
+        return nil;
+    }
+    return self.hint;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
In an effort to maintain a bit of sanity, I've divided the primary readability changes into two parts.

This first part is solely dropping our usage of `WPTableViewSectionHeaderFooterView`. The forthcoming second PR disables the `WPTableViewCell` margin hack and begins following readable margins, but requires this step first.

For this PR, note:

1. First requires reviewing, merging, and updating to WP-iOS-Shared pod `0.6.0` via PR: https://github.com/wordpress-mobile/WordPress-Shared-iOS/pull/105.
2. Since building this branch alone will result in the header/footer views being way out of alignment with the `WPTableViewCell` margin hack, we'll hold off on merging this one until we're also ready to merge https://github.com/wordpress-mobile/WordPress-iOS/pull/5764 which disables the margin hack and enforces readable margins.

To test:

1.  Review the header/footer view usage in each view controller of the changed files on iPad and iPhone.
2. Ensure that the header/footer views match the default iOS margins and sizing.

Note: This PR will build with mis-aligned cells which are instead resolved via part 2: #5756

Needs review: @frosty, let me know if I've lost my mind here 😅. Feel free to go ahead and review once you've checked out https://github.com/wordpress-mobile/WordPress-Shared-iOS/pull/103.
