### PR TITLE
Aztec: integrate latest

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '~> 0.10.1'
     pod 'WordPress-iOS-Editor', '1.8.1'
     pod 'WordPressCom-Analytics-iOS', '0.1.18'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => 'a6678565b94be670725cafd5ba261a4dfbe383f9'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => 'c78c858194f57bc8d4b29712b72a38c97af140ab'
     pod 'WordPressCom-Stats-iOS', '0.7.7'
     pod 'wpxmlrpc', '~> 0.8'
     

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -218,7 +218,7 @@ DEPENDENCIES:
   - SVProgressHUD (~> 1.1.3)
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `a6678565b94be670725cafd5ba261a4dfbe383f9`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `c78c858194f57bc8d4b29712b72a38c97af140ab`)
   - WordPress-iOS-Editor (= 1.8.1)
   - WordPress-iOS-Shared (= 0.6.0)
   - WordPressCom-Analytics-iOS (= 0.1.18)
@@ -236,7 +236,7 @@ EXTERNAL SOURCES:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: a6678565b94be670725cafd5ba261a4dfbe383f9
+    :commit: c78c858194f57bc8d4b29712b72a38c97af140ab
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -250,7 +250,7 @@ CHECKOUT OPTIONS:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: a6678565b94be670725cafd5ba261a4dfbe383f9
+    :commit: c78c858194f57bc8d4b29712b72a38c97af140ab
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -297,6 +297,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 645ecc2435293cc898c76180f3994358a68cae20
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: a40d257efbcb96bcf7bcf24529e5f7cef2c10844
+PODFILE CHECKSUM: cf3a0fd696d8ac6c3371f938697a9b9b5db37bd3
 
 COCOAPODS: 1.0.1

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -9,8 +9,7 @@ class AztecPostViewController: UIViewController
         presentingViewController?.dismissViewControllerAnimated(true, completion: nil)
     }
 
-    private var bottomConstraint: NSLayoutConstraint!
-
+    static let margin = CGFloat(20)
 
     private (set) lazy var editor: AztecVisualEditor = {
         return AztecVisualEditor(textView: self.richTextView)
@@ -19,29 +18,25 @@ class AztecPostViewController: UIViewController
 
     private(set) lazy var richTextView: UITextView = {
         let tv = AztecVisualEditor.createTextView()
-        let font = UIFont.preferredFontForTextStyle(UIFontTextStyleBody)
 
         tv.accessibilityLabel = NSLocalizedString("Rich Content", comment: "Post Rich content")
         tv.delegate = self
-        tv.font = font
+        tv.font = WPFontManager.merriweatherRegularFontOfSize(16)
         let toolbar = self.createToolbar()
         toolbar.frame = CGRect(x: 0, y: 0, width: self.view.frame.width, height: 44.0)
         toolbar.formatter = self
         tv.inputAccessoryView = toolbar
         tv.textColor = UIColor.darkTextColor()
         tv.translatesAutoresizingMaskIntoConstraints = false
-        tv.addSubview(self.titleTextField)
-        tv.addSubview(self.separatorView)
 
         return tv
     }()
 
     private(set) lazy var htmlTextView: UITextView = {
         let tv = UITextView()
-        let font = UIFont.preferredFontForTextStyle(UIFontTextStyleBody)
 
         tv.accessibilityLabel = NSLocalizedString("HTML Content", comment: "Post HTML content")
-        tv.font = font
+        tv.font = WPFontManager.merriweatherRegularFontOfSize(16)
         tv.textColor = UIColor.darkTextColor()
         tv.translatesAutoresizingMaskIntoConstraints = false
         tv.hidden = true
@@ -55,26 +50,25 @@ class AztecPostViewController: UIViewController
 
         tf.accessibilityLabel = NSLocalizedString("Title", comment: "Post title")
         tf.attributedPlaceholder = NSAttributedString(string: placeholderText,
-                                                      attributes: [NSForegroundColorAttributeName: UIColor.lightGrayColor()])
-        tf.autoresizingMask = [UIViewAutoresizing.FlexibleWidth]
+                                                      attributes: [NSForegroundColorAttributeName: WPStyleGuide.greyLighten30()])
         tf.delegate = self
-        tf.font = UIFont.preferredFontForTextStyle(UIFontTextStyleHeadline)
+        tf.font = WPFontManager.merriweatherBoldFontOfSize(24.0)
         let toolbar = self.createToolbar()
         toolbar.frame = CGRect(x: 0, y: 0, width: self.view.frame.width, height: 44.0)
         toolbar.enabled = false
         tf.inputAccessoryView = toolbar
         tf.returnKeyType = .Next
         tf.textColor = UIColor.darkTextColor()
+        tf.translatesAutoresizingMaskIntoConstraints = false
 
         return tf
     }()
 
