### PR TITLE
Issue/6059 batch media upload crashes

### DIFF
--- a/WordPress/Classes/Extensions/PHAsset+Exporters.swift
+++ b/WordPress/Classes/Extensions/PHAsset+Exporters.swift
@@ -26,6 +26,7 @@ typealias ErrorHandler = (error: NSError) -> ()
                      targetUTI: String,
                      maximumResolution: CGSize,
                      stripGeoLocation: Bool,
+                     synchronous: Bool,
                      successHandler: SuccessHandler,
                      errorHandler: ErrorHandler)
 
@@ -73,6 +74,7 @@ extension PHAsset: ExportableAsset {
         targetUTI: String,
         maximumResolution: CGSize,
         stripGeoLocation: Bool,
+        synchronous: Bool,
         successHandler: SuccessHandler,
         errorHandler: ErrorHandler) {
 
@@ -82,6 +84,7 @@ extension PHAsset: ExportableAsset {
                 targetUTI: targetUTI,
                 maximumResolution: maximumResolution,
                 stripGeoLocation: stripGeoLocation,
+                synchronous: synchronous,
                 successHandler: successHandler,
                 errorHandler: errorHandler)
         case .Video:
@@ -102,13 +105,14 @@ extension PHAsset: ExportableAsset {
         targetUTI: String,
         maximumResolution: CGSize,
         stripGeoLocation: Bool,
+        synchronous: Bool,
         successHandler: SuccessHandler,
         errorHandler: ErrorHandler) {
 
         let pixelSize = CGSize(width: pixelWidth, height: pixelHeight)
         let requestedSize = maximumResolution.clamp(min: CGSizeZero, max: pixelSize)
 
-        exportImageWithSize(requestedSize) { (image, info) in
+        exportImageWithSize(requestedSize, synchronous: synchronous) { (image, info) in
             guard let image = image else {
                 if let error = info?[PHImageErrorKey] as? NSError {
                     errorHandler(error: error)
@@ -140,15 +144,15 @@ extension PHAsset: ExportableAsset {
 
     func exportMaximumSizeImage(completion: (UIImage?, [NSObject : AnyObject]?) -> Void) {
         let targetSize = CGSize(width: pixelWidth, height: pixelHeight)
-        exportImageWithSize(targetSize, completion: completion)
+        exportImageWithSize(targetSize, synchronous: false, completion: completion)
     }
 
-    func exportImageWithSize(targetSize: CGSize, completion: (UIImage?, [NSObject : AnyObject]?) -> Void) {
+    func exportImageWithSize(targetSize: CGSize, synchronous: Bool, completion: (UIImage?, [NSObject : AnyObject]?) -> Void) {
         let options = PHImageRequestOptions()
         options.version = .Current
         options.deliveryMode = .HighQualityFormat
         options.resizeMode = .Exact
-        options.synchronous = false
+        options.synchronous = synchronous
         options.networkAccessAllowed = true
 
         let manager = PHImageManager.defaultManager()

--- a/WordPress/Classes/Extensions/UIImage+Exporters.swift
+++ b/WordPress/Classes/Extensions/UIImage+Exporters.swift
@@ -81,6 +81,7 @@ extension UIImage: ExportableAsset
                      targetUTI: String,
                      maximumResolution: CGSize,
                      stripGeoLocation: Bool,
+                     synchronous: Bool,
                      successHandler: SuccessHandler,
                      errorHandler: ErrorHandler)
     {

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -112,6 +112,7 @@
                                       targetUTI:assetUTI
                               maximumResolution:maximumResolution
                                stripGeoLocation:stripGeoLocation
+                                    synchronous:true
                                  successHandler:^(CGSize resultingSize) {
                                      [self createMediaForPost:postObjectID
                                                      mediaURL:mediaURL

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1720,7 +1720,7 @@ EditImageDetailsViewControllerDelegate
     [self.editorView.contentField focus];
     
     [self prepareMediaProgressForNumberOfAssets:assets.count];
-    for (id<WPMediaAsset> asset in assets) {
+    for (id<WPMediaAsset> asset in [assets reverseObjectEnumerator]) {
         if ([asset isKindOfClass:[PHAsset class]]){
             [self addDeviceMediaAsset:(PHAsset *)asset];
         } else if ([asset isKindOfClass:[Media class]]) {


### PR DESCRIPTION
Fixes #6059

To test:
 - On a low spec device (iPad mini 1 or iPhone 5)
 - Tap on create a new post on the app
 - Tap on the add image option and select multiples images ( 4 should be enough)
 - Click Done
 - Check if the app doesn't crash.

Needs review: @koke 