### PR TITLE
Integrates the Aztec pod into WordPress-iOS.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,6 +50,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '~> 0.10.1'
     pod 'WordPress-iOS-Editor', '1.8'
     pod 'WordPressCom-Analytics-iOS', '0.1.17'
+    pod 'WordPress-Aztec-iOS', '0.1.0'
     pod 'WordPressCom-Stats-iOS', '0.7.6'
     pod 'wpxmlrpc', '~> 0.8'
     

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -155,6 +155,7 @@ PODS:
   - SVProgressHUD (1.1.3)
   - UIDeviceIdentifier (0.5.0)
   - WordPress-AppbotX (1.0.6)
+  - WordPress-Aztec-iOS (0.1.0)
   - WordPress-iOS-Editor (1.8):
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
@@ -217,6 +218,7 @@ DEPENDENCIES:
   - SVProgressHUD (~> 1.1.3)
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
+  - WordPress-Aztec-iOS (= 0.1.0)
   - WordPress-iOS-Editor (= 1.8)
   - WordPress-iOS-Shared (= 0.6.0)
   - WordPressCom-Analytics-iOS (= 0.1.17)
@@ -280,6 +282,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 748080e4f36e603f6c02aec292664239df5279c1
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
+  WordPress-Aztec-iOS: 2962889a7ac75071440acfbbd98427117086a3be
   WordPress-iOS-Editor: 50a09646fb62af3efdbb56d13ff656272a079066
   WordPress-iOS-Shared: f799334b41f3af509ccb76d7970f8c74a7716f14
   WordPressCom-Analytics-iOS: 02c94167d80f43684bdc83cf8df2f4b6fc0909ba
@@ -288,6 +291,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 645ecc2435293cc898c76180f3994358a68cae20
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: f05cafce394f51695d6fd1dc03f79c83dafdd8ca
+PODFILE CHECKSUM: 19e00951a8b8ee0b081ff4adf95c5ec0386bd6a5
 
 COCOAPODS: 1.0.1


### PR DESCRIPTION
Closes [this PR](https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/16).

The Aztec pod version is the only one published so far - it's not a good candidate for complete integration into WPiOS.  In fact there is nothing we can show in the app with this version.

The purpose of this PR is only to make sure the published pod works, and integrate an initial version of it into WPiOS, while not breaking anything else.

We'll be updating the version as soon as we publish a new one.

**To test:**
1. Just do the Pod dance.
2. Make sure the app builds.

Needs review: @kurzee .
