### PR TITLE
Reader: Display date created not sort date.

### DIFF
--- a/WordPress/Classes/Models/ReaderPost.m
+++ b/WordPress/Classes/Models/ReaderPost.m
@@ -189,7 +189,7 @@ NSString * const ReaderPostStoredCommentTextKey = @"comment";
 
 - (NSDate *)dateForDisplay
 {
-    return [self sortDate];
+    return [self dateCreated];
 }
 
 - (NSString *)contentPreviewForDisplay


### PR DESCRIPTION
Reader posts were showing the "sort date" on cards and detail which makes no sense for search results.  This PR switches from using the sortDate to using dateCreated, which is really more proper. 

To test:
Test release/6.5 and perform a search to confirm the bug. Note that the dates shown are incorrect for the post's dateCreated. 
Test this branch and confirm that the dateCreated is now shown. 

Needs review: @sendhil could I trouble you for a quick review? 

