### PR TITLE
Adds Me & My Sites analytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -49,7 +49,7 @@ abstract_target 'WordPress_Base' do
     pod 'Simperium', '0.8.17'
     pod 'WPMediaPicker', '~> 0.10.1'
     pod 'WordPress-iOS-Editor', '1.8.1'
-    pod 'WordPressCom-Analytics-iOS', '0.1.18'
+    pod 'WordPressCom-Analytics-iOS', '0.1.19'
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => 'c78c858194f57bc8d4b29712b72a38c97af140ab'
     pod 'WordPressCom-Stats-iOS', '0.7.7'
     pod 'wpxmlrpc', '~> 0.8'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -162,7 +162,7 @@ PODS:
     - WordPressCom-Analytics-iOS (~> 0.1.0)
   - WordPress-iOS-Shared (0.6.0):
     - CocoaLumberjack (~> 2.2.0)
-  - WordPressCom-Analytics-iOS (0.1.18)
+  - WordPressCom-Analytics-iOS (0.1.19)
   - WordPressCom-Stats-iOS (0.7.7):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
@@ -221,7 +221,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `c78c858194f57bc8d4b29712b72a38c97af140ab`)
   - WordPress-iOS-Editor (= 1.8.1)
   - WordPress-iOS-Shared (= 0.6.0)
