### PR TITLE
Removing gridicon visible as that's for post visiblity in WordPress (…

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -63,7 +63,7 @@ NSString *const kWPEditorConfigURLParamAvailable = @"available";
 NSString *const kWPEditorConfigURLParamEnabled = @"enabled";
 
 static CGFloat const RightSpacingOnExitNavbarButton = 5.0f;
-static CGFloat const CompactTitleButtonWidth = 125.0f;
+static CGFloat const CompactTitleButtonWidth = 100.0f;
 static CGFloat const RegularTitleButtonWidth = 300.0f;
 static CGFloat const RegularTitleButtonHeight = 30.0f;
 static NSDictionary *DisabledButtonBarStyle;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1225,13 +1225,12 @@ EditImageDetailsViewControllerDelegate
 - (UIBarButtonItem *)previewBarButtonItem
 {
 	if (!_previewBarButtonItem) {
-        UIImage *image = [Gridicon iconOfType:GridiconTypeVisible];
-        WPButtonForNavigationBar* button = [WPStyleGuide buttonForBarWithImage:image
+        NSString *buttonTitle = NSLocalizedString(@"Preview", @"Action button to preview the content of post or page on the  live site");
+        _previewBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:buttonTitle
+                                                                 style:[WPStyleGuide barButtonStyleForDone]
                                                                 target:self
-                                                              selector:@selector(showPreview)];
-        
-        _previewBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:button];
-        _previewBarButtonItem.accessibilityLabel = NSLocalizedString(@"Preview", @"Action button to preview the content of post or page on the  live site");
+                                                                action:@selector(showPreview)];
+        _previewBarButtonItem.accessibilityLabel = buttonTitle;
     }
 	
 	return _previewBarButtonItem;


### PR DESCRIPTION
Fixes #5687 

Removing `GridIconVisible` as that's for post visiblity in WordPress (generally). Changing to `Preview` text.

![simulator screen shot jul 21 2016 11 03 16 pm](https://cloud.githubusercontent.com/assets/1158819/17046306/55096414-4f97-11e6-8c06-f988d59cbdd7.png)


To test: Verify eye GridIcon is now "Preview" and that clicking it still opens the preview

Needs review: @sendhil 