### PR TITLE
Readability Part 2, life without WPTableViewCell

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ use_frameworks!
 platform :ios, '9.0'
 
 abstract_target 'WordPress_Base' do
-  pod 'WordPress-iOS-Shared', '0.5.9'
+  pod 'WordPress-iOS-Shared', '0.6.0'
   ## This pod is only being included to support the share extension ATM - https://github.com/wordpress-mobile/WordPress-iOS/issues/5081
   pod 'WordPressComKit', :git => 'https://github.com/Automattic/WordPressComKit.git', :tag => '0.0.4'
 

--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ use_frameworks!
 platform :ios, '9.0'
 
 abstract_target 'WordPress_Base' do
-  pod 'WordPress-iOS-Shared', '0.6.0'
+  pod 'WordPress-iOS-Shared', '0.6.1'
   ## This pod is only being included to support the share extension ATM - https://github.com/wordpress-mobile/WordPress-iOS/issues/5081
   pod 'WordPressComKit', :git => 'https://github.com/Automattic/WordPressComKit.git', :tag => '0.0.4'
 

--- a/WordPress/Classes/Categories/WPStyleGuide+ReadableMargins.h
+++ b/WordPress/Classes/Categories/WPStyleGuide+ReadableMargins.h
@@ -2,6 +2,7 @@
 
 @interface WPStyleGuide (ReadableMargins)
 
-+ (void)resetReadableMarginsForTableView:(UITableView *)tableView;
+
++ (void)resetReadableMarginsForTableView:(UITableView *)tableView __deprecated_msg("Follow readable margins via constraints or instead explicitly set setCellLayoutMarginsFollowReadableWidth on UITableView.");
 
 @end

--- a/WordPress/Classes/Utility/ImmuTable+WordPress.swift
+++ b/WordPress/Classes/Utility/ImmuTable+WordPress.swift
@@ -1,46 +1,16 @@
 import WordPressShared
 
-/// Until https://github.com/wordpress-mobile/WordPress-iOS/pull/4591 is fixed, we
-/// need to use the custom WPTableViewSectionHeaderFooterView.
-///
 /// This lives as an extension on a separate file because it's specific to our UI
 /// implementation and shouldn't be in a generic ImmuTable that we might eventually
 /// release as a standalone library.
 ///
 extension ImmuTableViewHandler {
-    public func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if let title = self.tableView(tableView, titleForHeaderInSection: section) {
-            return WPTableViewSectionHeaderFooterView.heightForHeader(title, width: tableView.frame.width)
-        } else {
-            return UITableViewAutomaticDimension
-        }
+
+    public func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
-    public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let title = self.tableView(tableView, titleForHeaderInSection: section) else {
-            return nil
-        }
-
-        let view = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        view.title = title
-        return view
-    }
-
-    public func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        if let title = self.tableView(tableView, titleForFooterInSection: section) {
-            return WPTableViewSectionHeaderFooterView.heightForFooter(title, width: tableView.frame.width)
-        } else {
-            return UITableViewAutomaticDimension
-        }
-    }
-
-    public func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        guard let title = self.tableView(tableView, titleForFooterInSection: section) else {
-            return nil
-        }
-
-        let view = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        view.title = title
-        return view
+    public func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 }

--- a/WordPress/Classes/Utility/ImmuTableViewController.swift
+++ b/WordPress/Classes/Utility/ImmuTableViewController.swift
@@ -77,7 +77,6 @@ final class ImmuTableViewController: UITableViewController, ImmuTablePresenter {
 
         noticeAnimator = NoticeAnimator(target: view)
 
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/Utility/WPTableViewHandler.h
+++ b/WordPress/Classes/Utility/WPTableViewHandler.h
@@ -39,6 +39,8 @@
 - (CGFloat)tableView:(nonnull UITableView *)tableView heightForHeaderInSection:(NSInteger)section;
 - (nullable UIView *)tableView:(nonnull UITableView *)tableView viewForFooterInSection:(NSInteger)section;
 - (CGFloat)tableView:(nonnull UITableView *)tableView heightForFooterInSection:(NSInteger)section;
+- (void)tableView:(nonnull UITableView *)tableView willDisplayHeaderView:(nonnull UIView *)view forSection:(NSInteger)section;
+- (void)tableView:(nonnull UITableView *)tableView willDisplayFooterView:(nonnull UIView *)view forSection:(NSInteger)section;
 
 #pragma mark - Editing table rows
 
@@ -63,7 +65,8 @@
 
 - (nonnull UITableViewCell *)tableView:(nonnull UITableView *)tableView cellForRowAtIndexPath:(nonnull NSIndexPath *)indexPath;
 
-- (nullable NSString *)titleForHeaderInSection:(NSInteger)section;
+- (nullable NSString *)tableView:(nonnull UITableView *)tableView titleForHeaderInSection:(NSInteger)section;
+- (nullable NSString *)tableView:(nonnull UITableView *)tableView titleForFooterInSection:(NSInteger)section;
 
 #pragma mark - Inserting or deleting table rows
 
@@ -95,7 +98,6 @@
 @property (nonatomic) UITableViewRowAnimation sectionRowAnimation;
 
 - (nonnull instancetype)initWithTableView:(nonnull UITableView *)tableView;
-- (void)updateTitleForSection:(NSUInteger)section;
 - (void)clearCachedRowHeights;
 - (void)refreshCachedRowHeightsForWidth:(CGFloat)width;
 - (void)invalidateCachedRowHeightAtIndexPath:(nonnull NSIndexPath *)indexPath;

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -57,12 +57,6 @@ static CGFloat const DefaultCellHeight = 44.0;
 
 #pragma mark - Public Methods
 
-- (void)updateTitleForSection:(NSUInteger)section
-{
-    WPTableViewSectionHeaderFooterView *sectionHeaderView = (WPTableViewSectionHeaderFooterView *)[self tableView:self.tableView viewForHeaderInSection:section];
-    sectionHeaderView.title = [self titleForHeaderInSection:section];
-}
-
 - (void)clearCachedRowHeights
 {
     [self.cachedRowHeights removeAllObjects];
@@ -281,14 +275,6 @@ static CGFloat const DefaultCellHeight = 44.0;
     return nil;
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
-{
-    if ([self.delegate respondsToSelector:@selector(titleForHeaderInSection:)]) {
-        return [self.delegate titleForHeaderInSection:section];
-    }
-    return nil;
-}
-
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {
     if ([self.delegate respondsToSelector:@selector(tableView:canEditRowAtIndexPath:)]) {
@@ -429,54 +415,6 @@ static CGFloat const DefaultCellHeight = 44.0;
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    if ([self.delegate respondsToSelector:@selector(tableView:viewForHeaderInSection:)]) {
-        return [self.delegate tableView:tableView viewForHeaderInSection:section];
-    }
-
-    WPTableViewSectionHeaderFooterView *header;
-    if ([self.sectionHeaders count] > section) {
-        header = [self.sectionHeaders objectAtIndex:section];
-    } else {
-        header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-        [self.sectionHeaders addObject:header];
-    }
-
-    header.title = [self titleForHeaderInSection:section];
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    if ([self.delegate respondsToSelector:@selector(tableView:heightForHeaderInSection:)]) {
-        return [self.delegate tableView:tableView heightForHeaderInSection:section];
-    }
-
-    NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.tableView.bounds)];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    if ([self.delegate respondsToSelector:@selector(tableView:heightForFooterInSection:)]) {
-        return [self.delegate tableView:tableView heightForFooterInSection:section];
-    }
-
-    // Remove footer height for all but last section
-    return section == [[self.resultsController sections] count] - 1 ? UITableViewAutomaticDimension : 1.0;
-}
-
-
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
-{
-    if ([self.delegate respondsToSelector:@selector(tableView:viewForFooterInSection:)]) {
-        return [self.delegate tableView:tableView viewForFooterInSection:section];
-    }
-
-    return nil;
-}
-
 - (void)tableView:(UITableView *)tableView didEndDisplayingCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
     if ([self.delegate respondsToSelector:@selector(tableView:didEndDisplayingCell:forRowAtIndexPath:)]) {
@@ -484,6 +422,55 @@ static CGFloat const DefaultCellHeight = 44.0;
     }
 }
 
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:viewForHeaderInSection:)]) {
+        return [self.delegate tableView:tableView viewForHeaderInSection:section];
+    }
+    return nil;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:heightForHeaderInSection:)]) {
+        return [self.delegate tableView:tableView heightForHeaderInSection:section];
+    }
+    return UITableViewAutomaticDimension;
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:viewForFooterInSection:)]) {
+        return [self.delegate tableView:tableView viewForFooterInSection:section];
+    }
+    return nil;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:heightForFooterInSection:)]) {
+        return [self.delegate tableView:tableView heightForFooterInSection:section];
+    }
+    return UITableViewAutomaticDimension;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:willDisplayHeaderView:forSection:)]) {
+        [self.delegate tableView:tableView willDisplayHeaderView:view forSection:section];
+    } else {
+        [WPStyleGuide configureTableViewSectionHeader:view];
+    }
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:willDisplayFooterView:forSection:)]) {
+        [self.delegate tableView:tableView willDisplayFooterView:view forSection:section];
+    } else {
+        [WPStyleGuide configureTableViewSectionFooter:view];
+    }
+}
 
 #pragma mark - TableView Datasource Methods
 
@@ -505,10 +492,20 @@ static CGFloat const DefaultCellHeight = 44.0;
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
+    if ([self.delegate respondsToSelector:@selector(tableView:titleForHeaderInSection:)]) {
+        return [self.delegate tableView:tableView titleForHeaderInSection:section];
+    }
     id <NSFetchedResultsSectionInfo> sectionInfo = [[self.resultsController sections] objectAtIndex:section];
     return [sectionInfo name];
 }
 
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:titleForFooterInSection:)]) {
+        return [self.delegate tableView:tableView titleForFooterInSection:section];
+    }
+    return nil;
+}
 
 #pragma mark - UIScrollViewDelegate Methods
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -6,12 +6,13 @@
 
 
 const CGFloat BlogDetailHeaderViewBlavatarSize = 40.0;
-const CGFloat BlogDetailHeaderViewLabelHeight = 20.0;
 const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 
 @interface BlogDetailHeaderView ()
 
+@property (nonatomic, strong) UIStackView *stackView;
 @property (nonatomic, strong) UIImageView *blavatarImageView;
