### PR TITLE
Fix Travis builds not failing for tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -253,7 +253,7 @@ def xcodebuild(*build_cmds)
   cmd += " -configuration #{xcode_configuration}"
   cmd += " "
   cmd += build_cmds.map(&:to_s).join(" ")
-  cmd += " | bundle exec xcpretty -f `bundle exec xcpretty-travis-formatter`" unless ENV['verbose']
+  cmd += " | bundle exec xcpretty -f `bundle exec xcpretty-travis-formatter` && exit ${PIPESTATUS[0]}" unless ENV['verbose']
   sh(cmd)
 end
 


### PR DESCRIPTION
Travis builds haven't been failing when tests fail (last example was addressed by #5797). This is fixed by having the build command return a non-zero exit code when tests fail.

To test:

1. You can find a commit with failing tests by checking out `4e2eaa624050fcbc1a7e5f292894105dae2903db`
2. Before applying this change: `rake test & echo $?`. You'll see that two tests fail, and exit code is 0. Travis would consider this to be passing.
3. After applying this change, run the same command and you'll see two tests fail but the exit code will be 1. On Travis, this will consider this failing.

__Update:__
You can also just check out these builds [with](https://travis-ci.org/wordpress-mobile/WordPress-iOS/builds/149222838) and [without](https://travis-ci.org/wordpress-mobile/WordPress-iOS/builds/149313694) a broken test.

Needs review: @kwonye