### PR TITLE
Remove post visibility icon as preview

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1259,18 +1259,12 @@ EditImageDetailsViewControllerDelegate
 - (UIBarButtonItem *)previewBarButtonItem
 {
 	if (!_previewBarButtonItem) {
-        UIImage *image = [Gridicon iconOfType:GridiconTypeVisible];
-        WPButtonForNavigationBar* button = [self buttonForBarWithImage:image
-                                                                 frame:NavigationBarButtonRect
+        NSString *buttonTitle = NSLocalizedString(@"Preview", @"Action button to preview the content of post or page on the  live site");
+        _previewBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:buttonTitle
+                                                                 style:[WPStyleGuide barButtonStyleForDone]
                                                                 target:self
-                                                              selector:@selector(showPreview)];
-        
-        button.removeDefaultRightSpacing = YES;
-        button.rightSpacing = SpacingBetweeenNavbarButtons / 2.0f;
-        button.removeDefaultLeftSpacing = YES;
-        button.leftSpacing = SpacingBetweeenNavbarButtons / 2.0f;
-        _previewBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:button];
-        _previewBarButtonItem.accessibilityLabel = NSLocalizedString(@"Preview", @"Action button to preview the content of post or page on the  live site");
+                                                                action:@selector(showPreview)];
+        _previewBarButtonItem.accessibilityLabel = buttonTitle;
     }
 	
 	return _previewBarButtonItem;


### PR DESCRIPTION
Fixes #5687 

Removing `GridIconVisible` as that's for post visiblity in WordPress (generally). Changing to `Preview` text.

![simulator screen shot jul 21 2016 11 03 16 pm](https://cloud.githubusercontent.com/assets/1158819/17046306/55096414-4f97-11e6-8c06-f988d59cbdd7.png)


To test: Verify eye GridIcon is now "Preview" and that clicking it still opens the preview

Needs review: @sendhil 
