### PR TITLE
Issue/5916 Reader gap color

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
@@ -19,6 +19,7 @@ public class ReaderGapMarkerCell: UITableViewCell
         // Background styles
         selectedBackgroundView = UIView(frame: innerContentView.frame)
         selectedBackgroundView?.backgroundColor = WPStyleGuide.greyLighten30()
+        contentView.backgroundColor = WPStyleGuide.greyLighten30()
         innerContentView.backgroundColor = WPStyleGuide.greyLighten30()
         tearMaskView.backgroundColor = WPStyleGuide.greyLighten30()
 


### PR DESCRIPTION
Fixes #5916 

To test:

1. Create a gap, manually or not.
2. Verify gap cell's contentView is no longer white.

Needs review: @aerych 
