### PR TITLE
Issues/5868 sort by offset

### DIFF
--- a/WordPress/Classes/Models/ReaderPost.h
+++ b/WordPress/Classes/Models/ReaderPost.h
@@ -34,7 +34,8 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 @property (nonatomic, strong) NSNumber *likeCount;
 @property (nonatomic, strong) NSNumber *score;
 @property (nonatomic, strong) NSNumber *siteID;
-// Normalizes sorting between score or sortDate depending on the flavor of post.
+// Normalizes sorting between offset or sortDate depending on the flavor of post.
+// Note that this can store a negative value.
 @property (nonatomic, strong) NSNumber *sortRank;
 // Normalizes the date to sort by depending on the flavor of post.
 @property (nonatomic, strong) NSDate *sortDate;

--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -9,6 +9,8 @@
 #import "WordPress-Swift.h"
 #import "PhotonImageURLHelper.h"
 
+CGFloat const ReaderPostServiceRemotOffsetRankCap = 1000000.0;
+
 // REST Post dictionary keys
 NSString * const PostRESTKeyAttachments = @"attachments";
 NSString * const PostRESTKeyAuthor = @"author";
@@ -221,17 +223,27 @@ static const NSUInteger ReaderPostTitleLength = 30;
                            failure:(void (^)(NSError *))failure
 {
     NSString *path = [endpoint absoluteString];
-    
     [self.wordPressComRestApi GET:path
            parameters:params
               success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                   if (!success) {
                       return;
                   }
+
+                  // NOTE: If an offset param was specified sortRank will be derived
+                  // from the offset + order of the results.
+                  BOOL rankByOffset = [params objectForKey:@"offset"] != nil;
+                  __block CGFloat offset = [[params numberForKey:@"offset"] floatValue];
                   NSString *algorithm = [responseObject stringForKey:ParamsKeyAlgorithm];
                   NSArray *jsonPosts = [responseObject arrayForKey:PostRESTKeyPosts];
                   NSArray *posts = [jsonPosts wp_map:^id(NSDictionary *jsonPost) {
+                      if (rankByOffset) {
+                          RemoteReaderPost *post = [self formatPostDictionary:jsonPost offset:offset];
+                          offset++;
+                          return post;
+                      }
                       return [self formatPostDictionary:jsonPost];
+
                   }];
                   success(posts, algorithm);
 
@@ -240,6 +252,17 @@ static const NSUInteger ReaderPostTitleLength = 30;
                       failure(error);
                   }
               }];
