### PR TITLE
Include plans as tags in Helpshift conversations

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -573,7 +573,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
 {
     NSString *extra = @"";
     if (self.account) {
-        extra = [NSString stringWithFormat:@" wp.com account: %@ blogId: %@", self.account ? self.account.username : @"NO", self.dotComID];
+        extra = [NSString stringWithFormat:@" wp.com account: %@ blogId: %@ plan: %@ (%@)", self.account ? self.account.username : @"NO", self.dotComID, self.planTitle, self.planID];
     } else if (self.jetpackAccount) {
         extra = [NSString stringWithFormat:@" jetpack: 🚀🚀 Jetpack %@ fully connected as %@ with site ID %@", self.jetpack.version, self.jetpackAccount.username, self.jetpack.siteID];
     } else {

--- a/WordPress/Classes/Models/WPAccount.h
+++ b/WordPress/Classes/Models/WPAccount.h
@@ -18,9 +18,9 @@
 @property (nonatomic, strong)   NSDate      *dateCreated;
 @property (nonatomic, strong)   NSString    *email;
 @property (nonatomic, strong)   NSString    *displayName;
-@property (nonatomic, strong)   NSSet       *blogs;
-@property (nonatomic, strong)   NSSet       *jetpackBlogs;
-@property (nonatomic, readonly) NSArray     *visibleBlogs;
+@property (nonatomic, strong)   NSSet<Blog *>       *blogs;
+@property (nonatomic, strong)   NSSet<Blog *>       *jetpackBlogs;
+@property (nonatomic, readonly) NSArray<Blog *>     *visibleBlogs;
 @property (nonatomic, strong)   Blog        *defaultBlog;
 @property (nonatomic, strong)   ManagedAccountSettings *managedSettings;
 

--- a/WordPress/Classes/Utility/HelpshiftUtils.h
+++ b/WordPress/Classes/Utility/HelpshiftUtils.h
@@ -3,11 +3,14 @@
 extern NSString *const UserDefaultsHelpshiftWasUsed;
 extern NSString *const HelpshiftUnreadCountUpdatedNotification;
 
+@class WPAccount;
+
 @interface HelpshiftUtils : NSObject
 
 + (void)setup;
 + (BOOL)isHelpshiftEnabled;
 + (NSInteger)unreadNotificationCount;
 + (void)refreshUnreadNotificationCount;
++ (NSArray<NSString *> *)planTagsForAccount:(WPAccount *)account;
 
 @end

--- a/WordPress/Classes/Utility/HelpshiftUtils.m
+++ b/WordPress/Classes/Utility/HelpshiftUtils.m
@@ -3,6 +3,8 @@
 #import "ApiCredentials.h"
 #import <Helpshift/HelpshiftCore.h>
 #import <Helpshift/HelpshiftSupport.h>
+#import "WPAccount.h"
+#import "Blog.h"
 
 NSString *const UserDefaultsHelpshiftEnabled = @"wp_helpshift_enabled";
 NSString *const UserDefaultsHelpshiftWasUsed = @"wp_helpshift_used";
@@ -105,6 +107,22 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
 + (void)refreshUnreadNotificationCount
 {
     [HelpshiftSupport getNotificationCountFromRemote:YES];
+}
+
++ (NSArray<NSString *> *)planTagsForAccount:(WPAccount *)account
+{
+    NSMutableSet<NSString *> *titles = [NSMutableSet set];
+    for (Blog *blog in account.blogs) {
+        // Helpshift won't take any capitalized tag names, so convert to lowercase first
+        [titles addObject:[blog.planTitle lowercaseString]];
+    }
+
+    // If there's more than one unique title, then there is a paid plan.
+    // Don't return the Free tag
+    if ([titles count] > 1) {
+        [titles removeObject:@"free"];
+    }
+    return [titles allObjects];
 }
 
 #pragma mark - HelpshiftSupport Delegate

--- a/WordPress/Classes/Utility/HelpshiftUtils.m
+++ b/WordPress/Classes/Utility/HelpshiftUtils.m
@@ -111,18 +111,16 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
 
 + (NSArray<NSString *> *)planTagsForAccount:(WPAccount *)account
 {
-    NSMutableSet<NSString *> *titles = [NSMutableSet set];
+    NSMutableSet<NSString *> *tags = [NSMutableSet set];
     for (Blog *blog in account.blogs) {
-        // Helpshift won't take any capitalized tag names, so convert to lowercase first
-        [titles addObject:[blog.planTitle lowercaseString]];
+        if (blog.planID == nil) {
+            continue;
+        }
+        NSString *tag = [NSString stringWithFormat:@"plan:%@", blog.planID];
+        [tags addObject:tag];
     }
 
-    // If there's more than one unique title, then there is a paid plan.
-    // Don't return the Free tag
-    if ([titles count] > 1) {
-        [titles removeObject:@"free"];
-    }
-    return [titles allObjects];
+    return [tags allObjects];
 }
 
 #pragma mark - HelpshiftSupport Delegate

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -172,6 +172,10 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
         [self showLoadingSpinner];
 
         [metaData addEntriesFromDictionary:@{@"WPCom Username": defaultAccount.username}];
+        NSArray *tags = [HelpshiftUtils planTagsForAccount:defaultAccount];
+        if (tags) {
+            [metaData setObject:tags forKey:HelpshiftSupportTagsKey];
+        }
 
         [defaultAccount.wordPressComRestApi GET:@"v1.1/me"
                          parameters:nil


### PR DESCRIPTION
If there's a WordPress.com account, go through every blog and add a tag for
each plan.

I've also added the plan name and ID to the log.

Fixes #6060

Needs Review: @frosty 