### PR TITLE
ReplyTextView: Overlap Glitch

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -307,6 +307,8 @@ extension NotificationDetailsViewController
             self?.replyCommentWithBlock(block, content: content)
         }
 
+        replyTextView.setContentCompressionResistancePriority(UILayoutPriorityRequired, forAxis: .Vertical)
+
         self.replyTextView = replyTextView
     }
 


### PR DESCRIPTION
To test:
1. Open a Comment-Y notification. Please, note that it's contents should cover most of the screen.
2. Tap over the Reply field
3. Enter several new lines

Please, verify, that the Reply field grows, and that it doesn't remain in a single line.

Needs review: @kurzee 
Brent, may i bug you with a hopefully painful review?

Thanks in advance!


