### PR TITLE
Aztec/36 feature flag and setting for aztec editor

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/WordPress.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<false/>
+</dict>
+</plist>

--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -2,6 +2,7 @@
 /// different builds.
 @objc
 enum FeatureFlag: Int {
+    case NativeEditor
     case ExampleFeature
 
     /// Returns a boolean indicating if the feature is enabled
@@ -9,6 +10,12 @@ enum FeatureFlag: Int {
         switch self {
         case .ExampleFeature:
             return true
+        case .NativeEditor:
+            // At the moment this is only active in debug mode
+            if build(.Debug) {
+                return true
+            }
+            return false
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -123,7 +123,8 @@ public class AppSettingsViewController: UITableViewController {
             } else {
                 WPAnalytics.track(.EditorToggledOff)
             }
-            WPPostViewController.setNewEditorEnabled(enabled)            
+            WPPostViewController.setNewEditorEnabled(enabled)
+            self.handler.viewModel = self.tableViewModel()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -53,11 +53,22 @@ public class AppSettingsViewController: UITableViewController {
         )
 
         let editorHeader = NSLocalizedString("Editor", comment: "Title label for the editor settings section in the app settings")
+        var editorRows = [ImmuTableRow]()
         let visualEditor = SwitchRow(
             title: NSLocalizedString("Visual Editor", comment: "Option to enable the visual editor"),
             value: WPPostViewController.isNewEditorEnabled(),
             onChange: visualEditorChanged()
         )
+        editorRows.append(visualEditor)
+
+        if FeatureFlag.NativeEditor.enabled && WPPostViewController.isNewEditorEnabled() {
+            let nativeEditor = SwitchRow(
+                title: NSLocalizedString("Native Editor", comment: "Option to enable the native visual editor"),
+                value: WPPostViewController.isNativeEditorEnabled(),
+                onChange: nativeEditorChanged()
+            )
+            editorRows.append(nativeEditor)
+        }
 
         let aboutHeader = NSLocalizedString("About", comment: "Link to About section (contains info about the app)")
         let aboutApp = NavigationItemRow(
@@ -75,9 +86,7 @@ public class AppSettingsViewController: UITableViewController {
                 footerText: nil),
             ImmuTableSection(
                 headerText: editorHeader,
-                rows: [
-                    visualEditor
-                ],
+                rows: editorRows,
                 footerText: nil),
             ImmuTableSection(
                 headerText: aboutHeader,
@@ -114,7 +123,14 @@ public class AppSettingsViewController: UITableViewController {
             } else {
                 WPAnalytics.track(.EditorToggledOff)
             }
-            WPPostViewController.setNewEditorEnabled(enabled)
+            WPPostViewController.setNewEditorEnabled(enabled)            
+        }
+    }
+
+    func nativeEditorChanged() -> Bool -> Void {
+        return {
+            enabled in
+            WPPostViewController.setNativeEditorEnabled(enabled)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -320,11 +320,17 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
         let navController : UINavigationController
 
         if EditPageViewController.isNewEditorEnabled() {
-            let postViewController = EditPageViewController(draftForBlog: blog)
+            let postViewController: UIViewController
+            if WPPostViewController.isNativeEditorEnabled() {
+                postViewController = AztecPostViewController()
+                navController = UINavigationController(rootViewController: postViewController)
+            } else {
+                postViewController = EditPageViewController(draftForBlog: blog)
 
-            navController = UINavigationController(rootViewController: postViewController)
-            navController.restorationIdentifier = WPEditorNavigationRestorationID
-            navController.restorationClass = EditPageViewController.self
+                navController = UINavigationController(rootViewController: postViewController)
+                navController.restorationIdentifier = WPEditorNavigationRestorationID
+                navController.restorationClass = EditPageViewController.self
+            }
         } else {
             let editPostViewController = WPLegacyEditPageViewController(draftForLastUsedBlog: ())
 
@@ -344,7 +350,12 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
         WPAnalytics.track(.PostListEditAction, withProperties: propertiesForAnalytics())
 
         if EditPageViewController.isNewEditorEnabled() {
-            let pageViewController = EditPageViewController(post: apost, mode: kWPPostViewControllerModePreview)
+            let pageViewController: UIViewController
+            if WPPostViewController.isNativeEditorEnabled() {
+                pageViewController = AztecPostViewController()
+            } else {
+                pageViewController = EditPageViewController(post: apost, mode: kWPPostViewControllerModePreview)
+            }
 
             navigationController?.pushViewController(pageViewController, animated: true)
         } else {

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1,0 +1,17 @@
+import Foundation
+import UIKit
+
+class AztecPostViewController: UIViewController
+{
+    override func viewDidLoad() {
+        title = NSLocalizedString("Aztec Native Editor", comment: "")
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Done,
+                                                                target: self,
+                                                                action: #selector(AztecPostViewController.closeAction))
+        view.backgroundColor = UIColor.whiteColor()
+    }
+
+    func closeAction(sender: AnyObject) {
+        presentingViewController?.dismissViewControllerAnimated(true, completion: nil)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -355,10 +355,22 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
 
     override func createPost() {
         if WPPostViewController.isNewEditorEnabled() {
-            createPostInNewEditor()
+            if WPPostViewController.isNativeEditorEnabled() {
+                createPostInNativeEditor()
+            } else {
+                createPostInNewEditor()
+            }
         } else {
             createPostInOldEditor()
         }
+    }
+
+    private func createPostInNativeEditor() {
+        let postViewController = AztecPostViewController()
+        let navController = UINavigationController(rootViewController: postViewController)
+        navController.modalPresentationStyle = .FullScreen
+        presentViewController(navController, animated: true, completion: nil)
+        WPAppAnalytics.track(.EditorCreatedPost, withProperties: ["tap_source": "posts_view"], withBlog: blog)
     }
 
     private func createPostInNewEditor() {
@@ -411,6 +423,13 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         WPAnalytics.track(.PostListEditAction, withProperties: propertiesForAnalytics())
 
         if WPPostViewController.isNewEditorEnabled() {
+            if (WPPostViewController.isNativeEditorEnabled()) {
+                let postViewController = AztecPostViewController()
+                let navController = UINavigationController(rootViewController: postViewController)
+                navController.modalPresentationStyle = .FullScreen
+                presentViewController(navController, animated: true, completion: nil)
+                return
+            }
             let postViewController = WPPostViewController(post: apost, mode: mode)
 
             postViewController.onClose = {[weak self] viewController, changesSaved in

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.h
@@ -144,6 +144,21 @@ typedef void (^EditPostCompletionHandler)(WPPostViewController* viewController, 
  */
 + (void)setNewEditorEnabled:(BOOL)isEnabled;
 
+/**
+ *	@brief		Enables the new native editor.
+ *	@details	This is set to NO by default.
+ *
+ *	@param		isAvailable		YES means the new editor will be enabled.
+ */
++ (void)setNativeEditorEnabled:(BOOL)isEnabled;
+
+/**
+ *	@brief		Check if the new editor is enabled.
+ *
+ *	@return		YES if the new editor is enabled, NO otherwise.
+ */
++ (BOOL)isNativeEditorEnabled;
+
 #pragma mark - Misc methods
 
 - (void)didSaveNewPost;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -55,6 +55,8 @@ NSString* const WPPostViewControllerOptionNotAnimated = @"WPPostViewControllerNo
 NSString* const kUserDefaultsNewEditorAvailable = @"kUserDefaultsNewEditorAvailable";
 NSString* const kUserDefaultsNewEditorEnabled = @"kUserDefaultsNewEditorEnabled";
 
+NSString* const kUserDefaultsNativeEditorEnabled = @"kUserDefaultsNativeEditorEnabled";
+
 // Secret URL config parameters
 NSString *const kWPEditorConfigURLParamAvailable = @"available";
 NSString *const kWPEditorConfigURLParamEnabled = @"enabled";
@@ -936,9 +938,29 @@ EditImageDetailsViewControllerDelegate
 }
 
 + (BOOL)isNewEditorEnabled
-{    
+{
     return [[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsNewEditorEnabled];
 }
+
++ (BOOL)isNativeEditorEnabled
+{    
+    return [[NSUserDefaults standardUserDefaults] boolForKey:kUserDefaultsNativeEditorEnabled];
+}
+
++ (void)setNativeEditorEnabled:(BOOL)isEnabled
+{
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setBool:isEnabled forKey:kUserDefaultsNativeEditorEnabled];
+    [defaults synchronize];
+}
+
++ (void)isNativeEditorEnabled:(BOOL)isEnabled
+{
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setBool:isEnabled forKey:kUserDefaultsNativeEditorEnabled];
+    [defaults synchronize];
+}
+
 
 #pragma mark - Instance Methods
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -318,6 +318,13 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
     UINavigationController *navController;
     if ([WPPostViewController isNewEditorEnabled]) {
+        if ([WPPostViewController isNativeEditorEnabled]) {
+            AztecPostViewController *postViewController = [[AztecPostViewController alloc] init];
+            UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController: postViewController];
+            navController.modalPresentationStyle = UIModalPresentationFullScreen;
+            [self presentViewController:navController animated: YES completion: nil];
+            return;
+        }
         WPPostViewController *editPostViewController;
         if (!options) {
             editPostViewController = [[WPPostViewController alloc] initWithDraftForLastUsedBlog];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -842,6 +842,7 @@
 		FD21397F13128C5300099582 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FD21397E13128C5300099582 /* libiconv.dylib */; };
 		FD3D6D2C1349F5D30061136A /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD3D6D2B1349F5D30061136A /* ImageIO.framework */; };
 		FD9A948C12FAEA2300438F94 /* DateUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FD9A948B12FAEA2300438F94 /* DateUtils.m */; };
+		FF06FFB81D65CB480095CDF7 /* AztecPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF06FFB71D65CB480095CDF7 /* AztecPostViewController.swift */; };
 		FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF0AAE091A150A560089841D /* WPProgressTableViewCell.m */; };
 		FF0AAE0D1A16550D0089841D /* WPMediaProgressTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FF0AAE0C1A16550D0089841D /* WPMediaProgressTableViewController.m */; };
 		FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */; };
@@ -2181,6 +2182,7 @@
 		FD9A948B12FAEA2300438F94 /* DateUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DateUtils.m; sourceTree = "<group>"; };
 		FDCB9A89134B75B900E5C776 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		FDFB011916B1EA1C00F589A8 /* WordPress 10.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 10.xcdatamodel"; sourceTree = "<group>"; };
+		FF06FFB71D65CB480095CDF7 /* AztecPostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecPostViewController.swift; sourceTree = "<group>"; };
 		FF0AAE081A1509C50089841D /* WPProgressTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPProgressTableViewCell.h; sourceTree = "<group>"; };
 		FF0AAE091A150A560089841D /* WPProgressTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPProgressTableViewCell.m; sourceTree = "<group>"; };
 		FF0AAE0B1A16550D0089841D /* WPMediaProgressTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPMediaProgressTableViewController.h; sourceTree = "<group>"; };
@@ -3659,6 +3661,7 @@
 				FF0AAE0C1A16550D0089841D /* WPMediaProgressTableViewController.m */,
 				5D8CBC451A6F47880081F4AE /* EditImageDetailsViewController.h */,
 				5D8CBC461A6F47880081F4AE /* EditImageDetailsViewController.m */,
+				FF06FFB71D65CB480095CDF7 /* AztecPostViewController.swift */,
 			);
 			path = Post;
 			sourceTree = "<group>";
@@ -5682,6 +5685,7 @@
 				08CC677E1C49B65A00153AD7 /* MenuItem.m in Sources */,
 				E1DD4CCB1CAE41B800C3863E /* PagedViewController.swift in Sources */,
 				B549BA681CF7447E0086C608 /* InvitePersonViewController.swift in Sources */,
+				FF06FFB81D65CB480095CDF7 /* AztecPostViewController.swift in Sources */,
 				B535209B1AF7BBB800B33BA8 /* PushAuthenticationManager.swift in Sources */,
 				319D6E8119E44C680013871C /* SuggestionsTableView.m in Sources */,
 				ACBAB6860E1247F700F38795 /* PostPreviewViewController.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Alpha.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Alpha.xcscheme
@@ -52,7 +52,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release-Alpha"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Internal.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Internal.xcscheme
@@ -62,7 +62,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release-Internal"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/36

To test:
 - Start the app using the standard scheme: WordPress-iOS on Debug mode
 - Go to app settings and activate the Native editor option
 - Tap on the following places to check if the new editor placeholder view is used:
  - Post List
  - Page List
  - New Post on the Tab Bar
- Disable the setting on  app settings
- Go to the same places and check if the regular visual editor shows up.

Needs review: @diegoreymendez 