### PR TITLE
Readability: Revised People Management layout.

### DIFF
--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -22,8 +22,8 @@
                             <rect key="frame" x="0.0" y="136.5" width="600" height="30"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
-                                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="L1Z-xm-37g">
-                                    <rect key="frame" x="110" y="5" width="20" height="20"/>
+                                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="L1Z-xm-37g">
+                                    <rect key="frame" x="290" y="5" width="20" height="20"/>
                                 </activityIndicatorView>
                             </subviews>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>

--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -4,11 +4,6 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
-    <customFonts key="customFonts">
-        <mutableArray key="Merriweather-Bold.ttf">
-            <string>Merriweather-Bold</string>
-        </mutableArray>
-    </customFonts>
     <scenes>
         <!--Team-->
         <scene sceneID="0Jd-lB-cu0">
@@ -52,7 +47,7 @@
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="18" id="1up-XI-AiZ"/>
                                             </constraints>
-                                            <fontDescription key="fontDescription" name="Merriweather-Bold" family="Merriweather" pointSize="14"/>
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                             <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>

--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5ll-RY-leg">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="5ll-RY-leg">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -209,7 +209,7 @@
                         <sections>
                             <tableViewSection id="5Np-Zr-9XP">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="88" id="VTq-Of-ZQm" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="88" id="VTq-Of-ZQm" customClass="WPTableViewCell">
                                         <rect key="frame" x="0.0" y="35" width="600" height="88"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="VTq-Of-ZQm" id="v2L-Gv-S2P">
@@ -264,7 +264,7 @@
                             </tableViewSection>
                             <tableViewSection id="8p7-Vy-ixj">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="4sp-JN-Bx2" detailTextLabel="T95-Yj-X6p" style="IBUITableViewCellStyleValue1" id="o1C-ov-hGM" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="4sp-JN-Bx2" detailTextLabel="T95-Yj-X6p" style="IBUITableViewCellStyleValue1" id="o1C-ov-hGM" customClass="WPTableViewCell">
                                         <rect key="frame" x="0.0" y="159" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="o1C-ov-hGM" id="HfA-TE-ytF">
@@ -288,7 +288,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="tmz-lK-Wvy" detailTextLabel="D2b-CS-14p" style="IBUITableViewCellStyleValue1" id="pV6-Ik-qI1" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="tmz-lK-Wvy" detailTextLabel="D2b-CS-14p" style="IBUITableViewCellStyleValue1" id="pV6-Ik-qI1" customClass="WPTableViewCell">
                                         <rect key="frame" x="0.0" y="203" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pV6-Ik-qI1" id="5fS-CZ-T2g">
@@ -312,7 +312,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="Pm6-os-m4g" detailTextLabel="dAy-Pc-MaL" style="IBUITableViewCellStyleValue1" id="7Gu-cx-Zbk" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="Pm6-os-m4g" detailTextLabel="dAy-Pc-MaL" style="IBUITableViewCellStyleValue1" id="7Gu-cx-Zbk" customClass="WPTableViewCell">
                                         <rect key="frame" x="0.0" y="247" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7Gu-cx-Zbk" id="g2l-de-pk6">
@@ -336,7 +336,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="FPE-fh-8t7" detailTextLabel="H0N-bf-Yh1" style="IBUITableViewCellStyleValue1" id="tAU-rX-e3c" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="FPE-fh-8t7" detailTextLabel="H0N-bf-Yh1" style="IBUITableViewCellStyleValue1" id="tAU-rX-e3c" customClass="WPTableViewCell">
                                         <rect key="frame" x="0.0" y="291" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="tAU-rX-e3c" id="AJR-SK-Yg6">
@@ -364,7 +364,7 @@
                             </tableViewSection>
                             <tableViewSection id="TkT-75-L4b">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="oVe-xS-Qxh" style="IBUITableViewCellStyleDefault" id="2lp-Fq-KG5" customClass="PersonCell" customModule="WordPress" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="oVe-xS-Qxh" style="IBUITableViewCellStyleDefault" id="2lp-Fq-KG5" customClass="WPTableViewCell">
                                         <rect key="frame" x="0.0" y="371" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2lp-Fq-KG5" id="Y1J-8j-FCu">

