### PR TITLE
Prevent duplicate posts in Post List

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -249,7 +249,9 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
     if (self.revision) {
         [self.managedObjectContext performBlock:^{
             [self.managedObjectContext deleteObject:self.revision];
+            [self willChangeValueForKey:@"revision"];
             [self setPrimitiveValue:nil forKey:@"revision"];
+            [self didChangeValueForKey:@"revision"];
         }];
     }
 }
@@ -292,12 +294,20 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 
 - (AbstractPost *)revision
 {
-    return [self primitiveValueForKey:@"revision"];
+    [self willAccessValueForKey:@"revision"];
+    AbstractPost *revision = [self primitiveValueForKey:@"revision"];
+    [self didAccessValueForKey:@"revision"];
+
+    return revision;
 }
 
 - (AbstractPost *)original
 {
-    return [self primitiveValueForKey:@"original"];
+    [self willAccessValueForKey:@"original"];
+    AbstractPost *original = [self primitiveValueForKey:@"original"];
+    [self didAccessValueForKey:@"original"];
+
+    return original;
 }
 
 

--- a/WordPress/Classes/Networking/MediaServiceRemote.h
+++ b/WordPress/Classes/Networking/MediaServiceRemote.h
@@ -18,8 +18,8 @@
  *  Update media details on the server
  *
  *  @param media   the media object to update
- *  @param success uccess a block to be executed when the request finishes with success.
- *  @param failure failure a block to be execute when the request fails.
+ *  @param success a block to be executed when the request finishes with success.
+ *  @param failure a block to be executed when the request fails.
  */
 - (void)updateMedia:(RemoteMedia *)media
             success:(void (^)(RemoteMedia *remoteMedia))success

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -68,6 +68,18 @@
             failure:(void (^)(NSError *error))failure;
 
 /**
+ Updates multiple media objects similar to -updateMedia:success:failure: but batches them
+ together. The success handler is only called when all updates succeed. Failure is called
+ if the entire process fails in some catostrophic way.
+ 
+ @param mediaObjects An array of media objects to update
+ @param success
+ */
+- (void)updateMultipleMedia:(NSArray<Media *> *)mediaObjects
+             overallSuccess:(void (^)())overallSuccess
+                    failure:(void (^)(NSError *error))failure;
+
+/**
  Find the media object in the local database.
  
  @param mediaID

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -14,7 +14,7 @@
  @param asset
  @param postObjectID
  @param thumbnailCallback a block that will be invoked when the thumbail for the media object is ready
- @completion a block that will be invoked when the media is created, on success it will return a valid Media object, on failure it will return a nil Media and an error object with the details.
+ @param completion a block that will be invoked when the media is created, on success it will return a valid Media object, on failure it will return a nil Media and an error object with the details.
  */
 - (void)createMediaWithPHAsset:(PHAsset *)asset
              forPostObjectID:(NSManagedObjectID *)postObjectID
@@ -32,8 +32,8 @@
  
  @param mediaID
  @param blog
- @success a block that will be invoked when the media is retrieved
- @failure a block that will be invoked if an error happens returnin the associated error object with the details.
+ @param success a block that will be invoked when the media is retrieved
+ @param failure a block that will be invoked if an error happens returnin the associated error object with the details.
  */
 - (void)getMediaWithID:(NSNumber *)mediaID
                 inBlog:(Blog *)blog
@@ -45,8 +45,8 @@
  
  @param media object to upload to the server.
  @param progress a NSProgress that tracks the upload progress to the server.
- @sucess a block that will be invoked when the media upload finished with success
- @failure a block that will be invoked when there is upload error.
+ @param success a block that will be invoked when the media upload finished with success
+ @param failure a block that will be invoked when there is upload error.
  */
 - (void)uploadMedia:(Media *)media
            progress:(NSProgress **) progress
@@ -60,10 +60,9 @@
  caption, alternative text, etc...
 
  @param media object to upload to the server.
- @sucess a block that will be invoked when the media upload finished with success
+ @success a block that will be invoked when the media upload finished with success
  @failure a block that will be invoked when there is upload error.
  */
-
 - (void)updateMedia:(Media *)media
             success:(void (^)())success
             failure:(void (^)(NSError *error))failure;
@@ -105,7 +104,7 @@
  + Get a thumbnail image for a Media by downloading its image or using the local cache
  +
  + @param media