+@property (nonatomic, strong) UIStackView *labelsStackView;
 @property (nonatomic, strong) UILabel *titleLabel;
 @property (nonatomic, strong) UILabel *subtitleLabel;
 
@@ -23,16 +24,11 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 {
     self = [super initWithFrame:frame];
     if (self) {
-        _blavatarImageView = [self newImageViewForBlavatar];
-        [self addSubview:_blavatarImageView];
-
-        _titleLabel = [self newLabelForTitle];
-        [self addSubview:_titleLabel];
-
-        _subtitleLabel = [self newLabelForSubtitle];
-        [self addSubview:_subtitleLabel];
-
-        [self configureConstraints];
+        [self setupStackView];
+        [self setupBalavatarImageView];
+        [self setupLabelsStackView];
+        [self setupTitleLabel];
+        [self setupSubtitleLabel];
     }
     return self;
 }
@@ -47,39 +43,88 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     NSString *blogName = blog.settings.name;
     [self.titleLabel setText:((blogName && !blogName.isEmpty) ? blogName : blog.displayURL)];
     [self.subtitleLabel setText:blog.displayURL];
+    [self.labelsStackView setNeedsLayout];
 }
 
-#pragma mark - Private Methods
+#pragma mark - Subview setup
 
-- (void)configureConstraints
+- (void)setupStackView
 {
-    NSDictionary *views = NSDictionaryOfVariableBindings(_blavatarImageView, _titleLabel, _subtitleLabel);
-    NSDictionary *metrics = @{@"blavatarSize": @(BlogDetailHeaderViewBlavatarSize),
-                              @"labelHeight":@(BlogDetailHeaderViewLabelHeight),
-                              @"labelHorizontalPadding": @(BlogDetailHeaderViewLabelHorizontalPadding)};
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_blavatarImageView(blavatarSize)]|"
-                                                                 options:0
-                                                                 metrics:metrics
-                                                                   views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|[_blavatarImageView(blavatarSize)]-labelHorizontalPadding-[_titleLabel]|"
-                                                                 options:0
-                                                                 metrics:metrics
-                                                                   views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|[_blavatarImageView(blavatarSize)]-labelHorizontalPadding-[_subtitleLabel]|"
-                                                                 options:0
-                                                                 metrics:metrics
-                                                                   views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_titleLabel(labelHeight)][_subtitleLabel(labelHeight)]"
-                                                                 options:0
-                                                                 metrics:metrics
-                                                                   views:views]];
-    [super setNeedsUpdateConstraints];
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    stackView.axis = UILayoutConstraintAxisHorizontal;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.alignment = UIStackViewAlignmentCenter;
+    stackView.spacing = BlogDetailHeaderViewLabelHorizontalPadding;
+    [self addSubview:stackView];
+
+    NSLayoutConstraint *leadingConstraint;
+    NSLayoutConstraint *trailingConstraint;
+
+    if ([WPDeviceIdentification isiPhone]) {
+        // On iPhone, the readable content guide seems to be accurately aligned with the cell's content margins.
+        UILayoutGuide *readableGuide = self.readableContentGuide;
+        leadingConstraint = [stackView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor];
+        trailingConstraint = [stackView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor];
+    } else {
+        // On iPad, the correct readable margins seem to already be inherited via the tableHeaderView
+        // so following this view's readable content guide is not necessary.
+        leadingConstraint = [stackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor];
+        trailingConstraint = [stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor];
+    }
+
+    [NSLayoutConstraint activateConstraints:@[
+                                              leadingConstraint,
+                                              trailingConstraint,
+                                              [stackView.topAnchor constraintEqualToAnchor:self.topAnchor],
+                                              [stackView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+                                              [stackView.centerXAnchor constraintEqualToAnchor:self.centerXAnchor],
+                                              [stackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor]
+                                              ]];
+    _stackView = stackView;
 }
 
-#pragma mark - Subview factories
-
-- (UILabel *)newLabelForTitle
+- (void)setupBalavatarImageView
 {
+    NSAssert(_stackView != nil, @"stackView was nil");
+
+    CGRect blavatarFrame = CGRectMake(0.0f, 0.0f, BlogDetailHeaderViewBlavatarSize, BlogDetailHeaderViewBlavatarSize);
+    UIImageView *imageView = [[UIImageView alloc] initWithFrame:blavatarFrame];
+    imageView.backgroundColor = [UIColor whiteColor];
+    imageView.translatesAutoresizingMaskIntoConstraints = NO;
+    imageView.layer.borderColor = [[UIColor whiteColor] CGColor];
+    imageView.layer.borderWidth = 1.0;
+    [_stackView addArrangedSubview:imageView];
+
+    [NSLayoutConstraint activateConstraints:@[
+                                              [imageView.widthAnchor constraintEqualToConstant:BlogDetailHeaderViewBlavatarSize],
+                                              [imageView.heightAnchor constraintEqualToConstant:BlogDetailHeaderViewBlavatarSize]
+                                              ]];
+    _blavatarImageView = imageView;
+}
+
+- (void)setupLabelsStackView
+{
+    NSAssert(_stackView != nil, @"stackView was nil");
+
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    stackView.axis = UILayoutConstraintAxisVertical;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.alignment = UIStackViewAlignmentFill;
+
+    [_stackView addArrangedSubview:stackView];
+
+    [stackView setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+    [stackView setContentCompressionResistancePriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+
+    _labelsStackView = stackView;
+}
+
+- (void)setupTitleLabel
+{
+    NSAssert(_labelsStackView != nil, @"labelsStackView was nil");
+
     UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
     label.translatesAutoresizingMaskIntoConstraints = NO;
     label.numberOfLines = 1;
@@ -89,11 +134,15 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     label.font = [WPFontManager systemRegularFontOfSize:16.0];
     label.adjustsFontSizeToFitWidth = NO;
 
-    return label;
+    [_labelsStackView addArrangedSubview:label];
+
+    _titleLabel = label;
 }
 
-- (UILabel *)newLabelForSubtitle
+- (void)setupSubtitleLabel
 {
+    NSAssert(_labelsStackView != nil, @"labelsStackView was nil");
+
     UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
     label.translatesAutoresizingMaskIntoConstraints = NO;
     label.numberOfLines = 1;
@@ -103,18 +152,9 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     label.font = [WPFontManager systemItalicFontOfSize:12.0];
     label.adjustsFontSizeToFitWidth = NO;
 
-    return label;
-}
+    [_labelsStackView addArrangedSubview:label];
 
-- (UIImageView *)newImageViewForBlavatar
-{
-    CGRect blavatarFrame = CGRectMake(0.0f, 0.0f, BlogDetailHeaderViewBlavatarSize, BlogDetailHeaderViewBlavatarSize);
-    UIImageView *imageView = [[UIImageView alloc] initWithFrame:blavatarFrame];
-    imageView.backgroundColor = [UIColor whiteColor];
-    imageView.translatesAutoresizingMaskIntoConstraints = NO;
-    imageView.layer.borderColor = [[UIColor whiteColor] CGColor];
-    imageView.layer.borderWidth = 1.0;
-    return imageView;
+    _subtitleLabel = label;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -12,7 +12,6 @@
 #import "WPAccount.h"
 #import "WPAppAnalytics.h"
 #import "WPGUIConstants.h"
-#import "WPStyleGuide+ReadableMargins.h"
 #import "WPTableViewCell.h"
 #import "WPTableViewSectionHeaderFooterView.h"
 #import "WPWebViewController.h"
@@ -166,7 +165,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewDidLoad];
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:BlogDetailsCellIdentifier];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -480,28 +480,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     return WPTableViewDefaultRowHeight;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:self.tableView titleForHeaderInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     BlogDetailsSection *detailSection = [self.tableSections objectAtIndex:section];
     return detailSection.title;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 #pragma mark - Private methods

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -294,8 +294,6 @@ static NSInteger HideSearchMinSites = 3;
     self.tableView.accessibilityIdentifier = NSLocalizedString(@"Blogs", @"");
 
     self.tableView.tableFooterView = [UIView new];
-
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
 }
 
 - (void)configureSearchController

--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
@@ -90,7 +90,6 @@ static CGFloat BlogCellRowHeight = 74.0;
     // TableView
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     
-    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     [self.tableView registerClass:[WPBlogTableViewCell class] forCellReuseIdentifier:BlogCellIdentifier];
     [self.tableView reloadData];
 

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -48,7 +48,6 @@ public class DiscussionSettingsViewController : UITableViewController
 
     private func setupTableView() {
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-        tableView.cellLayoutMarginsFollowReadableWidth = false
 
         // Note: We really want to handle 'Unselect' manually.
         // Reason: we always reload previously selected rows.

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -127,40 +127,26 @@ public class DiscussionSettingsViewController : UITableViewController
         return cell
     }
 
-    public override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard let headerText = sections[section].headerText else {
-            return CGFloat.min
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForHeader(headerText, width: tableView.bounds.width)
-    }
-
-    public override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard let headerText = sections[section].headerText else {
             return nil
         }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        footerView.title = headerText
-        return footerView
+        return headerText
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        guard let footerText = sections[section].footerText else {
-            return 0
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForFooter(footerText, width: tableView.bounds.width)
+    public override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard let footerText = sections[section].footerText else {
             return nil
         }
+        return footerText
+    }
 
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title = footerText
-        return footerView
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
@@ -31,7 +31,6 @@ public class LanguageViewController : UITableViewController
 
         // Setup tableView
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
     }
 
     public override func viewWillAppear(animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
@@ -65,17 +65,13 @@ public class LanguageViewController : UITableViewController
         return cell!
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return WPTableViewSectionHeaderFooterView.heightForFooter(footerText, width: view.bounds.width)
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return footerText
     }
 
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        let headerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        headerView.title = footerText
-        return headerView
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
-
-
 
     // MARK: - UITableViewDelegate Methods
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {

--- a/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
@@ -6,7 +6,6 @@
 #import "SettingTableViewCell.h"
 #import "RelatedPostsPreviewTableViewCell.h"
 #import "WPTableViewSectionHeaderFooterView.h"
-#import "WPStyleGuide+ReadableMargins.h"
 
 #import <WordPressShared/WPStyleGuide.h>
 #import <SVProgressHUD/SVProgressHUD.h>
@@ -58,7 +57,6 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     self.navigationItem.title = NSLocalizedString(@"Related Posts", @"Title for screen that allows configuration of your blog/site related posts settings.");
     self.tableView.allowsSelection = NO;
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
 }
 
 

