### PR TITLE
Comments: Default transparency for label background colors.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -97,8 +97,6 @@ public class CommentsTableViewCell : WPTableViewCell
     private func refreshBackground() {
         let color = Style.backgroundColor(isApproved: approved)
         backgroundColor = color
-        detailsLabel.backgroundColor = color
-        timestampLabel.backgroundColor = color
     }
 
     private func refreshImages() {


### PR DESCRIPTION
Fixes an issue created in 8ee180ee8c0b919f7911a67aaead4bf395476884 where labels now had a background color that would show when selecting a comment cell.

To test:

- Open Comments
- Select a cell, make sure the label's background is transparent.

Needs review: @jleandroperez 

![simulator screen shot oct 18 2016 6 06 40 pm](https://cloud.githubusercontent.com/assets/1873422/19499855/58e3bdfc-955e-11e6-88ce-04ea2c3a8d48.png)