--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -9,7 +9,7 @@
         <scene sceneID="0Jd-lB-cu0">
             <objects>
                 <tableViewController storyboardIdentifier="PeopleViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="5ll-RY-leg" customClass="PeopleViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="86" sectionHeaderHeight="18" sectionFooterHeight="1" id="HU2-1s-xgj">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="86" sectionHeaderHeight="18" sectionFooterHeight="1" id="HU2-1s-xgj">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -28,10 +28,10 @@
                             </constraints>
                         </view>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="PeopleCell" rowHeight="86" id="kMD-3K-Yok" customClass="PeopleCell" customModule="WordPress" customModuleProvider="target">
+                            <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="PeopleCell" rowHeight="86" id="kMD-3K-Yok" customClass="PeopleCell" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="49.5" width="600" height="86"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="kMD-3K-Yok" id="HXS-gQ-WaR">
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="kMD-3K-Yok" id="HXS-gQ-WaR">
                                     <rect key="frame" x="0.0" y="0.0" width="567" height="85.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
@@ -43,7 +43,7 @@
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Jorge Bernal" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SRh-jK-Qmd">
-                                            <rect key="frame" x="86" y="17" width="466" height="18"/>
+                                            <rect key="frame" x="86" y="19" width="473" height="18"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="18" id="1up-XI-AiZ"/>
                                             </constraints>
@@ -52,13 +52,13 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@koke" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ake-ZW-wkV">
-                                            <rect key="frame" x="86" y="35" width="466" height="13.5"/>
+                                            <rect key="frame" x="86" y="37" width="473" height="13.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                             <color key="textColor" red="0.0" green="0.66666666669999997" blue="0.86274509799999999" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="left" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="FCF-E3-KhT" customClass="PeopleRoleBadgeLabel" customModule="WordPress" customModuleProvider="target">
-                                            <rect key="frame" x="86" y="51" width="39.5" height="16"/>
+                                            <rect key="frame" x="86" y="53" width="39.5" height="16"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="H5Y-Fw-e4K"/>
@@ -77,7 +77,7 @@
                                             </userDefinedRuntimeAttributes>
                                         </view>
                                         <view contentMode="left" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="ecj-mn-SNZ" customClass="PeopleRoleBadgeLabel" customModule="WordPress" customModuleProvider="target">
-                                            <rect key="frame" x="133" y="51" width="71" height="16"/>
+                                            <rect key="frame" x="133" y="53" width="71" height="16"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="string" keyPath="text" value="Superadmin"/>
@@ -94,30 +94,20 @@
                                         </view>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="bottom" secondItem="FCF-E3-KhT" secondAttribute="bottom" constant="20.5" id="Gg6-lw-KHy"/>
                                         <constraint firstItem="FCF-E3-KhT" firstAttribute="leading" secondItem="Ake-ZW-wkV" secondAttribute="leading" id="O7s-V9-ShE"/>
                                         <constraint firstItem="fUp-Sh-uv5" firstAttribute="top" secondItem="HXS-gQ-WaR" secondAttribute="top" constant="15" id="Pba-X9-kWd"/>
-                                        <constraint firstAttribute="trailing" secondItem="FCF-E3-KhT" secondAttribute="trailing" constant="422" id="SeY-zu-xvA"/>
                                         <constraint firstItem="Ake-ZW-wkV" firstAttribute="top" secondItem="SRh-jK-Qmd" secondAttribute="bottom" id="TnJ-il-F2r"/>
-                                        <constraint firstItem="FCF-E3-KhT" firstAttribute="leading" secondItem="HXS-gQ-WaR" secondAttribute="leading" constant="136" id="V2u-HQ-CvJ"/>
                                         <constraint firstItem="SRh-jK-Qmd" firstAttribute="leading" secondItem="Ake-ZW-wkV" secondAttribute="leading" id="Wm0-WC-uBC"/>
                                         <constraint firstItem="SRh-jK-Qmd" firstAttribute="width" secondItem="Ake-ZW-wkV" secondAttribute="width" id="Wwx-oT-Bdx"/>
