### PR TITLE
Menus: Typo fix courtesy of @pixolin

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -347,7 +347,7 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
             }
         };
         void(^failureBlock)(NSError *) = ^(NSError *error) {
-            weakSelf.itemsLoadingLabel.text = NSLocalizedString(@"An error occurred loading the menu, pelase check your internet connection.", @"Menus error message seen when an error occurred loading a specific menu.");
+            weakSelf.itemsLoadingLabel.text = NSLocalizedString(@"An error occurred loading the menu, please check your internet connection.", @"Menus error message seen when an error occurred loading a specific menu.");
         };
         [self.menusService generateDefaultMenuItemsForBlog:self.blog
                                                    success:successBlock


### PR DESCRIPTION
Resolves https://github.com/wordpress-mobile/WordPress-iOS/pull/5834

Rebuilding the original PR as just the typo, and into our release branch for 6.4. (Chose not to cherry-pick since the original commit is in a fork)

Thanks to @pixolin

Needs review: @astralbodies 

