### PR TITLE
Issues/5817 traintracks

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,9 @@ This file documents changes in the data model. Please explain any changes to the
 data model as well as any custom migrations.
 
 ## WordPress 51
+- @aerych 2016-08-12
+- Added `algoritym` optional string field to `ReaderAbstractTopic`.
+- Added `railcar` optional NSData field to `ReaderPost`.
 - @aerych 2016-08-05
 - Removed `ReaderSite` entity.
 - @aerych 2016-07-19

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,7 +5,7 @@ data model as well as any custom migrations.
 
 ## WordPress 51
 - @aerych 2016-08-12
-- Added `algoritym` optional string field to `ReaderAbstractTopic`.
+- Added `algorithm` optional string field to `ReaderAbstractTopic`.
 - Added `railcar` optional NSData field to `ReaderPost`.
 - @aerych 2016-08-05
 - Removed `ReaderSite` entity.

--- a/Podfile
+++ b/Podfile
@@ -49,7 +49,7 @@ abstract_target 'WordPress_Base' do
     pod 'Simperium', '0.8.15'
     pod 'WPMediaPicker', '~> 0.10.1'
     pod 'WordPress-iOS-Editor', '1.8'
-    pod 'WordPressCom-Analytics-iOS', '0.1.17'
+    pod 'WordPressCom-Analytics-iOS', '0.1.18'
     pod 'WordPressCom-Stats-iOS', '0.7.6'
     pod 'wpxmlrpc', '~> 0.8'
     

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -161,7 +161,7 @@ PODS:
     - WordPressCom-Analytics-iOS (~> 0.1.0)
   - WordPress-iOS-Shared (0.6.0):
     - CocoaLumberjack (~> 2.2.0)
-  - WordPressCom-Analytics-iOS (0.1.17)
+  - WordPressCom-Analytics-iOS (0.1.18)
   - WordPressCom-Stats-iOS (0.7.6):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
@@ -219,7 +219,7 @@ DEPENDENCIES:
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
   - WordPress-iOS-Editor (= 1.8)
   - WordPress-iOS-Shared (= 0.6.0)
