### PR TITLE
Blog Details: Rewrites proper readable margins layout.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -24,6 +24,9 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 {
     self = [super initWithFrame:frame];
     if (self) {
+
+        self.preservesSuperviewLayoutMargins = YES;
+
         [self setupStackView];
         [self setupBlavatarImageView];
         [self setupLabelsStackView];
@@ -58,24 +61,9 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     stackView.spacing = BlogDetailHeaderViewLabelHorizontalPadding;
     [self addSubview:stackView];
 
-    NSLayoutConstraint *leadingConstraint;
-    NSLayoutConstraint *trailingConstraint;
-
-    if ([WPDeviceIdentification isiPhone]) {
-        // On iPhone, the readable content guide seems to be accurately aligned with the cell's content margins.
-        UILayoutGuide *readableGuide = self.readableContentGuide;
-        leadingConstraint = [stackView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor];
-        trailingConstraint = [stackView.trailingAnchor constraintEqualToAnchor:readableGuide.trailingAnchor];
-    } else {
-        // On iPad, the correct readable margins seem to already be inherited via the tableHeaderView
-        // so following this view's readable content guide is not necessary.
-        leadingConstraint = [stackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor];
-        trailingConstraint = [stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor];
-    }
-
     [NSLayoutConstraint activateConstraints:@[
-                                              leadingConstraint,
-                                              trailingConstraint,
+                                              [stackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor],
+                                              [stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor],
                                               [stackView.topAnchor constraintEqualToAnchor:self.topAnchor],
                                               [stackView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
                                               ]];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -26,7 +26,6 @@ static NSString *const BlogDetailsPlanCellIdentifier = @"BlogDetailsPlanCell";
 
 NSString * const WPBlogDetailsRestorationID = @"WPBlogDetailsID";
 NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
-NSInteger const BlogDetailHeaderViewHorizontalMarginiPhone = 15;
 NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
 CGFloat const BLogDetailGridiconAccessorySize = 17.0;
 
@@ -365,6 +364,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     // Wrapper view
     UIView *headerWrapper = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, CGRectGetWidth(self.view.bounds), BlogDetailHeaderViewBlavatarSize + BlogDetailHeaderViewVerticalMargin * 2)];
+    headerWrapper.preservesSuperviewLayoutMargins = YES;
     self.tableView.tableHeaderView = headerWrapper;
 
     // Blog detail header view


### PR DESCRIPTION
This resolves an issue with the margins layout of `BlogDetailHeaderView`. Previously, the margins were not being followed correctly and were misaligned on iPhone.

Note: Also removed unused `const` `BlogDetailHeaderViewHorizontalMarginiPhone`.

To test:

- Open up the Blog Details for a site.
- On iPhone, ensure the icon in the header is aligned with the icons in the cells below.
- On iPad, ensure the icon in the header is aligned with the icons in the cells below.

Needs review: @diegoreymendez can you take a quick run-through? 🏃