### PR TITLE
Posts & Pages: Autosizing and Readability

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.m
@@ -1,10 +1,14 @@
 #import "PageListSectionHeaderView.h"
 #import "WPStyleGuide+Posts.h"
+#import "WPDeviceIdentification.h"
 
 @interface PageListSectionHeaderView()
 
 @property (nonatomic, strong) IBOutlet UILabel *titleLabel;
-@property (nonatomic, strong) IBOutlet UIView *contentView;
+@property (nonatomic, strong) IBOutlet UIView *topBorderView;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint *topBorderHeightConstraint;
+@property (nonatomic, strong) IBOutlet UIView *bottomBorderView;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint *bottomBorderHeightConstraint;
 
 @end
 
@@ -18,9 +22,16 @@
 
 - (void)applyStyles
 {
-    self.backgroundColor = [WPStyleGuide greyLighten30];
-    self.contentView.backgroundColor = [WPStyleGuide lightGrey];
+    self.backgroundColor = [WPStyleGuide lightGrey];
     [WPStyleGuide applySectionHeaderTitleStyle:self.titleLabel];
+
+    self.topBorderView.backgroundColor = [WPStyleGuide greyLighten20];
+    self.bottomBorderView.backgroundColor = self.topBorderView.backgroundColor;
+
+    if ([WPDeviceIdentification isRetina]) {
+        self.topBorderHeightConstraint.constant = 0.5;
+        self.bottomBorderHeightConstraint.constant = self.topBorderHeightConstraint.constant;
+    }
 }
 
 - (void)setTite:(NSString *)title

--- a/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.xib
@@ -2,56 +2,70 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="PageListSectionHeaderView">
+        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" customClass="PageListSectionHeaderView">
             <rect key="frame" x="0.0" y="0.0" width="320" height="24"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="efX-hG-Sds">
-                    <rect key="frame" x="6" y="0.0" width="308" height="23"/>
-                    <subviews>
-                        <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reader-postaction-time" translatesAutoresizingMaskIntoConstraints="NO" id="Ai0-Ac-pOc">
-                            <rect key="frame" x="10" y="4" width="16" height="16"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="16" id="R0e-Oi-bFn"/>
-                                <constraint firstAttribute="width" constant="16" id="drN-3K-RBH"/>
-                            </constraints>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T0w-kY-8uW">
-                            <rect key="frame" x="32" y="3" width="268" height="17"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nJ3-Q4-QJM">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="1"/>
+                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                     <constraints>
-                        <constraint firstItem="T0w-kY-8uW" firstAttribute="leading" secondItem="Ai0-Ac-pOc" secondAttribute="trailing" constant="6" id="Wsa-tE-gWT"/>
-                        <constraint firstAttribute="trailing" secondItem="T0w-kY-8uW" secondAttribute="trailing" constant="8" id="Xsw-Up-pnb"/>
-                        <constraint firstItem="Ai0-Ac-pOc" firstAttribute="leading" secondItem="efX-hG-Sds" secondAttribute="leading" constant="10" id="dri-xh-fhD"/>
-                        <constraint firstAttribute="centerY" secondItem="Ai0-Ac-pOc" secondAttribute="centerY" id="oQk-Ec-Dja"/>
-                        <constraint firstAttribute="centerY" secondItem="T0w-kY-8uW" secondAttribute="centerY" id="wtN-Mq-k8V"/>
+                        <constraint firstAttribute="height" constant="1" id="hXv-IA-XbK"/>
                     </constraints>
                 </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bJd-dp-RN2">
+                    <rect key="frame" x="0.0" y="23" width="320" height="1"/>
+                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="1" id="fhB-Qm-C4L"/>
+                    </constraints>
+                </view>
+                <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reader-postaction-time" translatesAutoresizingMaskIntoConstraints="NO" id="Ai0-Ac-pOc">
+                    <rect key="frame" x="7" y="4" width="16" height="16"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="16" id="R0e-Oi-bFn"/>
+                        <constraint firstAttribute="width" constant="16" id="drN-3K-RBH"/>
+                    </constraints>
+                </imageView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T0w-kY-8uW">
+                    <rect key="frame" x="29" y="3.5" width="283" height="17"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
-            <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
-                <constraint firstItem="efX-hG-Sds" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="6" id="Aef-iO-3Oa"/>
-                <constraint firstAttribute="trailing" secondItem="efX-hG-Sds" secondAttribute="trailing" constant="6" id="cLT-oe-KgI"/>
-                <constraint firstAttribute="bottom" secondItem="efX-hG-Sds" secondAttribute="bottom" constant="1" id="of4-Ii-10A"/>
-                <constraint firstItem="efX-hG-Sds" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="upM-9B-YNK"/>
+                <constraint firstItem="Ai0-Ac-pOc" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="64x-dU-a3c"/>
+                <constraint firstItem="Ai0-Ac-pOc" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" constant="-1" id="7Wu-6v-QcC"/>
+                <constraint firstItem="T0w-kY-8uW" firstAttribute="leading" secondItem="Ai0-Ac-pOc" secondAttribute="trailing" constant="6" id="7pq-Nb-ala"/>
+                <constraint firstItem="bJd-dp-RN2" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="9A0-4L-WMX"/>
+                <constraint firstAttribute="trailing" secondItem="nJ3-Q4-QJM" secondAttribute="trailing" id="9eL-ov-BQP"/>
+                <constraint firstAttribute="trailingMargin" secondItem="T0w-kY-8uW" secondAttribute="trailing" id="DfH-Qk-uHM"/>
+                <constraint firstItem="nJ3-Q4-QJM" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="PRb-az-V8p"/>
+                <constraint firstAttribute="bottom" secondItem="bJd-dp-RN2" secondAttribute="bottom" id="am2-tc-4xx"/>
+                <constraint firstItem="nJ3-Q4-QJM" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="f1P-dL-BJO"/>
+                <constraint firstAttribute="trailing" secondItem="bJd-dp-RN2" secondAttribute="trailing" id="mXp-Ea-6nm"/>
+                <constraint firstItem="bJd-dp-RN2" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="mtJ-7h-uHm"/>
+                <constraint firstItem="T0w-kY-8uW" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="nrC-M7-CNT"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="contentView" destination="efX-hG-Sds" id="IZX-YI-2he"/>
+                <outlet property="bottomBorderHeightConstraint" destination="fhB-Qm-C4L" id="lqN-rL-w52"/>
+                <outlet property="bottomBorderView" destination="bJd-dp-RN2" id="CAU-Wm-qGF"/>
                 <outlet property="titleLabel" destination="T0w-kY-8uW" id="YvO-AP-LKa"/>
+                <outlet property="topBorderHeightConstraint" destination="hXv-IA-XbK" id="2ZR-XG-AUs"/>
+                <outlet property="topBorderView" destination="nJ3-Q4-QJM" id="0z3-DK-zX9"/>
             </connections>
+            <point key="canvasLocation" x="235" y="185"/>
         </view>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -30,29 +29,17 @@
                     </subviews>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <constraints>
-                        <constraint firstAttribute="width" priority="750" constant="600" id="FtB-JF-glz"/>
                         <constraint firstItem="T0w-kY-8uW" firstAttribute="leading" secondItem="Ai0-Ac-pOc" secondAttribute="trailing" constant="6" id="Wsa-tE-gWT"/>
                         <constraint firstAttribute="trailing" secondItem="T0w-kY-8uW" secondAttribute="trailing" constant="8" id="Xsw-Up-pnb"/>
                         <constraint firstItem="Ai0-Ac-pOc" firstAttribute="leading" secondItem="efX-hG-Sds" secondAttribute="leading" constant="10" id="dri-xh-fhD"/>
                         <constraint firstAttribute="centerY" secondItem="Ai0-Ac-pOc" secondAttribute="centerY" id="oQk-Ec-Dja"/>
                         <constraint firstAttribute="centerY" secondItem="T0w-kY-8uW" secondAttribute="centerY" id="wtN-Mq-k8V"/>
                     </constraints>
-                    <variation key="default">
-                        <mask key="constraints">
-                            <exclude reference="FtB-JF-glz"/>
-                        </mask>
-                    </variation>
-                    <variation key="heightClass=regular-widthClass=regular">
-                        <mask key="constraints">
-                            <include reference="FtB-JF-glz"/>
-                        </mask>
-                    </variation>
                 </view>
             </subviews>
             <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="efX-hG-Sds" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="6" id="Aef-iO-3Oa"/>
-                <constraint firstAttribute="centerX" secondItem="efX-hG-Sds" secondAttribute="centerX" id="NNx-Uw-e0a"/>
                 <constraint firstAttribute="trailing" secondItem="efX-hG-Sds" secondAttribute="trailing" constant="6" id="cLT-oe-KgI"/>
                 <constraint firstAttribute="bottom" secondItem="efX-hG-Sds" secondAttribute="bottom" constant="1" id="of4-Ii-10A"/>
                 <constraint firstItem="efX-hG-Sds" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="upM-9B-YNK"/>
@@ -61,18 +48,6 @@
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <variation key="default">
-                <mask key="constraints">
-                    <exclude reference="NNx-Uw-e0a"/>
-                </mask>
-            </variation>
-            <variation key="heightClass=regular-widthClass=regular">
-                <mask key="constraints">
-                    <exclude reference="Aef-iO-3Oa"/>
-                    <include reference="NNx-Uw-e0a"/>
-                    <exclude reference="cLT-oe-KgI"/>
-                </mask>
-            </variation>
             <connections>
                 <outlet property="contentView" destination="efX-hG-Sds" id="IZX-YI-2he"/>
                 <outlet property="titleLabel" destination="T0w-kY-8uW" id="YvO-AP-LKa"/>

--- a/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.xib
@@ -46,7 +46,7 @@
                 <constraint firstItem="T0w-kY-8uW" firstAttribute="leading" secondItem="Ai0-Ac-pOc" secondAttribute="trailing" constant="6" id="7pq-Nb-ala"/>
                 <constraint firstItem="bJd-dp-RN2" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="9A0-4L-WMX"/>
                 <constraint firstAttribute="trailing" secondItem="nJ3-Q4-QJM" secondAttribute="trailing" id="9eL-ov-BQP"/>
-                <constraint firstAttribute="trailingMargin" secondItem="T0w-kY-8uW" secondAttribute="trailing" id="DfH-Qk-uHM"/>
+                <constraint firstAttribute="trailingMargin" secondItem="T0w-kY-8uW" secondAttribute="trailing" priority="999" id="DfH-Qk-uHM"/>
                 <constraint firstItem="nJ3-Q4-QJM" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="PRb-az-V8p"/>
                 <constraint firstAttribute="bottom" secondItem="bJd-dp-RN2" secondAttribute="bottom" id="am2-tc-4xx"/>
                 <constraint firstItem="nJ3-Q4-QJM" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="f1P-dL-BJO"/>

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -61,7 +61,6 @@
 
 - (void)applyStyles
 {
-    [WPStyleGuide applyPostCardStyle:self];
     [WPStyleGuide applyPageTitleStyle:self.titleLabel];
 }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -7,7 +7,6 @@
 @property (nonatomic, strong) IBOutlet UIView *pageContentView;
 @property (nonatomic, strong) IBOutlet UILabel *titleLabel;
 @property (nonatomic, strong) IBOutlet UIButton *menuButton;
-@property (nonatomic, strong) IBOutlet NSLayoutConstraint *maxIPadWidthConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *titleLabelTopMarginConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *titleLabelBottomMarginConstraint;
 
