### PR TITLE
Reader: Restores previously removed gap detection, but avoids searches.

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -604,6 +604,16 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
                 NSSet *existingGlobalIDs = [self globalIDsOfExistingPostsForTopic:readerTopic];
                 NSSet *newGlobalIDs = [self globalIDsOfRemotePosts:posts];
                 overlap = [existingGlobalIDs intersectsSet:newGlobalIDs];
+
+                // A strategy to avoid false positives in gap detection is to sync
+                // one extra post. Only remove the extra post if we received a
+                // full set of results. A partial set means we've reached
+                // the end of syncable content.
+                if ([posts count] == [self numberToSyncForTopic:readerTopic] && ![ReaderHelpers isTopicSearchTopic:readerTopic]) {
+                    posts = [posts subarrayWithRange:NSMakeRange(0, [posts count] - 2)];
+                    postsCount = [posts count];
+                }
+
             }
 
             // Create or update the synced posts.


### PR DESCRIPTION
Closes #5917 
This restores some previously gap detection code, with an added condition to avoid applying it to search results (which are sorted by offset not date).
This partly resolves the behavior shown in #5917, however we're still seeing false positives in gap detection due to some current wonkiness in the API.

To test: 
Confirm the code was correctly restored and that the conditional properly excludes search results.

Needs review: @kurzee would you be so kind?