-
     private(set) lazy var separatorView: UIView = {
         let v = UIView(frame: CGRect(x: 0, y: 0, width: 44, height: 1))
 
-        v.autoresizingMask = [.FlexibleWidth]
-        v.backgroundColor = UIColor.darkTextColor()
+        v.backgroundColor = WPStyleGuide.greyLighten30()
+        v.translatesAutoresizingMaskIntoConstraints = false
 
         return v
     }()
@@ -121,21 +115,21 @@ class AztecPostViewController: UIViewController
         edgesForExtendedLayout = .None
         navigationController?.navigationBar.translucent = false
 
+        view.addSubview(titleTextField)
+        view.addSubview(separatorView)
         view.addSubview(richTextView)
         view.addSubview(htmlTextView)
 
         editor.setHTML(post.content ?? "")
         titleTextField.text = post.postTitle
 
-        configureConstraints()
+        view.setNeedsUpdateConstraints()
         configureNavigationBar()
 
-        layoutTextView()
-
         title = NSLocalizedString("Aztec Native Editor", comment: "")
-        self.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Done,
-                                                                 target: self,
-                                                                 action: #selector(AztecPostViewController.closeAction))
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Done,
+                                                                target: self,
+                                                                action: #selector(AztecPostViewController.closeAction))
         view.backgroundColor = UIColor.whiteColor()
     }
 
@@ -167,14 +161,29 @@ class AztecPostViewController: UIViewController
 
     // MARK: - Configuration Methods
 
