### PR TITLE
Reader Followed Sites: Readability for iPad layouts.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -633,10 +633,11 @@
         <scene sceneID="I2o-bP-1jd">
             <objects>
                 <tableViewController id="FBk-BW-Oyk" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="54" sectionHeaderHeight="18" sectionFooterHeight="18" id="q5P-P8-r6d">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="54" sectionHeaderHeight="18" sectionFooterHeight="18" id="q5P-P8-r6d">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="536"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                        <variation key="heightClass=regular-widthClass=regular" layoutMarginsFollowReadableWidth="YES"/>
                         <connections>
                             <outlet property="dataSource" destination="FBk-BW-Oyk" id="yba-yB-ea9"/>
                             <outlet property="delegate" destination="FBk-BW-Oyk" id="Lvf-We-O91"/>

--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -633,11 +633,10 @@
         <scene sceneID="I2o-bP-1jd">
             <objects>
                 <tableViewController id="FBk-BW-Oyk" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="54" sectionHeaderHeight="18" sectionFooterHeight="18" id="q5P-P8-r6d">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="54" sectionHeaderHeight="18" sectionFooterHeight="18" id="q5P-P8-r6d">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="536"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                        <variation key="heightClass=regular-widthClass=regular" layoutMarginsFollowReadableWidth="YES"/>
                         <connections>
                             <outlet property="dataSource" destination="FBk-BW-Oyk" id="yba-yB-ea9"/>
                             <outlet property="delegate" destination="FBk-BW-Oyk" id="Lvf-We-O91"/>

--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -408,20 +408,7 @@
                         <subviews>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="B6J-Lg-PdX">
                                 <rect key="frame" x="0.0" y="20" width="600" height="44"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="600" id="d6x-GN-HTJ"/>
-                                </constraints>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="d6x-GN-HTJ"/>
-                                    </mask>
-                                </variation>
-                                <variation key="heightClass=regular-widthClass=regular">
-                                    <mask key="constraints">
-                                        <include reference="d6x-GN-HTJ"/>
-                                    </mask>
-                                </variation>
                                 <connections>
                                     <outlet property="delegate" destination="e0f-8T-Sz8" id="8aD-d4-C9q"/>
                                 </connections>
@@ -436,18 +423,28 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="POi-4x-5Dc" firstAttribute="top" secondItem="49S-3J-OMN" secondAttribute="bottom" id="0rH-fk-AGg"/>
-                            <constraint firstAttribute="trailing" secondItem="B6J-Lg-PdX" secondAttribute="trailing" id="FB0-IT-8ty"/>
+                            <constraint firstAttribute="trailing" secondItem="B6J-Lg-PdX" secondAttribute="trailing" id="8Ig-Pa-nrt"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="B6J-Lg-PdX" secondAttribute="trailing" constant="-10" id="FB0-IT-8ty"/>
                             <constraint firstItem="49S-3J-OMN" firstAttribute="top" secondItem="B6J-Lg-PdX" secondAttribute="bottom" id="FPy-1r-Z0H"/>
-                            <constraint firstItem="B6J-Lg-PdX" firstAttribute="leading" secondItem="zNg-ay-PFI" secondAttribute="leading" id="LlQ-Hl-xwi"/>
+                            <constraint firstItem="B6J-Lg-PdX" firstAttribute="leading" secondItem="zNg-ay-PFI" secondAttribute="leading" id="KUL-kZ-3vg"/>
+                            <constraint firstItem="B6J-Lg-PdX" firstAttribute="leading" secondItem="zNg-ay-PFI" secondAttribute="leadingMargin" constant="-10" id="LlQ-Hl-xwi"/>
                             <constraint firstAttribute="trailing" secondItem="49S-3J-OMN" secondAttribute="trailing" id="M8m-fa-9Kl"/>
                             <constraint firstItem="49S-3J-OMN" firstAttribute="leading" secondItem="zNg-ay-PFI" secondAttribute="leading" id="Tjg-wk-KPx"/>
                             <constraint firstItem="B6J-Lg-PdX" firstAttribute="top" secondItem="POD-Dc-YbQ" secondAttribute="bottom" id="Wy7-AW-DmL"/>
                             <constraint firstItem="B6J-Lg-PdX" firstAttribute="centerX" secondItem="zNg-ay-PFI" secondAttribute="centerX" id="kaH-A8-bk2"/>
                         </constraints>
-                        <variation key="heightClass=regular-widthClass=regular">
+                        <variation key="default">
                             <mask key="constraints">
                                 <exclude reference="FB0-IT-8ty"/>
                                 <exclude reference="LlQ-Hl-xwi"/>
+                            </mask>
+                        </variation>
+                        <variation key="heightClass=regular-widthClass=regular" layoutMarginsFollowReadableWidth="YES">
+                            <mask key="constraints">
+                                <exclude reference="8Ig-Pa-nrt"/>
+                                <include reference="FB0-IT-8ty"/>
+                                <exclude reference="KUL-kZ-3vg"/>
+                                <include reference="LlQ-Hl-xwi"/>
                             </mask>
                         </variation>
                     </view>
@@ -636,7 +633,7 @@
         <scene sceneID="I2o-bP-1jd">
             <objects>
                 <tableViewController id="FBk-BW-Oyk" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="54" sectionHeaderHeight="18" sectionFooterHeight="18" id="q5P-P8-r6d">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="54" sectionHeaderHeight="18" sectionFooterHeight="18" id="q5P-P8-r6d">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="536"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -274,10 +274,6 @@ extension ReaderFollowedSitesViewController : WPTableViewHandlerDelegate
             return
         }
 
-        if let wpCell = cell as? WPTableViewCell {
-            wpCell.forceCustomCellMargins = true
-        }
-
         cell.accessoryType = .DisclosureIndicator
         cell.imageView?.backgroundColor = WPStyleGuide.greyLighten30()
 


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/5792#issuecomment-235706730

Resolving the header margin misalignment by adapting readable margins on iPad for the tableView and search bar up top. We'll leave the margins as is for iPhone layouts for now.

To test:

1. Open the `ReaderFollowedSitesViewController` on iPad.
2. Ensure the margins for the tableView, cells and header are following the expected readable margins.
3. Ensure the margins for the searchBar are following the expected readable margins.
4. Open on iPhone.
5. Ensure the margins are as originally expected for iPhone.

Needs review: @aerych can you take a look?
