### PR TITLE
Bump Tracks pod to 0.1.1 to include networking fixes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -42,7 +42,7 @@ abstract_target 'WordPress_Base' do
     # --------------------
     # WordPress components
     # --------------------
-    pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.1.0'
+    pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.1.1'
     pod 'Gridicons', '0.2'
     pod 'NSObject-SafeExpectations', '0.0.2'
     pod 'NSURL+IDN', '0.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
     - AFNetworking/NSURLSession
   - Alamofire (3.4.1)
   - AMPopTip (0.10.2)
-  - Automattic-Tracks-iOS (0.1.0):
+  - Automattic-Tracks-iOS (0.1.1):
     - CocoaLumberjack (~> 2.2.0)
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 0.4)
@@ -192,7 +192,7 @@ DEPENDENCIES:
   - 1PasswordExtension (= 1.8.1)
   - AFNetworking (= 3.1.0)
   - AMPopTip (~> 0.7)
-  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, tag `0.1.0`)
+  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, tag `0.1.1`)
   - CocoaLumberjack (~> 2.2.0)
   - Crashlytics
   - DTCoreText (= 1.6.16)
@@ -229,7 +229,7 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.1.0
+    :tag: 0.1.1
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
@@ -240,7 +240,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.1.0
+    :tag: 0.1.1
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
@@ -253,7 +253,7 @@ SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   Alamofire: 01a82e2f6c0f860ade35534c8dd88be61bdef40c
   AMPopTip: 0788a9452806049e3aa0d6d09324606fc41ea646
-  Automattic-Tracks-iOS: 5b76290a74355cc8be18e5177b4af58774a63a46
+  Automattic-Tracks-iOS: b130494633946a970ffe70c02461cf61c2bf488a
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   Crashlytics: 130ab943f8c78cda7a814b434f270b2e2c8a3cba
   DTCoreText: 934a16fe9ffdd169c96261721b39dc312b75713d
@@ -288,6 +288,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 645ecc2435293cc898c76180f3994358a68cae20
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 1323241e9ee269572f284db3b4c8995414756fae
+PODFILE CHECKSUM: f147b7aeb93d9a4808ce84fd9c38b94e07ee1e0b
 
 COCOAPODS: 1.0.1


### PR DESCRIPTION
Re-Do of #5776

Bumps the Tracks pod to 0.1.1 which includes a fix for HTTP errors preventing events from getting cleared and not using the shared NSURLSession.

Needs review: @sendhil


