### PR TITLE
Improve post preloading

### DIFF
--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -73,6 +73,13 @@ typedef void(^PostServiceSyncFailure)(NSError *error);
                 failure:(PostServiceSyncFailure)failure;
 
 /**
+ Determine if a recent cache is available
+ 
+ @param blog The blog that may have cached posts.
+ */
++ (BOOL)shouldRefreshCacheFor:(Blog *)blog;
+
+/**
  Syncs local changes on a post back to the server.
 
  @param post The post or page to upload

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -184,10 +184,57 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
                    }];
 }
 
-+ (BOOL)shouldRefreshCacheFor:(Blog *)blog
++ (NSMutableSet *)syncingCommentsLocks
 {
-    NSDate *lastSynced = blog.lastCommentsSync;
-    BOOL isSyncing = [self isSyncingCommentsForBlog:blog];
+    static NSMutableSet *syncingCommentsLocks;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        syncingCommentsLocks = [NSMutableSet set];
+    });
+    return syncingCommentsLocks;
+}
+
++ (BOOL)isSyncingCommentsForBlog:(Blog *)blog {
+    return [self isSyncingCommentsForBlogID:blog.objectID];
+}
+
++ (BOOL)isSyncingCommentsForBlogID:(NSManagedObjectID *)blogID
+{
+    NSParameterAssert(blogID);
+    return [[self syncingCommentsLocks] containsObject:blogID];
+}
+
++ (BOOL)startSyncingCommentsForBlog:(NSManagedObjectID *)blogID
+{
+    NSParameterAssert(blogID);
+    @synchronized([self syncingCommentsLocks]) {
+        if ([self isSyncingCommentsForBlogID:blogID]){
+            return NO;
+        }
+        [[self syncingCommentsLocks] addObject:blogID];
+        return YES;
+    }
+}
+
++ (void)stopSyncingCommentsForBlog:(NSManagedObjectID *)blogID
+{
+    NSParameterAssert(blogID);
+    @synchronized([self syncingCommentsLocks]) {
+        [[self syncingCommentsLocks] removeObject:blogID];
+    }
+}
+
++ (BOOL)shouldRefreshPostCacheFor:(Blog *)blog
+{
+    NSDate *lastSynced = blog.lastPostsSync;
+    BOOL isSyncing = [self isSyncingPostsForBlog:blog];
+    return !isSyncing && (lastSynced == nil || ABS(lastSynced.timeIntervalSinceNow) > CommentsRefreshTimeoutInSeconds);
+}
+
++ (BOOL)shouldRefreshPageCacheFor:(Blog *)blog
+{
+    NSDate *lastSynced = blog.lastPostsSync;
+    BOOL isSyncing = [self isSyncingPagesForBlog:blog];
     return !isSyncing && (lastSynced == nil || ABS(lastSynced.timeIntervalSinceNow) > CommentsRefreshTimeoutInSeconds);
 }
 


### PR DESCRIPTION
Improves #5537 in response to @koke's suggestions [here](https://github.com/wordpress-mobile/WordPress-iOS/issues/5537#issuecomment-249917822). 

### Discussion

Basically, adds a cache timer to stop from frequent server requests.

This implementation works because `AbstractPostListViewController` already had code looking at `lastPostsSync/lastPagesSync`. So that's a freebie.

## To test: 
### Ensure preloading doesn't happen on LTE/3G
1. View the detail screen for a blog
1. The network activity icon shouldn't appear in the status bar

### Ensure preloading happens on Wi-fi
1. View the detail screen for a blog
1. The network activity icon should appear in the status bar, however this isn't concrete evidence because this screen performs other preloading
1. Ensure new post(s) appear immediately when viewing the Blog Posts screen, not after a new network request from this screen
1. Further, this screen should not fire its own network request when the preloading has happened within the last 5 minutes
1. Repeat for pages 😄 

### The lists screens should refresh when a slow preloading request returns
1. View the detail screen for a blog
1. Quickly tap the 'Blog Posts' button, before the preloading requests have returned
1. The Blog Posts list shouldn't fire its own network request
1. When the preloading request has finished, the list of blog posts should then update

Needs review: @kurzee 