@@ -55,15 +54,8 @@
 {
     CGFloat width = 0.0;
     CGFloat titleMargin = CGRectGetMinX(self.titleLabel.frame);
-    // FIXME: Ideally we'd check `self.maxIPadWidthConstraint.isActive` but that
-    // property is iOS 8 only. When iOS 7 support is ended update this and check
-    // the constraint.
-    if ([UIDevice isPad]) {
-        width = self.maxIPadWidthConstraint.constant;
-    } else {
-        width = size.width;
-        width -= (CGRectGetMinX(self.pageContentView.frame) * 2);
-    }
+    width = size.width;
+    width -= (CGRectGetMinX(self.pageContentView.frame) * 2);
     width -= titleMargin;
     return width;
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -20,16 +20,6 @@
     [self applyStyles];
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
-{
-    // Don't respond to taps in margins.
-    if (!CGRectContainsPoint(self.pageContentView.frame, point)) {
-        return nil;
-    }
-    return [super hitTest:point withEvent:event];
-}
-
-
 #pragma mark - Accessors
 
 - (CGSize)sizeThatFits:(CGSize)size

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -4,11 +4,8 @@
 
 @interface PageListTableViewCell()
 
-@property (nonatomic, strong) IBOutlet UIView *pageContentView;
 @property (nonatomic, strong) IBOutlet UILabel *titleLabel;
 @property (nonatomic, strong) IBOutlet UIButton *menuButton;
-@property (nonatomic, strong) IBOutlet NSLayoutConstraint *titleLabelTopMarginConstraint;
-@property (nonatomic, strong) IBOutlet NSLayoutConstraint *titleLabelBottomMarginConstraint;
 
 @end
 
@@ -22,40 +19,11 @@
 
 #pragma mark - Accessors
 
-- (CGSize)sizeThatFits:(CGSize)size
-{
-    CGFloat innerWidth = [self innerWidthForSize:size];
-
-    CGFloat availableWidth = innerWidth - CGRectGetWidth(self.menuButton.frame);
-    CGSize availableSize = CGSizeMake(availableWidth, CGFLOAT_MAX);
-
-    // Add up all the things.
-    CGFloat height = self.titleLabelTopMarginConstraint.constant;
-    height += self.titleLabelBottomMarginConstraint.constant;
-    height += [self.titleLabel sizeThatFits:availableSize].height;
-
-    height = MAX(height, CGRectGetHeight(self.menuButton.frame));
-    height += 1; // 1 pixel rule.
-
-    return CGSizeMake(size.width, height);
-}
-
-- (CGFloat)innerWidthForSize:(CGSize)size
-{
-    CGFloat width = 0.0;
-    CGFloat titleMargin = CGRectGetMinX(self.titleLabel.frame);
-    width = size.width;
-    width -= (CGRectGetMinX(self.pageContentView.frame) * 2);
-    width -= titleMargin;
-    return width;
-}
-
 - (void)setPost:(AbstractPost *)post
 {
     [super setPost:post];
     [self configureTitle];
 }
-
 
 #pragma mark - Configuration
 
@@ -69,7 +37,6 @@
     AbstractPost *post = [self.post hasRevision] ? [self.post revision] : self.post;
     NSString *str = [post titleForDisplay] ?: [NSString string];
     self.titleLabel.attributedText = [[NSAttributedString alloc] initWithString:str attributes:[WPStyleGuide pageCellTitleAttributes]];
-    self.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
@@ -45,7 +45,7 @@
                     <constraint firstItem="rQF-5A-jGg" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="3" id="7Gc-2J-MRU"/>
                     <constraint firstItem="rQF-5A-jGg" firstAttribute="trailing" secondItem="VPZ-yr-cJj" secondAttribute="leading" id="RLU-wZ-YQJ"/>
                     <constraint firstItem="VPZ-yr-cJj" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="lSG-c9-EIu"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="VPZ-yr-cJj" secondAttribute="trailing" constant="-18" id="xAc-P7-tWc"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="VPZ-yr-cJj" secondAttribute="trailing" priority="999" constant="-18" id="xAc-P7-tWc"/>
                     <constraint firstItem="rQF-5A-jGg" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="yIh-Cz-VAv"/>
                 </constraints>
             </tableViewCellContentView>

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
@@ -2,33 +2,32 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="PageListTableViewCell">
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="PageListTableViewCell">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XtG-U3-A3y">
-                        <rect key="frame" x="6" y="0.0" width="308" height="42"/>
+                        <rect key="frame" x="15" y="0.0" width="305" height="44"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Page Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="rQF-5A-jGg">
-                                <rect key="frame" x="13" y="10" width="252" height="19"/>
+                                <rect key="frame" x="0.0" y="10" width="254" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VPZ-yr-cJj">
-                                <rect key="frame" x="265" y="0.0" width="43" height="43"/>
+                                <rect key="frame" x="254" y="0.0" width="54" height="43"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="43" id="3OU-Uq-a1V"/>
-                                    <constraint firstAttribute="width" constant="43" id="Smb-26-LSz">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="63"/>
-                                    </constraint>
+                                    <constraint firstAttribute="width" constant="54" id="Smb-26-LSz"/>
                                 </constraints>
                                 <inset key="contentEdgeInsets" minX="0.0" minY="4" maxX="0.0" maxY="0.0"/>
                                 <state key="normal" image="icon-post-actionbar-more">
@@ -42,21 +41,19 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="rQF-5A-jGg" secondAttribute="bottom" constant="13" id="9nE-Yy-XkF"/>
-                            <constraint firstAttribute="trailing" secondItem="VPZ-yr-cJj" secondAttribute="trailing" id="JKZ-rj-e2v"/>
                             <constraint firstItem="VPZ-yr-cJj" firstAttribute="top" secondItem="XtG-U3-A3y" secondAttribute="top" id="K0s-MT-gRD"/>
-                            <constraint firstItem="rQF-5A-jGg" firstAttribute="leading" secondItem="XtG-U3-A3y" secondAttribute="leading" constant="13" id="WhQ-hL-heF">
-                                <variation key="heightClass=regular-widthClass=regular" constant="22"/>
-                            </constraint>
+                            <constraint firstItem="rQF-5A-jGg" firstAttribute="leading" secondItem="XtG-U3-A3y" secondAttribute="leading" id="WhQ-hL-heF"/>
                             <constraint firstItem="VPZ-yr-cJj" firstAttribute="leading" secondItem="rQF-5A-jGg" secondAttribute="trailing" id="g8I-1V-waz"/>
                             <constraint firstItem="rQF-5A-jGg" firstAttribute="top" secondItem="XtG-U3-A3y" secondAttribute="top" constant="10" id="kYH-1D-hI7"/>
                         </constraints>
                     </view>
                 </subviews>
-                <color key="backgroundColor" red="0.80000001190000003" green="0.80000001190000003" blue="0.80000001190000003" alpha="1" colorSpace="calibratedRGB"/>
+                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="XtG-U3-A3y" secondAttribute="bottom" constant="1" id="Oes-sZ-IDx"/>
-                    <constraint firstAttribute="trailing" secondItem="XtG-U3-A3y" secondAttribute="trailing" constant="6" id="cEw-Ry-D45"/>
-                    <constraint firstItem="XtG-U3-A3y" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="6" id="jMJ-o2-wS1"/>
+                    <constraint firstItem="VPZ-yr-cJj" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" constant="18" id="HnQ-0Z-Ac0"/>
+                    <constraint firstAttribute="bottom" secondItem="XtG-U3-A3y" secondAttribute="bottom" id="Oes-sZ-IDx"/>
+                    <constraint firstAttribute="trailing" secondItem="XtG-U3-A3y" secondAttribute="trailing" id="cEw-Ry-D45"/>
+                    <constraint firstItem="XtG-U3-A3y" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="jMJ-o2-wS1"/>
                     <constraint firstItem="XtG-U3-A3y" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="mmi-ns-491"/>
                 </constraints>
             </tableViewCellContentView>

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
@@ -4,6 +4,11 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <mutableArray key="Merriweather-Regular.ttf">
+            <string>Merriweather</string>
+        </mutableArray>
+    </customFonts>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -14,55 +19,39 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XtG-U3-A3y">
-                        <rect key="frame" x="15" y="0.0" width="305" height="44"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Page Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="rQF-5A-jGg">
-                                <rect key="frame" x="0.0" y="10" width="254" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VPZ-yr-cJj">
-                                <rect key="frame" x="254" y="0.0" width="54" height="43"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="43" id="3OU-Uq-a1V"/>
-                                    <constraint firstAttribute="width" constant="54" id="Smb-26-LSz"/>
-                                </constraints>
-                                <inset key="contentEdgeInsets" minX="0.0" minY="4" maxX="0.0" maxY="0.0"/>
-                                <state key="normal" image="icon-post-actionbar-more">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <connections>
-                                    <action selector="onAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="asl-aB-XVB"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Page Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rQF-5A-jGg">
+                        <rect key="frame" x="15" y="13" width="254" height="18"/>
+                        <fontDescription key="fontDescription" name="Merriweather" family="Merriweather" pointSize="15"/>
+                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VPZ-yr-cJj">
+                        <rect key="frame" x="269" y="0.0" width="54" height="47"/>
                         <constraints>
-                            <constraint firstAttribute="bottom" secondItem="rQF-5A-jGg" secondAttribute="bottom" constant="13" id="9nE-Yy-XkF"/>
-                            <constraint firstItem="VPZ-yr-cJj" firstAttribute="top" secondItem="XtG-U3-A3y" secondAttribute="top" id="K0s-MT-gRD"/>
-                            <constraint firstItem="rQF-5A-jGg" firstAttribute="leading" secondItem="XtG-U3-A3y" secondAttribute="leading" id="WhQ-hL-heF"/>
-                            <constraint firstItem="VPZ-yr-cJj" firstAttribute="leading" secondItem="rQF-5A-jGg" secondAttribute="trailing" id="g8I-1V-waz"/>
-                            <constraint firstItem="rQF-5A-jGg" firstAttribute="top" secondItem="XtG-U3-A3y" secondAttribute="top" constant="10" id="kYH-1D-hI7"/>
+                            <constraint firstAttribute="height" constant="47" id="3OU-Uq-a1V"/>
+                            <constraint firstAttribute="width" constant="54" id="Smb-26-LSz"/>
                         </constraints>
-                    </view>
+                        <state key="normal" image="icon-post-actionbar-more">
+                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                        </state>
+                        <connections>
+                            <action selector="onAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="asl-aB-XVB"/>
+                        </connections>
+                    </button>
                 </subviews>
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                 <constraints>
-                    <constraint firstItem="VPZ-yr-cJj" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" constant="18" id="HnQ-0Z-Ac0"/>
-                    <constraint firstAttribute="bottom" secondItem="XtG-U3-A3y" secondAttribute="bottom" id="Oes-sZ-IDx"/>
-                    <constraint firstAttribute="trailing" secondItem="XtG-U3-A3y" secondAttribute="trailing" id="cEw-Ry-D45"/>
-                    <constraint firstItem="XtG-U3-A3y" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="jMJ-o2-wS1"/>
-                    <constraint firstItem="XtG-U3-A3y" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="mmi-ns-491"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="rQF-5A-jGg" secondAttribute="bottom" constant="3" id="44f-0V-sCs"/>
+                    <constraint firstItem="rQF-5A-jGg" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="3" id="7Gc-2J-MRU"/>
+                    <constraint firstItem="rQF-5A-jGg" firstAttribute="trailing" secondItem="VPZ-yr-cJj" secondAttribute="leading" id="RLU-wZ-YQJ"/>
+                    <constraint firstItem="VPZ-yr-cJj" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="lSG-c9-EIu"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="VPZ-yr-cJj" secondAttribute="trailing" constant="-18" id="xAc-P7-tWc"/>
+                    <constraint firstItem="rQF-5A-jGg" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="yIh-Cz-VAv"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
                 <outlet property="menuButton" destination="VPZ-yr-cJj" id="yjZ-Su-mum"/>
-                <outlet property="pageContentView" destination="XtG-U3-A3y" id="Xag-Cn-jck"/>
                 <outlet property="titleLabel" destination="rQF-5A-jGg" id="HkF-g8-kZX"/>
-                <outlet property="titleLabelBottomMarginConstraint" destination="9nE-Yy-XkF" id="zdK-IB-6a0"/>
-                <outlet property="titleLabelTopMarginConstraint" destination="kYH-1D-hI7" id="4gS-Tl-HyR"/>
             </connections>
         </tableViewCell>
     </objects>

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
@@ -15,7 +15,7 @@
         <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="PageListTableViewCell">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
@@ -49,18 +49,7 @@
                             </constraint>
                             <constraint firstItem="VPZ-yr-cJj" firstAttribute="leading" secondItem="rQF-5A-jGg" secondAttribute="trailing" id="g8I-1V-waz"/>
                             <constraint firstItem="rQF-5A-jGg" firstAttribute="top" secondItem="XtG-U3-A3y" secondAttribute="top" constant="10" id="kYH-1D-hI7"/>
-                            <constraint firstAttribute="width" priority="750" constant="600" id="nXd-Nr-ibg"/>
                         </constraints>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="nXd-Nr-ibg"/>
-                            </mask>
-                        </variation>
-                        <variation key="heightClass=regular-widthClass=regular">
-                            <mask key="constraints">
-                                <include reference="nXd-Nr-ibg"/>
-                            </mask>
-                        </variation>
                     </view>
                 </subviews>
                 <color key="backgroundColor" red="0.80000001190000003" green="0.80000001190000003" blue="0.80000001190000003" alpha="1" colorSpace="calibratedRGB"/>
@@ -69,23 +58,9 @@
                     <constraint firstAttribute="trailing" secondItem="XtG-U3-A3y" secondAttribute="trailing" constant="6" id="cEw-Ry-D45"/>
                     <constraint firstItem="XtG-U3-A3y" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="6" id="jMJ-o2-wS1"/>
                     <constraint firstItem="XtG-U3-A3y" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="mmi-ns-491"/>
-                    <constraint firstAttribute="centerX" secondItem="XtG-U3-A3y" secondAttribute="centerX" id="zEC-4Y-q5P"/>
                 </constraints>
-                <variation key="default">
-                    <mask key="constraints">
-                        <exclude reference="zEC-4Y-q5P"/>
-                    </mask>
-                </variation>
-                <variation key="heightClass=regular-widthClass=regular">
-                    <mask key="constraints">
-                        <exclude reference="cEw-Ry-D45"/>
-                        <exclude reference="jMJ-o2-wS1"/>
-                        <include reference="zEC-4Y-q5P"/>
-                    </mask>
-                </variation>
             </tableViewCellContentView>
             <connections>
-                <outlet property="maxIPadWidthConstraint" destination="nXd-Nr-ibg" id="p6k-Lc-M7W"/>
                 <outlet property="menuButton" destination="VPZ-yr-cJj" id="yjZ-Su-mum"/>
                 <outlet property="pageContentView" destination="XtG-U3-A3y" id="Xag-Cn-jck"/>
                 <outlet property="titleLabel" destination="rQF-5A-jGg" id="HkF-g8-kZX"/>

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 import WordPressComAnalytics
 
 class PageListViewController : AbstractPostListViewController, UIViewControllerRestoration {
@@ -13,6 +14,12 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     private static let currentPageListStatusFilterKey = "CurrentPageListStatusFilterKey"
 
     private var cellForLayout : PageListTableViewCell!
+
+    private lazy var sectionFooterSepatatorView : UIView = {
+        let footer = UIView()
+        footer.backgroundColor = WPStyleGuide.greyLighten20()
+        return footer
+    }()
 
     // MARK: - GUI
 
@@ -87,7 +94,6 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     override func configureTableView() {
         tableView.accessibilityIdentifier = "PagesTable"
         tableView.isAccessibilityElement = true
-        tableView.separatorStyle = .None
 
         let bundle = NSBundle.mainBundle()
 
@@ -97,6 +103,8 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
 
         let restorePageCellNib = UINib(nibName: self.dynamicType.restorePageCellNibName, bundle: bundle)
         tableView.registerNib(restorePageCellNib, forCellReuseIdentifier: self.dynamicType.restorePageCellIdentifier)
+
+        WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 
     override func configureSearchController() {
@@ -251,6 +259,9 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     }
 
     func tableView(tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        if section == tableView.numberOfSections - 1 {
+            return WPDeviceIdentification.isRetina() ? 0.5 : 1.0
+        }
         return CGFloat.min
     }
 
@@ -267,6 +278,9 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     }
 
     func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView! {
+        if section == tableView.numberOfSections - 1 {
+            return sectionFooterSepatatorView
+        }
         return UIView(frame: CGRectZero)
     }
 
@@ -298,13 +312,13 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
         }
 
         cell.accessoryType = .None
-        cell.selectionStyle = .None
 
         if cell.reuseIdentifier == self.dynamicType.pageCellIdentifier {
             cell.onAction = { [weak self] cell, button, page in
                 self?.handleMenuAction(fromCell: cell, fromButton: button, forPage: page)
             }
         } else if cell.reuseIdentifier == self.dynamicType.restorePageCellIdentifier {
+            cell.selectionStyle = .None
             cell.onAction = { [weak self] cell, _, page in
                 self?.handleRestoreAction(fromCell: cell, forPage: page)
             }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -13,7 +13,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     private static let restorePageCellNibName = "RestorePageTableViewCell"
     private static let currentPageListStatusFilterKey = "CurrentPageListStatusFilterKey"
 
-    private lazy var sectionFooterSepatatorView : UIView = {
+    private lazy var sectionFooterSeparatorView : UIView = {
         let footer = UIView()
         footer.backgroundColor = WPStyleGuide.greyLighten20()
         return footer
@@ -248,7 +248,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
 
     func tableView(tableView: UITableView, viewForFooterInSection section: Int) -> UIView! {
         if section == tableView.numberOfSections - 1 {
-            return sectionFooterSepatatorView
+            return sectionFooterSeparatorView
         }
         return UIView(frame: CGRectZero)
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -5,7 +5,7 @@ import WordPressComAnalytics
 class PageListViewController : AbstractPostListViewController, UIViewControllerRestoration {
 
     private static let pageSectionHeaderHeight = CGFloat(24.0)
-    private static let pageCellEstimatedRowHeight = CGFloat(44.0)
+    private static let pageCellEstimatedRowHeight = CGFloat(46.0)
     private static let pagesViewControllerRestorationKey = "PagesViewControllerRestorationKey"
     private static let pageCellIdentifier = "PageCellIdentifier"
     private static let pageCellNibName = "PageListTableViewCell"
@@ -235,23 +235,13 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     }
 
     func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-
         let page = pageAtIndexPath(indexPath)
 
         if cellIdentifierForPage(page) == self.dynamicType.restorePageCellIdentifier {
             return self.dynamicType.pageCellEstimatedRowHeight
         }
 
-        let width = tableView.bounds.width
-        return self.tableView(tableView, heightForRowAtIndexPath: indexPath, forWidth: width)
-    }
-
-    func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath, forWidth width: CGFloat) -> CGFloat {
-        configureCell(cellForLayout, atIndexPath: indexPath)
-        let size = cellForLayout.sizeThatFits(CGSizeMake(width, CGFloat.max))
-        let height = ceil(size.height)
-
-        return height
+        return UITableViewAutomaticDimension
     }
 
     func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -262,7 +262,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
         if section == tableView.numberOfSections - 1 {
             return WPDeviceIdentification.isRetina() ? 0.5 : 1.0
         }
-        return CGFloat.min
+        return 0.0
     }
 
     func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView! {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -5,15 +5,13 @@ import WordPressComAnalytics
 class PageListViewController : AbstractPostListViewController, UIViewControllerRestoration {
 
     private static let pageSectionHeaderHeight = CGFloat(24.0)
-    private static let pageCellEstimatedRowHeight = CGFloat(46.0)
+    private static let pageCellEstimatedRowHeight = CGFloat(47.0)
     private static let pagesViewControllerRestorationKey = "PagesViewControllerRestorationKey"
     private static let pageCellIdentifier = "PageCellIdentifier"
     private static let pageCellNibName = "PageListTableViewCell"
     private static let restorePageCellIdentifier = "RestorePageCellIdentifier"
     private static let restorePageCellNibName = "RestorePageTableViewCell"
     private static let currentPageListStatusFilterKey = "CurrentPageListStatusFilterKey"
-
-    private var cellForLayout : PageListTableViewCell!
 
     private lazy var sectionFooterSepatatorView : UIView = {
         let footer = UIView()
@@ -84,16 +82,11 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
 
     // MARK: - Configuration
 
-    override func configureCellsForLayout() {
-
-        let bundle = NSBundle.mainBundle()
-
-        cellForLayout = bundle.loadNibNamed(self.dynamicType.pageCellNibName, owner: nil, options: nil)[0] as! PageListTableViewCell
-    }
-
     override func configureTableView() {
         tableView.accessibilityIdentifier = "PagesTable"
         tableView.isAccessibilityElement = true
+        tableView.estimatedRowHeight = self.dynamicType.pageCellEstimatedRowHeight
+        tableView.rowHeight = UITableViewAutomaticDimension
 
         let bundle = NSBundle.mainBundle()
 
@@ -228,20 +221,6 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
 
     func sectionNameKeyPath() -> String {
         return NSStringFromSelector(#selector(Page.sectionIdentifier))
-    }
-
-    func tableView(tableView: UITableView, estimatedHeightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        return self.dynamicType.pageCellEstimatedRowHeight
-    }
-
-    func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        let page = pageAtIndexPath(indexPath)
-
-        if cellIdentifierForPage(page) == self.dynamicType.restorePageCellIdentifier {
-            return self.dynamicType.pageCellEstimatedRowHeight
-        }
-
-        return UITableViewAutomaticDimension
     }
 
     func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
+++ b/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -80,7 +80,7 @@
         <scene sceneID="nof-o6-aRy">
             <objects>
                 <tableViewController id="54R-UA-mAH" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="y3a-Ok-AN1">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="y3a-Ok-AN1">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
+++ b/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
@@ -80,10 +80,11 @@
         <scene sceneID="nof-o6-aRy">
             <objects>
                 <tableViewController id="54R-UA-mAH" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="y3a-Ok-AN1">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="47" sectionHeaderHeight="24" sectionFooterHeight="1" id="y3a-Ok-AN1">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <sections/>
                         <connections>
                             <outlet property="dataSource" destination="54R-UA-mAH" id="mDP-Tv-HsW"/>
                             <outlet property="delegate" destination="54R-UA-mAH" id="aOd-Bh-W9d"/>

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.m
@@ -20,16 +20,6 @@
     [self applyStyles];
 }
 
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
-{
-    // Don't respond to taps in margins.
-    if (!CGRectContainsPoint(self.pageContentView.frame, point)) {
-        return nil;
-    }
-    return [super hitTest:point withEvent:event];
-}
-
-
 #pragma mark - Configuration
 
 - (void)applyStyles

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.m
@@ -3,7 +3,6 @@
 
 @interface RestorePageTableViewCell()
 
-@property (nonatomic, strong) IBOutlet UIView *pageContentView;
 @property (nonatomic, strong) IBOutlet UILabel *restoreLabel;
 @property (nonatomic, strong) IBOutlet UIButton *restoreButton;
 

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.m
@@ -24,7 +24,6 @@
 
 - (void)applyStyles
 {
-    [WPStyleGuide applyPostCardStyle:self];
     [WPStyleGuide applyRestorePageLabelStyle:self.restoreLabel];
     [WPStyleGuide applyRestorePageButtonStyle:self.restoreButton];
 }

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
@@ -7,21 +7,24 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="44" id="AgI-Sn-JeL" customClass="RestorePageTableViewCell">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="AgI-Sn-JeL" customClass="RestorePageTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="47"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="AgI-Sn-JeL" id="QqJ-JC-nik">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="46.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Page moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au3-8f-nAh">
-                        <rect key="frame" x="15" y="10" width="219" height="24"/>
+                        <rect key="frame" x="15" y="10" width="219" height="26"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="26" id="qR0-Nb-d3i"/>
+                        </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dPd-xc-GkE">
-                        <rect key="frame" x="234" y="10" width="86" height="24"/>
+                        <rect key="frame" x="234" y="10" width="86" height="26"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="86" id="E4N-1W-JWu"/>
                         </constraints>
@@ -42,6 +45,7 @@
                     <constraint firstAttribute="bottomMargin" secondItem="au3-8f-nAh" secondAttribute="bottom" id="89D-jc-v4X"/>
                     <constraint firstItem="au3-8f-nAh" firstAttribute="trailing" secondItem="dPd-xc-GkE" secondAttribute="leading" id="AiD-9Q-fgp"/>
                     <constraint firstAttribute="trailingMargin" secondItem="dPd-xc-GkE" secondAttribute="trailing" constant="-15" id="C74-Dt-B2F"/>
+                    <constraint firstItem="dPd-xc-GkE" firstAttribute="height" secondItem="au3-8f-nAh" secondAttribute="height" id="Cla-B1-42i"/>
                     <constraint firstAttribute="bottomMargin" secondItem="dPd-xc-GkE" secondAttribute="bottom" id="UV7-70-RXp"/>
                     <constraint firstItem="dPd-xc-GkE" firstAttribute="top" secondItem="QqJ-JC-nik" secondAttribute="topMargin" id="nw1-vq-uW6"/>
                     <constraint firstItem="au3-8f-nAh" firstAttribute="leading" secondItem="QqJ-JC-nik" secondAttribute="leadingMargin" id="wtp-OO-AfT"/>
@@ -52,7 +56,7 @@
                 <outlet property="restoreButton" destination="dPd-xc-GkE" id="DzB-1H-s5r"/>
                 <outlet property="restoreLabel" destination="au3-8f-nAh" id="e4g-Ll-eEo"/>
             </connections>
-            <point key="canvasLocation" x="568" y="210"/>
+            <point key="canvasLocation" x="568" y="209.5"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
@@ -47,45 +47,21 @@
                             <constraint firstAttribute="trailing" secondItem="dPd-xc-GkE" secondAttribute="trailing" constant="14" id="TF1-Iy-WTJ">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
-                            <constraint firstAttribute="width" constant="600" id="UOv-L4-TfA"/>
                             <constraint firstAttribute="bottom" secondItem="dPd-xc-GkE" secondAttribute="bottom" id="VuC-Uj-kS2"/>
                             <constraint firstItem="au3-8f-nAh" firstAttribute="top" secondItem="qtC-jW-wnY" secondAttribute="top" id="aEF-bJ-dLs"/>
                             <constraint firstItem="au3-8f-nAh" firstAttribute="leading" secondItem="qtC-jW-wnY" secondAttribute="leading" constant="13" id="ly1-3i-mjX">
                                 <variation key="heightClass=regular-widthClass=regular" constant="22"/>
                             </constraint>
                         </constraints>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="UOv-L4-TfA"/>
-                            </mask>
-                        </variation>
-                        <variation key="heightClass=regular-widthClass=regular">
-                            <mask key="constraints">
-                                <include reference="UOv-L4-TfA"/>
-                            </mask>
-                        </variation>
                     </view>
                 </subviews>
                 <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                 <constraints>
                     <constraint firstItem="qtC-jW-wnY" firstAttribute="top" secondItem="QqJ-JC-nik" secondAttribute="top" id="Bt5-qm-4ab"/>
                     <constraint firstItem="qtC-jW-wnY" firstAttribute="leading" secondItem="QqJ-JC-nik" secondAttribute="leading" constant="6" id="Ldq-L9-1TE"/>
-                    <constraint firstAttribute="centerX" secondItem="qtC-jW-wnY" secondAttribute="centerX" id="c5X-JV-HuI"/>
                     <constraint firstAttribute="trailing" secondItem="qtC-jW-wnY" secondAttribute="trailing" constant="6" id="ejN-GF-xfr"/>
                     <constraint firstAttribute="bottom" secondItem="qtC-jW-wnY" secondAttribute="bottom" constant="1" id="tKa-MQ-ESY"/>
                 </constraints>
-                <variation key="default">
-                    <mask key="constraints">
-                        <exclude reference="c5X-JV-HuI"/>
-                    </mask>
-                </variation>
-                <variation key="heightClass=regular-widthClass=regular">
-                    <mask key="constraints">
-                        <exclude reference="Ldq-L9-1TE"/>
-                        <include reference="c5X-JV-HuI"/>
-                        <exclude reference="ejN-GF-xfr"/>
-                    </mask>
-                </variation>
             </tableViewCellContentView>
             <connections>
                 <outlet property="pageContentView" destination="qtC-jW-wnY" id="Bqm-qT-TJI"/>

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
@@ -14,54 +14,41 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qtC-jW-wnY">
-                        <rect key="frame" x="15" y="0.0" width="290" height="44"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Page moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au3-8f-nAh">
-                                <rect key="frame" x="0.0" y="0.0" width="138" height="44"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dPd-xc-GkE">
-                                <rect key="frame" x="224" y="0.0" width="66" height="44"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="66" id="E4N-1W-JWu"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <inset key="contentEdgeInsets" minX="3" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                <inset key="imageEdgeInsets" minX="-3" minY="0.0" maxX="3" maxY="0.0"/>
-                                <state key="normal" title="Undo" image="icon-post-undo">
-                                    <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                </state>
-                                <connections>
-                                    <action selector="onAction:" destination="AgI-Sn-JeL" eventType="touchUpInside" id="4Wu-zq-FWn"/>
-                                </connections>
-                            </button>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Page moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au3-8f-nAh">
+                        <rect key="frame" x="15" y="10" width="219" height="24"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dPd-xc-GkE">
+                        <rect key="frame" x="234" y="10" width="86" height="24"/>
                         <constraints>
-                            <constraint firstItem="dPd-xc-GkE" firstAttribute="top" secondItem="qtC-jW-wnY" secondAttribute="top" id="3BZ-ED-4O8"/>
-                            <constraint firstItem="dPd-xc-GkE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="au3-8f-nAh" secondAttribute="trailing" constant="3" id="4yA-13-Cxl"/>
-                            <constraint firstAttribute="bottom" secondItem="au3-8f-nAh" secondAttribute="bottom" id="BAj-O1-1jz"/>
-                            <constraint firstAttribute="trailing" secondItem="dPd-xc-GkE" secondAttribute="trailing" id="TF1-Iy-WTJ"/>
-                            <constraint firstAttribute="bottom" secondItem="dPd-xc-GkE" secondAttribute="bottom" id="VuC-Uj-kS2"/>
-                            <constraint firstItem="au3-8f-nAh" firstAttribute="top" secondItem="qtC-jW-wnY" secondAttribute="top" id="aEF-bJ-dLs"/>
-                            <constraint firstItem="au3-8f-nAh" firstAttribute="leading" secondItem="qtC-jW-wnY" secondAttribute="leading" id="ly1-3i-mjX"/>
+                            <constraint firstAttribute="width" constant="86" id="E4N-1W-JWu"/>
                         </constraints>
-                    </view>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <inset key="contentEdgeInsets" minX="3" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        <inset key="imageEdgeInsets" minX="-3" minY="0.0" maxX="3" maxY="0.0"/>
+                        <state key="normal" title="Undo" image="icon-post-undo">
+                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                        </state>
+                        <connections>
+                            <action selector="onAction:" destination="AgI-Sn-JeL" eventType="touchUpInside" id="4Wu-zq-FWn"/>
+                        </connections>
+                    </button>
                 </subviews>
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                 <constraints>
-                    <constraint firstItem="qtC-jW-wnY" firstAttribute="top" secondItem="QqJ-JC-nik" secondAttribute="top" id="Bt5-qm-4ab"/>
-                    <constraint firstItem="qtC-jW-wnY" firstAttribute="leading" secondItem="QqJ-JC-nik" secondAttribute="leadingMargin" id="Ldq-L9-1TE"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="qtC-jW-wnY" secondAttribute="trailing" id="ejN-GF-xfr"/>
-                    <constraint firstAttribute="bottom" secondItem="qtC-jW-wnY" secondAttribute="bottom" id="tKa-MQ-ESY"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="au3-8f-nAh" secondAttribute="bottom" id="89D-jc-v4X"/>
+                    <constraint firstItem="au3-8f-nAh" firstAttribute="trailing" secondItem="dPd-xc-GkE" secondAttribute="leading" id="AiD-9Q-fgp"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="dPd-xc-GkE" secondAttribute="trailing" constant="-15" id="C74-Dt-B2F"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="dPd-xc-GkE" secondAttribute="bottom" id="UV7-70-RXp"/>
+                    <constraint firstItem="dPd-xc-GkE" firstAttribute="top" secondItem="QqJ-JC-nik" secondAttribute="topMargin" id="nw1-vq-uW6"/>
+                    <constraint firstItem="au3-8f-nAh" firstAttribute="leading" secondItem="QqJ-JC-nik" secondAttribute="leadingMargin" id="wtp-OO-AfT"/>
+                    <constraint firstItem="au3-8f-nAh" firstAttribute="top" secondItem="QqJ-JC-nik" secondAttribute="topMargin" id="xJJ-MG-1hV"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="pageContentView" destination="qtC-jW-wnY" id="Bqm-qT-TJI"/>
                 <outlet property="restoreButton" destination="dPd-xc-GkE" id="DzB-1H-s5r"/>
                 <outlet property="restoreLabel" destination="au3-8f-nAh" id="e4g-Ll-eEo"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
@@ -44,7 +44,7 @@
                 <constraints>
                     <constraint firstAttribute="bottomMargin" secondItem="au3-8f-nAh" secondAttribute="bottom" id="89D-jc-v4X"/>
                     <constraint firstItem="au3-8f-nAh" firstAttribute="trailing" secondItem="dPd-xc-GkE" secondAttribute="leading" id="AiD-9Q-fgp"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="dPd-xc-GkE" secondAttribute="trailing" constant="-15" id="C74-Dt-B2F"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="dPd-xc-GkE" secondAttribute="trailing" priority="999" constant="-15" id="C74-Dt-B2F"/>
                     <constraint firstItem="dPd-xc-GkE" firstAttribute="height" secondItem="au3-8f-nAh" secondAttribute="height" id="Cla-B1-42i"/>
                     <constraint firstAttribute="bottomMargin" secondItem="dPd-xc-GkE" secondAttribute="bottom" id="UV7-70-RXp"/>
                     <constraint firstItem="dPd-xc-GkE" firstAttribute="top" secondItem="QqJ-JC-nik" secondAttribute="topMargin" id="nw1-vq-uW6"/>

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
@@ -2,28 +2,29 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="44" id="AgI-Sn-JeL" customClass="RestorePageTableViewCell">
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="44" id="AgI-Sn-JeL" customClass="RestorePageTableViewCell">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" tableViewCell="AgI-Sn-JeL" id="QqJ-JC-nik">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="AgI-Sn-JeL" id="QqJ-JC-nik">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qtC-jW-wnY">
-                        <rect key="frame" x="6" y="0.0" width="308" height="42"/>
+                        <rect key="frame" x="15" y="0.0" width="290" height="44"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Page moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au3-8f-nAh">
-                                <rect key="frame" x="13" y="0.0" width="138" height="42"/>
+                                <rect key="frame" x="0.0" y="0.0" width="138" height="44"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dPd-xc-GkE">
-                                <rect key="frame" x="228" y="0.0" width="66" height="42"/>
+                                <rect key="frame" x="224" y="0.0" width="66" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="66" id="E4N-1W-JWu"/>
                                 </constraints>
@@ -44,23 +45,19 @@
                             <constraint firstItem="dPd-xc-GkE" firstAttribute="top" secondItem="qtC-jW-wnY" secondAttribute="top" id="3BZ-ED-4O8"/>
                             <constraint firstItem="dPd-xc-GkE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="au3-8f-nAh" secondAttribute="trailing" constant="3" id="4yA-13-Cxl"/>
                             <constraint firstAttribute="bottom" secondItem="au3-8f-nAh" secondAttribute="bottom" id="BAj-O1-1jz"/>
-                            <constraint firstAttribute="trailing" secondItem="dPd-xc-GkE" secondAttribute="trailing" constant="14" id="TF1-Iy-WTJ">
-                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                            </constraint>
+                            <constraint firstAttribute="trailing" secondItem="dPd-xc-GkE" secondAttribute="trailing" id="TF1-Iy-WTJ"/>
                             <constraint firstAttribute="bottom" secondItem="dPd-xc-GkE" secondAttribute="bottom" id="VuC-Uj-kS2"/>
                             <constraint firstItem="au3-8f-nAh" firstAttribute="top" secondItem="qtC-jW-wnY" secondAttribute="top" id="aEF-bJ-dLs"/>
-                            <constraint firstItem="au3-8f-nAh" firstAttribute="leading" secondItem="qtC-jW-wnY" secondAttribute="leading" constant="13" id="ly1-3i-mjX">
-                                <variation key="heightClass=regular-widthClass=regular" constant="22"/>
-                            </constraint>
+                            <constraint firstItem="au3-8f-nAh" firstAttribute="leading" secondItem="qtC-jW-wnY" secondAttribute="leading" id="ly1-3i-mjX"/>
                         </constraints>
                     </view>
                 </subviews>
-                <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                 <constraints>
                     <constraint firstItem="qtC-jW-wnY" firstAttribute="top" secondItem="QqJ-JC-nik" secondAttribute="top" id="Bt5-qm-4ab"/>
-                    <constraint firstItem="qtC-jW-wnY" firstAttribute="leading" secondItem="QqJ-JC-nik" secondAttribute="leading" constant="6" id="Ldq-L9-1TE"/>
-                    <constraint firstAttribute="trailing" secondItem="qtC-jW-wnY" secondAttribute="trailing" constant="6" id="ejN-GF-xfr"/>
-                    <constraint firstAttribute="bottom" secondItem="qtC-jW-wnY" secondAttribute="bottom" constant="1" id="tKa-MQ-ESY"/>
+                    <constraint firstItem="qtC-jW-wnY" firstAttribute="leading" secondItem="QqJ-JC-nik" secondAttribute="leadingMargin" id="Ldq-L9-1TE"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="qtC-jW-wnY" secondAttribute="trailing" id="ejN-GF-xfr"/>
+                    <constraint firstAttribute="bottom" secondItem="qtC-jW-wnY" secondAttribute="bottom" id="tKa-MQ-ESY"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -164,10 +164,11 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
 
-        searchController.active = false
+        if searchController.active {
+            searchController.active = false
+        }
 
         NSNotificationCenter.defaultCenter().removeObserver(self, name: UIApplicationDidBecomeActiveNotification, object: nil)
-
         unregisterForKeyboardNotifications()
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -825,7 +825,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
                 strongSelf.recentlyTrashedPostObjectIDs.removeAtIndex(index)
 
                 if let indexPath = indexPath {
-                    strongSelf.tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Fade)
+                    strongSelf.tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
                 }
             }
         }

--- a/WordPress/Classes/ViewRelated/Post/ConfigurablePostView.h
+++ b/WordPress/Classes/ViewRelated/Post/ConfigurablePostView.h
@@ -14,14 +14,4 @@
 ///
 - (void)configureWithPost:(nonnull Post*)post;
 
-/// Same as `configureWithPost:` but only for the purpose of layout.
-///
-/// - Parameters:
-///     - post: the post to visually represent.
-///     - layoutOnly: `true` if the configure call is meant for layout purposes only.
-///             if set to `false`, this should behave exactly like `configureWithPost:`.
-///
-- (void)configureWithPost:(nonnull Post*)post
-            forLayoutOnly:(BOOL)layoutOnly;
-
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
@@ -6,7 +6,7 @@
 #import "WordPress-Swift.h"
 
 static NSInteger ActionBarMoreButtonIndex = 999;
-static CGFloat ActionBarMinButtonWidth = 100.0;
+static CGFloat ActionBarMinButtonWidth = 90.0;
 
 static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
@@ -23,11 +23,6 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
 
 #pragma mark - Life Cycle Methods
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)awakeFromNib
 {
     [super awakeFromNib];
@@ -43,13 +38,6 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
     }
     return self;
 }
