### PR TITLE
Properly sizes gallery images

### DIFF
--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -985,6 +985,10 @@ static const NSUInteger ReaderPostTitleLength = 30;
 
 - (NSString *)resizeGalleryImageURLsForContent:(NSString *)content isPrivateSite:(BOOL)isPrivateSite
 {
+    if (!content) {
+        return @"";
+    }
+
     NSMutableString *mcontent = [content mutableCopy];
 
     static NSRegularExpression *regexTiledGalleryDivs;

--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -1015,8 +1015,6 @@ static const NSUInteger ReaderPostTitleLength = 30;
                                   withString:modifiedURL.absoluteString
                                      options:NSLiteralSearch
                                        range:NSMakeRange(0, mcontent.length)];
-
-        NSLog(@"Original: %@ Modified: %@", originalURL, modifiedURL);
     }
 
     return mcontent;

--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -791,7 +791,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
     content = [self normalizeParagraphs:content];
     content = [self removeInlineStyles:content];
     content = [content stringByReplacingHTMLEmoticonsWithEmoji];
-    content = [self fixImageURLsForContent:content isPrivateSite:isPrivateSite];
+    content = [self resizeGalleryImageURLsForContent:content isPrivateSite:isPrivateSite];
 
     return content;
 }
@@ -983,7 +983,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
     return mstr;
 }
 
-- (NSString *)fixImageURLsForContent:(NSString *)content isPrivateSite:(BOOL)isPrivateSite
+- (NSString *)resizeGalleryImageURLsForContent:(NSString *)content isPrivateSite:(BOOL)isPrivateSite
 {
     NSMutableString *mcontent = [content mutableCopy];
 
@@ -1011,7 +1011,10 @@ static const NSUInteger ReaderPostTitleLength = 30;
             modifiedURL = [PhotonImageURLHelper photonURLWithSize:imageSize forImageURL:originalURL];
         }
 
-        [mcontent replaceOccurrencesOfString:srcImageURLString withString:modifiedURL.absoluteString options:NSLiteralSearch range:NSRangeFromString(mcontent)];
+        [mcontent replaceOccurrencesOfString:srcImageURLString
+                                  withString:modifiedURL.absoluteString
+                                     options:NSLiteralSearch
+                                       range:NSMakeRange(0, mcontent.length)];
 
         NSLog(@"Original: %@ Modified: %@", originalURL, modifiedURL);
     }

--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -700,7 +700,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
     NSString *content = [self stringOrEmptyString:[dict stringForKey:PostRESTKeyContent]];
     BOOL isPrivateSite = [self siteIsPrivateFromPostDictionary:dict];
 
-    return [self formatContent:content forPrivateSite:isPrivateSite];
+    return [self formatContent:content isPrivateSite:isPrivateSite];
 }
 
 /**
@@ -783,7 +783,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
  @param content The post content as a string.
  @return The formatted content.
  */
-- (NSString *)formatContent:(NSString *)content forPrivateSite:(BOOL)isPrivateSite
+- (NSString *)formatContent:(NSString *)content isPrivateSite:(BOOL)isPrivateSite
 {
     if ([self containsVideoPress:content]) {
         content = [self formatVideoPress:content];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 		931D270019EDAE8600114F17 /* CoreDataMigrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 931D26FF19EDAE8600114F17 /* CoreDataMigrationTests.m */; };
 		931DF4D618D09A2F00540BDD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 931DF4D818D09A2F00540BDD /* InfoPlist.strings */; };
 		932225B11C7CE50300443B02 /* WordPressShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 932225A71C7CE50300443B02 /* WordPressShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		932AB00B1D526C1400BE486D /* gallery-reader-post-private.json in Resources */ = {isa = PBXBuildFile; fileRef = 932AB00A1D526C1400BE486D /* gallery-reader-post-private.json */; };
 		932C6CB31D521DFA006E4A62 /* gallery-reader-post-public.json in Resources */ = {isa = PBXBuildFile; fileRef = 932C6CB21D521DFA006E4A62 /* gallery-reader-post-public.json */; };
 		934884AB19B73BA6004028D8 /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CC05F51962150600975CAC /* Constants.m */; };
 		934884AD19B78723004028D8 /* WordPressTodayWidget-Internal.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 934884AC19B78723004028D8 /* WordPressTodayWidget-Internal.entitlements */; };
@@ -1545,6 +1546,7 @@
 		931DF4DF18D09B3900540BDD /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		932225A71C7CE50300443B02 /* WordPressShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WordPressShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		93267A6019B896CD00997EB8 /* Info-Internal.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-Internal.plist"; sourceTree = "<group>"; };
+		932AB00A1D526C1400BE486D /* gallery-reader-post-private.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gallery-reader-post-private.json"; sourceTree = "<group>"; };
 		932C6CB21D521DFA006E4A62 /* gallery-reader-post-public.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "gallery-reader-post-public.json"; path = "../gallery-reader-post-public.json"; sourceTree = "<group>"; };
 		93460A36189D5091000E26CE /* WordPress 14.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 14.xcdatamodel"; sourceTree = "<group>"; };
 		934884AC19B78723004028D8 /* WordPressTodayWidget-Internal.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "WordPressTodayWidget-Internal.entitlements"; sourceTree = "<group>"; };
@@ -4599,6 +4601,7 @@
 				B5BC25A51CFCBDB600F7D8B9 /* people-send-invitation-success.json */,
 				B5BC25A31CFCBA6A00F7D8B9 /* people-send-invitation-failure.json */,
 				932C6CB21D521DFA006E4A62 /* gallery-reader-post-public.json */,
