### PR TITLE
AbstractPostList: Hides table header (search bar) when displaying no results

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -313,14 +313,18 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     // MARK: - GUI: No results view logic
 
     private func hideNoResultsView() {
+        tableView.tableHeaderView?.hidden = false
         postListFooterView.hidden = false
+
         noResultsView.removeFromSuperview()
     }
 
     private func showNoResultsView() {
         precondition(refreshNoResultsView != nil)
 
+        tableView.tableHeaderView?.hidden = true
         postListFooterView.hidden = true
+
         refreshNoResultsView(noResultsView)
 
         // Only add and animate no results view if it isn't already


### PR DESCRIPTION
Fixes #5765. We were only hiding the table footer when no results were available, but the newly added table header (search bar) was still being displayed, obscuring the no results view on small screens. Now we hide both.

To test: Verify that the posts list now displays correctly on the iPhone 4S, and ensure that the search bar is appropriately hidden / shown when the screen transitions between no results / results states.

Needs review: @aerych 
Thanks!