--- a/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
@@ -99,82 +99,34 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
     return 0;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            WPTableViewSectionHeaderFooterView *headerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-            return headerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            WPTableViewSectionHeaderFooterView *headerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-            headerView.title = NSLocalizedString(@"Preview", @"Section title for related posts section preview");
-            return headerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
+        case RelatedPostsSettingsSectionPreview:
+            return NSLocalizedString(@"Preview", @"Section title for related posts section preview");
+        default:
+            return nil;
     }
-    return nil;
-
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil
-                                                                                                                           style:WPTableViewSectionStyleFooter];
-            footerView.title = NSLocalizedString(@"Related Posts displays relevant content from your site below your posts", @"Information of what related post are and how they are presented");
-            return footerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil
-                                                                                                                           style:WPTableViewSectionStyleFooter];
-            return footerView;
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
-    }
-    return nil;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            return [WPTableViewSectionHeaderFooterView heightForHeader:@"" width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            return [WPTableViewSectionHeaderFooterView heightForHeader:NSLocalizedString(@"Preview", @"Section title for related posts section preview") width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
+        case RelatedPostsSettingsSectionOptions:
+            return NSLocalizedString(@"Related Posts displays relevant content from your site below your posts", @"Information of what related post are and how they are presented");;
+        default:
+            return nil;
     }
-    return 0;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
 {
-    switch (section) {
-        case RelatedPostsSettingsSectionOptions:{
-            return [WPTableViewSectionHeaderFooterView heightForFooter:NSLocalizedString(@"Related Posts displays relevant content from your site below your posts.", @"Information of what related post are and how they are presented.")
-                                                                 width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionPreview:{
-            return [WPTableViewSectionHeaderFooterView heightForFooter:@"" width:tableView.frame.size.width];
-        }
-            break;
-        case RelatedPostsSettingsSectionCount:
-            break;
-    }
-    return 0;
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -89,7 +89,6 @@ import WordPressShared
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
         tableView.setEditing(true, animated: false)
         tableView.allowsSelectionDuringEditing = true
-        tableView.cellLayoutMarginsFollowReadableWidth = false
     }
 
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -795,20 +795,8 @@ import WordPressShared
     }
 
 
-    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let title = self.tableView(tableView, titleForHeaderInSection: section) else {
-            return nil
-        }
-
-        let headerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        headerView.title = title
-        return headerView
-    }
-
-
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        let title = self.tableView(tableView, titleForHeaderInSection: section)
-        return WPTableViewSectionHeaderFooterView.heightForHeader(title, width: view.bounds.width)
+    override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
 
@@ -817,20 +805,8 @@ import WordPressShared
     }
 
 
-    override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        guard let title = self.tableView(tableView, titleForFooterInSection: section) else {
-            return nil
-        }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title = title
-        return footerView
-    }
-
-
-    override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        let title = self.tableView(tableView, titleForFooterInSection: section)
-        return WPTableViewSectionHeaderFooterView.heightForFooter(title, width: view.bounds.width)
+    override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 
@@ -840,6 +816,16 @@ import WordPressShared
             tableView.deselectRowAtIndexPath(indexPath, animated: true)
         }
         row.action?()
+    }
+
+
+    override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        // We only actual editing (ordering) with sections that canSort and are not toggled in the UI activating/deactivating.
+        let section = sections[indexPath.section]
+        if section.canSort && !section.editing && indexPath.row > 0 {
+            return true
+        }
+        return false
     }
 
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -47,7 +47,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
     self.navigationItem.title = self.publicizeService.label;
 
-    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:CellIdentifier];
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -98,12 +98,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return 1;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSString *title;
@@ -113,20 +107,12 @@ static NSString *const CellIdentifier = @"CellIdentifier";
         NSString *format = NSLocalizedString(@"Publicize to %@", @"Title. `Publicize` is used as a verb here but `Share` (verb) would also work here. The `%@` is a placeholder for the service name.");
         title = [NSString stringWithFormat:format, self.publicizeService.label];
     }
-
     return title;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
@@ -134,21 +120,13 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     if ([self hasConnectedAccounts] && section == 0) {
         return nil;
     }
-
     NSString *title = NSLocalizedString(@"Connect to automatically share your blog posts to %@", @"Instructional text appearing below a `Connect` button. The `%@` is a placeholder for the name of a third-party sharing service.");
     return [NSString stringWithFormat:title, self.publicizeService.label];
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForFooterInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *footer = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    footer.title = title;
-    return footer;
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -49,7 +49,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
     self.navigationItem.title = self.publicizeConnection.externalDisplay;
 
-    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:CellIdentifier];
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -74,12 +74,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return 2;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     if (section == 0) {
@@ -89,16 +83,9 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
@@ -113,16 +100,9 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForFooterInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *footer = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    footer.title = title;
-    return footer;
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -43,7 +43,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
     self.navigationItem.title = NSLocalizedString(@"Sharing", @"Title for blog detail sharing screen.");
 
-    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 
     // Optimistically sync the sharing buttons.

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -83,12 +83,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return count;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     switch (section) {
@@ -101,16 +95,9 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForHeaderInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
@@ -121,16 +108,9 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
 {
-    NSString *title = [self tableView:tableView titleForFooterInSection:section];
-    if (title.length == 0) {
-        return nil;
-    }
-
-    WPTableViewSectionHeaderFooterView *footer = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    footer.title = title;
-    return footer;
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
@@ -49,7 +49,6 @@ public class StartOverViewController: UITableViewController
 
         title = NSLocalizedString("Start Over", comment: "Title of Start Over settings page")
 
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -14,7 +14,6 @@
 #import "SettingTableViewCell.h"
 #import "SettingsTextViewController.h"
 #import "WordPress-Swift.h"
-#import "WPStyleGuide+ReadableMargins.h"
 #import "WPWebViewController.h"
 #import "WordPress-Swift.h"
 #import "BlogServiceRemoteXMLRPC.h"
@@ -123,7 +122,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
                                                  name:NSManagedObjectContextObjectsDidChangeNotification
                                                object:self.blog.managedObjectContext];
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     
     self.refreshControl = [[UIRefreshControl alloc] init];

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -536,29 +536,22 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 
 #pragma mark - UITableViewDelegate
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSInteger settingsSection = [self.tableSections[section] integerValue];
     NSString *title = [self titleForHeaderInSection:settingsSection];
-    if (title.length == 0) {
-        return [UIView new];
-    }
-    
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
+
+    return title.length > 0 ? title : nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     return WPTableViewDefaultRowHeight;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSInteger settingsSection = [self.tableSections[section] integerValue];
-    NSString *title = [self titleForHeaderInSection:settingsSection];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
 }
 
 - (NSString *)titleForHeaderInSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Cells/MediaSizeSliderCell.xib
+++ b/WordPress/Classes/ViewRelated/Cells/MediaSizeSliderCell.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
@@ -10,28 +10,31 @@
         <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="108" id="7mS-Jn-IfN" customClass="MediaSizeSliderCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="108"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7mS-Jn-IfN" id="twB-EW-2j3">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="107"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" layoutMarginsFollowReadableWidth="YES" tableViewCell="7mS-Jn-IfN" id="twB-EW-2j3">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="107.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="VNV-La-F2d">
                         <rect key="frame" x="16" y="8" width="288" height="91"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IZE-tn-T3b">
-                                <rect key="frame" x="0.0" y="0.0" width="288" height="0.0"/>
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="41"/>
                                 <accessibility key="accessibilityConfiguration" identifier=""/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="joS-zC-6YB">
-                                <rect key="frame" x="-2" y="0.0" width="292" height="71"/>
+                                <rect key="frame" x="-2" y="41" width="292" height="31"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="tTE-DQ-2mh"/>
+                                </constraints>
                                 <connections>
                                     <action selector="sliderChanged:" destination="7mS-Jn-IfN" eventType="valueChanged" id="1ET-wg-Itm"/>
                                 </connections>
                             </slider>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Original" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hsz-Em-99p">
-                                <rect key="frame" x="0.0" y="70" width="288" height="21"/>
+                                <rect key="frame" x="0.0" y="71" width="288" height="20"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <bool key="isElement" value="NO"/>
                                 </accessibility>
@@ -40,13 +43,16 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="joS-zC-6YB" secondAttribute="bottom" constant="20" symbolic="YES" id="WHG-uU-blp"/>
+                        </constraints>
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="VNV-La-F2d" firstAttribute="top" secondItem="twB-EW-2j3" secondAttribute="topMargin" id="5SI-ZY-ndG"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="VNV-La-F2d" secondAttribute="bottom" id="RsH-NY-bp4"/>
-                    <constraint firstItem="VNV-La-F2d" firstAttribute="leading" secondItem="twB-EW-2j3" secondAttribute="leadingMargin" id="qMp-22-LUF"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="VNV-La-F2d" secondAttribute="trailing" id="xaR-7t-dwK"/>
+                    <constraint firstItem="VNV-La-F2d" firstAttribute="trailing" secondItem="twB-EW-2j3" secondAttribute="trailingMargin" id="BsB-4s-JSW"/>
+                    <constraint firstItem="VNV-La-F2d" firstAttribute="leading" secondItem="twB-EW-2j3" secondAttribute="leadingMargin" id="Nr5-S4-die"/>
+                    <constraint firstItem="VNV-La-F2d" firstAttribute="top" secondItem="twB-EW-2j3" secondAttribute="topMargin" id="n5i-7d-bnn"/>
+                    <constraint firstItem="VNV-La-F2d" firstAttribute="centerY" secondItem="twB-EW-2j3" secondAttribute="centerY" id="qer-xy-kaF"/>
                 </constraints>
                 <edgeInsets key="layoutMargins" top="8" left="16" bottom="8" right="16"/>
             </tableViewCellContentView>

--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
@@ -5,7 +5,7 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
 
 @interface PostFeaturedImageCell ()
 
-//@property (nonatomic, strong) UIImageView *imageView;
+@property (nonatomic, strong) UIImageView *featuredImageView;
 @property (nonatomic, strong) UIActivityIndicatorView *activityView;
 
 @end
@@ -16,45 +16,45 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
 {
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
-        [self configureSubviews];
+        [self setupSubviews];
     }
     return self;
 }
 
-- (void)configureSubviews
+- (void)setupSubviews
 {
-    CGRect contentFrame = self.contentView.frame;
-    self.imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    self.imageView.contentMode = UIViewContentModeScaleAspectFill;
-    self.imageView.clipsToBounds = YES;
-    [self.contentView addSubview:self.imageView];
+    UIImageView *imageView = [[UIImageView alloc] init];
+    imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    imageView.contentMode = UIViewContentModeScaleAspectFill;
+    imageView.clipsToBounds = YES;
+    imageView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.contentView addSubview:imageView];
 
