### PR TITLE
Fixing Notifications Header

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -474,7 +474,7 @@ private extension NotificationsViewController
     }
 
     @objc func defaultAccountDidChange(note: NSNotification) {
-        setNeedsReloadResults()
+        needsReloadResults = true
         resetApplicationBadge()
     }
 }
@@ -639,10 +639,6 @@ private extension NotificationsViewController
         } catch {
             DDLogSwift.logError("Error refreshing Notification Row \(error)")
         }
-    }
-
-    func setNeedsReloadResults() {
-        needsReloadResults = true
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -55,6 +55,10 @@ class NotificationsViewController : UITableViewController
     ///
     private var lastReloadDate = NSDate()
 
+    /// Indicates whether the view is required to reload results on viewWillAppear, or not
+    ///
+    private var needsReloadResults = false
+
     /// Notifications that must be deleted display an "Undo" button, which simply cancels the deletion task.
     ///
     private var notificationDeletionActions: [NSManagedObjectID: NotificationDeletion.Action] = [:]
@@ -470,6 +474,7 @@ private extension NotificationsViewController
     }
 
     @objc func defaultAccountDidChange(note: NSNotification) {
+        setNeedsReloadResults()
         resetApplicationBadge()
     }
 }
@@ -595,7 +600,7 @@ private extension NotificationsViewController
         // For that reason, let's force a reload, only when 1 day has elapsed, and sections would have changed.
         //
         let daysElapsed = NSCalendar.currentCalendar().daysElapsedSinceDate(lastReloadDate)
-        guard daysElapsed != 0 else {
+        guard daysElapsed != 0 || needsReloadResults else {
             return
         }
 
@@ -617,6 +622,7 @@ private extension NotificationsViewController
 
         // Don't overwork!
         lastReloadDate = NSDate()
+        needsReloadResults = false
     }
 
     func reloadRowForNotificationWithID(noteObjectID: NSManagedObjectID?) {
@@ -633,6 +639,10 @@ private extension NotificationsViewController
         } catch {
             DDLogSwift.logError("Error refreshing Notification Row \(error)")
         }
+    }
+
+    func setNeedsReloadResults() {
+        needsReloadResults = true
     }
 }
 


### PR DESCRIPTION
Fixes #5913

#### To test:
1. Be signed into a wpcom account and be showing a section header in the Notifications screen.
2. Confirm the header is the correct width.
3. Switch to the Me tab and sign out of the app.
4. Sign back into the app with the same account.
5. Switch to the Notifications tab.

As a result, the Section Header should have the expected width.

Needs review: @aerych 
Eric, may i bug you with a quick review?

Thanks in advance!!
