### PR TITLE
PostService: Avoid setting uncategorized by default, on new posts.

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -34,9 +34,9 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     post.remoteStatus = AbstractPostRemoteStatusSync;
     PostCategoryService *postCategoryService = [[PostCategoryService alloc] initWithManagedObjectContext:self.managedObjectContext];
 
-    if (blog.settings.defaultCategoryID) {
+    if (blog.settings.defaultCategoryID && blog.settings.defaultCategoryID.integerValue != PostCategoryUncategorized) {
         PostCategory *category = [postCategoryService findWithBlogObjectID:blog.objectID andCategoryID:blog.settings.defaultCategoryID];
-        if (category && category.categoryID.integerValue != PostCategoryUncategorized) {
+        if (category) {
             [post addCategoriesObject:category];
         }
     }

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -33,10 +33,14 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     post.blog = blog;
     post.remoteStatus = AbstractPostRemoteStatusSync;
     PostCategoryService *postCategoryService = [[PostCategoryService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    PostCategory *category = [postCategoryService findWithBlogObjectID:blog.objectID andCategoryID:blog.settings.defaultCategoryID];
-    if (category && category.categoryID.integerValue != PostCategoryUncategorized) {
-        [post addCategoriesObject:category];
+
+    if (blog.settings.defaultCategoryID) {
+        PostCategory *category = [postCategoryService findWithBlogObjectID:blog.objectID andCategoryID:blog.settings.defaultCategoryID];
+        if (category && category.categoryID.integerValue != PostCategoryUncategorized) {
+            [post addCategoriesObject:category];
+        }
     }
+
     post.postFormat = blog.settings.defaultPostFormat;
     post.postType = Post.typeDefaultIdentifier;
 

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -34,7 +34,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     post.remoteStatus = AbstractPostRemoteStatusSync;
     PostCategoryService *postCategoryService = [[PostCategoryService alloc] initWithManagedObjectContext:self.managedObjectContext];
     PostCategory *category = [postCategoryService findWithBlogObjectID:blog.objectID andCategoryID:blog.settings.defaultCategoryID];
-    if (category) {
+    if (category && category.categoryID.integerValue != PostCategoryUncategorized) {
         [post addCategoriesObject:category];
     }
     post.postFormat = blog.settings.defaultPostFormat;


### PR DESCRIPTION
This partially addresses an issue with not syncing a site's settings before editing a new post.

Previously when creating a new post, if a site's settings were not already synced, the post would simply be set with the "uncategorized" ID. This would then override whatever the user actually had set to the default category for their site, upon posting.

Now, we'll avoid setting a default category ID unless we actually have one for `blog.settings.defaultCategoryID`, allowing both self-hosted and .com sites to default to the correct default category on post once it hits the API.

## Testing
1. Log out of the app.
2. Sign in to .com account.
3. Hit the new post button on the tab bar.
4. Post a new post.
5. Check the post on the site and that it used the correct default post category.
6. Change the default category on the site, via the web.
7. Post another post via the app.
8. Check the new post on the site and that it used the new default post category.
9. In the app, create another post, but set a category via the post options.
10. Post via the app and check it on the site to ensure it used the selected category from the app.
11. In the app, open the site's settings.
12. The default category, and other settings, will sync automatically.
13. Create another post, open post settings.
14. Check that the newly synced setting is being displayed for the default category.
15. Post a post, check that is used the synced default category.

☕️ break

1. Repeat the above steps for a jetpack site 😄 

☕️ break

1. Log out.
2. Add a self-hosted site.
3. Hit the new post button on the tab bar.
4. Post a new post.
5. Check the post on the site and that it used the correct default post category.
6. Change the default category on the site, via the web.
7. Post another post via the app.
8. Check the new post on the site and that it used the new default post category.
9. In the app, create another post, but set a category via the post options.
10. Post via the app and check it on the site to ensure it used the selected category from the app.

🎉 

Moving forward, we'll have to find an elegant time to sync a site's settings, to ensure we both set and display the correct default category for a post and its settings fields. (separate PR)

Needs review: @diegoreymendez can you take a gander? 👾 

