### PR TITLE
Reader: Bumps analytics when views appear, not when loaded.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -188,6 +188,9 @@ public class ReaderDetailViewController : UIViewController, UIViewControllerRest
         // The UIApplicationDidBecomeActiveNotification notification is broadcast
         // when the app is resumed as a part of split screen multitasking on the iPad.
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(ReaderDetailViewController.handleApplicationDidBecomeActive(_:)), name: UIApplicationDidBecomeActiveNotification, object: nil)
+
+        bumpStats()
+        bumpPageViewsForPost()
     }
 
 
@@ -318,9 +321,6 @@ public class ReaderDetailViewController : UIViewController, UIViewControllerRest
         configureTag()
         configureActionButtons()
         configureFooterIfNeeded()
-
-        bumpStats()
-        bumpPageViewsForPost()
 
         NSNotificationCenter.defaultCenter().addObserver(self,
             selector: #selector(ReaderDetailViewController.handleBlockSiteNotification(_:)),

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -22,6 +22,7 @@ import Gridicons
     private let searchBarSearchIconSize = CGFloat(13.0)
     private var suggestionsController: ReaderSearchSuggestionsViewController?
     private var restoredSearchTopic: ReaderSearchTopic?
+    private var didBumpStats = false
 
 
     /// A convenience method for instantiating the controller from the storyboard.
@@ -31,7 +32,6 @@ import Gridicons
     public class func controller() -> ReaderSearchViewController {
         let storyboard = UIStoryboard(name: "Reader", bundle: NSBundle.mainBundle())
         let controller = storyboard.instantiateViewControllerWithIdentifier("ReaderSearchViewController") as! ReaderSearchViewController
-        WPAppAnalytics.track(.ReaderSearchLoaded)
         return controller
     }
 
@@ -114,6 +114,14 @@ import Gridicons
         ReaderTopicService(managedObjectContext: context).deleteAllSearchTopics()
     }
 
+
+    public override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+
+        bumpStats()
+    }
+
+
     public override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
 
@@ -122,6 +130,18 @@ import Gridicons
 
         NSNotificationCenter.defaultCenter().removeObserver(self, name: UIKeyboardDidShowNotification, object: nil)
         NSNotificationCenter.defaultCenter().removeObserver(self, name: UIKeyboardWillHideNotification, object: nil)
+    }
+
+
+    // MARK: - Analytics
+
+
+    func bumpStats() {
+        if didBumpStats {
+            return
+        }
+        WPAppAnalytics.track(.ReaderSearchLoaded)
+        didBumpStats = true
     }
 
 


### PR DESCRIPTION
This PR fixes an issue with the way certain reader analytics are being bumped and iOS state restoration.  

Previously, the reader stream and detail controllers would bump their analytics when their views were loaded. This was fine when the reader had only marginal support for state restoration.  Now that SI is fully supported, when the app is resumed and the reader is restored to its previous state *all* controller views in the navigation hierarchy are being loaded when state is restored, whether the reader tab is selected (and the reader visible) or not. 

This PR changes it so reader analytics are bumped in `viewDidAppear` and a flag is set so stats are only bumped once.  This approach allows for a stat to still be bumped when state is restored if that controller's view is actually seen by the user. 

To test in the Simulator: 
### Setup
Open `WPAnalyticsTrackerAutomatticTracks` and add breakpoints for the following stats:
- reader_article_opened
- reader_list_loaded
- reader_search_loaded
- reader_tag_loaded
- reader_discover_viewed

### Regular navigation
In the reader, view a tag, discover, search, a list (if you are subscribed to one) and a post detail. Confirm that the appropriate stat is called once when the view appears, and not called again if you return to that view controller.  (Note that reader_article_opened is intentionally called twice when its from a Search but we're bumping two different metrics.)

### State restoration
Navigate to:
Search > [Search term of choice] > Tap on a card to preview a tag > View a post detail. 
Switch to a different tab.
Tap Cmd+H twice to background the app, triggering state restoration. 
Tap on the app icon to resume the app. 
In Xcode stop the simulator, then run the simulator again.
Confirm the app resumes on the tab you were last viewing and none of the breakpoints for the reader stats are hit.
Switch to the reader and confirm the correct stat is fired now that the view is visible. 
Tap back through the hierarchy confirming the correct stats are fired.

Repeat this for the Discover topic and a list (if you are subscribed to one). 

Needs review: @kurzee 
cc @sendhil 