-
-- (void)layoutSubviews
-{
-    [super layoutSubviews];
-    [self setupButtonsIfNeeded];
-}
-
 
 #pragma mark - Setup
 
@@ -74,15 +62,12 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
                                                                  metrics:nil
                                                                    views:views]];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(orientationDidChange:)
-                                                 name:UIDeviceOrientationDidChangeNotification
-                                               object:nil];
-
     // Trap double taps to prevent touches from regstering in the parent cell while the bar is animating.
     UITapGestureRecognizer *tgr = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTap:)];
     tgr.numberOfTapsRequired = 2;
     [self addGestureRecognizer:tgr];
+
+    [self setupButtonsIfNeeded];
 }
 
 - (void)setupConstraints
@@ -279,11 +264,12 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
 
 #pragma mark - Notifications
 
-- (void)orientationDidChange:(NSNotification *)notification
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
+    [super traitCollectionDidChange:previousTraitCollection];
+
     [self setupButtonsIfNeeded];
 }
-
 
 #pragma mark - Accessors
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -10,7 +10,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="448"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="CUK-Fg-fJ5" id="lmn-sx-Q9M">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="447.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="448"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="00o-oC-uzQ">
@@ -41,7 +41,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbp-gj-1hE">
-                                                <rect key="frame" x="42" y="18" width="234" height="14.5"/>
+                                                <rect key="frame" x="42" y="18" width="234" height="15"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -94,7 +94,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xhs-nZ-clP">
-                                                <rect key="frame" x="21" y="2" width="175" height="14.5"/>
+                                                <rect key="frame" x="21" y="2" width="175" height="15"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -124,7 +124,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mYl-tz-yRu">
-                                                <rect key="frame" x="21" y="2" width="255" height="14.5"/>
+                                                <rect key="frame" x="21" y="2" width="255" height="15"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -220,7 +220,6 @@
                                     </constraint>
                                     <constraint firstItem="U6E-MB-03K" firstAttribute="centerY" secondItem="zle-VU-ygo" secondAttribute="centerY" id="NCb-6E-SND"/>
                                     <constraint firstItem="Y9d-Yk-F4X" firstAttribute="top" secondItem="rIp-IY-Ng4" secondAttribute="bottom" constant="15" id="QbH-qP-NR7"/>
-                                    <constraint firstAttribute="width" priority="900" constant="600" id="Qi6-dA-tg8"/>
                                     <constraint firstItem="rIp-IY-Ng4" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="SmN-xb-mWD">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
@@ -247,42 +246,23 @@
                                         <variation key="heightClass=regular-widthClass=regular" constant="16"/>
                                     </constraint>
                                 </constraints>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="Qi6-dA-tg8"/>
-                                    </mask>
-                                </variation>
-                                <variation key="heightClass=regular-widthClass=regular">
-                                    <mask key="constraints">
-                                        <include reference="Qi6-dA-tg8"/>
-                                    </mask>
-                                </variation>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="b5E-yQ-veP" firstAttribute="top" secondItem="00o-oC-uzQ" secondAttribute="top" constant="10" id="0UX-EC-CFr"/>
-                            <constraint firstAttribute="centerX" secondItem="b5E-yQ-veP" secondAttribute="centerX" id="95F-8n-BLS"/>
-                            <constraint firstAttribute="trailing" secondItem="b5E-yQ-veP" secondAttribute="trailing" constant="6" id="IhB-5o-fWK"/>
+                            <constraint firstAttribute="trailing" secondItem="b5E-yQ-veP" secondAttribute="trailing" constant="6" id="IhB-5o-fWK">
+                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            </constraint>
                             <constraint firstItem="b5E-yQ-veP" firstAttribute="top" secondItem="8uW-Eg-69o" secondAttribute="top" constant="1" id="KTV-F2-9x4"/>
                             <constraint firstItem="b5E-yQ-veP" firstAttribute="bottom" secondItem="8uW-Eg-69o" secondAttribute="bottom" constant="-1" id="QWt-JY-Uqy"/>
                             <constraint firstItem="b5E-yQ-veP" firstAttribute="leading" secondItem="8uW-Eg-69o" secondAttribute="leading" constant="1" id="SSF-mO-oAJ"/>
                             <constraint firstAttribute="bottom" secondItem="b5E-yQ-veP" secondAttribute="bottom" constant="11" id="gQs-6I-fOg"/>
                             <constraint firstItem="b5E-yQ-veP" firstAttribute="trailing" secondItem="8uW-Eg-69o" secondAttribute="trailing" constant="-1" id="kBU-fR-RAo"/>
-                            <constraint firstItem="b5E-yQ-veP" firstAttribute="leading" secondItem="00o-oC-uzQ" secondAttribute="leading" constant="6" id="vWx-63-G4B"/>
+                            <constraint firstItem="b5E-yQ-veP" firstAttribute="leading" secondItem="00o-oC-uzQ" secondAttribute="leading" constant="6" id="vWx-63-G4B">
+                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            </constraint>
                         </constraints>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="95F-8n-BLS"/>
-                            </mask>
-                        </variation>
-                        <variation key="heightClass=regular-widthClass=regular">
-                            <mask key="constraints">
-                                <include reference="95F-8n-BLS"/>
-                                <exclude reference="IhB-5o-fWK"/>
-                                <exclude reference="vWx-63-G4B"/>
-                            </mask>
-                        </variation>
                     </view>
                 </subviews>
                 <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
@@ -307,7 +287,6 @@
                 <outlet property="headerViewLeftConstraint" destination="SmN-xb-mWD" id="sB9-to-eqY"/>
                 <outlet property="headerViewLowerConstraint" destination="QbH-qP-NR7" id="yVA-nc-yCf"/>
                 <outlet property="innerContentView" destination="00o-oC-uzQ" id="wq9-Kq-6nW"/>
-                <outlet property="maxIPadWidthConstraint" destination="Qi6-dA-tg8" id="CNS-yZ-LO9"/>
                 <outlet property="metaButtonLeft" destination="f2K-8g-nnA" id="6Rd-TT-m9U"/>
                 <outlet property="metaButtonRight" destination="U4X-fn-9uf" id="SHw-FM-KL3"/>
                 <outlet property="metaView" destination="U6E-MB-03K" id="XZt-Fn-PJ2"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -10,267 +11,243 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="448"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="CUK-Fg-fJ5" id="lmn-sx-Q9M">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="448"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="447.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="00o-oC-uzQ">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="447"/>
+                    <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b5E-yQ-veP">
+                        <rect key="frame" x="6" y="10" width="308" height="426"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8uW-Eg-69o">
-                                <rect key="frame" x="5" y="9" width="310" height="428"/>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                            </view>
-                            <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b5E-yQ-veP">
-                                <rect key="frame" x="6" y="10" width="308" height="426"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rIp-IY-Ng4">
+                                <rect key="frame" x="16" y="15" width="276" height="34"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rIp-IY-Ng4">
-                                        <rect key="frame" x="16" y="15" width="276" height="34"/>
-                                        <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="DWo-S7-Yu2">
-                                                <rect key="frame" x="0.0" y="1" width="32" height="32"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="32" id="MkS-EF-k5K"/>
-                                                    <constraint firstAttribute="height" constant="32" id="y6f-IQ-yFt"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LUv-id-3Yc">
-                                                <rect key="frame" x="42" y="0.0" width="234" height="17"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbp-gj-1hE">
-                                                <rect key="frame" x="42" y="18" width="234" height="15"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="DWo-S7-Yu2">
+                                        <rect key="frame" x="0.0" y="1" width="32" height="32"/>
                                         <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="bbp-gj-1hE" secondAttribute="trailing" id="3WE-jM-XJb"/>
-                                            <constraint firstItem="LUv-id-3Yc" firstAttribute="leading" secondItem="DWo-S7-Yu2" secondAttribute="trailing" constant="10" id="fyX-PF-hal"/>
-                                            <constraint firstItem="bbp-gj-1hE" firstAttribute="leading" secondItem="DWo-S7-Yu2" secondAttribute="trailing" constant="10" id="g5j-Ku-I7r"/>
-                                            <constraint firstAttribute="height" constant="34" id="hQY-s6-IDE"/>
-                                            <constraint firstAttribute="bottom" secondItem="bbp-gj-1hE" secondAttribute="bottom" constant="1" id="jYA-gw-mUG"/>
-                                            <constraint firstAttribute="bottom" secondItem="LUv-id-3Yc" secondAttribute="bottom" constant="17" id="m5z-2V-aNd"/>
-                                            <constraint firstAttribute="bottom" secondItem="DWo-S7-Yu2" secondAttribute="bottom" constant="1" id="oFG-Wx-6aR"/>
-                                            <constraint firstAttribute="trailing" secondItem="LUv-id-3Yc" secondAttribute="trailing" id="xQ7-iO-jkF"/>
-                                            <constraint firstItem="DWo-S7-Yu2" firstAttribute="leading" secondItem="rIp-IY-Ng4" secondAttribute="leading" id="xwc-7q-5QP"/>
-                                        </constraints>
-                                    </view>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Y9d-Yk-F4X">
-                                        <rect key="frame" x="0.0" y="64" width="308" height="196"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="196" id="0wl-TX-0Ed">
-                                                <variation key="heightClass=regular-widthClass=regular" constant="226"/>
-                                            </constraint>
+                                            <constraint firstAttribute="width" constant="32" id="MkS-EF-k5K"/>
+                                            <constraint firstAttribute="height" constant="32" id="y6f-IQ-yFt"/>
                                         </constraints>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="E9Y-IT-TUt">
