### PR TITLE
Readability: Comments Cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -26,7 +26,6 @@ public class CommentsTableViewCell : WPTableViewCell
     }
     public var approved : Bool = false {
         didSet {
-            refreshSeparatorsColor()
             refreshTimestampLabel()
             refreshDetailsLabel()
             refreshBackground()
@@ -63,14 +62,10 @@ public class CommentsTableViewCell : WPTableViewCell
         super.awakeFromNib()
 
         assert(layoutView != nil)
-        assert(separatorsView != nil)
         assert(gravatarImageView != nil)
         assert(detailsLabel != nil)
         assert(timestampImageView != nil)
         assert(timestampLabel != nil)
-
-        separatorsView.bottomVisible = true
-        separatorsView.bottomInsets = separatorInsets
     }
 
     public override func setSelected(selected: Bool, animated: Bool) {
@@ -101,10 +96,6 @@ public class CommentsTableViewCell : WPTableViewCell
 
     private func refreshBackground() {
         backgroundColor = Style.backgroundColor(isApproved: approved)
-    }
-
-    private func refreshSeparatorsColor() {
-        separatorsView.bottomColor = Style.separatorsColor(isApproved: approved)
     }
 
     private func refreshImages() {
@@ -162,9 +153,6 @@ public class CommentsTableViewCell : WPTableViewCell
     // MARK: - Aliases
     typealias Style = WPStyleGuide.Comments
 
-    // MARK: - Private Constants
-    private let separatorInsets = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 0.0)
-
     // MARK: - Private Properties
     private var gravatarURL : NSURL?
 
@@ -175,7 +163,6 @@ public class CommentsTableViewCell : WPTableViewCell
 
     // MARK: - IBOutlets
     @IBOutlet private var layoutView            : UIView!
-    @IBOutlet private var separatorsView        : SeparatorsView!
     @IBOutlet private var gravatarImageView     : CircularImageView!
     @IBOutlet private var detailsLabel          : UILabel!
     @IBOutlet private var timestampImageView    : UIImageView!

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -17,10 +17,6 @@
                     <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AUn-YX-qnu" userLabel="Layout View">
                         <rect key="frame" x="8" y="0.0" width="304" height="70"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kcl-X2-f1f" customClass="SeparatorsView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="304" height="70"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                            </view>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="12" y="12" width="46" height="46"/>
                                 <constraints>
@@ -51,19 +47,15 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="AUn-YX-qnu" secondAttribute="top" constant="12" id="8ks-PZ-pXh"/>
-                            <constraint firstAttribute="trailing" secondItem="Kcl-X2-f1f" secondAttribute="trailing" id="AHC-y2-kH6"/>
                             <constraint firstItem="bDl-id-9M7" firstAttribute="centerY" secondItem="rcg-tb-060" secondAttribute="centerY" id="DOj-EN-RRl"/>
                             <constraint firstItem="0Gm-n3-CNm" firstAttribute="leading" secondItem="AUn-YX-qnu" secondAttribute="leading" constant="12" id="DbB-wE-25b"/>
                             <constraint firstItem="Wrp-Wr-ZBq" firstAttribute="leading" secondItem="0Gm-n3-CNm" secondAttribute="trailing" constant="10" id="IXJ-3i-CFq"/>
-                            <constraint firstItem="Kcl-X2-f1f" firstAttribute="leading" secondItem="AUn-YX-qnu" secondAttribute="leading" id="KvL-C9-BsK"/>
                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="bDl-id-9M7" secondAttribute="bottom" priority="750" constant="9" id="PVc-g0-lrn"/>
-                            <constraint firstAttribute="bottom" secondItem="Kcl-X2-f1f" secondAttribute="bottom" id="QxH-g8-9jc"/>
                             <constraint firstAttribute="trailing" secondItem="bDl-id-9M7" secondAttribute="trailing" constant="12" id="WP3-62-HDv"/>
                             <constraint firstAttribute="trailing" secondItem="Wrp-Wr-ZBq" secondAttribute="trailing" constant="12" id="WyT-D4-F81"/>
                             <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="Wrp-Wr-ZBq" secondAttribute="top" constant="4" id="Xqq-1P-og4"/>
                             <constraint firstItem="rcg-tb-060" firstAttribute="top" secondItem="Wrp-Wr-ZBq" secondAttribute="bottom" constant="2" id="Zbd-5G-fWz"/>
                             <constraint firstItem="bDl-id-9M7" firstAttribute="leading" secondItem="rcg-tb-060" secondAttribute="trailing" constant="4" id="eSq-C3-JsX"/>
-                            <constraint firstItem="Kcl-X2-f1f" firstAttribute="top" secondItem="AUn-YX-qnu" secondAttribute="top" id="gJO-Or-Auf"/>
                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="0Gm-n3-CNm" secondAttribute="bottom" priority="750" constant="12" id="mv0-17-x7y"/>
                             <constraint firstItem="rcg-tb-060" firstAttribute="leading" secondItem="Wrp-Wr-ZBq" secondAttribute="leading" id="xOk-Yf-b3f"/>
                         </constraints>
@@ -81,7 +73,6 @@
                 <outlet property="detailsLabel" destination="Wrp-Wr-ZBq" id="Fos-Bf-RYL"/>
                 <outlet property="gravatarImageView" destination="0Gm-n3-CNm" id="GXM-xm-h6r"/>
                 <outlet property="layoutView" destination="AUn-YX-qnu" id="gcz-64-y5u"/>
-                <outlet property="separatorsView" destination="Kcl-X2-f1f" id="UCV-vD-QcQ"/>
                 <outlet property="timestampImageView" destination="rcg-tb-060" id="cp9-u0-P57"/>
                 <outlet property="timestampLabel" destination="bDl-id-9M7" id="sk9-hl-b6r"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -7,38 +7,38 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="Upg-EE-wRd" customClass="CommentsTableViewCell" customModule="WordPress" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="Upg-EE-wRd" customClass="CommentsTableViewCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" layoutMarginsFollowReadableWidth="YES" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="69.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AUn-YX-qnu" userLabel="Layout View">
-                        <rect key="frame" x="8" y="0.0" width="304" height="70"/>
+                        <rect key="frame" x="15" y="0.0" width="290" height="70"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="12" y="12" width="46" height="46"/>
+                                <rect key="frame" x="0.0" y="12" width="46" height="46"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="46" id="h59-o3-ocT"/>
                                     <constraint firstAttribute="width" constant="46" id="pBo-eH-W4J"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq">
-                                <rect key="frame" x="68" y="8" width="224" height="20.5"/>
+                                <rect key="frame" x="56" y="8" width="234" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reader-postaction-time" translatesAutoresizingMaskIntoConstraints="NO" id="rcg-tb-060">
-                                <rect key="frame" x="68" y="30" width="16" height="16"/>
+                                <rect key="frame" x="56" y="30" width="16" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="16" id="YZR-zM-ndp"/>
                                     <constraint firstAttribute="height" constant="16" id="xwF-CO-6ZI"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
-                                <rect key="frame" x="88" y="28.5" width="204" height="20.5"/>
+                                <rect key="frame" x="76" y="28.5" width="214" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -48,11 +48,11 @@
                         <constraints>
                             <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="AUn-YX-qnu" secondAttribute="top" constant="12" id="8ks-PZ-pXh"/>
                             <constraint firstItem="bDl-id-9M7" firstAttribute="centerY" secondItem="rcg-tb-060" secondAttribute="centerY" id="DOj-EN-RRl"/>
-                            <constraint firstItem="0Gm-n3-CNm" firstAttribute="leading" secondItem="AUn-YX-qnu" secondAttribute="leading" constant="12" id="DbB-wE-25b"/>
+                            <constraint firstItem="0Gm-n3-CNm" firstAttribute="leading" secondItem="AUn-YX-qnu" secondAttribute="leading" id="DbB-wE-25b"/>
                             <constraint firstItem="Wrp-Wr-ZBq" firstAttribute="leading" secondItem="0Gm-n3-CNm" secondAttribute="trailing" constant="10" id="IXJ-3i-CFq"/>
                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="bDl-id-9M7" secondAttribute="bottom" priority="750" constant="9" id="PVc-g0-lrn"/>
-                            <constraint firstAttribute="trailing" secondItem="bDl-id-9M7" secondAttribute="trailing" constant="12" id="WP3-62-HDv"/>
-                            <constraint firstAttribute="trailing" secondItem="Wrp-Wr-ZBq" secondAttribute="trailing" constant="12" id="WyT-D4-F81"/>
+                            <constraint firstAttribute="trailing" secondItem="bDl-id-9M7" secondAttribute="trailing" id="WP3-62-HDv"/>
+                            <constraint firstAttribute="trailing" secondItem="Wrp-Wr-ZBq" secondAttribute="trailing" id="WyT-D4-F81"/>
                             <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="Wrp-Wr-ZBq" secondAttribute="top" constant="4" id="Xqq-1P-og4"/>
                             <constraint firstItem="rcg-tb-060" firstAttribute="top" secondItem="Wrp-Wr-ZBq" secondAttribute="bottom" constant="2" id="Zbd-5G-fWz"/>
                             <constraint firstItem="bDl-id-9M7" firstAttribute="leading" secondItem="rcg-tb-060" secondAttribute="trailing" constant="4" id="eSq-C3-JsX"/>

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -141,7 +141,6 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (void)configureTableView
 {
-    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.tableView.accessibilityIdentifier  = @"Comments Table";
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     


### PR DESCRIPTION
Reworking the comments cell layout a bit to better follow readability margins for leading and trailing. Also drops the use of the custom separator to instead use the default separator which does extend to the far right.

Note: There's still a bit of wonky layout here with the dedicated `layoutView` and how the height for these cells is calculated by running a layout calculation... but we'll leave that for another day.

To test:
- Ensure the comments cells load as expected under Comments.
- Ensure the height calculations are correct and no lines are cut off.
- Ensure the margins follow the readable margins on iPad.
- Ensure the margins are as expected on iPhone.

Needs review: @jleandroperez can you take a peak? 😐🍔
