### PR TITLE
Reader: Moves text 'reset' to WPRichTextView

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
+++ b/WordPress/Classes/ViewRelated/Reader/CommentContentView.m
@@ -449,9 +449,6 @@ static const UIEdgeInsets ReplyAndLikeButtonEdgeInsets = {0.0f, 4.0f, 0.0f, -4.0
 
 - (void)configureContentView
 {
-    // Set the content to an empty string first. This "resets" the text layout
-    // and helps clear up some artifacting and drawing errors in certain edge cases.
-    self.textContentView.content = @"";
     self.textContentView.privateContent = [self.contentProvider isPrivateContent];
     self.textContentView.content = [self sanitizedContentStringForDisplay:[self.contentProvider contentForDisplay]];
 }

--- a/WordPress/Classes/ViewRelated/Views/WPRichTextView.m
+++ b/WordPress/Classes/ViewRelated/Views/WPRichTextView.m
@@ -162,6 +162,10 @@ NSString * const WPRichTextDefaultFontName = @"Merriweather";
     }
     _content = content;
 
+    // Assign an empty attributed string first. This "resets" the text layout
+    // and helps clear up some artifacting and drawing errors in certain edge cases.
+    self.attributedString = [[NSAttributedString alloc] initWithString:@""];
+
     NSData *data = [_content dataUsingEncoding:NSUTF8StringEncoding];
     self.attributedString = [[NSAttributedString alloc] initWithHTMLData:data
                                                                  options:self.textOptions


### PR DESCRIPTION
Fixes #5796 
#5654 introduced a subtle bug where comment images could be loaded over and over in a never ending loop.  The normal flow should be:
1. The table view loads its data.
2. A comment cell is configured with a comment.
3. The comment cells comment view processes its content provider and assigns the comment content to its internal WPRichTextView
4. The WPRichTextView renders its text and begins loading any images.
5. Delegates are notified when any images have finished loading.
6. The tableview refreshes clears cached cell heights and reloads so the images are correctly rendered. 

When the tableView reloads steps 1 - 3 repeat, however since the same content is being assigned to the richtext view the process ends there.  Or rather that's what should happen. #5654 introduced code to "reset" the richtext view to clean up some artificating and other edge cases.  A consequence of this is the richtext view went through the entire layout and image loading process all over again, resulting in an infinite loading loop. 

This PR moves the optimization out of the `CommentContentView` and into `WPRichTextView`.  This is probably a better place for it since it really a DT issue, and it allows the reset to still occur when the content being displayed changes. 


To test: 
In the reader, view a comment whose content includes images.  Confirm the images load correctly and do not continuously reload.  You can set a breakpoint in `[ReaderCommentsViewController commentView:updatedAttachmentViewsForProvider:]` to confirm the same image is not being loaded over and over. 

Repeat the tests listed in #5654 and confirm that there is no regression with this change.

Needs review: @jleandroperez 

