### PR TITLE
Share Extension: Empty Posts

### DIFF
--- a/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
+++ b/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
@@ -33,6 +33,12 @@ extension NSExtensionContext {
         }
     }
 
+    /// Verifies if the Context contains an Image Attachment, or not
+    ///
+    func containsMediaAttachment() -> Bool {
+        return firstItemProviderConformingToTypeIdentifier(Identifier.PublicImage) != nil
+    }
+
 
 
     // MARK: - Private

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -104,7 +104,10 @@ class ShareViewController: SLComposeServiceViewController {
         // Even when the oAuth Token is nil, it's possible the default site hasn't been retrieved yet.
         // Let's disable Post, until the user picks a valid site.
         //
-        return selectedSiteID != nil
+        let containsMedia = extensionContext?.containsMediaAttachment() ?? false
+        let containsText = contentText.isEmpty == false
+
+        return selectedSiteID != nil && (containsText || containsMedia)
     }
 
     override func didSelectCancel() {


### PR DESCRIPTION
#### Details:
This PR updates the `Post` button logic, so that it's disabled whenever there is actually no content.

--

#### Scenario A: Empty text with attachments
1. Launch the Share Extension from Photos.app
2. Make sure the TextView's content is empty
3. Verify that the **Post** button is enabled

Please, try posting to both, dotcom and self-hosted (empty text with attachments). Verify that everything works as expected

#### Scenario B: No Attachments
1. Launch the Share Extension from Safari.app
2. Verify that the **Post** button is enabled
3. Nuke the TextView's contents
4. Verify that the **Post** button gets disabled
5. Add at least a character. Verify that the button gets enabled again.


Needs review: @astralbodies 
Aaron, up for a quick review?

Thanks!!!
