### PR TITLE
Forces the format of the timestamp to drop decimal places

### DIFF
--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -32,7 +32,7 @@ public class Tracks
 
     // MARK: - Private Helpers
     private func payloadWithEventName(eventName: String, properties: [String: AnyObject]?) -> [String: AnyObject] {
-        let timestamp   = NSDate().timeIntervalSince1970 * 1000
+        let timestamp   = String(Int64(NSDate().timeIntervalSince1970 * 1000))
         let userID      = NSUUID().UUIDString
         let device      = UIDevice.currentDevice()
         let bundle      = NSBundle.mainBundle()

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -32,7 +32,7 @@ public class Tracks
 
     // MARK: - Private Helpers
     private func payloadWithEventName(eventName: String, properties: [String: AnyObject]?) -> [String: AnyObject] {
-        let timestamp   = String(Int64(NSDate().timeIntervalSince1970 * 1000))
+        let timestamp   = NSNumber(longLong: Int64(NSDate().timeIntervalSince1970 * 1000))
         let userID      = NSUUID().UUIDString
         let device      = UIDevice.currentDevice()
         let bundle      = NSBundle.mainBundle()


### PR DESCRIPTION
Fixes #5837 

To test:
1. Add a logging statement to the `payloadWithEventName` method.
2. Load the share extension or Today extension.
3. Verify timestamps are 13 or more digits (roughly looking like 1470339213034) and no decimal point or numbers afterwards are included.

Needs review: @jleandroperez 

cc: @xyu