-  - WordPressCom-Analytics-iOS (= 0.1.17)
+  - WordPressCom-Analytics-iOS (= 0.1.18)
   - WordPressCom-Stats-iOS (= 0.7.6)
   - WordPressCom-Stats-iOS/Services (= 0.7.6)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.4`)
@@ -282,12 +282,12 @@ SPEC CHECKSUMS:
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
   WordPress-iOS-Editor: 50a09646fb62af3efdbb56d13ff656272a079066
   WordPress-iOS-Shared: f799334b41f3af509ccb76d7970f8c74a7716f14
-  WordPressCom-Analytics-iOS: 02c94167d80f43684bdc83cf8df2f4b6fc0909ba
+  WordPressCom-Analytics-iOS: f8e3823c3d528d5238bfe6721cd0d67b9e7cc4f6
   WordPressCom-Stats-iOS: 2689a457fd18268d36266fca76e96dd13e4af991
   WordPressComKit: 0742c47e5b55bff0e6d26d40db9e010404675a73
   WPMediaPicker: 645ecc2435293cc898c76180f3994358a68cae20
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: f05cafce394f51695d6fd1dc03f79c83dafdd8ca
+PODFILE CHECKSUM: f805b5577a33aac2204eccd964f59dbbfcb7883b
 
 COCOAPODS: 1.0.1

--- a/WordPress/Classes/Models/ReaderAbstractTopic.swift
+++ b/WordPress/Classes/Models/ReaderAbstractTopic.swift
@@ -8,6 +8,7 @@ import CoreData
 
     // Properties
     @NSManaged public var preserveForRestoration: Bool
+    @NSManaged public var algorithm: String?
     @NSManaged public var following: Bool
     @NSManaged public var lastSynced: NSDate?
     @NSManaged public var path: String

--- a/WordPress/Classes/Models/ReaderPost.h
+++ b/WordPress/Classes/Models/ReaderPost.h
@@ -57,7 +57,7 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 @property (nonatomic, strong) ReaderCrossPostMeta *crossPostMeta;
 @property (nonatomic, strong) NSString *railcar;
 
-// For use tracking when a post was rendered (displayed) and bumping the train tracks rendered event.
+// Used for tracking when a post is rendered (displayed), and bumping the train tracks rendered event.
 @property (nonatomic) BOOL rendered;
 
 - (BOOL)isCrossPost;

--- a/WordPress/Classes/Models/ReaderPost.h
+++ b/WordPress/Classes/Models/ReaderPost.h
@@ -55,6 +55,7 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 @property (nonatomic) NSNumber *wordCount;
 @property (nonatomic) NSNumber *readingTime;
 @property (nonatomic, strong) ReaderCrossPostMeta *crossPostMeta;
+@property (nonatomic, strong) NSString *railcar;
 
 - (BOOL)isCrossPost;
 - (BOOL)isPrivate;

--- a/WordPress/Classes/Models/ReaderPost.h
+++ b/WordPress/Classes/Models/ReaderPost.h
@@ -57,6 +57,9 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 @property (nonatomic, strong) ReaderCrossPostMeta *crossPostMeta;
 @property (nonatomic, strong) NSString *railcar;
 
+// For use tracking when a post was rendered (displayed) and bumping the train tracks rendered event.
+@property (nonatomic) BOOL rendered;
+
 - (BOOL)isCrossPost;
 - (BOOL)isPrivate;
 - (NSString *)authorString;
@@ -65,6 +68,7 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 - (void)fetchAvatarWithSize:(CGSize)size success:(void (^)(UIImage *image))success;
 - (BOOL)contentIncludesFeaturedImage;
 - (BOOL)isSourceAttributionWPCom;
+- (NSDictionary *)railcarDictionary;
 
 @end
 

--- a/WordPress/Classes/Models/ReaderPost.m
+++ b/WordPress/Classes/Models/ReaderPost.m
@@ -57,6 +57,7 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
 @dynamic crossPostMeta;
 @dynamic railcar;
 
+@synthesize rendered;
 
 - (BOOL)isCrossPost
 {
@@ -287,6 +288,21 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
 - (BOOL)isCommentCrossPost
 {
     return self.crossPostMeta.commentURL.length > 0;
+}
+
+- (NSDictionary *)railcarDictionary
+{
+    if (!self.railcar) {
+        return nil;
+    }
+
+    NSData *jsonData = [self.railcar dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *error;
+    id jsonObj = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+    if ([jsonObj isKindOfClass:[NSDictionary class]]) {
+        return (NSDictionary *)jsonObj;
+    }
+    return nil;
 }
 
 

--- a/WordPress/Classes/Models/ReaderPost.m
+++ b/WordPress/Classes/Models/ReaderPost.m
@@ -55,6 +55,7 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
 @dynamic wordCount;
 @dynamic readingTime;
 @dynamic crossPostMeta;
+@dynamic railcar;
 
 
 - (BOOL)isCrossPost

--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.h
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.h
@@ -8,29 +8,33 @@
 /**
  Fetches the posts from the specified remote endpoint
 
+ @param algorithm meta data used in paging
  @param count number of posts to fetch.
  @param before the date to fetch posts before.
  @param success block called on a successful fetch.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
 - (void)fetchPostsFromEndpoint:(NSURL *)endpoint
+                     algorithm:(NSString *)algorithm
                          count:(NSUInteger)count
                         before:(NSDate *)date
-                       success:(void (^)(NSArray<RemoteReaderPost *> *posts))success
+                       success:(void (^)(NSArray<RemoteReaderPost *> *posts, NSString *algorithm))success
                        failure:(void (^)(NSError *error))failure;
 
 /**
  Fetches the posts from the specified remote endpoint
 
+ @param algorithm meta data used in paging
  @param count number of posts to fetch.
  @param offset The offset of the fetch.
  @param success block called on a successful fetch.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
 - (void)fetchPostsFromEndpoint:(NSURL *)endpoint
+                     algorithm:(NSString *)algorithm
                          count:(NSUInteger)count
                         offset:(NSUInteger)offset
-                       success:(void (^)(NSArray<RemoteReaderPost *> *))success
+                       success:(void (^)(NSArray<RemoteReaderPost *> *posts, NSString *algorithm))success
                        failure:(void (^)(NSError *))failure;
 
 /**

--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -80,6 +80,8 @@ NSString * const ParamKeyMeta = @"meta";
 NSString * const ParamKeyNumber = @"number";
 NSString * const ParamKeyOffset = @"offset";
 NSString * const ParamKeyOrder = @"order";
+NSString * const ParamKeyDescending = @"DESC";
+NSString * const ParamKeyMetaValue = @"site,feed";
 
 static const NSInteger AvgWordsPerMinuteRead = 250;
 static const NSInteger MinutesToReadThreshold = 2;
@@ -98,8 +100,8 @@ static const NSUInteger ReaderPostTitleLength = 30;
     NSMutableDictionary *params = [@{
                                      ParamKeyNumber:numberToFetch,
                                      ParamKeyBefore: [DateUtils isoStringFromDate:date],
-                                     ParamKeyOrder: @"DESC",
-                                     ParamKeyMeta:@"site,feed"
+                                     ParamKeyOrder: ParamKeyDescending,
+                                     ParamKeyMeta: ParamKeyMetaValue
                                      } mutableCopy];
     if (algorithm) {
         params[ParamsKeyAlgorithm] = algorithm;
@@ -118,8 +120,8 @@ static const NSUInteger ReaderPostTitleLength = 30;
     NSMutableDictionary *params = [@{
                                      ParamKeyNumber:@(count),
                                      ParamKeyOffset: @(offset),
-                                     ParamKeyOrder: @"DESC",
-                                     ParamKeyMeta:@"site,feed"
+                                     ParamKeyOrder: ParamKeyDescending,
+                                     ParamKeyMeta: ParamKeyMetaValue
                                      } mutableCopy];
     if (algorithm) {
         params[ParamsKeyAlgorithm] = algorithm;

--- a/WordPress/Classes/Networking/Remote Objects/RemoteReaderPost.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteReaderPost.h
@@ -45,6 +45,7 @@
 @property (nonatomic) BOOL isJetpack;
 @property (nonatomic) NSNumber *wordCount;
 @property (nonatomic) NSNumber *readingTime;
+@property (nonatomic, strong) NSString *railcar;
 
 // Base Post Model
 @property (nonatomic, strong) NSString *author;

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -94,10 +94,10 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
 }
 
 
-- (void)updateTopic:(NSManagedObjectID *)topicID withAlgorithm:(NSString *)algorithm
+- (void)updateTopic:(NSManagedObjectID *)topicObjectID withAlgorithm:(NSString *)algorithm
 {
     NSError *error;
-    ReaderAbstractTopic *topic = (ReaderAbstractTopic *)[self.managedObjectContext existingObjectWithID:topicID error:&error];
+    ReaderAbstractTopic *topic = (ReaderAbstractTopic *)[self.managedObjectContext existingObjectWithID:topicObjectID error:&error];
     topic.algorithm = algorithm;
 
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
@@ -111,6 +111,8 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
                    failure:(void (^)(NSError *error))failure
 {
     // Don't pass the algorithm if fetching a brand new list.
+    // When fetching the beginning of a date ordered list the date passed will "now".
+    // If the passed date is equal to the current date we know we're starting from scratch.
     NSString *reqAlgorithm = [date isEqualToDate:[NSDate date]] ? nil : topic.algorithm;
 
     NSManagedObjectID *topicObjectID = topic.objectID;

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -210,7 +210,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
         }
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
 
-
+        NSDictionary *railcar = [readerPost railcarDictionary];
         // Define success block.
         NSNumber *postID = readerPost.postID;
         NSNumber *siteID = readerPost.siteID;
@@ -222,6 +222,9 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
                                               };
                 if (like) {
                     [WPAppAnalytics track:WPAnalyticsStatReaderArticleLiked withProperties:properties];
+                    if (railcar) {
+                        [WPAppAnalytics trackTrainTracksInteraction:WPAnalyticsStatReaderArticleLiked withProperties:railcar];
+                    }
                 } else {
                     [WPAppAnalytics track:WPAnalyticsStatReaderArticleUnliked withProperties:properties];
                 }

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -111,7 +111,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
                    failure:(void (^)(NSError *error))failure
 {
     // Don't pass the algorithm if fetching a brand new list.
-    // When fetching the beginning of a date ordered list the date passed will "now".
+    // When fetching the beginning of a date ordered list the date passed is "now".
     // If the passed date is equal to the current date we know we're starting from scratch.
     NSString *reqAlgorithm = [date isEqualToDate:[NSDate date]] ? nil : topic.algorithm;
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.h
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.h
@@ -3,4 +3,6 @@
 
 @interface WPAnalyticsTrackerAutomatticTracks : NSObject<WPAnalyticsTracker>
 
++ (NSString *)eventNameForStat:(WPAnalyticsStat)stat;
+
 @end

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -30,6 +30,12 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
 
 @implementation WPAnalyticsTrackerAutomatticTracks
 
++ (NSString *)eventNameForStat:(WPAnalyticsStat)stat
+{
+    WPAnalyticsTrackerAutomatticTracks *tracker = [WPAnalyticsTrackerAutomatticTracks new];
+    return [tracker eventPairForStat:stat].eventName;
+}
+
 - (instancetype)init
 {
     self = [super init];
@@ -795,6 +801,12 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
             break;
         case WPAnalyticsStatThemesSupportAccessed:
             eventName = @"themes_support_accessed";
+            break;
+        case WPAnalyticsStatTrainTracksInteract:
+            eventName = @"traintracks_interact";
+            break;
+        case WPAnalyticsStatTrainTracksRender:
+            eventName = @"traintracks_render";
             break;
         case WPAnalyticsStatTwoFactorCodeRequested:
             eventName = @"two_factor_code_requested";

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -32,8 +32,7 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
 
 + (NSString *)eventNameForStat:(WPAnalyticsStat)stat
 {
-    WPAnalyticsTrackerAutomatticTracks *tracker = [WPAnalyticsTrackerAutomatticTracks new];
-    return [tracker eventPairForStat:stat].eventName;
+    return [self eventPairForStat:stat].eventName;
 }
 
 - (instancetype)init
@@ -53,7 +52,7 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
 
 - (void)track:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties
 {
-    TracksEventPair *eventPair = [self eventPairForStat:stat];
+    TracksEventPair *eventPair = [[self class] eventPairForStat:stat];
     if (!eventPair) {
         DDLogInfo(@"WPAnalyticsStat not supported by WPAnalyticsTrackerAutomatticTracks: %@", @(stat));
         return;
@@ -155,7 +154,7 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
     return _anonymousID;
 }
 
-- (TracksEventPair *)eventPairForStat:(WPAnalyticsStat)stat
++ (TracksEventPair *)eventPairForStat:(WPAnalyticsStat)stat
 {
     NSString *eventName;
     NSDictionary *eventProperties;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -1025,7 +1025,12 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatMenusSavedMenu:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Menus - Menu Saved"];
             break;
-            
+
+        case WPAnalyticsStatTrainTracksInteract:
+        case WPAnalyticsStatTrainTracksRender:
+            // Do nothing. These events are just for Tracks.
+            break;
+
             // to be implemented with the sign in refactor
         case WPAnalyticsStatLoginMagicLinkExited:
         case WPAnalyticsStatLoginMagicLinkFailed:

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -70,6 +70,11 @@ extern NSString * const WPAppAnalyticsKeyIsJetpack;
  */
 + (void)track:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties withBlogID:(NSNumber*)blogID;
 
+/**
+    @brief      Used only for bumping the TrainTracks interaction event. The stat's
+                event name is passed as an "action" property.
+ */
++ (void)trackTrainTracksInteraction:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties;
 
 /**
  *  @brief      Pass-through methods to WPAnalytics

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -201,7 +201,7 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
     } else {
         mutableProperties = [NSMutableDictionary new];
     }
-    // TrainTracks are specific to the AutomaticTracks tracker.
+    // TrainTracks are specific to the AutomatticTracks tracker.
     // The action property should be the event string for the stat.
     // Other trackers should ignore `WPAnalyticsStatTrainTracksInteract`
     NSString *eventName = [WPAnalyticsTrackerAutomatticTracks eventNameForStat:stat];

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -193,6 +193,23 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
     }
 }
 
++ (void)trackTrainTracksInteraction:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties
+{
+    NSMutableDictionary *mutableProperties;
+    if (properties) {
+        mutableProperties = [NSMutableDictionary dictionaryWithDictionary:properties];
+    } else {
+        mutableProperties = [NSMutableDictionary new];
+    }
+    // TrainTracks are specific to the AutomaticTracks tracker.
+    // The action property should be the event string for the stat.
+    // Other trackers should ignore `WPAnalyticsStatTrainTracksInteract`
+    NSString *eventName = [WPAnalyticsTrackerAutomatticTracks eventNameForStat:stat];
+    [mutableProperties setObject:eventName forKey:@"action"];
+
+    [self track:WPAnalyticsStatTrainTracksInteract withProperties:mutableProperties];
+}
+
 /**
  *  @brief      Pass-through method to [WPAnalytics track:stat]. Use this method instead of calling WPAnalytics directly.
  */

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -756,6 +756,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 {
     __typeof(self) __weak weakSelf = self;
     ReaderPost *post = self.post;
+    NSDictionary *railcar = post.railcarDictionary;
     void (^successBlock)() = ^void() {
         NSMutableDictionary *properties = [NSMutableDictionary dictionary];
         properties[WPAppAnalyticsKeyBlogID] = post.siteID;
@@ -766,7 +767,9 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
             properties[WPAppAnalyticsKeyFeedItemID] = post.feedItemID;
         }
         [WPAppAnalytics track:WPAnalyticsStatReaderArticleCommentedOn withProperties:properties];
-
+        if (railcar) {
+            [WPAppAnalytics trackTrainTracksInteraction:WPAnalyticsStatTrainTracksInteract withProperties:railcar];
+        }
         [weakSelf.tableView deselectSelectedRowWithAnimation:YES];
         [weakSelf refreshReplyTextViewPlaceholder];
     };

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -738,10 +738,17 @@ public class ReaderDetailViewController : UIViewController, UIViewControllerRest
         let isOfflineView = ReachabilityUtils.isInternetReachable() ? "no" : "yes"
         let detailType = post!.topic?.type == ReaderSiteTopic.TopicType ? DetailAnalyticsConstants.TypePreviewSite : DetailAnalyticsConstants.TypeNormal
 
+
         var properties = ReaderHelpers.statsPropertiesForPost(post!, andValue: nil, forKey: nil)
         properties[DetailAnalyticsConstants.TypeKey] = detailType
         properties[DetailAnalyticsConstants.OfflineKey] = isOfflineView
-        WPAppAnalytics.track(WPAnalyticsStat.ReaderArticleOpened, withProperties: properties)
+        WPAppAnalytics.track(.ReaderArticleOpened, withProperties: properties)
+
+        // We can remove the nil check and use `if let` when `ReaderPost` adopts nullibility.
+        let railcar = post?.railcarDictionary()
+        if railcar != nil {
+            WPAppAnalytics.trackTrainTracksInteraction(.ReaderArticleOpened, withProperties: railcar)
+        }
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1691,9 +1691,9 @@ extension ReaderStreamViewController : WPTableViewHandlerDelegate {
             WPAppAnalytics.track(.ReaderSearchResultTapped)
 
             // We can use `if let` when `ReaderPost` adopts nullability.
-            let railcard = apost.railcarDictionary()
-            if railcard != nil {
-                WPAppAnalytics.trackTrainTracksInteraction(.ReaderSearchResultTapped, withProperties: railcard)
+            let railcar = apost.railcarDictionary()
+            if railcar != nil {
+                WPAppAnalytics.trackTrainTracksInteraction(.ReaderSearchResultTapped, withProperties: railcar)
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1652,6 +1652,16 @@ extension ReaderStreamViewController : WPTableViewHandlerDelegate {
                 syncHelper.syncMoreContent()
             }
         }
+
+        // Bump the render tracker if necessary.
+        let posts = tableViewHandler.resultsController.fetchedObjects as! [ReaderPost]
+        let post = posts[indexPath.row]
+        let railcar = post.railcarDictionary()
+        if post.isKindOfClass(ReaderGapMarker) || railcar == nil || post.rendered {
+            return
+        }
+        post.rendered = true
+        WPAppAnalytics.track(.TrainTracksRender, withProperties: railcar)
     }
 
 
@@ -1679,6 +1689,12 @@ extension ReaderStreamViewController : WPTableViewHandlerDelegate {
 
         if let topic = post.topic where ReaderHelpers.isTopicSearchTopic(topic) {
             WPAppAnalytics.track(.ReaderSearchResultTapped)
+
+            // We can use `if let` when `ReaderPost` adopts nullability.
+            let railcard = apost.railcarDictionary()
+            if railcard != nil {
+                WPAppAnalytics.trackTrainTracksInteraction(.ReaderSearchResultTapped, withProperties: railcard)
+            }
         }
 
         var controller: ReaderDetailViewController

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 51.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 51.xcdatamodel/contents
@@ -482,6 +482,7 @@
         <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <entity name="ReaderAbstractTopic" representedClassName="WordPress.ReaderAbstractTopic" isAbstract="YES" syncable="YES">
+        <attribute name="algorithm" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="following" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="lastSynced" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="path" attributeType="String" indexed="YES" syncable="YES"/>
@@ -537,6 +538,7 @@
         <attribute name="postAvatar" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="primaryTag" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="primaryTagSlug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="railcar" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="readingTime" optional="YES" attributeType="Integer 16" defaultValueString="0" syncable="YES"/>
         <attribute name="score" optional="YES" attributeType="Double" defaultValueString="0.0" syncable="YES"/>
         <attribute name="siteIconURL" optional="YES" attributeType="String" syncable="YES"/>
@@ -641,12 +643,12 @@
         <element name="PostType" positionX="27" positionY="153" width="128" height="105"/>
         <element name="PublicizeConnection" positionX="27" positionY="162" width="128" height="330"/>
         <element name="PublicizeService" positionX="18" positionY="153" width="128" height="195"/>
-        <element name="ReaderAbstractTopic" positionX="9" positionY="153" width="128" height="165"/>
+        <element name="ReaderAbstractTopic" positionX="9" positionY="153" width="128" height="180"/>
         <element name="ReaderCrossPostMeta" positionX="18" positionY="153" width="128" height="135"/>
         <element name="ReaderDefaultTopic" positionX="18" positionY="162" width="128" height="45"/>
         <element name="ReaderGapMarker" positionX="18" positionY="153" width="128" height="45"/>
         <element name="ReaderListTopic" positionX="45" positionY="189" width="128" height="135"/>
-        <element name="ReaderPost" positionX="0" positionY="0" width="128" height="630"/>
+        <element name="ReaderPost" positionX="0" positionY="0" width="128" height="645"/>
         <element name="ReaderSearchSuggestion" positionX="36" positionY="162" width="128" height="75"/>
         <element name="ReaderSearchTopic" positionX="27" positionY="153" width="128" height="45"/>
         <element name="ReaderSiteTopic" positionX="36" positionY="180" width="128" height="210"/>


### PR DESCRIPTION
Fixes #5817 

To test: 
Build the app.  Confirm there are no errors. 
Set breakpoints where the new trackers are added.  Confirm that the events are fired appropriately. (Currently only search results contain railcars so test via reader search results.)
Confirm that render events are only fired once over the lifetime of the instance of a post.  

Needs review: @kurzee  could I trouble you for a (down to the wire) review? 
