### PR TITLE
Fixing Notifications TableViewHandler Crash

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -128,7 +128,7 @@ class NotificationsViewController : UITableViewController
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-        tableViewHandler.clearCachedRowHeights()
+        tableViewHandler?.clearCachedRowHeights()
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -128,6 +128,8 @@ class NotificationsViewController : UITableViewController
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
+        // Note: We're assuming `tableViewHandler` might be nil. Weird iPad Multitasking flow in which the view
+        // never gets loaded, yet, this method is executed.
         tableViewHandler?.clearCachedRowHeights()
     }
 


### PR DESCRIPTION
To test:
1. Log into a dotcom account on an iPad Device
2. Make sure *NEVER* to open the Notifications tab (ensuring that the view doesn't load)
3. Switch to Safari
4. Open WPiOS side-by-side

Verify that the app doesn't crash right away.

Needs review: @kurzee 
Brent, may i bug you with a quick review?. Thanks for catching this one!!!


