### PR TITLE
Issues/5951 manage sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
@@ -30,7 +30,7 @@ import WordPressShared.WPStyleGuide
 
         titleLabel.font = WPStyleGuide.tableviewTextFont()
         titleLabel.textColor = WPStyleGuide.darkGrey()
-        titleLabel.text = NSLocalizedString("Manage Sites", comment: "Button title. Tapping lets the user manage the sites they follow.")
+        titleLabel.text = NSLocalizedString("Manage", comment: "Button title. Tapping lets the user manage the sites they follow.")
 
         disclosureIcon.image = Gridicon.iconOfType(.ChevronRight, withSize: disclosureIcon.frame.size)
         disclosureIcon.tintColor = WPStyleGuide.accessoryDefaultTintColor()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -24,6 +24,11 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         return WPNoResultsView(title: title, message: message, accessoryView: nil, buttonTitle: nil)
     }()
 
+    lazy var loadingView: WPNoResultsView = {
+        let title = NSLocalizedString("Fetching sites...", comment:"A short message to inform the user data for their followed sites is being fetched..")
+        return WPNoResultsView(title: title, message: nil, accessoryView: nil, buttonTitle: nil)
+    }()
+
 
     /// Convenience method for instantiating an instance of ReaderFollowedSitesViewController
     ///
@@ -73,8 +78,8 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
 
-        configureNoResultsView()
         syncSites()
+        configureNoResultsView()
     }
 
 
@@ -122,8 +127,15 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
 
 
     func configureNoResultsView() {
+        noResultsView.removeFromSuperview()
+        loadingView.removeFromSuperview()
         if let count = tableViewHandler.resultsController.fetchedObjects?.count where count > 0 {
-            noResultsView.removeFromSuperview()
+            return
+        }
+
+        if (isSyncing) {
+            view.addSubview(loadingView)
+            loadingView.centerInSuperview()
         } else {
             view.addSubview(noResultsView)
             noResultsView.centerInSuperview()
@@ -141,14 +153,15 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         isSyncing = true
         let service = ReaderTopicService(managedObjectContext: managedObjectContext())
         service.fetchFollowedSitesWithSuccess({[weak self] in
+            self?.isSyncing = false
             self?.configureNoResultsView()
             self?.refreshControl.endRefreshing()
-            self?.isSyncing = false
         }, failure: { [weak self] (error) in
             DDLogSwift.logError("Could not sync sites: \(error)")
+            self?.isSyncing = false
             self?.configureNoResultsView()
             self?.refreshControl.endRefreshing()
-            self?.isSyncing = false
+
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -61,7 +61,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.title = NSLocalizedString("Manage Sites", comment: "Page title for the screen to manage your list of followed sites.")
+        self.title = NSLocalizedString("Manage", comment: "Page title for the screen to manage your list of followed sites.")
         setupTableView()
         setupTableViewHandler()
         configureSearchBar()
@@ -302,7 +302,7 @@ extension ReaderFollowedSitesViewController : WPTableViewHandlerDelegate
     func tableView(tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         let count = tableViewHandler.resultsController.fetchedObjects?.count ?? 0
         if count > 0 {
-            return NSLocalizedString("Sites", comment: "Section title for sites the user has followed.")
+            return NSLocalizedString("Followed Sites", comment: "Section title for sites the user has followed.")
         }
         return nil
     }


### PR DESCRIPTION
Fixes #5951 

To test: 
- Double check text changes. (We'll also want the 👍 from our designers).
- Sign out of the app. 
- Use Apple's Network Link Conditioner utility to slow your connection (or already have a very slow connection)
- Sign into the app. Go to the Reader > Followed Sites > Manage and confirm a loading message appears. 
- Confirm the loading message is removed when the fetch ends. 
- Confirm that either "No Sites" is shown or a list of followed sites is shown as appropriate. 

Needs review: @kurzee would you mind taking this one?