### PR TITLE
Removes fallback min software version. Adds check for 0 version.

### DIFF
--- a/WordPress/Classes/Networking/RemoteBlogOptionsHelper.m
+++ b/WordPress/Classes/Networking/RemoteBlogOptionsHelper.m
@@ -32,9 +32,6 @@
                 options[key] = [response valueForKeyPath:sourceKeyPath];
             }
         }
-    } else {
-        //valid default values
-        options[@"software_version"] = @"3.6";
     }
     NSMutableDictionary *valueOptions = [NSMutableDictionary dictionaryWithCapacity:options.count];
     [options enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -771,8 +771,9 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
             }
             blog.options = [NSDictionary dictionaryWithDictionary:options];
 
+            // NOTE: `[blog version]` can return nil. If this happens `version` will be `0`
             CGFloat version = [[blog version] floatValue];
-            if (version < [WordPressMinimumVersion floatValue]) {
+            if (version > 0 && version < [WordPressMinimumVersion floatValue]) {
                 if (blog.lastUpdateWarning == nil
                     || [blog.lastUpdateWarning floatValue] < [WordPressMinimumVersion floatValue])
                 {


### PR DESCRIPTION
Fixes #5732 

To test:
The easiest way to test this is to edit [RemoteBlogOptionsHelper mapOptionsFromResponse:] and comment out the `software_version` key. This will simulate the issue described in #5732 with a wpcom acct. 
- Start signed out of the app.
- Sign into the app with a wpcom acct, and view the blog details screen.
- Confirm you are not prompted about WordPress being too old.
- Confirm you do not experience other errors due to the software version being `0`.

Needs review: @frosty 