-    self.activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
-    CGRect activityFrame = self.activityView.frame;
+    UILayoutGuide *readableGuide = self.contentView.readableContentGuide;
+    [NSLayoutConstraint activateConstraints:@[
+                                              [imageView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
+                                              [imageView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
+                                              [imageView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:PostFeaturedImageCellMargin],
+                                              [imageView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor constant:-PostFeaturedImageCellMargin]
+                                              ]];
+    _featuredImageView = imageView;
+
+    CGRect contentFrame = self.contentView.frame;
+    UIActivityIndicatorView *activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    CGRect activityFrame = activityView.frame;
     CGFloat x = (contentFrame.size.width - activityFrame.size.width) / 2.0f;
     CGFloat y = (contentFrame.size.height - activityFrame.size.height) / 2.0f;
     activityFrame = CGRectMake(x, y, activityFrame.size.width, activityFrame.size.height);
-    self.activityView.frame = activityFrame;
-    self.activityView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
-    self.activityView.hidesWhenStopped = YES;
-    [self.contentView addSubview:self.activityView];
-}
-
-- (void)layoutSubviews
-{
-    [super layoutSubviews];
-    if (!self.imageView.hidden) {
-        CGFloat x = PostFeaturedImageCellMargin;
-        CGFloat y = PostFeaturedImageCellMargin;
-        CGFloat w = CGRectGetWidth(self.contentView.frame) - (PostFeaturedImageCellMargin * 2);
-        CGFloat h = CGRectGetHeight(self.contentView.frame) - (PostFeaturedImageCellMargin * 2);
-        self.imageView.frame = CGRectMake(x, y, w, h);
-    }
+    activityView.frame = activityFrame;
+    activityView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
+    activityView.hidesWhenStopped = YES;
+    [self.contentView addSubview:activityView];
+    _activityView = activityView;
 }
 
 - (void)setImage:(UIImage *)image
 {
-    [self.imageView setImage:image];
+    [self.featuredImageView setImage:image];
     [self showLoadingSpinner:NO];
 }
 
@@ -65,7 +65,7 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
     } else {
         [self.activityView stopAnimating];
     }
-    self.imageView.hidden = showSpinner;
+    self.featuredImageView.hidden = showSpinner;
     self.textLabel.text = @"";
 }
 

--- a/WordPress/Classes/ViewRelated/Cells/PostGeolocationCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/PostGeolocationCell.m
@@ -24,24 +24,21 @@ CGFloat const PostGeolocationCellMargin = 15.0f;
 
 - (void)configureSubviews
 {
-    self.geoView = [[PostGeolocationView alloc] initWithFrame:self.contentView.bounds];
-    self.geoView.labelMargin = 0.0f;
-    self.geoView.scrollEnabled = NO;
-    self.geoView.chevronHidden = YES;
-    self.geoView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    [self.contentView addSubview:self.geoView];
-}
+    PostGeolocationView *geoView = [[PostGeolocationView alloc] initWithFrame:self.contentView.bounds];
+    geoView.translatesAutoresizingMaskIntoConstraints = NO;
+    geoView.labelMargin = 0.0f;
+    geoView.scrollEnabled = NO;
+    geoView.chevronHidden = YES;
+    [self.contentView addSubview:geoView];
 
-- (void)layoutSubviews
-{
-    [super layoutSubviews];
-
-    CGFloat x = PostGeolocationCellMargin;
-    CGFloat y = PostGeolocationCellMargin;
-    CGFloat w = CGRectGetWidth(self.contentView.frame) - (PostGeolocationCellMargin * 2);
-    CGFloat h = CGRectGetHeight(self.contentView.frame) - (PostGeolocationCellMargin * 2);
-
-    self.geoView.frame = CGRectMake(x, y, w, h);
+    UILayoutGuide *readableGuide = self.contentView.readableContentGuide;
+    [NSLayoutConstraint activateConstraints:@[
+                                              [geoView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
+                                              [geoView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
+                                              [geoView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:PostGeolocationCellMargin],
+                                              [geoView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor]
+                                              ]];
+    _geoView = geoView;
 }
 
 - (void)setCoordinate:(Coordinate *)coordinate andAddress:(NSString *)address

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -65,17 +65,19 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
                                           action:@selector(dismissKeyboardIfNeeded:)];
     tapRecognizer.cancelsTouchesInView = NO;
 
-    self.tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
-    self.tableView.translatesAutoresizingMaskIntoConstraints = NO;
-    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
-    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
-    self.tableView.delegate = self;
-    self.tableView.dataSource = self;
-    self.tableView.estimatedRowHeight = 44.0;
-    [self.tableView addGestureRecognizer:tapRecognizer];
-    [self.view addSubview:self.tableView];
+    UITableView *tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
+    tableView.translatesAutoresizingMaskIntoConstraints = NO;
+    tableView.cellLayoutMarginsFollowReadableWidth = NO;
+    tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+    tableView.delegate = self;
+    tableView.dataSource = self;
+    tableView.estimatedRowHeight = 44.0;
+    [tableView addGestureRecognizer:tapRecognizer];
+    [self.view addSubview:tableView];
 
-    [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
+    self.tableView = tableView;
+
+    [WPStyleGuide configureColorsForView:self.view andTableView:tableView];
 
     // Register Cell Nibs
     NSArray *cellClassNames = @[
@@ -92,7 +94,6 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
         [self.tableView registerNib:tableViewCellNib forCellReuseIdentifier:[cellClass reuseIdentifier]];
         [self.tableView registerNib:tableViewCellNib forCellReuseIdentifier:[cellClass layoutIdentifier]];
     }
-
     
     [self attachSuggestionsTableViewIfNeeded];
     [self attachReplyViewIfNeeded];
@@ -325,7 +326,13 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 - (void)setupCell:(UITableViewCell *)cell
 {
     NSParameterAssert(cell);
-    
+
+    if ([cell isKindOfClass:[WPTableViewCell class]]) {
+        // Temporarily force margins for WPTableViewCell hack.
+        // Brent C. Jul/19/2016
+        [(WPTableViewCell *)cell setForceCustomCellMargins:YES];
+    }
+
     // This is gonna look way better in Swift!
     if ([cell isKindOfClass:[NoteBlockHeaderTableViewCell class]]) {
         [self setupHeaderCell:(NoteBlockHeaderTableViewCell *)cell];

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -9,15 +10,15 @@
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="Upg-EE-wRd" customClass="CommentsTableViewCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" layoutMarginsFollowReadableWidth="YES" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="69.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AUn-YX-qnu" userLabel="Layout View">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
+                    <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AUn-YX-qnu" userLabel="Layout View">
+                        <rect key="frame" x="8" y="0.0" width="304" height="70"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kcl-X2-f1f" customClass="SeparatorsView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
+                                <rect key="frame" x="0.0" y="0.0" width="304" height="70"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -28,7 +29,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq">
-                                <rect key="frame" x="68" y="8" width="240" height="20.5"/>
+                                <rect key="frame" x="68" y="8" width="224" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -41,7 +42,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
-                                <rect key="frame" x="88" y="28.5" width="220" height="20.5"/>
+                                <rect key="frame" x="88" y="28.5" width="204" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -58,7 +59,7 @@
                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="bDl-id-9M7" secondAttribute="bottom" priority="750" constant="9" id="PVc-g0-lrn"/>
                             <constraint firstAttribute="bottom" secondItem="Kcl-X2-f1f" secondAttribute="bottom" id="QxH-g8-9jc"/>
                             <constraint firstAttribute="trailing" secondItem="bDl-id-9M7" secondAttribute="trailing" constant="12" id="WP3-62-HDv"/>
-                            <constraint firstAttribute="trailing" secondItem="Wrp-Wr-ZBq" secondAttribute="trailing" priority="750" constant="12" id="WyT-D4-F81"/>
+                            <constraint firstAttribute="trailing" secondItem="Wrp-Wr-ZBq" secondAttribute="trailing" constant="12" id="WyT-D4-F81"/>
                             <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="Wrp-Wr-ZBq" secondAttribute="top" constant="4" id="Xqq-1P-og4"/>
                             <constraint firstItem="rcg-tb-060" firstAttribute="top" secondItem="Wrp-Wr-ZBq" secondAttribute="bottom" constant="2" id="Zbd-5G-fWz"/>
                             <constraint firstItem="bDl-id-9M7" firstAttribute="leading" secondItem="rcg-tb-060" secondAttribute="trailing" constant="4" id="eSq-C3-JsX"/>
@@ -69,10 +70,10 @@
                     </view>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="AUn-YX-qnu" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leading" id="3mF-u8-Qvl"/>
+                    <constraint firstItem="AUn-YX-qnu" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leadingMargin" id="3mF-u8-Qvl"/>
                     <constraint firstItem="AUn-YX-qnu" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="top" id="Loo-Lw-U24"/>
                     <constraint firstAttribute="bottom" secondItem="AUn-YX-qnu" secondAttribute="bottom" id="lzS-Au-eFv"/>
-                    <constraint firstAttribute="trailing" secondItem="AUn-YX-qnu" secondAttribute="trailing" id="wHU-Ba-gic"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="AUn-YX-qnu" secondAttribute="trailing" id="wHU-Ba-gic"/>
                 </constraints>
             </tableViewCellContentView>
             <inset key="separatorInset" minX="12" minY="0.0" maxX="0.0" maxY="0.0"/>

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -65,7 +65,6 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     [self configureTableViewFooter];
     [self configureTableViewHandler];
     [self configureTableViewLayoutCell];
-    [self adjustTableViewInsetsIfNeeded];
 
     [self refreshAndSyncIfNeeded];
 }
@@ -87,12 +86,6 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     [self.tableViewHandler clearCachedRowHeights];
 }
 
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
-{
-    [super traitCollectionDidChange:previousTraitCollection];
-
-    [self adjustTableViewInsetsIfNeeded];
-}
 
 #pragma mark - Configuration
 
@@ -177,20 +170,6 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     tableViewHandler.cacheRowHeights        = YES;
     tableViewHandler.delegate               = self;
     self.tableViewHandler                   = tableViewHandler;
-}
-
-- (void)adjustTableViewInsetsIfNeeded
-{
-    if ([WPDeviceIdentification isiPad]) {
-        BOOL isPadFullScreen = [self.traitCollection containsTraitsInCollection:[UITraitCollection traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassRegular]];
-        if (isPadFullScreen) {
-            UIEdgeInsets inset = self.tableView.contentInset;
-            inset.top = WPTableViewTopMargin;
-            self.tableView.contentInset = inset;
-        } else {
-            self.tableView.contentInset = UIEdgeInsetsZero;
-        }
-    }
 }
 
 #pragma mark - UITableViewDelegate Methods

--- a/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
@@ -93,7 +93,6 @@ class DomainsListViewController: UITableViewController, ImmuTablePresenter {
 
         title = NSLocalizedString("Domains", comment: "Title for the Domains list")
 
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
 
         if let dotComID = blog.dotComID {

--- a/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
@@ -148,26 +148,12 @@ class DomainsListViewController: UITableViewController, ImmuTablePresenter {
         return tableView.rowHeight
     }
 
-    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        if let title = self.tableView(tableView, titleForHeaderInSection: section) where !title.isEmpty {
-            let header = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-            header.title = title
-            return header
-        } else {
-            return nil
-        }
-    }
-
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if let headerView = self.tableView(tableView, viewForHeaderInSection: section) as? WPTableViewSectionHeaderFooterView {
-            return WPTableViewSectionHeaderFooterView.heightForHeader(headerView.title, width: CGRectGetWidth(view.bounds))
-        } else {
-            return 0
-        }
-    }
-
     override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return viewModel.sections[section].headerText
+    }
+
+    override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
@@ -9,7 +9,6 @@ public class AboutViewController : UITableViewController
         super.viewDidLoad()
 
         setupNavigationItem()