-                                        <constraint firstItem="fUp-Sh-uv5" firstAttribute="leading" secondItem="HXS-gQ-WaR" secondAttribute="leading" constant="15" id="aLY-Pv-M2Y"/>
+                                        <constraint firstItem="fUp-Sh-uv5" firstAttribute="leading" secondItem="HXS-gQ-WaR" secondAttribute="leadingMargin" id="aLY-Pv-M2Y"/>
                                         <constraint firstItem="ecj-mn-SNZ" firstAttribute="leading" secondItem="FCF-E3-KhT" secondAttribute="trailing" constant="8" id="d57-7i-RaC"/>
                                         <constraint firstItem="SRh-jK-Qmd" firstAttribute="top" secondItem="HXS-gQ-WaR" secondAttribute="topMargin" constant="9" id="dCD-Nj-Mju"/>
                                         <constraint firstItem="ecj-mn-SNZ" firstAttribute="centerY" secondItem="FCF-E3-KhT" secondAttribute="centerY" id="dEi-xM-Dr5"/>
                                         <constraint firstItem="SRh-jK-Qmd" firstAttribute="leading" secondItem="fUp-Sh-uv5" secondAttribute="trailing" constant="15" id="jCI-Ib-bvd"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="SRh-jK-Qmd" secondAttribute="trailing" constant="7" id="p9j-4O-zkj"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="SRh-jK-Qmd" secondAttribute="trailing" id="p9j-4O-zkj"/>
                                         <constraint firstItem="FCF-E3-KhT" firstAttribute="top" secondItem="Ake-ZW-wkV" secondAttribute="bottom" constant="3" id="qmv-5j-PTa"/>
                                         <constraint firstItem="ecj-mn-SNZ" firstAttribute="height" secondItem="FCF-E3-KhT" secondAttribute="height" id="zm6-Il-wpY"/>
                                     </constraints>
-                                    <variation key="default">
-                                        <mask key="constraints">
-                                            <exclude reference="Gg6-lw-KHy"/>
-                                            <exclude reference="SeY-zu-xvA"/>
-                                            <exclude reference="V2u-HQ-CvJ"/>
-                                        </mask>
-                                    </variation>
                                 </tableViewCellContentView>
                                 <connections>
                                     <outlet property="avatarImageView" destination="fUp-Sh-uv5" id="KNy-Ip-YOk"/>
@@ -168,15 +158,15 @@
         <scene sceneID="yMT-e5-sxj">
             <objects>
                 <tableViewController id="TOR-rB-bMi" userLabel="Roles View Controller" customClass="RoleViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="j3m-Xo-X8T">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="j3m-Xo-X8T">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="roleCell" id="uAe-CK-SUe" customClass="WPTableViewCell">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="roleCell" id="uAe-CK-SUe" customClass="WPTableViewCell">
                                 <rect key="frame" x="0.0" y="93.5" width="600" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uAe-CK-SUe" id="vI7-cS-zeY">
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="uAe-CK-SUe" id="vI7-cS-zeY">
                                     <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
@@ -197,38 +187,38 @@
         <scene sceneID="BP3-gy-RUF">
             <objects>
                 <tableViewController id="IBP-CG-w3b" customClass="PersonViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="aAs-1a-UQ6">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="aAs-1a-UQ6">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                         <sections>
                             <tableViewSection id="5Np-Zr-9XP">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="88" id="VTq-Of-ZQm" customClass="WPTableViewCell">
-                                        <rect key="frame" x="0.0" y="35" width="600" height="88"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="87" id="VTq-Of-ZQm" customClass="WPTableViewCell">
+                                        <rect key="frame" x="0.0" y="35" width="600" height="87"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="VTq-Of-ZQm" id="v2L-Gv-S2P">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="87.5"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="VTq-Of-ZQm" id="v2L-Gv-S2P">
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="86.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="yMs-a3-NfF" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                                    <rect key="frame" x="14" y="15" width="57" height="57"/>
+                                                    <rect key="frame" x="15" y="15" width="57" height="57"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="57" id="rnF-Rc-Lji"/>
                                                         <constraint firstAttribute="height" constant="57" id="s0U-2z-55g"/>
                                                     </constraints>
                                                 </imageView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mh2-fk-1eW">
