### PR TITLE
Using new method name for handling defaultAccount change (logging out)

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.m
@@ -56,7 +56,7 @@ static NSTimeInterval NotificationsUndoTimeout          = 4;
 
         // Listen to Logout Notifications
         NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
-        [nc addObserver:self selector:@selector(handleDefaultAccountChangedNote:) name:WPAccountDefaultWordPressComAccountChangedNotification object:nil];
+        [nc addObserver:self selector:@selector(defaultAccountDidChange:) name:WPAccountDefaultWordPressComAccountChangedNotification object:nil];
         
         // All of the data will be fetched during the FetchedResultsController init. Prevent overfetching
         self.lastReloadDate = [NSDate date];


### PR DESCRIPTION
The name of the selector method changed.

To test:
Log out and the app shouldn't crash

Needs review: @jleandroperez 

Feel free to merge if this work for you @jleandroperez, and once this is merged, #5723 can be merged by you 👍 