-        setupTableViewFooter()
         setupTableView()
         setupDismissButtonIfNeeded()
     }
@@ -40,16 +39,6 @@ public class AboutViewController : UITableViewController
         tableView.contentInset      = WPTableViewContentInsets
 
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-    }
-
-    private func setupTableViewFooter() {
-        let calendar                = NSCalendar.currentCalendar()
-        let year                    = calendar.components(.Year, fromDate: NSDate()).year
-
-        let footerView              = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title            = NSLocalizedString("© \(year) Automattic, Inc.", comment: "About View's Footer Text")
-        footerView.titleAlignment   = .Center
-        self.footerView             = footerView
     }
 
     private func setupDismissButtonIfNeeded() {
@@ -101,22 +90,18 @@ public class AboutViewController : UITableViewController
         return cell!
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        let isLastSection = section == (rows.count - 1)
-        if isLastSection == false || footerView == nil {
-            return CGFloat.min
-        }
-
-        let height = WPTableViewSectionHeaderFooterView.heightForFooter(footerView!.title, width: view.frame.width)
-        return height + footerBottomPadding
-    }
-
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if section != (rows.count - 1) {
             return nil
         }
+        return footerTitleText
+    }
 
-        return footerView
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
+        if let footerView = view as? UITableViewHeaderFooterView {
+            footerView.textLabel?.textAlignment = .Center
+        }
     }
 
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
@@ -175,8 +160,14 @@ public class AboutViewController : UITableViewController
     private let iconBottomPadding   = CGFloat(30)
     private let footerBottomPadding = CGFloat(12)
 
+
+
     // MARK: - Private Properties
-    private var footerView : WPTableViewSectionHeaderFooterView!
+    private lazy var footerTitleText: String = {
+        let calendar = NSCalendar.currentCalendar()
+        let year = calendar.components(.Year, fromDate: NSDate()).year
+        return NSLocalizedString("© \(year) Automattic, Inc.", comment: "About View's Footer Text")
+    }()
 
     private var rows : [[Row]] {
         let appsBlogHostname = NSURL(string: WPAutomatticAppsBlogURL)?.host ?? String()

--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.xib
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AboutViewController" customModule="WordPress" customModuleProvider="target">
@@ -11,10 +10,10 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="fZ7-an-PJC">
+        <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="fZ7-an-PJC">
             <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
         </tableView>
     </objects>
 </document>

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -33,7 +33,6 @@ public class AppSettingsViewController: UITableViewController {
         handler = ImmuTableViewHandler(takeOver: self)
         handler.viewModel = tableViewModel()
 
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -54,7 +54,6 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
         refreshAccountDetails()
 
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -546,6 +546,10 @@ static NSInteger NotificationSectionCount               = 1;
 
 - (void)setupCell:(NoteBlockTableViewCell *)cell blockGroup:(NotificationBlockGroup *)blockGroup
 {
+    // Temporarily force margins for WPTableViewCell hack.
+    // Brent C. Jul/19/2016
+    cell.forceCustomCellMargins = YES;
+
     // Note: This is gonna look awesome in Swift
     if (blockGroup.type == NoteBlockGroupTypeHeader) {
         [self setupHeaderCell:(NoteBlockHeaderTableViewCell *)cell blockGroup:blockGroup];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -67,8 +67,6 @@ public class NotificationSettingDetailsViewController : UITableViewController
 
         // Style!
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-
-        tableView.cellLayoutMarginsFollowReadableWidth = false
     }
 
     @IBAction func reloadTable() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -151,42 +151,27 @@ public class NotificationSettingDetailsViewController : UITableViewController
         return cell!
     }
 
-    public override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard section == firstSectionIndex else {
-            return 0
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForHeader(siteName, width: view.bounds.width)
-    }
-
-    public override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard section == firstSectionIndex else {
             return nil
         }
-
-        let headerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        headerView.title    = siteName
-        return headerView
+        return siteName
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        guard let footerText = sections[section].footerText else {
-            return CGFloat.min
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForFooter(footerText, width: view.bounds.width)
+    public override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard let footerText = sections[section].footerText else {
             return nil
         }
-
-        let footerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title    = footerText
-        return footerView
+        return footerText
     }
 
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
+    }
 
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         tableView.deselectSelectedRowWithAnimation(true)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -54,8 +54,6 @@ public class NotificationSettingStreamsViewController : UITableViewController
 
         // Style!
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-
-        tableView.cellLayoutMarginsFollowReadableWidth = false
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -107,16 +107,12 @@ public class NotificationSettingStreamsViewController : UITableViewController
         return cell!
     }
 
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        let headerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        headerView.title = footerForStream(streamAtSection(section))
-        return headerView
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return footerForStream(streamAtSection(section))
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        let title = footerForStream(streamAtSection(section))
-        let width = view.frame.width
-        return WPTableViewSectionHeaderFooterView.heightForFooter(title, width: width)
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -49,8 +49,6 @@ public class NotificationSettingsViewController : UIViewController
 
         // Style!
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-
-        tableView.cellLayoutMarginsFollowReadableWidth = false
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -161,53 +161,32 @@ public class NotificationSettingsViewController : UIViewController
         return isBlogSection && isNotPagination ? blogRowHeight : WPTableViewDefaultRowHeight
     }
 
-    public func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    public func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         // Hide when the section is empty!
         if isSectionEmpty(section) {
             return nil
         }
 
         let theSection      = Section(rawValue: section)!
-        let footerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        footerView.title    = theSection.headerText()
-        return footerView
+        return theSection.headerText()
     }
 
-    public func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        // Hide when the section is empty!
-        if isSectionEmpty(section) {
-            return CGFloat.min
-        }
-
-        let theSection      = Section(rawValue: section)!
-        let width           = view.frame.width
-        return WPTableViewSectionHeaderFooterView.heightForHeader(theSection.headerText(), width: width)
+    public func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
-    public func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         // Hide when the section is empty!
         if isSectionEmpty(section) {
             return nil
         }
 
         let theSection      = Section(rawValue: section)!
-        let footerView      = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title    = theSection.footerText()
-
-        return footerView
+        return theSection.footerText()
     }
 
-    public func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        // Hide when the section is empty!
-        if isSectionEmpty(section) {
-            return CGFloat.min
-        }
-
-        let section         = Section(rawValue: section)!
-        let padding         = section.footerPadding()
-        let height          = WPTableViewSectionHeaderFooterView.heightForFooter(section.footerText(), width: view.frame.width)
-
-        return height + padding
+    public func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NotificationSettingsViewController" customModule="WordPress" customModuleProvider="target">
@@ -17,7 +16,7 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="n1E-Bx-YgH">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="n1E-Bx-YgH">
                     <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                     <connections>

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -46,6 +46,7 @@ extension NotificationsViewController
 
         // UITableView
         tableView.accessibilityIdentifier  = "Notifications Table"
+        tableView.cellLayoutMarginsFollowReadableWidth = false
         WPStyleGuide.configureColorsForView(view, andTableView:tableView)
     }
 
@@ -261,6 +262,7 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
         let isMarkedForDeletion     = isNoteMarkedForDeletion(note.objectID)
         let isLastRow               = tableViewHandler.resultsController.isLastIndexPathInSection(indexPath)
 
+        cell.forceCustomCellMargins = true
         cell.attributedSubject      = note.subjectBlock()?.attributedSubjectText()
         cell.attributedSnippet      = note.snippetBlock()?.attributedSnippetText()
         cell.read                   = note.read.boolValue

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -108,22 +108,15 @@ class InvitePersonViewController : UITableViewController {
 
     // MARK: - UITableView Methods
 
-    override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        guard section == lastSectionIndex else {
-            return CGFloat.min
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForFooter(lastSectionFooterText, width: view.bounds.width)
-    }
-
-    override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard section == lastSectionIndex else {
             return nil
         }
+        return lastSectionFooterText
+    }
 
-        let headerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        headerView.title = lastSectionFooterText
-        return headerView
+    override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 

--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -209,7 +209,7 @@
                         <sections>
                             <tableViewSection id="5Np-Zr-9XP">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="88" id="VTq-Of-ZQm" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="88" id="VTq-Of-ZQm" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="35" width="600" height="88"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="VTq-Of-ZQm" id="v2L-Gv-S2P">
@@ -264,7 +264,7 @@
                             </tableViewSection>
                             <tableViewSection id="8p7-Vy-ixj">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="4sp-JN-Bx2" detailTextLabel="T95-Yj-X6p" style="IBUITableViewCellStyleValue1" id="o1C-ov-hGM" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="4sp-JN-Bx2" detailTextLabel="T95-Yj-X6p" style="IBUITableViewCellStyleValue1" id="o1C-ov-hGM" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="159" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="o1C-ov-hGM" id="HfA-TE-ytF">
