### PR TITLE
Reader: Prevent crash when unblocking site

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1672,7 +1672,7 @@ extension ReaderStreamViewController : WPTableViewHandlerDelegate {
             return
         }
 
-        if recentlyBlockedSitePostObjectIDs.containsObject(post.objectID) {
+        if recentlyBlockedSitePostObjectIDs.containsObject(apost.objectID) {
             unblockSiteForPost(apost)
             return
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -969,16 +969,13 @@ import WordPressComAnalytics
     }
 
 
-    private func unblockSiteForPost(post: ReaderPost) {
-        guard let indexPath = tableViewHandler.resultsController.indexPathForObject(post) else {
-            return
-        }
+    private func unblockSiteForPost(post: ReaderPost, rowIndexPath: NSIndexPath) {
 
         let objectID = post.objectID
         recentlyBlockedSitePostObjectIDs.removeObject(objectID)
 
-        tableViewHandler.invalidateCachedRowHeightAtIndexPath(indexPath)
-        tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: UITableViewRowAnimation.Fade)
+        tableViewHandler.invalidateCachedRowHeightAtIndexPath(rowIndexPath)
+        tableView.reloadRowsAtIndexPaths([rowIndexPath], withRowAnimation: UITableViewRowAnimation.Fade)
 
         let service = ReaderSiteService(managedObjectContext: managedObjectContext())
         service.flagSiteWithID(post.siteID,
@@ -986,8 +983,8 @@ import WordPressComAnalytics
             success: nil,
             failure: { [weak self] (error:NSError?) in
                 self?.recentlyBlockedSitePostObjectIDs.addObject(objectID)
-                self?.tableViewHandler.invalidateCachedRowHeightAtIndexPath(indexPath)
-                self?.tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: UITableViewRowAnimation.Fade)
+                self?.tableViewHandler.invalidateCachedRowHeightAtIndexPath(rowIndexPath)
+                self?.tableView.reloadRowsAtIndexPaths([rowIndexPath], withRowAnimation: UITableViewRowAnimation.Fade)
 
                 let message = error?.localizedDescription ?? ""
                 let errorTitle = NSLocalizedString("Error Unblocking Site", comment:"Title of a prompt letting the user know there was an error trying to unblock a site from appearing in the reader.")
@@ -1673,7 +1670,7 @@ extension ReaderStreamViewController : WPTableViewHandlerDelegate {
         }
 
         if recentlyBlockedSitePostObjectIDs.containsObject(post.objectID) {
-            unblockSiteForPost(post)
+            unblockSiteForPost(post, rowIndexPath: indexPath)
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -970,10 +970,13 @@ import WordPressComAnalytics
 
 
     private func unblockSiteForPost(post: ReaderPost) {
+        guard let indexPath = tableViewHandler.resultsController.indexPathForObject(post) else {
+            return
+        }
+
         let objectID = post.objectID
         recentlyBlockedSitePostObjectIDs.removeObject(objectID)
 
-        let indexPath = tableViewHandler.resultsController.indexPathForObject(post)!
         tableViewHandler.invalidateCachedRowHeightAtIndexPath(indexPath)
         tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: UITableViewRowAnimation.Fade)
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -969,13 +969,16 @@ import WordPressComAnalytics
     }
 
 
-    private func unblockSiteForPost(post: ReaderPost, rowIndexPath: NSIndexPath) {
-
+    private func unblockSiteForPost(post: ReaderPost) {
+        guard let indexPath = tableViewHandler.resultsController.indexPathForObject(post) else {
+            return
+        }
+        
         let objectID = post.objectID
         recentlyBlockedSitePostObjectIDs.removeObject(objectID)
 
-        tableViewHandler.invalidateCachedRowHeightAtIndexPath(rowIndexPath)
-        tableView.reloadRowsAtIndexPaths([rowIndexPath], withRowAnimation: UITableViewRowAnimation.Fade)
+        tableViewHandler.invalidateCachedRowHeightAtIndexPath(indexPath)
+        tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: UITableViewRowAnimation.Fade)
 
         let service = ReaderSiteService(managedObjectContext: managedObjectContext())
         service.flagSiteWithID(post.siteID,
@@ -983,8 +986,8 @@ import WordPressComAnalytics
             success: nil,
             failure: { [weak self] (error:NSError?) in
                 self?.recentlyBlockedSitePostObjectIDs.addObject(objectID)
-                self?.tableViewHandler.invalidateCachedRowHeightAtIndexPath(rowIndexPath)
-                self?.tableView.reloadRowsAtIndexPaths([rowIndexPath], withRowAnimation: UITableViewRowAnimation.Fade)
+                self?.tableViewHandler.invalidateCachedRowHeightAtIndexPath(indexPath)
+                self?.tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: UITableViewRowAnimation.Fade)
 
                 let message = error?.localizedDescription ?? ""
                 let errorTitle = NSLocalizedString("Error Unblocking Site", comment:"Title of a prompt letting the user know there was an error trying to unblock a site from appearing in the reader.")
@@ -1670,7 +1673,7 @@ extension ReaderStreamViewController : WPTableViewHandlerDelegate {
         }
 
         if recentlyBlockedSitePostObjectIDs.containsObject(post.objectID) {
-            unblockSiteForPost(post, rowIndexPath: indexPath)
+            unblockSiteForPost(apost)
             return
         }
 


### PR DESCRIPTION
Fixes a crash when unblocking a site that was just blocked.

Looks like this particular method `unblockSiteForPost` should have been updated similarly to how `blockSiteForPost` was updated to handle the indexPath guard.

I'm guessing something happens after `recentlyBlockedSitePostObjectIDs.removeObject(objectID)` causing a crash when trying to access that post. `¯\_(ツ)_/¯`

To test:

1. Open the Reader.
2. Block a site with the `...` button.
3. Unblock the site by tapping the blocked cell.
4. Don't crash, and the site should be unblocked.

Needs review: @aerych can you take a peak?