+				932AB00A1D526C1400BE486D /* gallery-reader-post-private.json */,
 			);
 			name = "Mock Data";
 			path = "Test Data";
@@ -5299,6 +5302,7 @@
 				E15618FF16DBA983006532C4 /* xmlrpc-response-newpost.xml in Resources */,
 				B5AEEC7C1ACACFDA008BF2A4 /* notifications-new-follower.json in Resources */,
 				B5AEEC791ACACFDA008BF2A4 /* notifications-badge.json in Resources */,
+				932AB00B1D526C1400BE486D /* gallery-reader-post-private.json in Resources */,
 				E156190116DBABDE006532C4 /* xmlrpc-response-getpost.xml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 		931D270019EDAE8600114F17 /* CoreDataMigrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 931D26FF19EDAE8600114F17 /* CoreDataMigrationTests.m */; };
 		931DF4D618D09A2F00540BDD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 931DF4D818D09A2F00540BDD /* InfoPlist.strings */; };
 		932225B11C7CE50300443B02 /* WordPressShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 932225A71C7CE50300443B02 /* WordPressShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		932C6CB31D521DFA006E4A62 /* gallery-reader-post-public.json in Resources */ = {isa = PBXBuildFile; fileRef = 932C6CB21D521DFA006E4A62 /* gallery-reader-post-public.json */; };
 		934884AB19B73BA6004028D8 /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CC05F51962150600975CAC /* Constants.m */; };
 		934884AD19B78723004028D8 /* WordPressTodayWidget-Internal.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 934884AC19B78723004028D8 /* WordPressTodayWidget-Internal.entitlements */; };
 		934884AF19B7875C004028D8 /* WordPress-Internal.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 934884AE19B7875C004028D8 /* WordPress-Internal.entitlements */; };
@@ -1544,6 +1545,7 @@
 		931DF4DF18D09B3900540BDD /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		932225A71C7CE50300443B02 /* WordPressShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WordPressShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		93267A6019B896CD00997EB8 /* Info-Internal.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-Internal.plist"; sourceTree = "<group>"; };
+		932C6CB21D521DFA006E4A62 /* gallery-reader-post-public.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "gallery-reader-post-public.json"; path = "../gallery-reader-post-public.json"; sourceTree = "<group>"; };
 		93460A36189D5091000E26CE /* WordPress 14.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 14.xcdatamodel"; sourceTree = "<group>"; };
 		934884AC19B78723004028D8 /* WordPressTodayWidget-Internal.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "WordPressTodayWidget-Internal.entitlements"; sourceTree = "<group>"; };
 		934884AE19B7875C004028D8 /* WordPress-Internal.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "WordPress-Internal.entitlements"; sourceTree = "<group>"; };
@@ -4596,6 +4598,7 @@
 				B5BC25A71CFCBEFF00F7D8B9 /* people-validate-invitation-failure.json */,
 				B5BC25A51CFCBDB600F7D8B9 /* people-send-invitation-success.json */,
 				B5BC25A31CFCBA6A00F7D8B9 /* people-send-invitation-failure.json */,
+				932C6CB21D521DFA006E4A62 /* gallery-reader-post-public.json */,
 			);
 			name = "Mock Data";
 			path = "Test Data";
@@ -5274,6 +5277,7 @@
 				B5BC25A81CFCBEFF00F7D8B9 /* people-validate-invitation-failure.json in Resources */,
 				B5BC25A61CFCBDB600F7D8B9 /* people-send-invitation-success.json in Resources */,
 				B5AEEC7A1ACACFDA008BF2A4 /* notifications-like.json in Resources */,
+				932C6CB31D521DFA006E4A62 /* gallery-reader-post-public.json in Resources */,
 				FFB8DC9F1CE320C700D4D1B7 /* WordPressComRestApiFailUnauthorized.json in Resources */,
 				E1E4CE0617739FAB00430844 /* test-image.jpg in Resources */,
 				FAFB84061BBF3638000BBA8E /* get-multiple-themes-v1.2.json in Resources */,

--- a/WordPress/WordPressTest/ReaderPostServiceRemoteTests.m
+++ b/WordPress/WordPressTest/ReaderPostServiceRemoteTests.m
@@ -27,6 +27,7 @@
 - (NSString *)removeInlineStyles:(NSString *)string;
 - (NSString *)postTitleFromPostDictionary:(NSDictionary *)dict;
 - (NSString *)postSummaryFromPostDictionary:(NSDictionary *)dict orPostContent:(NSString *)content;
+- (NSString *)fixImageURLsForContent:(NSString *)content isPrivateSite:(BOOL)isPrivateSite;
 
 @end
 
@@ -388,6 +389,26 @@
     phrase = @"coffee & cake";
     endpoint = [remoteService endpointUrlForSearchPhrase:phrase];
     XCTAssertTrue([endpoint hasSuffix:@"q=coffee%20&%20cake"], @"The expected search term was not found");