-                                        <rect key="frame" x="16" y="274" width="276" height="24"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Cbe-bm-gnv">
-                                        <rect key="frame" x="16" y="307" width="276" height="18"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LUv-id-3Yc">
+                                        <rect key="frame" x="42" y="0.0" width="234" height="17"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zle-VU-ygo">
-                                        <rect key="frame" x="16" y="334" width="196" height="18"/>
-                                        <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="ed0-E7-1lw">
-                                                <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="18" id="Ief-ts-XAf"/>
-                                                    <constraint firstAttribute="width" constant="18" id="ci3-JD-GRl"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xhs-nZ-clP">
-                                                <rect key="frame" x="21" y="2" width="175" height="15"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstItem="Xhs-nZ-clP" firstAttribute="leading" secondItem="ed0-E7-1lw" secondAttribute="trailing" constant="3" id="89C-6t-aYu"/>
-                                            <constraint firstAttribute="centerY" secondItem="ed0-E7-1lw" secondAttribute="centerY" id="8fH-dp-dze"/>
-                                            <constraint firstAttribute="centerY" secondItem="Xhs-nZ-clP" secondAttribute="centerY" id="E9l-b9-67r"/>
-                                            <constraint firstAttribute="height" constant="18" id="ILf-yy-NWf">
-                                                <variation key="heightClass=regular-widthClass=regular" constant="22"/>
-                                            </constraint>
-                                            <constraint firstItem="ed0-E7-1lw" firstAttribute="leading" secondItem="zle-VU-ygo" secondAttribute="leading" id="QAU-jj-6DZ"/>
-                                            <constraint firstAttribute="trailing" secondItem="Xhs-nZ-clP" secondAttribute="trailing" id="mtJ-F3-lig"/>
-                                        </constraints>
-                                    </view>
-                                    <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="2OR-ox-Csb">
-                                        <rect key="frame" x="16" y="358" width="276" height="18"/>
-                                        <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="WhA-sd-qfz">
-                                                <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="18" id="Jyn-II-qDA"/>
-                                                    <constraint firstAttribute="width" constant="18" id="VrZ-Fl-jC7"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mYl-tz-yRu">
-                                                <rect key="frame" x="21" y="2" width="255" height="15"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="centerY" secondItem="mYl-tz-yRu" secondAttribute="centerY" id="CAw-Am-yKk"/>
-                                            <constraint firstItem="mYl-tz-yRu" firstAttribute="leading" secondItem="WhA-sd-qfz" secondAttribute="trailing" constant="3" id="EFd-kA-u50"/>
-                                            <constraint firstAttribute="trailing" secondItem="mYl-tz-yRu" secondAttribute="trailing" id="Hw8-bJ-BbY"/>
-                                            <constraint firstAttribute="height" constant="18" id="IM4-IL-uMR">
-                                                <variation key="heightClass=regular-widthClass=regular" constant="22"/>
-                                            </constraint>
-                                            <constraint firstItem="WhA-sd-qfz" firstAttribute="leading" secondItem="2OR-ox-Csb" secondAttribute="leading" id="JU7-3a-O3d"/>
-                                            <constraint firstAttribute="centerY" secondItem="WhA-sd-qfz" secondAttribute="centerY" id="nyR-qa-fRd"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U6E-MB-03K">
-                                        <rect key="frame" x="212" y="334" width="80" height="18"/>
-                                        <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U4X-fn-9uf" customClass="PostMetaButton">
-                                                <rect key="frame" x="50" y="0.0" width="30" height="18"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="18" id="YVF-bx-Qxo"/>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="bog-Fu-vOf"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
-                                                <state key="normal" title="0" image="icon-postmeta-like">
-                                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                </state>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f2K-8g-nnA" customClass="PostMetaButton">
-                                                <rect key="frame" x="4" y="0.0" width="30" height="18"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="18" id="GFc-LE-9Ao"/>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="tYz-rL-6ud"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
-                                                <state key="normal" title="0" image="icon-postmeta-comment">
-                                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                </state>
-                                            </button>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstItem="U4X-fn-9uf" firstAttribute="leading" secondItem="f2K-8g-nnA" secondAttribute="trailing" constant="16" id="LNj-rX-kqd"/>
-                                            <constraint firstAttribute="trailing" secondItem="U4X-fn-9uf" secondAttribute="trailing" id="QZF-fS-FFc"/>
-                                            <constraint firstAttribute="centerY" secondItem="U4X-fn-9uf" secondAttribute="centerY" id="VcK-NY-1yM"/>
-                                            <constraint firstItem="f2K-8g-nnA" firstAttribute="leading" secondItem="U6E-MB-03K" secondAttribute="leading" constant="4" id="dBi-M9-Rs2"/>
-                                            <constraint firstAttribute="centerY" secondItem="f2K-8g-nnA" secondAttribute="centerY" id="hQm-nM-Vny"/>
-                                            <constraint firstAttribute="height" constant="18" id="uug-wT-fqt">
-                                                <variation key="heightClass=regular-widthClass=regular" constant="22"/>
-                                            </constraint>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pkq-mO-MBJ" customClass="PostCardActionBar">
-                                        <rect key="frame" x="0.0" y="389" width="308" height="37"/>
-                                        <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="37" id="WGi-rg-iHS"/>
-                                        </constraints>
-                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbp-gj-1hE">
+                                        <rect key="frame" x="42" y="18" width="234" height="15"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="Cbe-bm-gnv" secondAttribute="trailing" constant="16" id="27Y-c8-O7j">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                                    <constraint firstAttribute="trailing" secondItem="bbp-gj-1hE" secondAttribute="trailing" id="3WE-jM-XJb"/>
+                                    <constraint firstItem="LUv-id-3Yc" firstAttribute="leading" secondItem="DWo-S7-Yu2" secondAttribute="trailing" constant="10" id="fyX-PF-hal"/>
+                                    <constraint firstItem="bbp-gj-1hE" firstAttribute="leading" secondItem="DWo-S7-Yu2" secondAttribute="trailing" constant="10" id="g5j-Ku-I7r"/>
+                                    <constraint firstAttribute="height" constant="34" id="hQY-s6-IDE"/>
+                                    <constraint firstAttribute="bottom" secondItem="bbp-gj-1hE" secondAttribute="bottom" constant="1" id="jYA-gw-mUG"/>
+                                    <constraint firstAttribute="bottom" secondItem="LUv-id-3Yc" secondAttribute="bottom" constant="17" id="m5z-2V-aNd"/>
+                                    <constraint firstAttribute="bottom" secondItem="DWo-S7-Yu2" secondAttribute="bottom" constant="1" id="oFG-Wx-6aR"/>
+                                    <constraint firstAttribute="trailing" secondItem="LUv-id-3Yc" secondAttribute="trailing" id="xQ7-iO-jkF"/>
+                                    <constraint firstItem="DWo-S7-Yu2" firstAttribute="leading" secondItem="rIp-IY-Ng4" secondAttribute="leading" id="xwc-7q-5QP"/>
+                                </constraints>
+                            </view>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Y9d-Yk-F4X">
+                                <rect key="frame" x="0.0" y="64" width="308" height="196"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="196" id="0wl-TX-0Ed">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="226"/>
                                     </constraint>
-                                    <constraint firstItem="2OR-ox-Csb" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="2Wh-mV-Zph">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                                </constraints>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="E9Y-IT-TUt">
+                                <rect key="frame" x="16" y="274" width="276" height="24"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Cbe-bm-gnv">
+                                <rect key="frame" x="16" y="307" width="276" height="18"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zle-VU-ygo">
+                                <rect key="frame" x="16" y="334" width="196" height="18"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="ed0-E7-1lw">
+                                        <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="18" id="Ief-ts-XAf"/>
+                                            <constraint firstAttribute="width" constant="18" id="ci3-JD-GRl"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xhs-nZ-clP">
+                                        <rect key="frame" x="21" y="2" width="175" height="15"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="Xhs-nZ-clP" firstAttribute="leading" secondItem="ed0-E7-1lw" secondAttribute="trailing" constant="3" id="89C-6t-aYu"/>
+                                    <constraint firstAttribute="centerY" secondItem="ed0-E7-1lw" secondAttribute="centerY" id="8fH-dp-dze"/>
+                                    <constraint firstAttribute="centerY" secondItem="Xhs-nZ-clP" secondAttribute="centerY" id="E9l-b9-67r"/>
+                                    <constraint firstAttribute="height" constant="18" id="ILf-yy-NWf">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="22"/>
                                     </constraint>
-                                    <constraint firstItem="zle-VU-ygo" firstAttribute="top" secondItem="Cbe-bm-gnv" secondAttribute="bottom" constant="9" id="54w-4V-wCw">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="9"/>
+                                    <constraint firstItem="ed0-E7-1lw" firstAttribute="leading" secondItem="zle-VU-ygo" secondAttribute="leading" id="QAU-jj-6DZ"/>
+                                    <constraint firstAttribute="trailing" secondItem="Xhs-nZ-clP" secondAttribute="trailing" id="mtJ-F3-lig"/>
+                                </constraints>
+                            </view>
+                            <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="2OR-ox-Csb">
+                                <rect key="frame" x="16" y="358" width="276" height="18"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="WhA-sd-qfz">
+                                        <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="18" id="Jyn-II-qDA"/>
+                                            <constraint firstAttribute="width" constant="18" id="VrZ-Fl-jC7"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mYl-tz-yRu">
+                                        <rect key="frame" x="21" y="2" width="255" height="15"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="centerY" secondItem="mYl-tz-yRu" secondAttribute="centerY" id="CAw-Am-yKk"/>
+                                    <constraint firstItem="mYl-tz-yRu" firstAttribute="leading" secondItem="WhA-sd-qfz" secondAttribute="trailing" constant="3" id="EFd-kA-u50"/>
+                                    <constraint firstAttribute="trailing" secondItem="mYl-tz-yRu" secondAttribute="trailing" id="Hw8-bJ-BbY"/>
+                                    <constraint firstAttribute="height" constant="18" id="IM4-IL-uMR">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="22"/>
                                     </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="pkq-mO-MBJ" secondAttribute="trailing" id="94D-vc-Bfy"/>
-                                    <constraint firstItem="Cbe-bm-gnv" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="AAS-zA-QSN">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="rIp-IY-Ng4" firstAttribute="top" secondItem="b5E-yQ-veP" secondAttribute="top" constant="15" id="Af8-lU-jWg"/>
-                                    <constraint firstItem="Y9d-Yk-F4X" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" id="JnV-Io-ZDa"/>
-                                    <constraint firstAttribute="trailing" secondItem="E9Y-IT-TUt" secondAttribute="trailing" constant="16" id="Ll1-Y8-bQN">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="zle-VU-ygo" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="MPI-RN-znl">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="E9Y-IT-TUt" firstAttribute="top" secondItem="Y9d-Yk-F4X" secondAttribute="bottom" constant="14" id="N8M-5Y-cWJ"/>
-                                    <constraint firstItem="E9Y-IT-TUt" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="NBs-7e-hP4">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="U6E-MB-03K" firstAttribute="centerY" secondItem="zle-VU-ygo" secondAttribute="centerY" id="NCb-6E-SND"/>
-                                    <constraint firstItem="Y9d-Yk-F4X" firstAttribute="top" secondItem="rIp-IY-Ng4" secondAttribute="bottom" constant="15" id="QbH-qP-NR7"/>
-                                    <constraint firstItem="rIp-IY-Ng4" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="SmN-xb-mWD">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="U6E-MB-03K" secondAttribute="trailing" constant="16" id="T0c-A5-khY">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="rIp-IY-Ng4" secondAttribute="trailing" constant="16" id="U9A-yx-smS">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="2OR-ox-Csb" firstAttribute="top" secondItem="zle-VU-ygo" secondAttribute="bottom" constant="6" id="cCR-ch-CxK">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="8"/>
-                                    </constraint>
-                                    <constraint firstItem="Cbe-bm-gnv" firstAttribute="top" secondItem="E9Y-IT-TUt" secondAttribute="bottom" constant="9" id="hdt-ZQ-dHo">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="7"/>
-                                    </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="2OR-ox-Csb" secondAttribute="trailing" constant="16" id="iO3-Io-6Bk">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="pkq-mO-MBJ" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" id="pl8-s7-Mjm"/>
-                                    <constraint firstAttribute="trailing" secondItem="Y9d-Yk-F4X" secondAttribute="trailing" id="rWg-Oz-OEh"/>
-                                    <constraint firstAttribute="bottom" secondItem="pkq-mO-MBJ" secondAttribute="bottom" id="tgK-m9-bll"/>
-                                    <constraint firstItem="U6E-MB-03K" firstAttribute="leading" secondItem="zle-VU-ygo" secondAttribute="trailing" id="wYq-9R-DJF"/>
-                                    <constraint firstItem="pkq-mO-MBJ" firstAttribute="top" secondItem="2OR-ox-Csb" secondAttribute="bottom" priority="900" constant="13" id="waW-2I-Gom">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="16"/>
+                                    <constraint firstItem="WhA-sd-qfz" firstAttribute="leading" secondItem="2OR-ox-Csb" secondAttribute="leading" id="JU7-3a-O3d"/>
+                                    <constraint firstAttribute="centerY" secondItem="WhA-sd-qfz" secondAttribute="centerY" id="nyR-qa-fRd"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U6E-MB-03K">
+                                <rect key="frame" x="212" y="334" width="80" height="18"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U4X-fn-9uf" customClass="PostMetaButton">
+                                        <rect key="frame" x="50" y="0.0" width="30" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="18" id="YVF-bx-Qxo"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="bog-Fu-vOf"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
+                                        <state key="normal" title="0" image="icon-postmeta-like">
+                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f2K-8g-nnA" customClass="PostMetaButton">
+                                        <rect key="frame" x="4" y="0.0" width="30" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="18" id="GFc-LE-9Ao"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="tYz-rL-6ud"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
+                                        <state key="normal" title="0" image="icon-postmeta-comment">
+                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="U4X-fn-9uf" firstAttribute="leading" secondItem="f2K-8g-nnA" secondAttribute="trailing" constant="16" id="LNj-rX-kqd"/>
+                                    <constraint firstAttribute="trailing" secondItem="U4X-fn-9uf" secondAttribute="trailing" id="QZF-fS-FFc"/>
+                                    <constraint firstAttribute="centerY" secondItem="U4X-fn-9uf" secondAttribute="centerY" id="VcK-NY-1yM"/>
+                                    <constraint firstItem="f2K-8g-nnA" firstAttribute="leading" secondItem="U6E-MB-03K" secondAttribute="leading" constant="4" id="dBi-M9-Rs2"/>
+                                    <constraint firstAttribute="centerY" secondItem="f2K-8g-nnA" secondAttribute="centerY" id="hQm-nM-Vny"/>
+                                    <constraint firstAttribute="height" constant="18" id="uug-wT-fqt">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="22"/>
                                     </constraint>
                                 </constraints>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pkq-mO-MBJ" customClass="PostCardActionBar">
+                                <rect key="frame" x="0.0" y="389" width="308" height="37"/>
+                                <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="37" id="WGi-rg-iHS"/>
+                                </constraints>
+                            </view>
                         </subviews>
-                        <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="b5E-yQ-veP" firstAttribute="top" secondItem="00o-oC-uzQ" secondAttribute="top" constant="10" id="0UX-EC-CFr"/>
-                            <constraint firstAttribute="trailing" secondItem="b5E-yQ-veP" secondAttribute="trailing" constant="6" id="IhB-5o-fWK">
-                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            <constraint firstAttribute="trailing" secondItem="Cbe-bm-gnv" secondAttribute="trailing" constant="16" id="27Y-c8-O7j">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
-                            <constraint firstItem="b5E-yQ-veP" firstAttribute="top" secondItem="8uW-Eg-69o" secondAttribute="top" constant="1" id="KTV-F2-9x4"/>
-                            <constraint firstItem="b5E-yQ-veP" firstAttribute="bottom" secondItem="8uW-Eg-69o" secondAttribute="bottom" constant="-1" id="QWt-JY-Uqy"/>
-                            <constraint firstItem="b5E-yQ-veP" firstAttribute="leading" secondItem="8uW-Eg-69o" secondAttribute="leading" constant="1" id="SSF-mO-oAJ"/>
-                            <constraint firstAttribute="bottom" secondItem="b5E-yQ-veP" secondAttribute="bottom" constant="11" id="gQs-6I-fOg"/>
-                            <constraint firstItem="b5E-yQ-veP" firstAttribute="trailing" secondItem="8uW-Eg-69o" secondAttribute="trailing" constant="-1" id="kBU-fR-RAo"/>
-                            <constraint firstItem="b5E-yQ-veP" firstAttribute="leading" secondItem="00o-oC-uzQ" secondAttribute="leading" constant="6" id="vWx-63-G4B">
-                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            <constraint firstItem="2OR-ox-Csb" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="2Wh-mV-Zph">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="zle-VU-ygo" firstAttribute="top" secondItem="Cbe-bm-gnv" secondAttribute="bottom" constant="9" id="54w-4V-wCw">
+                                <variation key="heightClass=regular-widthClass=regular" constant="9"/>
+                            </constraint>
+                            <constraint firstAttribute="trailing" secondItem="pkq-mO-MBJ" secondAttribute="trailing" id="94D-vc-Bfy"/>
+                            <constraint firstItem="Cbe-bm-gnv" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="AAS-zA-QSN">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="rIp-IY-Ng4" firstAttribute="top" secondItem="b5E-yQ-veP" secondAttribute="top" constant="15" id="Af8-lU-jWg"/>
+                            <constraint firstItem="Y9d-Yk-F4X" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" id="JnV-Io-ZDa"/>
+                            <constraint firstAttribute="trailing" secondItem="E9Y-IT-TUt" secondAttribute="trailing" constant="16" id="Ll1-Y8-bQN">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="zle-VU-ygo" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="MPI-RN-znl">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="E9Y-IT-TUt" firstAttribute="top" secondItem="Y9d-Yk-F4X" secondAttribute="bottom" constant="14" id="N8M-5Y-cWJ"/>
+                            <constraint firstItem="E9Y-IT-TUt" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="NBs-7e-hP4">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="U6E-MB-03K" firstAttribute="centerY" secondItem="zle-VU-ygo" secondAttribute="centerY" id="NCb-6E-SND"/>
+                            <constraint firstItem="Y9d-Yk-F4X" firstAttribute="top" secondItem="rIp-IY-Ng4" secondAttribute="bottom" constant="15" id="QbH-qP-NR7"/>
+                            <constraint firstItem="rIp-IY-Ng4" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="SmN-xb-mWD">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstAttribute="trailing" secondItem="U6E-MB-03K" secondAttribute="trailing" constant="16" id="T0c-A5-khY">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstAttribute="trailing" secondItem="rIp-IY-Ng4" secondAttribute="trailing" constant="16" id="U9A-yx-smS">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="2OR-ox-Csb" firstAttribute="top" secondItem="zle-VU-ygo" secondAttribute="bottom" constant="6" id="cCR-ch-CxK">
+                                <variation key="heightClass=regular-widthClass=regular" constant="8"/>
+                            </constraint>
+                            <constraint firstItem="Cbe-bm-gnv" firstAttribute="top" secondItem="E9Y-IT-TUt" secondAttribute="bottom" constant="9" id="hdt-ZQ-dHo">
+                                <variation key="heightClass=regular-widthClass=regular" constant="7"/>
+                            </constraint>
+                            <constraint firstAttribute="trailing" secondItem="2OR-ox-Csb" secondAttribute="trailing" constant="16" id="iO3-Io-6Bk">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="pkq-mO-MBJ" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" id="pl8-s7-Mjm"/>
+                            <constraint firstAttribute="trailing" secondItem="Y9d-Yk-F4X" secondAttribute="trailing" id="rWg-Oz-OEh"/>
+                            <constraint firstAttribute="bottom" secondItem="pkq-mO-MBJ" secondAttribute="bottom" id="tgK-m9-bll"/>
+                            <constraint firstItem="U6E-MB-03K" firstAttribute="leading" secondItem="zle-VU-ygo" secondAttribute="trailing" id="wYq-9R-DJF"/>
+                            <constraint firstItem="pkq-mO-MBJ" firstAttribute="top" secondItem="2OR-ox-Csb" secondAttribute="bottom" priority="900" constant="13" id="waW-2I-Gom">
+                                <variation key="heightClass=regular-widthClass=regular" constant="16"/>
                             </constraint>
                         </constraints>
                     </view>
                 </subviews>
                 <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="00o-oC-uzQ" secondAttribute="bottom" id="JWp-5h-zBn"/>
-                    <constraint firstAttribute="trailing" secondItem="00o-oC-uzQ" secondAttribute="trailing" id="UZn-qQ-HKP"/>
-                    <constraint firstItem="00o-oC-uzQ" firstAttribute="leading" secondItem="lmn-sx-Q9M" secondAttribute="leading" id="dOZ-hU-HTf"/>
-                    <constraint firstItem="00o-oC-uzQ" firstAttribute="top" secondItem="lmn-sx-Q9M" secondAttribute="top" id="sjy-hb-n0n"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="b5E-yQ-veP" secondAttribute="trailing" constant="-2" id="5CP-ZE-K8w"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="b5E-yQ-veP" secondAttribute="bottom" constant="3.5" id="O2f-he-2mN"/>
+                    <constraint firstItem="b5E-yQ-veP" firstAttribute="top" secondItem="lmn-sx-Q9M" secondAttribute="topMargin" constant="2" id="TjT-xs-ca9"/>
+                    <constraint firstItem="b5E-yQ-veP" firstAttribute="leading" secondItem="lmn-sx-Q9M" secondAttribute="leadingMargin" constant="-2" id="mGT-Pg-afU"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
@@ -286,16 +263,13 @@
                 <outlet property="headerViewHeightConstraint" destination="hQY-s6-IDE" id="JE0-4W-dHL"/>
                 <outlet property="headerViewLeftConstraint" destination="SmN-xb-mWD" id="sB9-to-eqY"/>
                 <outlet property="headerViewLowerConstraint" destination="QbH-qP-NR7" id="yVA-nc-yCf"/>
-                <outlet property="innerContentView" destination="00o-oC-uzQ" id="wq9-Kq-6nW"/>
                 <outlet property="metaButtonLeft" destination="f2K-8g-nnA" id="6Rd-TT-m9U"/>
                 <outlet property="metaButtonRight" destination="U4X-fn-9uf" id="SHw-FM-KL3"/>
                 <outlet property="metaView" destination="U6E-MB-03K" id="XZt-Fn-PJ2"/>
                 <outlet property="postCardImageView" destination="Y9d-Yk-F4X" id="ftE-Cm-xPY"/>
                 <outlet property="postCardImageViewBottomConstraint" destination="N8M-5Y-cWJ" id="lhh-cM-CR0"/>
                 <outlet property="postCardImageViewHeightConstraint" destination="0wl-TX-0Ed" id="lHP-O3-pox"/>
