### PR TITLE
Reader: Set navBars visible after a scrollToTop.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -937,4 +937,8 @@ extension ReaderDetailViewController : UIScrollViewDelegate
         }
     }
 
+    public func scrollViewDidScrollToTop(scrollView: UIScrollView) {
+        setBarsHidden(false)
+    }
+
 }


### PR DESCRIPTION
Small fix for the Reader when on the detail view, if a user was scrolled down a bit and the nav bars hidden, tapping on the iOS status bar scrolled to top without revealing the nav bars.

To test:

1. Open Reader, tap on a detail post.
2. Scroll down on detail post, nav bar will hide.
3. Tap the status bar to scroll to top.
4. Navbars should become visible again.

Needs review: @aerych can you take a peak?