+}
+
+- (void)testFixImageURLsForContent
+{
+    ReaderPostServiceRemote *remoteService = nil;
+    XCTAssertNoThrow(remoteService = [self service]);
+
+    NSString *path = [[NSBundle bundleForClass:[self class]] pathForResource:@"gallery-reader-post-public" ofType:@"json"];
+    NSData *data = [NSData dataWithContentsOfFile:path];
+    NSDictionary *postDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+
+    XCTAssertNotNil(postDict);
+
+    NSString *content = [postDict stringForKey:@"content"];
+
+    XCTAssertNotNil(content);
+
+    NSString *resultContent = [remoteService fixImageURLsForContent:content isPrivateSite:YES];
+    NSLog(@"Result content:\n\n%@", resultContent);
+
 }
 
 @end

--- a/WordPress/WordPressTest/ReaderPostServiceRemoteTests.m
+++ b/WordPress/WordPressTest/ReaderPostServiceRemoteTests.m
@@ -27,7 +27,7 @@
 - (NSString *)removeInlineStyles:(NSString *)string;
 - (NSString *)postTitleFromPostDictionary:(NSDictionary *)dict;
 - (NSString *)postSummaryFromPostDictionary:(NSDictionary *)dict orPostContent:(NSString *)content;
-- (NSString *)fixImageURLsForContent:(NSString *)content isPrivateSite:(BOOL)isPrivateSite;
+- (NSString *)resizeGalleryImageURLsForContent:(NSString *)content isPrivateSite:(BOOL)isPrivateSite;
 
 @end
 
@@ -391,7 +391,7 @@
     XCTAssertTrue([endpoint hasSuffix:@"q=coffee%20&%20cake"], @"The expected search term was not found");
 }
 
-- (void)testFixImageURLsForContent
+- (void)testResizeGalleryImageURLsForContentPublic
 {
     ReaderPostServiceRemote *remoteService = nil;
     XCTAssertNoThrow(remoteService = [self service]);
@@ -406,9 +406,26 @@
 
     XCTAssertNotNil(content);
 
-    NSString *resultContent = [remoteService fixImageURLsForContent:content isPrivateSite:YES];
-    NSLog(@"Result content:\n\n%@", resultContent);
+    NSString *resultContent = [remoteService resizeGalleryImageURLsForContent:content isPrivateSite:NO];
+}
 
+- (void)testResizeGalleryImageURLsForContentPrivate
+{
+    ReaderPostServiceRemote *remoteService = nil;
+    XCTAssertNoThrow(remoteService = [self service]);
+
+    NSString *path = [[NSBundle bundleForClass:[self class]] pathForResource:@"gallery-reader-post-private" ofType:@"json"];
+    NSData *data = [NSData dataWithContentsOfFile:path];
+    NSDictionary *postDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+
+    XCTAssertNotNil(postDict);
+
+    NSString *content = [postDict stringForKey:@"content"];
+
+    XCTAssertNotNil(content);
+
+    NSString *resultContent = [remoteService resizeGalleryImageURLsForContent:content isPrivateSite:YES];
+    NSLog(@"Result content:\n\n%@", resultContent);
 }
 
 @end

--- a/WordPress/WordPressTest/ReaderPostServiceRemoteTests.m
+++ b/WordPress/WordPressTest/ReaderPostServiceRemoteTests.m
@@ -407,6 +407,11 @@
     XCTAssertNotNil(content);
 
     NSString *resultContent = [remoteService resizeGalleryImageURLsForContent:content isPrivateSite:NO];
+
+    // Verify that the image source was updated with a Photon-friendly sized URL
+    XCTAssertTrue([content rangeOfString:@"src=\"https://lanteanartest.files.wordpress.com/2016/07/image217.png?w=1024&#038;h=1365\""].length > 0);
+    XCTAssertTrue([resultContent rangeOfString:@"src=\"https://lanteanartest.files.wordpress.com/2016/07/image217.png?w=1024&#038;h=1365\""].length == 0);
+    XCTAssertTrue([resultContent rangeOfString:@"src=\"https://i0.wp.com/lanteanartest.files.wordpress.com/2016/07/image217.png?quality=80&resize=1242,2208&ssl=1\""].length > 0);
 }
 
 - (void)testResizeGalleryImageURLsForContentPrivate
@@ -425,7 +430,31 @@
     XCTAssertNotNil(content);
 
     NSString *resultContent = [remoteService resizeGalleryImageURLsForContent:content isPrivateSite:YES];
-    NSLog(@"Result content:\n\n%@", resultContent);
+
+    XCTAssertTrue([content rangeOfString:@"src=\"https://picklessaltyporkvonhausen.files.wordpress.com/2016/07/img_8961.jpg?w=181&#038;h=135&#038;crop=1\""].length > 0);
+    XCTAssertTrue([resultContent rangeOfString:@"src=\"https://picklessaltyporkvonhausen.files.wordpress.com/2016/07/img_8961.jpg?w=181&#038;h=135&#038;crop=1\""].length == 0);
+    XCTAssertTrue([resultContent rangeOfString:@"src=\"https://picklessaltyporkvonhausen.files.wordpress.com/2016/07/img_8961.jpg?h=2208.0&w=1242.0\""].length > 0);
 }
