### PR TITLE
Tests: Update broken tests

### DIFF
--- a/WordPress/WordPressTest/FeatureFlagTest.swift
+++ b/WordPress/WordPressTest/FeatureFlagTest.swift
@@ -24,10 +24,9 @@ class FeatureFlagTest: XCTestCase {
 
     func testEnsureDisabledFeaturesInProduction() {
         Build.withCurrent(.AppStore) {
-            expect(FeatureFlag.People.enabled).to(beFalse())
+            expect(FeatureFlag.ReaderMenu.enabled).to(beFalse())
         }
     }
-
 }
 
 extension Build {

--- a/WordPress/WordPressTest/ViewRelated/Blog/Style/WPStyleGuide+BlogTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Blog/Style/WPStyleGuide+BlogTests.swift
@@ -26,6 +26,6 @@ class WPStyleGuide_BlogTests: XCTestCase {
 
     func testConfigureTableViewBlogCellSetsBackgroundColor() {
         WPStyleGuide.configureTableViewBlogCell(testCell)
-        XCTAssertEqual(WPStyleGuide.lightGrey(), testCell.backgroundColor)
+        XCTAssertEqual(UIColor.whiteColor(), testCell.backgroundColor)
     }
 }


### PR DESCRIPTION
Updates the tests configuration for the currently disabled feature flags and recent blog list cell changes. (tests were failing)

To test:

- Run all of the tests for WordPressTest, ensure all pass.

Needs review: @frosty 