### PR TITLE
Notifications: Updates a comment to reflect how the crash occurs.

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -128,8 +128,8 @@ class NotificationsViewController : UITableViewController
 
     override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-        // Note: We're assuming `tableViewHandler` might be nil. Weird iPad Multitasking flow in which the view
-        // never gets loaded, yet, this method is executed.
+        // Note: We're assuming `tableViewHandler` might be nil. Weird case in which the view
+        // hasn't loaded, yet, but the method is still executed.
         tableViewHandler?.clearCachedRowHeights()
     }
 


### PR DESCRIPTION
Just updating this comment as the crash was actually not unique to iPad multitasking and occurs even on iPhone, as long as that view controller was not initially loaded.

Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/5810

Needs review: @jleandroperez 