-                                                    <rect key="frame" x="79" y="22" width="513" height="44"/>
+                                                    <rect key="frame" x="80" y="21.5" width="505" height="44"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iII-kx-uUz">
-                                                            <rect key="frame" x="0.0" y="0.0" width="513" height="21"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="505" height="21"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PK5-u5-2r7">
-                                                            <rect key="frame" x="0.0" y="23" width="513" height="21"/>
+                                                            <rect key="frame" x="0.0" y="23" width="505" height="21"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -249,9 +239,9 @@
                                             <constraints>
                                                 <constraint firstItem="Mh2-fk-1eW" firstAttribute="centerY" secondItem="v2L-Gv-S2P" secondAttribute="centerY" id="9gV-mj-ave"/>
                                                 <constraint firstItem="Mh2-fk-1eW" firstAttribute="leading" secondItem="yMs-a3-NfF" secondAttribute="trailing" constant="8" id="HG9-YQ-Uv0"/>
-                                                <constraint firstItem="yMs-a3-NfF" firstAttribute="leading" secondItem="v2L-Gv-S2P" secondAttribute="leading" constant="14" id="VPt-Vf-Ir3"/>
+                                                <constraint firstItem="yMs-a3-NfF" firstAttribute="leading" secondItem="v2L-Gv-S2P" secondAttribute="leadingMargin" id="VPt-Vf-Ir3"/>
                                                 <constraint firstItem="yMs-a3-NfF" firstAttribute="centerY" secondItem="v2L-Gv-S2P" secondAttribute="centerY" id="YEa-2g-UFc"/>
-                                                <constraint firstAttribute="trailing" secondItem="Mh2-fk-1eW" secondAttribute="trailing" constant="8" id="ZV4-gb-pqe"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Mh2-fk-1eW" secondAttribute="trailing" id="ZV4-gb-pqe"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -259,10 +249,10 @@
                             </tableViewSection>
                             <tableViewSection id="8p7-Vy-ixj">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="4sp-JN-Bx2" detailTextLabel="T95-Yj-X6p" style="IBUITableViewCellStyleValue1" id="o1C-ov-hGM" customClass="WPTableViewCell">
-                                        <rect key="frame" x="0.0" y="159" width="600" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="4sp-JN-Bx2" detailTextLabel="T95-Yj-X6p" style="IBUITableViewCellStyleValue1" id="o1C-ov-hGM" customClass="WPTableViewCell">
+                                        <rect key="frame" x="0.0" y="158" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="o1C-ov-hGM" id="HfA-TE-ytF">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="o1C-ov-hGM" id="HfA-TE-ytF">
                                             <rect key="frame" x="0.0" y="0.0" width="567" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
