### PR TITLE
Adding 3D Touch widget shortcut

### DIFF
--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -103,5 +103,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>UIApplicationShortcutWidget</key>
+	<string>org.wordpress.WordPressTodayWidget</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #5982 

Quick little thing that'll add the today widget to the shortcuts items

To test:

3D touch the icon and the today widget will show up

Needs review: @sendhil