+}
+
+- (RemoteReaderPost *)formatPostDictionary:(NSDictionary *)dict offset:(CGFloat)offset
+{
+    RemoteReaderPost *post = [self formatPostDictionary:dict];
+    // Its assumed that sortRank values are in descending order. Since
+    // offsets are ascending, we subtract the offset from an arbitrarily
+    // high value to ensure we get a proper sort order.
+    CGFloat adjustedOffset = ReaderPostServiceRemotOffsetRankCap - offset;
+    post.sortRank = @(adjustedOffset);
+    return post;
 }
 
 /**
@@ -284,7 +307,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
     post.score = [dict numberForKey:PostRESTKeyScore];
     post.siteID = [dict numberForKey:PostRESTKeySiteID];
     post.sortDate = [self sortDateFromPostDictionary:dict];
-    post.sortRank = [self sortRankFromScore:post.score orSortDate:post.sortDate];
+    post.sortRank = @(post.sortDate.timeIntervalSinceReferenceDate);
     post.status = [self stringOrEmptyString:[dict stringForKey:PostRESTKeyStatus]];
     post.summary = [self postSummaryFromPostDictionary:dict orPostContent:post.content];
     post.tags = [self tagsFromPostDictionary:dict];
@@ -760,21 +783,6 @@ static const NSUInteger ReaderPostTitleLength = 30;
 }
 
 /**
- Derive a sort rank from either the score or the sortDate.
- 
- @param score The search score of a post. 
- @param sortDate The sort date of the post.
- @return A numeric sort rank (double) as an NSNumber.
- */
-- (NSNumber *)sortRankFromScore:(NSNumber *)score orSortDate:(NSDate *)sortDate
-{
-    if (score > 0) {
-        return score;
-    }
-    return @(sortDate.timeIntervalSinceReferenceDate);
-}
-
-/**
  Retrives the privacy preference for the post's site.
 
  @param dict A dictionary representing a post object from the REST API.
@@ -798,9 +806,6 @@ static const NSUInteger ReaderPostTitleLength = 30;
         return [dict stringForKey:PostRESTKeySlug];
     }];
 }
-
-
-
 
 
 #pragma mark - Content Formatting and Sanitization

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -604,15 +604,6 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
                 NSSet *existingGlobalIDs = [self globalIDsOfExistingPostsForTopic:readerTopic];
                 NSSet *newGlobalIDs = [self globalIDsOfRemotePosts:posts];
                 overlap = [existingGlobalIDs intersectsSet:newGlobalIDs];
-
-                // A strategy to avoid false positives in gap detection is to sync
-                // one extra post. Only remove the extra post if we received a
-                // full set of results. A partial set means we've reached
-                // the end of syncable content.
-                if ([posts count] == [self numberToSyncForTopic:readerTopic]) {
-                    posts = [posts subarrayWithRange:NSMakeRange(0, [posts count] - 2)];
-                    postsCount = [posts count];
-                }
             }
 
             // Create or update the synced posts.
@@ -732,6 +723,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
 
     // There should only ever be one, but loop over all results just in case.
     for (ReaderGapMarker *marker in results) {
+        DDLogInfo(@"Deleting Gap Marker: %@", marker);
         [self.managedObjectContext deleteObject:marker];
     }
 }
@@ -905,6 +897,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     // If the last remaining post is a gap marker, remove it.
     ReaderPost *lastPost = [posts objectAtIndex:maxPosts - 1];
     if ([lastPost isKindOfClass:[ReaderGapMarker class]]) {
+        DDLogInfo(@"Deleting Last GapMarker: %@", lastPost);
         [self.managedObjectContext deleteObject:lastPost];
     }
 }
@@ -976,10 +969,12 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     fetchRequest.predicate = [NSPredicate predicateWithFormat:@"globalID = %@ AND topic = %@", globalID, topic];
     NSArray *arr = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
 
+    BOOL existing = false;
     if (error) {
         DDLogError(@"Error fetching an existing reader post. - %@", error);
     } else if ([arr count] > 0) {
         post = (ReaderPost *)[arr objectAtIndex:0];
+        existing = true;
     } else {
         post = [NSEntityDescription insertNewObjectForEntityForName:@"ReaderPost"
                                              inManagedObjectContext:self.managedObjectContext];
@@ -1015,7 +1010,16 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     post.score = remotePost.score;
     post.siteID = remotePost.siteID;
     post.sortDate = remotePost.sortDate;
-    post.sortRank = remotePost.sortRank;
+
+    if (!existing) {
+        // Failsafe.  The `read/searc` endpoint might return the same post on
+        // more than one page. If this happens preserve the *original* sortRank
+        // to avoid content jumping around in the UI.
+        // Posts from other endpoits will store a date value which shouldn't
+        // change anyway.
+        post.sortRank = remotePost.sortRank;
+    }
+
     post.status = remotePost.status;
     post.summary = remotePost.summary;
     post.tags = remotePost.tags;

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -1012,10 +1012,10 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     post.sortDate = remotePost.sortDate;
 
     if (!existing) {
-        // Failsafe.  The `read/searc` endpoint might return the same post on
+        // Failsafe.  The `read/search` endpoint might return the same post on
         // more than one page. If this happens preserve the *original* sortRank
         // to avoid content jumping around in the UI.
-        // Posts from other endpoits will store a date value which shouldn't
+        // Posts from other endpoints will store a date value which shouldn't
         // change, ergo they should be unaffected.
         post.sortRank = remotePost.sortRank;
     }

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -1016,7 +1016,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
         // more than one page. If this happens preserve the *original* sortRank
         // to avoid content jumping around in the UI.
         // Posts from other endpoits will store a date value which shouldn't
-        // change anyway.
+        // change, ergo they should be unaffected.
         post.sortRank = remotePost.sortRank;
     }
 

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -43,6 +43,12 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 - (NSUInteger)numberOfSubscribedTopics;
 
 /**
+ Deletes all search topics from core data and saves the context.
+ Use to clean-up searches when they are finished.
+ */
+- (void)deleteAllSearchTopics;
+
+/**
  Deletes all topics that do not appear in the menu from core data and saves the context.
  Use to clean-up previewed topics that are lingering in core data.
  */

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -154,6 +154,25 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     return count;
 }
 