@@ -283,10 +273,10 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="tmz-lK-Wvy" detailTextLabel="D2b-CS-14p" style="IBUITableViewCellStyleValue1" id="pV6-Ik-qI1" customClass="WPTableViewCell">
-                                        <rect key="frame" x="0.0" y="203" width="600" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" textLabel="tmz-lK-Wvy" detailTextLabel="D2b-CS-14p" style="IBUITableViewCellStyleValue1" id="pV6-Ik-qI1" customClass="WPTableViewCell">
+                                        <rect key="frame" x="0.0" y="202" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pV6-Ik-qI1" id="5fS-CZ-T2g">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="pV6-Ik-qI1" id="5fS-CZ-T2g">
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
@@ -307,10 +297,10 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="Pm6-os-m4g" detailTextLabel="dAy-Pc-MaL" style="IBUITableViewCellStyleValue1" id="7Gu-cx-Zbk" customClass="WPTableViewCell">
-                                        <rect key="frame" x="0.0" y="247" width="600" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" textLabel="Pm6-os-m4g" detailTextLabel="dAy-Pc-MaL" style="IBUITableViewCellStyleValue1" id="7Gu-cx-Zbk" customClass="WPTableViewCell">
+                                        <rect key="frame" x="0.0" y="246" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="7Gu-cx-Zbk" id="g2l-de-pk6">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="7Gu-cx-Zbk" id="g2l-de-pk6">
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
@@ -331,10 +321,10 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" textLabel="FPE-fh-8t7" detailTextLabel="H0N-bf-Yh1" style="IBUITableViewCellStyleValue1" id="tAU-rX-e3c" customClass="WPTableViewCell">
-                                        <rect key="frame" x="0.0" y="291" width="600" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" textLabel="FPE-fh-8t7" detailTextLabel="H0N-bf-Yh1" style="IBUITableViewCellStyleValue1" id="tAU-rX-e3c" customClass="WPTableViewCell">
+                                        <rect key="frame" x="0.0" y="290" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="tAU-rX-e3c" id="AJR-SK-Yg6">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="tAU-rX-e3c" id="AJR-SK-Yg6">
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
@@ -359,10 +349,10 @@
                             </tableViewSection>
                             <tableViewSection id="TkT-75-L4b">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="oVe-xS-Qxh" style="IBUITableViewCellStyleDefault" id="2lp-Fq-KG5" customClass="WPTableViewCell">
-                                        <rect key="frame" x="0.0" y="371" width="600" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" textLabel="oVe-xS-Qxh" style="IBUITableViewCellStyleDefault" id="2lp-Fq-KG5" customClass="WPTableViewCell">
+                                        <rect key="frame" x="0.0" y="370" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2lp-Fq-KG5" id="Y1J-8j-FCu">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="2lp-Fq-KG5" id="Y1J-8j-FCu">
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
@@ -404,17 +394,17 @@
         <scene sceneID="UM5-rK-in7">
             <objects>
                 <tableViewController title="Invite View Controller" id="jns-Ol-UES" customClass="InvitePersonViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="q0k-QX-oPY">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="q0k-QX-oPY">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                         <sections>
                             <tableViewSection id="TSO-dY-4Cz">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="RII-cM-wkT" detailTextLabel="igf-wZ-skT" style="IBUITableViewCellStyleValue1" id="i2R-sD-lxa">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" textLabel="RII-cM-wkT" detailTextLabel="igf-wZ-skT" style="IBUITableViewCellStyleValue1" id="i2R-sD-lxa">
                                         <rect key="frame" x="0.0" y="79" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="i2R-sD-lxa" id="wJl-zz-akk">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="i2R-sD-lxa" id="wJl-zz-akk">
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
@@ -442,10 +432,10 @@
                             </tableViewSection>
                             <tableViewSection id="UIx-0o-NSH">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="zZ5-1U-KBD" detailTextLabel="w3p-Ei-KVz" style="IBUITableViewCellStyleValue1" id="JUH-Ao-gEv">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" textLabel="zZ5-1U-KBD" detailTextLabel="w3p-Ei-KVz" style="IBUITableViewCellStyleValue1" id="JUH-Ao-gEv">
                                         <rect key="frame" x="0.0" y="159" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="JUH-Ao-gEv" id="TzL-Fg-C5x">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="JUH-Ao-gEv" id="TzL-Fg-C5x">
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
@@ -473,15 +463,15 @@
                             </tableViewSection>
                             <tableViewSection id="KTt-dH-XgO">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="88" id="sdj-uY-1LY">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="88" id="sdj-uY-1LY">
                                         <rect key="frame" x="0.0" y="239" width="600" height="88"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="sdj-uY-1LY" id="Y8v-KJ-xnc">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="sdj-uY-1LY" id="Y8v-KJ-xnc">
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="87.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nh9-39-Mdw">
-                                                    <rect key="frame" x="11" y="4" width="581" height="79.5"/>
+                                                    <rect key="frame" x="15" y="10" width="570" height="68"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="72" id="ARy-hL-nFx"/>
@@ -497,10 +487,10 @@
                                                 </textView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="nh9-39-Mdw" secondAttribute="trailing" constant="8" id="06N-1n-lgP"/>
