### PR TITLE
Disables state restoration after updates.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -334,7 +334,20 @@ int ddLogLevel = DDLogLevelInfo;
 
 - (BOOL)application:(UIApplication *)application shouldRestoreApplicationState:(NSCoder *)coder
 {
-    return self.shouldRestoreApplicationState;
+    NSUserDefaults* standardUserDefaults = [NSUserDefaults standardUserDefaults];
+
+    NSString* const lastSavedStateVersionKey = @"lastSavedStateVersionKey";
+    NSString* lastSavedStateVersion = [standardUserDefaults objectForKey:lastSavedStateVersionKey];
+    NSString* currentVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleShortVersionString"];
+    BOOL shouldRestoreApplicationState = NO;
+
+    if (lastSavedStateVersion && [lastSavedStateVersion length] > 0 && [lastSavedStateVersion isEqualToString:currentVersion]) {
+        shouldRestoreApplicationState = self.shouldRestoreApplicationState;;
+    }
+
+    [standardUserDefaults setObject:currentVersion forKey:lastSavedStateVersionKey];
+
+    return shouldRestoreApplicationState;
 }
 
 - (void)application: (UIApplication *)application performActionForShortcutItem:(nonnull UIApplicationShortcutItem *)shortcutItem completionHandler:(nonnull void (^)(BOOL))completionHandler


### PR DESCRIPTION
Fixes #5636 for `release/6.4.1`.

**What it does:**

This patch effectively disables state restoration on the first launch after the WPiOS App is updated.

**To test:**

Make sure you run all tests in the exact same simulator device.

1. Run 6.3.
2. Go to the list of posts for a blog.  Background the app, and then stop it in Xcode.  It won't save its state if you manually quit the app in the simulator.
3. Run the app from this branch.  Make sure it doesn't crash (nor restore state).

**Important note:**

This will fail if you test it twice going back and forth between versions.  This is expected and non-reproduceable by real users, since they can't go back to the previous version.

To avoid this problem, reset the device info before going back to the previous version.

Needs review: @astralbodies  