### PR TITLE
Reader: Trim tag and check length before following.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -262,7 +262,9 @@ import WordPressShared
         let controller = SettingsTextViewController(text: nil, placeholder: placeholder, hint: nil)
         controller.title = NSLocalizedString("Add a Tag", comment: "Title of a feature to add a new tag to the tags subscribed by the user.")
         controller.onValueChanged = { value in
-            self.followTagNamed(value)
+            if value.trim().characters.count > 0 {
+                self.followTagNamed(value.trim())
+            }
         }
         controller.mode = .LowerCaseText
         controller.displaysActionButton = true


### PR DESCRIPTION
Fixes #5908

To test:
Go to the reader menu.
Tap the Add a Tag option.
Type some spaces then tap the done button (or hit return).
Confirm that controller silently dismisses and a follow attempt is not made for the empty tag.

Needs review: @jleandroperez
