### PR TITLE
Notifications: Details Cells Cleanup

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyBezierView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyBezierView.swift
@@ -4,36 +4,36 @@ import WordPressShared.WPStyleGuide
 //  NOTE:
 //  ReplyBezierView is a helper class, used to render the ReplyTextView bubble
 //
-public class ReplyBezierView : UIView
+class ReplyBezierView : UIView
 {
-    public var outerColor = WPStyleGuide.Reply.backgroundColor {
+    var outerColor = WPStyleGuide.Reply.backgroundColor {
         didSet {
             setNeedsDisplay()
         }
     }
-    public var bezierColor = WPStyleGuide.Reply.separatorColor {
+    var bezierColor = WPStyleGuide.Reply.separatorColor {
         didSet {
             setNeedsDisplay()
         }
     }
-    public var bezierRadius = CGFloat(5) {
+    var bezierRadius = CGFloat(5) {
         didSet {
             setNeedsDisplay()
         }
     }
-    public var insets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 1) {
+    var insets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 1) {
         didSet {
             setNeedsDisplay()
         }
     }
 
     // MARK: - Initializers
-    public required init(coder aDecoder: NSCoder) {
+    required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)!
         setupView()
     }
 
-    public override init(frame: CGRect) {
+    override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
     }
@@ -44,7 +44,7 @@ public class ReplyBezierView : UIView
     }
 
     // MARK: - View Methods
-    public override func drawRect(rect: CGRect) {
+    override func drawRect(rect: CGRect) {
         // Draw the background, while clipping a rounded rect with the given insets
         var bezierRect          = bounds
         bezierRect.origin.x     += insets.left

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationMediaDownloader.swift
@@ -7,7 +7,7 @@ import AFNetworking
 /// Since the user may rotate the device, we also provide a second helper (resizeMediaWithIncorrectSize),
 /// which will take care of resizing the original image, to fit the new orientation.
 ///
-@objc public class NotificationMediaDownloader : NSObject
+class NotificationMediaDownloader : NSObject
 {
     // MARK: - Public Methods
 
@@ -23,7 +23,7 @@ import AFNetworking
     ///     - maximumWidth: Represents the maximum width that a returned image should have.
     ///     - completion: Is a closure that will get executed once all of the assets are ready
     ///
-    public func downloadMedia(urls urls: Set<NSURL>, maximumWidth: CGFloat, completion: SuccessBlock) {
+    func downloadMedia(urls urls: Set<NSURL>, maximumWidth: CGFloat, completion: SuccessBlock) {
         let missingUrls         = urls.filter { self.shouldDownloadImage(url: $0) }
         let group               = dispatch_group_create()
         let shouldHitCompletion = !missingUrls.isEmpty
@@ -69,7 +69,7 @@ import AFNetworking
     ///     - maximumWidth: Represents the maximum width that a returned image should have
     ///     - completion: Is a closure that will get executed just one time, after all of the assets get resized
     ///
-    public func resizeMediaWithIncorrectSize(maximumWidth: CGFloat, completion: SuccessBlock) {
+    func resizeMediaWithIncorrectSize(maximumWidth: CGFloat, completion: SuccessBlock) {
         let group               = dispatch_group_create()
         var shouldHitCompletion = false
 
@@ -105,7 +105,7 @@ import AFNetworking
     ///
     /// - Returns: A dictionary with URL as Key, and Image as Value.
     ///
-    public func imagesForUrls(urls: [NSURL]) -> [NSURL: UIImage] {
+    func imagesForUrls(urls: [NSURL]) -> [NSURL: UIImage] {
         var filtered = [NSURL: UIImage]()
 
         for (url, image) in resizedImagesMap {
@@ -220,7 +220,7 @@ import AFNetworking
 
 
     // MARK: - Public Aliases
-    public typealias SuccessBlock   = (Void -> Void)
+    typealias SuccessBlock          = (Void -> Void)
 
     // MARK: - Private Constants
     private let maximumRetryCount   = 3

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -1,45 +1,46 @@
 import Foundation
 import WordPressShared.WPStyleGuide
 
-@objc public class NoteBlockActionsTableViewCell : NoteBlockTableViewCell
+
+class NoteBlockActionsTableViewCell: NoteBlockTableViewCell
 {
-    public typealias EventHandler = ((sender: AnyObject) -> Void)
+    typealias EventHandler = ((sender: AnyObject) -> Void)
 
     // MARK: - Public Properties
-    public var onReplyClick: EventHandler?
-    public var onLikeClick: EventHandler?
-    public var onUnlikeClick: EventHandler?
-    public var onApproveClick: EventHandler?
-    public var onUnapproveClick: EventHandler?
-    public var onTrashClick: EventHandler?
-    public var onSpamClick: EventHandler?
+    var onReplyClick: EventHandler?
+    var onLikeClick: EventHandler?
+    var onUnlikeClick: EventHandler?
+    var onApproveClick: EventHandler?
+    var onUnapproveClick: EventHandler?
+    var onTrashClick: EventHandler?
+    var onSpamClick: EventHandler?
 
-    public var isReplyEnabled: Bool = false {
+    var isReplyEnabled: Bool = false {
         didSet {
             btnReply.hidden = !isReplyEnabled
         }
     }
-    public var isLikeEnabled: Bool = false {
+    var isLikeEnabled: Bool = false {
         didSet {
             btnLike.hidden = !isLikeEnabled
         }
     }
-    public var isApproveEnabled: Bool = false {
+    var isApproveEnabled: Bool = false {
         didSet {
             btnApprove.hidden = !isApproveEnabled
         }
     }
-    public var isTrashEnabled: Bool = false {
+    var isTrashEnabled: Bool = false {
         didSet {
             btnTrash.hidden = !isTrashEnabled
         }
     }
-    public var isSpamEnabled: Bool = false {
+    var isSpamEnabled: Bool = false {
         didSet {
             btnSpam.hidden = !isSpamEnabled
         }
     }
-    public var isLikeOn: Bool {
+    var isLikeOn: Bool {
         set {
             btnLike.selected = newValue
             btnLike.accessibilityLabel = likeAccesibilityLabel
@@ -51,7 +52,7 @@ import WordPressShared.WPStyleGuide
             return btnLike.selected
         }
     }
-    public var isApproveOn: Bool {
+    var isApproveOn: Bool {
         set {
             btnApprove.selected = newValue
             btnApprove.accessibilityLabel = approveAccesibilityLabel
@@ -67,7 +68,7 @@ import WordPressShared.WPStyleGuide
 
 
     // MARK: - View Methods
-    public override func awakeFromNib() {
+    override func awakeFromNib() {
         super.awakeFromNib()
 
         selectionStyle = .None
@@ -108,7 +109,7 @@ import WordPressShared.WPStyleGuide
         btnTrash.accessibilityLabel = trashTitle
     }
 
-    public override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
+    override func traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         actionsView.spacing = buttonSpacingForCurrentTraits
     }
@@ -116,27 +117,27 @@ import WordPressShared.WPStyleGuide
 
 
     // MARK: - IBActions
-    @IBAction public func replyWasPressed(sender: AnyObject) {
+    @IBAction func replyWasPressed(sender: AnyObject) {
         onReplyClick?(sender: sender)
     }
 
-    @IBAction public func likeWasPressed(sender: AnyObject) {
+    @IBAction func likeWasPressed(sender: AnyObject) {
         let onClick = isLikeOn ? onUnlikeClick : onLikeClick
         onClick?(sender: sender)
         isLikeOn = !isLikeOn
     }
 
-    @IBAction public func approveWasPressed(sender: AnyObject) {
+    @IBAction func approveWasPressed(sender: AnyObject) {
         let onClick = isApproveOn ? onUnapproveClick : onApproveClick
         onClick?(sender: sender)
         isApproveOn = !isApproveOn
     }
 
-    @IBAction public func trashWasPressed(sender: AnyObject) {
+    @IBAction func trashWasPressed(sender: AnyObject) {
         onTrashClick?(sender: sender)
     }
 
-    @IBAction public func spamWasPressed(sender: AnyObject) {
+    @IBAction func spamWasPressed(sender: AnyObject) {
         onSpamClick?(sender: sender)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
@@ -1,19 +1,20 @@
 import Foundation
 import WordPressShared.WPStyleGuide
 
-@objc public class NoteBlockCommentTableViewCell : NoteBlockTextTableViewCell
+
+class NoteBlockCommentTableViewCell: NoteBlockTextTableViewCell
 {
-    public typealias EventHandler = ((sender: AnyObject) -> Void)
+    typealias EventHandler = ((sender: AnyObject) -> Void)
 
     // MARK: - Public Properties
-    public var onDetailsClick: EventHandler?
+    var onDetailsClick: EventHandler?
 
-    public var attributedCommentText: NSAttributedString? {
+    var attributedCommentText: NSAttributedString? {
         didSet {
             refreshApprovalColors()
         }
     }
-    public var commentText: String? {
+    var commentText: String? {
         set {
             let text = newValue ?? String()
             attributedCommentText = NSMutableAttributedString(string: text, attributes: Style.contentBlockRegularStyle)
@@ -22,18 +23,18 @@ import WordPressShared.WPStyleGuide
             return attributedCommentText?.string
         }
     }
-    public var isApproved: Bool = false {
+    var isApproved: Bool = false {
         didSet {
             refreshApprovalColors()
             refreshSeparators()
         }
     }
-    public var isRepliedComment: Bool = false {
+    var isRepliedComment: Bool = false {
         didSet {
             refreshSeparators()
         }
     }
-    public var name: String? {
+    var name: String? {
         set {
             titleLabel.text  = newValue
         }
@@ -41,12 +42,12 @@ import WordPressShared.WPStyleGuide
             return titleLabel.text
         }
     }
-    public var timestamp: String? {
+    var timestamp: String? {
         didSet {
             refreshDetails()
         }
     }
-    public var site: String? {
+    var site: String? {
         didSet {
             refreshDetails()
         }
@@ -55,13 +56,13 @@ import WordPressShared.WPStyleGuide
 
 
     // MARK: - Public Methods
-    public func downloadGravatarWithURL(url: NSURL?) {
+    func downloadGravatarWithURL(url: NSURL?) {
         let gravatar = url.flatMap { Gravatar($0) }
 
         gravatarImageView.downloadGravatar(gravatar, placeholder: placeholderImage, animate: true)
     }
 
-    public func downloadGravatarWithEmail(email: String?) {
+    func downloadGravatarWithEmail(email: String?) {
         guard let unwrappedEmail = email else {
             gravatarImageView.image = placeholderImage
             return
@@ -72,7 +73,7 @@ import WordPressShared.WPStyleGuide
 
 
     // MARK: - View Methods
-    public override func awakeFromNib() {
+    override func awakeFromNib() {
         super.awakeFromNib()
 
         // Setup Labels
@@ -98,7 +99,7 @@ import WordPressShared.WPStyleGuide
 
 
     // MARK: - Approval Color Helpers
-    public override func refreshSeparators() {
+    override func refreshSeparators() {
         // Left Separator
         separatorsView.leftVisible = !isApproved
         separatorsView.leftColor = Style.blockUnapprovedSideColor
@@ -149,7 +150,7 @@ import WordPressShared.WPStyleGuide
 
 
     // MARK: - Event Handlers
-    @IBAction public func detailsWasPressed(sender: AnyObject) {
+    @IBAction func detailsWasPressed(sender: AnyObject) {
         onDetailsClick?(sender: sender)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.swift
@@ -1,10 +1,10 @@
 import Foundation
 import WordPressShared.WPStyleGuide
 
-@objc public class NoteBlockHeaderTableViewCell : NoteBlockTableViewCell
+class NoteBlockHeaderTableViewCell: NoteBlockTableViewCell
 {
     // MARK: - Public Properties
-    public var headerTitle: String? {
+    var headerTitle: String? {
         set {
             headerTitleLabel.text  = newValue
         }
@@ -13,7 +13,7 @@ import WordPressShared.WPStyleGuide
         }
     }
 
-    public var attributedHeaderTitle: NSAttributedString? {
+    var attributedHeaderTitle: NSAttributedString? {
         set {
             headerTitleLabel.attributedText  = newValue
         }
@@ -22,7 +22,7 @@ import WordPressShared.WPStyleGuide
         }
     }
 
-    public var headerDetails: String? {
+    var headerDetails: String? {
         set {
             headerDetailsLabel.text = newValue
         }
@@ -33,7 +33,7 @@ import WordPressShared.WPStyleGuide
 
 
     // MARK: - Public Methods
-    public func downloadGravatarWithURL(url: NSURL?) {
+    func downloadGravatarWithURL(url: NSURL?) {
         if url == gravatarURL {
             return
         }
@@ -46,7 +46,7 @@ import WordPressShared.WPStyleGuide
     }
 
     // MARK: - View Methods
-    public override func awakeFromNib() {
+    override func awakeFromNib() {
         super.awakeFromNib()
 
         accessoryType = .DisclosureIndicator
@@ -66,7 +66,7 @@ import WordPressShared.WPStyleGuide
     }
 
     // MARK: - Overriden Methods
-    public override func refreshSeparators() {
+    override func refreshSeparators() {
         separatorsView.bottomVisible = true
         separatorsView.bottomInsets = UIEdgeInsetsZero
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockImageTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockImageTableViewCell.swift
@@ -1,17 +1,18 @@
 import Foundation
 import WordPressShared.WPStyleGuide
 
-@objc public class NoteBlockImageTableViewCell : NoteBlockTableViewCell
+
+class NoteBlockImageTableViewCell: NoteBlockTableViewCell
 {
     // MARK: - Public Properties
-    public override var isBadge: Bool {
+    override var isBadge: Bool {
         didSet {
             backgroundColor = isBadge ? Styles.badgeBackgroundColor : Styles.blockBackgroundColor
         }
     }
 
     // MARK: - Public Methods
-    public func downloadImageWithURL(url: NSURL?) {
+    func downloadImageWithURL(url: NSURL?) {
         let success = { (image: UIImage) in
             self.blockImageView.image = image
             self.blockImageView.displayWithSpringAnimation()
@@ -21,7 +22,7 @@ import WordPressShared.WPStyleGuide
     }
 
     // MARK: - View Methods
-    public override func awakeFromNib() {
+    override func awakeFromNib() {
         super.awakeFromNib()
         selectionStyle = .None
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTableViewCell.swift
@@ -1,23 +1,23 @@
 import Foundation
 import WordPressShared
 
-@objc public class NoteBlockTableViewCell : WPTableViewCell
+class NoteBlockTableViewCell: WPTableViewCell
 {
     // MARK: - Public Properties
-    public var isBadge: Bool = false {
+    var isBadge: Bool = false {
         didSet {
             refreshSeparators()
         }
     }
-    public var isLastRow: Bool = false {
+    var isLastRow: Bool = false {
         didSet {
             refreshSeparators()
         }
     }
-    public var separatorsView = SeparatorsView()
+    var separatorsView = SeparatorsView()
 
     // MARK: - Public Methods
-    public func refreshSeparators() {
+    func refreshSeparators() {
         // Exception: Badges require no separators
         if isBadge {
             separatorsView.bottomVisible = false
@@ -30,21 +30,21 @@ import WordPressShared
 
     }
 
-    public func isLayoutCell() -> Bool {
+    func isLayoutCell() -> Bool {
         return self.dynamicType.layoutIdentifier() == reuseIdentifier
     }
 
-    public class func reuseIdentifier() -> String {
+    class func reuseIdentifier() -> String {
         return classNameWithoutNamespaces()
     }
 
-    public class func layoutIdentifier() -> String {
+    class func layoutIdentifier() -> String {
         return classNameWithoutNamespaces() + "-Layout"
     }
 
 
     // MARK: - View Methods
-    public override func awakeFromNib() {
+    override func awakeFromNib() {
         super.awakeFromNib()
         backgroundView = separatorsView
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -2,12 +2,12 @@ import Foundation
 import WordPressShared
 
 
-public class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource, RichTextViewDelegate
+class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource, RichTextViewDelegate
 {
     // MARK: - Public Properties
-    public var onUrlClick: (NSURL -> Void)?
-    public var onAttachmentClick: (NSTextAttachment -> Void)?
-    public var attributedText: NSAttributedString? {
+    var onUrlClick: (NSURL -> Void)?
+    var onAttachmentClick: (NSTextAttachment -> Void)?
+    var attributedText: NSAttributedString? {
         set {
             textView.attributedText = newValue
             invalidateIntrinsicContentSize()
@@ -17,13 +17,13 @@ public class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDat
         }
     }
 
-    public override var isBadge: Bool {
+    override var isBadge: Bool {
         didSet {
             backgroundColor = WPStyleGuide.Notifications.blockBackgroundColorForRichText(isBadge)
         }
     }
 
-    public var linkColor: UIColor? {
+    var linkColor: UIColor? {
         didSet {
             if let unwrappedLinkColor = linkColor {
                 textView.linkTextAttributes = [NSForegroundColorAttributeName : unwrappedLinkColor]
@@ -31,7 +31,7 @@ public class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDat
         }
     }
 
-    public var dataDetectors: UIDataDetectorTypes {
+    var dataDetectors: UIDataDetectorTypes {
         set {
             textView.dataDetectorTypes = newValue ?? .None
         }
@@ -40,7 +40,7 @@ public class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDat
         }
     }
 
-    public var isTextViewSelectable: Bool {
+    var isTextViewSelectable: Bool {
         set {
             textView.selectable = newValue
         }
@@ -49,7 +49,7 @@ public class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDat
         }
     }
 
-    public var isTextViewClickable: Bool {
+    var isTextViewClickable: Bool {
         set {
             textView.userInteractionEnabled = newValue
         }
@@ -59,7 +59,7 @@ public class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDat
     }
 
     // MARK: - View Methods
-    public override func awakeFromNib() {
+    override func awakeFromNib() {
         super.awakeFromNib()
 
         backgroundColor = WPStyleGuide.Notifications.blockBackgroundColor
@@ -80,23 +80,23 @@ public class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDat
 
 
     // MARK: - RichTextView Data Source
-    public func textView(textView: UITextView, shouldInteractWithURL URL: NSURL, inRange characterRange: NSRange) -> Bool {
+    func textView(textView: UITextView, shouldInteractWithURL URL: NSURL, inRange characterRange: NSRange) -> Bool {
         onUrlClick?(URL)
         return false
     }
 
-    public func textView(textView: UITextView, didPressLink link: NSURL) {
+    func textView(textView: UITextView, didPressLink link: NSURL) {
         onUrlClick?(link)
     }
 
-    public func textView(textView: UITextView, shouldInteractWithTextAttachment textAttachment: NSTextAttachment, inRange characterRange: NSRange) -> Bool {
+    func textView(textView: UITextView, shouldInteractWithTextAttachment textAttachment: NSTextAttachment, inRange characterRange: NSRange) -> Bool {
         onAttachmentClick?(textAttachment)
         return false
     }
 
 
     // MARK: - Constants
-    public static let defaultLabelPadding = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 12.0)
+    static let defaultLabelPadding = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 12.0)
 
     // MARK: - IBOutlets
     @IBOutlet private weak var textView: RichTextView!

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.swift
@@ -1,15 +1,16 @@
 import Foundation
 import WordPressShared
 
-@objc public class NoteBlockUserTableViewCell : NoteBlockTableViewCell
+
+class NoteBlockUserTableViewCell: NoteBlockTableViewCell
 {
-    public typealias EventHandler = (() -> Void)
+    typealias EventHandler = (() -> Void)
 
     // MARK: - Public Properties
-    public var onFollowClick    : EventHandler?
-    public var onUnfollowClick  : EventHandler?
+    var onFollowClick    : EventHandler?
+    var onUnfollowClick  : EventHandler?
 
-    public var isFollowEnabled: Bool {
+    var isFollowEnabled: Bool {
         set {
             btnFollow.hidden = !newValue
         }
@@ -17,7 +18,7 @@ import WordPressShared
             return !btnFollow.hidden
         }
     }
-    public var isFollowOn: Bool {
+    var isFollowOn: Bool {
         set {
             btnFollow.selected = newValue
         }
@@ -26,7 +27,7 @@ import WordPressShared
         }
     }
 
-    public var name: String? {
+    var name: String? {
         set {
             nameLabel.text  = newValue
         }
@@ -34,7 +35,7 @@ import WordPressShared
             return nameLabel.text
         }
     }
-    public var blogTitle: String? {
+    var blogTitle: String? {
         set {
             blogLabel.text  = newValue
         }
@@ -44,7 +45,7 @@ import WordPressShared
     }
 
     // MARK: - Public Methods
-    public func downloadGravatarWithURL(url: NSURL?) {
+    func downloadGravatarWithURL(url: NSURL?) {
         if url == gravatarURL {
             return
         }
@@ -57,7 +58,7 @@ import WordPressShared
     }
 
     // MARK: - View Methods
-    public override func awakeFromNib() {
+    override func awakeFromNib() {
         super.awakeFromNib()
 
         WPStyleGuide.configureFollowButton(btnFollow)
@@ -82,7 +83,7 @@ import WordPressShared
     }
 
     // MARK: - IBActions
-    @IBAction public func followWasPressed(sender: AnyObject) {
+    @IBAction func followWasPressed(sender: AnyObject) {
         if let listener = isFollowOn ? onUnfollowClick : onFollowClick {
             listener()
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
@@ -4,10 +4,10 @@ import WordPressShared
 /// This class renders a view with top and bottom separators, meant to be used as UITableView section
 /// header in NotificationsViewController.
 ///
-@objc public class NoteTableHeaderView : UIView
+class NoteTableHeaderView: UIView
 {
     // MARK: - Public Properties
-    public var title: String? {
+    var title: String? {
         set {
             // For layout reasons, we need to ensure that the titleLabel uses an exact Paragraph Height!
             let unwrappedTitle = newValue?.uppercaseStringWithLocale(NSLocale.currentLocale()) ?? String()
@@ -20,7 +20,7 @@ import WordPressShared
         }
     }
 
-    public var separatorColor: UIColor? {
+    var separatorColor: UIColor? {
         set {
             layoutView.bottomColor = newValue ?? UIColor.clearColor()
             layoutView.topColor = newValue ?? UIColor.clearColor()
@@ -33,16 +33,16 @@ import WordPressShared
 
 
     // MARK: - Convenience Initializers
-    public convenience init() {
+    convenience init() {
         self.init(frame: CGRectZero)
     }
 
-    required override public init(frame: CGRect) {
+    required override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
     }
 
-    required public init(coder aDecoder: NSCoder) {
+    required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)!
         setupView()
     }
@@ -78,7 +78,7 @@ import WordPressShared
     typealias Style = WPStyleGuide.Notifications
 
     // MARK: - Static Properties
-    public static let headerHeight  = CGFloat(26)
+    static let headerHeight  = CGFloat(26)
 
     // MARK: - Outlets
     @IBOutlet private var contentView: UIView!

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -7,24 +7,24 @@ import WordPressShared
 /// Supports specific styles for Unapproved Comment Notifications, Unread Notifications, and a brand
 /// new "Undo Deletion" mechanism has been implemented. See "NoteUndoOverlayView" for reference.
 ///
-@objc public class NoteTableViewCell : WPTableViewCell
+class NoteTableViewCell: WPTableViewCell
 {
     // MARK: - Public Properties
-    public var read: Bool = false {
+    var read: Bool = false {
         didSet {
             if read != oldValue {
                 refreshBackgrounds()
             }
         }
     }
-    public var unapproved: Bool = false {
+    var unapproved: Bool = false {
         didSet {
             if unapproved != oldValue {
                 refreshBackgrounds()
             }
         }
     }
-    public var markedForDeletion: Bool = false {
+    var markedForDeletion: Bool = false {
         didSet {
             if markedForDeletion != oldValue {
                 refreshSubviewVisibility()
@@ -33,7 +33,7 @@ import WordPressShared
             }
         }
     }
-    public var showsBottomSeparator: Bool {
+    var showsBottomSeparator: Bool {
         set {
             separatorsView.bottomVisible = newValue
         }
@@ -41,7 +41,7 @@ import WordPressShared
             return separatorsView.bottomVisible == false
         }
     }
-    public var attributedSubject: NSAttributedString? {
+    var attributedSubject: NSAttributedString? {
         set {
             subjectLabel.attributedText = newValue
             setNeedsLayout()
@@ -50,7 +50,7 @@ import WordPressShared
             return subjectLabel.attributedText
         }
     }
-    public var attributedSnippet: NSAttributedString? {
+    var attributedSnippet: NSAttributedString? {
         set {
             snippetLabel.attributedText = newValue
             refreshNumberOfLines()
@@ -60,7 +60,7 @@ import WordPressShared
             return snippetLabel.attributedText
         }
     }
-    public var noticon: String? {
+    var noticon: String? {
         set {
             noticonLabel.text = newValue
         }
@@ -68,16 +68,16 @@ import WordPressShared
             return noticonLabel.text
         }
     }
-    public var onUndelete: (Void -> Void)?
+    var onUndelete: (Void -> Void)?
 
 
 
     // MARK: - Public Methods
-    public class func reuseIdentifier() -> String {
+    class func reuseIdentifier() -> String {
         return classNameWithoutNamespaces()
     }
 
-    public func downloadIconWithURL(url: NSURL?) {
+    func downloadIconWithURL(url: NSURL?) {
         let isGravatarURL = url.map { Gravatar.isGravatarURL($0) } ?? false
         if isGravatarURL {
             downloadGravatarWithURL(url)
@@ -130,7 +130,7 @@ import WordPressShared
 
 
     // MARK: - UITableViewCell Methods
-    public override func awakeFromNib() {
+    override func awakeFromNib() {
         super.awakeFromNib()
 
         contentView.autoresizingMask = [.FlexibleHeight, .FlexibleWidth]
@@ -154,19 +154,19 @@ import WordPressShared
         backgroundView = separatorsView
     }
 
-    public override func layoutSubviews() {
+    override func layoutSubviews() {
         refreshLabelPreferredMaxLayoutWidth()
         refreshBackgrounds()
         super.layoutSubviews()
     }
 
-    public override func setSelected(selected: Bool, animated: Bool) {
+    override func setSelected(selected: Bool, animated: Bool) {
         // Note: this is required, since the cell unhighlight mechanism will reset the new background color
         super.setSelected(selected, animated: animated)
         refreshBackgrounds()
     }
 
-    public override func setHighlighted(highlighted: Bool, animated: Bool) {
+    override func setHighlighted(highlighted: Bool, animated: Bool) {
         // Note: this is required, since the cell unhighlight mechanism will reset the new background color
         super.setHighlighted(highlighted, animated: animated)
         refreshBackgrounds()
@@ -238,7 +238,7 @@ import WordPressShared
 
 
     // MARK: - Public Static Helpers
-    public class func layoutHeightWithWidth(width: CGFloat, subject: NSAttributedString?, snippet: NSAttributedString?) -> CGFloat {
+    class func layoutHeightWithWidth(width: CGFloat, subject: NSAttributedString?, snippet: NSAttributedString?) -> CGFloat {
 
         // Limit the width (iPad Devices)
         let cellWidth = min(width, Style.maximumCellWidth)
@@ -274,7 +274,7 @@ import WordPressShared
 
 
     // MARK: - Action Handlers
-    @IBAction public func undeleteWasPressed(sender: AnyObject) {
+    @IBAction func undeleteWasPressed(sender: AnyObject) {
         onUndelete?()
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteUndoOverlayView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteUndoOverlayView.swift
@@ -9,10 +9,10 @@ import WordPressShared
 /// we don't need to duplicate any of the mechanisms already available in NoteTableViewCell, such as
 /// custom cell separators and Height Calculation.
 ///
-@objc public class NoteUndoOverlayView : UIView
+class NoteUndoOverlayView: UIView
 {
     // MARK: - NSCoder
-    public override func awakeFromNib() {
+    override func awakeFromNib() {
         super.awakeFromNib()
         backgroundColor = Style.noteUndoBackgroundColor
 


### PR DESCRIPTION
#### Details:
- Nukes `@objc` statements, since those are not needed anymore
- Nuked `public` modifiers, since those are not required!

Ref #5613

#### To test:
Build the app and verify nothing breaks!

Needs review: @nheagy 
Nate, may i bug you with a (hopefully fun) review?

Thanks in advance!

