### PR TITLE
Reader: Updates 'Visit Site' to show the post on the site.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -6,7 +6,7 @@ struct ReaderPostMenuButtonTitles
 {
     static let cancel = NSLocalizedString("Cancel", comment:"The title of a cancel button.")
     static let blockSite = NSLocalizedString("Block This Site", comment:"The title of a button that triggers blocking a site from the user's reader.")
-    static let share = NSLocalizedString("Share", comment:"Verb. Title of a button. Pressing the lets the user share a post to others.")
+    static let share = NSLocalizedString("Share", comment:"Verb. Title of a button. Pressing lets the user share a post to others.")
     static let visit = NSLocalizedString("Visit", comment:"An option to visit the site to which a specific post belongs")
     static let unfollow = NSLocalizedString("Unfollow Site", comment:"Verb. An option to unfollow a site.")
     static let follow = NSLocalizedString("Follow Site", comment:"Verb. An option to follow a site.")

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -1,20 +1,21 @@
 import Foundation
 import SVProgressHUD
 
+
+struct ReaderPostMenuButtonTitles
+{
+    static let cancel = NSLocalizedString("Cancel", comment:"The title of a cancel button.")
+    static let blockSite = NSLocalizedString("Block This Site", comment:"The title of a button that triggers blocking a site from the user's reader.")
+    static let share = NSLocalizedString("Share", comment:"Verb. Title of a button. Pressing the lets the user share a post to others.")
+    static let visit = NSLocalizedString("Visit", comment:"An option to visit the site to which a specific post belongs")
+    static let unfollow = NSLocalizedString("Unfollow Site", comment:"Verb. An option to unfollow a site.")
+    static let follow = NSLocalizedString("Follow Site", comment:"Verb. An option to follow a site.")
+}
+
+
 public class ReaderPostMenu
 {
     public static let BlockSiteNotification = "ReaderPostMenuBlockSiteNotification"
-
-    struct ReaderPostMenuButtonTitles
-    {
-        static let cancel = NSLocalizedString("Cancel", comment:"The title of a cancel button.")
-        static let blockSite = NSLocalizedString("Block This Site", comment:"The title of a button that triggers blocking a site from the user's reader.")
-        static let share = NSLocalizedString("Share", comment:"Verb. Title of a button. Pressing the lets the user share a post to others.")
-        static let visit = NSLocalizedString("Visit Site", comment:"An option to visit the site to which a specific post belongs")
-        static let unfollow = NSLocalizedString("Unfollow Site", comment:"Verb. An option to unfollow a site.")
-        static let follow = NSLocalizedString("Follow Site", comment:"Verb. An option to follow a site.")
-    }
-
 
     public class func showMenuForPost(post:ReaderPost, fromView anchorView:UIView, inViewController viewController:UIViewController) {
         // Create the action sheet
@@ -118,7 +119,12 @@ public class ReaderPostMenu
 
 
     private class func visitSiteForPost(post:ReaderPost, presentingViewController viewController:UIViewController) {
-        let siteURL = NSURL(string: post.blogURL)!
+        guard
+            let permalink = post.permaLink,
+            let siteURL = NSURL(string: permalink) else {
+                return
+        }
+
         let controller = WPWebViewController(URL: siteURL)
         controller.addsWPComReferrer = true
         let navController = UINavigationController(rootViewController: controller)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -3,16 +3,6 @@ import Foundation
 extension ReaderStreamViewController
 {
 
-    struct ActionSheetButtonTitles
-    {
-        static let cancel = NSLocalizedString("Cancel", comment:"The title of a cancel button.")
-        static let blockSite = NSLocalizedString("Block This Site", comment:"The title of a button that triggers blocking a site from the user's reader.")
-        static let share = NSLocalizedString("Share", comment:"Verb. Title of a button. Pressing the lets the user share a post to others.")
-        static let visit = NSLocalizedString("Visit Site", comment:"An option to visit the site to which a specific post belongs")
-        static let unfollow = NSLocalizedString("Unfollow Site", comment:"Verb. An option to unfollow a site.")
-        static let follow = NSLocalizedString("Follow Site", comment:"Verb. An option to follow a site.")
-    }
-
     // A simple struct defining a title and message for use with a WPNoResultsView
     public struct NoResultsResponse
     {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -726,11 +726,11 @@ import WordPressComAnalytics
 
         // Create the action sheet
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .ActionSheet)
-        alertController.addCancelActionWithTitle(ActionSheetButtonTitles.cancel, handler: nil)
+        alertController.addCancelActionWithTitle(ReaderPostMenuButtonTitles.cancel, handler: nil)
 
         // Block button
         if shouldShowBlockSiteMenuItem() {
-            alertController.addActionWithTitle(ActionSheetButtonTitles.blockSite,
+            alertController.addActionWithTitle(ReaderPostMenuButtonTitles.blockSite,
                 style: .Destructive,
                 handler: { (action:UIAlertAction) in
                     if let post = self.postWithObjectID(post.objectID) {
@@ -741,7 +741,7 @@ import WordPressComAnalytics
 
         // Following
         if ReaderHelpers.topicIsFollowing(topic) {
-            let buttonTitle = post.isFollowing ? ActionSheetButtonTitles.unfollow : ActionSheetButtonTitles.follow
+            let buttonTitle = post.isFollowing ? ReaderPostMenuButtonTitles.unfollow : ReaderPostMenuButtonTitles.follow
             alertController.addActionWithTitle(buttonTitle,
                 style: .Default,
                 handler: { (action:UIAlertAction) in
@@ -752,7 +752,7 @@ import WordPressComAnalytics
         }
 
         // Visit site
-        alertController.addActionWithTitle(ActionSheetButtonTitles.visit,
+        alertController.addActionWithTitle(ReaderPostMenuButtonTitles.visit,
             style: .Default,
             handler: { (action:UIAlertAction) in
                 if let post = self.postWithObjectID(post.objectID) {
@@ -761,7 +761,7 @@ import WordPressComAnalytics
         })
 
         // Share
-        alertController.addActionWithTitle(ActionSheetButtonTitles.share,
+        alertController.addActionWithTitle(ReaderPostMenuButtonTitles.share,
             style: .Default,
             handler: { [weak self] (action:UIAlertAction) in
                 self?.sharePost(post.objectID, fromView: anchorView)
@@ -848,7 +848,12 @@ import WordPressComAnalytics
 
 
     private func visitSiteForPost(post:ReaderPost) {
-        let siteURL = NSURL(string: post.blogURL)!
+        guard
+            let permalink = post.permaLink,
+            let siteURL = NSURL(string: permalink) else {
+                return
+        }
+
         let controller = WPWebViewController(URL: siteURL)
         controller.addsWPComReferrer = true
         let navController = UINavigationController(rootViewController: controller)


### PR DESCRIPTION
Fixes #5620 
Now when using the "Visit Site" option, instead of loading the site URL, we'll load the post permalink. 
This PR also updates the text of the menu option from "Visit Site" to "Visit" for better consistency with the web, and removes some redundancy in menu item names.

To test:
Open the menu for a post in both the stream, and in the detail vcs.  Confirm the "Visit" option opens the post's permalink.

@kurzee would you care to take this one? 

Needs review: @kurzee 

