### PR TITLE
Merge latest from release/6.5 into develop

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,9 +23,9 @@ abstract_target 'WordPress_Base' do
     pod 'CocoaLumberjack', '~> 2.2.0'
     pod 'DTCoreText',   '1.6.16'
     pod 'FormatterKit', '~> 1.8.1'
-    pod 'Helpshift', '~> 5.6.2'
+    pod 'Helpshift', '~> 5.7.1'
     pod 'HockeySDK', '~> 3.8.0', :configurations => ['Release-Internal', 'Release-Alpha']
-    pod 'Lookback', '1.3.0', :configurations => ['Release-Internal', 'Release-Alpha']
+    pod 'Lookback', '1.4.1', :configurations => ['Release-Internal', 'Release-Alpha']
     pod 'MRProgress', '~>0.7.0'
     pod 'Mixpanel', '2.9.4'
     pod 'Reachability',	'3.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -75,11 +75,11 @@ PODS:
   - FormatterKit/URLRequestFormatter (1.8.1):
     - FormatterKit/Resources
   - Gridicons (0.2)
-  - Helpshift (5.6.2)
+  - Helpshift (5.7.1)
   - HockeySDK (3.8.6):
     - HockeySDK/AllFeaturesLib (= 3.8.6)
   - HockeySDK/AllFeaturesLib (3.8.6)
-  - Lookback (1.3.0):
+  - Lookback (1.4.1):
     - PDKTZipArchive
   - Mixpanel (2.9.4):
     - Mixpanel/Mixpanel (= 2.9.4)
@@ -200,9 +200,9 @@ DEPENDENCIES:
   - Expecta (= 1.0.5)
   - FormatterKit (~> 1.8.1)
   - Gridicons (= 0.2)
-  - Helpshift (~> 5.6.2)
+  - Helpshift (~> 5.7.1)
   - HockeySDK (~> 3.8.0)
-  - Lookback (= 1.3.0)
+  - Lookback (= 1.4.1)
   - Mixpanel (= 2.9.4)
   - MRProgress (~> 0.7.0)
   - Nimble (~> 4.0.0)
@@ -264,9 +264,9 @@ SPEC CHECKSUMS:
   Fabric: 5755268d0171435ab167e3d0878a28a777deaf10
   FormatterKit: 11ad17b983200629246a5a466f6f1bfa2df823cb
   Gridicons: 5c33065054b19e56a47d252b52e321746b97a414
-  Helpshift: aadcbbe47f67deb96552503333774b29bdda19d5
+  Helpshift: 48ee4b24dc5f0ae7d1dfd8dded6eea327069a014
   HockeySDK: ab68303eec6680f6b539de65d747742dd276e934
-  Lookback: e126cf9ea6e916cba0b9105eafea701741789e4c
+  Lookback: 37c23f97894612f6eccc215440c8f990fbb5a607
   Mixpanel: 80d2ca9bb38ae91c1044d738e80fe448377ac89f
   MRProgress: 1cb0051b678be4a2ef4881414cd316768fc70028
   Nimble: 0f3c8b8b084cda391209c3c5efbb48bedeeb920a
@@ -291,6 +291,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 645ecc2435293cc898c76180f3994358a68cae20
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: d54bcafa99324ec834634e30654bc6655280fb79
+PODFILE CHECKSUM: 7c94937ae0ddf3713c065bc2c9712444e26ebd6b
 
 COCOAPODS: 1.0.1

--- a/WordPress/Classes/Networking/ReaderTopicServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderTopicServiceRemote.m
@@ -133,8 +133,7 @@ static NSString * const SiteDictionarySubscriptionsKey = @"subscribers_count";
              withSuccess:(void (^)(NSNumber *topicID))success
                  failure:(void (^)(NSError *error))failure
 {
-    NSString *slug = [self slugForTopicName:topicName];
-    [self followTopicWithSlug:slug withSuccess:success failure:failure];
+    [self followTopicWithSlug:topicName withSuccess:success failure:failure];
 }
 
 - (void)followTopicWithSlug:(NSString *)slug
@@ -142,6 +141,7 @@ static NSString * const SiteDictionarySubscriptionsKey = @"subscribers_count";
                  failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"read/tags/%@/mine/new", slug];