-                                                <constraint firstAttribute="bottom" secondItem="nh9-39-Mdw" secondAttribute="bottom" constant="4" id="Avz-ZP-kHa"/>
-                                                <constraint firstItem="nh9-39-Mdw" firstAttribute="top" secondItem="Y8v-KJ-xnc" secondAttribute="top" constant="4" id="HlP-n4-smH"/>
-                                                <constraint firstItem="nh9-39-Mdw" firstAttribute="leading" secondItem="Y8v-KJ-xnc" secondAttribute="leading" constant="11" id="Sq4-Av-m3J"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="nh9-39-Mdw" secondAttribute="trailing" id="06N-1n-lgP"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="nh9-39-Mdw" secondAttribute="bottom" id="Avz-ZP-kHa"/>
+                                                <constraint firstItem="nh9-39-Mdw" firstAttribute="top" secondItem="Y8v-KJ-xnc" secondAttribute="topMargin" id="HlP-n4-smH"/>
+                                                <constraint firstItem="nh9-39-Mdw" firstAttribute="leading" secondItem="Y8v-KJ-xnc" secondAttribute="leadingMargin" id="Sq4-Av-m3J"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
@@ -530,7 +520,7 @@
         <scene sceneID="tMT-sn-IIW">
             <objects>
                 <tableViewController title="Username TextViewController" id="7bM-Qc-hri" customClass="SettingsTextViewController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="U01-Fw-ZiF">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="U01-Fw-ZiF">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -548,7 +538,7 @@
         <scene sceneID="B3z-fY-Ctb">
             <objects>
                 <tableViewController title="Message ViewController" id="OAN-Wl-zn9" customClass="SettingsMultiTextViewController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="ibd-2Q-Phm">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="ibd-2Q-Phm">
                         <rect key="frame" x="0.0" y="44" width="600" height="556"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>

--- a/WordPress/Classes/ViewRelated/People/PeopleCell.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleCell.swift
@@ -9,7 +9,6 @@ class PeopleCell: WPTableViewCell {
     @IBOutlet var superAdminRoleBadge: PeopleRoleBadgeLabel!
 
     override func awakeFromNib() {
-        forceCustomCellMargins = true
         displayNameLabel.font = WPFontManager.merriweatherBoldFontOfSize(14)
     }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleCell.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleCell.swift
@@ -9,7 +9,7 @@ class PeopleCell: WPTableViewCell {
     @IBOutlet var superAdminRoleBadge: PeopleRoleBadgeLabel!
 
     override func awakeFromNib() {
-        displayNameLabel.font = WPFontManager.merriweatherBoldFontOfSize(14)
+        displayNameLabel.font = WPFontManager.systemBoldFontOfSize(14)
     }
 
     func bindViewModel(viewModel: PeopleCellViewModel) {

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -155,7 +155,6 @@ public class PeopleViewController: UITableViewController, NSFetchedResultsContro
                                                             target: self,
                                                             action: #selector(invitePersonWasPressed))
 
-        tableView.cellLayoutMarginsFollowReadableWidth = false
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
 
         // By default, let's display the Blog's Users

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -405,12 +405,3 @@ private extension PersonViewController {
         return person as? User
     }
 }
-
-
-// MARK: Private Cell
-//
-class PersonCell : WPTableViewCell {
-    override func awakeFromNib() {
-        forceCustomCellMargins = true
-    }
-}


### PR DESCRIPTION
This removes the previously added toggle for forcing fixed width cells via `WPTableViewCell` and revises the layout to follow readable margins instead.

- Also drops the constant values used for trailing and leading (no longer needed)
- Also changed the name label font to use the system font instead of Merriweather.

To test:

1. Ensure the People management views follow readable margins on iPad.
2. Ensure the same People management views follow the expected margins on iPhone devices.

Note: In the future, this layout could probably use some `UIStackView` goodness.

Needs review: @frosty can you take a look? 🕶