@@ -288,7 +288,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="tmz-lK-Wvy" detailTextLabel="D2b-CS-14p" style="IBUITableViewCellStyleValue1" id="pV6-Ik-qI1" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="tmz-lK-Wvy" detailTextLabel="D2b-CS-14p" style="IBUITableViewCellStyleValue1" id="pV6-Ik-qI1" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="203" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pV6-Ik-qI1" id="5fS-CZ-T2g">
@@ -312,7 +312,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="Pm6-os-m4g" detailTextLabel="dAy-Pc-MaL" style="IBUITableViewCellStyleValue1" id="7Gu-cx-Zbk" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="Pm6-os-m4g" detailTextLabel="dAy-Pc-MaL" style="IBUITableViewCellStyleValue1" id="7Gu-cx-Zbk" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="247" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7Gu-cx-Zbk" id="g2l-de-pk6">
@@ -336,7 +336,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="FPE-fh-8t7" detailTextLabel="H0N-bf-Yh1" style="IBUITableViewCellStyleValue1" id="tAU-rX-e3c" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="FPE-fh-8t7" detailTextLabel="H0N-bf-Yh1" style="IBUITableViewCellStyleValue1" id="tAU-rX-e3c" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="291" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="tAU-rX-e3c" id="AJR-SK-Yg6">
@@ -364,7 +364,7 @@
                             </tableViewSection>
                             <tableViewSection id="TkT-75-L4b">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="oVe-xS-Qxh" style="IBUITableViewCellStyleDefault" id="2lp-Fq-KG5" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="oVe-xS-Qxh" style="IBUITableViewCellStyleDefault" id="2lp-Fq-KG5" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="371" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2lp-Fq-KG5" id="Y1J-8j-FCu">
@@ -412,7 +412,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="q0k-QX-oPY">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                         <sections>
                             <tableViewSection id="TSO-dY-4Cz">
                                 <cells>
@@ -427,7 +427,7 @@
                                                     <rect key="frame" x="15" y="12" width="74.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="igf-wZ-skT">
@@ -458,7 +458,7 @@
                                                     <rect key="frame" x="15" y="12" width="32" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="w3p-Ei-KVz">
@@ -538,7 +538,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="U01-Fw-ZiF">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="7bM-Qc-hri" id="vdJ-54-Tvk"/>
                             <outlet property="delegate" destination="7bM-Qc-hri" id="MUH-xN-W5Q"/>
@@ -556,7 +556,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="ibd-2Q-Phm">
                         <rect key="frame" x="0.0" y="44" width="600" height="556"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="OAN-Wl-zn9" id="DqT-Mq-i56"/>
                             <outlet property="delegate" destination="OAN-Wl-zn9" id="Ixm-UX-ILF"/>

--- a/WordPress/Classes/ViewRelated/People/PeopleCell.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleCell.swift
@@ -9,6 +9,7 @@ class PeopleCell: WPTableViewCell {
     @IBOutlet var superAdminRoleBadge: PeopleRoleBadgeLabel!
 
     override func awakeFromNib() {
+        forceCustomCellMargins = true
         displayNameLabel.font = WPFontManager.merriweatherBoldFontOfSize(14)
     }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -154,6 +154,8 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Add,
                                                             target: self,
                                                             action: #selector(invitePersonWasPressed))
+
+        tableView.cellLayoutMarginsFollowReadableWidth = false
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
 
         // By default, let's display the Blog's Users

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -405,3 +405,12 @@ private extension PersonViewController {
         return person as? User
     }
 }
+
+
+// MARK: Private Cell
+//
+class PersonCell : WPTableViewCell {
+    override func awakeFromNib() {
+        forceCustomCellMargins = true
+    }
+}

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -291,21 +291,7 @@ extension PlanDetailViewController: UITableViewDataSource, UITableViewDelegate {
         return tableViewModel.sections[section].headerText
     }
 
-    func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        if let title = self.tableView(tableView, titleForHeaderInSection: section) where !title.isEmpty {
-            let header = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-            header.title = title
-            return header
-        } else {
-            return nil
-        }
-    }
-
-    func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if let headerView = self.tableView(tableView, viewForHeaderInSection: section) as? WPTableViewSectionHeaderFooterView {
-            return WPTableViewSectionHeaderFooterView.heightForHeader(headerView.title, width: CGRectGetWidth(view.bounds))
-        } else {
-            return 0
-        }
+    func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 }

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -9,36 +9,7 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
         didSet {
             handler.viewModel = viewModel.tableViewModelWithPresenter(self, planService: service)
             updateNoResults()
-            updateFooterView()
         }
-    }
-
-    func updateFooterView() {
-        let footerViewModel = viewModel.tableFooterViewModelWithPresenter(self)
-
-        tableView.tableFooterView = tableFooterViewWithViewModel(footerViewModel)
-    }
-
-    private var footerTapAction: (() -> Void)?
-    private func tableFooterViewWithViewModel(viewModel: (title: String, action: () -> Void)?) -> UIView? {
-        guard let viewModel = viewModel else { return nil }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: "ToSFooterView", style: .Footer)
-
-        let title = viewModel.title
-        footerView.title = title
-        footerView.frame.size.height = WPTableViewSectionHeaderFooterView.heightForFooter(title, width: footerView.bounds.width)
-
-        // Don't add a recognizer if we already have one
-        let recognizers = footerView.gestureRecognizers
-        if recognizers == nil || recognizers?.count == 0 {
-            footerTapAction = viewModel.action
-
-            let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(footerTapped))
-            footerView.addGestureRecognizer(tapRecognizer)
-        }
-
-        return footerView
     }
 
     private let noResultsView = WPNoResultsView()
@@ -114,10 +85,6 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
                 self.viewModel = .Error(String(error))
             }
         )
-    }
-
-    func footerTapped() {
-        footerTapAction?()
     }
 
     // MARK: - ImmuTablePresenter

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -67,7 +67,6 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
         ImmuTable.registerRows([PlanListRow.self], tableView: tableView)
         handler.viewModel = viewModel.tableViewModelWithPresenter(self, planService: service)

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
@@ -89,7 +89,8 @@ enum PlanListViewModel {
             return ImmuTable(sections: [
                 ImmuTableSection(
                     headerText: NSLocalizedString("WordPress.com Plans", comment: "Title for the Plans list header"),
-                    rows: rows)
+                    rows: rows,
+                    footerText: NSLocalizedString("Manage your plan at WordPress.com/plans", comment: "Footer for Plans list"))
                 ])
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
@@ -41,7 +41,6 @@ static const CGFloat CategoryCellIndentation = 16.0;
     [super viewDidLoad];
 
     self.tableView.accessibilityIdentifier = @"CategoriesList";
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     // Hide extra cell separators.
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];

--- a/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
@@ -160,10 +160,6 @@ static const CGFloat CategoryCellIndentation = 16.0;
 {
     WPTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CategoryCellIdentifier forIndexPath:indexPath];
     
-    // HACK: We use zero here, because the the separator inset will do the work we want
-    cell.indentationLevel = 0;
-    cell.indentationWidth = CategoryCellIndentation;
-    
     NSInteger row = indexPath.row; // Use this index for the remainder for this method.
     
     // When showing this VC in mode CategoriesSelectionModeParent, we want the first item to be
@@ -191,7 +187,8 @@ static const CGFloat CategoryCellIndentation = 16.0;
     
     PostCategory* category = self.categories[row];
     NSInteger indentationLevel = [[self.categoryIndentationDict objectForKey:[category.categoryID stringValue]] integerValue];
-    cell.separatorInset = UIEdgeInsetsMake(0, (indentationLevel+1) * cell.indentationWidth, 0, 0);
+    cell.indentationLevel = indentationLevel;
+    cell.indentationWidth = CategoryCellIndentation;
     cell.textLabel.text = [category.categoryName stringByDecodingXMLCharacters];
     [WPStyleGuide configureTableViewCell:cell];
 