+- (void)deleteAllSearchTopics
+{
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ReaderSearchTopic classNameWithoutNamespaces]];
+
+    NSError *error;
+    NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
+    if (error) {
+        DDLogError(@"%@ error executing fetch request: %@", NSStringFromSelector(_cmd), error);
+        return;
+    }
+
+    for (ReaderAbstractTopic *topic in results) {
+        [self.managedObjectContext deleteObject:topic];
+    }
+    [self.managedObjectContext performBlockAndWait:^{
+        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+    }];
+}
+
 - (void)deleteNonMenuTopics
 {
     NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ReaderAbstractTopic classNameWithoutNamespaces]];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -69,6 +69,7 @@ import WordPressShared
         restorationIdentifier = self.dynamicType.restorationIdentifier
         restorationClass = self.dynamicType
 
+        cleanupStaleContent(removeAllTopics: false)
         setupRefreshControl()
         setupAccountChangeNotificationObserver()
     }
@@ -136,6 +137,20 @@ import WordPressShared
 
     // MARK: - Instance Methods
 
+    /// Clean up topics that do not belong in the menu and posts that have no topic
+    /// This is merely a convenient place to perform this task.
+    ///
+    func cleanupStaleContent(removeAllTopics removeAll: Bool) {
+        let context = ContextManager.sharedInstance().mainContext
+        ReaderPostService(managedObjectContext: context).deletePostsWithNoTopic()
+
+        if removeAll {
+            ReaderTopicService(managedObjectContext: context).deleteAllTopics()
+        } else {
+            ReaderTopicService(managedObjectContext: context).deleteNonMenuTopics()
+        }
+    }
+
 
     /// When logged out return the nav stack to the menu
     ///
@@ -147,11 +162,10 @@ import WordPressShared
         readerHasBeenPreviouslyViewed = false
 
         // Clean up obsolete content.
-        let context = ContextManager.sharedInstance().mainContext
-        ReaderTopicService(managedObjectContext: context).deleteAllTopics()
-        ReaderPostService(managedObjectContext: context).deletePostsWithNoTopic()
+        cleanupStaleContent(removeAllTopics: true)
 
         // Clean up stale search history
+        let context = ContextManager.sharedInstance().mainContext
         ReaderSearchSuggestionService(managedObjectContext: context).deleteAllSuggestions()
 
         // Sync the menu fresh

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -103,6 +103,17 @@ import Gridicons
     }
 
 
+    public override func didMoveToParentViewController(parent: UIViewController?) {
+        super.didMoveToParentViewController(parent)
+        if let _ = parent {
+            return
+        }
+        // When the parent is nil then we've been removed from the nav stack.
+        // Clean up any search topics at this point.
+        let context = ContextManager.sharedInstance().mainContext
+        ReaderTopicService(managedObjectContext: context).deleteAllSearchTopics()
+    }
+
     public override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
 
@@ -185,6 +196,8 @@ import Gridicons
             return
         }
 
+        let previousTopic = streamController.readerTopic
+
         let context = ContextManager.sharedInstance().mainContext
         let service = ReaderTopicService(managedObjectContext: context)
 
@@ -195,6 +208,10 @@ import Gridicons
         // Hide the starting label now that a topic has been set.
         label.hidden = true
         endSearch()
+
+        if let previousTopic = previousTopic {
+            service.deleteTopic(previousTopic)
+        }
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1092,6 +1092,15 @@ import WordPressComAnalytics
             return
         }
 
+        if ReaderHelpers.isTopicSearchTopic(topic) && topic.posts.count > 0 {
+            // We only perform an initial sync if the topic has no results.
+            // The rest of the time it should just support infinite scroll.
+            // Normal the newly added topic will have no existing posts. The
+            // exception is state restoration of a search topic that was being
+            // viewed when the app was backgrounded.
+            return
+        }
+
         let lastSynced = topic.lastSynced ?? NSDate(timeIntervalSince1970: 0)
         let interval = Int( NSDate().timeIntervalSinceDate(lastSynced))
         if canSync() && (interval >= refreshInterval || topic.posts.count == 0) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1285,11 +1285,13 @@ import WordPressComAnalytics
     }
 
 
