### PR TITLE
Readability Part 2, life without WPTableViewCell (almost)

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ use_frameworks!
 platform :ios, '9.0'
 
 abstract_target 'WordPress_Base' do
-  pod 'WordPress-iOS-Shared', '0.5.9'
+  pod 'WordPress-iOS-Shared', '0.6.0'
   ## This pod is only being included to support the share extension ATM - https://github.com/wordpress-mobile/WordPress-iOS/issues/5081
   pod 'WordPressComKit', :git => 'https://github.com/Automattic/WordPressComKit.git', :tag => '0.0.4'
 

--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '~> 0.10.1'
     pod 'WordPress-iOS-Editor', '1.8'
     pod 'WordPressCom-Analytics-iOS', '0.1.16'
-    pod 'WordPressCom-Stats-iOS', '0.7.4'
+    pod 'WordPressCom-Stats-iOS', '0.7.6'
     pod 'wpxmlrpc', '~> 0.8'
     
     target :WordPressTest do
@@ -69,7 +69,7 @@ abstract_target 'WordPress_Base' do
   end
 
   target 'WordPressTodayWidget' do
-    pod 'WordPressCom-Stats-iOS/Services', '0.7.4'
+    pod 'WordPressCom-Stats-iOS/Services', '0.7.6'
   end
 
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -159,28 +159,28 @@ PODS:
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
-  - WordPress-iOS-Shared (0.5.9):
+  - WordPress-iOS-Shared (0.6.0):
     - CocoaLumberjack (~> 2.2.0)
   - WordPressCom-Analytics-iOS (0.1.16)
-  - WordPressCom-Stats-iOS (0.7.4):
+  - WordPressCom-Stats-iOS (0.7.6):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.3)
+    - WordPress-iOS-Shared (~> 0.6.0)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-    - WordPressCom-Stats-iOS/Services (= 0.7.4)
-    - WordPressCom-Stats-iOS/UI (= 0.7.4)
-  - WordPressCom-Stats-iOS/Services (0.7.4):
+    - WordPressCom-Stats-iOS/Services (= 0.7.6)
+    - WordPressCom-Stats-iOS/UI (= 0.7.6)
+  - WordPressCom-Stats-iOS/Services (0.7.6):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.3)
+    - WordPress-iOS-Shared (~> 0.6.0)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-  - WordPressCom-Stats-iOS/UI (0.7.4):
+  - WordPressCom-Stats-iOS/UI (0.7.6):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.3)
+    - WordPress-iOS-Shared (~> 0.6.0)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
     - WordPressCom-Stats-iOS/Services
   - WordPressComKit (0.0.4):
@@ -218,10 +218,10 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
   - WordPress-iOS-Editor (= 1.8)
-  - WordPress-iOS-Shared (= 0.5.9)
+  - WordPress-iOS-Shared (= 0.6.0)
   - WordPressCom-Analytics-iOS (= 0.1.16)
