### PR TITLE
Avoid showing error when playing audio files.

### DIFF
--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -33,6 +33,8 @@ static CGFloat const WPWebViewAnimationAlphaHidden          = 0.0;
 
 static NSString *const WPComReferrerURL = @"https://wordpress.com";
 
+static NSString *const WPWebViewWebKitErrorDomain = @"WebKitErrorDomain";
+static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
 
 #pragma mark - Private Properties
 
@@ -395,6 +397,8 @@ static NSString *const WPComReferrerURL = @"https://wordpress.com";
 
     // Don't show Ajax Cancelled or Frame Load Interrupted errors
     if (error.code == WPWebViewErrorAjaxCancelled || error.code == WPWebViewErrorFrameLoadInterrupted) {
+        return;
+    } else if ([error.domain isEqualToString:WPWebViewWebKitErrorDomain] && error.code == WPWebViewErrorPluginHandledLoad) {
         return;
     }
 


### PR DESCRIPTION
Fixes #5788 

Attempting to load audio files directly in a UIWebView yields a web kit error, yet the audio continues to play.  The error isn't helpful to the user, so since the audio still plays let's not show the prompt.  

This PR checks for the error and returns vs showing an alert.  The error domain and code do not seem to be exposed via system consts (not that I could find anyway) so I've added some of our own.

To test: Follow the steps outlined in the issue and confirm an alert does not appear.

@nheagy would you be game to review this one?

Needs review: @nheagy

