### PR TITLE
Notifications: Destructive Actions Legend

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -62,7 +62,7 @@ class NotificationDetailsViewController: UIViewController
     /// In turn, the Deletion Action block also expects (yet another) callback as a parameter, to be called
     /// in the eventuallity of a failure.
     ///
-    var onDeletionRequestCallback: NotificationDeletion.Request?
+    var onDeletionRequestCallback: (NotificationDeletionRequest -> Void)?
 
 
     deinit {
@@ -959,7 +959,7 @@ private extension NotificationDetailsViewController
     func spamCommentWithBlock(block: NotificationBlock) {
         precondition(onDeletionRequestCallback != nil)
 
-        onDeletionRequestCallback? { onCompletion in
+        let request = NotificationDeletionRequest(kind: .Spamming, action: { onCompletion in
             let mainContext = ContextManager.sharedInstance().mainContext
             let service = NotificationActionsService(managedObjectContext: mainContext)
             service.spamCommentWithBlock(block) { success in
@@ -967,7 +967,9 @@ private extension NotificationDetailsViewController
             }
 
             WPAppAnalytics.track(.NotificationsCommentFlaggedAsSpam, withBlogID: block.metaSiteID)
-        }
+        })
+
+        onDeletionRequestCallback?(request)
 
         // We're thru
         navigationController?.popToRootViewControllerAnimated(true)
@@ -977,7 +979,7 @@ private extension NotificationDetailsViewController
         precondition(onDeletionRequestCallback != nil)
 
         // Hit the DeletionRequest Callback
-        onDeletionRequestCallback? { onCompletion in
+        let request = NotificationDeletionRequest(kind: .Deletion, action: { onCompletion in
             let mainContext = ContextManager.sharedInstance().mainContext
             let service = NotificationActionsService(managedObjectContext: mainContext)
             service.deleteCommentWithBlock(block) { success in
@@ -985,7 +987,9 @@ private extension NotificationDetailsViewController
             }
 
             WPAppAnalytics.track(.NotificationsCommentTrashed, withBlogID: block.metaSiteID)
-        }
+        })
+
+        onDeletionRequestCallback?(request)
 
         // We're thru
         navigationController?.popToRootViewControllerAnimated(true)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -57,7 +57,7 @@ class NotificationsViewController : UITableViewController
 
     /// Notifications that must be deleted display an "Undo" button, which simply cancels the deletion task.
     ///
-    private var notificationDeletionActions: [NSManagedObjectID: NotificationDeletion.Action] = [:]
+    private var notificationDeletionRequests: [NSManagedObjectID: NotificationDeletionRequest] = [:]
 
     /// Notifications being deleted are proactively filtered from the list.
     ///
@@ -217,7 +217,7 @@ class NotificationsViewController : UITableViewController
         }
 
         // Push the Details: Unless the note has a pending deletion!
-        guard isNoteMarkedForDeletion(note.objectID) == false else {
+        guard deletionRequestForNoteWithID(note.objectID) == nil else {
             return
         }
 
@@ -234,8 +234,8 @@ class NotificationsViewController : UITableViewController
         }
 
         detailsViewController.setupWithNotification(note)
-        detailsViewController.onDeletionRequestCallback = { onUndoTimeout in
-            self.showUndeleteForNoteWithID(note.objectID, onTimeout: onUndoTimeout)
+        detailsViewController.onDeletionRequestCallback = { request in
+            self.showUndeleteForNoteWithID(note.objectID, request: request)
         }
     }
 }
@@ -274,11 +274,13 @@ extension NotificationsViewController
             let title = NSLocalizedString("Trash", comment: "Trashes a comment")
 
             let trash = UITableViewRowAction(style: .Destructive, title: title, handler: { [weak self] _ in
-                self?.showUndeleteForNoteWithID(note.objectID) { onCompletion in
+                let request = NotificationDeletionRequest(kind: .Deletion, action: { [weak self] onCompletion in
                     self?.actionsService.deleteCommentWithBlock(block) { success in
                         onCompletion(success)
                     }
-                }
+                })
+
+                self?.showUndeleteForNoteWithID(note.objectID, request: request)
 
                 self?.tableView.setEditing(false, animated: true)
             })
@@ -539,15 +541,15 @@ extension NotificationsViewController
     ///
     /// -   Parameters:
     ///     -   noteObjectID: The Core Data ObjectID associated to a given notification.
-    ///     -   onTimeout: A "destructive" closure, to be executed after a given timeout.
+    ///     -   request: A DeletionRequest Struct
     ///