+
+- (void)testResizeGalleryImageURLsForContentEmptyString
+{
+    ReaderPostServiceRemote *remoteService = nil;
+    XCTAssertNoThrow(remoteService = [self service]);
+
+    NSString *resultContent = [remoteService resizeGalleryImageURLsForContent:@"" isPrivateSite:NO];
+
+    XCTAssertTrue([resultContent isEqualToString:@""]);
+}
+
+- (void)testResizeGalleryImageURLsForContentNilString
+{
+    ReaderPostServiceRemote *remoteService = nil;
+    XCTAssertNoThrow(remoteService = [self service]);
+
+    NSString *resultContent = [remoteService resizeGalleryImageURLsForContent:nil isPrivateSite:NO];
+
+    XCTAssertTrue([resultContent isEqualToString:@""]);
+}
+
 
 @end

--- a/WordPress/WordPressTest/Test Data/gallery-reader-post-private.json
+++ b/WordPress/WordPressTest/Test Data/gallery-reader-post-private.json
@@ -1,0 +1,175 @@
+{
+    "ID": 18,
+    "site_ID": 114137068,
+    "author": {
+        "ID": 55224769,
+        "login": "ardwptest1",
+        "email": false,
+        "name": "ardwptest1",
+        "first_name": "Dem 123",
+        "last_name": "Nutz",
+        "nice_name": "ardwptest1",
+        "URL": "http:\/\/www.xcode.wtf",
+        "avatar_URL": "https:\/\/2.gravatar.com\/avatar\/25c423b6c3907669104c65c9f03a185d?s=96&d=identicon&r=G",
+        "profile_URL": "http:\/\/en.gravatar.com\/ardwptest1",
+        "site_ID": 57773116
+    },
+    "date": "2016-07-15T14:14:39+00:00",
+    "modified": "2016-08-03T18:29:00+00:00",
+    "title": "Gallery Tiled",
+    "URL": "https:\/\/picklessaltyporkvonhausen.wordpress.com\/2016\/07\/15\/gallery-tiled\/",
+    "short_URL": "http:\/\/wp.me\/p7IUgs-i",
+    "content": "<div class=\"tiled-gallery type-rectangular tiled-gallery-unresized\" data-original-width=\"500\" data-carousel-extra='{&quot;blog_id&quot;:114137068,&quot;permalink&quot;:&quot;https:\\\/\\\/picklessaltyporkvonhausen.wordpress.com\\\/2016\\\/07\\\/15\\\/gallery-tiled\\\/&quot;,&quot;likes_blog_id&quot;:114137068}' > <div class=\"gallery-row\" style=\"width: 500px; height: 419px;\" data-original-width=\"500\" data-original-height=\"419\" > <div class=\"gallery-group images-3\" style=\"width: 185px; height: 419px;\" data-original-width=\"185\" data-original-height=\"419\" > <div class=\"tiled-gallery-item tiled-gallery-item-small\"> <a href=\"https:\/\/picklessaltyporkvonhausen.wordpress.com\/2016\/07\/15\/gallery-tiled\/img_8961\/\" border=\"0\"> <img data-attachment-id=\"19\" data-orig-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8961.jpg\" data-orig-size=\"4032,3024\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;2.2&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;iPhone 6s Plus&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;1456495721&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;4.15&quot;,&quot;iso&quot;:&quot;25&quot;,&quot;shutter_speed&quot;:&quot;0.00050709939148073&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;1&quot;}\" data-image-title=\"IMG_8961\" data-image-description=\"\" data-medium-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8961.jpg?w=300\" data-large-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8961.jpg?w=1024\" src=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8961.jpg?w=181&#038;h=135&#038;crop=1\" width=\"181\" height=\"135\" data-original-width=\"181\" data-original-height=\"135\" title=\"IMG_8961\" alt=\"IMG_8961\" style=\"width: 181px; height: 135px;\" \/> <\/a> <\/div> <div class=\"tiled-gallery-item tiled-gallery-item-small\"> <a href=\"https:\/\/picklessaltyporkvonhausen.wordpress.com\/2016\/07\/15\/gallery-tiled\/img_8985\/\" border=\"0\"> <img data-attachment-id=\"20\" data-orig-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8985.jpg\" data-orig-size=\"4032,3024\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;2.2&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;iPhone 6s Plus&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;1456495981&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;4.15&quot;,&quot;iso&quot;:&quot;25&quot;,&quot;shutter_speed&quot;:&quot;0.00053304904051173&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;1&quot;}\" data-image-title=\"IMG_8985\" data-image-description=\"\" data-medium-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8985.jpg?w=300\" data-large-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8985.jpg?w=1024\" src=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8985.jpg?w=181&#038;h=136&#038;crop=1\" width=\"181\" height=\"136\" data-original-width=\"181\" data-original-height=\"136\" title=\"IMG_8985\" alt=\"IMG_8985\" style=\"width: 181px; height: 136px;\" \/> <\/a> <\/div> <div class=\"tiled-gallery-item tiled-gallery-item-small\"> <a href=\"https:\/\/picklessaltyporkvonhausen.wordpress.com\/2016\/07\/15\/gallery-tiled\/img_8986\/\" border=\"0\"> <img data-attachment-id=\"21\" data-orig-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8986.jpg\" data-orig-size=\"4032,3024\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;2.2&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;iPhone 6s Plus&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;1456495987&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;4.15&quot;,&quot;iso&quot;:&quot;25&quot;,&quot;shutter_speed&quot;:&quot;0.00055897149245388&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;1&quot;}\" data-image-title=\"IMG_8986\" data-image-description=\"\" data-medium-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8986.jpg?w=300\" data-large-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8986.jpg?w=1024\" src=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8986.jpg?w=181&#038;h=136&#038;crop=1\" width=\"181\" height=\"136\" data-original-width=\"181\" data-original-height=\"136\" title=\"IMG_8986\" alt=\"IMG_8986\" style=\"width: 181px; height: 136px;\" \/> <\/a> <\/div> <\/div> <!-- close group --> <div class=\"gallery-group images-1\" style=\"width: 315px; height: 419px;\" data-original-width=\"315\" data-original-height=\"419\" > <div class=\"tiled-gallery-item tiled-gallery-item-large\"> <a href=\"https:\/\/picklessaltyporkvonhausen.wordpress.com\/2016\/07\/15\/gallery-tiled\/img_8987\/\" border=\"0\"> <img data-attachment-id=\"22\" data-orig-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8987.jpg\" data-orig-size=\"3024,4032\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;2.2&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;iPhone 6s Plus&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;1456495996&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;4.15&quot;,&quot;iso&quot;:&quot;25&quot;,&quot;shutter_speed&quot;:&quot;0.00071479628305933&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;1&quot;}\" data-image-title=\"IMG_8987\" data-image-description=\"\" data-medium-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8987.jpg?w=225\" data-large-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8987.jpg?w=768\" src=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8987.jpg?w=311&#038;h=415&#038;crop=1\" width=\"311\" height=\"415\" data-original-width=\"311\" data-original-height=\"415\" title=\"IMG_8987\" alt=\"IMG_8987\" style=\"width: 311px; height: 415px;\" \/> <\/a> <\/div> <\/div> <!-- close group --> <\/div> <!-- close row --> <div class=\"gallery-row\" style=\"width: 500px; height: 251px;\" data-original-width=\"500\" data-original-height=\"251\" > <div class=\"gallery-group images-1\" style=\"width: 334px; height: 251px;\" data-original-width=\"334\" data-original-height=\"251\" > <div class=\"tiled-gallery-item tiled-gallery-item-large\"> <a href=\"https:\/\/picklessaltyporkvonhausen.wordpress.com\/2016\/07\/15\/gallery-tiled\/img_8956\/\" border=\"0\"> <img data-attachment-id=\"23\" data-orig-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8956.jpg\" data-orig-size=\"4032,3024\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;2.2&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;iPhone 6s Plus&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;1456493679&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;4.15&quot;,&quot;iso&quot;:&quot;25&quot;,&quot;shutter_speed&quot;:&quot;0.00040306328093511&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;1&quot;}\" data-image-title=\"IMG_8956\" data-image-description=\"\" data-medium-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8956.jpg?w=300\" data-large-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8956.jpg?w=1024\" src=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8956.jpg?w=330&#038;h=247&#038;crop=1\" width=\"330\" height=\"247\" data-original-width=\"330\" data-original-height=\"247\" title=\"IMG_8956\" alt=\"IMG_8956\" style=\"width: 330px; height: 247px;\" \/> <\/a> <\/div> <\/div> <!-- close group --> <div class=\"gallery-group images-2\" style=\"width: 166px; height: 251px;\" data-original-width=\"166\" data-original-height=\"251\" > <div class=\"tiled-gallery-item tiled-gallery-item-small\"> <a href=\"https:\/\/picklessaltyporkvonhausen.wordpress.com\/2016\/07\/15\/gallery-tiled\/img_8957\/\" border=\"0\"> <img data-attachment-id=\"24\" data-orig-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8957.jpg\" data-orig-size=\"4032,3024\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;2.2&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;iPhone 6s Plus&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;1456493683&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;4.15&quot;,&quot;iso&quot;:&quot;25&quot;,&quot;shutter_speed&quot;:&quot;0.00024697456162015&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;1&quot;}\" data-image-title=\"IMG_8957\" data-image-description=\"\" data-medium-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8957.jpg?w=300\" data-large-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8957.jpg?w=1024\" src=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8957.jpg?w=162&#038;h=121&#038;crop=1\" width=\"162\" height=\"121\" data-original-width=\"162\" data-original-height=\"121\" title=\"IMG_8957\" alt=\"IMG_8957\" style=\"width: 162px; height: 121px;\" \/> <\/a> <\/div> <div class=\"tiled-gallery-item tiled-gallery-item-small\"> <a href=\"https:\/\/picklessaltyporkvonhausen.wordpress.com\/2016\/07\/15\/gallery-tiled\/img_8958\/\" border=\"0\"> <img data-attachment-id=\"25\" data-orig-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8958.jpg\" data-orig-size=\"4032,3024\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;2.2&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;iPhone 6s Plus&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;1456494188&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;4.15&quot;,&quot;iso&quot;:&quot;25&quot;,&quot;shutter_speed&quot;:&quot;0.00020798668885191&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;1&quot;}\" data-image-title=\"IMG_8958\" data-image-description=\"\" data-medium-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8958.jpg?w=300\" data-large-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8958.jpg?w=1024\" src=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8958.jpg?w=162&#038;h=122&#038;crop=1\" width=\"162\" height=\"122\" data-original-width=\"162\" data-original-height=\"122\" title=\"IMG_8958\" alt=\"IMG_8958\" style=\"width: 162px; height: 122px;\" \/> <\/a> <\/div> <\/div> <!-- close group --> <\/div> <!-- close row --> <div class=\"gallery-row\" style=\"width: 500px; height: 189px;\" data-original-width=\"500\" data-original-height=\"189\" > <div class=\"gallery-group images-1\" style=\"width: 250px; height: 189px;\" data-original-width=\"250\" data-original-height=\"189\" > <div class=\"tiled-gallery-item tiled-gallery-item-small\"> <a href=\"https:\/\/picklessaltyporkvonhausen.wordpress.com\/2016\/07\/15\/gallery-tiled\/img_8959\/\" border=\"0\"> <img data-attachment-id=\"26\" data-orig-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8959.jpg\" data-orig-size=\"4032,3024\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;2.2&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;iPhone 6s Plus&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;1456494191&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;4.15&quot;,&quot;iso&quot;:&quot;25&quot;,&quot;shutter_speed&quot;:&quot;0.00018198362147407&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;1&quot;}\" data-image-title=\"IMG_8959\" data-image-description=\"\" data-medium-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8959.jpg?w=300\" data-large-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8959.jpg?w=1024\" src=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8959.jpg?w=246&#038;h=185&#038;crop=1\" width=\"246\" height=\"185\" data-original-width=\"246\" data-original-height=\"185\" title=\"IMG_8959\" alt=\"IMG_8959\" style=\"width: 246px; height: 185px;\" \/> <\/a> <\/div> <\/div> <!-- close group --> <div class=\"gallery-group images-1\" style=\"width: 250px; height: 189px;\" data-original-width=\"250\" data-original-height=\"189\" > <div class=\"tiled-gallery-item tiled-gallery-item-small\"> <a href=\"https:\/\/picklessaltyporkvonhausen.wordpress.com\/2016\/07\/15\/gallery-tiled\/img_8960\/\" border=\"0\"> <img data-attachment-id=\"27\" data-orig-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8960.jpg\" data-orig-size=\"4032,3024\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;2.2&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;iPhone 6s Plus&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;1456495080&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;4.15&quot;,&quot;iso&quot;:&quot;25&quot;,&quot;shutter_speed&quot;:&quot;0.00029904306220096&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;1&quot;}\" data-image-title=\"IMG_8960\" data-image-description=\"\" data-medium-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8960.jpg?w=300\" data-large-file=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8960.jpg?w=1024\" src=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8960.jpg?w=246&#038;h=185&#038;crop=1\" width=\"246\" height=\"185\" data-original-width=\"246\" data-original-height=\"185\" title=\"IMG_8960\" alt=\"IMG_8960\" style=\"width: 246px; height: 185px;\" \/> <\/a> <\/div> <\/div> <!-- close group --> <\/div> <!-- close row --> <\/div>\n<p>&nbsp;<\/p>\n<p>This is text after.<\/p>\n<p>And an image that isn&#8217;t in the gallery:<\/p>\n<p><img class=\"alignnone size-full wp-image-15\" src=\"https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/stairs-lights-abstract-bubbles1.jpg?w=5184&#038;h=3456\" alt=\"Placeholder Image\" width=\"5184\" height=\"3456\" \/><\/p>\n",
+    "excerpt": "<p>&nbsp; This is text after. And an image that isn&#8217;t in the gallery:<\/p>\n",
+    "slug": "gallery-tiled",
+    "guid": "https:\/\/picklessaltyporkvonhausen.wordpress.com\/?p=18",
+    "status": "publish",
+    "sticky": false,
+    "password": "",
+    "parent": false,
+    "type": "post",
+    "comments_open": true,
+    "pings_open": true,
+    "likes_enabled": true,
+    "sharing_enabled": true,
+    "comment_count": 0,
+    "like_count": 1,
+    "i_like": true,
+    "is_reblogged": false,
+    "is_following": true,
+    "global_ID": "ad34d353ea54a9fd1498b4fc123bf0d9",
+    "featured_image": "",
+    "post_thumbnail": null,
+    "format": "gallery",
+    "geo": false,
+    "menu_order": 0,
+    "publicize_URLs": [],
+    "tags": {},
+    "categories": {
+        "Uncategorized": {
+            "ID": 1,
+            "name": "Uncategorized",
+            "slug": "uncategorized",
+            "description": "",
+            "post_count": 2,
+            "parent": 0,
+            "meta": {
+                "links": {
+                    "self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/114137068\/categories\/slug:uncategorized",
+                    "help": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/114137068\/categories\/slug:uncategorized\/help",
+                    "site": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/114137068"
+                }
+            }
+        }
+    },
+    "attachments": {
+        "27": {
+            "ID": 27,
+            "URL": "https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8960.jpg",
+            "guid": "http:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8960.jpg",
+            "mime_type": "image\/jpeg",
+            "width": 4032,
+            "height": 3024
+        },
+        "26": {
+            "ID": 26,
+            "URL": "https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8959.jpg",
+            "guid": "http:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8959.jpg",
+            "mime_type": "image\/jpeg",
+            "width": 4032,
+            "height": 3024
+        },
+        "25": {
+            "ID": 25,
+            "URL": "https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8958.jpg",
+            "guid": "http:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8958.jpg",
+            "mime_type": "image\/jpeg",
+            "width": 4032,
+            "height": 3024
+        },
+        "24": {
+            "ID": 24,
+            "URL": "https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8957.jpg",
+            "guid": "http:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8957.jpg",
+            "mime_type": "image\/jpeg",
+            "width": 4032,
+            "height": 3024
+        },
+        "23": {
+            "ID": 23,
+            "URL": "https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8956.jpg",
+            "guid": "http:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8956.jpg",
+            "mime_type": "image\/jpeg",
+            "width": 4032,
+            "height": 3024
+        },
+        "22": {
+            "ID": 22,
+            "URL": "https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8987.jpg",
+            "guid": "http:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8987.jpg",
+            "mime_type": "image\/jpeg",
+            "width": 3024,
+            "height": 4032
+        },
+        "21": {
+            "ID": 21,
+            "URL": "https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8986.jpg",
+            "guid": "http:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8986.jpg",
+            "mime_type": "image\/jpeg",
+            "width": 4032,
+            "height": 3024
+        },
+        "20": {
+            "ID": 20,
+            "URL": "https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8985.jpg",
+            "guid": "http:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8985.jpg",
+            "mime_type": "image\/jpeg",
+            "width": 4032,
+            "height": 3024
+        },
+        "19": {
+            "ID": 19,
+            "URL": "https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8961.jpg",
+            "guid": "http:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8961.jpg",
+            "mime_type": "image\/jpeg",
+            "width": 4032,
+            "height": 3024
+        }
+    },
+    "metadata": [{
+                 "id": "136",
+                 "key": "jabber_published",
+                 "value": "1468592079"
+                 }],
+    "meta": {
+        "links": {
+            "self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/114137068\/posts\/18",
+            "help": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/114137068\/posts\/18\/help",
+            "site": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/114137068",
+            "replies": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/114137068\/posts\/18\/replies\/",
+            "likes": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/114137068\/posts\/18\/likes\/"
+        }
+    },
+    "current_user_can": {
+        "publish_post": true,
+        "delete_post": true,
+        "edit_post": true
+    },
+    "capabilities": {
+        "publish_post": true,
+        "delete_post": true,
+        "edit_post": true
+    },
+    "pseudo_ID": "ad34d353ea54a9fd1498b4fc123bf0d9",
+    "is_external": false,
+    "site_name": "picklessaltyporkvonhausen",
+    "site_URL": "https:\/\/picklessaltyporkvonhausen.wordpress.com",
+    "site_is_private": true,
+    "featured_media": {
+        "uri": "https:\/\/picklessaltyporkvonhausen.files.wordpress.com\/2016\/07\/img_8960.jpg",
+        "width": 4032,
+        "height": 3024,
+        "type": "image"
+    },
+    "feed_ID": 50989203
+}

