### PR TITLE
PlansRemote: Removes sorting, so plans are returned in API order.

### DIFF
--- a/WordPress/Classes/Networking/PlansRemote.swift
+++ b/WordPress/Classes/Networking/PlansRemote.swift
@@ -71,7 +71,7 @@ private func mapPlansResponse(response: AnyObject) throws -> (activePlan: Plan, 
     guard let activePlan = parsedResponse.0 else {
         throw PlansRemote.Error.NoActivePlan
     }
-    let availablePlans = parsedResponse.1.sort()
+    let availablePlans = parsedResponse.1
     return (activePlan, availablePlans)
 }
 


### PR DESCRIPTION
Fixes #5813. Removes manual sorting (by ID) of plans, and simply uses them in the order returned by the API.

The missing plan icon should be fixed on the server side soon.

To test: 

* Select a site
* View plans
* Check that the plans are ordered Free, Personal, Premium, Business.

Needs review: @kwonye 