### PR TITLE
Issues/5927 non latin tags

### DIFF
--- a/WordPress/Classes/Networking/ReaderTopicServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderTopicServiceRemote.m
@@ -142,6 +142,7 @@ static NSString * const SiteDictionarySubscriptionsKey = @"subscribers_count";
                  failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"read/tags/%@/mine/new", slug];
+    path = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 

--- a/WordPress/Classes/Networking/ReaderTopicServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderTopicServiceRemote.m
@@ -133,8 +133,7 @@ static NSString * const SiteDictionarySubscriptionsKey = @"subscribers_count";
              withSuccess:(void (^)(NSNumber *topicID))success
                  failure:(void (^)(NSError *error))failure
 {
-    NSString *slug = [self slugForTopicName:topicName];
-    [self followTopicWithSlug:slug withSuccess:success failure:failure];
+    [self followTopicWithSlug:topicName withSuccess:success failure:failure];
 }
 
 - (void)followTopicWithSlug:(NSString *)slug


### PR DESCRIPTION
Fixes #5927 

To test:
Try following one of the tags mentioned in the issue. 
Confirm you can successfully add and remove the tag.
Additionally, try to follow the special character `%` as mentioned in @rachelmcr's comment in #5908.  Its a bit weird, but confirm that the behavior matches the web reader.

Needs review: @kurzee 