-  - WordPressCom-Stats-iOS (= 0.7.4)
-  - WordPressCom-Stats-iOS/Services (= 0.7.4)
+  - WordPressCom-Stats-iOS (= 0.7.6)
+  - WordPressCom-Stats-iOS/Services (= 0.7.6)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.4`)
   - WPMediaPicker (~> 0.10.1)
   - wpxmlrpc (~> 0.8)
@@ -281,13 +281,13 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
   WordPress-iOS-Editor: 50a09646fb62af3efdbb56d13ff656272a079066
-  WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
+  WordPress-iOS-Shared: f799334b41f3af509ccb76d7970f8c74a7716f14
   WordPressCom-Analytics-iOS: 46cbb47a84670f3b8548c8617da939c6b74cfda8
-  WordPressCom-Stats-iOS: 87b64bc36015e90789fec4abdb931af87c6e4cfe
+  WordPressCom-Stats-iOS: 2689a457fd18268d36266fca76e96dd13e4af991
   WordPressComKit: 0742c47e5b55bff0e6d26d40db9e010404675a73
   WPMediaPicker: 645ecc2435293cc898c76180f3994358a68cae20
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 0c6445565ade8440c8db5ab17792a08637b27e4f
+PODFILE CHECKSUM: 76c709696c126ed5a9bb5045e8ac5135e4e76ca5
 
 COCOAPODS: 1.0.1

--- a/WordPress/Classes/Categories/WPStyleGuide+ReadableMargins.h
+++ b/WordPress/Classes/Categories/WPStyleGuide+ReadableMargins.h
@@ -2,6 +2,7 @@
 
 @interface WPStyleGuide (ReadableMargins)
 
-+ (void)resetReadableMarginsForTableView:(UITableView *)tableView;
+
++ (void)resetReadableMarginsForTableView:(UITableView *)tableView __deprecated_msg("Follow readable margins via constraints or instead explicitly set setCellLayoutMarginsFollowReadableWidth on UITableView.");
 
 @end

--- a/WordPress/Classes/Utility/ImmuTableViewController.swift
+++ b/WordPress/Classes/Utility/ImmuTableViewController.swift
@@ -77,7 +77,6 @@ final class ImmuTableViewController: UITableViewController, ImmuTablePresenter {
 
         noticeAnimator = NoticeAnimator(target: view)
 
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -6,12 +6,13 @@
 
 
 const CGFloat BlogDetailHeaderViewBlavatarSize = 40.0;
-const CGFloat BlogDetailHeaderViewLabelHeight = 20.0;
 const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 
 @interface BlogDetailHeaderView ()
 
+@property (nonatomic, strong) UIStackView *stackView;
 @property (nonatomic, strong) UIImageView *blavatarImageView;
+@property (nonatomic, strong) UIStackView *labelsStackView;
 @property (nonatomic, strong) UILabel *titleLabel;
 @property (nonatomic, strong) UILabel *subtitleLabel;
 
@@ -23,16 +24,11 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 {
     self = [super initWithFrame:frame];
     if (self) {
-        _blavatarImageView = [self newImageViewForBlavatar];
-        [self addSubview:_blavatarImageView];
-
-        _titleLabel = [self newLabelForTitle];
-        [self addSubview:_titleLabel];
-
-        _subtitleLabel = [self newLabelForSubtitle];
-        [self addSubview:_subtitleLabel];
-
-        [self configureConstraints];
+        [self setupStackView];
+        [self setupBalavatarImageView];
+        [self setupLabelsStackView];
+        [self setupTitleLabel];
+        [self setupSubtitleLabel];
     }
     return self;
 }
@@ -47,39 +43,88 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     NSString *blogName = blog.settings.name;
     [self.titleLabel setText:((blogName && !blogName.isEmpty) ? blogName : blog.displayURL)];
     [self.subtitleLabel setText:blog.displayURL];
+    [self.labelsStackView setNeedsLayout];
 }
 
-#pragma mark - Private Methods
+#pragma mark - Subview setup
 
-- (void)configureConstraints
+- (void)setupStackView
 {
-    NSDictionary *views = NSDictionaryOfVariableBindings(_blavatarImageView, _titleLabel, _subtitleLabel);
-    NSDictionary *metrics = @{@"blavatarSize": @(BlogDetailHeaderViewBlavatarSize),
-                              @"labelHeight":@(BlogDetailHeaderViewLabelHeight),
-                              @"labelHorizontalPadding": @(BlogDetailHeaderViewLabelHorizontalPadding)};
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_blavatarImageView(blavatarSize)]|"
-                                                                 options:0
-                                                                 metrics:metrics
-                                                                   views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|[_blavatarImageView(blavatarSize)]-labelHorizontalPadding-[_titleLabel]|"
-                                                                 options:0
-                                                                 metrics:metrics
-                                                                   views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|[_blavatarImageView(blavatarSize)]-labelHorizontalPadding-[_subtitleLabel]|"
-                                                                 options:0
-                                                                 metrics:metrics
-                                                                   views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_titleLabel(labelHeight)][_subtitleLabel(labelHeight)]"
-                                                                 options:0
-                                                                 metrics:metrics
-                                                                   views:views]];
-    [super setNeedsUpdateConstraints];
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    stackView.axis = UILayoutConstraintAxisHorizontal;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.alignment = UIStackViewAlignmentCenter;
+    stackView.spacing = BlogDetailHeaderViewLabelHorizontalPadding;
+    [self addSubview:stackView];
+
+    NSLayoutConstraint *leadingConstraint;
+    NSLayoutConstraint *trailingConstraint;
+
+    if ([WPDeviceIdentification isiPhone]) {
+        // On iPhone, the readable content guide seems to be accurately aligned with the cell's content margins.
+        UILayoutGuide *readableGuide = self.readableContentGuide;
+        leadingConstraint = [stackView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor];
+        trailingConstraint = [stackView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor];
+    } else {
+        // On iPad, the correct readable margins seem to already be inherited via the tableHeaderView
+        // so following this view's readable content guide is not necessary.
+        leadingConstraint = [stackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor];
+        trailingConstraint = [stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor];
+    }
+
+    [NSLayoutConstraint activateConstraints:@[
+                                              leadingConstraint,
+                                              trailingConstraint,
+                                              [stackView.topAnchor constraintEqualToAnchor:self.topAnchor],
+                                              [stackView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
+                                              [stackView.centerXAnchor constraintEqualToAnchor:self.centerXAnchor],
+                                              [stackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor]
+                                              ]];
+    _stackView = stackView;
 }
 
-#pragma mark - Subview factories
-
-- (UILabel *)newLabelForTitle
+- (void)setupBalavatarImageView
 {
+    NSAssert(_stackView != nil, @"stackView was nil");
+
+    CGRect blavatarFrame = CGRectMake(0.0f, 0.0f, BlogDetailHeaderViewBlavatarSize, BlogDetailHeaderViewBlavatarSize);
+    UIImageView *imageView = [[UIImageView alloc] initWithFrame:blavatarFrame];
+    imageView.backgroundColor = [UIColor whiteColor];
+    imageView.translatesAutoresizingMaskIntoConstraints = NO;
+    imageView.layer.borderColor = [[UIColor whiteColor] CGColor];
+    imageView.layer.borderWidth = 1.0;
+    [_stackView addArrangedSubview:imageView];
+
+    [NSLayoutConstraint activateConstraints:@[
+                                              [imageView.widthAnchor constraintEqualToConstant:BlogDetailHeaderViewBlavatarSize],
+                                              [imageView.heightAnchor constraintEqualToConstant:BlogDetailHeaderViewBlavatarSize]
+                                              ]];
+    _blavatarImageView = imageView;
+}
+
+- (void)setupLabelsStackView
+{
+    NSAssert(_stackView != nil, @"stackView was nil");
+
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    stackView.axis = UILayoutConstraintAxisVertical;
+    stackView.distribution = UIStackViewDistributionFill;
+    stackView.alignment = UIStackViewAlignmentFill;
+
+    [_stackView addArrangedSubview:stackView];
+
+    [stackView setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+    [stackView setContentCompressionResistancePriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+
+    _labelsStackView = stackView;
+}
+
+- (void)setupTitleLabel
+{
+    NSAssert(_labelsStackView != nil, @"labelsStackView was nil");
+
     UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
     label.translatesAutoresizingMaskIntoConstraints = NO;
     label.numberOfLines = 1;
@@ -89,11 +134,15 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     label.font = [WPFontManager systemRegularFontOfSize:16.0];
     label.adjustsFontSizeToFitWidth = NO;
 
-    return label;
+    [_labelsStackView addArrangedSubview:label];
+
+    _titleLabel = label;
 }
 
-- (UILabel *)newLabelForSubtitle
+- (void)setupSubtitleLabel
 {
+    NSAssert(_labelsStackView != nil, @"labelsStackView was nil");
+
     UILabel *label = [[UILabel alloc] initWithFrame:CGRectZero];
     label.translatesAutoresizingMaskIntoConstraints = NO;
     label.numberOfLines = 1;
@@ -103,18 +152,9 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     label.font = [WPFontManager systemItalicFontOfSize:12.0];
     label.adjustsFontSizeToFitWidth = NO;
 
-    return label;
-}
+    [_labelsStackView addArrangedSubview:label];
 
-- (UIImageView *)newImageViewForBlavatar
-{
-    CGRect blavatarFrame = CGRectMake(0.0f, 0.0f, BlogDetailHeaderViewBlavatarSize, BlogDetailHeaderViewBlavatarSize);
-    UIImageView *imageView = [[UIImageView alloc] initWithFrame:blavatarFrame];
-    imageView.backgroundColor = [UIColor whiteColor];
-    imageView.translatesAutoresizingMaskIntoConstraints = NO;
-    imageView.layer.borderColor = [[UIColor whiteColor] CGColor];
-    imageView.layer.borderWidth = 1.0;
-    return imageView;
+    _subtitleLabel = label;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -25,7 +25,7 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     self = [super initWithFrame:frame];
     if (self) {
         [self setupStackView];
-        [self setupBalavatarImageView];
+        [self setupBlavatarImageView];
         [self setupLabelsStackView];
         [self setupTitleLabel];
         [self setupSubtitleLabel];
@@ -78,18 +78,15 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
                                               trailingConstraint,
                                               [stackView.topAnchor constraintEqualToAnchor:self.topAnchor],
                                               [stackView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
-                                              [stackView.centerXAnchor constraintEqualToAnchor:self.centerXAnchor],
-                                              [stackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor]
                                               ]];
     _stackView = stackView;
 }
 
-- (void)setupBalavatarImageView
+- (void)setupBlavatarImageView
 {
     NSAssert(_stackView != nil, @"stackView was nil");
 
-    CGRect blavatarFrame = CGRectMake(0.0f, 0.0f, BlogDetailHeaderViewBlavatarSize, BlogDetailHeaderViewBlavatarSize);
-    UIImageView *imageView = [[UIImageView alloc] initWithFrame:blavatarFrame];
+    UIImageView *imageView = [[UIImageView alloc] init];
     imageView.backgroundColor = [UIColor whiteColor];
     imageView.translatesAutoresizingMaskIntoConstraints = NO;
     imageView.layer.borderColor = [[UIColor whiteColor] CGColor];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -12,7 +12,6 @@
 #import "WPAccount.h"
 #import "WPAppAnalytics.h"
 #import "WPGUIConstants.h"
-#import "WPStyleGuide+ReadableMargins.h"
 #import "WPTableViewCell.h"
 #import "WPTableViewSectionHeaderFooterView.h"
 #import "WPWebViewController.h"
@@ -166,7 +165,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewDidLoad];
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:BlogDetailsCellIdentifier];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -368,7 +368,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     self.tableView.tableHeaderView = headerWrapper;
 
     // Blog detail header view
-    BlogDetailHeaderView *headerView = [[BlogDetailHeaderView alloc] initWithFrame:headerWrapper.bounds];
+    BlogDetailHeaderView *headerView = [[BlogDetailHeaderView alloc] init];
     headerView.translatesAutoresizingMaskIntoConstraints = NO;
     [headerWrapper addSubview:headerView];
 
@@ -378,8 +378,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                               [headerView.topAnchor constraintEqualToAnchor:headerWrapper.topAnchor],
                                               [headerView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
                                               [headerView.bottomAnchor constraintEqualToAnchor:headerWrapper.bottomAnchor],
-                                              [headerView.centerXAnchor constraintEqualToAnchor:headerWrapper.centerXAnchor],
-                                              [headerView.centerYAnchor constraintEqualToAnchor:headerWrapper.centerYAnchor]
                                               ]];
      self.headerView = headerView;
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -294,8 +294,6 @@ static NSInteger HideSearchMinSites = 3;
     self.tableView.accessibilityIdentifier = NSLocalizedString(@"Blogs", @"");
 
     self.tableView.tableFooterView = [UIView new];
-
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
 }
 
 - (void)configureSearchController

--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
@@ -90,7 +90,6 @@ static CGFloat BlogCellRowHeight = 74.0;
     // TableView
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     
-    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     [self.tableView registerClass:[WPBlogTableViewCell class] forCellReuseIdentifier:BlogCellIdentifier];
     [self.tableView reloadData];
 

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -48,7 +48,6 @@ public class DiscussionSettingsViewController : UITableViewController
 
     private func setupTableView() {
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-        tableView.cellLayoutMarginsFollowReadableWidth = false
 
         // Note: We really want to handle 'Unselect' manually.
         // Reason: we always reload previously selected rows.

--- a/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/LanguageViewController.swift
@@ -31,7 +31,6 @@ public class LanguageViewController : UITableViewController
 
         // Setup tableView
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
     }
 
     public override func viewWillAppear(animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
@@ -6,7 +6,6 @@
 #import "SettingTableViewCell.h"
 #import "RelatedPostsPreviewTableViewCell.h"
 #import "WPTableViewSectionHeaderFooterView.h"
-#import "WPStyleGuide+ReadableMargins.h"
 
 #import <WordPressShared/WPStyleGuide.h>
 #import <SVProgressHUD/SVProgressHUD.h>
@@ -58,7 +57,6 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     self.navigationItem.title = NSLocalizedString(@"Related Posts", @"Title for screen that allows configuration of your blog/site related posts settings.");
     self.tableView.allowsSelection = NO;
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
 }
 
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -89,7 +89,6 @@ import WordPressShared
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
         tableView.setEditing(true, animated: false)
         tableView.allowsSelectionDuringEditing = true
-        tableView.cellLayoutMarginsFollowReadableWidth = false
     }
 
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -842,6 +842,14 @@ import WordPressShared
     }
 
 
+    override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+        // Since we want to be able to order particular rows, let's only allow editing for those specific rows.
+        // Note: We have to allow editing because UITableView will only give us the ordering accessory while editing is toggled.
+        let section = sections[indexPath.section]
+        return section.canSort && !section.editing && indexPath.row > 0
+    }
+
+
     override func tableView(tableView: UITableView, canMoveRowAtIndexPath indexPath: NSIndexPath) -> Bool {
         let section = sections[indexPath.section]
         return section.canSort && !section.editing && indexPath.row > 0

--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -47,7 +47,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
     self.navigationItem.title = self.publicizeService.label;
 
-    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:CellIdentifier];
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -49,7 +49,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
     self.navigationItem.title = self.publicizeConnection.externalDisplay;
 
-    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self.tableView registerClass:[WPTableViewCell class] forCellReuseIdentifier:CellIdentifier];
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -43,7 +43,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
     self.navigationItem.title = NSLocalizedString(@"Sharing", @"Title for blog detail sharing screen.");
 
-    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 
     // Optimistically sync the sharing buttons.

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
@@ -49,7 +49,6 @@ public class StartOverViewController: UITableViewController
 
         title = NSLocalizedString("Start Over", comment: "Title of Start Over settings page")
 
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -14,7 +14,6 @@
 #import "SettingTableViewCell.h"
 #import "SettingsTextViewController.h"
 #import "WordPress-Swift.h"
-#import "WPStyleGuide+ReadableMargins.h"
 #import "WPWebViewController.h"
 #import "WordPress-Swift.h"
 #import "BlogServiceRemoteXMLRPC.h"
@@ -123,7 +122,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
                                                  name:NSManagedObjectContextObjectsDidChangeNotification
                                                object:self.blog.managedObjectContext];
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     
     self.refreshControl = [[UIRefreshControl alloc] init];

--- a/WordPress/Classes/ViewRelated/Cells/MediaSizeSliderCell.xib
+++ b/WordPress/Classes/ViewRelated/Cells/MediaSizeSliderCell.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
@@ -10,28 +10,31 @@
         <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="108" id="7mS-Jn-IfN" customClass="MediaSizeSliderCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="108"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7mS-Jn-IfN" id="twB-EW-2j3">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="107"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" layoutMarginsFollowReadableWidth="YES" tableViewCell="7mS-Jn-IfN" id="twB-EW-2j3">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="107.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="VNV-La-F2d">
                         <rect key="frame" x="16" y="8" width="288" height="91"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IZE-tn-T3b">
-                                <rect key="frame" x="0.0" y="0.0" width="288" height="0.0"/>
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="41"/>
                                 <accessibility key="accessibilityConfiguration" identifier=""/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="joS-zC-6YB">
-                                <rect key="frame" x="-2" y="0.0" width="292" height="71"/>
+                                <rect key="frame" x="-2" y="41" width="292" height="31"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="tTE-DQ-2mh"/>
+                                </constraints>
                                 <connections>
                                     <action selector="sliderChanged:" destination="7mS-Jn-IfN" eventType="valueChanged" id="1ET-wg-Itm"/>
                                 </connections>
                             </slider>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Original" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hsz-Em-99p">
-                                <rect key="frame" x="0.0" y="70" width="288" height="21"/>
+                                <rect key="frame" x="0.0" y="71" width="288" height="20"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <bool key="isElement" value="NO"/>
                                 </accessibility>
@@ -40,13 +43,16 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="joS-zC-6YB" secondAttribute="bottom" constant="20" symbolic="YES" id="WHG-uU-blp"/>
+                        </constraints>
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="VNV-La-F2d" firstAttribute="top" secondItem="twB-EW-2j3" secondAttribute="topMargin" id="5SI-ZY-ndG"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="VNV-La-F2d" secondAttribute="bottom" id="RsH-NY-bp4"/>
-                    <constraint firstItem="VNV-La-F2d" firstAttribute="leading" secondItem="twB-EW-2j3" secondAttribute="leadingMargin" id="qMp-22-LUF"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="VNV-La-F2d" secondAttribute="trailing" id="xaR-7t-dwK"/>
+                    <constraint firstItem="VNV-La-F2d" firstAttribute="trailing" secondItem="twB-EW-2j3" secondAttribute="trailingMargin" id="BsB-4s-JSW"/>
+                    <constraint firstItem="VNV-La-F2d" firstAttribute="leading" secondItem="twB-EW-2j3" secondAttribute="leadingMargin" id="Nr5-S4-die"/>
+                    <constraint firstItem="VNV-La-F2d" firstAttribute="top" secondItem="twB-EW-2j3" secondAttribute="topMargin" id="n5i-7d-bnn"/>
+                    <constraint firstItem="VNV-La-F2d" firstAttribute="centerY" secondItem="twB-EW-2j3" secondAttribute="centerY" id="qer-xy-kaF"/>
                 </constraints>
                 <edgeInsets key="layoutMargins" top="8" left="16" bottom="8" right="16"/>
             </tableViewCellContentView>

--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
@@ -5,7 +5,7 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
 
 @interface PostFeaturedImageCell ()
 
-//@property (nonatomic, strong) UIImageView *imageView;
+@property (nonatomic, strong) UIImageView *featuredImageView;
 @property (nonatomic, strong) UIActivityIndicatorView *activityView;
 
 @end
@@ -16,45 +16,45 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
 {
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
-        [self configureSubviews];
+        [self setupSubviews];
     }
     return self;
 }
 
-- (void)configureSubviews
+- (void)setupSubviews
 {
-    CGRect contentFrame = self.contentView.frame;
-    self.imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    self.imageView.contentMode = UIViewContentModeScaleAspectFill;
-    self.imageView.clipsToBounds = YES;
-    [self.contentView addSubview:self.imageView];
+    UIImageView *imageView = [[UIImageView alloc] init];
+    imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    imageView.contentMode = UIViewContentModeScaleAspectFill;
+    imageView.clipsToBounds = YES;
+    imageView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.contentView addSubview:imageView];
 
-    self.activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
-    CGRect activityFrame = self.activityView.frame;
+    UILayoutGuide *readableGuide = self.contentView.readableContentGuide;
+    [NSLayoutConstraint activateConstraints:@[
+                                              [imageView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
+                                              [imageView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
+                                              [imageView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:PostFeaturedImageCellMargin],
+                                              [imageView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor constant:-PostFeaturedImageCellMargin]
+                                              ]];
+    _featuredImageView = imageView;
+
+    CGRect contentFrame = self.contentView.frame;
+    UIActivityIndicatorView *activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    CGRect activityFrame = activityView.frame;
     CGFloat x = (contentFrame.size.width - activityFrame.size.width) / 2.0f;
     CGFloat y = (contentFrame.size.height - activityFrame.size.height) / 2.0f;
     activityFrame = CGRectMake(x, y, activityFrame.size.width, activityFrame.size.height);
-    self.activityView.frame = activityFrame;
-    self.activityView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
-    self.activityView.hidesWhenStopped = YES;
-    [self.contentView addSubview:self.activityView];
-}
-
-- (void)layoutSubviews
-{
-    [super layoutSubviews];
-    if (!self.imageView.hidden) {
-        CGFloat x = PostFeaturedImageCellMargin;
-        CGFloat y = PostFeaturedImageCellMargin;
-        CGFloat w = CGRectGetWidth(self.contentView.frame) - (PostFeaturedImageCellMargin * 2);
-        CGFloat h = CGRectGetHeight(self.contentView.frame) - (PostFeaturedImageCellMargin * 2);
-        self.imageView.frame = CGRectMake(x, y, w, h);
-    }
+    activityView.frame = activityFrame;
+    activityView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
+    activityView.hidesWhenStopped = YES;
+    [self.contentView addSubview:activityView];
+    _activityView = activityView;
 }
 
 - (void)setImage:(UIImage *)image
 {
-    [self.imageView setImage:image];
+    [self.featuredImageView setImage:image];
     [self showLoadingSpinner:NO];
 }
 
@@ -65,7 +65,7 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
     } else {
         [self.activityView stopAnimating];
     }
-    self.imageView.hidden = showSpinner;
+    self.featuredImageView.hidden = showSpinner;
     self.textLabel.text = @"";
 }
 

--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
@@ -24,7 +24,6 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
 - (void)setupSubviews
 {
     UIImageView *imageView = [[UIImageView alloc] init];
-    imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     imageView.contentMode = UIViewContentModeScaleAspectFill;
     imageView.clipsToBounds = YES;
     imageView.translatesAutoresizingMaskIntoConstraints = NO;

--- a/WordPress/Classes/ViewRelated/Cells/PostGeolocationCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/PostGeolocationCell.m
@@ -24,24 +24,21 @@ CGFloat const PostGeolocationCellMargin = 15.0f;
 
 - (void)configureSubviews
 {
-    self.geoView = [[PostGeolocationView alloc] initWithFrame:self.contentView.bounds];
-    self.geoView.labelMargin = 0.0f;
-    self.geoView.scrollEnabled = NO;
-    self.geoView.chevronHidden = YES;
-    self.geoView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    [self.contentView addSubview:self.geoView];
-}
+    PostGeolocationView *geoView = [[PostGeolocationView alloc] initWithFrame:self.contentView.bounds];
+    geoView.translatesAutoresizingMaskIntoConstraints = NO;
+    geoView.labelMargin = 0.0f;
+    geoView.scrollEnabled = NO;
+    geoView.chevronHidden = YES;
+    [self.contentView addSubview:geoView];
 
-- (void)layoutSubviews
-{
-    [super layoutSubviews];
-
-    CGFloat x = PostGeolocationCellMargin;
-    CGFloat y = PostGeolocationCellMargin;
-    CGFloat w = CGRectGetWidth(self.contentView.frame) - (PostGeolocationCellMargin * 2);
-    CGFloat h = CGRectGetHeight(self.contentView.frame) - (PostGeolocationCellMargin * 2);
-
-    self.geoView.frame = CGRectMake(x, y, w, h);
+    UILayoutGuide *readableGuide = self.contentView.readableContentGuide;
+    [NSLayoutConstraint activateConstraints:@[
+                                              [geoView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
+                                              [geoView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
+                                              [geoView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:PostGeolocationCellMargin],
+                                              [geoView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor]
+                                              ]];
+    _geoView = geoView;
 }
 
 - (void)setCoordinate:(Coordinate *)coordinate andAddress:(NSString *)address

--- a/WordPress/Classes/ViewRelated/Cells/PostGeolocationCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/PostGeolocationCell.m
@@ -24,7 +24,7 @@ CGFloat const PostGeolocationCellMargin = 15.0f;
 
 - (void)configureSubviews
 {
-    PostGeolocationView *geoView = [[PostGeolocationView alloc] initWithFrame:self.contentView.bounds];
+    PostGeolocationView *geoView = [[PostGeolocationView alloc] init];
     geoView.translatesAutoresizingMaskIntoConstraints = NO;
     geoView.labelMargin = 0.0f;
     geoView.scrollEnabled = NO;

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -65,17 +65,19 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
                                           action:@selector(dismissKeyboardIfNeeded:)];
     tapRecognizer.cancelsTouchesInView = NO;
 
-    self.tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
-    self.tableView.translatesAutoresizingMaskIntoConstraints = NO;
-    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
-    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
-    self.tableView.delegate = self;
-    self.tableView.dataSource = self;
-    self.tableView.estimatedRowHeight = 44.0;
-    [self.tableView addGestureRecognizer:tapRecognizer];
-    [self.view addSubview:self.tableView];
+    UITableView *tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
+    tableView.translatesAutoresizingMaskIntoConstraints = NO;
+    tableView.cellLayoutMarginsFollowReadableWidth = NO;
+    tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+    tableView.delegate = self;
+    tableView.dataSource = self;
+    tableView.estimatedRowHeight = 44.0;
+    [tableView addGestureRecognizer:tapRecognizer];
+    [self.view addSubview:tableView];
 
-    [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
+    self.tableView = tableView;
+
+    [WPStyleGuide configureColorsForView:self.view andTableView:tableView];
 
     // Register Cell Nibs
     NSArray *cellClassNames = @[
@@ -92,7 +94,6 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
         [self.tableView registerNib:tableViewCellNib forCellReuseIdentifier:[cellClass reuseIdentifier]];
         [self.tableView registerNib:tableViewCellNib forCellReuseIdentifier:[cellClass layoutIdentifier]];
     }
-
     
     [self attachSuggestionsTableViewIfNeeded];
     [self attachReplyViewIfNeeded];
@@ -325,7 +326,13 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 - (void)setupCell:(UITableViewCell *)cell
 {
     NSParameterAssert(cell);
-    
+
+    if ([cell isKindOfClass:[WPTableViewCell class]]) {
+        // Temporarily force margins for WPTableViewCell hack.
+        // Brent C. Jul/19/2016
+        [(WPTableViewCell *)cell setForceCustomCellMargins:YES];
+    }
+
     // This is gonna look way better in Swift!
     if ([cell isKindOfClass:[NoteBlockHeaderTableViewCell class]]) {
         [self setupHeaderCell:(NoteBlockHeaderTableViewCell *)cell];

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -9,15 +10,15 @@
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="Upg-EE-wRd" customClass="CommentsTableViewCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" layoutMarginsFollowReadableWidth="YES" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="69.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AUn-YX-qnu" userLabel="Layout View">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
+                    <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AUn-YX-qnu" userLabel="Layout View">
+                        <rect key="frame" x="8" y="0.0" width="304" height="70"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kcl-X2-f1f" customClass="SeparatorsView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
+                                <rect key="frame" x="0.0" y="0.0" width="304" height="70"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -28,7 +29,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq">
-                                <rect key="frame" x="68" y="8" width="240" height="20.5"/>
+                                <rect key="frame" x="68" y="8" width="224" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -41,7 +42,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
-                                <rect key="frame" x="88" y="28.5" width="220" height="20.5"/>
+                                <rect key="frame" x="88" y="28.5" width="204" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -58,7 +59,7 @@
                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="bDl-id-9M7" secondAttribute="bottom" priority="750" constant="9" id="PVc-g0-lrn"/>
                             <constraint firstAttribute="bottom" secondItem="Kcl-X2-f1f" secondAttribute="bottom" id="QxH-g8-9jc"/>
                             <constraint firstAttribute="trailing" secondItem="bDl-id-9M7" secondAttribute="trailing" constant="12" id="WP3-62-HDv"/>
-                            <constraint firstAttribute="trailing" secondItem="Wrp-Wr-ZBq" secondAttribute="trailing" priority="750" constant="12" id="WyT-D4-F81"/>
+                            <constraint firstAttribute="trailing" secondItem="Wrp-Wr-ZBq" secondAttribute="trailing" constant="12" id="WyT-D4-F81"/>
                             <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="Wrp-Wr-ZBq" secondAttribute="top" constant="4" id="Xqq-1P-og4"/>
                             <constraint firstItem="rcg-tb-060" firstAttribute="top" secondItem="Wrp-Wr-ZBq" secondAttribute="bottom" constant="2" id="Zbd-5G-fWz"/>
                             <constraint firstItem="bDl-id-9M7" firstAttribute="leading" secondItem="rcg-tb-060" secondAttribute="trailing" constant="4" id="eSq-C3-JsX"/>
@@ -69,10 +70,10 @@
                     </view>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="AUn-YX-qnu" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leading" id="3mF-u8-Qvl"/>
+                    <constraint firstItem="AUn-YX-qnu" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leadingMargin" id="3mF-u8-Qvl"/>
                     <constraint firstItem="AUn-YX-qnu" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="top" id="Loo-Lw-U24"/>
                     <constraint firstAttribute="bottom" secondItem="AUn-YX-qnu" secondAttribute="bottom" id="lzS-Au-eFv"/>
-                    <constraint firstAttribute="trailing" secondItem="AUn-YX-qnu" secondAttribute="trailing" id="wHU-Ba-gic"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="AUn-YX-qnu" secondAttribute="trailing" id="wHU-Ba-gic"/>
                 </constraints>
             </tableViewCellContentView>
             <inset key="separatorInset" minX="12" minY="0.0" maxX="0.0" maxY="0.0"/>

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -65,7 +65,6 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     [self configureTableViewFooter];
     [self configureTableViewHandler];
     [self configureTableViewLayoutCell];
-    [self adjustTableViewInsetsIfNeeded];
 
     [self refreshAndSyncIfNeeded];
 }
@@ -87,12 +86,6 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     [self.tableViewHandler clearCachedRowHeights];
 }
 
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
-{
-    [super traitCollectionDidChange:previousTraitCollection];
-
-    [self adjustTableViewInsetsIfNeeded];
-}
 
 #pragma mark - Configuration
 
@@ -177,20 +170,6 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     tableViewHandler.cacheRowHeights        = YES;
     tableViewHandler.delegate               = self;
     self.tableViewHandler                   = tableViewHandler;
-}
-
-- (void)adjustTableViewInsetsIfNeeded
-{
-    if ([WPDeviceIdentification isiPad]) {
-        BOOL isPadFullScreen = [self.traitCollection containsTraitsInCollection:[UITraitCollection traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassRegular]];
-        if (isPadFullScreen) {
-            UIEdgeInsets inset = self.tableView.contentInset;
-            inset.top = WPTableViewTopMargin;
-            self.tableView.contentInset = inset;
-        } else {
-            self.tableView.contentInset = UIEdgeInsetsZero;
-        }
-    }
 }
 
 #pragma mark - UITableViewDelegate Methods

--- a/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
@@ -93,7 +93,6 @@ class DomainsListViewController: UITableViewController, ImmuTablePresenter {
 
         title = NSLocalizedString("Domains", comment: "Title for the Domains list")
 
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
 
         if let dotComID = blog.dotComID {

--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.xib
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AboutViewController" customModule="WordPress" customModuleProvider="target">
@@ -11,10 +10,10 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="fZ7-an-PJC">
+        <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="fZ7-an-PJC">
             <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
         </tableView>
     </objects>
 </document>

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -33,7 +33,6 @@ public class AppSettingsViewController: UITableViewController {
         handler = ImmuTableViewHandler(takeOver: self)
         handler.viewModel = tableViewModel()
 
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -54,7 +54,6 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
         refreshAccountDetails()
 
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.m
@@ -546,6 +546,10 @@ static NSInteger NotificationSectionCount               = 1;
 
 - (void)setupCell:(NoteBlockTableViewCell *)cell blockGroup:(NotificationBlockGroup *)blockGroup
 {
+    // Temporarily force margins for WPTableViewCell hack.
+    // Brent C. Jul/19/2016
+    cell.forceCustomCellMargins = YES;
+
     // Note: This is gonna look awesome in Swift
     if (blockGroup.type == NoteBlockGroupTypeHeader) {
         [self setupHeaderCell:(NoteBlockHeaderTableViewCell *)cell blockGroup:blockGroup];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -67,8 +67,6 @@ public class NotificationSettingDetailsViewController : UITableViewController
 
         // Style!
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-
-        tableView.cellLayoutMarginsFollowReadableWidth = false
     }
 
     @IBAction func reloadTable() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -54,8 +54,6 @@ public class NotificationSettingStreamsViewController : UITableViewController
 
         // Style!
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-
-        tableView.cellLayoutMarginsFollowReadableWidth = false
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -49,8 +49,6 @@ public class NotificationSettingsViewController : UIViewController
 
         // Style!
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-
-        tableView.cellLayoutMarginsFollowReadableWidth = false
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NotificationSettingsViewController" customModule="WordPress" customModuleProvider="target">
@@ -17,7 +16,7 @@
             <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="n1E-Bx-YgH">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" translatesAutoresizingMaskIntoConstraints="NO" id="n1E-Bx-YgH">
                     <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                     <connections>

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+Extensions.swift
@@ -46,6 +46,7 @@ extension NotificationsViewController
 
         // UITableView
         tableView.accessibilityIdentifier  = "Notifications Table"
+        tableView.cellLayoutMarginsFollowReadableWidth = false
         WPStyleGuide.configureColorsForView(view, andTableView:tableView)
     }
 
@@ -261,6 +262,7 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
         let isMarkedForDeletion     = isNoteMarkedForDeletion(note.objectID)
         let isLastRow               = tableViewHandler.resultsController.isLastIndexPathInSection(indexPath)
 
+        cell.forceCustomCellMargins = true
         cell.attributedSubject      = note.subjectBlock()?.attributedSubjectText()
         cell.attributedSnippet      = note.snippetBlock()?.attributedSnippetText()
         cell.read                   = note.read.boolValue

--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -209,7 +209,7 @@
                         <sections>
                             <tableViewSection id="5Np-Zr-9XP">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="88" id="VTq-Of-ZQm" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="88" id="VTq-Of-ZQm" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="35" width="600" height="88"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="VTq-Of-ZQm" id="v2L-Gv-S2P">
@@ -264,7 +264,7 @@
                             </tableViewSection>
                             <tableViewSection id="8p7-Vy-ixj">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="4sp-JN-Bx2" detailTextLabel="T95-Yj-X6p" style="IBUITableViewCellStyleValue1" id="o1C-ov-hGM" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="4sp-JN-Bx2" detailTextLabel="T95-Yj-X6p" style="IBUITableViewCellStyleValue1" id="o1C-ov-hGM" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="159" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="o1C-ov-hGM" id="HfA-TE-ytF">
@@ -288,7 +288,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="tmz-lK-Wvy" detailTextLabel="D2b-CS-14p" style="IBUITableViewCellStyleValue1" id="pV6-Ik-qI1" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="tmz-lK-Wvy" detailTextLabel="D2b-CS-14p" style="IBUITableViewCellStyleValue1" id="pV6-Ik-qI1" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="203" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pV6-Ik-qI1" id="5fS-CZ-T2g">
@@ -312,7 +312,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="Pm6-os-m4g" detailTextLabel="dAy-Pc-MaL" style="IBUITableViewCellStyleValue1" id="7Gu-cx-Zbk" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="Pm6-os-m4g" detailTextLabel="dAy-Pc-MaL" style="IBUITableViewCellStyleValue1" id="7Gu-cx-Zbk" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="247" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7Gu-cx-Zbk" id="g2l-de-pk6">
@@ -336,7 +336,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="FPE-fh-8t7" detailTextLabel="H0N-bf-Yh1" style="IBUITableViewCellStyleValue1" id="tAU-rX-e3c" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="FPE-fh-8t7" detailTextLabel="H0N-bf-Yh1" style="IBUITableViewCellStyleValue1" id="tAU-rX-e3c" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="291" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="tAU-rX-e3c" id="AJR-SK-Yg6">
@@ -364,7 +364,7 @@
                             </tableViewSection>
                             <tableViewSection id="TkT-75-L4b">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="oVe-xS-Qxh" style="IBUITableViewCellStyleDefault" id="2lp-Fq-KG5" customClass="WPTableViewCell">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="oVe-xS-Qxh" style="IBUITableViewCellStyleDefault" id="2lp-Fq-KG5" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="371" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2lp-Fq-KG5" id="Y1J-8j-FCu">
@@ -412,7 +412,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="q0k-QX-oPY">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                         <sections>
                             <tableViewSection id="TSO-dY-4Cz">
                                 <cells>
@@ -427,7 +427,7 @@
                                                     <rect key="frame" x="15" y="12" width="74.5" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="igf-wZ-skT">
@@ -458,7 +458,7 @@
                                                     <rect key="frame" x="15" y="12" width="32" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="w3p-Ei-KVz">
@@ -538,7 +538,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="U01-Fw-ZiF">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="7bM-Qc-hri" id="vdJ-54-Tvk"/>
                             <outlet property="delegate" destination="7bM-Qc-hri" id="MUH-xN-W5Q"/>
@@ -556,7 +556,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="ibd-2Q-Phm">
                         <rect key="frame" x="0.0" y="44" width="600" height="556"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="OAN-Wl-zn9" id="DqT-Mq-i56"/>
                             <outlet property="delegate" destination="OAN-Wl-zn9" id="Ixm-UX-ILF"/>

--- a/WordPress/Classes/ViewRelated/People/PeopleCell.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleCell.swift
@@ -9,6 +9,7 @@ class PeopleCell: WPTableViewCell {
     @IBOutlet var superAdminRoleBadge: PeopleRoleBadgeLabel!
 
     override func awakeFromNib() {
+        forceCustomCellMargins = true
         displayNameLabel.font = WPFontManager.merriweatherBoldFontOfSize(14)
     }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -154,6 +154,8 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Add,
                                                             target: self,
                                                             action: #selector(invitePersonWasPressed))
+
+        tableView.cellLayoutMarginsFollowReadableWidth = false
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
 
         // By default, let's display the Blog's Users

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -405,3 +405,12 @@ private extension PersonViewController {
         return person as? User
     }
 }
+
+
+// MARK: Private Cell
+//
+class PersonCell : WPTableViewCell {
+    override func awakeFromNib() {
+        forceCustomCellMargins = true
+    }
+}

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -96,7 +96,6 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
         ImmuTable.registerRows([PlanListRow.self], tableView: tableView)
         handler.viewModel = viewModel.tableViewModelWithPresenter(self, planService: service)

--- a/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
@@ -41,7 +41,6 @@ static const CGFloat CategoryCellIndentation = 16.0;
     [super viewDidLoad];
 
     self.tableView.accessibilityIdentifier = @"CategoriesList";
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     // Hide extra cell separators.
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];

--- a/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
@@ -160,10 +160,6 @@ static const CGFloat CategoryCellIndentation = 16.0;
 {
     WPTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CategoryCellIdentifier forIndexPath:indexPath];
     
-    // HACK: We use zero here, because the the separator inset will do the work we want
-    cell.indentationLevel = 0;
-    cell.indentationWidth = CategoryCellIndentation;
-    
     NSInteger row = indexPath.row; // Use this index for the remainder for this method.
     
     // When showing this VC in mode CategoriesSelectionModeParent, we want the first item to be
@@ -191,7 +187,8 @@ static const CGFloat CategoryCellIndentation = 16.0;
     
     PostCategory* category = self.categories[row];
     NSInteger indentationLevel = [[self.categoryIndentationDict objectForKey:[category.categoryID stringValue]] integerValue];
-    cell.separatorInset = UIEdgeInsetsMake(0, (indentationLevel+1) * cell.indentationWidth, 0, 0);
+    cell.indentationLevel = indentationLevel;
+    cell.indentationWidth = CategoryCellIndentation;
     cell.textLabel.text = [category.categoryName stringByDecodingXMLCharacters];
     [WPStyleGuide configureTableViewCell:cell];
 

--- a/WordPress/Classes/ViewRelated/Post/Categories/WPAddPostCategoryViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Categories/WPAddPostCategoryViewController.m
@@ -51,7 +51,6 @@ static const CGFloat HorizontalMargin = 15.0f;
 
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
                                                                                           target:self action:@selector(dismiss:)];
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -109,7 +109,6 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
     DDLogInfo(@"%@ %@", self, NSStringFromSelector(_cmd));
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 
     self.visibilityList = @[NSLocalizedString(@"Public", @"Privacy setting for posts set to 'Public' (default). Should be the same as in core WP."),

--- a/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
@@ -42,7 +42,6 @@ static CGFloat const FollowSitesRowHeight = 54.0;
     self.tableViewHandler = [[WPTableViewHandler alloc] initWithTableView:self.tableView];
     self.tableViewHandler.delegate = self;
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
@@ -167,7 +167,9 @@ static CGFloat const FollowSitesRowHeight = 54.0;
 {
     UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:SiteCellIdentifier];
     if (!cell) {
-        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:SiteCellIdentifier];
+        WPTableViewCell *wpCell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:SiteCellIdentifier];
+        wpCell.forceCustomCellMargins = YES;
+        cell = wpCell;
     }
     [self configureCell:cell atIndexPath:indexPath];
     return cell;

--- a/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/FollowedSitesViewController.m
@@ -30,6 +30,7 @@ static CGFloat const FollowSitesRowHeight = 54.0;
 
     self.tableView = [[UITableView alloc] initWithFrame:self.view.bounds style:UITableViewStyleGrouped];
     self.tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     [self.view addSubview:self.tableView];
 
     if (IS_IPHONE) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.m
@@ -28,6 +28,9 @@ static const CGFloat ReaderCommentCellBottomPaddingMore = -20.0;
 {
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
+
+        self.forceCustomCellMargins = YES;
+
         UIView *selectedBackgroundView = [[UIView alloc] initWithFrame:self.bounds];
         selectedBackgroundView.backgroundColor = [UIColor whiteColor];
         self.selectedBackgroundView = selectedBackgroundView;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -305,6 +305,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 {
     self.tableView = [[UITableView alloc] initWithFrame:self.view.bounds style:UITableViewStylePlain];
     self.tableView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     [self.view addSubview:self.tableView];
 
     [self.tableView registerClass:[ReaderCommentCell class] forCellReuseIdentifier:CommentCellIdentifier];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -92,7 +92,6 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         assert(tableViewController != nil, "The tableViewController must be assigned before configuring the tableView")
 
         tableView = tableViewController.tableView
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
 
         refreshControl = tableViewController.refreshControl!
         refreshControl.addTarget(self, action: #selector(ReaderStreamViewController.handleRefresh(_:)), forControlEvents: .ValueChanged)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -274,6 +274,10 @@ extension ReaderFollowedSitesViewController : WPTableViewHandlerDelegate
             return
         }
 
+        if let wpCell = cell as? WPTableViewCell {
+            wpCell.forceCustomCellMargins = true
+        }
+
         cell.accessoryType = .DisclosureIndicator
         cell.imageView?.backgroundColor = WPStyleGuide.greyLighten30()
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -76,7 +76,6 @@ import WordPressShared
 
 
     func configureTableView() {
-        WPStyleGuide.resetReadableMarginsForTableView(tableView)
 
         tableView.registerClass(WPTableViewCell.self, forCellReuseIdentifier: defaultCellIdentifier)
         tableView.registerClass(WPTableViewCell.self, forCellReuseIdentifier: actionCellIdentifier)

--- a/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
@@ -47,7 +47,6 @@
     self.tableViewHandler = [[WPTableViewHandler alloc] initWithTableView:self.tableView];
     self.tableViewHandler.delegate = self;
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/RecommendedTopicsViewController.m
@@ -32,6 +32,7 @@
     }
 
     self.tableView = [[UITableView alloc] initWithFrame:self.view.bounds style:UITableViewStyleGrouped];
+    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     self.tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.tableView.rowHeight = 44.0;
     self.tableView.estimatedRowHeight = 44.0;
@@ -134,6 +135,11 @@
 
 - (void)configureCell:(UITableViewCell *)cell atIndexPath:(NSIndexPath *)indexPath
 {
+    if ([cell isKindOfClass:[WPTableViewCell class]]) {
+        WPTableViewCell *wpCell = (WPTableViewCell *)cell;
+        wpCell.forceCustomCellMargins = YES;
+    }
+
     if ([cell.textLabel.text length] == 0) {
         // The sizeToFit call in [WPStyleGuide configureTableViewCell:] seems to mess with the
         // UI when cells are configured the first time round and the modal animation is playing.

--- a/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
@@ -42,7 +42,6 @@
     self.tableViewHandler = [[WPTableViewHandler alloc] initWithTableView:self.tableView];
     self.tableViewHandler.delegate = self;
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/SubscribedTopicsViewController.m
@@ -28,6 +28,7 @@
     self.title = NSLocalizedString(@"Followed Topics", @"Page title for the list of subscribed topics.");
 
     self.tableView = [[UITableView alloc] initWithFrame:self.view.bounds style:UITableViewStyleGrouped];
+    self.tableView.cellLayoutMarginsFollowReadableWidth = NO;
     self.tableView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.tableView.rowHeight = 44.0;
     self.tableView.estimatedRowHeight = 44.0;
@@ -155,6 +156,11 @@
 
 - (void)configureCell:(UITableViewCell *)cell atIndexPath:(NSIndexPath *)indexPath
 {
+    if ([cell isKindOfClass:[WPTableViewCell class]]) {
+        WPTableViewCell *wpCell = (WPTableViewCell *)cell;
+        wpCell.forceCustomCellMargins = YES;
+    }
+
     if ([cell.textLabel.text length] == 0) {
         // The sizeToFit call in [WPStyleGuide configureTableViewCell:] seems to mess with the
         // UI when cells are configured the first time round and the modal animation is playing.

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogDetailViewController.m
@@ -25,19 +25,29 @@
 {
     [super viewDidLoad];
 
-    self.textView = [[UITextView alloc] initWithFrame:self.view.bounds];
-    self.textView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-    self.textView.editable = NO;
-    self.textView.text = self.logText;
-    self.textView.font = [WPStyleGuide subtitleFont];
-    [self.view addSubview:self.textView];
+    [WPStyleGuide configureColorsForView:self.view andTableView:nil];
+
+    UITextView *textView = [[UITextView alloc] initWithFrame:self.view.bounds];
+    textView.editable = NO;
+    textView.text = self.logText;
+    textView.font = [WPStyleGuide subtitleFont];
+    textView.backgroundColor = [UIColor whiteColor];
+    [self.view addSubview:textView];
+    textView.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    UILayoutGuide *readableGuide = self.view.readableContentGuide;
+    [NSLayoutConstraint activateConstraints:@[
+                                              [textView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
+                                              [textView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+                                              [textView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
+                                              [textView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
+                                              ]];
+    self.textView = textView;
 
     UIBarButtonItem *shareButton = nil;
-
     shareButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction
                                                                 target:self
                                                                 action:@selector(showShareOptions:)];
-
     self.navigationItem.rightBarButtonItem = shareButton;
 }
 

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogDetailViewController.m
@@ -27,7 +27,7 @@
 
     [WPStyleGuide configureColorsForView:self.view andTableView:nil];
 
-    UITextView *textView = [[UITextView alloc] initWithFrame:self.view.bounds];
+    UITextView *textView = [[UITextView alloc] init];
     textView.editable = NO;
     textView.text = self.logText;
     textView.font = [WPStyleGuide subtitleFont];
@@ -44,8 +44,7 @@
                                               ]];
     self.textView = textView;
 
-    UIBarButtonItem *shareButton = nil;
-    shareButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction
+    UIBarButtonItem *shareButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction
                                                                 target:self
                                                                 action:@selector(showShareOptions:)];
     self.navigationItem.rightBarButtonItem = shareButton;

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
@@ -45,7 +45,6 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
     
     [self.tableView setRowHeight:WPTableViewDefaultRowHeight];
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self loadLogFiles];
 

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -99,7 +99,6 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
     [self.tableView setRowHeight:WPTableViewDefaultRowHeight];
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
 
     [self.navigationController setNavigationBarHidden:NO animated:YES];
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListEditorViewController.swift
@@ -55,7 +55,6 @@ public class SettingsListEditorViewController : UITableViewController
 
     private func setupTableView() {
         tableView.registerClass(WPTableViewCell.self, forCellReuseIdentifier: reuseIdentifier)
-        tableView.cellLayoutMarginsFollowReadableWidth = false
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsListPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsListPickerViewController.swift
@@ -67,7 +67,6 @@ class SettingsListPickerViewController<T:Equatable> : UITableViewController
 
     // MARK: - Setup Helpers
     private func setupTableView() {
-        tableView.cellLayoutMarginsFollowReadableWidth = false
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -46,7 +46,6 @@ static CGFloat const SettingsMinHeight = 41.0f;
 {
     [super viewDidLoad];
     self.tableView.allowsSelection = NO;
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 
@@ -63,17 +62,35 @@ static CGFloat const SettingsMinHeight = 41.0f;
     }
     _textViewCell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
     _textViewCell.selectionStyle = UITableViewCellSelectionStyleNone;
-    self.textView = [[UITextView alloc] initWithFrame:CGRectInset(self.textViewCell.bounds, SettingsTextPadding.dx, SettingsTextPadding.dy)];
-    self.textView.text = self.text;
-    self.textView.returnKeyType = UIReturnKeyDefault;
-    self.textView.keyboardType = UIKeyboardTypeDefault;
-    self.textView.secureTextEntry = self.isPassword;
-    self.textView.font = [WPStyleGuide tableviewTextFont];
-    self.textView.textColor = [WPStyleGuide darkGrey];
-    self.textView.delegate = self;
-    self.textView.scrollEnabled = NO;
-    [_textViewCell.contentView addSubview:self.textView];
-    
+
+    UITextView *textView = [[UITextView alloc] initWithFrame:CGRectInset(self.textViewCell.bounds, SettingsTextPadding.dx, SettingsTextPadding.dy)];
+    textView.text = self.text;
+    textView.returnKeyType = UIReturnKeyDefault;
+    textView.keyboardType = UIKeyboardTypeDefault;
+    textView.secureTextEntry = self.isPassword;
+    textView.font = [WPStyleGuide tableviewTextFont];
+    textView.textColor = [WPStyleGuide darkGrey];
+    textView.delegate = self;
+    textView.scrollEnabled = NO;
+
+    UIEdgeInsets textInset = textView.textContainerInset;
+    textInset.left = 0.0;
+    textInset.right = 0.0;
+    textView.textContainerInset = textInset;
+    textView.textContainer.lineFragmentPadding = 0.0;
+
+    [_textViewCell.contentView addSubview:textView];
+    textView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    UILayoutGuide *readableGuide = _textViewCell.contentView.readableContentGuide;
+    [NSLayoutConstraint activateConstraints:@[
+                                              [textView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
+                                              [textView.topAnchor constraintEqualToAnchor:_textViewCell.contentView.topAnchor],
+                                              [textView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
+                                              [textView.bottomAnchor constraintEqualToAnchor:_textViewCell.contentView.bottomAnchor],
+                                              ]];
+    self.textView = textView;
+
     return _textViewCell;
 }
 
@@ -127,15 +144,13 @@ static CGFloat const SettingsMinHeight = 41.0f;
 
 - (void)adjustCellSize
 {
-    CGFloat widthInUse = CGRectGetWidth(self.textView.frame);
-    CGFloat widthAvailable = CGRectGetWidth(self.textViewCell.contentView.bounds) - (2 * SettingsTextPadding.dx);
-    CGSize size = [self.textView sizeThatFits:CGSizeMake(widthAvailable, CGFLOAT_MAX)];
+    CGSize size = [self.textView sizeThatFits:CGSizeMake(self.textView.frame.size.width, CGFLOAT_MAX)];
     CGFloat height = size.height;
 
-    if (fabs(self.tableView.rowHeight - height) > (self.textView.font.lineHeight * 0.5f) || widthInUse != widthAvailable)
+    if (fabs(self.tableView.rowHeight - height) > (self.textView.font.lineHeight * 0.5f))
     {
         [self.tableView beginUpdates];
-        self.textView.frame = CGRectMake(SettingsTextPadding.dx, SettingsTextPadding.dy, widthAvailable, height);
+        self.textView.frame = CGRectMake(SettingsTextPadding.dx, SettingsTextPadding.dy, self.textView.frame.size.width, height);
         self.tableView.rowHeight = MAX(height, SettingsMinHeight) + SettingsTextPadding.dy;
         [self.tableView endUpdates];
     }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -63,7 +63,7 @@ static CGFloat const SettingsMinHeight = 41.0f;
     _textViewCell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
     _textViewCell.selectionStyle = UITableViewCellSelectionStyleNone;
 
-    UITextView *textView = [[UITextView alloc] initWithFrame:CGRectInset(self.textViewCell.bounds, SettingsTextPadding.dx, SettingsTextPadding.dy)];
+    UITextView *textView = [[UITextView alloc] init];
     textView.text = self.text;
     textView.returnKeyType = UIReturnKeyDefault;
     textView.keyboardType = UIKeyboardTypeDefault;

--- a/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
@@ -61,8 +61,6 @@ public class SettingsPickerViewController : UITableViewController
     // MARK: - Setup Helpers
     private func setupTableView() {
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-
-        tableView.cellLayoutMarginsFollowReadableWidth = false
         tableView.estimatedRowHeight = estimatedRowHeight
         tableView.rowHeight = UITableViewAutomaticDimension
     }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
@@ -61,7 +61,6 @@ CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
 
     [self configureCancelButton];
 
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -84,7 +84,6 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     self.shouldNotifyValue = YES;
 
     [self startListeningTextfieldChanges];
-    [WPStyleGuide resetReadableMarginsForTableView:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -177,9 +177,18 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
         return _textFieldCell;
     }
     _textFieldCell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
+    _textFieldCell.selectionStyle = UITableViewCellSelectionStyleNone;
     [_textFieldCell.contentView addSubview:self.textField];
-    _textField.frame = CGRectInset(_textFieldCell.bounds, SettingsTextHorizontalMargin, 0);
-    
+
+    self.textField.translatesAutoresizingMaskIntoConstraints = NO;
+    UILayoutGuide *readableGuide = _textFieldCell.contentView.readableContentGuide;
+    [NSLayoutConstraint activateConstraints:@[
+                                               [self.textField.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
+                                               [self.textField.topAnchor constraintEqualToAnchor:_textFieldCell.contentView.topAnchor],
+                                               [self.textField.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor],
+                                               [self.textField.bottomAnchor constraintEqualToAnchor:_textFieldCell.contentView.bottomAnchor],
+                                               ]];
+
     return _textFieldCell;
 }
 
@@ -212,7 +221,6 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     _textField.placeholder = self.placeholder;
     _textField.returnKeyType = UIReturnKeyDone;
     _textField.keyboardType = UIKeyboardTypeDefault;
-    _textField.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     _textField.delegate = self;
     _textField.autocorrectionType = self.autocorrectionType;
     


### PR DESCRIPTION
Rebuilt from: https://github.com/wordpress-mobile/WordPress-iOS/pull/5761

Part II of readability support actually starts to follow readable margins and content guides.

For the most part, we're really only tackling views and controllers that can support readability without many changes. We have cleaned up a few spots along the way, with a bit of use of `UIStackView`. Other views and controllers use the new `WPTableVieCell` toggle of `forceCustomCellMargins` to temporarily restrict the layout until those can be properly updated.

For this PR, note:

1. First requires reviewing, merging, and updating to WP-iOS-Shared pod `0.6.0` via PR: https://github.com/wordpress-mobile/WordPress-Shared-iOS/pull/105.
2. Merging this PR should happen alongside merging https://github.com/wordpress-mobile/WordPress-iOS/pull/5756.

To test:

(1.) Ensure the following views/controllers, on iPad, are following the default readable margins in both landscape and portrait orientation:

- Blog list
- Blog Details
  - Plans
  - Comments
  - Sharing
  - Settings
- Me tab
  - My Profile
  - Account Settings
  - App Settings
  - Notification Settings
  - Help & Support
- Reader tab
  - Followed Sites "Manage"
- Post Settings
  - Categories (with parent/child indentation)
  - Featured image
  - Location

(2.) Ensure the following views/controller are using the original margin hack (until they can be adapted):

- Notifications
- CommentViewController (when viewing a single comment)
- Pages
- Blog Posts
- People

Note: This PR will build with mis-aligned header views which are instead resolved via part 1: https://github.com/wordpress-mobile/WordPress-iOS/pull/5756
Note: Reader posts/cards are untouched for this go around.

Needs review: @frosty ready for your inspection sir 😁 👀 
