### PR TITLE
Notifications List: Autosizing Cells

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -187,16 +187,7 @@ class NotificationsViewController : UITableViewController
     }
 
     override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        // Load the Subject + Snippet
-        guard let note = tableViewHandler.resultsController.objectOfType(Notification.self, atIndexPath: indexPath) else {
-            return CGFloat.min
-        }
-
-        // Old School Height Calculation
-        let subject = note.subjectBlock?.attributedSubjectText
-        let snippet = note.snippetBlock?.attributedSnippetText
-
-        return NoteTableViewCell.layoutHeightWithWidth(tableView.bounds.width, subject:subject, snippet:snippet)
+        return UITableViewAutomaticDimension
     }
 
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -155,7 +155,6 @@ class NoteTableViewCell: WPTableViewCell
     }
 
     override func layoutSubviews() {
-        refreshLabelPreferredMaxLayoutWidth()
         refreshBackgrounds()
         super.layoutSubviews()
     }
@@ -175,12 +174,6 @@ class NoteTableViewCell: WPTableViewCell
 
 
     // MARK: - Private Methods
-    private func refreshLabelPreferredMaxLayoutWidth() {
-        let maxWidthLabel = frame.width - Settings.textInsets.right - subjectLabel.frame.minX
-        subjectLabel.preferredMaxLayoutWidth = maxWidthLabel
-        snippetLabel.preferredMaxLayoutWidth = maxWidthLabel
-    }
-
     private func refreshBackgrounds() {
         // Noticon Background
         if unapproved {
@@ -237,42 +230,6 @@ class NoteTableViewCell: WPTableViewCell
 
 
 
-    // MARK: - Public Static Helpers
-    class func layoutHeightWithWidth(width: CGFloat, subject: NSAttributedString?, snippet: NSAttributedString?) -> CGFloat {
-
-        // Limit the width (iPad Devices)
-        let cellWidth = min(width, Style.maximumCellWidth)
-        var cellHeight = Settings.textInsets.top + Settings.textInsets.bottom
-
-        // Calculate the maximum label size
-        let maxLabelWidth = cellWidth - Settings.textInsets.left - Settings.textInsets.right
-        let maxLabelSize = CGSize(width: maxLabelWidth, height: CGFloat.max)
-
-        // Helpers
-        let showsSnippet = snippet != nil
-
-        // If we must render a snippet, the maximum subject height will change. Account for that please
-        if let unwrappedSubject = subject {
-            let subjectRect = unwrappedSubject.boundingRectWithSize(maxLabelSize,
-                                                                    options: .UsesLineFragmentOrigin,
-                                                                    context: nil)
-
-            cellHeight += min(subjectRect.height, Settings.subjectMaximumHeight(showsSnippet))
-        }
-
-        if let unwrappedSubject = snippet {
-            let snippetRect = unwrappedSubject.boundingRectWithSize(maxLabelSize,
-                                                                    options: .UsesLineFragmentOrigin,
-                                                                    context: nil)
-
-            cellHeight += min(snippetRect.height, Settings.snippetMaximumHeight())
-        }
-
-        return max(cellHeight, Settings.minimumCellHeight)
-    }
-
-
-
     // MARK: - Action Handlers
     @IBAction func undeleteWasPressed(sender: AnyObject) {
         onUndelete?()
@@ -285,8 +242,6 @@ class NoteTableViewCell: WPTableViewCell
 
     // MARK: - Private Settings
     private struct Settings {
-        static let minimumCellHeight = CGFloat(70)
-        static let textInsets = UIEdgeInsets(top: 9.0, left: 71.0, bottom: 12.0, right: 12.0)
         static let separatorInsets = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 0.0)
         static let subjectNumberOfLinesWithoutSnippet = 3
         static let subjectNumberOfLinesWithSnippet = 2


### PR DESCRIPTION
#### Details:
It's time to enable Autosizing Cells in the Notifications List.

Ref. #5613

#### To test:
1. Log into a dotcom account
2. Test the Notifications List on iPhone / iPad Devices
3. Try rotations as well!

Needs review: @astralbodies 

Thought you might love this PR Aaron!!
