### PR TITLE
Update to stats pod 0.7.5 to include localization fix for date strings

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '~> 0.10.1'
     pod 'WordPress-iOS-Editor', '1.8'
     pod 'WordPressCom-Analytics-iOS', '0.1.16'
-    pod 'WordPressCom-Stats-iOS', '0.7.4'
+    pod 'WordPressCom-Stats-iOS', '0.7.5'
     pod 'wpxmlrpc', '~> 0.8'
     
     target :WordPressTest do
@@ -69,7 +69,7 @@ abstract_target 'WordPress_Base' do
   end
 
   target 'WordPressTodayWidget' do
-    pod 'WordPressCom-Stats-iOS/Services', '0.7.4'
+    pod 'WordPressCom-Stats-iOS/Services', '0.7.5'
   end
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -162,21 +162,21 @@ PODS:
   - WordPress-iOS-Shared (0.5.9):
     - CocoaLumberjack (~> 2.2.0)
   - WordPressCom-Analytics-iOS (0.1.16)
-  - WordPressCom-Stats-iOS (0.7.4):
+  - WordPressCom-Stats-iOS (0.7.5):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.3)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-    - WordPressCom-Stats-iOS/Services (= 0.7.4)
-    - WordPressCom-Stats-iOS/UI (= 0.7.4)
-  - WordPressCom-Stats-iOS/Services (0.7.4):
+    - WordPressCom-Stats-iOS/Services (= 0.7.5)
+    - WordPressCom-Stats-iOS/UI (= 0.7.5)
+  - WordPressCom-Stats-iOS/Services (0.7.5):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.3)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-  - WordPressCom-Stats-iOS/UI (0.7.4):
+  - WordPressCom-Stats-iOS/UI (0.7.5):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
@@ -220,8 +220,8 @@ DEPENDENCIES:
   - WordPress-iOS-Editor (= 1.8)
   - WordPress-iOS-Shared (= 0.5.9)
   - WordPressCom-Analytics-iOS (= 0.1.16)
-  - WordPressCom-Stats-iOS (= 0.7.4)
-  - WordPressCom-Stats-iOS/Services (= 0.7.4)
+  - WordPressCom-Stats-iOS (= 0.7.5)
+  - WordPressCom-Stats-iOS/Services (= 0.7.5)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.4`)
   - WPMediaPicker (~> 0.10.1)
   - wpxmlrpc (~> 0.8)
@@ -283,11 +283,11 @@ SPEC CHECKSUMS:
   WordPress-iOS-Editor: 50a09646fb62af3efdbb56d13ff656272a079066
   WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
   WordPressCom-Analytics-iOS: 46cbb47a84670f3b8548c8617da939c6b74cfda8
-  WordPressCom-Stats-iOS: 87b64bc36015e90789fec4abdb931af87c6e4cfe
+  WordPressCom-Stats-iOS: 8a8b25ee6362f0758f487d2a21a68300825ea18d
   WordPressComKit: 0742c47e5b55bff0e6d26d40db9e010404675a73
   WPMediaPicker: 645ecc2435293cc898c76180f3994358a68cae20
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 0c6445565ade8440c8db5ab17792a08637b27e4f
+PODFILE CHECKSUM: 1323241e9ee269572f284db3b4c8995414756fae
 
 COCOAPODS: 1.0.1


### PR DESCRIPTION
Fixes #5710 

**To test:**
1. Update pods.
2. Verify compilation and that stats screens all load.

Functionality was validated in https://github.com/wordpress-mobile/WordPressCom-Stats-iOS/pull/420

![Stats in Dutch](https://cloud.githubusercontent.com/assets/373903/17023107/3efab810-4f17-11e6-9b04-bda0c6a1d484.png)

Needs review: @jleandroperez 

