### PR TITLE
Reader: Restore bars when scrolling to the bottom of a post detail.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -714,18 +714,29 @@ public class ReaderDetailViewController : UIViewController, UIViewControllerRest
 
         } else {
             // Shows the navbar and footer view
+            let pinToBottom = isScrollViewAtBottom()
+
             navigationController?.setNavigationBarHidden(false, animated: true)
             footerViewHeightConstraint.constant = footerViewHeightConstraintConstant
             UIView.animateWithDuration(0.3,
                 delay: 0.0,
                 options: [.BeginFromCurrentState, .AllowUserInteraction],
-                animations: { () -> Void in
+                animations: {
                     self.view.layoutIfNeeded()
+                    if pinToBottom {
+                        let y = self.scrollView.contentSize.height - self.scrollView.frame.height
+                        self.scrollView.setContentOffset(CGPoint(x: 0, y: y), animated: false)
+                    }
+
                 }, completion: nil)
         }
 
     }
 
+
+    func isScrollViewAtBottom() -> Bool {
+        return scrollView.contentOffset.y + scrollView.frame.height == scrollView.contentSize.height
+    }
 
     // MARK: - Analytics
 
@@ -937,8 +948,16 @@ extension ReaderDetailViewController : UIScrollViewDelegate
         }
     }
 
+
     public func scrollViewDidScrollToTop(scrollView: UIScrollView) {
         setBarsHidden(false)
+    }
+
+
+    public func scrollViewDidEndDecelerating(scrollView: UIScrollView) {
+        if isScrollViewAtBottom() {
+            setBarsHidden(false)
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #5964

To test:
View a post detail that has enough content to scroll and hide the bars. 
Confirm that the bars are restored when reaching the bottom of the post.
Confirm that the offset is correctly adjusted to continue showing the bottom of the post rather than the bottom bar covering up part of the content and necessitating another scroll. 

Needs review: @nheagy could I trouble you with this one? 
