### PR TITLE
Issues/4094 minor fixes, and removes feature flag

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -200,15 +200,9 @@ int ddLogLevel = DDLogLevelInfo;
                 NSNumber *postId = [params numberForKey:@"postId"];
 
                 WPTabBarController *tabBarController = [WPTabBarController sharedInstance];
-                if ([Feature enabled: FeatureFlagReaderMenu]) {
-                    [tabBarController.readerMenuViewController.navigationController popToRootViewControllerAnimated:NO];
-                    [tabBarController showReaderTab];
-                    [tabBarController.readerMenuViewController openPost:postId onBlog:blogId];
-                } else {
-                    [tabBarController.readerViewController.navigationController popToRootViewControllerAnimated:NO];
-                    [tabBarController showReaderTab];
-                    [tabBarController.readerViewController openPost:postId onBlog:blogId];
-                }
+                [tabBarController.readerMenuViewController.navigationController popToRootViewControllerAnimated:NO];
+                [tabBarController showReaderTab];
+                [tabBarController.readerMenuViewController openPost:postId onBlog:blogId];
 
                 returnValue = YES;
             }

--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -2,7 +2,6 @@
 /// different builds.
 @objc
 enum FeatureFlag: Int {
-    case ReaderMenu
     /// My Sites > Site > People
     /// Development on hold while we focus on Me
     case People
@@ -14,8 +13,6 @@ enum FeatureFlag: Int {
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
         switch self {
-        case .ReaderMenu:
-            return build(.Debug)
         case .People, .MyProfile, .AccountSettings:
             return true
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
@@ -35,7 +35,7 @@ import WordPressShared.WPStyleGuide
         disclosureIcon.image = Gridicon.iconOfType(.ChevronRight, withSize: disclosureIcon.frame.size)
         disclosureIcon.tintColor = WPStyleGuide.accessoryDefaultTintColor()
 
-        imageView.image = Gridicon.iconOfType(.Cog, withSize: imageView.frame.size)
+        imageView.image = Gridicon.iconOfType(.Cog)
         imageView.tintColor = UIColor.whiteColor()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -337,6 +337,12 @@ extension ReaderFollowedSitesViewController : WPTableViewHandlerDelegate
 
     func tableViewDidChangeContent(tableView: UITableView) {
         configureNoResultsView()
+
+        // If we're not following any sites, reload the table view to ensure the
+        // section header is no longer showing.
+        if tableViewHandler.resultsController.fetchedObjects?.count == 0 {
+            tableView.reloadData()
+        }
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -243,7 +243,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
 
     func promptWithTitle(title: String, message: String) {
         let buttonTitle = NSLocalizedString("OK", comment: "Button title. Acknowledges a prompt.")
-        let alert = UIAlertController(title: title, message: description, preferredStyle: .Alert)
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .Alert)
         alert.addCancelActionWithTitle(buttonTitle)
         alert.presentFromRootViewController()
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewModel.swift
@@ -147,7 +147,7 @@ enum ReaderDefaultMenuItemOrder: Int {
         // Rebuild!
         setupDefaultsSection()
 
-        if ReaderHelpers.isLoggedIn() {
+        if ReaderHelpers.isLoggedIn() && listsFetchedResultsController.fetchedObjects?.count > 0 {
             setupListsSection()
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -34,7 +34,7 @@ extension ReaderStreamViewController
             return nil
         }
 
-        if ReaderHelpers.topicIsFollowing(topic) && Feature.enabled(.ReaderMenu) {
+        if ReaderHelpers.topicIsFollowing(topic) {
             return NSBundle.mainBundle().loadNibNamed("ReaderFollowedSitesStreamHeader", owner: nil, options: nil).first as! ReaderFollowedSitesStreamHeader
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -508,7 +508,7 @@ import WordPressComAnalytics
         resultsStatusView.titleText = response.title
         resultsStatusView.messageText = response.message
         resultsStatusView.accessoryView = nil
-        if ReaderHelpers.topicIsFollowing(topic) && Feature.enabled(.ReaderMenu) {
+        if ReaderHelpers.topicIsFollowing(topic) {
             resultsStatusView.buttonTitle = NSLocalizedString("Manage Sites", comment: "Button title. Tapping lets the user manage the sites they follow.")
             resultsStatusView.delegate = self
         } else {
@@ -599,7 +599,6 @@ import WordPressComAnalytics
         managedObjectContext().reset()
 
         configureTitleForTopic()
-        configureNavigationItemForTopic()
         hideResultsStatus()
         recentlyBlockedSitePostObjectIDs.removeAllObjects()
         updateAndPerformFetchRequest()
@@ -636,27 +635,6 @@ import WordPressComAnalytics
         }
 
         title = topic.title
-    }
-
-
-    func configureNavigationItemForTopic() {
-        if Feature.enabled(.ReaderMenu) {
-            return
-        }
-
-        guard let topic = readerTopic else {
-            navigationItem.rightBarButtonItems = nil
-            return
-        }
-        if ReaderHelpers.isTopicSearchTopic(topic) {
-            navigationItem.rightBarButtonItems = nil
-            return
-        }
-        let button = UIBarButtonItem(image: UIImage(named: "icon-post-search"),
-                                     style: .Plain,
-                                     target: self,
-                                     action: #selector(ReaderStreamViewController.handleSearchButtonTapped(_:)))
-        navigationItem.rightBarButtonItem = button
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderViewController.m
@@ -12,16 +12,12 @@
 #import "WPTabBarController.h"
 #import "WordPress-Swift.h"
 
-@interface ReaderViewController () <UIViewControllerRestoration>
+@interface ReaderViewController ()
 @property (nonatomic, strong) ReaderStreamViewController *postsViewController;
 @end
 
 @implementation ReaderViewController
 
-+ (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
-{
-    return [[WPTabBarController sharedInstance] readerViewController];
-}
 
 #pragma mark - Life Cycle
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -16,13 +16,11 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 @class BlogListViewController;
 @class MeViewController;
 @class NotificationsViewController;
-@class ReaderViewController;
 @class ReaderMenuViewController;
 
 @interface WPTabBarController : UITabBarController
 
 @property (nonatomic, strong, readonly) BlogListViewController *blogListViewController;
-@property (nonatomic, strong, readonly) ReaderViewController *readerViewController;
 @property (nonatomic, strong, readonly) ReaderMenuViewController *readerMenuViewController;
 @property (nonatomic, strong, readonly) NotificationsViewController *notificationsViewController;
 @property (nonatomic, strong, readonly) MeViewController *meViewController;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -9,7 +9,6 @@
 
 #import "BlogListViewController.h"
 #import "BlogDetailsViewController.h"
-#import "ReaderViewController.h"
 #import "StatsViewController.h"
 #import "WPPostViewController.h"
 #import "WPLegacyEditPageViewController.h"
@@ -49,7 +48,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 @interface WPTabBarController () <UITabBarControllerDelegate, UIViewControllerRestoration>
 
 @property (nonatomic, strong) BlogListViewController *blogListViewController;
-@property (nonatomic, strong) ReaderViewController *readerViewController;
 @property (nonatomic, strong) ReaderMenuViewController *readerMenuViewController;
 @property (nonatomic, strong) NotificationsViewController *notificationsViewController;
 @property (nonatomic, strong) MeViewController *meViewController;
@@ -198,14 +196,9 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         return _readerNavigationController;
     }
 
-    self.readerViewController = [[ReaderViewController alloc] init];
     self.readerMenuViewController = [ReaderMenuViewController sharedInstance];
 
-    if ([Feature enabled: FeatureFlagReaderMenu]) {
-        _readerNavigationController = [[UINavigationController alloc] initWithRootViewController:self.readerMenuViewController];
-    } else {
-        _readerNavigationController = [[UINavigationController alloc] initWithRootViewController:self.readerViewController];
-    }
+    _readerNavigationController = [[UINavigationController alloc] initWithRootViewController:self.readerMenuViewController];
 
     _readerNavigationController.navigationBar.translucent = NO;
     UIImage *readerTabBarImage = [UIImage imageNamed:@"icon-tab-reader"];

--- a/WordPress/WordPressTest/FeatureFlagTest.swift
+++ b/WordPress/WordPressTest/FeatureFlagTest.swift
@@ -22,9 +22,11 @@ class FeatureFlagTest: XCTestCase {
         }
     }
 
+    // Add tests for features that should be disabled in production here.
     func testEnsureDisabledFeaturesInProduction() {
         Build.withCurrent(.AppStore) {
-            expect(FeatureFlag.ReaderMenu.enabled).to(beFalse())
+//            Example:
+//            expect(FeatureFlag.[FeatureEnum].enabled).to(beFalse())
         }
     }
 }


### PR DESCRIPTION
Refs #4094 

This PR removes the new Reader menu's feature flag, enabling the new menu and navigation flow in the app for everyone. Also, as it was convenient, it includes some small fixes to #5799 and #5800, and a slight style tweak to an icon requested by @jancavan.

Needs review: @kurzee, would you be so kind sir? 
