### PR TITLE
Posts/Pages: Avoid windowless cells

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -264,6 +264,10 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     }
 
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        if let windowlessCell = dequeCellForWindowlessTableViewLoadingIfNeeded(tableView) {
+            return windowlessCell
+        }
+
         let page = pageAtIndexPath(indexPath)
 
         let identifier = cellIdentifierForPage(page)

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -264,7 +264,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     }
 
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        if let windowlessCell = dequeCellForWindowlessTableViewLoadingIfNeeded(tableView) {
+        if let windowlessCell = dequeCellForWindowlessLoadingIfNeeded(tableView) {
             return windowlessCell
         }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -15,6 +15,8 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     private static let defaultHeightForFooterView = CGFloat(44.0)
 
+    private let abstractPostWindowlessCellIdenfitier = "AbstractPostWindowlessCellIdenfitier"
+
     var blog : Blog!
 
     /// This closure will be executed whenever the noResultsView must be visually refreshed.  It's up
@@ -22,6 +24,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     ///
     var refreshNoResultsView : ((WPNoResultsView) -> ())!
     var tableViewController : UITableViewController!
+    var reloadTableViewBeforeAppearing = false
 
     var tableView : UITableView {
         get {
@@ -95,6 +98,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
         configureTableView()
         configureFooterView()
+        configureWindowlessCell()
         configureNavbar()
         configureSearchController()
         configureSearchHelper()
@@ -106,8 +110,13 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
-        refreshResults()
 
+        if reloadTableViewBeforeAppearing {
+            reloadTableViewBeforeAppearing = false
+            tableView.reloadData()
+        }
+
+        refreshResults()
         registerForKeyboardNotifications()
     }
 
@@ -219,6 +228,10 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         tableView.tableFooterView = postListFooterView
     }
 
+    func configureWindowlessCell() {
+        tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: abstractPostWindowlessCellIdenfitier)
+    }
+
     private func refreshResults() {
         guard isViewLoaded() == true else {
             return
@@ -302,6 +315,22 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         }
 
         tableView.sendSubviewToBack(noResultsView)
+    }
+
+    // MARK: - TableView Helpers
+
+    func dequeCellForWindowlessTableViewLoadingIfNeeded(tableView: UITableView) -> UITableViewCell? {
+        // As also seen in ReaderStreamViewController:
+        // We want to avoid dequeuing card cells when we're not present in a window, on the iPad.
+        // Doing so can create a situation where cells are not updated with the correct NSTraitCollection.
+        // The result is the cells do not show the correct layouts relative to superview margins.
+        // HACK: kurzee, 2016-07-12
+        // Use a generic cell in this situation and reload the table view once its back in a window.
+        if (tableView.window == nil) {
+            reloadTableViewBeforeAppearing = true
+            return tableView.dequeueReusableCellWithIdentifier(abstractPostWindowlessCellIdenfitier)
+        }
+        return nil
     }
 
     // MARK: - TableViewHandler Delegate Methods

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -319,7 +319,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     // MARK: - TableView Helpers
 
-    func dequeCellForWindowlessTableViewLoadingIfNeeded(tableView: UITableView) -> UITableViewCell? {
+    func dequeCellForWindowlessLoadingIfNeeded(tableView: UITableView) -> UITableViewCell? {
         // As also seen in ReaderStreamViewController:
         // We want to avoid dequeuing card cells when we're not present in a window, on the iPad.
         // Doing so can create a situation where cells are not updated with the correct NSTraitCollection.

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -307,6 +307,9 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
     }
 
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        if let windowlessCell = dequeCellForWindowlessTableViewLoadingIfNeeded(tableView) {
+            return windowlessCell
+        }
 
         let post = postAtIndexPath(indexPath)
         let identifier = cellIdentifierForPost(post)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -307,7 +307,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
     }
 
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        if let windowlessCell = dequeCellForWindowlessTableViewLoadingIfNeeded(tableView) {
+        if let windowlessCell = dequeCellForWindowlessLoadingIfNeeded(tableView) {
             return windowlessCell
         }
 


### PR DESCRIPTION
Fixes #5857

Fixes the full-width issue for Posts and Pages as previously solved for Reader cards in https://github.com/wordpress-mobile/WordPress-iOS/pull/5617 and discovered in https://github.com/wordpress-mobile/WordPress-iOS/issues/5082#issuecomment-228387047

To test:
- On iPad, delete the app, reinstall.
- Let the posts or pages for a site load.
- While it’s fetching, move to another tab.
- Let the sync finish.
- Go back to the posts or pages tab.
- Cells should follow correct margins.

Needs review: @aerych take a run-through? Thanks for finding this one!