+    path = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -5,11 +5,10 @@
 @class Blog, Post, Page, AbstractPost;
 @class RemotePost;
 
-typedef NS_ENUM(NSInteger, PostServiceType) {
-    PostServiceTypePost,
-    PostServiceTypePage,
-    PostServiceTypeAny
-};
+typedef NSString * PostServiceType;
+extern PostServiceType const PostServiceTypePost;
+extern PostServiceType const PostServiceTypePage;
+extern PostServiceType const PostServiceTypeAny;
 
 extern const NSUInteger PostServiceDefaultNumberToSync;
 
@@ -23,8 +22,6 @@ typedef void(^PostServiceSyncFailure)(NSError *error);
 
 + (Post *)createDraftPostInMainContextForBlog:(Blog *)blog;
 + (Page *)createDraftPageInMainContextForBlog:(Blog *)blog;
-
-+ (NSString *)keyForType:(PostServiceType)postType;
 
 - (AbstractPost *)findPostWithID:(NSNumber *)postID inBlog:(Blog *)blog;
 

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -604,6 +604,16 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
                 NSSet *existingGlobalIDs = [self globalIDsOfExistingPostsForTopic:readerTopic];
                 NSSet *newGlobalIDs = [self globalIDsOfRemotePosts:posts];
                 overlap = [existingGlobalIDs intersectsSet:newGlobalIDs];
+
+                // A strategy to avoid false positives in gap detection is to sync
+                // one extra post. Only remove the extra post if we received a
+                // full set of results. A partial set means we've reached
+                // the end of syncable content.
+                if ([posts count] == [self numberToSyncForTopic:readerTopic] && ![ReaderHelpers isTopicSearchTopic:readerTopic]) {
+                    posts = [posts subarrayWithRange:NSMakeRange(0, [posts count] - 2)];
+                    postsCount = [posts count];
+                }
+
             }
 
             // Create or update the synced posts.

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditingHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditingHeaderView.m
@@ -14,16 +14,9 @@
 
 @implementation MenuItemEditingHeaderView
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)awakeFromNib
 {
     [super awakeFromNib];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(deviceOrientationDidChangeNotification) name:UIDeviceOrientationDidChangeNotification object:nil];
 
     self.backgroundColor = [UIColor clearColor];
 
@@ -131,9 +124,9 @@
                                               ]];
 }
 
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+- (void)layoutSubviews
 {
-    [super traitCollectionDidChange:previousTraitCollection];
+    [super layoutSubviews];
     [self setNeedsDisplay];
 }
 
