### PR TITLE
Posts: Better calculation for action bar buttons count.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
@@ -6,7 +6,8 @@
 #import "WordPress-Swift.h"
 
 static NSInteger ActionBarMoreButtonIndex = 999;
-static CGFloat ActionBarMinButtonWidth = 90.0;
+static NSInteger const ActionBarMaxNumButtonsHorizontallyCompact = 3;
+static NSInteger const ActionBarMaxNumButtonsHorizontallyRegular = 6;
 
 static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
 
@@ -37,6 +38,15 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
         [self setupView];
     }
     return self;
+}
+
+#pragma mark - Layout
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+
+    [self setupButtonsIfNeeded];
 }
 
 #pragma mark - Setup
@@ -261,16 +271,6 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
     [self configureButtons];
 }
 
-
-#pragma mark - Notifications
-
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
-{
-    [super traitCollectionDidChange:previousTraitCollection];
-
-    [self setupButtonsIfNeeded];
-}
-
 #pragma mark - Accessors
 
 - (NSInteger)indexOfItem:(PostCardActionBarItem *)item
@@ -280,7 +280,17 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
 
 - (NSInteger)maxButtonsToDisplay
 {
-    return (NSInteger)floor(CGRectGetWidth(self.frame) / ActionBarMinButtonWidth);
+    NSInteger count;
+    if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+        count = ActionBarMaxNumButtonsHorizontallyRegular;
+    } else if ( [WPDeviceIdentification isiPhone] && UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation])) {
+        // On iPhone, if we're not horizontally regular, but in landscape orientation, go ahead
+        // and allow the max button count for horizontally regular since we have the screen space.
+        count = ActionBarMaxNumButtonsHorizontallyRegular;
+    } else {
+        count = ActionBarMaxNumButtonsHorizontallyCompact;
+    }
+    return count;
 }
 
 - (BOOL)checkIfShouldShowMoreButton

--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
@@ -7,7 +7,7 @@
 
 static NSInteger ActionBarMoreButtonIndex = 999;
 static NSInteger const ActionBarMaxNumButtonsHorizontallyCompact = 3;
-static NSInteger const ActionBarMaxNumButtonsHorizontallyRegular = 6;
+static NSInteger const ActionBarMaxNumButtonsHorizontallyRegular = 4;
 
 static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
 


### PR DESCRIPTION
Fixes #5915 

To test:

1. Open Blog Posts on iPad.
2. Verify four action buttons are visible in Portrait and Landscape.
3. Transition to multitasking, verify only three action buttons are visible.
4. Transition from multitasking to full-screen, verify all four buttons are visible again.

To test:

1. Open Blog Posts on iPhone.
2. Verify three action buttons are visible in portrait orientation.
3. Verify four action buttons are visible in landscape orientation.

Needs review: @frosty 