### PR TITLE
Reader comment gravatars are now retina quality

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -553,7 +553,9 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     WPAvatarSource *source = [WPAvatarSource sharedSource];
 
     NSString *hash;
-    CGSize size = CGSizeMake(CommentAvatarSize, CommentAvatarSize);
+    CGFloat scale = [[UIScreen mainScreen] scale];
+    CGSize size = CGSizeMake(CommentAvatarSize * scale, CommentAvatarSize * scale);
+
     NSURL *url = [comment avatarURLForDisplay];
     WPAvatarSourceType type = [source parseURL:url forAvatarHash:&hash];
 
@@ -666,8 +668,9 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     }
     
     [self.postHeaderView setTitle:self.post.titleForDisplay];
-    
-    CGSize imageSize = CGSizeMake(PostHeaderViewAvatarSize, PostHeaderViewAvatarSize);
+
+    CGFloat scale = [[UIScreen mainScreen] scale];
+    CGSize imageSize = CGSizeMake(PostHeaderViewAvatarSize * scale, PostHeaderViewAvatarSize * scale);
     UIImage *image = [self.post cachedAvatarWithSize:imageSize];
     if (image) {
         [self.postHeaderView setAvatarImage:image];


### PR DESCRIPTION
I noticed last night that gravatars in the reader we non-retina and so looked pixellated. I thought we'd fixed this before, but perhaps not.

I've updated `ReaderCommentsViewController` to take into account the screen scale when populating the comment gravatars.

Before:

<img width="58" alt="screen shot 2016-09-28 at 10 47 13" src="https://cloud.githubusercontent.com/assets/4780/18908855/32038e7e-8569-11e6-8bf3-9783b4860ee0.png">

After:

<img width="58" alt="screen shot 2016-09-28 at 10 44 42" src="https://cloud.githubusercontent.com/assets/4780/18908856/349ceb26-8569-11e6-9301-e1fa4e2d72f8.png">

To test: view the comments for a post in the reader!

Needs review: @aerych 