-    public func cleanupAfterSync() {
+    public func cleanupAfterSync(refresh refresh: Bool = true) {
         syncIsFillingGap = false
         indexPathForGapMarker = nil
         cleanupAndRefreshAfterScrolling = false
-        tableViewHandler.refreshTableViewPreservingOffset()
+        if refresh {
+            tableViewHandler.refreshTableViewPreservingOffset()
+        }
         refreshControl.endRefreshing()
         footerView.showSpinner(false)
     }
@@ -1437,6 +1439,10 @@ extension ReaderStreamViewController : WPContentSyncHelperDelegate {
         cleanupAfterSync()
     }
 
+
+    public func syncContentFailed() {
+        cleanupAfterSync(refresh: false)
+    }
 }
 
 
@@ -1647,7 +1653,7 @@ extension ReaderStreamViewController : WPTableViewHandlerDelegate {
         // Check to see if we need to load more.
         let criticalRow = tableView.numberOfRowsInSection(indexPath.section) - loadMoreThreashold
         if (indexPath.section == tableView.numberOfSections - 1) && (indexPath.row >= criticalRow) {
-            if syncHelper.hasMoreContent {
+            if syncHelper.hasMoreContent && !syncHelper.isSyncing {
                 syncHelper.syncMoreContent()
             }
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1253,7 +1253,7 @@ import WordPressComAnalytics
         let earlierThan = post.sortDate
         let syncContext = ContextManager.sharedInstance().newDerivedContext()
         let service =  ReaderPostService(managedObjectContext: syncContext)
-
+        let offset = tableViewHandler.resultsController.fetchedObjects?.count ?? 0
         syncContext.performBlock {
             guard let topicInContext = (try? syncContext.existingObjectWithID(topic.objectID)) as? ReaderAbstractTopic else {
                 DDLogSwift.logError("Error: Could not retrieve an existing topic via its objectID")
@@ -1273,8 +1273,7 @@ import WordPressComAnalytics
             }
 
             if ReaderHelpers.isTopicSearchTopic(topicInContext) {
-                let offset = UInt(topicInContext.posts.count)
-                service.fetchPostsForTopic(topicInContext, atOffset: offset, deletingEarlier: false, success: successBlock, failure: failureBlock)
+                service.fetchPostsForTopic(topicInContext, atOffset: UInt(offset), deletingEarlier: false, success: successBlock, failure: failureBlock)
             } else {
                 service.fetchPostsForTopic(topicInContext, earlierThan: earlierThan, success: successBlock, failure: failureBlock)
             }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1170,7 +1170,7 @@ import WordPressComAnalytics
             }
 
             if ReaderHelpers.isTopicSearchTopic(topicInContext) {
-                service.fetchPostsForTopic(topicInContext, atOffset: 0, deletingEarlier: true, success: successBlock, failure: failureBlock)
+                service.fetchPostsForTopic(topicInContext, atOffset: 0, deletingEarlier: false, success: successBlock, failure: failureBlock)
             } else {
                 service.fetchPostsForTopic(topicInContext, earlierThan: NSDate(), success: successBlock, failure: failureBlock)
             }


### PR DESCRIPTION
Fixes #5868 
This also fixes a couple of issues impacting the UI.  
We were pruning some of the results (expected duplicates) to avoid doing unnecessary work but it was throwing counts off a bit. That code was removed.  
I also found that the search API sometimes returns the same post across multiple pages. When this happened the sortRank would get updated causing it to be shifted from its previous location, throwing off the placement of things in the UI. The effect was the content in the list would suddenly shift.  We no longer overwrite the original sortRank. 

To test:
Go to the reader search feature and perform a search. Scroll to invoke the infinite scroll behavior.  Confirm that the list performs as expected. 
Go to any non-search topic in the reader.  Confirm that the post continues to load as expected. 
Browse a high traffic tag like "art".  Wait about an hour or so for content to build up after your last visit.  Return to the list and let it load.  Confirm that a "gap marker" appears to let you fill in any content missing between what was just synced and what was previously synced.  Tap the gap marker and confirm that content loads correctly. 

Note:
I've noticed a couple of odd glitches with Search that I haven't been able to reproduce or guess the cause. In once instance a gap marker suddenly appeared after I'd been aggressively scrolling to load more.  In another instance, the loading spinner seemed to get "stuck".  I haven't been able to reproduce these more than once and it *might* have been related to either the previous logic.  Something we should watch for.

Needs review: @kurzee up for another one? 
