### PR TITLE
Cleanup a few forced downcasts

### DIFF
--- a/WordPress/Classes/Models/BlogSettings+Discussion.swift
+++ b/WordPress/Classes/Models/BlogSettings+Discussion.swift
@@ -212,7 +212,11 @@ extension BlogSettings
     ///
     var commentsSorting : CommentsSorting {
         get {
-            return CommentsSorting(rawValue: commentsSortOrder as! Int) ?? .Ascending
+            guard let sortOrder = commentsSortOrder as Int?,
+                sorting = CommentsSorting(rawValue: sortOrder) else {
+                    return .Ascending
+            }
+            return sorting
         }
         set {
             commentsSortOrder = newValue.rawValue

--- a/WordPress/Classes/Models/BlogSettings+Discussion.swift
+++ b/WordPress/Classes/Models/BlogSettings+Discussion.swift
@@ -212,7 +212,8 @@ extension BlogSettings
     ///
     var commentsSorting : CommentsSorting {
         get {
-            guard let sortOrder = commentsSortOrder as Int?,
+            guard let
+                sortOrder = commentsSortOrder as Int?,
                 sorting = CommentsSorting(rawValue: sortOrder) else {
                     return .Ascending
             }

--- a/WordPress/Classes/Networking/AccountSettingsRemote.swift
+++ b/WordPress/Classes/Networking/AccountSettingsRemote.swift
@@ -17,8 +17,8 @@ class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         // when it's fetched again it would create a different api object.
         // FIXME: not thread safe
         // @koke 2016-01-21
-        if let remote = remotes.objectForKey(api) {
-            return remote as! AccountSettingsRemote
+        if let remote = remotes.objectForKey(api) as? AccountSettingsRemote {
+            return remote
         } else {
             let remote = AccountSettingsRemote(wordPressComRestApi: api)
             remotes.setObject(remote, forKey: api)

--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -165,12 +165,12 @@ class AccountSettingsService {
 
     private func createAccountSettings(userID: Int, settings: AccountSettings) {
         let accountService = AccountService(managedObjectContext: context)
-        guard let account = accountService.findAccountWithUserID(userID) else {
+        guard let account = accountService.findAccountWithUserID(userID),
+        let managedSettings = NSEntityDescription.insertNewObjectForEntityForName(ManagedAccountSettings.entityName, inManagedObjectContext: context) as? ManagedAccountSettings else {
             DDLogSwift.logError("Tried to create settings for a missing account (ID: \(userID)): \(settings)")
             return
         }
 
-        let managedSettings = NSEntityDescription.insertNewObjectForEntityForName(ManagedAccountSettings.entityName, inManagedObjectContext: context) as! ManagedAccountSettings
         managedSettings.updateWith(settings)
         managedSettings.account = account
     }

--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -159,20 +159,23 @@ class AccountSettingsService {
         let request = NSFetchRequest(entityName: ManagedAccountSettings.entityName)
         request.predicate = NSPredicate(format: "account.userID = %d", userID)
         request.fetchLimit = 1
-        let results = (try? context.executeFetchRequest(request)) as? [ManagedAccountSettings] ?? []
+        guard let results = (try? context.executeFetchRequest(request)) as? [ManagedAccountSettings] else {
+            return nil
+        }
         return results.first
     }
 
     private func createAccountSettings(userID: Int, settings: AccountSettings) {
         let accountService = AccountService(managedObjectContext: context)
-        guard let account = accountService.findAccountWithUserID(userID),
-        let managedSettings = NSEntityDescription.insertNewObjectForEntityForName(ManagedAccountSettings.entityName, inManagedObjectContext: context) as? ManagedAccountSettings else {
+        guard let account = accountService.findAccountWithUserID(userID) else {
             DDLogSwift.logError("Tried to create settings for a missing account (ID: \(userID)): \(settings)")
             return
         }
 
-        managedSettings.updateWith(settings)
-        managedSettings.account = account
+        if let managedSettings = NSEntityDescription.insertNewObjectForEntityForName(ManagedAccountSettings.entityName, inManagedObjectContext: context) as? ManagedAccountSettings {
+            managedSettings.updateWith(settings)
+            managedSettings.account = account
+        }
     }
 
     enum Errors: ErrorType {

--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -159,7 +159,7 @@ class AccountSettingsService {
         let request = NSFetchRequest(entityName: ManagedAccountSettings.entityName)
         request.predicate = NSPredicate(format: "account.userID = %d", userID)
         request.fetchLimit = 1
-        let results = (try? context.executeFetchRequest(request) as! [ManagedAccountSettings]) ?? []
+        let results = (try? context.executeFetchRequest(request)) as? [ManagedAccountSettings] ?? []
         return results.first
     }
 


### PR DESCRIPTION
I fixed a few of our uses of `as!` to prove out my thoughts while writing [a style guide proposal](https://github.com/wordpress-mobile/swift-style-guide/issues/7)

**To test:**

Functionality should not have changed. If account settings and comment sorting still work, then that would appear to be the case.

_For authoring the first accepted style guide proposal:_

Needs review: @diegoreymendez 