- + @success a block that will be invoked when the media is retrieved
+ + @param success a block that will be invoked when the media is retrieved
  + @failure a block that will be invoked if an error happens returnin the associated error object with the details.
  + */
 - (void)thumbnailForMedia:(Media *)media

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -183,7 +183,6 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         [self.managedObjectContext performBlock:^{
             AbstractPost *postInContext = (AbstractPost *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
-                
                 if ([postInContext isRevision]) {
                     postInContext = postInContext.original;
                     [postInContext applyRevision];
@@ -192,18 +191,18 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
                 
                 [self updatePost:postInContext withRemotePost:post];
                 postInContext.remoteStatus = AbstractPostRemoteStatusSync;
+
+                NSPredicate *unattachedMediaPredicate = [NSPredicate predicateWithFormat:@"postID <= 0"];
+                NSArray<Media *> *mediaToUpdate = [[postInContext.media filteredSetUsingPredicate:unattachedMediaPredicate] allObjects];
+
                 MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:self.managedObjectContext];
-                for (Media *media in postInContext.media) {
-                    if ([media.postID longLongValue] <= 0) {
-                        media.postID = post.postID;
-                        [mediaService updateMedia:media success:nil failure:nil];
+                [mediaService updateMultipleMedia:mediaToUpdate overallSuccess:^{
+                    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+
+                    if (success) {
+                        success(postInContext);
                     }
-                }
-                [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-                
-                if (success) {
-                    success(postInContext);
-                }
+                } failure:failure];
             } else {
                 // This can happen if the post was deleted right after triggering the upload.
                 if (success) {

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -39,6 +39,9 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     }
     post.postFormat = blog.settings.defaultPostFormat;
     post.postType = Post.typeDefaultIdentifier;
+
+    [[ContextManager sharedInstance] obtainPermanentIDForObject:post];
+    
     return post;
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -251,7 +251,8 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         var predicates = [NSPredicate]()
 
         if let blog = blog {
-            let basePredicate = NSPredicate(format: "blog = %@ && original = nil", blog)
+            // Show all original posts without a revision & revision posts.
+            let basePredicate = NSPredicate(format: "blog = %@ && revision = nil", blog)
             predicates.append(basePredicate)
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -251,7 +251,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         var predicates = [NSPredicate]()
 
         if let blog = blog {
-            let basePredicate = NSPredicate(format: "blog = %@ && revision = nil", blog)
+            let basePredicate = NSPredicate(format: "blog = %@ && original = nil", blog)
             predicates.append(basePredicate)
         }
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1404,7 +1404,8 @@ EditImageDetailsViewControllerDelegate
         [self showFailedMediaRemovalAlert];
         return;
     }
-    //Make sure that we are saving the latest content on the editor.
+
+    // Make sure that we are saving the latest content on the editor.
     [self autosaveContent];
     [self stopEditing];
     [self savePost];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1407,9 +1407,7 @@ EditImageDetailsViewControllerDelegate
 
     // Make sure that we are saving the latest content on the editor.
     [self autosaveContent];
-    [self stopEditing];
     [self savePost];
-    [self dismissEditView:YES];
 }
 
 /**
@@ -1422,16 +1420,30 @@ EditImageDetailsViewControllerDelegate
     DDLogMethod();
     [self logSavePostStats];
 
-    [self.view endEditing:YES];
-
 	__block NSString *postTitle = self.post.postTitle;
     __block NSString *postStatus = self.post.status;
     __block BOOL postIsScheduled = self.post.isScheduled;
-    
+    void (^stopEditingAndDismiss)() = ^() {
+        [self stopEditing];
+        [self.view endEditing:YES];
+        [self didSaveNewPost];
+        [self dismissEditView:YES];
+    };
+
+    NSString *hudText;
+    if (postIsScheduled) {
+        hudText = NSLocalizedString(@"Scheduling...", @"Text displayed in HUD while a post is being scheduled to be published.");
+    } else if ([postStatus isEqualToString:@"publish"]){
+        hudText = NSLocalizedString(@"Publishing...", @"Text displayed in HUD while a post is being published.");
+    } else {
+        hudText = NSLocalizedString(@"Saving...", @"Text displayed in HUD while a post is being saved as a draft.");
+    }
+    [SVProgressHUD showWithStatus:hudText];
+
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     PostService *postService = [[PostService alloc] initWithManagedObjectContext:context];
     [postService uploadPost:self.post
-                    success:^(AbstractPost *post){
+                    success:^(AbstractPost *post) {
                         self.post = post;                        
                         DDLogInfo(@"post uploaded: %@", postTitle);
                         NSString *hudText;
@@ -1443,8 +1455,11 @@ EditImageDetailsViewControllerDelegate
                         } else {
                             hudText = NSLocalizedString(@"Saved!", @"Text displayed in HUD after a post was successfully saved as a draft.");
                         }
+                        [SVProgressHUD dismiss];
                         [SVProgressHUD showSuccessWithStatus:hudText];
                         [WPNotificationFeedbackGenerator notificationOccurred:WPNotificationFeedbackTypeSuccess];
+
+                        stopEditingAndDismiss();
                     } failure:^(NSError *error) {
                         DDLogError(@"post failed: %@", [error localizedDescription]);
                         NSString *hudText;
@@ -1455,11 +1470,12 @@ EditImageDetailsViewControllerDelegate
                         } else {
                             hudText = NSLocalizedString(@"Error occurred\nduring saving", @"Text displayed in HUD after attempting to save a draft post and an error occurred.");
                         }
+                        [SVProgressHUD dismiss];
                         [SVProgressHUD showErrorWithStatus:hudText];
                         [WPNotificationFeedbackGenerator notificationOccurred:WPNotificationFeedbackTypeError];
-                    }];
 
-    [self didSaveNewPost];
+                        stopEditingAndDismiss();
+                    }];
 }
 
 - (void)didSaveNewPost


### PR DESCRIPTION
**Original issue:**
Sometimes when publishing a new post a duplicate post will appear in the post list. It was determined that the cause of this is the dismissal of the editor before the post has finished being published. The post list view controller initiated a refresh of posts before the post saves properly to Core Data and then a duplicate appears. If the posting was done within the timeout period of the list view controller (less than 5 minutes) then the issue wouldn't present itself.

Several improvements were made:
1. Added KVC life cycle calls to AbstractPost to prevent any possible issues with accessing `original` and `revision`.
2. Updated the filter on the post list to only show "original" posts. The filter was showing original and revision posts which can add to the confusion.
3. Added a method to MediaService to allow for uploading of multiple media and not calling success until they have all finished.
4. Prevent the editor UI from being dismissed until the publishing (and updating of media) has completed. Added another HUD to indicate an operation is in progress.

**To test:**
1. Change `postsControllerRefreshInterval` in `AbstractPostListViewController` to a low value like `1`.
2. Publish a new post.
3. Verify no duplicate posts appear in the list.

Variations of "new post" should include:
* Published and Draft posts.
* With and without media.
* Single and multiple media.

We should also try offline condition testing as I've slightly altered behavior with the failure handlers.

Needs review: @SergioEstevao @nheagy @diegoreymendez @jleandroperez 
