### PR TITLE
Issues/5867 search history

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -151,6 +151,9 @@ import WordPressShared
         ReaderTopicService(managedObjectContext: context).deleteAllTopics()
         ReaderPostService(managedObjectContext: context).deletePostsWithNoTopic()
 
+        // Clean up stale search history
+        ReaderSearchSuggestionService(managedObjectContext: context).deleteAllSuggestions()
+
         // Sync the menu fresh
         syncTopics()
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
@@ -7,7 +7,6 @@ import WordPressShared
 protocol ReaderSearchSuggestionsDelegate
 {
     func searchSuggestionsController(controller: ReaderSearchSuggestionsViewController, selectedItem: String)
-    func clearSuggestionsForSearchController(controller: ReaderSearchSuggestionsViewController)
 }
 
 
@@ -176,7 +175,9 @@ extension ReaderSearchSuggestionsViewController : WPTableViewHandlerDelegate
 
 
     func configureCell(cell: UITableViewCell, atIndexPath indexPath: NSIndexPath) {
-        let suggestions = tableViewHandler.resultsController.fetchedObjects as! [ReaderSearchSuggestion]
+        guard let suggestions = tableViewHandler.resultsController.fetchedObjects as? [ReaderSearchSuggestion] else {
+            return
+        }
         let suggestion = suggestions[indexPath.row]
         cell.textLabel?.text = suggestion.searchPhrase
         cell.textLabel?.textColor = WPStyleGuide.darkGrey()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -324,9 +324,4 @@ extension ReaderSearchViewController : ReaderSearchSuggestionsDelegate {
         performSearch()
     }
 
-
-    func clearSuggestionsForSearchController(controller: ReaderSearchSuggestionsViewController) {
-        let service = ReaderSearchSuggestionService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        service.deleteAllSuggestions()
-    }
 }


### PR DESCRIPTION
Fixes #5867 

To test:
Start signed in to wpcom
- Search for something in the reader.  Confirm the search term you entered is saved and appears as an option in the drop down if you search again. 
- Signout of wpcom. 
- Return to the reader search screen. Confirm that your previously entered search term is absent. 
- Perform a new search and confirm the search term appears as an option in the drop down if you search again. 
- Sign in to wpcom.
- Return to the reader search screen. Confirm that your previously entered search term is absent. 

Needs review: @nheagy would you be game for a quick review? 
