### PR TITLE
Reader: Adds filter for svg smiley images.

### DIFF
--- a/WordPress/Classes/Categories/NSString+Helpers.m
+++ b/WordPress/Classes/Categories/NSString+Helpers.m
@@ -198,15 +198,27 @@ static NSString *const Ellipsis =  @"\u2026";
 
     static NSRegularExpression *smiliesRegex;
     static NSRegularExpression *coreEmojiImgRegex;
+    static NSRegularExpression *wpcomSvgSmilies;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSError *error;
         smiliesRegex = [NSRegularExpression regularExpressionWithPattern:@"<img.*?src=['\"].*?wp-includes/images/smilies/(.+?)(?:.gif|.png)[^'\"]*['\"][^//]+/?>" options:NSRegularExpressionCaseInsensitive error:&error];
         coreEmojiImgRegex = [NSRegularExpression regularExpressionWithPattern:@"<img.*?src=['\"].*?images/core/emoji/[^/]+/.+?.png['\"][^//]+/?>" options:NSRegularExpressionCaseInsensitive error:&error];
+        wpcomSvgSmilies = [NSRegularExpression regularExpressionWithPattern:@"<img.*?src=['\"].*?wp-content/mu-plugins/wpcom-smileys/(.+?).svg['\"][^//]+/?>" options:NSRegularExpressionCaseInsensitive error:&error];
 
     });
 
     NSArray *matches = [smiliesRegex matchesInString:result options:0 range:NSMakeRange(0, [result length])];
+    for (NSTextCheckingResult *match in [matches reverseObjectEnumerator]) {
+        NSRange range = [match rangeAtIndex:1];
+        NSString *icon = [result substringWithRange:range];
+        NSString *replacement = [replacements objectForKey:icon];
+        if (replacement) {
+            [result replaceCharactersInRange:[match range] withString:replacement];
+        }
+    }
+
+    matches = [wpcomSvgSmilies matchesInString:result options:0 range:NSMakeRange(0, [result length])];
     for (NSTextCheckingResult *match in [matches reverseObjectEnumerator]) {
         NSRange range = [match rangeAtIndex:1];
         NSString *icon = [result substringWithRange:range];


### PR DESCRIPTION
Fixes #5780 

To test: 
### Setup:
- In a browser, create a new post on wpcom add some content including an ascii smiley like ":)"  Publish the post. 
- Add a comment to the post containing some content and the same ascii. 
- Check the image URL and confirm that in both cases it is an .svg.
- Like the post. 

### Test 1:
- Go to the reader and open the Liked feed. 
- Find the post in the feed and view its detail. 
- Confirm that the smiley emoji is correctly displayed in the detail, and also in the post card's summary if appropriate. 

### Test 2:
- View the comments for the post. 
- Confirm that the smiley emoji is correctly displayed in the comment. 

Needs review: @bummytime would you be up for a quick review? 

