### PR TITLE
Issues/4094 reader menu sync

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -148,12 +148,19 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 - (void)markUnfollowedSiteTopicWithSiteID:(NSNumber *)siteID;
 
 /**
-
  Fetch the topic for 'sites I follow' if it exists.
 
  @return A `ReaderAbstractTopic` instance or nil.
  */
 - (ReaderAbstractTopic *)topicForFollowedSites;
+
+/**
+ Fetch the topic for 'Discover' if it exists.
+
+ @return A `ReaderAbstractTopic` instance or nil.
+ */
+- (ReaderAbstractTopic *)topicForDiscover;
+
 
 /**
  Fetch a tag topic for a tag with the specified slug.

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -161,7 +161,6 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  */
 - (ReaderAbstractTopic *)topicForDiscover;
 
-
 /**
  Fetch a tag topic for a tag with the specified slug.
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -511,6 +511,19 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     return (ReaderAbstractTopic *)[results firstObject];
 }
 
+- (ReaderAbstractTopic *)topicForDiscover
+{
+    NSError *error;
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ReaderAbstractTopic classNameWithoutNamespaces]];
+    request.predicate = [NSPredicate predicateWithFormat:@"path LIKE %@", @"*/read/sites/53424024/posts"];
+    NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
+    if (error) {
+        DDLogError(@"Failed to fetch topic for Discover: %@", error);
+        return nil;
+    }
+    return (ReaderAbstractTopic *)[results firstObject];
+}
+
 - (void)siteTopicForSiteWithID:(NSNumber *)siteID
                         isFeed:(BOOL)isFeed
                        success:(void (^)(NSManagedObjectID *objectID, BOOL isFollowing))success

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1576,6 +1576,9 @@ extension ReaderStreamViewController : WPTableViewHandlerDelegate {
 
     public func tableViewHandlerDidRefreshTableViewPreservingOffset(tableViewHandler: WPTableViewHandler) {
         if tableViewHandler.resultsController.fetchedObjects?.count == 0 {
+            if syncHelper.isSyncing {
+                return
+            }
             displayNoResultsView()
         } else {
             hideResultsStatus()


### PR DESCRIPTION
Refs #4094

This PR introduces syncing to the new menu. A sync is performed silently when the menu is first loaded, or via a pull to refresh gesture on demand.  Additionally, the Discover feed is now presented when the Reader is first launched. 

To test:
- Set a break point and confirm the menu is synced when it is first loaded. 
- Try the pull to refresh gesture and confirm the menu syncs.
- Try to pull to refresh while syncing and confirm that a second sync is not started. 
- Sign out of wpcom. Switch to the reader.  Confirm you see the Discover feed (and the correct Loading screen).
- Sign into wpcom.  Switch to the reader.  Confirm you see the Discover feed (and the correct Loading screen). 
- Open the reader to a topic other than discover. Background the app, then restore the app.  Switch to a different tab.  Quit the app. Relaunch the app and switch back to the reader tab.  Confirm that state restoration properly restored the feed you selected and that you are *not* viewing the Discover feed.

Needs review: @kurzee would you mind taking this one?  