--- a/WordPress/WordPressTest/gallery-reader-post-public.json
+++ b/WordPress/WordPressTest/gallery-reader-post-public.json
@@ -1,0 +1,102 @@
+{
+    "ID": 1039,
+    "site_ID": 66291871,
+    "author": {
+        "ID": 45413599,
+        "login": "lanteanar",
+        "email": false,
+        "name": "Jorge Leandro Perez",
+        "first_name": "Jorge Leandro",
+        "last_name": "Perez",
+        "nice_name": "lanteanar",
+        "URL": "http://www.lantean.co",
+        "avatar_URL": "https://2.gravatar.com/avatar/e44d9c00c3af8037f203ca42207a99d7?s=96&d=identicon&r=G",
+        "profile_URL": "http://en.gravatar.com/lanteanar",
+        "site_ID": 46233804
+    },
+    "date": "2016-07-11T22:14:35+00:00",
+    "modified": "2016-07-11T22:14:35+00:00",
+    "title": "Ja,g,jhglkjhlkjhluugjhlghj,",
+    "URL": "https://lanteanartest.wordpress.com/2016/07/11/jagjhglkjhlkjhluugjhlghj-12/",
+    "short_URL": "http://wp.me/p4u9xJ-gL",
+    "content": "\n\t\t<style type='text/css'>\n\t\t\t#gallery-1039-1 {\n\t\t\t\tmargin: auto;\n\t\t\t}\n\t\t\t#gallery-1039-1 .gallery-item {\n\t\t\t\tfloat: left;\n\t\t\t\tmargin-top: 10px;\n\t\t\t\ttext-align: center;\n\t\t\t\twidth: 100%;\n\t\t\t}\n\t\t\t#gallery-1039-1 img {\n\t\t\t\tborder: 2px solid #cfcfcf;\n\t\t\t}\n\t\t\t#gallery-1039-1 .gallery-caption {\n\t\t\t\tmargin-left: 0;\n\t\t\t}\n\t\t\t/* see gallery_shortcode() in wp-includes/media.php */\n\t\t</style>\n\t\t<div data-carousel-extra='{\"blog_id\":66291871,\"permalink\":\"https:\\/\\/lanteanartest.wordpress.com\\/2016\\/07\\/11\\/jagjhglkjhlkjhluugjhlghj-12\\/\"}' id='gallery-1039-1' class='gallery galleryid-1039 gallery-columns-1 gallery-size-full'><dl class='gallery-item'>\n\t\t\t<dt class='gallery-icon portrait'>\n\t\t\t\t<a href='https://lanteanartest.wordpress.com/2016/07/11/jagjhglkjhlkjhluugjhlghj-12/image-34/'><img width=\"1024\" height=\"1365\" src=\"https://lanteanartest.files.wordpress.com/2016/07/image217.png?w=1024&#038;h=1365\" class=\"attachment-full size-full\" alt=\"image\" data-attachment-id=\"1041\" data-orig-file=\"https://lanteanartest.files.wordpress.com/2016/07/image217.png?w=1024&#038;h=1365\" data-orig-size=\"3024,4032\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"image\" data-image-description=\"\" data-medium-file=\"https://lanteanartest.files.wordpress.com/2016/07/image217.png?w=1024&#038;h=1365?w=225\" data-large-file=\"https://lanteanartest.files.wordpress.com/2016/07/image217.png?w=1024&#038;h=1365?w=768\" /></a>\n\t\t\t</dt></dl><br style=\"clear: both\" />\n\t\t</div>\n\n<p>Mjgfhjgfhmgfghm</p>\n",
+    "excerpt": "<p>Mjgfhjgfhmgfghm</p>\n",
+    "slug": "jagjhglkjhlkjhluugjhlghj-12",
+    "guid": "https://lanteanartest.wordpress.com/2016/07/11/jagjhglkjhlkjhluugjhlghj-12/",
+    "status": "publish",
+    "sticky": false,
+    "password": "",
+    "parent": false,
+    "type": "post",
+    "comments_open": true,
+    "pings_open": true,
+    "likes_enabled": true,
+    "sharing_enabled": true,
+    "comment_count": 0,
+    "like_count": 0,
+    "i_like": false,
+    "is_reblogged": false,
+    "is_following": true,
+    "global_ID": "772c1a4d273b4f778036ba259c126340",
+    "featured_image": "",
+    "post_thumbnail": null,
+    "format": "standard",
+    "geo": false,
+    "menu_order": 0,
+    "publicize_URLs": [],
+    "tags": {},
+    "categories": {
+        "Testing": {
+            "ID": 12,
+            "name": "Testing",
+            "slug": "testing",
+            "description": "",
+            "post_count": 59,
+            "parent": 0,
+            "meta": {
+                "links": {
+                    "self": "https://public-api.wordpress.com/rest/v1.1/sites/66291871/categories/slug:testing",
+                    "help": "https://public-api.wordpress.com/rest/v1.1/sites/66291871/categories/slug:testing/help",
+                    "site": "https://public-api.wordpress.com/rest/v1.1/sites/66291871"
+                }
+            }
+        }
+    },
+    "attachments": {
+        "1041": {
+            "ID": 1041,
+            "URL": "https://lanteanartest.files.wordpress.com/2016/07/image217.png",
+            "guid": "http://lanteanartest.files.wordpress.com/2016/07/image217.png",
+            "mime_type": "image/png",
+            "width": 3024,
+            "height": 4032
+        }
+    },
+    "metadata": false,
+    "meta": {
+        "links": {
+            "self": "https://public-api.wordpress.com/rest/v1.1/sites/66291871/posts/1039",
+            "help": "https://public-api.wordpress.com/rest/v1.1/sites/66291871/posts/1039/help",
+            "site": "https://public-api.wordpress.com/rest/v1.1/sites/66291871",
+            "replies": "https://public-api.wordpress.com/rest/v1.1/sites/66291871/posts/1039/replies/",
+            "likes": "https://public-api.wordpress.com/rest/v1.1/sites/66291871/posts/1039/likes/"
+        }
+    },
+    "current_user_can": {
+        "publish_post": false,
+        "delete_post": false,
+        "edit_post": false
+    },
+    "capabilities": {
+        "publish_post": false,
+        "delete_post": false,
+        "edit_post": false
+    },
+    "pseudo_ID": "772c1a4d273b4f778036ba259c126340",
+    "is_external": false,
+    "site_name": "Testing Blogzz",
+    "site_URL": "https://lanteanartest.wordpress.com",
+    "site_is_private": false,
+    "featured_media": {},
+    "feed_ID": 26034561
+},

--- a/WordPress/WordPressTest/gallery-reader-post-public.json
+++ b/WordPress/WordPressTest/gallery-reader-post-public.json
@@ -99,4 +99,4 @@
     "site_is_private": false,
     "featured_media": {},
     "feed_ID": 26034561
-},
+}


### PR DESCRIPTION
Related: #1260 

This PR causes images within a gallery to have their `src` attributes modified with parameters to resize them more appropriately for the current device screen. This solves an issue with images in mosaic galleries being of different sizes, mostly on private sites only.

![img_0522](https://cloud.githubusercontent.com/assets/373903/17378897/7ece7c4c-5985-11e6-91f2-f35f153761fa.PNG)

("Before" screenshot was taken on an older branch so the header styling does not match)

### To test:

Ensure images load properly for the following scenarios in Reader:
1. A post with no gallery but several images. (images should remain unresized)
2. A post on a public site with a gallery of 1 or more images. (images will be resized and pulled from Photon)
3. A post on a private site with a gallery of 1 or more images. (images will be resized).


Needs review: @aerych 
