### PR TITLE
Posts/Themes: Preventing call to willDismissSearchController.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -162,10 +162,11 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
 
-        searchController.active = false
+        if searchController.active {
+            searchController.active = false
+        }
 
         NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationDidBecomeActiveNotification, object: nil)
-
         unregisterForKeyboardNotifications()
     }
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -267,7 +267,11 @@ public protocol ThemePresenter: class
     }
 
     public override func viewWillDisappear(animated: Bool) {
-        searchController.active = false
+
+        if searchController.active {
+            searchController.active = false
+        }
+
         super.viewWillDisappear(animated)
 
         unregisterForKeyboardNotifications()


### PR DESCRIPTION
Setting the `searchController` to not `active` when it already wasn’t active subsequently called `willDismissSearchController` on the delegate, producing unexpected search cancelling results.

This specifically caused an issue with the tableView's offset when leaving the view controller, where `willDismissSearchController` is called, `searchText` is set to `nil`, and the tableView's content and offset are updated.

To test:

1. Open Blog Posts.
2. Scroll down a bit, select a post.
3. Go back.
4. The tableView offset should be where it was originally.
5. The `willDismissSearchController` should not have been called.

To Test:

1. Open Blog Posts.
2. Search for posts.
3. Select a post.
4. Search should be cancelled, as expected.

To Test:

1. Repeat above, but for Themes.

Needs review: @frosty (no rush)

Note: Perhaps we shouldn't be deactivating search when selecting a search result? 🤔