--- a/WordPress/Classes/ViewRelated/Post/Categories/WPAddPostCategoryViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Categories/WPAddPostCategoryViewController.m
@@ -51,7 +51,6 @@ static const CGFloat HorizontalMargin = 15.0f;
 
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
                                                                                           target:self action:@selector(dismiss:)];
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
 
 + (instancetype)controllerForDetails:(WPImageMeta *)details forPost:(AbstractPost *)post
 {
-    EditImageDetailsViewController *controller = [EditImageDetailsViewController new];
+    EditImageDetailsViewController *controller = [[EditImageDetailsViewController alloc] initWithStyle:UITableViewStyleGrouped];
     controller.imageDetails = details;
     controller.post = post;
     return controller;
@@ -258,7 +258,7 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
     return 0;
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSInteger sec = [[self.sections objectAtIndex:section] integerValue];
     if (sec == ImageDetailsSectionDetails) {
@@ -267,31 +267,12 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
     } else if (sec == ImageDetailsSectionDisplay) {
         return NSLocalizedString(@"Web Display Settings", @"The title of the option group for editing an image's size, alignment, etc. on the image details screen.");
     }
-
-    return @"";
+    return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = [self titleForHeaderInSection:section];
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    if (section == 0) {
-        return WPTableViewTopMargin;
-    }
-
-    NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    // Remove extra padding caused by section footers in grouped table views
-    return 1.0f;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -109,7 +109,6 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
     DDLogInfo(@"%@ %@", self, NSStringFromSelector(_cmd));
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 
     self.visibilityList = @[NSLocalizedString(@"Public", @"Privacy setting for posts set to 'Public' (default). Should be the same as in core WP."),

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -401,7 +401,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     return 0;
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     NSInteger sec = [[self.sections objectAtIndex:section] integerValue];
     if (sec == PostSettingsSectionTaxonomy) {
@@ -418,41 +418,23 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
     } else if (sec == PostSettingsSectionGeolocation) {
         return NSLocalizedString(@"Location", @"Label for the geolocation feature (tagging posts by their physical location).");
-
+        
     }
-    return @"";
+    return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = [self titleForHeaderInSection:section];
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    if (IS_IPAD && section == 0) {
-        return WPTableViewTopMargin;
-    }
-
-    NSString *title = [self titleForHeaderInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    // Remove extra padding caused by section footers in grouped table views
-    return 1.0f;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    CGFloat width = IS_IPAD ? WPTableViewFixedWidth : CGRectGetWidth(self.tableView.frame);
+    CGFloat width = CGRectGetWidth(self.tableView.frame);
     NSInteger sectionId = [[self.sections objectAtIndex:indexPath.section] integerValue];
 
     if (sectionId == PostSettingsSectionGeolocation && self.post.geolocation != nil) {
-        return ceilf(width * 0.75f);
+        return ceilf(width * 0.50f);
     }
 
     if (sectionId == PostSettingsSectionFeaturedImage) {

--- a/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
@@ -42,7 +42,6 @@ static CGFloat const FollowSitesRowHeight = 54.0;
     self.tableViewHandler = [[WPTableViewHandler alloc] initWithTableView:self.tableView];
     self.tableViewHandler.delegate = self;
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
@@ -204,19 +204,16 @@ static CGFloat const FollowSitesRowHeight = 54.0;
     return NSLocalizedString(@"Unfollow", @"Label of the table view cell's delete button, when unfollowing a site.");
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     if ([[self.tableViewHandler.resultsController fetchedObjects] count] > 0) {
         return NSLocalizedString(@"Sites", @"Section title for sites the user has followed.");
     }
-    // Return an space instead of empty string or nil to preserve the section
-    // header's height if all items are removed and then one added back.
-    return @" ";
+    return nil;
 }
 
 - (void)tableViewDidChangeContent:(UITableView *)tableView
 {
-    [self.tableViewHandler updateTitleForSection:0];
     [self configureNoResultsView];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -300,15 +300,13 @@ extension ReaderFollowedSitesViewController : WPTableViewHandlerDelegate
         return 54.0
     }
 
-
-    func titleForHeaderInSection(section: Int) -> String? {
+    func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         let count = tableViewHandler.resultsController.fetchedObjects?.count ?? 0
         if count > 0 {
             return NSLocalizedString("Sites", comment: "Section title for sites the user has followed.")
         }
-        return " "
+        return nil
     }
-
 
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         guard let site = tableViewHandler.resultsController.objectAtIndexPath(indexPath) as? ReaderSiteTopic else {
@@ -340,7 +338,6 @@ extension ReaderFollowedSitesViewController : WPTableViewHandlerDelegate
 
     func tableViewDidChangeContent(tableView: UITableView) {
         configureNoResultsView()
-        tableViewHandler.updateTitleForSection(0)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -92,7 +92,6 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         assert(tableViewController != nil, "The tableViewController must be assigned before configuring the tableView")
 
         tableView = tableViewController.tableView
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
 
         refreshControl = tableViewController.refreshControl!
         refreshControl.addTarget(self, action: #selector(ReaderStreamViewController.handleRefresh(_:)), forControlEvents: .ValueChanged)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -76,7 +76,6 @@ import WordPressShared
 
 
     func configureTableView() {
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
 
         tableView.registerClass(WPTableViewCell.self, forCellReuseIdentifier: defaultCellIdentifier)
         tableView.registerClass(WPTableViewCell.self, forCellReuseIdentifier: actionCellIdentifier)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -262,20 +262,13 @@ import WordPressShared
         return viewModel.numberOfItemsInSection(section)
     }
 
-
-    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let title = viewModel.titleForSection(section)
-        let header = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        header.title = title
-        return header
+    override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return viewModel.titleForSection(section)
     }
 
-
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        let title = viewModel.titleForSection(section)
-        return WPTableViewSectionHeaderFooterView.heightForHeader(title, width: view.frame.width)
+    override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
-
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let menuItem = viewModel.menuItemAtIndexPath(indexPath)

--- a/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
@@ -47,7 +47,6 @@
     self.tableViewHandler = [[WPTableViewHandler alloc] initWithTableView:self.tableView];
     self.tableViewHandler.delegate = self;
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
@@ -168,7 +168,7 @@
     }
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     id <NSFetchedResultsSectionInfo> sectionInfo = [self.tableViewHandler.resultsController.sections objectAtIndex:section];
 
@@ -180,7 +180,8 @@
         return NSLocalizedString(@"Tags", @"Section title for reader tags you can browse");
     }
 
-    return nil;}
+    return nil;
+}
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {

--- a/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
@@ -42,7 +42,6 @@
     self.tableViewHandler = [[WPTableViewHandler alloc] initWithTableView:self.tableView];
     self.tableViewHandler.delegate = self;
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
@@ -182,7 +182,7 @@
     [[NSNotificationCenter defaultCenter] postNotificationName:ReaderTopicDidChangeViaUserInteractionNotification object:nil];
 }
 
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     id <NSFetchedResultsSectionInfo> sectionInfo = [self.tableViewHandler.resultsController.sections objectAtIndex:section];
 

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogDetailViewController.m
@@ -25,19 +25,29 @@
 {
     [super viewDidLoad];
 
-    self.textView = [[UITextView alloc] initWithFrame:self.view.bounds];
-    self.textView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-    self.textView.editable = NO;
-    self.textView.text = self.logText;
-    self.textView.font = [WPStyleGuide subtitleFont];
-    [self.view addSubview:self.textView];
+    [WPStyleGuide configureColorsForView:self.view andTableView:nil];
+
+    UITextView *textView = [[UITextView alloc] initWithFrame:self.view.bounds];
+    textView.editable = NO;
+    textView.text = self.logText;
+    textView.font = [WPStyleGuide subtitleFont];
+    textView.backgroundColor = [UIColor whiteColor];
+    [self.view addSubview:textView];
+    textView.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    UILayoutGuide *readableGuide = self.view.readableContentGuide;
+    [NSLayoutConstraint activateConstraints:@[
+                                              [textView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
+                                              [textView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+                                              [textView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
+                                              [textView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
+                                              ]];
+    self.textView = textView;
 
     UIBarButtonItem *shareButton = nil;
-
     shareButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction
                                                                 target:self
                                                                 action:@selector(showShareOptions:)];
-
     self.navigationItem.rightBarButtonItem = shareButton;
 }
 

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
@@ -45,7 +45,6 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
     
     [self.tableView setRowHeight:WPTableViewDefaultRowHeight];
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self loadLogFiles];
 

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
@@ -109,30 +109,7 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
     return cell;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self titleForHeaderInSection:section];
-    if (!title) {
-        return nil;
-    }
-    
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleHeader];
-    header.title = title;
-    return header;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    NSString *title = [self titleForHeaderInSection:section];
-    if (!title) {
-        // Fix: Prevents extra spacing when dealing with empty footers
-        return CGFLOAT_MIN;
-    }
-    
-    return [WPTableViewSectionHeaderFooterView heightForHeader:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (NSString *)titleForHeaderInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
     if (section == 0) {
         return NSLocalizedString(@"Log Files By Created Date", @"");
@@ -140,25 +117,22 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
-    WPTableViewSectionHeaderFooterView *header = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    header.title = [self titleForFooterInSection:section];
-    return header;
+    [WPStyleGuide configureTableViewSectionHeader:view];
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    NSString *title = [self titleForFooterInSection:section];
-    return [WPTableViewSectionHeaderFooterView heightForFooter:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (NSString *)titleForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     if (section == 0) {
         return NSLocalizedString(@"Up to seven days worth of logs are saved.", @"Help text shown below the list of debug logs.");
     }
     return nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 #pragma mark - Table view delegate

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -99,7 +99,6 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
     [self.tableView setRowHeight:WPTableViewDefaultRowHeight];
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
 
     [self.navigationController setNavigationBarHidden:NO animated:YES];
 

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -326,28 +326,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
-{
-    NSString *title = [self titleForFooterInSection:section];
-    if (!title) {
-        return nil;
-    }
-    
-    WPTableViewSectionHeaderFooterView *footer = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    footer.title = title;
-    return footer;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    NSString *title = [self titleForFooterInSection:section];
-    if (!title) {
-        return UITableViewAutomaticDimension;
-    }
-    return [WPTableViewSectionHeaderFooterView heightForFooter:title width:CGRectGetWidth(self.view.bounds)];
-}
-
-- (NSString *)titleForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     if (section == SettingsSectionFAQForums) {
         if ([HelpshiftUtils isHelpshiftEnabled]) {
@@ -359,6 +338,11 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
         return NSLocalizedString(@"The Extra Debug feature includes additional information in activity logs, and can help us troubleshoot issues with the app.", @"");
     }
     return nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 #pragma mark - Table view delegate

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
@@ -55,7 +55,6 @@ public class SettingsListEditorViewController : UITableViewController
 
     private func setupTableView() {
         tableView.registerClass(WPTableViewCell.self, forCellReuseIdentifier: reuseIdentifier)
-        tableView.cellLayoutMarginsFollowReadableWidth = false
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
@@ -99,25 +99,15 @@ public class SettingsListEditorViewController : UITableViewController
         return cell
     }
 
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard let unwrappedFooterText = footerText else {
             return nil
         }
-
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title = unwrappedFooterText
-
-        return footerView
+        return unwrappedFooterText
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        guard let unwrappedFooterText = footerText else {
-            return CGFloat.min
-        }
-
-        let height = WPTableViewSectionHeaderFooterView.heightForFooter(unwrappedFooterText, width: view.frame.width)
-        return height
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
     public override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListPickerViewController.swift
@@ -67,7 +67,6 @@ class SettingsListPickerViewController<T:Equatable> : UITableViewController
 
     // MARK: - Setup Helpers
     private func setupTableView() {
-        tableView.cellLayoutMarginsFollowReadableWidth = false
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListPickerViewController.swift
@@ -101,42 +101,26 @@ class SettingsListPickerViewController<T:Equatable> : UITableViewController
         return cell!
     }
 
-    override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    override func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard let text = headers?[section] else {
             return nil
         }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Header)
-        footerView.title = text
-
-        return footerView
+        return text
     }
 
-    override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard let text = headers?[section] else {
-            return 0
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForHeader(text, width: view.frame.width)
+    override func tableView(tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
-    override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         guard let text = footers?[section] else {
             return nil
         }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title = text
-
-        return footerView
+        return text
     }
 
-    override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        guard let text = footers?[section] else {
-            return 0
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForFooter(text, width: view.frame.width)
+    override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -45,7 +45,6 @@ static CGFloat const SettingsMinHeight = 41.0f;
 {
     [super viewDidLoad];
     self.tableView.allowsSelection = NO;
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 
@@ -62,17 +61,35 @@ static CGFloat const SettingsMinHeight = 41.0f;
     }
     _textViewCell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
     _textViewCell.selectionStyle = UITableViewCellSelectionStyleNone;
-    self.textView = [[UITextView alloc] initWithFrame:CGRectInset(self.textViewCell.bounds, SettingsTextPadding.dx, SettingsTextPadding.dy)];
-    self.textView.text = self.text;
-    self.textView.returnKeyType = UIReturnKeyDefault;
-    self.textView.keyboardType = UIKeyboardTypeDefault;
-    self.textView.secureTextEntry = self.isPassword;
-    self.textView.font = [WPStyleGuide tableviewTextFont];
-    self.textView.textColor = [WPStyleGuide darkGrey];
-    self.textView.delegate = self;
-    self.textView.scrollEnabled = NO;
-    [_textViewCell.contentView addSubview:self.textView];
-    
+
+    UITextView *textView = [[UITextView alloc] initWithFrame:CGRectInset(self.textViewCell.bounds, SettingsTextPadding.dx, SettingsTextPadding.dy)];
+    textView.text = self.text;
+    textView.returnKeyType = UIReturnKeyDefault;
+    textView.keyboardType = UIKeyboardTypeDefault;
+    textView.secureTextEntry = self.isPassword;
+    textView.font = [WPStyleGuide tableviewTextFont];
+    textView.textColor = [WPStyleGuide darkGrey];
+    textView.delegate = self;
+    textView.scrollEnabled = NO;
+
+    UIEdgeInsets textInset = textView.textContainerInset;
+    textInset.left = 0.0;
+    textInset.right = 0.0;
+    textView.textContainerInset = textInset;
+    textView.textContainer.lineFragmentPadding = 0.0;
+
+    [_textViewCell.contentView addSubview:textView];
+    textView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    UILayoutGuide *readableGuide = _textViewCell.contentView.readableContentGuide;
+    [NSLayoutConstraint activateConstraints:@[
+                                              [textView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
+                                              [textView.topAnchor constraintEqualToAnchor:_textViewCell.contentView.topAnchor],
+                                              [textView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
+                                              [textView.bottomAnchor constraintEqualToAnchor:_textViewCell.contentView.bottomAnchor],
+                                              ]];
+    self.textView = textView;
+
     return _textViewCell;
 }
 
@@ -120,15 +137,13 @@ static CGFloat const SettingsMinHeight = 41.0f;
 
 - (void)adjustCellSize
 {
-    CGFloat widthInUse = CGRectGetWidth(self.textView.frame);
-    CGFloat widthAvailable = CGRectGetWidth(self.textViewCell.contentView.bounds) - (2 * SettingsTextPadding.dx);
-    CGSize size = [self.textView sizeThatFits:CGSizeMake(widthAvailable, CGFLOAT_MAX)];
+    CGSize size = [self.textView sizeThatFits:CGSizeMake(self.textView.frame.size.width, CGFLOAT_MAX)];
     CGFloat height = size.height;
 
-    if (fabs(self.tableView.rowHeight - height) > (self.textView.font.lineHeight * 0.5f) || widthInUse != widthAvailable)
+    if (fabs(self.tableView.rowHeight - height) > (self.textView.font.lineHeight * 0.5f))
     {
         [self.tableView beginUpdates];
-        self.textView.frame = CGRectMake(SettingsTextPadding.dx, SettingsTextPadding.dy, widthAvailable, height);
+        self.textView.frame = CGRectMake(SettingsTextPadding.dx, SettingsTextPadding.dy, self.textView.frame.size.width, height);
         self.tableView.rowHeight = MAX(height, SettingsMinHeight) + SettingsTextPadding.dy;
         [self.tableView endUpdates];
     }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -10,7 +10,6 @@ static CGFloat const SettingsMinHeight = 41.0f;
 
 @property (nonatomic, strong) UITableViewCell *textViewCell;
 @property (nonatomic, strong) UITextView *textView;
-@property (nonatomic, strong) UIView *hintView;
 
 @end
 
@@ -77,17 +76,6 @@ static CGFloat const SettingsMinHeight = 41.0f;
     return _textViewCell;
 }
 
-- (UIView *)hintView
-{
-    if (_hintView) {
-        return _hintView;
-    }
-    WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    [footerView setTitle:_hint];
-    _hintView = footerView;
-    return _hintView;
-}
-
 - (void)viewWillDisappear:(BOOL)animated
 {
     if (self.onValueChanged) {
@@ -115,9 +103,14 @@ static CGFloat const SettingsMinHeight = 41.0f;
     return nil;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    return self.hintView;
+    return self.hint;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (void)textViewDidChange:(UITextView *)textView

--- a/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
@@ -61,8 +61,6 @@ public class SettingsPickerViewController : UITableViewController
     // MARK: - Setup Helpers
     private func setupTableView() {
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-
-        tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.estimatedRowHeight = estimatedRowHeight
         tableView.rowHeight = UITableViewAutomaticDimension
     }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
@@ -94,24 +94,16 @@ public class SettingsPickerViewController : UITableViewController
         return cell
     }
 
-    public override func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        if section != sectionWithFooter || pickerHint == nil {
-            return 0
-        }
-
-        return WPTableViewSectionHeaderFooterView.heightForFooter(pickerHint!, width: tableView.bounds.width)
-    }
-
-    public override func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    public override func tableView(tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if section != sectionWithFooter || pickerHint == nil {
             return nil
         }
-
-        let footerView = WPTableViewSectionHeaderFooterView(reuseIdentifier: nil, style: .Footer)
-        footerView.title = pickerHint!
-        return footerView
+        return pickerHint!
     }
 
+    public override func tableView(tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
+    }
 
 
     // MARK: - Cell Setup Helpers

--- a/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
@@ -57,7 +57,6 @@ CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
 
     [self configureCancelButton];
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
@@ -14,10 +14,6 @@ NSString * const SettingsSelectionCurrentValueKey = @"CurrentValue";
 
 CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
 
-@interface SettingsSelectionViewController ()
-@property (nonatomic, strong) WPTableViewSectionHeaderFooterView *hintView;
-@end
-
 @implementation SettingsSelectionViewController
 
 /**
@@ -95,22 +91,6 @@ CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
     }
 }
 
-- (UIView *)hintView
-{
-    if (!self.hints) {
-        return nil;
-    }
-    
-    if (!_hintView) {
-        _hintView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    }
-    
-    NSUInteger position = [self.values indexOfObject:self.currentValue];
-    _hintView.title = (position != NSNotFound) ? self.hints[position] : [NSString string];
-
-    return _hintView;
-}
-
 #pragma mark - Table view data source
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
@@ -157,9 +137,15 @@ CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
     }
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    return self.hintView;
+    NSUInteger position = [self.values indexOfObject:self.currentValue];
+    return (position != NSNotFound) ? self.hints[position] : nil;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (void)dismiss

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -176,9 +176,18 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
         return _textFieldCell;
     }
     _textFieldCell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    _textFieldCell.selectionStyle = UITableViewCellSelectionStyleNone;
     [_textFieldCell.contentView addSubview:self.textField];
-    _textField.frame = CGRectInset(_textFieldCell.bounds, SettingsTextHorizontalMargin, 0);
-    
+
+    self.textField.translatesAutoresizingMaskIntoConstraints = NO;
+    UILayoutGuide *readableGuide = _textFieldCell.contentView.readableContentGuide;
+    [NSLayoutConstraint activateConstraints:@[
+                                               [self.textField.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
+                                               [self.textField.topAnchor constraintEqualToAnchor:_textFieldCell.contentView.topAnchor],
+                                               [self.textField.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
+                                               [self.textField.bottomAnchor constraintEqualToAnchor:_textFieldCell.contentView.bottomAnchor],
+                                               ]];
+
     return _textFieldCell;
 }
 
@@ -211,7 +220,6 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     _textField.placeholder = self.placeholder;
     _textField.returnKeyType = UIReturnKeyDone;
     _textField.keyboardType = UIKeyboardTypeDefault;
-    _textField.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     _textField.delegate = self;
     _textField.autocorrectionType = self.autocorrectionType;
     

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -23,7 +23,6 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
 @property (nonatomic, strong) WPTableViewCell   *textFieldCell;
 @property (nonatomic, strong) WPTableViewCell   *actionCell;
 @property (nonatomic, strong) UITextField       *textField;
-@property (nonatomic, strong) UIView            *hintView;
 @property (nonatomic, assign) BOOL              doneButtonEnabled;
 @property (nonatomic, assign) BOOL              shouldNotifyValue;
 @end
@@ -220,18 +219,6 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     return _textField;
 }
 
-- (UIView *)hintView
-{
-    if (_hintView) {
-        return _hintView;
-    }
-    
-    WPTableViewSectionHeaderFooterView *footerView = [[WPTableViewSectionHeaderFooterView alloc] initWithReuseIdentifier:nil style:WPTableViewSectionStyleFooter];
-    [footerView setTitle:_hint];
-    _hintView = footerView;
-    return _hintView;
-}
-
 
 #pragma mark - UITableViewDelegate
 
@@ -254,9 +241,17 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     return self.actionCell;
 }
 
-- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
-    return (section == SettingsTextSectionsTextfield) ? self.hintView : nil;
+    if (section != SettingsTextSectionsTextfield) {
+        return nil;
+    }
+    return self.hint;
+}
+
+- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
+{
+    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -83,7 +83,6 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     self.shouldNotifyValue = YES;
 
     [self startListeningTextfieldChanges];
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 


### PR DESCRIPTION
Part II of readability support actually starts to follow readable margins and content guides.

For the most part, we're really only tackling views and controllers that can support readability without many changes. We have cleaned up a few spots though, with a bit of use of `UIStackView`.

For this PR, note:

1. First requires a review, merge and updating to WP-iOS-Shared pod 0.6.1 via PR: https://github.com/wordpress-mobile/WordPress-Shared-iOS/pull/104
2. Also requires first merging and then pulling the changes from WP-iOS https://github.com/wordpress-mobile/WordPress-iOS/pull/5756 (Those commits are included here as well and can be diffed out via updating or just ignored for review)

To test:

(1.) Ensure the following views/controllers, on iPad, are following the default readable margins in both landscape and portrait orientation:

- Blog list
- Blog Details
  - Plans
  - Comments
  - Sharing
  - Settings
- Me tab
  - My Profile
  - Account Settings
  - App Settings
  - Notification Settings
  - Help & Support
- Reader tab
  - Followed Sites "Manage"
- Post Settings
  - Categories (with parent/child indentation)
  - Featured image
  - Location

(2.) Ensure the following views/controller are using the original margin hack (until they can be adapted):

- Notifications
- CommentViewController (when viewing a single comment)
- Pages
- Blog Posts
- People

Note: Reader posts/cards are untouched for this go around.

Needs review: @frosty can I push your eyes to the limit for another review? 😁 👀 
