### PR TITLE
Signin: Populates the stubs for magic links analytic events.

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -832,13 +832,21 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         case WPAnalyticsStatSharingPublicizeConnectionAvailableToAllChanged:
             eventName = @"publicize_connection_availability_changed";
             break;
-
-            // to be implemented with Signin refactor
         case WPAnalyticsStatLoginMagicLinkExited:
+            eventName = @"login_magic_link_exited";
+            break;
         case WPAnalyticsStatLoginMagicLinkFailed:
+            eventName = @"login_magic_link_failed";
+            break;
         case WPAnalyticsStatLoginMagicLinkOpened:
+            eventName = @"login_magic_link_opened";
+            break;
         case WPAnalyticsStatLoginMagicLinkRequested:
+            eventName = @"login_magic_link_requested";
+            break;
         case WPAnalyticsStatLoginMagicLinkSucceeded:
+            eventName = @"login_magic_link_succeeded";
+            break;
 
             // to be implemented
         case WPAnalyticsStatDefaultAccountChanged:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -1022,13 +1022,21 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatMenusSavedMenu:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Menus - Menu Saved"];
             break;
-            
-            // to be implemented with the sign in refactor
         case WPAnalyticsStatLoginMagicLinkExited:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Login - Magic Link exited"];
+            break;
         case WPAnalyticsStatLoginMagicLinkFailed:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Login - Magic Link failed"];
+            break;
         case WPAnalyticsStatLoginMagicLinkOpened:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Login - Magic Link opened"];
+            break;
         case WPAnalyticsStatLoginMagicLinkRequested:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Login - Magic Link requested"];
+            break;
         case WPAnalyticsStatLoginMagicLinkSucceeded:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Login - Magic Link succeeded"];
+            break;
 
             // To be implemented
         case WPAnalyticsStatAppUpgraded:


### PR DESCRIPTION
Assigns values to the magic links events. 

Needs review: @sendhil 