-  - WordPressCom-Analytics-iOS (= 0.1.18)
+  - WordPressCom-Analytics-iOS (= 0.1.19)
   - WordPressCom-Stats-iOS (= 0.7.7)
   - WordPressCom-Stats-iOS/Services (= 0.7.7)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.4`)
@@ -291,12 +291,12 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 2d4f65d04e9ce1c319c7893f725aec80a1c6af3f
   WordPress-iOS-Editor: 3118f5d6b142b6bf322f3393a7dd98a28bca68cb
   WordPress-iOS-Shared: f799334b41f3af509ccb76d7970f8c74a7716f14
-  WordPressCom-Analytics-iOS: f8e3823c3d528d5238bfe6721cd0d67b9e7cc4f6
+  WordPressCom-Analytics-iOS: 1b01177ee3f588e984465b5b37ebcbb342836a8d
   WordPressCom-Stats-iOS: 5996ea5bc7ce2096400fdc33e3368b5524f7288a
   WordPressComKit: 0742c47e5b55bff0e6d26d40db9e010404675a73
   WPMediaPicker: 645ecc2435293cc898c76180f3994358a68cae20
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: cf3a0fd696d8ac6c3371f938697a9b9b5db37bd3
+PODFILE CHECKSUM: 2c00a1915a25073ccd08b5b9806c1931da5dc80e
 
 COCOAPODS: 1.0.1

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -744,9 +744,6 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
             eventName = @"stats_period_accessed";
             eventProperties = @{ @"period" : @"years" };
             break;
-        case WPAnalyticsStatStatsOpenedWebVersion:
-            eventName = @"stats_opened_web_version_accessed";
-            break;
         case WPAnalyticsStatStatsScrolledToBottom:
             eventName = @"stats_scrolled_to_bottom";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -374,6 +374,12 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         case WPAnalyticsStatMenusSavedMenu:
             eventName = @"menus_saved_menu";
             break;
+        case WPAnalyticsStatMeTabAccessed:
+            eventName = @"me_tab_accessed";
+            break;
+        case WPAnalyticsStatMySitesTabAccessed:
+            eventName = @"my_site_tab_accessed";
+            break;
         case WPAnalyticsStatNotificationsCommentApproved:
             eventName = @"notifications_approved";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -1040,8 +1040,16 @@ NSString *const SessionCount = @"session_count";
         case WPAnalyticsStatLoginMagicLinkSucceeded:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Login - Magic Link succeeded"];
             break;
+        case WPAnalyticsStatMeTabAccessed:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Me Tab - Accessed"];
+            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_me_tab"];
+            break;
+        case WPAnalyticsStatMySitesTabAccessed:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"My Site - Accessed"];
+            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_my_site"];
+            break;
 
-            // To be implemented
+        // To be implemented
         case WPAnalyticsStatAppUpgraded:
         case WPAnalyticsStatDefaultAccountChanged:
         case WPAnalyticsStatLogSpecialCondition:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -435,11 +435,6 @@ NSString *const SessionCount = @"session_count";
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_insights_screen_stats"];
             [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_insights_screen_stats"];
             break;
-        case WPAnalyticsStatStatsOpenedWebVersion:
-            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Stats - Opened Web Version"];
-            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_web_version_of_stats"];
-            [instructions setCurrentDateForPeopleProperty:@"last_time_accessed_web_version_of_stats"];
-            break;
         case WPAnalyticsStatStatsPeriodDaysAccessed:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Stats - Period Days Accessed"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_days_screen_stats"];

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -141,7 +141,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         // Bumping the stat in this method works for cases where the selected tab is
         // set in response to other feature behavior (e.g. a notifications), and
         // when set via state restoration.
-        [WPAnalytics track:WPAnalyticsStatReaderAccessed];
+        [WPAppAnalytics track:WPAnalyticsStatReaderAccessed];
     }
 }
 
@@ -483,6 +483,9 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         // Don't kick of this auto selecting behavior if the user taps the the active tab as it
         // would break from standard iOS UX
         if (tabBarController.selectedIndex != WPTabNewPost) {
+            // Bump the accessed stat when switching to the My Sites tab, but not if the tab is tapped when already selected.
+            [WPAppAnalytics track:WPAnalyticsStatMySitesTabAccessed];
+
             UINavigationController *navController = (UINavigationController *)viewController;
             BlogListViewController *blogListViewController = (BlogListViewController *)navController.viewControllers[0];
             if ([blogListViewController shouldBypassBlogListViewControllerWhenSelectedFromTabBar]) {
@@ -493,7 +496,10 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         }
     } else if ([tabBarController.viewControllers indexOfObject:viewController] == WPTabReader && tabBarController.selectedIndex != WPTabReader) {
         // Bump the accessed stat when switching to the reader tab, but not if the tab is tapped when already selected.
-        [WPAnalytics track:WPAnalyticsStatReaderAccessed];
+        [WPAppAnalytics track:WPAnalyticsStatReaderAccessed];
+    } else if ([tabBarController.viewControllers indexOfObject:viewController] == WPTabMe && tabBarController.selectedIndex != WPTabMe) {
+        // Bump the accessed stat when switching to the My Sites tab, but not if the tab is tapped when already selected.
+        [WPAppAnalytics track:WPAnalyticsStatMeTabAccessed];
     }
 
     // If the current view controller is selected already and it's at its root then scroll to the top

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -137,11 +137,23 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 - (void)setSelectedIndex:(NSUInteger)selectedIndex
 {
     [super setSelectedIndex:selectedIndex];
-    if (selectedIndex == WPTabReader) {
-        // Bumping the stat in this method works for cases where the selected tab is
-        // set in response to other feature behavior (e.g. a notifications), and
-        // when set via state restoration.
-        [WPAppAnalytics track:WPAnalyticsStatReaderAccessed];
+
+    // Bumping the stat in this method works for cases where the selected tab is
+    // set in response to other feature behavior (e.g. a notifications), and
+    // when set via state restoration.
+    switch (selectedIndex) {
+        case WPTabMe:
+            [WPAppAnalytics track:WPAnalyticsStatMeTabAccessed];
+            break;
+        case WPTabMySites:
+            [WPAppAnalytics track:WPAnalyticsStatMySitesTabAccessed];
+            break;
+        case WPTabReader:
+            [WPAppAnalytics track:WPAnalyticsStatReaderAccessed];
+            break;
+
+        default:
+            break;
     }
 }
 


### PR DESCRIPTION
Fixes #4071 

Whacks `WPAnalyticsStatStatsOpenedWebVersion` analytics event and adds `WPAnalyticsStatMeTabAccessed` & `WPAnalyticsStatMySitesTabAccessed` events.

To test:
1. Run the application.
2. Set a breakpoint in `TracksServiceRemote` in `sendBatchOfEvents:withSharedProperties:completionHandler:` (or dump the dictionaries out to NSLog).
2. Tap on Me Tab & My Sites tab.
3. Wait 10 seconds or less for your breakpoint to fire or log statement to verify those two events are being sent.

Needs review: @sendhil 
