### PR TITLE
Remove PostServiceType enum

### DIFF
--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -5,11 +5,10 @@
 @class Blog, Post, Page, AbstractPost;
 @class RemotePost;
 
-typedef NS_ENUM(NSInteger, PostServiceType) {
-    PostServiceTypePost,
-    PostServiceTypePage,
-    PostServiceTypeAny
-};
+typedef NSString * PostServiceType;
+extern PostServiceType const PostServiceTypePost;
+extern PostServiceType const PostServiceTypePage;
+extern PostServiceType const PostServiceTypeAny;
 
 extern const NSUInteger PostServiceDefaultNumberToSync;
 
@@ -23,8 +22,6 @@ typedef void(^PostServiceSyncFailure)(NSError *error);
 
 + (Post *)createDraftPostInMainContextForBlog:(Blog *)blog;
 + (Page *)createDraftPageInMainContextForBlog:(Blog *)blog;
-
-+ (NSString *)keyForType:(PostServiceType)postType;
 
 - (AbstractPost *)findPostWithID:(NSNumber *)postID inBlog:(Blog *)blog;
 

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractPostsViewController.m
@@ -56,6 +56,8 @@
 
     PostService *service = [[PostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
     PostServiceSyncOptions *options = [self syncOptions];
+    [service syncPostsOfType:@"asdf" withOptions:nil forBlog:nil success:nil failure:nil];
+
     [service syncPostsOfType:[self sourceItemType]
                  withOptions:options
                      forBlog:[self blog]

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractPostsViewController.m
@@ -56,8 +56,6 @@
 
     PostService *service = [[PostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
     PostServiceSyncOptions *options = [self syncOptions];
-    [service syncPostsOfType:@"asdf" withOptions:nil forBlog:nil success:nil failure:nil];
-
     [service syncPostsOfType:[self sourceItemType]
                  withOptions:options
                      forBlog:[self blog]

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -150,7 +150,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     // MARK: - Sync Methods
 
     override internal func postTypeToSync() -> PostServiceType {
-        return PostServiceType.Page
+        return PostServiceTypePage
     }
 
     override internal func lastSyncDate() -> NSDate? {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -283,7 +283,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     func propertiesForAnalytics() -> [String:AnyObject] {
         var properties = [String:AnyObject]()
 
-        properties["type"] = PostService.keyForType(postTypeToSync())
+        properties["type"] = postTypeToSync()
         properties["filter"] = filterSettings.currentPostListFilter().title
 
         if let dotComID = blog.dotComID {
@@ -553,7 +553,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     internal func postTypeToSync() -> PostServiceType {
         // Subclasses should override.
-        return PostServiceType.Any
+        return PostServiceTypeAny
     }
 
     func lastSyncDate() -> NSDate? {
@@ -578,7 +578,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         options.purgesLocalSync = true
 
         postService.syncPostsOfType(
-            postTypeToSync(),
+            postTypeToSync() as String,
             withOptions: options,
             forBlog: blog,
             success: {[weak self] posts in
@@ -631,7 +631,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         options.offset = tableViewHandler.resultsController.fetchedObjects?.count
 
         postService.syncPostsOfType(
-            postTypeToSync(),
+            postTypeToSync() as String,
             withOptions: options,
             forBlog: blog,
             success: {[weak self] posts in
@@ -768,7 +768,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         options.search = searchText
 
         postService.syncPostsOfType(
-            postTypeToSync(),
+            postTypeToSync() as String,
             withOptions: options,
             forBlog: blog,
             success: { [weak self] posts in

--- a/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
@@ -83,9 +83,9 @@ class PostListFilterSettings: NSObject {
 
     func keyForCurrentListStatusFilter() -> String {
         switch postType {
-        case .Page:
+        case PostServiceTypePage:
             return self.dynamicType.currentPageListStatusFilterKey
-        case .Post:
+        case PostServiceTypePost:
             return self.dynamicType.currentPageListStatusFilterKey
         default:
             return ""
@@ -121,7 +121,7 @@ class PostListFilterSettings: NSObject {
     // MARK: - Author-related methods
 
     func canFilterByAuthor() -> Bool {
-        if postType == .Post
+        if postType == PostServiceTypePost
         {
             return blog.isHostedAtWPcom && blog.isMultiAuthor && blog.account?.userID != nil
         }
@@ -170,7 +170,7 @@ class PostListFilterSettings: NSObject {
     func propertiesForAnalytics() -> [String:AnyObject] {
         var properties = [String:AnyObject]()
 
-        properties["type"] = PostService.keyForType(postType)
+        properties["type"] = postType
         properties["filter"] = currentPostListFilter().title
 
         if let dotComID = blog.dotComID {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -200,7 +200,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
     // MARK: - Sync Methods
 
     override func postTypeToSync() -> PostServiceType {
-        return PostServiceType.Post
+        return PostServiceTypePost
     }
 
     override func lastSyncDate() -> NSDate? {
@@ -253,7 +253,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
             predicates.append(basePredicate)
         }
 
-        let typePredicate = NSPredicate(format: "postType = %@", PostService.keyForType(postTypeToSync()))
+        let typePredicate = NSPredicate(format: "postType = %@", postTypeToSync())
         predicates.append(typePredicate)
 
         let searchText = currentSearchTerm()


### PR DESCRIPTION
Removes the `PostServiceType` enum and returns the `PostService` sync method to using strings. This is in anticipation of growing support for custom post types.

Uses a `typedef` for a cleaner API, and _especially_ as a step toward [Swift 3's stringly/strongly API](https://youtu.be/UU2fNq35xkM?t=31m43s) support.

### To test:
Best test is probably to make sure the menus now sync the correct post type instead of everything. You'll know how to do this better than I, @kurzee.

Another test that's easy is to verify the right posts are being preloaded:
1. with the device on wifi select a site from the *My Sites* screen
2. the network activity indicator should show up in the status bar, indicating that posts and pages are being preloaded. Wait until it's gone so that preloading has completed.
3. view both *Blog Posts* and *Pages* screen have preloaded content. If you see more posts pop-in after selecting the screen, preload probably failed.
4. This test may still appear to pass if, like the menu code, it syncs every kind of post.

Needs review: @kurzee 