-                <outlet property="postContentBottomConstraint" destination="gQs-6I-fOg" id="1aL-Pl-3MO"/>
                 <outlet property="postContentView" destination="b5E-yQ-veP" id="m4f-f7-d0h"/>
-                <outlet property="shadowView" destination="8uW-Eg-69o" id="Qfj-VW-sqC"/>
                 <outlet property="snippetLabel" destination="Cbe-bm-gnv" id="ccW-VN-byK"/>
                 <outlet property="snippetLowerConstraint" destination="54w-4V-wCw" id="g8b-qX-e62"/>
                 <outlet property="statusHeightConstraint" destination="IM4-IL-uMR" id="rF3-yu-usm"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -244,7 +244,7 @@
                 </subviews>
                 <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
                 <constraints>
-                    <constraint firstAttribute="trailingMargin" secondItem="b5E-yQ-veP" secondAttribute="trailing" constant="-2" id="5CP-ZE-K8w">
+                    <constraint firstAttribute="trailingMargin" secondItem="b5E-yQ-veP" secondAttribute="trailing" priority="999" constant="-2" id="5CP-ZE-K8w">
                         <variation key="widthClass=regular" constant="0.0"/>
                     </constraint>
                     <constraint firstAttribute="bottomMargin" secondItem="b5E-yQ-veP" secondAttribute="bottom" constant="4" id="O2f-he-2mN">

--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -244,12 +244,22 @@
                 </subviews>
                 <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
                 <constraints>
-                    <constraint firstAttribute="trailingMargin" secondItem="b5E-yQ-veP" secondAttribute="trailing" constant="-2" id="5CP-ZE-K8w"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="b5E-yQ-veP" secondAttribute="bottom" constant="3.5" id="O2f-he-2mN"/>
-                    <constraint firstItem="b5E-yQ-veP" firstAttribute="top" secondItem="lmn-sx-Q9M" secondAttribute="topMargin" constant="2" id="TjT-xs-ca9"/>
-                    <constraint firstItem="b5E-yQ-veP" firstAttribute="leading" secondItem="lmn-sx-Q9M" secondAttribute="leadingMargin" constant="-2" id="mGT-Pg-afU"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="b5E-yQ-veP" secondAttribute="trailing" constant="-2" id="5CP-ZE-K8w">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
+                    <constraint firstAttribute="bottomMargin" secondItem="b5E-yQ-veP" secondAttribute="bottom" constant="4" id="O2f-he-2mN">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
+                    <constraint firstItem="b5E-yQ-veP" firstAttribute="top" secondItem="lmn-sx-Q9M" secondAttribute="topMargin" constant="2" id="TjT-xs-ca9">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
+                    <constraint firstItem="b5E-yQ-veP" firstAttribute="leading" secondItem="lmn-sx-Q9M" secondAttribute="leadingMargin" constant="-2" id="mGT-Pg-afU">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
                 </constraints>
+                <variation key="widthClass=regular" layoutMarginsFollowReadableWidth="YES" preservesSuperviewLayoutMargins="YES"/>
             </tableViewCellContentView>
+            <variation key="widthClass=regular" layoutMarginsFollowReadableWidth="YES" preservesSuperviewLayoutMargins="YES"/>
             <connections>
                 <outlet property="actionBar" destination="pkq-mO-MBJ" id="1kC-XT-wKH"/>
                 <outlet property="authorBlogLabel" destination="LUv-id-3Yc" id="amv-hH-UV1"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -19,8 +19,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 @interface PostCardTableViewCell()
 
-@property (nonatomic, strong) IBOutlet UIView *innerContentView;
-@property (nonatomic, strong) IBOutlet UIView *shadowView;
 @property (nonatomic, strong) IBOutlet UIView *postContentView;
 @property (nonatomic, strong) IBOutlet UIView *headerView;
 @property (nonatomic, strong) IBOutlet UIImageView *avatarImageView;
@@ -105,12 +103,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 #pragma mark - Accessors
 
