### PR TITLE
iPad Splitview: Me

### DIFF
--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -8,16 +8,18 @@ struct NavigationItemRow : ImmuTableRow {
     let title: String
     let icon: UIImage?
     let action: ImmuTableAction?
+    let showsDisclosureIndicator: Bool
 
-    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, action: ImmuTableAction) {
+    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, showsDisclosureIndicator: Bool = true, action: ImmuTableAction) {
         self.title = title
         self.icon = icon
+        self.showsDisclosureIndicator = showsDisclosureIndicator
         self.action = action
     }
 
     func configureCell(cell: UITableViewCell) {
         cell.textLabel?.text = title
-        cell.accessoryType = .DisclosureIndicator
+        cell.accessoryType = showsDisclosureIndicator ? .DisclosureIndicator : .None
         cell.imageView?.image = icon
 
         WPStyleGuide.configureTableViewCell(cell)
@@ -31,11 +33,13 @@ struct BadgeNavigationItemRow: ImmuTableRow {
     let icon: UIImage?
     let action: ImmuTableAction?
     let badgeCount: Int
+    let showsDisclosureIndicator: Bool
 
-    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, action: ImmuTableAction) {
+    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, showsDisclosureIndicator: Bool = true, action: ImmuTableAction) {
         self.title = title
         self.icon = icon
         self.badgeCount = badgeCount
+        self.showsDisclosureIndicator = showsDisclosureIndicator
         self.action = action
     }
 
@@ -43,7 +47,7 @@ struct BadgeNavigationItemRow: ImmuTableRow {
         let cell = cell as! WPTableViewCellBadge
 
         cell.textLabel?.text = title
-        cell.accessoryType = .None
+        cell.accessoryType = showsDisclosureIndicator ? .DisclosureIndicator : .None
         cell.imageView?.image = icon
         cell.badgeCount = badgeCount
 

--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -8,18 +8,18 @@ struct NavigationItemRow : ImmuTableRow {
     let title: String
     let icon: UIImage?
     let action: ImmuTableAction?
-    let showsDisclosureIndicator: Bool
+    let accessoryType: UITableViewCellAccessoryType
 
-    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, showsDisclosureIndicator: Bool = true, action: ImmuTableAction) {
+    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, accessoryType: UITableViewCellAccessoryType = .DisclosureIndicator, action: ImmuTableAction) {
         self.title = title
         self.icon = icon
-        self.showsDisclosureIndicator = showsDisclosureIndicator
+        self.accessoryType = accessoryType
         self.action = action
     }
 
     func configureCell(cell: UITableViewCell) {
         cell.textLabel?.text = title
-        cell.accessoryType = showsDisclosureIndicator ? .DisclosureIndicator : .None
+        cell.accessoryType = accessoryType
         cell.imageView?.image = icon
 
         WPStyleGuide.configureTableViewCell(cell)
@@ -33,13 +33,13 @@ struct BadgeNavigationItemRow: ImmuTableRow {
     let icon: UIImage?
     let action: ImmuTableAction?
     let badgeCount: Int
-    let showsDisclosureIndicator: Bool
+    let accessoryType: UITableViewCellAccessoryType
 
-    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, showsDisclosureIndicator: Bool = true, action: ImmuTableAction) {
+    init(title: String, icon: UIImage? = nil, badgeCount: Int = 0, accessoryType: UITableViewCellAccessoryType = .DisclosureIndicator, action: ImmuTableAction) {
         self.title = title
         self.icon = icon
         self.badgeCount = badgeCount
-        self.showsDisclosureIndicator = showsDisclosureIndicator
+        self.accessoryType = accessoryType
         self.action = action
     }
 
@@ -47,7 +47,7 @@ struct BadgeNavigationItemRow: ImmuTableRow {
         let cell = cell as! WPTableViewCellBadge
 
         cell.textLabel?.text = title
-        cell.accessoryType = showsDisclosureIndicator ? .DisclosureIndicator : .None
+        cell.accessoryType = accessoryType
         cell.imageView?.image = icon
         cell.badgeCount = badgeCount
 

--- a/WordPress/Classes/ViewRelated/Cells/WPReusableTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/WPReusableTableViewCells.swift
@@ -69,8 +69,19 @@ class WPTableViewCellBadge: WPTableViewCellDefault {
                 accessoryType = .None
             } else {
                 accessoryView = nil
-                accessoryType = .DisclosureIndicator
+                accessoryType = previousAccessoryType
             }
+        }
+    }
+
+    // Allows us to restore the previous accessory type whenever we clear the badge
+    private lazy var previousAccessoryType: UITableViewCellAccessoryType = {
+        return self.accessoryType
+    }()
+
+    override var accessoryType: UITableViewCellAccessoryType {
+        didSet {
+            previousAccessoryType = oldValue
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Cells/WPReusableTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/WPReusableTableViewCells.swift
@@ -69,19 +69,7 @@ class WPTableViewCellBadge: WPTableViewCellDefault {
                 accessoryType = .None
             } else {
                 accessoryView = nil
-                accessoryType = previousAccessoryType
             }
-        }
-    }
-
-    // Allows us to restore the previous accessory type whenever we clear the badge
-    private lazy var previousAccessoryType: UITableViewCellAccessoryType = {
-        return self.accessoryType
-    }()
-
-    override var accessoryType: UITableViewCellAccessoryType {
-        didSet {
-            previousAccessoryType = oldValue
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -83,7 +83,7 @@ private class AccountSettingsController: SettingsController {
         let email = EditableTextRow(
             title: NSLocalizedString("Email", comment: "Account Settings Email label"),
             value: settings?.emailForDisplay ?? "",
-            action: presenter.prompt(editEmailAddress(settings, service: service))
+            action: presenter.push(editEmailAddress(settings, service: service))
         )
 
         let primarySite = EditableTextRow(
@@ -95,7 +95,7 @@ private class AccountSettingsController: SettingsController {
         let webAddress = EditableTextRow(
             title: NSLocalizedString("Web Address", comment: "Account Settings Web Address label"),
             value: settings?.webAddress ?? "",
-            action: presenter.prompt(editWebAddress(service))
+            action: presenter.push(editWebAddress(service))
         )
 
         return ImmuTable(sections: [

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -85,7 +85,14 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         // based on if there's a header or not.
         tableView.tableHeaderView = account.map { headerViewForAccount($0) }
 
-        let selectedIndexPath = tableView.indexPathForSelectedRow
+        // After we've reloaded the view model, we'll either reselect the currently
+        // selected table row, or we'll select the first row if the split view
+        // is collapsed.
+        var selectedIndexPath = tableView.indexPathForSelectedRow
+        if selectedIndexPath == nil && !splitViewControllerIsCollapsed {
+            selectedIndexPath = NSIndexPath(forRow: 0, inSection: 0)
+        }
+
         handler.viewModel = tableViewModel(loggedIn, helpshiftBadgeCount: badgeCount)
         tableView.selectRowAtIndexPath(selectedIndexPath, animated: false, scrollPosition: .None)
     }
@@ -369,10 +376,6 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
 extension MeViewController: WPSplitViewControllerDetailProvider {
     func initialDetailViewControllerForSplitView(splitView: WPSplitViewController) -> UIViewController? {
-        // If the initial detail view controller is going to be presented, highlight
-        // the top row to indicate that it's that section being displayed.
-        tableView.selectRowAtIndexPath(NSIndexPath(forRow: 0, inSection: 0), animated: false, scrollPosition: .None)
-
         return myProfileViewController
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -110,37 +110,37 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
     }
 
     private func tableViewModel(loggedIn: Bool, helpshiftBadgeCount: Int) -> ImmuTable {
-        let showsDisclosureIndicator = splitViewControllerIsHorizontallyCompact
+        let accessoryType: UITableViewCellAccessoryType = (splitViewControllerIsHorizontallyCompact) ? .DisclosureIndicator : .None
 
         let myProfile = NavigationItemRow(
             title: NSLocalizedString("My Profile", comment: "Link to My Profile section"),
             icon: Gridicon.iconOfType(.User),
-            showsDisclosureIndicator: showsDisclosureIndicator,
+            accessoryType: accessoryType,
             action: pushMyProfile())
 
         let accountSettings = NavigationItemRow(
             title: NSLocalizedString("Account Settings", comment: "Link to Account Settings section"),
             icon: Gridicon.iconOfType(.Cog),
-            showsDisclosureIndicator: showsDisclosureIndicator,
+            accessoryType: accessoryType,
             action: pushAccountSettings())
 
         let appSettings = NavigationItemRow(
             title: NSLocalizedString("App Settings", comment: "Link to App Settings section"),
             icon: Gridicon.iconOfType(.Phone),
-            showsDisclosureIndicator: showsDisclosureIndicator,
+            accessoryType: accessoryType,
             action: pushAppSettings())
 
         let notificationSettings = NavigationItemRow(
             title: NSLocalizedString("Notification Settings", comment: "Link to Notification Settings section"),
             icon: Gridicon.iconOfType(.Bell),
-            showsDisclosureIndicator: showsDisclosureIndicator,
+            accessoryType: accessoryType,
             action: pushNotificationSettings())
 
         let helpAndSupport = BadgeNavigationItemRow(
             title: NSLocalizedString("Help & Support", comment: "Link to Help section"),
             icon: Gridicon.iconOfType(.Help),
             badgeCount: helpshiftBadgeCount,
-            showsDisclosureIndicator: showsDisclosureIndicator,
+            accessoryType: accessoryType,
             action: pushHelp())
 
         let logIn = ButtonRow(

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -362,6 +362,10 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
 extension MeViewController: WPSplitViewControllerDetailProvider {
     func initialDetailViewControllerForSplitView(splitView: WPSplitViewController) -> UIViewController? {
+        // If the initial detail view controller is going to be presented, highlight
+        // the top row to indicate that it's that section being displayed.
+        tableView.selectRowAtIndexPath(NSIndexPath(forRow: 0, inSection: 0), animated: false, scrollPosition: .None)
+
         return myProfileViewController
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -60,10 +60,6 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         HelpshiftUtils.refreshUnreadNotificationCount()
-
-        if splitViewControllerIsCollapsed {
-            animateDeselectionInteractively()
-        }
     }
 
     override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -81,20 +81,22 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         // based on if there's a header or not.
         tableView.tableHeaderView = account.map { headerViewForAccount($0) }
 
-        // After we've reloaded the view model, we'll either reselect the currently
-        // selected table row, or we'll select the first row if the split view
-        // is collapsed.
+        // After we've reloaded the view model we should maintain the current
+        // table row selection, or if the split view we're in is not compact
+        // then we'll just select the first item in the table.
+
+        // First, we'll grab the appropriate index path so we can reselect it
+        // after reloading the table
         var selectedIndexPath = tableView.indexPathForSelectedRow
         if selectedIndexPath == nil && !splitViewControllerIsHorizontallyCompact {
             selectedIndexPath = NSIndexPath(forRow: 0, inSection: 0)
         }
 
+        // Then we'll reload the table view model (prompting a table reload)
         handler.viewModel = tableViewModel(loggedIn, helpshiftBadgeCount: badgeCount)
-        tableView.selectRowAtIndexPath(selectedIndexPath, animated: false, scrollPosition: .None)
-    }
 
-    private var splitViewControllerIsHorizontallyCompact: Bool {
-        return splitViewController?.isViewHorizontallyCompact() ?? isViewHorizontallyCompact()
+        // And finally we'll reselect the selected row, if there is one
+        tableView.selectRowAtIndexPath(selectedIndexPath, animated: false, scrollPosition: .None)
     }
 
     private func headerViewForAccount(account: WPAccount) -> MeHeaderView {

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -236,7 +236,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         presentViewController(pickerViewController, animated: true, completion: nil)
     }
 
-    private lazy var myProfileViewController: UIViewController? = {
+    private var myProfileViewController: UIViewController? {
         guard let account = self.defaultAccount() else {
             let error = "Tried to push My Profile without a default account. This shouldn't happen"
             assertionFailure(error)
@@ -245,7 +245,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         }
 
         return MyProfileViewController(account: account)
-    }()
+    }
 
     private func pushMyProfile() -> ImmuTableAction {
         return { [unowned self] row in
@@ -293,6 +293,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
     private func presentLogin() -> ImmuTableAction {
         return { [unowned self] row in
+            self.tableView.deselectSelectedRowWithAnimation(true)
             SigninHelpers.showSigninForJustWPComFromPresenter(self)
         }
     }
@@ -392,11 +393,9 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
 extension MeViewController: WPSplitViewControllerDetailProvider {
     func initialDetailViewControllerForSplitView(splitView: WPSplitViewController) -> UIViewController? {
-        // If we're not logged in yet, return an empty VC
+        // If we're not logged in yet, return app settings
         guard let _ = defaultAccount() else {
-            let viewController = UIViewController()
-            viewController.view.backgroundColor = WPStyleGuide.greyLighten30()
-            return viewController
+            return AppSettingsViewController()
         }
 
         return myProfileViewController

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -60,6 +60,10 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         HelpshiftUtils.refreshUnreadNotificationCount()
+
+        if splitViewControllerIsHorizontallyCompact {
+            animateDeselectionInteractively()
+        }
     }
 
     override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -89,12 +89,16 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         // selected table row, or we'll select the first row if the split view
         // is collapsed.
         var selectedIndexPath = tableView.indexPathForSelectedRow
-        if selectedIndexPath == nil && !splitViewControllerIsCollapsed {
+        if selectedIndexPath == nil && !splitViewControllerIsHorizontallyCompact {
             selectedIndexPath = NSIndexPath(forRow: 0, inSection: 0)
         }
 
         handler.viewModel = tableViewModel(loggedIn, helpshiftBadgeCount: badgeCount)
         tableView.selectRowAtIndexPath(selectedIndexPath, animated: false, scrollPosition: .None)
+    }
+
+    private var splitViewControllerIsHorizontallyCompact: Bool {
+        return splitViewController?.isViewHorizontallyCompact() ?? isViewHorizontallyCompact()
     }
 
     private func headerViewForAccount(account: WPAccount) -> MeHeaderView {
@@ -106,7 +110,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
     }
 
     private func tableViewModel(loggedIn: Bool, helpshiftBadgeCount: Int) -> ImmuTable {
-        let showsDisclosureIndicator = splitViewControllerIsCollapsed
+        let showsDisclosureIndicator = splitViewControllerIsHorizontallyCompact
 
         let myProfile = NavigationItemRow(
             title: NSLocalizedString("My Profile", comment: "Link to My Profile section"),

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -50,7 +50,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
         handler = ImmuTableViewHandler(takeOver: self)
 
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(MeViewController.reloadViewModel), name: WPAccountDefaultWordPressComAccountChangedNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(MeViewController.accountDidChange), name: WPAccountDefaultWordPressComAccountChangedNotification, object: nil)
 
         refreshAccountDetails()
 
@@ -71,6 +71,16 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
         // Required to update the tableview cell disclosure indicators
         reloadViewModel()
+    }
+
+    @objc private func accountDidChange() {
+        reloadViewModel()
+
+        // Reload the detail pane on account change and we're not in a compact split view                                                                                                                                                                                                                                                        
+        if let splitViewController = splitViewController as? WPSplitViewController,
+            let detailViewController = initialDetailViewControllerForSplitView(splitViewController) where !splitViewControllerIsHorizontallyCompact {
+            showDetailViewController(detailViewController, sender: self)
+        }
     }
 
     @objc private func reloadViewModel() {
@@ -382,6 +392,13 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
 extension MeViewController: WPSplitViewControllerDetailProvider {
     func initialDetailViewControllerForSplitView(splitView: WPSplitViewController) -> UIViewController? {
+        // If we're not logged in yet, return an empty VC
+        guard let _ = defaultAccount() else {
+            let viewController = UIViewController()
+            viewController.view.backgroundColor = WPStyleGuide.greyLighten30()
+            return viewController
+        }
+
         return myProfileViewController
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -66,6 +66,13 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         }
     }
 
+    override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        // Required to update the tableview cell disclosure indicators
+        reloadViewModel()
+    }
+
     @objc private func reloadViewModel() {
         let account = defaultAccount()
         let loggedIn = account != nil

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -102,7 +102,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
 
     [self.navigationController setNavigationBarHidden:NO animated:YES];
 
-    if ([self.navigationController.viewControllers count] == 1) {
+    if ([self.navigationController.viewControllers count] == 1 && !self.splitViewController) {
         self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Close", @"") style:[WPStyleGuide barButtonStyleForBordered] target:self action:@selector(dismiss)];
     }
 }

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -45,8 +45,9 @@ class WPSplitViewController: UISplitViewController {
         var detailVC = vc
 
         // Ensure that detail view controllers are wrapped in a navigation controller
-        if !(vc is UINavigationController || collapsed) {
-            detailVC = UINavigationController(rootViewController: vc)
+        // when the split is not collapsed
+        if !collapsed {
+            detailVC = wrapViewControllerInNavigationControllerIfRequired(vc)
         }
 
         super.showDetailViewController(detailVC, sender: self)
@@ -78,12 +79,11 @@ class WPSplitViewController: UISplitViewController {
             return nil
         }
 
-        // Ensure it's wrapped in a navigation controller
-        if detailViewController is UINavigationController {
-            return detailViewController
-        } else {
-            return UINavigationController(rootViewController: detailViewController)
-        }
+        return wrapViewControllerInNavigationControllerIfRequired(detailViewController)
+    }
+
+    private func wrapViewControllerInNavigationControllerIfRequired(viewController: UIViewController) -> UIViewController {
+        return (viewController is UINavigationController) ? viewController : UINavigationController(rootViewController: viewController)
     }
 
     private var primaryNavigationControllerStackHasBeenModified = false
@@ -137,6 +137,12 @@ extension WPSplitViewController: UISplitViewControllerDelegate {
         }
 
         return false
+    }
+}
+
+extension UIViewController {
+    var splitViewControllerIsHorizontallyCompact: Bool {
+        return splitViewController?.isViewHorizontallyCompact() ?? isViewHorizontallyCompact()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -1,0 +1,82 @@
+import UIKit
+import WordPressShared
+
+class WPSplitViewController: UISplitViewController, UISplitViewControllerDelegate {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        delegate = self
+        preferredDisplayMode = .AllVisible
+
+        extendedLayoutIncludesOpaqueBars = true
+
+        // Values based on the behaviour of Settings.app
+        preferredPrimaryColumnWidthFraction = 0.38
+        minimumPrimaryColumnWidth = 320
+        maximumPrimaryColumnWidth = 390
+    }
+
+    override func preferredStatusBarStyle() -> UIStatusBarStyle {
+        return .LightContent
+    }
+
+    override var viewControllers: [UIViewController] {
+        didSet {
+            // Ensure that each top level navigation controller has 
+            // `extendedLayoutIncludesOpaqueBars` set to true. Otherwise we
+            // see a large tab bar sized gap underneath each view controller.
+            for viewController in viewControllers {
+                if let viewController = viewController as? UINavigationController {
+                    viewController.extendedLayoutIncludesOpaqueBars = true
+                }
+            }
+        }
+    }
+
+    override func showDetailViewController(vc: UIViewController, sender: AnyObject?) {
+        var detailVC = vc
+
+        // Ensure that detail view controllers are wrapped in a navigation controller
+        if !(vc is UINavigationController || collapsed) {
+            detailVC = UINavigationController(rootViewController: vc)
+        }
+
+        super.showDetailViewController(detailVC, sender: self)
+    }
+
+    /** Sets the primary view controller of the split view as specified, and
+     *  automatically sets the detail view controller if the primary
+     *  conforms to `WPSplitViewControllerDetailProvider` and can vend a
+     *  detail view controller.
+     */
+    func setInitialPrimaryViewController(viewController: UIViewController) {
+        var initialViewControllers = [viewController]
+
+        if let navigationController = viewController as? UINavigationController,
+            let rootViewController = navigationController.viewControllers.first,
+            let detailProvider = rootViewController as? WPSplitViewControllerDetailProvider,
+            let detailViewController = detailProvider.initialDetailViewControllerForSplitView(self) {
+
+            // Ensure it's wrapped in a navigation controller
+            if detailViewController is UINavigationController {
+                initialViewControllers.append(detailViewController)
+            } else {
+                initialViewControllers.append(UINavigationController(rootViewController: detailViewController))
+            }
+
+            viewControllers = initialViewControllers
+        }
+    }
+}
+
+extension UIViewController {
+    var splitViewControllerIsCollapsed: Bool {
+        return splitViewController?.collapsed ?? true
+    }
+}
+
+@objc
+protocol WPSplitViewControllerDetailProvider {
+    func initialDetailViewControllerForSplitView(splitView: WPSplitViewController) -> UIViewController?
+}

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -21,6 +21,13 @@ class WPSplitViewController: UISplitViewController {
         return .LightContent
     }
 
+    override func overrideTraitCollectionForChildViewController(childViewController: UIViewController) -> UITraitCollection? {
+        guard let collection = super.overrideTraitCollectionForChildViewController(childViewController) else { return nil }
+
+        let overrideCollection = UITraitCollection(horizontalSizeClass: self.traitCollection.horizontalSizeClass)
+        return UITraitCollection(traitsFromCollections: [collection, overrideCollection])
+    }
+
     override var viewControllers: [UIViewController] {
         didSet {
             // Ensure that each top level navigation controller has

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -146,13 +146,6 @@ extension WPSplitViewController: UINavigationControllerDelegate {
     }
 }
 
-extension UIViewController {
-    /// Convenience method
-    var splitViewControllerIsCollapsed: Bool {
-        return splitViewController?.collapsed ?? true
-    }
-}
-
 @objc
 protocol WPSplitViewControllerDetailProvider {
     /**

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -72,7 +72,7 @@ class WPSplitViewController: UISplitViewController {
         }
     }
 
-    func initialDetailViewControllerForPrimaryViewController(viewController: UIViewController) -> UIViewController? {
+    private func initialDetailViewControllerForPrimaryViewController(viewController: UIViewController) -> UIViewController? {
         guard let detailProvider = viewController as? WPSplitViewControllerDetailProvider,
         let detailViewController = detailProvider.initialDetailViewControllerForSplitView(self)  else {
             return nil

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WordPressShared
 
-class WPSplitViewController: UISplitViewController, UISplitViewControllerDelegate {
+class WPSplitViewController: UISplitViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,7 +23,7 @@ class WPSplitViewController: UISplitViewController, UISplitViewControllerDelegat
 
     override var viewControllers: [UIViewController] {
         didSet {
-            // Ensure that each top level navigation controller has 
+            // Ensure that each top level navigation controller has
             // `extendedLayoutIncludesOpaqueBars` set to true. Otherwise we
             // see a large tab bar sized gap underneath each view controller.
             for viewController in viewControllers {
@@ -66,6 +66,33 @@ class WPSplitViewController: UISplitViewController, UISplitViewControllerDelegat
             }
 
             viewControllers = initialViewControllers
+        }
+    }
+}
+
+extension WPSplitViewController: UISplitViewControllerDelegate {
+    /** By default, the top view controller from the primary navigation
+     *  controller will be popped and used as the secondary view controller.
+     *  However, we want to ensure the the secondary view controller is a
+     *  navigation controller, so we'll pop off everything but the root view
+     *  controller and wrap it in a navigation controller if necessary.
+     */
+    func splitViewController(splitViewController: UISplitViewController, separateSecondaryViewControllerFromPrimaryViewController primaryViewController: UIViewController) -> UIViewController? {
+        guard let primaryNavigationController = primaryViewController as? UINavigationController else {
+            return nil
+        }
+
+        let viewControllers = Array(primaryNavigationController.viewControllers.dropFirst())
+        primaryNavigationController.popToRootViewControllerAnimated(false)
+
+        if let firstViewController = viewControllers.first as? UINavigationController {
+            // If it's already a navigation controller, just return it
+            return firstViewController
+        } else {
+            let navigationController = UINavigationController()
+            navigationController.viewControllers = viewControllers
+
+            return navigationController
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -61,6 +61,8 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 @property (nonatomic, strong) UINavigationController *notificationsNavigationController;
 @property (nonatomic, strong) UINavigationController *meNavigationController;
 
+@property (nonatomic, strong) WPSplitViewController *meSplitViewController;
+
 @property (nonatomic, strong) UIView *notificationBadgeIconView;
 
 @end
@@ -104,7 +106,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         [self setViewControllers:@[self.blogListNavigationController,
                                    self.readerNavigationController,
                                    self.newPostViewController,
-                                   self.meNavigationController,
+                                   self.meSplitViewController,
                                    self.notificationsNavigationController]];
 
         [self setSelectedViewController:self.blogListNavigationController];
@@ -244,7 +246,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         return _meNavigationController;
     }
 
-    self.meViewController = [MeViewController new];
     _meNavigationController = [[UINavigationController alloc] initWithRootViewController:self.meViewController];
     UIImage *meTabBarImage = [UIImage imageNamed:@"icon-tab-me"];
     _meNavigationController.tabBarItem.image = [meTabBarImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
@@ -255,6 +256,14 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     _meNavigationController.tabBarItem.accessibilityLabel = NSLocalizedString(@"Me", @"The accessibility value of the me tab.");
 
     return _meNavigationController;
+}
+
+- (MeViewController *)meViewController {
+    if (!_meViewController) {
+        _meViewController = [MeViewController new];
+    }
+
+    return _meViewController;
 }
 
 - (UINavigationController *)notificationsNavigationController
@@ -283,6 +292,21 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     CGFloat offset = [WPDeviceIdentification isiPad] ? WPTabBarIconOffsetiPad : WPTabBarIconOffsetiPhone;
 
     return UIEdgeInsetsMake(offset, 0, -offset, 0);
+}
+
+#pragma mark - Split View Controllers
+
+- (UISplitViewController *)meSplitViewController
+{
+    if (!_meSplitViewController) {
+        _meSplitViewController = [WPSplitViewController new];
+    }
+
+    [_meSplitViewController setInitialPrimaryViewController:self.meNavigationController];
+
+    _meSplitViewController.tabBarItem = self.meNavigationController.tabBarItem;
+
+    return _meSplitViewController;
 }
 
 #pragma mark - Navigation Helpers

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		1751E5931CE23801000CA08D /* NSAttributedString+StyledHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */; };
 		176579F71C63A40F0000978E /* PurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176579F61C63A40F0000978E /* PurchaseButton.swift */; };
 		1767494E1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */; };
+		176DEEE91D4615FE00331F30 /* WPSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */; };
 		178EDE701C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178EDE6F1C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift */; };
 		17AD36D51D36C1A60044B10D /* WPStyleGuide+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */; };
 		17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */; };
@@ -1102,6 +1103,7 @@
 		1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+StyledHTML.swift"; sourceTree = "<group>"; };
 		176579F61C63A40F0000978E /* PurchaseButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseButton.swift; sourceTree = "<group>"; };
 		1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSearchHeaderView.swift; sourceTree = "<group>"; };
+		176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPSplitViewController.swift; sourceTree = "<group>"; };
 		178EDE6F1C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PlanPostPurchaseViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Search.swift"; sourceTree = "<group>"; };
 		17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogSiteVisibilityHelperTest.m; sourceTree = "<group>"; };
@@ -3432,6 +3434,7 @@
 				E1DD4CCC1CAE41C800C3863E /* PagedViewController.xib */,
 				1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */,
 				171795821D1C65E8002F1EB2 /* FlingableViewHandler.swift */,
+				176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -6100,6 +6103,7 @@
 				85D239B31AE5A5FC0074768D /* WordPressXMLRPCAPIFacade.m in Sources */,
 				E183BD7417621D87000B0822 /* WPCookie.m in Sources */,
 				08216FD41CDBF96000304BA7 /* MenuItemTypeSelectionView.m in Sources */,
+				176DEEE91D4615FE00331F30 /* WPSplitViewController.swift in Sources */,
 				FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */,
 				5DBCD9D518F35D7500B32229 /* ReaderTopicService.m in Sources */,
 				E6DE44671B90D251000FA7EF /* ReaderHelpers.swift in Sources */,


### PR DESCRIPTION
Introduces `UISplitViewController` to the Me section of the app.

As we've discussed previously, this tries to mimic the system Settings app as much as possible. So the left pane always shows the top level navigation, and the right pane can be used to navigate into each item. I've also made the left pane wider in landscape, to match Settings, and it's always visible in both portrait and landscape.

I've made a number of customisations to `UISplitViewController` to support the behaviour we require, in the subclass `WPSplitViewController`. For example, it handles wrapping and unwrapping child view controllers in navigation controllers where required. 

It also handles automatically populating the right pane with a detail view controller through a protocol `WPSplitViewControllerDetailProvider`. A primary view controller (left pane) can implement the method 

```
func initialDetailViewControllerForSplitView(splitView: WPSplitViewController) -> UIViewController?
```

And return a view controller that should populate the right pane on first appearance. For example, the Me section shows the My Profile detail screen.

To test: 

* Try the Me section out on both iPhone and iPad, moving between orientations and multitasking configurations. 
* Navigate into each item within Me, and try to follow every navigation route to ensure things transition as you'd expect.

Needs review: @kurzee 

We'll review this, and I'll start working on the next section. It's quite likely that `WPSplitViewController` will need some tweaks to support other sections of the app, so we can see where that takes us before we merge any of this.