-    func showUndeleteForNoteWithID(noteObjectID: NSManagedObjectID, onTimeout: NotificationDeletion.Action) {
-        // Mark this note as Pending Deletichroon and Reload
-        notificationDeletionActions[noteObjectID] = onTimeout
+    func showUndeleteForNoteWithID(noteObjectID: NSManagedObjectID, request: NotificationDeletionRequest) {
+        // Mark this note as Pending Deletion and Reload
+        notificationDeletionRequests[noteObjectID] = request
         reloadRowForNotificationWithID(noteObjectID)
 
         // Dispatch the Action block
-        performSelector(#selector(deleteNoteWithID), withObject:noteObjectID, afterDelay:Syncing.undoTimeout)
+        performSelector(#selector(deleteNoteWithID), withObject: noteObjectID, afterDelay: Syncing.undoTimeout)
     }
 }
 
@@ -558,7 +560,7 @@ private extension NotificationsViewController
 {
     @objc func deleteNoteWithID(noteObjectID: NSManagedObjectID) {
         // Was the Deletion Cancelled?
-        guard let deletionBlock = notificationDeletionActions[noteObjectID] else {
+        guard let request = deletionRequestForNoteWithID(noteObjectID) else {
             return
         }
 
@@ -566,9 +568,9 @@ private extension NotificationsViewController
         notificationIdsBeingDeleted.insert(noteObjectID)
         reloadResultsController()
 
-        // Hit the Deletion Block
-        deletionBlock { success in
-            self.notificationDeletionActions.removeValueForKey(noteObjectID)
+        // Hit the Deletion Action
+        request.action { success in
+            self.notificationDeletionRequests.removeValueForKey(noteObjectID)
             self.notificationIdsBeingDeleted.remove(noteObjectID)
 
             // Error: let's unhide the row
@@ -578,15 +580,15 @@ private extension NotificationsViewController
         }
     }
 
-    func cancelDeletionForNoteWithID(noteObjectID: NSManagedObjectID) {
-        notificationDeletionActions.removeValueForKey(noteObjectID)
+    func cancelDeletionRequestForNoteWithID(noteObjectID: NSManagedObjectID) {
+        notificationDeletionRequests.removeValueForKey(noteObjectID)
         reloadRowForNotificationWithID(noteObjectID)
 
         NSObject.cancelPreviousPerformRequestsWithTarget(self, selector: #selector(deleteNoteWithID), object: noteObjectID)
     }
 
-    func isNoteMarkedForDeletion(noteObjectID: NSManagedObjectID) -> Bool {
-        return notificationDeletionActions[noteObjectID] != nil
+    func deletionRequestForNoteWithID(noteObjectID: NSManagedObjectID) -> NotificationDeletionRequest? {
+        return notificationDeletionRequests[noteObjectID]
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -715,8 +715,9 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
             return
         }
 
-        let isMarkedForDeletion     = isNoteMarkedForDeletion(note.objectID)
+        let undeleteOverlayText     = deletionRequestForNoteWithID(note.objectID)?.kind.legendText
         let isLastRow               = tableViewHandler.resultsController.isLastIndexPathInSection(indexPath)
+        let isSelectable            = undoOverlayText == nil
 
         cell.forceCustomCellMargins = true
         cell.attributedSubject      = note.subjectBlock?.attributedSubjectText
@@ -724,11 +725,11 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
         cell.read                   = note.read?.boolValue ?? false
         cell.noticon                = note.noticon
         cell.unapproved             = note.isUnapprovedComment
-        cell.markedForDeletion      = isMarkedForDeletion
-        cell.showsBottomSeparator   = !isLastRow && !isMarkedForDeletion
-        cell.selectionStyle         = isMarkedForDeletion ? .None : .Gray
+        cell.showsBottomSeparator   = !isLastRow
+        cell.selectable             = isSelectable
+        cell.undeleteOverlayText    = undeleteOverlayText
         cell.onUndelete             = { [weak self] in
-            self?.cancelDeletionForNoteWithID(note.objectID)
+            self?.cancelDeletionRequestForNoteWithID(note.objectID)
         }
 
         cell.downloadIconWithURL(note.iconURL)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -715,9 +715,8 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
             return
         }
 
-        let undeleteOverlayText     = deletionRequestForNoteWithID(note.objectID)?.kind.legendText
+        let deletionRequest         = deletionRequestForNoteWithID(note.objectID)
         let isLastRow               = tableViewHandler.resultsController.isLastIndexPathInSection(indexPath)
-        let isSelectable            = undoOverlayText == nil
 
         cell.forceCustomCellMargins = true
         cell.attributedSubject      = note.subjectBlock?.attributedSubjectText
@@ -726,8 +725,7 @@ extension NotificationsViewController: WPTableViewHandlerDelegate
         cell.noticon                = note.noticon
         cell.unapproved             = note.isUnapprovedComment
         cell.showsBottomSeparator   = !isLastRow
-        cell.selectable             = isSelectable
-        cell.undeleteOverlayText    = undeleteOverlayText
+        cell.undeleteOverlayText    = deletionRequest?.kind.legendText
         cell.onUndelete             = { [weak self] in
             self?.cancelDeletionRequestForNoteWithID(note.objectID)
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Helpers/NotificationDeletion.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Helpers/NotificationDeletion.swift
@@ -6,6 +6,15 @@ import Foundation
 enum NotificationDeletionKind {
     case Spamming
     case Deletion
+
+    var legendText: String {
+        switch self {
+        case .Deletion:
+            return NSLocalizedString("Comment has been deleted", comment: "Displayed when a Comment is deleted")
+        case .Spamming:
+            return NSLocalizedString("Comment has been marked as Spam", comment: "Displayed when a Comment is spammed")
+        }
+    }
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Helpers/NotificationDeletion.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Helpers/NotificationDeletion.swift
@@ -3,8 +3,14 @@ import Foundation
 
 /// Used by both NotificationsViewController and NotificationDetailsViewController.
 ///
-struct NotificationDeletion
+enum NotificationDeletionKind {
+    case Spamming
+    case Deletion
+}
+
+
+struct NotificationDeletionRequest
 {
-    typealias Request = (action: Action) -> Void
-    typealias Action  = (completion: (Bool -> Void)) -> Void
+    let kind    : NotificationDeletionKind
+    let action  : (completion: (Bool -> Void)) -> Void
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -24,7 +24,12 @@ class NoteTableViewCell: WPTableViewCell
             }
         }
     }
-    var showsUndoOverlay: Bool {
+    var selectable: Bool = false {
+        didSet {
+            refreshSelectionStyle()
+        }
+    }
+    var showsUndeleteOverlay: Bool {
         get {
             return undoOverlayText != nil
         }
@@ -56,9 +61,9 @@ class NoteTableViewCell: WPTableViewCell
             return snippetLabel.attributedText
         }
     }
-    var undoOverlayText: String? {
+    var undeleteOverlayText: String? {
         didSet {
-            if undoOverlayText != undoOverlayText {
+            if undeleteOverlayText != oldValue {
                 refreshSubviewVisibility()
                 refreshBackgrounds()
                 refreshUndoOverlay()
@@ -200,6 +205,10 @@ class NoteTableViewCell: WPTableViewCell
         }
     }
 
+    private func refreshSelectionStyle() {
+        selectionStyle = selectable ? .Gray : .None
+    }
+
     private func refreshSubviewVisibility() {
         for subview in contentView.subviews {
             subview.hidden = showsUndoOverlay
@@ -232,7 +241,7 @@ class NoteTableViewCell: WPTableViewCell
             contentView.pinSubviewToAllEdges(undoOverlayView)
         }
 
-        undoOverlayView.legendText = undoOverlayText
+        undoOverlayView.legendText = undeleteOverlayText
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -24,14 +24,9 @@ class NoteTableViewCell: WPTableViewCell
             }
         }
     }
-    var selectable: Bool = false {
-        didSet {
-            refreshSelectionStyle()
-        }
-    }
     var showsUndeleteOverlay: Bool {
         get {
-            return undoOverlayText != nil
+            return undeleteOverlayText != nil
         }
     }
     var showsBottomSeparator: Bool {
@@ -67,6 +62,7 @@ class NoteTableViewCell: WPTableViewCell
                 refreshSubviewVisibility()
                 refreshBackgrounds()
                 refreshUndoOverlay()
+                refreshSelectionStyle()
             }
         }
     }
@@ -206,12 +202,12 @@ class NoteTableViewCell: WPTableViewCell
     }
 
     private func refreshSelectionStyle() {
-        selectionStyle = selectable ? .Gray : .None
+        selectionStyle = showsUndeleteOverlay ? .Gray : .None
     }
 
     private func refreshSubviewVisibility() {
         for subview in contentView.subviews {
-            subview.hidden = showsUndoOverlay
+            subview.hidden = showsUndeleteOverlay
         }
     }
 
@@ -223,7 +219,7 @@ class NoteTableViewCell: WPTableViewCell
 
     private func refreshUndoOverlay() {
         // Remove
-        if showsUndoOverlay == false {
+        guard showsUndeleteOverlay else {
             undoOverlayView?.removeFromSuperview()
             return
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -24,13 +24,9 @@ class NoteTableViewCell: WPTableViewCell
             }
         }
     }
-    var markedForDeletion: Bool = false {
-        didSet {
-            if markedForDeletion != oldValue {
-                refreshSubviewVisibility()
-                refreshBackgrounds()
-                refreshUndoOverlay()
-            }
+    var showsUndoOverlay: Bool {
+        get {
+            return undoOverlayText != nil
         }
     }
     var showsBottomSeparator: Bool {
@@ -58,6 +54,15 @@ class NoteTableViewCell: WPTableViewCell
         }
         get {
             return snippetLabel.attributedText
+        }
+    }
+    var undoOverlayText: String? {
+        didSet {
+            if undoOverlayText != undoOverlayText {
+                refreshSubviewVisibility()
+                refreshBackgrounds()
+                refreshUndoOverlay()
+            }
         }
     }
     var noticon: String? {
@@ -197,7 +202,7 @@ class NoteTableViewCell: WPTableViewCell
 
     private func refreshSubviewVisibility() {
         for subview in contentView.subviews {
-            subview.hidden = markedForDeletion
+            subview.hidden = showsUndoOverlay
         }
     }
 
@@ -209,7 +214,7 @@ class NoteTableViewCell: WPTableViewCell
 
     private func refreshUndoOverlay() {
         // Remove
-        if markedForDeletion == false {
+        if showsUndoOverlay == false {
             undoOverlayView?.removeFromSuperview()
             return
         }
@@ -226,6 +231,8 @@ class NoteTableViewCell: WPTableViewCell
             contentView.addSubview(undoOverlayView)
             contentView.pinSubviewToAllEdges(undoOverlayView)
         }
+
+        undoOverlayView.legendText = undoOverlayText
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -221,22 +221,21 @@ class NoteTableViewCell: WPTableViewCell
         // Remove
         guard showsUndeleteOverlay else {
             undoOverlayView?.removeFromSuperview()
+            undoOverlayView = nil
             return
         }
 
-        // Load
+        // Lazy Load
         if undoOverlayView == nil {
             let nibName = NoteUndoOverlayView.classNameWithoutNamespaces()
             NSBundle.mainBundle().loadNibNamed(nibName, owner: self, options: nil)
             undoOverlayView.translatesAutoresizingMaskIntoConstraints = false
-        }
 
-        // Attach
-        if undoOverlayView.superview == nil {
             contentView.addSubview(undoOverlayView)
             contentView.pinSubviewToAllEdges(undoOverlayView)
         }
 
+        undoOverlayView.hidden = false
         undoOverlayView.legendText = undeleteOverlayText
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -202,7 +202,7 @@ class NoteTableViewCell: WPTableViewCell
     }
 
     private func refreshSelectionStyle() {
-        selectionStyle = showsUndeleteOverlay ? .Gray : .None
+        selectionStyle = showsUndeleteOverlay ? .None : .Gray
     }
 
     private func refreshSubviewVisibility() {

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteUndoOverlayView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteUndoOverlayView.swift
@@ -11,13 +11,37 @@ import WordPressShared
 ///
 class NoteUndoOverlayView: UIView
 {
-    // MARK: - NSCoder
+    // MARK: - Properties
+
+    /// Legend Text
+    ///
+    var legendText: String? {
+        get {
+            return legendLabel.text
+        }
+        set {
+            legendLabel.text = newValue
+        }
+    }
+
+    /// Action Button Text
+    ///
+    var buttonText: String? {
+        get {
+            return undoButton.titleForState(.Normal)
+        }
+        set {
+            undoButton.setTitle(newValue, forState: .Normal)
+        }
+    }
+
+
+    // MARK: - Overriden Methods
     override func awakeFromNib() {
         super.awakeFromNib()
         backgroundColor = Style.noteUndoBackgroundColor
 
         // Legend
-        legendLabel.text = NSLocalizedString("Comment has been deleted", comment: "Displayed when a Comment is removed")
         legendLabel.textColor = Style.noteUndoTextColor
         legendLabel.font = Style.noteUndoTextFont
 
@@ -26,7 +50,6 @@ class NoteUndoOverlayView: UIView
         undoButton.setTitle(NSLocalizedString("Undo", comment: "Revert an operation"), forState: .Normal)
         undoButton.setTitleColor(Style.noteUndoTextColor, forState: .Normal)
     }
-
 
 
     // MARK: - Private Alias


### PR DESCRIPTION
Closes #4230 

Needs review: @SergioEstevao 
Sergio, may i bug you with a review?

Thanks in advance!


--

### Scenario: Mark as Spam
1. Log into a dotcom account
2. Open a comment-Y notification
3. Press the `Spam` button

Please, verify that:
- The undo legend displays `Comment has been marked as Spam`
- After a while the comment is effectively marked as spam.
- Verify that the Undo button avoids the spam action.

### Scenario: Delete
1. Log into a dotcom account and open a Comment-Y notification
2. Press the `Delete` button

Please, verify that:
- The Undo Legend displays `Comment has been deleted`.
- After a while the comment is effectively deleted.
- Test that the Undo button avoids the deletion action.

### Scenario: Swipe to Delete
1. Log into a dotcom account
2. Locate a Comment-Y Notification and *Swipe* over the cell
3. Press the `Delete` button

Please, verify that:
- The Undo Legend displays `Comment has been deleted`.
- After a while the comment is effectively deleted.
- Test that the Undo button avoids the deletion action.