@@ -206,13 +199,6 @@
 - (void)textFieldValueDidChange:(UITextField *)textField
 {
     [self.delegate editingHeaderView:self didUpdateTextForItemName:textField.text];
-}
-
-#pragma mark - notifications
-
-- (void)deviceOrientationDidChangeNotification
-{
-    [self setNeedsDisplay];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.m
@@ -183,10 +183,6 @@ typedef NS_ENUM(NSUInteger, MenuItemEditingViewControllerContentLayout) {
 
 - (BOOL)shouldLayoutForCompactWidth
 {
-    if ([WPDeviceIdentification isiPad]) {
-        return NO;
-    }
-
     BOOL horizontallyCompact = [self.traitCollection containsTraitsInCollection:[UITraitCollection traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassCompact]];
 
     if (horizontallyCompact) {
@@ -216,7 +212,7 @@ typedef NS_ENUM(NSUInteger, MenuItemEditingViewControllerContentLayout) {
 {
     // compactWidthLayout is any screen size in which the width is less than the height (iPhone portrait)
     BOOL compactWidthLayout = [self shouldLayoutForCompactWidth];
-    BOOL minimizeLayoutForSourceViewTypying = ![WPDeviceIdentification isiPad] && self.sourceViewIsTyping;
+    BOOL minimizeLayoutForSourceViewTypying = compactWidthLayout && self.sourceViewIsTyping;
 
     if (minimizeLayoutForSourceViewTypying) {
         // headerView should be hidden while typing within the sourceView, to save screen space (iPhone)
@@ -225,15 +221,12 @@ typedef NS_ENUM(NSUInteger, MenuItemEditingViewControllerContentLayout) {
         [self setHeaderViewHidden:NO];
     }
 
-    if (![WPDeviceIdentification isiPad]) {
-
-        if (!compactWidthLayout) {
-            // on iPhone landscape we want to minimize the height of the footer to gain any vertical screen space we can
-            self.footerViewHeightConstraint.constant = FooterViewCompactHeight;
-        } else  {
-            // restore the height of the footer on portrait since we have more vertical screen space
-            self.footerViewHeightConstraint.constant = FooterViewDefaultHeight;
-        }
+    if (!compactWidthLayout) {
+        // on iPhone landscape we want to minimize the height of the footer to gain any vertical screen space we can
+        self.footerViewHeightConstraint.constant = FooterViewCompactHeight;
+    } else  {
+        // restore the height of the footer on portrait since we have more vertical screen space
+        self.footerViewHeightConstraint.constant = FooterViewDefaultHeight;
     }
 
     if (compactWidthLayout || minimizeLayoutForSourceViewTypying) {
@@ -323,6 +316,12 @@ typedef NS_ENUM(NSUInteger, MenuItemEditingViewControllerContentLayout) {
                 [NSLayoutConstraint activateConstraints:self.layoutConstraintsForDisplayingSourceAndTypeViews];
                 break;
             }
+        }
+
+        if (contentLayout == MenuItemEditingViewControllerContentLayoutDisplaysTypeAndSourceViews) {
+            [self.sourceViewController setHeaderViewHidden:YES];
+        } else {
+            [self.sourceViewController setHeaderViewHidden:NO];
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemSourceViewController.h
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemSourceViewController.h
@@ -14,7 +14,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) MenuItem *item;
 
 /**
- Toggled which sourceView should display based on the itemType.
+ Toggle whether or not the item type header view is hidden.
+ */
+- (void)setHeaderViewHidden:(BOOL)hidden;
+
+/**
+ Toggle which sourceView should display based on the itemType.
  */
 - (void)updateSourceSelectionForItemType:(NSString *)itemType;
 

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemSourceViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemSourceViewController.m
@@ -47,17 +47,6 @@ static CGFloat const SourceHeaderViewHeight = 60.0;
     _headerView = headerView;
 }
 
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
-{
-    [super traitCollectionDidChange:previousTraitCollection];
-
-    if (IS_IPAD || self.view.frame.size.width > self.view.frame.size.height) {
-        [self setHeaderViewHidden:YES];
-    } else  {
-        [self setHeaderViewHidden:NO];
-    }
-}
-
 - (void)setHeaderViewHidden:(BOOL)hidden
 {
     if (self.headerView.hidden != hidden) {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -150,7 +150,7 @@ class PageListViewController : AbstractPostListViewController, UIViewControllerR
     // MARK: - Sync Methods
 
     override internal func postTypeToSync() -> PostServiceType {
-        return PostServiceType.Page
+        return PostServiceTypePage
     }
 
     override internal func lastSyncDate() -> NSDate? {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -283,7 +283,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
     func propertiesForAnalytics() -> [String:AnyObject] {
         var properties = [String:AnyObject]()
 
-        properties["type"] = PostService.keyForType(postTypeToSync())
+        properties["type"] = postTypeToSync()
         properties["filter"] = filterSettings.currentPostListFilter().title
 
         if let dotComID = blog.dotComID {
@@ -553,7 +553,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
 
     internal func postTypeToSync() -> PostServiceType {
         // Subclasses should override.
-        return PostServiceType.Any
+        return PostServiceTypeAny
     }
 
     func lastSyncDate() -> NSDate? {
@@ -578,7 +578,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         options.purgesLocalSync = true
 
         postService.syncPostsOfType(
-            postTypeToSync(),
+            postTypeToSync() as String,
             withOptions: options,
             forBlog: blog,
             success: {[weak self] posts in
@@ -631,7 +631,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         options.offset = tableViewHandler.resultsController.fetchedObjects?.count
 
         postService.syncPostsOfType(
-            postTypeToSync(),
+            postTypeToSync() as String,
             withOptions: options,
             forBlog: blog,
             success: {[weak self] posts in
@@ -768,7 +768,7 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         options.search = searchText
 
         postService.syncPostsOfType(
-            postTypeToSync(),
+            postTypeToSync() as String,
             withOptions: options,
             forBlog: blog,
             success: { [weak self] posts in

--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
@@ -6,7 +6,8 @@
 #import "WordPress-Swift.h"
 
 static NSInteger ActionBarMoreButtonIndex = 999;
-static CGFloat ActionBarMinButtonWidth = 90.0;
+static NSInteger const ActionBarMaxNumButtonsHorizontallyCompact = 3;
+static NSInteger const ActionBarMaxNumButtonsHorizontallyRegular = 4;
 
 static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
 
@@ -37,6 +38,15 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
         [self setupView];
     }
     return self;
+}
+
+#pragma mark - Layout
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+
+    [self setupButtonsIfNeeded];
 }
 
 #pragma mark - Setup
@@ -261,16 +271,6 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
     [self configureButtons];
 }
 
-
-#pragma mark - Notifications
-
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
-{
-    [super traitCollectionDidChange:previousTraitCollection];
-
-    [self setupButtonsIfNeeded];
-}
-
 #pragma mark - Accessors
 
 - (NSInteger)indexOfItem:(PostCardActionBarItem *)item
@@ -280,7 +280,17 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
 
 - (NSInteger)maxButtonsToDisplay
 {
-    return (NSInteger)floor(CGRectGetWidth(self.frame) / ActionBarMinButtonWidth);
+    NSInteger count;
+    if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
+        count = ActionBarMaxNumButtonsHorizontallyRegular;
+    } else if ( [WPDeviceIdentification isiPhone] && UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation])) {
+        // On iPhone, if we're not horizontally regular, but in landscape orientation, go ahead
+        // and allow the max button count for horizontally regular since we have the screen space.
+        count = ActionBarMaxNumButtonsHorizontallyRegular;
+    } else {
+        count = ActionBarMaxNumButtonsHorizontallyCompact;
+    }
+    return count;
 }
 
 - (BOOL)checkIfShouldShowMoreButton

--- a/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
@@ -83,9 +83,9 @@ class PostListFilterSettings: NSObject {
 
     func keyForCurrentListStatusFilter() -> String {
         switch postType {
-        case .Page:
+        case PostServiceTypePage:
             return self.dynamicType.currentPageListStatusFilterKey
-        case .Post:
+        case PostServiceTypePost:
             return self.dynamicType.currentPageListStatusFilterKey
         default:
             return ""
@@ -121,7 +121,7 @@ class PostListFilterSettings: NSObject {
     // MARK: - Author-related methods
 
     func canFilterByAuthor() -> Bool {
-        if postType == .Post
+        if postType == PostServiceTypePost
         {
             return blog.isHostedAtWPcom && blog.isMultiAuthor && blog.account?.userID != nil
         }
@@ -170,7 +170,7 @@ class PostListFilterSettings: NSObject {
     func propertiesForAnalytics() -> [String:AnyObject] {
         var properties = [String:AnyObject]()
 
-        properties["type"] = PostService.keyForType(postType)
+        properties["type"] = postType
         properties["filter"] = currentPostListFilter().title
 
         if let dotComID = blog.dotComID {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -200,7 +200,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
     // MARK: - Sync Methods
 
     override func postTypeToSync() -> PostServiceType {
-        return PostServiceType.Post
+        return PostServiceTypePost
     }
 
     override func lastSyncDate() -> NSDate? {
@@ -253,7 +253,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
             predicates.append(basePredicate)
         }
 
-        let typePredicate = NSPredicate(format: "postType = %@", PostService.keyForType(postTypeToSync()))
+        let typePredicate = NSPredicate(format: "postType = %@", postTypeToSync())
         predicates.append(typePredicate)
 
         let searchText = currentSearchTerm()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
@@ -19,6 +19,7 @@ public class ReaderGapMarkerCell: UITableViewCell
         // Background styles
         selectedBackgroundView = UIView(frame: innerContentView.frame)
         selectedBackgroundView?.backgroundColor = WPStyleGuide.greyLighten30()
+        contentView.backgroundColor = WPStyleGuide.greyLighten30()
         innerContentView.backgroundColor = WPStyleGuide.greyLighten30()
         tearMaskView.backgroundColor = WPStyleGuide.greyLighten30()
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -262,7 +262,9 @@ import WordPressShared
         let controller = SettingsTextViewController(text: nil, placeholder: placeholder, hint: nil)
         controller.title = NSLocalizedString("Add a Tag", comment: "Title of a feature to add a new tag to the tags subscribed by the user.")
         controller.onValueChanged = { value in
-            self.followTagNamed(value)
+            if value.trim().characters.count > 0 {
+                self.followTagNamed(value.trim())
+            }
         }
         controller.mode = .LowerCaseText
         controller.displaysActionButton = true

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4</string>
+	<string>6.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -35,7 +35,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6.4.0.4</string>
+	<string>6.5.0.0</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4.0.20160819</string>
+	<string>6.5.0.20160906</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -44,7 +44,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>6.4.0.20160819</string>
+	<string>6.5.0.20160906</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>org-appextension-feature-password-management</string>

--- a/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
+++ b/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
@@ -21,6 +21,22 @@ public class WordPressOrgXMLRPCApi: NSObject
         return session
     }()
 
+    private var uploadSession: NSURLSession {
+        get {
+            if #available(iOS 10.0, *) {
+                return self.session
+            }
+            let sessionConfiguration = NSURLSessionConfiguration.defaultSessionConfiguration()
+            var additionalHeaders: [String : AnyObject] = ["Accept-Encoding":"gzip, deflate"]
+            if let userAgent = self.userAgent {
+                additionalHeaders["User-Agent"] = userAgent
+            }
+            sessionConfiguration.HTTPAdditionalHeaders = additionalHeaders
+            let session = NSURLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
+            return session
+        }
+    }
+
     public init(endpoint: NSURL, userAgent: String? = nil) {
         self.endpoint = endpoint
         self.userAgent = userAgent
@@ -123,7 +139,11 @@ public class WordPressOrgXMLRPCApi: NSObject
         }
 
         // Create task
+        let session = uploadSession
         let task = session.uploadTaskWithRequest(request, fromFile: fileURL, completionHandler: { (data, urlResponse, error) in
+            if session != self.session {
+                session.finishTasksAndInvalidate()
+            }
             let _ = try? NSFileManager.defaultManager().removeItemAtURL(fileURL)
             do {
                 let responseObject = try self.handleResponseWithData(data, urlResponse: urlResponse, error: error)

--- a/WordPress/WordPressShareExtension/Info-Internal.plist
+++ b/WordPress/WordPressShareExtension/Info-Internal.plist
@@ -21,11 +21,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4.0.20160722</string>
+	<string>6.5.0.20160901</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>6.4.0.20160722</string>
+	<string>6.5.0.20160901</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WordPress/WordPressShareExtension/Info.plist
+++ b/WordPress/WordPressShareExtension/Info.plist
@@ -21,11 +21,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4</string>
+	<string>6.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>6.4.0.4</string>
+	<string>6.5.0.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WordPress/WordPressTodayWidget/Info-Internal.plist
+++ b/WordPress/WordPressTodayWidget/Info-Internal.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4.0.20160722</string>
+	<string>6.5.0.20160901</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>6.4.0.20160722</string>
+	<string>6.5.0.20160901</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/WordPress/WordPressTodayWidget/Info.plist
+++ b/WordPress/WordPressTodayWidget/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.4</string>
+	<string>6.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>6.4.0.4</string>
+	<string>6.5.0.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>


### PR DESCRIPTION
Note, only conflict was Podfile.lock checksum, which is resolved by running `pod install` for the latest checksum between `develop` and `release/6.5`.

Needs review: @diegoreymendez I think this would be a case where we could just go ahead and auto-merge since there were no conflicts other than the Podfile.lock. Before I move forward with it, just wanted to give you a chance to take a look in an actual case of merging.

Note: Of course, eventually, if we were merging right after we merged something into the release branch, merging back would _only_ be our recent changes, so it would be less of a history of commits.