-- (void)setBackgroundColor:(UIColor *)backgroundColor
-{
-    [super setBackgroundColor:backgroundColor];
-    self.innerContentView.backgroundColor = backgroundColor;
-}
-
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated
 {
     BOOL previouslyHighlighted = self.highlighted;
@@ -143,7 +135,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
                           delay:0
                         options:UIViewAnimationCurveEaseInOut
                      animations:^{
-                         self.shadowView.hidden = highlighted;
+                         self.postContentView.layer.borderColor = highlighted ? [[UIColor clearColor] CGColor] : [[WPStyleGuide postCardBorderColor] CGColor];
                          self.alpha = highlighted ? .7f : 1.f;
                          if (highlighted) {
                              CGFloat perspective = IS_IPAD ? -0.00005 : -0.0001;
@@ -188,7 +180,8 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     [WPStyleGuide applyPostMetaButtonStyle:self.metaButtonRight];
     [WPStyleGuide applyPostMetaButtonStyle:self.metaButtonLeft];
     self.actionBar.backgroundColor = [WPStyleGuide lightGrey];
-    self.shadowView.backgroundColor = [WPStyleGuide postCardBorderColor];
+    self.postContentView.layer.borderColor = [[WPStyleGuide postCardBorderColor] CGColor];
+    self.postContentView.layer.borderWidth = 1.0;
 }
 
 #pragma mark - ConfigurablePostView

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -48,7 +48,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *statusHeightConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *statusViewLowerConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *postContentBottomConstraint;
-@property (nonatomic, strong) IBOutlet NSLayoutConstraint *maxIPadWidthConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *postCardImageViewBottomConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *postCardImageViewHeightConstraint;
 
@@ -148,17 +147,9 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (CGFloat)innerWidthForSize:(CGSize)size
 {
-    CGFloat width = 0.0;
+    CGFloat width = size.width;
     CGFloat horizontalMargin = self.headerViewLeftConstraint.constant;
-    // FIXME: Ideally we'd check `self.maxIPadWidthConstraint.isActive` but that
-    // property is iOS 8 only. When iOS 7 support is ended update this and check
-    // the constraint. 
-    if ([UIDevice isPad] && size.width >= self.maxIPadWidthConstraint.constant) {
-        width = self.maxIPadWidthConstraint.constant;
-    } else {
-        width = size.width;
-        horizontalMargin += CGRectGetMinX(self.postContentView.frame);
-    }
+    horizontalMargin += CGRectGetMinX(self.postContentView.frame);
     width -= (horizontalMargin * 2);
     return width;
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -60,7 +60,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 @property (nonatomic) CGFloat dateViewLowerMargin;
 @property (nonatomic) CGFloat statusViewHeight;
 @property (nonatomic) CGFloat statusViewLowerMargin;
-@property (nonatomic) BOOL configureForLayoutOnly;
 @property (nonatomic) BOOL didPreserveStartingConstraintConstants;
 @property (nonatomic) ActionBarMode currentActionBarMode;
 
@@ -100,59 +99,11 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     // the cell if needed.
     [self preserveStartingConstraintConstants];
     if (self.post) {
-        [self configureWithPost:self.post forLayoutOnly:self.configureForLayoutOnly];
+        [self configureWithPost:self.post];
     }
 }
 
 #pragma mark - Accessors
-
-- (CGSize)sizeThatFits:(CGSize)size
-{
-    CGFloat innerWidth = [self innerWidthForSize:size];
-    CGSize innerSize = CGSizeMake(innerWidth, CGFLOAT_MAX);
-
-    // Add up all the things.
-    CGFloat height = CGRectGetMinY(self.postContentView.frame);
-
-    height += CGRectGetMinY(self.headerView.frame);
-    if (self.headerViewHeightConstraint.constant > 0) {
-        height += self.headerViewHeight;
-        height += self.headerViewLowerMargin;
-    }
-
-    if (self.postCardImageView) {
-        // the image cell xib
-        height += self.postCardImageViewHeightConstraint.constant;
-        height += self.postCardImageViewBottomConstraint.constant;
-    }
-
-    height += [self.titleLabel sizeThatFits:innerSize].height;
-    height += self.titleLowerConstraint.constant;
-
-    height += [self.snippetLabel sizeThatFits:innerSize].height;
-    height += self.snippetLowerConstraint.constant;
-
-    height += CGRectGetHeight(self.dateView.frame);
-    height += self.dateViewLowerConstraint.constant;
-
-    height += self.statusHeightConstraint.constant;
-    height += self.statusViewLowerConstraint.constant;
-
-    height += CGRectGetHeight(self.actionBar.frame);
-
-    height += self.postContentBottomConstraint.constant;
-
-    return CGSizeMake(size.width, height);
-}
-
-- (CGFloat)innerWidthForSize:(CGSize)size
-{
-    CGFloat width = size.width;
-    CGFloat horizontalMargin = self.headerViewLeftConstraint.constant;
-    horizontalMargin += CGRectGetMinX(self.postContentView.frame);
-    width -= (horizontalMargin * 2);
-    return width;
-}
 
 - (void)setBackgroundColor:(UIColor *)backgroundColor
 {
@@ -244,13 +195,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (void)configureWithPost:(Post *)post
 {
-    [self configureWithPost:post forLayoutOnly:NO];
-}
-
-- (void)configureWithPost:(nonnull Post *)post
-            forLayoutOnly:(BOOL)layoutOnly
-{
-    self.configureForLayoutOnly = layoutOnly;
     self.post = post;
 
     if (!self.didPreserveStartingConstraintConstants) {
@@ -290,12 +234,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     self.headerView.hidden = NO;
     self.headerViewHeightConstraint.constant = self.headerViewHeight;
     self.headerViewLowerConstraint.constant = self.headerViewLowerMargin;
-
-    // No need to worry about text or image when configuring only layout
-    if (self.configureForLayoutOnly) {
-        return;
-    }
-
     self.authorBlogLabel.text = [self.post blogNameForDisplay];
     self.authorNameLabel.text = [self.post authorNameForDisplay];
     UIImage *placeholder = [UIImage imageNamed:@"post-blavatar-placeholder"];
@@ -305,10 +243,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (void)configureCardImage
 {
-    if (self.configureForLayoutOnly) {
-        return;
-    }
-
     if (!self.postCardImageView) {
         return;
     }
@@ -401,10 +335,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (void)configureMetaButtons
 {
-    if (self.configureForLayoutOnly) {
-        return;
-    }
-
     [self resetMetaButton:self.metaButtonRight];
     [self resetMetaButton:self.metaButtonLeft];
 
@@ -447,10 +377,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (void)configureActionBar
 {
-    if (self.configureForLayoutOnly) {
-        return;
-    }
-
     NSString *status = [self.post status];
     if ([status isEqualToString:PostStatusPublish] || [status isEqualToString:PostStatusPrivate]) {
         [self configurePublishedActionBar];

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -41,7 +41,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l4E-Qn-Vgl">
-                                                <rect key="frame" x="42" y="18" width="234" height="14.5"/>
+                                                <rect key="frame" x="42" y="18" width="234" height="15"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -86,7 +86,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q5D-nc-yvr">
-                                                <rect key="frame" x="21" y="2" width="175" height="14.5"/>
+                                                <rect key="frame" x="21" y="2" width="175" height="15"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -116,7 +116,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbu-l3-L8G">
-                                                <rect key="frame" x="21" y="2" width="255" height="14.5"/>
+                                                <rect key="frame" x="21" y="2" width="255" height="15"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -210,7 +210,6 @@
                                     <constraint firstAttribute="trailing" secondItem="POV-pe-wu8" secondAttribute="trailing" constant="16" id="SjY-e4-XWL">
                                         <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                                     </constraint>
-                                    <constraint firstAttribute="width" priority="900" constant="600" id="UEv-b1-gAx"/>
                                     <constraint firstItem="Z3W-ou-g2J" firstAttribute="top" secondItem="POV-pe-wu8" secondAttribute="bottom" constant="9" id="cgz-3E-MrQ">
                                         <variation key="heightClass=regular-widthClass=regular" constant="9"/>
                                     </constraint>
@@ -236,16 +235,6 @@
                                         <variation key="heightClass=regular-widthClass=regular" constant="8"/>
                                     </constraint>
                                 </constraints>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="UEv-b1-gAx"/>
-                                    </mask>
-                                </variation>
-                                <variation key="heightClass=regular-widthClass=regular">
-                                    <mask key="constraints">
-                                        <include reference="UEv-b1-gAx"/>
-                                    </mask>
-                                </variation>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
@@ -253,25 +242,16 @@
                             <constraint firstItem="Lk7-nZ-b0t" firstAttribute="trailing" secondItem="nUV-EO-Wtj" secondAttribute="trailing" constant="-1" id="9Ss-Um-KB9"/>
                             <constraint firstItem="Lk7-nZ-b0t" firstAttribute="top" secondItem="nUV-EO-Wtj" secondAttribute="top" constant="1" id="F75-CV-nRl"/>
                             <constraint firstItem="Lk7-nZ-b0t" firstAttribute="leading" secondItem="nUV-EO-Wtj" secondAttribute="leading" constant="1" id="LjT-fS-pfA"/>
-                            <constraint firstItem="Lk7-nZ-b0t" firstAttribute="leading" secondItem="P6C-o2-FTR" secondAttribute="leading" constant="6" id="NMO-YJ-xyb"/>
-                            <constraint firstAttribute="centerX" secondItem="Lk7-nZ-b0t" secondAttribute="centerX" id="Nqp-7c-aLc"/>
-                            <constraint firstAttribute="trailing" secondItem="Lk7-nZ-b0t" secondAttribute="trailing" constant="6" id="PT4-oy-27q"/>
+                            <constraint firstItem="Lk7-nZ-b0t" firstAttribute="leading" secondItem="P6C-o2-FTR" secondAttribute="leading" constant="6" id="NMO-YJ-xyb">
+                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            </constraint>
+                            <constraint firstAttribute="trailing" secondItem="Lk7-nZ-b0t" secondAttribute="trailing" constant="6" id="PT4-oy-27q">
+                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            </constraint>
                             <constraint firstAttribute="bottom" secondItem="Lk7-nZ-b0t" secondAttribute="bottom" constant="11" id="Z1Z-lv-uKl"/>
                             <constraint firstItem="Lk7-nZ-b0t" firstAttribute="bottom" secondItem="nUV-EO-Wtj" secondAttribute="bottom" constant="-1" id="Z49-P0-eAT"/>
                             <constraint firstItem="Lk7-nZ-b0t" firstAttribute="top" secondItem="P6C-o2-FTR" secondAttribute="top" constant="10" id="s2L-vI-ED0"/>
                         </constraints>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="Nqp-7c-aLc"/>
-                            </mask>
-                        </variation>
-                        <variation key="heightClass=regular-widthClass=regular">
-                            <mask key="constraints">
-                                <exclude reference="NMO-YJ-xyb"/>
-                                <include reference="Nqp-7c-aLc"/>
-                                <exclude reference="PT4-oy-27q"/>
-                            </mask>
-                        </variation>
                     </view>
                 </subviews>
                 <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
@@ -296,7 +276,6 @@
                 <outlet property="headerViewLeftConstraint" destination="2pB-iJ-nFa" id="1Ha-rq-koT"/>
                 <outlet property="headerViewLowerConstraint" destination="gXH-oU-BWB" id="DR5-aJ-6Ye"/>
                 <outlet property="innerContentView" destination="P6C-o2-FTR" id="iBv-yh-YB0"/>
-                <outlet property="maxIPadWidthConstraint" destination="UEv-b1-gAx" id="hOO-m5-lsB"/>
                 <outlet property="metaButtonLeft" destination="uDE-AO-Rii" id="NHd-hW-Cag"/>
                 <outlet property="metaButtonRight" destination="Ovg-ci-Pfb" id="dCB-Tf-ED7"/>
                 <outlet property="metaView" destination="YwV-AJ-Nvl" id="KYr-Rj-rfE"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -233,12 +233,22 @@
                 </subviews>
                 <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
                 <constraints>
-                    <constraint firstItem="Lk7-nZ-b0t" firstAttribute="trailing" secondItem="MWK-lj-FaS" secondAttribute="trailingMargin" constant="2" id="2At-kP-Urm"/>
-                    <constraint firstAttribute="leadingMargin" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="2" id="2n8-4V-L5z"/>
-                    <constraint firstItem="Lk7-nZ-b0t" firstAttribute="top" secondItem="MWK-lj-FaS" secondAttribute="topMargin" constant="2" id="FdQ-h9-rr5"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="Lk7-nZ-b0t" secondAttribute="bottom" constant="4" id="XHc-Nc-QKK"/>
+                    <constraint firstItem="Lk7-nZ-b0t" firstAttribute="trailing" secondItem="MWK-lj-FaS" secondAttribute="trailingMargin" constant="2" id="2At-kP-Urm">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
+                    <constraint firstAttribute="leadingMargin" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="2" id="2n8-4V-L5z">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
+                    <constraint firstItem="Lk7-nZ-b0t" firstAttribute="top" secondItem="MWK-lj-FaS" secondAttribute="topMargin" constant="2" id="FdQ-h9-rr5">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
+                    <constraint firstAttribute="bottomMargin" secondItem="Lk7-nZ-b0t" secondAttribute="bottom" constant="4" id="XHc-Nc-QKK">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
                 </constraints>
+                <variation key="widthClass=regular" layoutMarginsFollowReadableWidth="YES" preservesSuperviewLayoutMargins="YES"/>
             </tableViewCellContentView>
+            <variation key="widthClass=regular" layoutMarginsFollowReadableWidth="YES" preservesSuperviewLayoutMargins="YES"/>
             <connections>
                 <outlet property="actionBar" destination="BlB-Gp-P6A" id="Aem-q7-aIP"/>
                 <outlet property="authorBlogLabel" destination="Glg-dS-0y2" id="7c4-aF-PPA"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -13,253 +14,229 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="237.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P6C-o2-FTR">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="237"/>
+                    <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lk7-nZ-b0t">
+                        <rect key="frame" x="6" y="10" width="308" height="216"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nUV-EO-Wtj">
-                                <rect key="frame" x="5" y="9" width="310" height="218"/>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                            </view>
-                            <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lk7-nZ-b0t">
-                                <rect key="frame" x="6" y="10" width="308" height="216"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OuO-i7-2Ds">
+                                <rect key="frame" x="16" y="15" width="276" height="34"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OuO-i7-2Ds">
-                                        <rect key="frame" x="16" y="15" width="276" height="34"/>
-                                        <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="tB9-qp-pdv">
-                                                <rect key="frame" x="0.0" y="1" width="32" height="32"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="32" id="nUp-FQ-yAE"/>
-                                                    <constraint firstAttribute="height" constant="32" id="qKp-DE-p9K"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Glg-dS-0y2">
-                                                <rect key="frame" x="42" y="0.0" width="234" height="17"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l4E-Qn-Vgl">
-                                                <rect key="frame" x="42" y="18" width="234" height="15"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="tB9-qp-pdv">
+                                        <rect key="frame" x="0.0" y="1" width="32" height="32"/>
                                         <constraints>
-                                            <constraint firstItem="l4E-Qn-Vgl" firstAttribute="leading" secondItem="tB9-qp-pdv" secondAttribute="trailing" constant="10" id="ONX-Wv-JNt"/>
-                                            <constraint firstAttribute="height" constant="34" id="XPo-Pz-YMq"/>
-                                            <constraint firstAttribute="centerY" secondItem="tB9-qp-pdv" secondAttribute="centerY" id="XcJ-0j-93o"/>
-                                            <constraint firstItem="Glg-dS-0y2" firstAttribute="leading" secondItem="tB9-qp-pdv" secondAttribute="trailing" constant="10" id="a7e-Y3-7xM"/>
-                                            <constraint firstItem="l4E-Qn-Vgl" firstAttribute="top" secondItem="OuO-i7-2Ds" secondAttribute="top" constant="18" id="bSY-9k-nBq"/>
-                                            <constraint firstItem="Glg-dS-0y2" firstAttribute="top" secondItem="OuO-i7-2Ds" secondAttribute="top" id="cyI-Sx-yRb"/>
-                                            <constraint firstAttribute="trailing" secondItem="l4E-Qn-Vgl" secondAttribute="trailing" id="k2B-kw-1aC"/>
-                                            <constraint firstItem="tB9-qp-pdv" firstAttribute="leading" secondItem="OuO-i7-2Ds" secondAttribute="leading" id="pTC-Bl-UWR"/>
-                                            <constraint firstAttribute="trailing" secondItem="Glg-dS-0y2" secondAttribute="trailing" id="uVf-jK-JTU"/>
+                                            <constraint firstAttribute="width" constant="32" id="nUp-FQ-yAE"/>
+                                            <constraint firstAttribute="height" constant="32" id="qKp-DE-p9K"/>
                                         </constraints>
-                                    </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="xIT-FJ-g43">
-                                        <rect key="frame" x="16" y="61" width="276" height="24"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="POV-pe-wu8">
-                                        <rect key="frame" x="16" y="90" width="276" height="25"/>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Glg-dS-0y2">
+                                        <rect key="frame" x="42" y="0.0" width="234" height="17"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z3W-ou-g2J">
-                                        <rect key="frame" x="16" y="124" width="196" height="18"/>
-                                        <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="38V-Vw-GfJ">
-                                                <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="18" id="5A1-u0-oUB"/>
-                                                    <constraint firstAttribute="height" constant="18" id="oYP-3y-IxP"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q5D-nc-yvr">
-                                                <rect key="frame" x="21" y="2" width="175" height="15"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="18" id="9jY-pA-EoJ">
-                                                <variation key="heightClass=regular-widthClass=regular" constant="22"/>
-                                            </constraint>
-                                            <constraint firstAttribute="centerY" secondItem="q5D-nc-yvr" secondAttribute="centerY" id="ADt-mr-PBC"/>
-                                            <constraint firstAttribute="trailing" secondItem="q5D-nc-yvr" secondAttribute="trailing" id="Aat-jW-Rvc"/>
-                                            <constraint firstItem="q5D-nc-yvr" firstAttribute="leading" secondItem="38V-Vw-GfJ" secondAttribute="trailing" constant="3" id="B0Q-6z-ArY"/>
-                                            <constraint firstAttribute="centerY" secondItem="38V-Vw-GfJ" secondAttribute="centerY" id="fLg-c6-hQc"/>
-                                            <constraint firstItem="38V-Vw-GfJ" firstAttribute="leading" secondItem="Z3W-ou-g2J" secondAttribute="leading" id="mqd-xV-U6r"/>
-                                        </constraints>
-                                    </view>
-                                    <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="O28-fP-tpX">
-                                        <rect key="frame" x="16" y="148" width="276" height="18"/>
-                                        <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="8Cs-fq-wSe">
-                                                <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="18" id="hdA-We-Wej"/>
-                                                    <constraint firstAttribute="height" constant="18" id="tUS-Dc-Ofc"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbu-l3-L8G">
-                                                <rect key="frame" x="21" y="2" width="255" height="15"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="Dbu-l3-L8G" secondAttribute="trailing" id="JHG-At-nZk"/>
-                                            <constraint firstAttribute="centerY" secondItem="8Cs-fq-wSe" secondAttribute="centerY" id="Mli-g3-zHk"/>
-                                            <constraint firstAttribute="centerY" secondItem="Dbu-l3-L8G" secondAttribute="centerY" id="avR-UZ-xH3"/>
-                                            <constraint firstAttribute="height" constant="18" id="c7m-Gx-kDz">
-                                                <variation key="heightClass=regular-widthClass=regular" constant="22"/>
-                                            </constraint>
-                                            <constraint firstItem="8Cs-fq-wSe" firstAttribute="leading" secondItem="O28-fP-tpX" secondAttribute="leading" id="eEe-SX-X9G"/>
-                                            <constraint firstItem="Dbu-l3-L8G" firstAttribute="leading" secondItem="8Cs-fq-wSe" secondAttribute="trailing" constant="3" id="h3l-TW-NCA"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YwV-AJ-Nvl">
-                                        <rect key="frame" x="212" y="124" width="80" height="18"/>
-                                        <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ovg-ci-Pfb" customClass="PostMetaButton">
-                                                <rect key="frame" x="50" y="0.0" width="30" height="18"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="18" id="SlV-Re-dd7"/>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="i4C-dQ-DIP"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
-                                                <state key="normal" title="0" image="icon-postmeta-like">
-                                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                </state>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uDE-AO-Rii" customClass="PostMetaButton">
-                                                <rect key="frame" x="4" y="0.0" width="30" height="18"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="18" id="D2o-Od-Xsw"/>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="v14-tX-E5k"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
-                                                <state key="normal" title="0" image="icon-postmeta-comment">
-                                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                </state>
-                                            </button>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstItem="Ovg-ci-Pfb" firstAttribute="leading" secondItem="uDE-AO-Rii" secondAttribute="trailing" constant="16" id="I0b-Dk-6Hj"/>
-                                            <constraint firstAttribute="height" constant="18" id="L5g-Oq-HvR">
-                                                <variation key="heightClass=regular-widthClass=regular" constant="22"/>
-                                            </constraint>
-                                            <constraint firstItem="uDE-AO-Rii" firstAttribute="leading" secondItem="YwV-AJ-Nvl" secondAttribute="leading" constant="4" id="LIZ-Kr-wpf"/>
-                                            <constraint firstAttribute="centerY" secondItem="uDE-AO-Rii" secondAttribute="centerY" id="M7D-Wd-ErV"/>
-                                            <constraint firstAttribute="trailing" secondItem="Ovg-ci-Pfb" secondAttribute="trailing" id="Rit-2w-iGC"/>
-                                            <constraint firstAttribute="centerY" secondItem="Ovg-ci-Pfb" secondAttribute="centerY" id="jAb-xl-YQh"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BlB-Gp-P6A" customClass="PostCardActionBar">
-                                        <rect key="frame" x="0.0" y="179" width="308" height="37"/>
-                                        <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="37" id="tqV-2T-l9Q"/>
-                                        </constraints>
-                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l4E-Qn-Vgl">
+                                        <rect key="frame" x="42" y="18" width="234" height="15"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstItem="BlB-Gp-P6A" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="0LN-fC-xEM"/>
-                                    <constraint firstItem="OuO-i7-2Ds" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="2pB-iJ-nFa">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                                    <constraint firstItem="l4E-Qn-Vgl" firstAttribute="leading" secondItem="tB9-qp-pdv" secondAttribute="trailing" constant="10" id="ONX-Wv-JNt"/>
+                                    <constraint firstAttribute="height" constant="34" id="XPo-Pz-YMq"/>
+                                    <constraint firstAttribute="centerY" secondItem="tB9-qp-pdv" secondAttribute="centerY" id="XcJ-0j-93o"/>
+                                    <constraint firstItem="Glg-dS-0y2" firstAttribute="leading" secondItem="tB9-qp-pdv" secondAttribute="trailing" constant="10" id="a7e-Y3-7xM"/>
+                                    <constraint firstItem="l4E-Qn-Vgl" firstAttribute="top" secondItem="OuO-i7-2Ds" secondAttribute="top" constant="18" id="bSY-9k-nBq"/>
+                                    <constraint firstItem="Glg-dS-0y2" firstAttribute="top" secondItem="OuO-i7-2Ds" secondAttribute="top" id="cyI-Sx-yRb"/>
+                                    <constraint firstAttribute="trailing" secondItem="l4E-Qn-Vgl" secondAttribute="trailing" id="k2B-kw-1aC"/>
+                                    <constraint firstItem="tB9-qp-pdv" firstAttribute="leading" secondItem="OuO-i7-2Ds" secondAttribute="leading" id="pTC-Bl-UWR"/>
+                                    <constraint firstAttribute="trailing" secondItem="Glg-dS-0y2" secondAttribute="trailing" id="uVf-jK-JTU"/>
+                                </constraints>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="xIT-FJ-g43">
+                                <rect key="frame" x="16" y="61" width="276" height="24"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="POV-pe-wu8">
+                                <rect key="frame" x="16" y="90" width="276" height="25"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z3W-ou-g2J">
+                                <rect key="frame" x="16" y="124" width="196" height="18"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="38V-Vw-GfJ">
+                                        <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="18" id="5A1-u0-oUB"/>
+                                            <constraint firstAttribute="height" constant="18" id="oYP-3y-IxP"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q5D-nc-yvr">
+                                        <rect key="frame" x="21" y="2" width="175" height="15"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="18" id="9jY-pA-EoJ">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="22"/>
                                     </constraint>
-                                    <constraint firstItem="Z3W-ou-g2J" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="3cg-8s-lSo">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                                    <constraint firstAttribute="centerY" secondItem="q5D-nc-yvr" secondAttribute="centerY" id="ADt-mr-PBC"/>
+                                    <constraint firstAttribute="trailing" secondItem="q5D-nc-yvr" secondAttribute="trailing" id="Aat-jW-Rvc"/>
+                                    <constraint firstItem="q5D-nc-yvr" firstAttribute="leading" secondItem="38V-Vw-GfJ" secondAttribute="trailing" constant="3" id="B0Q-6z-ArY"/>
+                                    <constraint firstAttribute="centerY" secondItem="38V-Vw-GfJ" secondAttribute="centerY" id="fLg-c6-hQc"/>
+                                    <constraint firstItem="38V-Vw-GfJ" firstAttribute="leading" secondItem="Z3W-ou-g2J" secondAttribute="leading" id="mqd-xV-U6r"/>
+                                </constraints>
+                            </view>
+                            <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="O28-fP-tpX">
+                                <rect key="frame" x="16" y="148" width="276" height="18"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="8Cs-fq-wSe">
+                                        <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="18" id="hdA-We-Wej"/>
+                                            <constraint firstAttribute="height" constant="18" id="tUS-Dc-Ofc"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbu-l3-L8G">
+                                        <rect key="frame" x="21" y="2" width="255" height="15"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="Dbu-l3-L8G" secondAttribute="trailing" id="JHG-At-nZk"/>
+                                    <constraint firstAttribute="centerY" secondItem="8Cs-fq-wSe" secondAttribute="centerY" id="Mli-g3-zHk"/>
+                                    <constraint firstAttribute="centerY" secondItem="Dbu-l3-L8G" secondAttribute="centerY" id="avR-UZ-xH3"/>
+                                    <constraint firstAttribute="height" constant="18" id="c7m-Gx-kDz">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="22"/>
                                     </constraint>
-                                    <constraint firstItem="POV-pe-wu8" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="7ce-1f-hAw">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                                    <constraint firstItem="8Cs-fq-wSe" firstAttribute="leading" secondItem="O28-fP-tpX" secondAttribute="leading" id="eEe-SX-X9G"/>
+                                    <constraint firstItem="Dbu-l3-L8G" firstAttribute="leading" secondItem="8Cs-fq-wSe" secondAttribute="trailing" constant="3" id="h3l-TW-NCA"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YwV-AJ-Nvl">
+                                <rect key="frame" x="212" y="124" width="80" height="18"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ovg-ci-Pfb" customClass="PostMetaButton">
+                                        <rect key="frame" x="50" y="0.0" width="30" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="18" id="SlV-Re-dd7"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="i4C-dQ-DIP"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
+                                        <state key="normal" title="0" image="icon-postmeta-like">
+                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uDE-AO-Rii" customClass="PostMetaButton">
+                                        <rect key="frame" x="4" y="0.0" width="30" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="18" id="D2o-Od-Xsw"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="v14-tX-E5k"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
+                                        <state key="normal" title="0" image="icon-postmeta-comment">
+                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="Ovg-ci-Pfb" firstAttribute="leading" secondItem="uDE-AO-Rii" secondAttribute="trailing" constant="16" id="I0b-Dk-6Hj"/>
+                                    <constraint firstAttribute="height" constant="18" id="L5g-Oq-HvR">
+                                        <variation key="heightClass=regular-widthClass=regular" constant="22"/>
                                     </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="OuO-i7-2Ds" secondAttribute="trailing" constant="16" id="9p6-eN-M0a">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="BlB-Gp-P6A" secondAttribute="trailing" id="EAF-04-Ort"/>
-                                    <constraint firstItem="O28-fP-tpX" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="EvA-em-Rnw">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="BlB-Gp-P6A" firstAttribute="top" secondItem="O28-fP-tpX" secondAttribute="bottom" priority="900" constant="13" id="KPL-Ie-Sml">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="16"/>
-                                    </constraint>
-                                    <constraint firstAttribute="bottom" secondItem="BlB-Gp-P6A" secondAttribute="bottom" id="SVN-uV-BWH"/>
-                                    <constraint firstItem="OuO-i7-2Ds" firstAttribute="top" secondItem="Lk7-nZ-b0t" secondAttribute="top" constant="15" id="Seu-o3-dkG"/>
-                                    <constraint firstAttribute="trailing" secondItem="POV-pe-wu8" secondAttribute="trailing" constant="16" id="SjY-e4-XWL">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="Z3W-ou-g2J" firstAttribute="top" secondItem="POV-pe-wu8" secondAttribute="bottom" constant="9" id="cgz-3E-MrQ">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="9"/>
-                                    </constraint>
-                                    <constraint firstItem="xIT-FJ-g43" firstAttribute="top" secondItem="OuO-i7-2Ds" secondAttribute="bottom" constant="12" id="gXH-oU-BWB"/>
-                                    <constraint firstAttribute="trailing" secondItem="O28-fP-tpX" secondAttribute="trailing" constant="16" id="hDs-3W-qUQ">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="YwV-AJ-Nvl" firstAttribute="leading" secondItem="Z3W-ou-g2J" secondAttribute="trailing" id="jZK-gy-wGK"/>
-                                    <constraint firstAttribute="trailing" secondItem="xIT-FJ-g43" secondAttribute="trailing" constant="16" id="la2-OA-0qr">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstAttribute="trailing" secondItem="YwV-AJ-Nvl" secondAttribute="trailing" constant="16" id="pcg-aA-VMp">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="xIT-FJ-g43" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="uD9-vO-cJn">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="YwV-AJ-Nvl" firstAttribute="centerY" secondItem="Z3W-ou-g2J" secondAttribute="centerY" id="uVU-DQ-Fre"/>
-                                    <constraint firstItem="POV-pe-wu8" firstAttribute="top" secondItem="xIT-FJ-g43" secondAttribute="bottom" constant="5" id="wZc-29-y5d">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="7"/>
-                                    </constraint>
-                                    <constraint firstItem="O28-fP-tpX" firstAttribute="top" secondItem="Z3W-ou-g2J" secondAttribute="bottom" constant="6" id="zdK-e3-7HD">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="8"/>
-                                    </constraint>
+                                    <constraint firstItem="uDE-AO-Rii" firstAttribute="leading" secondItem="YwV-AJ-Nvl" secondAttribute="leading" constant="4" id="LIZ-Kr-wpf"/>
+                                    <constraint firstAttribute="centerY" secondItem="uDE-AO-Rii" secondAttribute="centerY" id="M7D-Wd-ErV"/>
+                                    <constraint firstAttribute="trailing" secondItem="Ovg-ci-Pfb" secondAttribute="trailing" id="Rit-2w-iGC"/>
+                                    <constraint firstAttribute="centerY" secondItem="Ovg-ci-Pfb" secondAttribute="centerY" id="jAb-xl-YQh"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BlB-Gp-P6A" customClass="PostCardActionBar">
+                                <rect key="frame" x="0.0" y="179" width="308" height="37"/>
+                                <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="37" id="tqV-2T-l9Q"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="Lk7-nZ-b0t" firstAttribute="trailing" secondItem="nUV-EO-Wtj" secondAttribute="trailing" constant="-1" id="9Ss-Um-KB9"/>
-                            <constraint firstItem="Lk7-nZ-b0t" firstAttribute="top" secondItem="nUV-EO-Wtj" secondAttribute="top" constant="1" id="F75-CV-nRl"/>
-                            <constraint firstItem="Lk7-nZ-b0t" firstAttribute="leading" secondItem="nUV-EO-Wtj" secondAttribute="leading" constant="1" id="LjT-fS-pfA"/>
-                            <constraint firstItem="Lk7-nZ-b0t" firstAttribute="leading" secondItem="P6C-o2-FTR" secondAttribute="leading" constant="6" id="NMO-YJ-xyb">
-                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            <constraint firstItem="BlB-Gp-P6A" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="0LN-fC-xEM"/>
+                            <constraint firstItem="OuO-i7-2Ds" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="2pB-iJ-nFa">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
-                            <constraint firstAttribute="trailing" secondItem="Lk7-nZ-b0t" secondAttribute="trailing" constant="6" id="PT4-oy-27q">
-                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            <constraint firstItem="Z3W-ou-g2J" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="3cg-8s-lSo">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
-                            <constraint firstAttribute="bottom" secondItem="Lk7-nZ-b0t" secondAttribute="bottom" constant="11" id="Z1Z-lv-uKl"/>
-                            <constraint firstItem="Lk7-nZ-b0t" firstAttribute="bottom" secondItem="nUV-EO-Wtj" secondAttribute="bottom" constant="-1" id="Z49-P0-eAT"/>
-                            <constraint firstItem="Lk7-nZ-b0t" firstAttribute="top" secondItem="P6C-o2-FTR" secondAttribute="top" constant="10" id="s2L-vI-ED0"/>
+                            <constraint firstItem="POV-pe-wu8" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="7ce-1f-hAw">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstAttribute="trailing" secondItem="OuO-i7-2Ds" secondAttribute="trailing" constant="16" id="9p6-eN-M0a">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstAttribute="trailing" secondItem="BlB-Gp-P6A" secondAttribute="trailing" id="EAF-04-Ort"/>
+                            <constraint firstItem="O28-fP-tpX" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="EvA-em-Rnw">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="BlB-Gp-P6A" firstAttribute="top" secondItem="O28-fP-tpX" secondAttribute="bottom" priority="900" constant="13" id="KPL-Ie-Sml">
+                                <variation key="heightClass=regular-widthClass=regular" constant="16"/>
+                            </constraint>
+                            <constraint firstAttribute="bottom" secondItem="BlB-Gp-P6A" secondAttribute="bottom" id="SVN-uV-BWH"/>
+                            <constraint firstItem="OuO-i7-2Ds" firstAttribute="top" secondItem="Lk7-nZ-b0t" secondAttribute="top" constant="15" id="Seu-o3-dkG"/>
+                            <constraint firstAttribute="trailing" secondItem="POV-pe-wu8" secondAttribute="trailing" constant="16" id="SjY-e4-XWL">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="Z3W-ou-g2J" firstAttribute="top" secondItem="POV-pe-wu8" secondAttribute="bottom" constant="9" id="cgz-3E-MrQ">
+                                <variation key="heightClass=regular-widthClass=regular" constant="9"/>
+                            </constraint>
+                            <constraint firstItem="xIT-FJ-g43" firstAttribute="top" secondItem="OuO-i7-2Ds" secondAttribute="bottom" constant="12" id="gXH-oU-BWB"/>
+                            <constraint firstAttribute="trailing" secondItem="O28-fP-tpX" secondAttribute="trailing" constant="16" id="hDs-3W-qUQ">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="YwV-AJ-Nvl" firstAttribute="leading" secondItem="Z3W-ou-g2J" secondAttribute="trailing" id="jZK-gy-wGK"/>
+                            <constraint firstAttribute="trailing" secondItem="xIT-FJ-g43" secondAttribute="trailing" constant="16" id="la2-OA-0qr">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstAttribute="trailing" secondItem="YwV-AJ-Nvl" secondAttribute="trailing" constant="16" id="pcg-aA-VMp">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="xIT-FJ-g43" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="uD9-vO-cJn">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="YwV-AJ-Nvl" firstAttribute="centerY" secondItem="Z3W-ou-g2J" secondAttribute="centerY" id="uVU-DQ-Fre"/>
+                            <constraint firstItem="POV-pe-wu8" firstAttribute="top" secondItem="xIT-FJ-g43" secondAttribute="bottom" constant="5" id="wZc-29-y5d">
+                                <variation key="heightClass=regular-widthClass=regular" constant="7"/>
+                            </constraint>
+                            <constraint firstItem="O28-fP-tpX" firstAttribute="top" secondItem="Z3W-ou-g2J" secondAttribute="bottom" constant="6" id="zdK-e3-7HD">
+                                <variation key="heightClass=regular-widthClass=regular" constant="8"/>
+                            </constraint>
                         </constraints>
                     </view>
                 </subviews>
                 <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
                 <constraints>
-                    <constraint firstItem="P6C-o2-FTR" firstAttribute="top" secondItem="MWK-lj-FaS" secondAttribute="top" id="GyR-99-Apd"/>
-                    <constraint firstItem="P6C-o2-FTR" firstAttribute="leading" secondItem="MWK-lj-FaS" secondAttribute="leading" id="X1O-6B-bP5"/>
-                    <constraint firstAttribute="trailing" secondItem="P6C-o2-FTR" secondAttribute="trailing" id="eDE-fW-zbf"/>
-                    <constraint firstAttribute="bottom" secondItem="P6C-o2-FTR" secondAttribute="bottom" id="fA1-2T-Wcv"/>
+                    <constraint firstItem="Lk7-nZ-b0t" firstAttribute="trailing" secondItem="MWK-lj-FaS" secondAttribute="trailingMargin" constant="2" id="2At-kP-Urm"/>
+                    <constraint firstAttribute="leadingMargin" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="2" id="2n8-4V-L5z"/>
+                    <constraint firstItem="Lk7-nZ-b0t" firstAttribute="top" secondItem="MWK-lj-FaS" secondAttribute="topMargin" constant="2" id="FdQ-h9-rr5"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="Lk7-nZ-b0t" secondAttribute="bottom" constant="4" id="XHc-Nc-QKK"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
@@ -275,13 +252,10 @@
                 <outlet property="headerViewHeightConstraint" destination="XPo-Pz-YMq" id="Hrp-nb-6G0"/>
                 <outlet property="headerViewLeftConstraint" destination="2pB-iJ-nFa" id="1Ha-rq-koT"/>
                 <outlet property="headerViewLowerConstraint" destination="gXH-oU-BWB" id="DR5-aJ-6Ye"/>
-                <outlet property="innerContentView" destination="P6C-o2-FTR" id="iBv-yh-YB0"/>
                 <outlet property="metaButtonLeft" destination="uDE-AO-Rii" id="NHd-hW-Cag"/>
                 <outlet property="metaButtonRight" destination="Ovg-ci-Pfb" id="dCB-Tf-ED7"/>
                 <outlet property="metaView" destination="YwV-AJ-Nvl" id="KYr-Rj-rfE"/>
-                <outlet property="postContentBottomConstraint" destination="Z1Z-lv-uKl" id="tQ0-ld-GES"/>
                 <outlet property="postContentView" destination="Lk7-nZ-b0t" id="Neo-yT-N8p"/>
-                <outlet property="shadowView" destination="nUV-EO-Wtj" id="FUb-C6-NSr"/>
                 <outlet property="snippetLabel" destination="POV-pe-wu8" id="fTi-7j-wzx"/>
                 <outlet property="snippetLowerConstraint" destination="cgz-3E-MrQ" id="eKC-rg-HSr"/>
                 <outlet property="statusHeightConstraint" destination="c7m-Gx-kDz" id="njw-Hw-OiF"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -233,7 +233,7 @@
                 </subviews>
                 <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
                 <constraints>
-                    <constraint firstItem="Lk7-nZ-b0t" firstAttribute="trailing" secondItem="MWK-lj-FaS" secondAttribute="trailingMargin" constant="2" id="2At-kP-Urm">
+                    <constraint firstItem="Lk7-nZ-b0t" firstAttribute="trailing" secondItem="MWK-lj-FaS" secondAttribute="trailingMargin" priority="999" constant="2" id="2At-kP-Urm">
                         <variation key="widthClass=regular" constant="0.0"/>
                     </constraint>
                     <constraint firstAttribute="leadingMargin" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="2" id="2n8-4V-L5z">

--- a/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
@@ -58,7 +58,7 @@
                 <constraint firstAttribute="bottom" secondItem="AoX-vc-zrF" secondAttribute="bottom" constant="11" id="CZF-8o-geK"/>
                 <constraint firstAttribute="trailing" secondItem="AoX-vc-zrF" secondAttribute="trailing" constant="7" id="ciu-4z-aHt"/>
                 <constraint firstItem="F4q-47-pPM" firstAttribute="centerX" secondItem="AoX-vc-zrF" secondAttribute="centerX" id="oYN-Kz-3Zu"/>
-                <constraint firstAttribute="trailingMargin" secondItem="AoX-vc-zrF" secondAttribute="trailing" id="s16-Gc-tvU"/>
+                <constraint firstAttribute="trailingMargin" secondItem="AoX-vc-zrF" secondAttribute="trailing" priority="999" id="s16-Gc-tvU"/>
                 <constraint firstItem="AoX-vc-zrF" firstAttribute="leading" secondItem="TCZ-n9-coy" secondAttribute="leadingMargin" id="yzD-7E-gw6"/>
                 <constraint firstItem="AoX-vc-zrF" firstAttribute="leading" secondItem="TCZ-n9-coy" secondAttribute="leading" constant="7" id="znD-ba-XuU"/>
                 <constraint firstItem="F4q-47-pPM" firstAttribute="centerY" secondItem="AoX-vc-zrF" secondAttribute="centerY" id="zvW-CV-pmP"/>

--- a/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -15,24 +14,24 @@
                     <rect key="frame" x="140" y="12" width="20" height="20"/>
                 </activityIndicatorView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AoX-vc-zrF">
-                    <rect key="frame" x="0.0" y="11" width="300" height="22"/>
+                    <rect key="frame" x="6" y="11" width="288" height="22"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MBZ-lN-HGt">
-                            <rect key="frame" x="6" y="11" width="125" height="1"/>
+                            <rect key="frame" x="0.0" y="11" width="125" height="1"/>
                             <color key="backgroundColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.88235294117647056" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="gOn-eC-zhZ"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wKm-Mr-TCA">
-                            <rect key="frame" x="169" y="11" width="125" height="1"/>
+                            <rect key="frame" x="163" y="11" width="125" height="1"/>
                             <color key="backgroundColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.88235294117647056" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="k2g-PF-m8U"/>
                             </constraints>
                         </view>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-list-footer" translatesAutoresizingMaskIntoConstraints="NO" id="2lx-TZ-H9w">
-                            <rect key="frame" x="139" y="0.0" width="22" height="22"/>
+                            <rect key="frame" x="133" y="0.0" width="22" height="22"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="22" id="3hc-zb-3fV"/>
                                 <constraint firstAttribute="height" constant="22" id="cJ3-uM-7zP"/>
@@ -43,52 +42,32 @@
                     <constraints>
                         <constraint firstAttribute="centerX" secondItem="2lx-TZ-H9w" secondAttribute="centerX" id="BXl-cW-Ywt"/>
                         <constraint firstAttribute="centerY" secondItem="MBZ-lN-HGt" secondAttribute="centerY" constant="-0.5" id="SM7-09-i4J"/>
-                        <constraint firstAttribute="width" priority="750" constant="612" id="URY-Vf-eVc"/>
                         <constraint firstAttribute="centerY" secondItem="wKm-Mr-TCA" secondAttribute="centerY" constant="-0.5" id="X37-jz-nrb"/>
                         <constraint firstItem="2lx-TZ-H9w" firstAttribute="leading" secondItem="MBZ-lN-HGt" secondAttribute="trailing" constant="8" id="Y0M-I9-BOr"/>
-                        <constraint firstAttribute="trailing" secondItem="wKm-Mr-TCA" secondAttribute="trailing" constant="6" id="b0b-rA-YhB"/>
-                        <constraint firstItem="MBZ-lN-HGt" firstAttribute="leading" secondItem="AoX-vc-zrF" secondAttribute="leading" constant="6" id="gr5-vp-wLh"/>
+                        <constraint firstAttribute="trailing" secondItem="wKm-Mr-TCA" secondAttribute="trailing" id="b0b-rA-YhB"/>
+                        <constraint firstItem="MBZ-lN-HGt" firstAttribute="leading" secondItem="AoX-vc-zrF" secondAttribute="leading" id="gr5-vp-wLh"/>
                         <constraint firstAttribute="height" constant="22" id="jnj-8K-NpN"/>
                         <constraint firstItem="wKm-Mr-TCA" firstAttribute="leading" secondItem="2lx-TZ-H9w" secondAttribute="trailing" constant="8" id="qGB-cG-EAL"/>
                         <constraint firstAttribute="centerY" secondItem="2lx-TZ-H9w" secondAttribute="centerY" id="wf6-gD-lPc"/>
                     </constraints>
-                    <variation key="default">
-                        <mask key="constraints">
-                            <exclude reference="URY-Vf-eVc"/>
-                        </mask>
-                    </variation>
-                    <variation key="heightClass=regular-widthClass=regular">
-                        <mask key="constraints">
-                            <include reference="URY-Vf-eVc"/>
-                        </mask>
-                    </variation>
                 </view>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="AoX-vc-zrF" secondAttribute="bottom" constant="11" id="CZF-8o-geK"/>
-                <constraint firstAttribute="trailing" secondItem="AoX-vc-zrF" secondAttribute="trailing" id="ciu-4z-aHt"/>
+                <constraint firstAttribute="trailing" secondItem="AoX-vc-zrF" secondAttribute="trailing" constant="6" id="ciu-4z-aHt">
+                    <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                </constraint>
                 <constraint firstItem="F4q-47-pPM" firstAttribute="centerX" secondItem="AoX-vc-zrF" secondAttribute="centerX" id="oYN-Kz-3Zu"/>
-                <constraint firstAttribute="centerX" secondItem="AoX-vc-zrF" secondAttribute="centerX" id="v8G-ji-OPE"/>
-                <constraint firstItem="AoX-vc-zrF" firstAttribute="leading" secondItem="TCZ-n9-coy" secondAttribute="leading" id="znD-ba-XuU"/>
+                <constraint firstItem="AoX-vc-zrF" firstAttribute="leading" secondItem="TCZ-n9-coy" secondAttribute="leading" constant="6" id="znD-ba-XuU">
+                    <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                </constraint>
                 <constraint firstItem="F4q-47-pPM" firstAttribute="centerY" secondItem="AoX-vc-zrF" secondAttribute="centerY" id="zvW-CV-pmP"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <variation key="default">
-                <mask key="constraints">
-                    <exclude reference="v8G-ji-OPE"/>
-                </mask>
-            </variation>
-            <variation key="heightClass=regular-widthClass=regular">
-                <mask key="constraints">
-                    <exclude reference="ciu-4z-aHt"/>
-                    <include reference="v8G-ji-OPE"/>
-                    <exclude reference="znD-ba-XuU"/>
-                </mask>
-            </variation>
             <connections>
                 <outlet property="activityView" destination="F4q-47-pPM" id="zVo-Q1-ggr"/>
                 <outlet property="bannerView" destination="AoX-vc-zrF" id="hSc-aF-tjn"/>

--- a/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -14,24 +15,24 @@
                     <rect key="frame" x="140" y="12" width="20" height="20"/>
                 </activityIndicatorView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AoX-vc-zrF">
-                    <rect key="frame" x="6" y="11" width="288" height="22"/>
+                    <rect key="frame" x="7" y="11" width="286" height="22"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MBZ-lN-HGt">
-                            <rect key="frame" x="0.0" y="11" width="125" height="1"/>
+                            <rect key="frame" x="0.0" y="11" width="124" height="1"/>
                             <color key="backgroundColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.88235294117647056" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="gOn-eC-zhZ"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wKm-Mr-TCA">
-                            <rect key="frame" x="163" y="11" width="125" height="1"/>
+                            <rect key="frame" x="162" y="11" width="124" height="1"/>
                             <color key="backgroundColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.88235294117647056" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="k2g-PF-m8U"/>
                             </constraints>
                         </view>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-list-footer" translatesAutoresizingMaskIntoConstraints="NO" id="2lx-TZ-H9w">
-                            <rect key="frame" x="133" y="0.0" width="22" height="22"/>
+                            <rect key="frame" x="132" y="0.0" width="22" height="22"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="22" id="3hc-zb-3fV"/>
                                 <constraint firstAttribute="height" constant="22" id="cJ3-uM-7zP"/>
@@ -55,19 +56,31 @@
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="AoX-vc-zrF" secondAttribute="bottom" constant="11" id="CZF-8o-geK"/>
-                <constraint firstAttribute="trailing" secondItem="AoX-vc-zrF" secondAttribute="trailing" constant="6" id="ciu-4z-aHt">
-                    <variation key="heightClass=regular-widthClass=regular" constant="10"/>
-                </constraint>
+                <constraint firstAttribute="trailing" secondItem="AoX-vc-zrF" secondAttribute="trailing" constant="7" id="ciu-4z-aHt"/>
                 <constraint firstItem="F4q-47-pPM" firstAttribute="centerX" secondItem="AoX-vc-zrF" secondAttribute="centerX" id="oYN-Kz-3Zu"/>
-                <constraint firstItem="AoX-vc-zrF" firstAttribute="leading" secondItem="TCZ-n9-coy" secondAttribute="leading" constant="6" id="znD-ba-XuU">
-                    <variation key="heightClass=regular-widthClass=regular" constant="10"/>
-                </constraint>
+                <constraint firstAttribute="trailingMargin" secondItem="AoX-vc-zrF" secondAttribute="trailing" id="s16-Gc-tvU"/>
+                <constraint firstItem="AoX-vc-zrF" firstAttribute="leading" secondItem="TCZ-n9-coy" secondAttribute="leadingMargin" id="yzD-7E-gw6"/>
+                <constraint firstItem="AoX-vc-zrF" firstAttribute="leading" secondItem="TCZ-n9-coy" secondAttribute="leading" constant="7" id="znD-ba-XuU"/>
                 <constraint firstItem="F4q-47-pPM" firstAttribute="centerY" secondItem="AoX-vc-zrF" secondAttribute="centerY" id="zvW-CV-pmP"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <variation key="default">
+                <mask key="constraints">
+                    <exclude reference="s16-Gc-tvU"/>
+                    <exclude reference="yzD-7E-gw6"/>
+                </mask>
+            </variation>
+            <variation key="widthClass=regular" layoutMarginsFollowReadableWidth="YES" preservesSuperviewLayoutMargins="YES">
+                <mask key="constraints">
+                    <exclude reference="ciu-4z-aHt"/>
+                    <include reference="s16-Gc-tvU"/>
+                    <include reference="yzD-7E-gw6"/>
+                    <exclude reference="znD-ba-XuU"/>
+                </mask>
+            </variation>
             <connections>
                 <outlet property="activityView" destination="F4q-47-pPM" id="zVo-Q1-ggr"/>
                 <outlet property="bannerView" destination="AoX-vc-zrF" id="hSc-aF-tjn"/>

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -186,6 +186,18 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         }
     }
 
+    // Mark - Layout Methods
+
+    override func willTransitionToTraitCollection(newCollection: UITraitCollection, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+        // Need to reload the table alongside a traitCollection change.
+        // This is mainly because we target Reg W and Any H vs all other size classes.
+        // If we transition between the two, the tableView may not update the cell heights accordingly.
+        // Brent C. Aug 3/2016
+        coordinator.animateAlongsideTransition({ context in
+            self.tableView.reloadData()
+            }, completion: nil)
+    }
+
     // MARK: - Sync Methods
 
     override func postTypeToSync() -> String {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -317,24 +317,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
             return self.dynamicType.postCardRestoreCellRowHeight
         }
 
-        // To work around a bug (https://github.com/wordpress-mobile/WordPress-iOS/issues/3844) where
-        // the table footer view would animate over cells, we'll only return estimated heights
-        // for cells that aren't in the visible area of the view.
-        let cellHeight = heightForEmptyCell
-        if cellHeight > 0 {
-            let visibleCellCount = Int(ceil(tableView.bounds.height / cellHeight))
-            if indexPath.row < visibleCellCount {
-                return self.tableView(tableView, heightForRowAtIndexPath: indexPath)
-            }
-        }
-
         return self.dynamicType.postCardEstimatedRowHeight
-    }
-
-    private var heightForEmptyCell: CGFloat {
-        let size = textCellForLayout.sizeThatFits(CGSizeMake(tableView.bounds.width, CGFloat.max))
-
-        return size.height
     }
 
     func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -108,7 +108,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
     }
 
     func forceUpdateCellLayout(cell: PostCardTableViewCell) {
-        // Force a layout pass to ensure that constrants are configured for the
+        // Force a layout pass to ensure that constraints are configured for the
         // proper size class.
         view.addSubview(cell)
         cell.removeFromSuperview()

--- a/WordPress/Classes/ViewRelated/Post/Posts.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Posts.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>

--- a/WordPress/Classes/ViewRelated/Post/Posts.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Posts.storyboard
@@ -126,7 +126,7 @@
         <scene sceneID="2RX-OH-EPn">
             <objects>
                 <tableViewController id="zOz-bT-2ph" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="300" sectionHeaderHeight="22" sectionFooterHeight="22" id="srU-rF-GC6">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="300" sectionHeaderHeight="22" sectionFooterHeight="22" id="srU-rF-GC6">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/WordPress/Classes/ViewRelated/Post/Posts.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Posts.storyboard
@@ -126,7 +126,7 @@
         <scene sceneID="2RX-OH-EPn">
             <objects>
                 <tableViewController id="zOz-bT-2ph" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="srU-rF-GC6">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="300" sectionHeaderHeight="22" sectionFooterHeight="22" id="srU-rF-GC6">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.m
@@ -6,8 +6,6 @@
 @interface RestorePostTableViewCell()
 
 @property (nonatomic, weak) id<InteractivePostViewDelegate> delegate;
-@property (nonatomic, strong) IBOutlet UIView *innerContentView;
-@property (nonatomic, strong) IBOutlet UIView *shadowView;
 @property (nonatomic, strong) IBOutlet UIView *postContentView;
 @property (nonatomic, strong) IBOutlet UILabel *restoreLabel;
 @property (nonatomic, strong) IBOutlet UIButton *restoreButton;
@@ -35,15 +33,6 @@
     return [super hitTest:point withEvent:event];
 }
 
-#pragma mark - Accessors
-
-- (void)setBackgroundColor:(UIColor *)backgroundColor
-{
-    [super setBackgroundColor:backgroundColor];
-    self.innerContentView.backgroundColor = backgroundColor;
-}
-
-
 #pragma mark - Configuration
 
 - (void)applyStyles
@@ -51,7 +40,9 @@
     [WPStyleGuide applyPostCardStyle:self];
     [WPStyleGuide applyRestorePostLabelStyle:self.restoreLabel];
     [WPStyleGuide applyRestorePostButtonStyle:self.restoreButton];
-    self.shadowView.backgroundColor = [WPStyleGuide postCardBorderColor];
+
+    self.postContentView.layer.borderColor = [[WPStyleGuide postCardBorderColor] CGColor];
+    self.postContentView.layer.borderWidth = 1.0;
 }
 
 - (void)configureView

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.m
@@ -68,12 +68,6 @@
     self.post = post;
 }
 
-- (void)configureWithPost:(Post *)post
-            forLayoutOnly:(BOOL)layoutOnly
-{
-    [self configureWithPost:post];
-}
-
 #pragma mark - InteractivePostView
 
 - (void)setInteractionDelegate:(id<InteractivePostViewDelegate>)delegate

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
@@ -7,29 +7,29 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="cm8-te-h9Y" customClass="RestorePostTableViewCell">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="65"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="56" id="cm8-te-h9Y" customClass="RestorePostTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" tableViewCell="cm8-te-h9Y" id="n47-YY-a6J">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="64.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XWn-76-OyW">
-                        <rect key="frame" x="6" y="10" width="308" height="44"/>
+                        <rect key="frame" x="8" y="8" width="304" height="40"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Post moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tDg-aX-r9a">
-                                <rect key="frame" x="13" y="0.0" width="134" height="44"/>
+                                <rect key="frame" x="16" y="0.0" width="186" height="40"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="LGI-mC-HeZ"/>
+                                    <constraint firstAttribute="height" constant="40" id="M7w-JQ-SVH"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5bW-zk-smP">
-                                <rect key="frame" x="228" y="0.0" width="66" height="44"/>
+                                <rect key="frame" x="202" y="0.0" width="86" height="40"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="66" id="oHA-R3-tyO"/>
+                                    <constraint firstAttribute="width" constant="86" id="oHA-R3-tyO"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <inset key="contentEdgeInsets" minX="3" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -45,26 +45,26 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="5bW-zk-smP" secondAttribute="trailing" constant="14" id="8G2-zh-deP">
+                            <constraint firstItem="5bW-zk-smP" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" id="6lX-Q1-ur2"/>
+                            <constraint firstAttribute="bottom" secondItem="5bW-zk-smP" secondAttribute="bottom" id="BbR-2G-nT2"/>
+                            <constraint firstItem="tDg-aX-r9a" firstAttribute="leading" secondItem="XWn-76-OyW" secondAttribute="leading" constant="16" id="KF0-nG-hVq">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
-                            <constraint firstItem="tDg-aX-r9a" firstAttribute="leading" secondItem="XWn-76-OyW" secondAttribute="leading" constant="13" id="Cd4-wE-Coz">
-                                <variation key="heightClass=regular-widthClass=regular" constant="22"/>
+                            <constraint firstAttribute="trailing" secondItem="5bW-zk-smP" secondAttribute="trailing" constant="16" id="UgL-KF-Pfu">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
-                            <constraint firstAttribute="bottom" secondItem="tDg-aX-r9a" secondAttribute="bottom" id="NVR-Tx-ea4"/>
-                            <constraint firstItem="tDg-aX-r9a" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" id="ay6-0i-iUF"/>
-                            <constraint firstAttribute="bottom" secondItem="5bW-zk-smP" secondAttribute="bottom" id="fd1-Xw-yJ2"/>
-                            <constraint firstItem="5bW-zk-smP" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tDg-aX-r9a" secondAttribute="trailing" constant="3" id="iiX-Ba-qGN"/>
-                            <constraint firstItem="5bW-zk-smP" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" id="lZy-0i-LeW"/>
+                            <constraint firstItem="tDg-aX-r9a" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" id="bil-hS-vtd"/>
+                            <constraint firstItem="tDg-aX-r9a" firstAttribute="trailing" secondItem="5bW-zk-smP" secondAttribute="leading" id="pHf-yg-2tp"/>
+                            <constraint firstAttribute="bottom" secondItem="tDg-aX-r9a" secondAttribute="bottom" id="wva-4O-VJ1"/>
                         </constraints>
                     </view>
                 </subviews>
                 <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
                 <constraints>
-                    <constraint firstItem="XWn-76-OyW" firstAttribute="leading" secondItem="n47-YY-a6J" secondAttribute="leadingMargin" constant="-2" id="2UK-xt-vyg"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="XWn-76-OyW" secondAttribute="bottom" constant="2.5" id="4gk-o4-Fo5"/>
-                    <constraint firstItem="XWn-76-OyW" firstAttribute="top" secondItem="n47-YY-a6J" secondAttribute="topMargin" constant="2" id="Q4u-gm-vVx"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="XWn-76-OyW" secondAttribute="trailing" constant="-2" id="nHh-lN-cc5"/>
+                    <constraint firstItem="XWn-76-OyW" firstAttribute="top" secondItem="n47-YY-a6J" secondAttribute="topMargin" id="RzW-GY-Om3"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="XWn-76-OyW" secondAttribute="bottom" id="dNy-yP-Cwz"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="XWn-76-OyW" secondAttribute="trailing" id="iUp-40-qkJ"/>
+                    <constraint firstItem="XWn-76-OyW" firstAttribute="leading" secondItem="n47-YY-a6J" secondAttribute="leadingMargin" id="uTm-ab-WRk"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
@@ -72,7 +72,7 @@
                 <outlet property="restoreButton" destination="5bW-zk-smP" id="ooK-Wf-Ygo"/>
                 <outlet property="restoreLabel" destination="tDg-aX-r9a" id="hWK-bR-Ar8"/>
             </connections>
-            <point key="canvasLocation" x="568" y="220.5"/>
+            <point key="canvasLocation" x="568" y="225"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -10,7 +10,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="65"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" tableViewCell="cm8-te-h9Y" id="n47-YY-a6J">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="64.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gcy-ef-aVi">
@@ -59,44 +59,24 @@
                                     <constraint firstAttribute="bottom" secondItem="5bW-zk-smP" secondAttribute="bottom" id="fd1-Xw-yJ2"/>
                                     <constraint firstItem="5bW-zk-smP" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tDg-aX-r9a" secondAttribute="trailing" constant="3" id="iiX-Ba-qGN"/>
                                     <constraint firstItem="5bW-zk-smP" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" id="lZy-0i-LeW"/>
-                                    <constraint firstAttribute="width" constant="600" id="zH8-kM-TvE"/>
                                 </constraints>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="zH8-kM-TvE"/>
-                                    </mask>
-                                </variation>
-                                <variation key="heightClass=regular-widthClass=regular">
-                                    <mask key="constraints">
-                                        <include reference="zH8-kM-TvE"/>
-                                    </mask>
-                                </variation>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="centerX" secondItem="XWn-76-OyW" secondAttribute="centerX" id="2wV-mH-4yr"/>
                             <constraint firstItem="xvL-vB-zkU" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" constant="-1" id="7VD-3Z-mSf"/>
-                            <constraint firstItem="XWn-76-OyW" firstAttribute="leading" secondItem="gcy-ef-aVi" secondAttribute="leading" constant="6" id="NEt-GT-pbh"/>
+                            <constraint firstItem="XWn-76-OyW" firstAttribute="leading" secondItem="gcy-ef-aVi" secondAttribute="leading" constant="6" id="NEt-GT-pbh">
+                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            </constraint>
                             <constraint firstItem="XWn-76-OyW" firstAttribute="top" secondItem="gcy-ef-aVi" secondAttribute="top" constant="10" id="eJm-2u-3Fj"/>
-                            <constraint firstAttribute="trailing" secondItem="XWn-76-OyW" secondAttribute="trailing" constant="6" id="gJL-pe-U6k"/>
+                            <constraint firstAttribute="trailing" secondItem="XWn-76-OyW" secondAttribute="trailing" constant="6" id="gJL-pe-U6k">
+                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            </constraint>
                             <constraint firstItem="xvL-vB-zkU" firstAttribute="leading" secondItem="XWn-76-OyW" secondAttribute="leading" constant="-1" id="lXP-3e-wIH"/>
                             <constraint firstAttribute="bottom" secondItem="XWn-76-OyW" secondAttribute="bottom" constant="10" id="oMM-ZU-bDR"/>
                             <constraint firstItem="xvL-vB-zkU" firstAttribute="trailing" secondItem="XWn-76-OyW" secondAttribute="trailing" constant="1" id="rmt-Ui-YMc"/>
                             <constraint firstItem="xvL-vB-zkU" firstAttribute="bottom" secondItem="XWn-76-OyW" secondAttribute="bottom" constant="1" id="vo1-d7-zGo"/>
                         </constraints>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="2wV-mH-4yr"/>
-                            </mask>
-                        </variation>
-                        <variation key="heightClass=regular-widthClass=regular">
-                            <mask key="constraints">
-                                <include reference="2wV-mH-4yr"/>
-                                <exclude reference="NEt-GT-pbh"/>
-                                <exclude reference="gJL-pe-U6k"/>
-                            </mask>
-                        </variation>
                     </view>
                 </subviews>
                 <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
@@ -118,6 +98,6 @@
         </tableViewCell>
     </objects>
     <resources>
-        <image name="icon-post-undo" width="16" height="16"/>
+        <image name="icon-post-undo" width="18" height="18"/>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
@@ -67,7 +67,7 @@
                     <constraint firstAttribute="bottomMargin" secondItem="XWn-76-OyW" secondAttribute="bottom" constant="4" id="dNy-yP-Cwz">
                         <variation key="widthClass=regular" constant="0.0"/>
                     </constraint>
-                    <constraint firstItem="XWn-76-OyW" firstAttribute="trailing" secondItem="n47-YY-a6J" secondAttribute="trailingMargin" constant="2" id="iUp-40-qkJ">
+                    <constraint firstItem="XWn-76-OyW" firstAttribute="trailing" secondItem="n47-YY-a6J" secondAttribute="trailingMargin" priority="999" constant="2" id="iUp-40-qkJ">
                         <variation key="widthClass=regular" constant="0.0"/>
                     </constraint>
                     <constraint firstAttribute="leadingMargin" secondItem="XWn-76-OyW" secondAttribute="leading" constant="2" id="uTm-ab-WRk">

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
@@ -7,27 +7,27 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="56" id="cm8-te-h9Y" customClass="RestorePostTableViewCell">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="66" id="cm8-te-h9Y" customClass="RestorePostTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="66"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" tableViewCell="cm8-te-h9Y" id="n47-YY-a6J">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="65.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XWn-76-OyW">
-                        <rect key="frame" x="8" y="8" width="304" height="40"/>
+                        <rect key="frame" x="6" y="10" width="308" height="44"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Post moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tDg-aX-r9a">
-                                <rect key="frame" x="16" y="0.0" width="186" height="40"/>
+                                <rect key="frame" x="16" y="0.0" width="190" height="44"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="M7w-JQ-SVH"/>
+                                    <constraint firstAttribute="height" constant="44" id="Tap-43-94N"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5bW-zk-smP">
-                                <rect key="frame" x="202" y="0.0" width="86" height="40"/>
+                                <rect key="frame" x="206" y="0.0" width="86" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="86" id="oHA-R3-tyO"/>
                                 </constraints>
@@ -61,12 +61,22 @@
                 </subviews>
                 <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
                 <constraints>
-                    <constraint firstItem="XWn-76-OyW" firstAttribute="top" secondItem="n47-YY-a6J" secondAttribute="topMargin" id="RzW-GY-Om3"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="XWn-76-OyW" secondAttribute="bottom" id="dNy-yP-Cwz"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="XWn-76-OyW" secondAttribute="trailing" id="iUp-40-qkJ"/>
-                    <constraint firstItem="XWn-76-OyW" firstAttribute="leading" secondItem="n47-YY-a6J" secondAttribute="leadingMargin" id="uTm-ab-WRk"/>
+                    <constraint firstItem="XWn-76-OyW" firstAttribute="top" secondItem="n47-YY-a6J" secondAttribute="topMargin" constant="2" id="RzW-GY-Om3">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
+                    <constraint firstAttribute="bottomMargin" secondItem="XWn-76-OyW" secondAttribute="bottom" constant="4" id="dNy-yP-Cwz">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
+                    <constraint firstItem="XWn-76-OyW" firstAttribute="trailing" secondItem="n47-YY-a6J" secondAttribute="trailingMargin" constant="2" id="iUp-40-qkJ">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
+                    <constraint firstAttribute="leadingMargin" secondItem="XWn-76-OyW" secondAttribute="leading" constant="2" id="uTm-ab-WRk">
+                        <variation key="widthClass=regular" constant="0.0"/>
+                    </constraint>
                 </constraints>
+                <variation key="widthClass=regular" layoutMarginsFollowReadableWidth="YES" preservesSuperviewLayoutMargins="YES"/>
             </tableViewCellContentView>
+            <variation key="widthClass=regular" layoutMarginsFollowReadableWidth="YES" preservesSuperviewLayoutMargins="YES"/>
             <connections>
                 <outlet property="postContentView" destination="XWn-76-OyW" id="BWV-ef-k8w"/>
                 <outlet property="restoreButton" destination="5bW-zk-smP" id="ooK-Wf-Ygo"/>

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
@@ -2,97 +2,75 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="65" id="cm8-te-h9Y" customClass="RestorePostTableViewCell">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="cm8-te-h9Y" customClass="RestorePostTableViewCell">
             <rect key="frame" x="0.0" y="0.0" width="320" height="65"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" tableViewCell="cm8-te-h9Y" id="n47-YY-a6J">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="64.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gcy-ef-aVi">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XWn-76-OyW">
+                        <rect key="frame" x="6" y="10" width="308" height="44"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xvL-vB-zkU">
-                                <rect key="frame" x="5" y="9" width="310" height="46"/>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XWn-76-OyW">
-                                <rect key="frame" x="6" y="10" width="308" height="44"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Post moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tDg-aX-r9a">
-                                        <rect key="frame" x="13" y="0.0" width="134" height="44"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5bW-zk-smP">
-                                        <rect key="frame" x="228" y="0.0" width="66" height="44"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="66" id="oHA-R3-tyO"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <inset key="contentEdgeInsets" minX="3" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                        <inset key="imageEdgeInsets" minX="-3" minY="0.0" maxX="3" maxY="0.0"/>
-                                        <state key="normal" title="Undo" image="icon-post-undo">
-                                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="restorePostAction:" destination="cm8-te-h9Y" eventType="touchUpInside" id="hvw-f9-pHe"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Post moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tDg-aX-r9a">
+                                <rect key="frame" x="13" y="0.0" width="134" height="44"/>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="5bW-zk-smP" secondAttribute="trailing" constant="14" id="8G2-zh-deP">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="24"/>
-                                    </constraint>
-                                    <constraint firstItem="tDg-aX-r9a" firstAttribute="leading" secondItem="XWn-76-OyW" secondAttribute="leading" constant="13" id="Cd4-wE-Coz">
-                                        <variation key="heightClass=regular-widthClass=regular" constant="22"/>
-                                    </constraint>
-                                    <constraint firstAttribute="bottom" secondItem="tDg-aX-r9a" secondAttribute="bottom" id="NVR-Tx-ea4"/>
-                                    <constraint firstItem="tDg-aX-r9a" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" id="ay6-0i-iUF"/>
-                                    <constraint firstAttribute="bottom" secondItem="5bW-zk-smP" secondAttribute="bottom" id="fd1-Xw-yJ2"/>
-                                    <constraint firstItem="5bW-zk-smP" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tDg-aX-r9a" secondAttribute="trailing" constant="3" id="iiX-Ba-qGN"/>
-                                    <constraint firstItem="5bW-zk-smP" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" id="lZy-0i-LeW"/>
+                                    <constraint firstAttribute="height" constant="44" id="LGI-mC-HeZ"/>
                                 </constraints>
-                            </view>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5bW-zk-smP">
+                                <rect key="frame" x="228" y="0.0" width="66" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="66" id="oHA-R3-tyO"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <inset key="contentEdgeInsets" minX="3" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                <inset key="imageEdgeInsets" minX="-3" minY="0.0" maxX="3" maxY="0.0"/>
+                                <state key="normal" title="Undo" image="icon-post-undo">
+                                    <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="restorePostAction:" destination="cm8-te-h9Y" eventType="touchUpInside" id="hvw-f9-pHe"/>
+                                </connections>
+                            </button>
                         </subviews>
-                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="xvL-vB-zkU" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" constant="-1" id="7VD-3Z-mSf"/>
-                            <constraint firstItem="XWn-76-OyW" firstAttribute="leading" secondItem="gcy-ef-aVi" secondAttribute="leading" constant="6" id="NEt-GT-pbh">
-                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            <constraint firstAttribute="trailing" secondItem="5bW-zk-smP" secondAttribute="trailing" constant="14" id="8G2-zh-deP">
+                                <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
-                            <constraint firstItem="XWn-76-OyW" firstAttribute="top" secondItem="gcy-ef-aVi" secondAttribute="top" constant="10" id="eJm-2u-3Fj"/>
-                            <constraint firstAttribute="trailing" secondItem="XWn-76-OyW" secondAttribute="trailing" constant="6" id="gJL-pe-U6k">
-                                <variation key="heightClass=regular-widthClass=regular" constant="10"/>
+                            <constraint firstItem="tDg-aX-r9a" firstAttribute="leading" secondItem="XWn-76-OyW" secondAttribute="leading" constant="13" id="Cd4-wE-Coz">
+                                <variation key="heightClass=regular-widthClass=regular" constant="22"/>
                             </constraint>
-                            <constraint firstItem="xvL-vB-zkU" firstAttribute="leading" secondItem="XWn-76-OyW" secondAttribute="leading" constant="-1" id="lXP-3e-wIH"/>
-                            <constraint firstAttribute="bottom" secondItem="XWn-76-OyW" secondAttribute="bottom" constant="10" id="oMM-ZU-bDR"/>
-                            <constraint firstItem="xvL-vB-zkU" firstAttribute="trailing" secondItem="XWn-76-OyW" secondAttribute="trailing" constant="1" id="rmt-Ui-YMc"/>
-                            <constraint firstItem="xvL-vB-zkU" firstAttribute="bottom" secondItem="XWn-76-OyW" secondAttribute="bottom" constant="1" id="vo1-d7-zGo"/>
+                            <constraint firstAttribute="bottom" secondItem="tDg-aX-r9a" secondAttribute="bottom" id="NVR-Tx-ea4"/>
+                            <constraint firstItem="tDg-aX-r9a" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" id="ay6-0i-iUF"/>
+                            <constraint firstAttribute="bottom" secondItem="5bW-zk-smP" secondAttribute="bottom" id="fd1-Xw-yJ2"/>
+                            <constraint firstItem="5bW-zk-smP" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tDg-aX-r9a" secondAttribute="trailing" constant="3" id="iiX-Ba-qGN"/>
+                            <constraint firstItem="5bW-zk-smP" firstAttribute="top" secondItem="XWn-76-OyW" secondAttribute="top" id="lZy-0i-LeW"/>
                         </constraints>
                     </view>
                 </subviews>
                 <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="gcy-ef-aVi" secondAttribute="bottom" id="1fm-BB-GMU"/>
-                    <constraint firstAttribute="trailing" secondItem="gcy-ef-aVi" secondAttribute="trailing" id="3jw-Hl-OoM"/>
-                    <constraint firstItem="gcy-ef-aVi" firstAttribute="top" secondItem="n47-YY-a6J" secondAttribute="top" id="mPx-Eq-ymj"/>
-                    <constraint firstItem="gcy-ef-aVi" firstAttribute="leading" secondItem="n47-YY-a6J" secondAttribute="leading" id="pao-FZ-URB"/>
+                    <constraint firstItem="XWn-76-OyW" firstAttribute="leading" secondItem="n47-YY-a6J" secondAttribute="leadingMargin" constant="-2" id="2UK-xt-vyg"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="XWn-76-OyW" secondAttribute="bottom" constant="2.5" id="4gk-o4-Fo5"/>
+                    <constraint firstItem="XWn-76-OyW" firstAttribute="top" secondItem="n47-YY-a6J" secondAttribute="topMargin" constant="2" id="Q4u-gm-vVx"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="XWn-76-OyW" secondAttribute="trailing" constant="-2" id="nHh-lN-cc5"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="innerContentView" destination="gcy-ef-aVi" id="mqQ-7M-n4l"/>
                 <outlet property="postContentView" destination="XWn-76-OyW" id="BWV-ef-k8w"/>
                 <outlet property="restoreButton" destination="5bW-zk-smP" id="ooK-Wf-Ygo"/>
                 <outlet property="restoreLabel" destination="tDg-aX-r9a" id="hWK-bR-Ar8"/>
-                <outlet property="shadowView" destination="xvL-vB-zkU" id="QNz-Hy-riG"/>
             </connections>
             <point key="canvasLocation" x="568" y="220.5"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -198,10 +198,8 @@
 + (NSDictionary *)pageCellTitleAttributes
 {
     CGFloat fontSize = 15.0;
-    CGFloat lineHeight = 22.5;
-    NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
-    paragraphStyle.minimumLineHeight = lineHeight;
-    paragraphStyle.maximumLineHeight = lineHeight;
+    NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+    paragraphStyle.lineSpacing = 4.0;
     return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager merriweatherRegularFontOfSize:fontSize]};
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -6593,7 +6593,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE = "4601e739-fb3d-43bd-bf22-56e7835186c5";
+				PROVISIONING_PROFILE = "1e83ed49-3613-4fe8-831f-3eccc83debb6";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -7110,7 +7110,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressShare;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "05a4e80b-5cbf-4725-8ab2-9d59c3492087";
+				PROVISIONING_PROFILE = "12dc0514-ca55-426f-b1dc-ed7bb4641741";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressShareExtension/WordPressShare-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -7477,7 +7477,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.wordpress.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_MODULE_NAME = WordPressWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "1d80ed9e-3046-4358-b581-e70757ed7722";
+				PROVISIONING_PROFILE = "6e71a957-55b8-4f7a-a6f2-b87e63a65b03";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressTodayWidget/WordPressTodayWidget-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";


### PR DESCRIPTION
While I originally set out to adapt Posts and Pages away from fixed widths, it ultimately brought me to this glorious refactoring for autosizing cells and following iOS imposed margins.

### Overview
- Cleans up the layout for Pages and Posts.
- Autosizes cells via `UITableViewAutomaticDimension`.
- Adopts readable margins for iPad and iPhone 6+ landscape (Reg Width and Any Height)
- Updates the Pages design just a _bit_.

For now we'll only follow readable margins on iPad and iPhone 6+ landscape. This conforms to the size classes of _Regular Width_ and _Any Height_. We'll leave default iPhone as is for now, as the margins there are technically hand-designed.

### Estimated Height Cacheing
With the autosizing cells, I absolutely could not find a way to keep cells from _bouncing_ their heights after any reload animations. Even if the cell's intrinsic size doesn't change, `UITableView` seems to start a cell's reload animation by key-framing the beginning height as whatever the estimated height is. So unless the estimated height is _precisely_ the layout of the cell, the animation will appear to bounce after firing off the reload calls.

To solve this, of course, we're cacheing the last known frame heights of the cell's based off of `willDisplayCell:`. This cached height is then used as the explicit estimated height for the given indexPath. This doesn't seem quite _auto_, but I can't find a better solution at this time.

### Pages Design
While adapting Pages for readability, the design had to be updated in accordance with the rest of the app and our iOS consistency patterns.

-

### Testing, Posts:

1. Open Posts on iPad, ensure the Post's content views are following readable margins on portrait and landscape orientations.
2. Open Posts via iPad multitasking, ensure the Post's content views are defaulting to the compact sized class margins, as also seen on iPhone. Ensure the margins transition as expected.
3. Open Posts on iPhone, ensure the Post's content views are defaulting to the compact sized class margins, as originally expected.
4. Open Posts on iPhone 6+ landscape, ensure the Post's content views are following readable margins on landscape orientation.
5. Transition from Posts on iPhone 6+ landscape to portrait, ensure the margins transition as expected.
6. Move a Post to Trash, ensure the Restore cell is loaded as expected and vice versa.
7. Ensure Post cell heights are correct and post content is only truncated as expected. (Compare to Store build)

### Testing, Pages:

1. Open Pages on iPhone and iPad, ensure the cell contents are following readable margins.
2. Move a Page to Trash, ensure the Restore cell is loaded as expected and vice versa.
3. Ensure Page cell heights are correct and also handle long, multi-line page titles.

Needs review: @frosty can I interest you in taking a dive into autosizing post cells? 😅