### PR TITLE
Menus: Layout issues on iPad multitasking

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditingHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditingHeaderView.m
@@ -14,16 +14,9 @@
 
 @implementation MenuItemEditingHeaderView
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)awakeFromNib
 {
     [super awakeFromNib];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(deviceOrientationDidChangeNotification) name:UIDeviceOrientationDidChangeNotification object:nil];
 
     self.backgroundColor = [UIColor clearColor];
 
@@ -131,9 +124,9 @@
                                               ]];
 }
 
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+- (void)layoutSubviews
 {
-    [super traitCollectionDidChange:previousTraitCollection];
+    [super layoutSubviews];
     [self setNeedsDisplay];
 }
 
@@ -206,13 +199,6 @@
 - (void)textFieldValueDidChange:(UITextField *)textField
 {
     [self.delegate editingHeaderView:self didUpdateTextForItemName:textField.text];
-}
-
-#pragma mark - notifications
-
-- (void)deviceOrientationDidChangeNotification
-{
-    [self setNeedsDisplay];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.m
@@ -183,10 +183,6 @@ typedef NS_ENUM(NSUInteger, MenuItemEditingViewControllerContentLayout) {
 
 - (BOOL)shouldLayoutForCompactWidth
 {
-    if ([WPDeviceIdentification isiPad]) {
-        return NO;
-    }
-
     BOOL horizontallyCompact = [self.traitCollection containsTraitsInCollection:[UITraitCollection traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassCompact]];
 
     if (horizontallyCompact) {
@@ -216,7 +212,7 @@ typedef NS_ENUM(NSUInteger, MenuItemEditingViewControllerContentLayout) {
 {
     // compactWidthLayout is any screen size in which the width is less than the height (iPhone portrait)
     BOOL compactWidthLayout = [self shouldLayoutForCompactWidth];
-    BOOL minimizeLayoutForSourceViewTypying = ![WPDeviceIdentification isiPad] && self.sourceViewIsTyping;
+    BOOL minimizeLayoutForSourceViewTypying = compactWidthLayout && self.sourceViewIsTyping;
 
     if (minimizeLayoutForSourceViewTypying) {
         // headerView should be hidden while typing within the sourceView, to save screen space (iPhone)
@@ -225,15 +221,12 @@ typedef NS_ENUM(NSUInteger, MenuItemEditingViewControllerContentLayout) {
         [self setHeaderViewHidden:NO];
     }
 
-    if (![WPDeviceIdentification isiPad]) {
-
-        if (!compactWidthLayout) {
-            // on iPhone landscape we want to minimize the height of the footer to gain any vertical screen space we can
-            self.footerViewHeightConstraint.constant = FooterViewCompactHeight;
-        } else  {
-            // restore the height of the footer on portrait since we have more vertical screen space
-            self.footerViewHeightConstraint.constant = FooterViewDefaultHeight;
-        }
+    if (!compactWidthLayout) {
+        // on iPhone landscape we want to minimize the height of the footer to gain any vertical screen space we can
+        self.footerViewHeightConstraint.constant = FooterViewCompactHeight;
+    } else  {
+        // restore the height of the footer on portrait since we have more vertical screen space
+        self.footerViewHeightConstraint.constant = FooterViewDefaultHeight;
     }
 
     if (compactWidthLayout || minimizeLayoutForSourceViewTypying) {
@@ -323,6 +316,12 @@ typedef NS_ENUM(NSUInteger, MenuItemEditingViewControllerContentLayout) {
                 [NSLayoutConstraint activateConstraints:self.layoutConstraintsForDisplayingSourceAndTypeViews];
                 break;
             }
+        }
+
+        if (contentLayout == MenuItemEditingViewControllerContentLayoutDisplaysTypeAndSourceViews) {
+            [self.sourceViewController setHeaderViewHidden:YES];
+        } else {
+            [self.sourceViewController setHeaderViewHidden:NO];
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemSourceViewController.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemSourceViewController.h
@@ -14,7 +14,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) MenuItem *item;
 
 /**
- Toggled which sourceView should display based on the itemType.
+ Toggle whether or not the item type header view is hidden.
+ */
+- (void)setHeaderViewHidden:(BOOL)hidden;
+
+/**
+ Toggle which sourceView should display based on the itemType.
  */
 - (void)updateSourceSelectionForItemType:(NSString *)itemType;
 

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemSourceViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemSourceViewController.m
@@ -47,17 +47,6 @@ static CGFloat const SourceHeaderViewHeight = 60.0;
     _headerView = headerView;
 }
 
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
-{
-    [super traitCollectionDidChange:previousTraitCollection];
-
-    if (IS_IPAD || self.view.frame.size.width > self.view.frame.size.height) {
-        [self setHeaderViewHidden:YES];
-    } else  {
-        [self setHeaderViewHidden:NO];
-    }
-}
-
 - (void)setHeaderViewHidden:(BOOL)hidden
 {
     if (self.headerView.hidden != hidden) {


### PR DESCRIPTION
Fixes a couple issues with Menus on the iPad while sliding into multi-tasking. Removes the previous device identification of iPad and instead decides what to do based on the size class, _as it should_.

To test:

1. Open Menus on iPad.
2. Select a Menu Item to bring up the modal item editor.
3. The view should have a "full" layout with the item types on the left and the selectable values on the right.
3. Background the app.
4. Select another app, such as Safari.
5. Slide in WPiOS for multitasking.
6. The editing modal should now display a "compact" layout with only the selectable items visible and the header displaying the "< Type" back button.
7. Tapping the back button should slide in the item types.
8. Slide the multitasking toggle to bring the app to full-screen.
9. The layout should now restore to the original "full" state.

Needs review: @jleandroperez can you take a gander? This might be a bit confusing, let me know if you need more clarity!

![simulator screen shot sep 2 2016 2 00 25 pm](https://cloud.githubusercontent.com/assets/1873422/18215202/af913b9c-7115-11e6-8172-95d75549a899.png)
![simulator screen shot sep 2 2016 2 00 43 pm](https://cloud.githubusercontent.com/assets/1873422/18215203/af9e9120-7115-11e6-83de-6acbc24a495a.png)
