### PR TITLE
Fixes a crash when trying to share a previewed post.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -338,7 +338,7 @@
         
         PostSharingController *sharingController = [[PostSharingController alloc] init];
         
-        [sharingController sharePost:post fromView:[self shareBarButtonItem].customView inViewController:self];
+        [sharingController sharePost:post fromBarButtonItem:[self shareBarButtonItem] inViewController:self];
     }
 }
 


### PR DESCRIPTION
Fixes #5952 

**To test:**
1. Launch the app using the simulator for iPad 2, under iOS 9.3.
2. Open a published post.
3. Preview the post.
4. Tap the share button.
5. Make sure sharing works.

Needs review: @sendhil

Props to @lancewillett for finding this bug.