### PR TITLE
PlanComparisonViewController page count now updates correctly

### DIFF
--- a/WordPress/Classes/ViewRelated/System/PagedViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/PagedViewController.swift
@@ -75,6 +75,8 @@ class PagedViewController: UIViewController {
 
             controller.didMoveToParentViewController(self)
         }
+
+        pageControl.numberOfPages = viewControllers.count
     }
 
     @IBAction func pageControlChanged() {


### PR DESCRIPTION
The plan comparison view controller didn't update the page count of its page control correctly to match the number of plans it was displaying. With the addition of the Personal plan, we were showing 3 page indicators, but 4 pages.

To test:

* View Plans for a site and then tap into a specific plan to view the comparison screen. Ensure that the number of dots on the page control at the bottom of the screen matches the number of pages in the scrollview.

Needs review: @kwonye 