-    func configureConstraints() {
-        bottomConstraint = richTextView.bottomAnchor.constraintEqualToAnchor(view.bottomAnchor)
+    override func updateViewConstraints() {
+
+        super.updateViewConstraints()
 
         NSLayoutConstraint.activateConstraints([
-            richTextView.leftAnchor.constraintEqualToAnchor(view.leftAnchor),
-            richTextView.rightAnchor.constraintEqualToAnchor(view.rightAnchor),
-            richTextView.topAnchor.constraintEqualToAnchor(view.topAnchor),
-            bottomConstraint!
+            titleTextField.leftAnchor.constraintEqualToAnchor(view.leftAnchor, constant: self.dynamicType.margin),
+            titleTextField.rightAnchor.constraintEqualToAnchor(view.rightAnchor, constant: -self.dynamicType.margin),
+            titleTextField.topAnchor.constraintEqualToAnchor(view.topAnchor, constant: self.dynamicType.margin),
+            titleTextField.heightAnchor.constraintEqualToConstant(titleTextField.font!.lineHeight)
+            ])
+
+        NSLayoutConstraint.activateConstraints([
+            separatorView.leftAnchor.constraintEqualToAnchor(view.leftAnchor, constant: self.dynamicType.margin),
+            separatorView.rightAnchor.constraintEqualToAnchor(view.rightAnchor, constant: -self.dynamicType.margin),
+            separatorView.topAnchor.constraintEqualToAnchor(titleTextField.bottomAnchor, constant: self.dynamicType.margin),
+            separatorView.heightAnchor.constraintEqualToConstant(separatorView.frame.height)
+            ])
+
+        NSLayoutConstraint.activateConstraints([
+            richTextView.leftAnchor.constraintEqualToAnchor(view.leftAnchor, constant: self.dynamicType.margin),
+            richTextView.rightAnchor.constraintEqualToAnchor(view.rightAnchor, constant: -self.dynamicType.margin),
+            richTextView.topAnchor.constraintEqualToAnchor(separatorView.bottomAnchor, constant: self.dynamicType.margin),
+            richTextView.bottomAnchor.constraintEqualToAnchor(view.bottomAnchor, constant: -self.dynamicType.margin)
             ])
 
         NSLayoutConstraint.activateConstraints([
@@ -201,42 +210,39 @@ class AztecPostViewController: UIViewController
     }
 
 
-
-    // MARK: - Layout
-
-    func layoutTextView() {
-        let lineHeight = titleTextField.font!.lineHeight
-        let offset: CGFloat = 15.0
-        let width: CGFloat = richTextView.frame.width - (offset * 2)
-        let height: CGFloat = lineHeight * 2.0
-        titleTextField.frame = CGRect(x: offset, y: 0, width: width, height: height)
-
-        separatorView.frame = CGRect(x: offset, y: titleTextField.frame.maxY, width: width, height: 1)
-
-        let top: CGFloat = separatorView.frame.maxY + lineHeight
-        richTextView.textContainerInset = UIEdgeInsets(top: top, left: offset, bottom: lineHeight, right: offset)
-    }
-
-
     // MARK: - Keyboard Handling
 
     func keyboardWillShow(notification: NSNotification) {
         guard
             let userInfo = notification.userInfo as? [String: AnyObject],
             let keyboardFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.CGRectValue(),
-            let duration: NSTimeInterval = (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue
+            let _: NSTimeInterval = (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue
             else {
                 return
         }
-        bottomConstraint?.constant = -(view.frame.maxY - keyboardFrame.minY)
-        UIView.animateWithDuration(duration) {
-            self.view.layoutIfNeeded()
-        }
+
+        htmlTextView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
+        htmlTextView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
+
+        richTextView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
+        richTextView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
     }
 
 
     func keyboardWillHide(notification: NSNotification) {
-        bottomConstraint?.constant = 0
+        guard
+            let userInfo = notification.userInfo as? [String: AnyObject],
+            let keyboardFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.CGRectValue(),
+            let _: NSTimeInterval = (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue
+            else {
+                return
+        }
+
+        htmlTextView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
+        htmlTextView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
+
+        richTextView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
+        richTextView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: view.frame.maxY - keyboardFrame.minY, right: 0)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -345,7 +345,7 @@ extension AztecPostViewController : Aztec.FormatBarDelegate
         case .Link:
             toggleLink()
         case .Media:
-            insertImage()
+            showImagePicker()
         }
         updateFormatBar()
     }
@@ -390,9 +390,18 @@ extension AztecPostViewController : Aztec.FormatBarDelegate
     }
 
 
-    func insertImage() {
-        editor.insertImage(richTextView.selectedRange.location, params: [String : AnyObject]())
+    func showImagePicker() {
+        let picker = UIImagePickerController()
+        picker.sourceType = .PhotoLibrary
+        picker.mediaTypes = UIImagePickerController.availableMediaTypesForSourceType(.PhotoLibrary) ?? []
+        picker.delegate = self
+        picker.allowsEditing = false
+        picker.navigationBar.translucent = false
+        picker.modalPresentationStyle = .CurrentContext
+
+        presentViewController(picker, animated: true, completion: nil)
     }
+
 
     // MARK: -
 
@@ -434,5 +443,35 @@ extension AztecPostViewController : Aztec.FormatBarDelegate
     func templateImage(named named: String) -> UIImage {
         return UIImage(named: named)!.imageWithRenderingMode(.AlwaysTemplate)
     }
+}
 
+
+extension AztecPostViewController: UINavigationControllerDelegate
+{
+
+}
+
+
+extension AztecPostViewController: UIImagePickerControllerDelegate
+{
+    func imagePickerController(picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : AnyObject]) {
+        dismissViewControllerAnimated(true, completion: nil)
+
+        guard let image = info[UIImagePickerControllerOriginalImage] as? UIImage else {
+            return
+        }
+
+        // Insert Image + Reclaim Focus
+        insertImage(image)
+        richTextView.becomeFirstResponder()
+    }
+}
+
+
+private extension AztecPostViewController
+{
+    func insertImage(image: UIImage) {
+        let index = richTextView.positionForCursor()
+        editor.insertImage(image, index: index)
+    }
 }


### PR DESCRIPTION
Integrates the latest from Aztec.
Improves the look & feel to look more like our live editor.
Enables HTML mode and moves the "Done" button to the left of the navigation bar.

**Known issues:**

It seems Aztec is having problems with starting a post from zero.  Switching to HTML is broken, styling is broken too.

We'll need to apply some extra fixes in Aztec before we can get it working properly under WPiOS.