### PR TITLE
Reader: For paranoia, adding extra checks before bumping stats.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -176,7 +176,7 @@ public class ReaderDetailViewController : UIViewController, UIViewControllerRest
 
         setupNavBar()
 
-        if post != nil {
+        if let _ = post {
             configureView()
         }
     }
@@ -321,6 +321,9 @@ public class ReaderDetailViewController : UIViewController, UIViewControllerRest
         configureTag()
         configureActionButtons()
         configureFooterIfNeeded()
+
+        bumpStats()
+        bumpPageViewsForPost()
 
         NSNotificationCenter.defaultCenter().addObserver(self,
             selector: #selector(ReaderDetailViewController.handleBlockSiteNotification(_:)),
@@ -741,22 +744,26 @@ public class ReaderDetailViewController : UIViewController, UIViewControllerRest
     // MARK: - Analytics
 
     private func bumpStats() {
+        guard let readerPost = post where isViewLoaded() && view.window != nil else {
+            return
+        }
+
         if didBumpStats {
             return
         }
         didBumpStats = true
 
         let isOfflineView = ReachabilityUtils.isInternetReachable() ? "no" : "yes"
-        let detailType = post!.topic?.type == ReaderSiteTopic.TopicType ? DetailAnalyticsConstants.TypePreviewSite : DetailAnalyticsConstants.TypeNormal
+        let detailType = readerPost.topic?.type == ReaderSiteTopic.TopicType ? DetailAnalyticsConstants.TypePreviewSite : DetailAnalyticsConstants.TypeNormal
 
 
-        var properties = ReaderHelpers.statsPropertiesForPost(post!, andValue: nil, forKey: nil)
+        var properties = ReaderHelpers.statsPropertiesForPost(readerPost, andValue: nil, forKey: nil)
         properties[DetailAnalyticsConstants.TypeKey] = detailType
         properties[DetailAnalyticsConstants.OfflineKey] = isOfflineView
         WPAppAnalytics.track(.ReaderArticleOpened, withProperties: properties)
 
         // We can remove the nil check and use `if let` when `ReaderPost` adopts nullibility.
-        let railcar = post?.railcarDictionary()
+        let railcar = readerPost.railcarDictionary()
         if railcar != nil {
             WPAppAnalytics.trackTrainTracksInteraction(.ReaderArticleOpened, withProperties: railcar)
         }
@@ -764,11 +771,14 @@ public class ReaderDetailViewController : UIViewController, UIViewControllerRest
 
 
     private func bumpPageViewsForPost() {
+        guard let readerPost = post where isViewLoaded() && view.window != nil else {
+            return
+        }
         if didBumpPageViews {
             return
         }
         didBumpPageViews = true
-        ReaderHelpers.bumpPageViewForPost(post!)
+        ReaderHelpers.bumpPageViewForPost(readerPost)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -744,13 +744,14 @@ public class ReaderDetailViewController : UIViewController, UIViewControllerRest
     // MARK: - Analytics
 
     private func bumpStats() {
+        if didBumpStats {
+            return
+        }
+
         guard let readerPost = post where isViewLoaded() && view.window != nil else {
             return
         }
 
-        if didBumpStats {
-            return
-        }
         didBumpStats = true
 
         let isOfflineView = ReachabilityUtils.isInternetReachable() ? "no" : "yes"
@@ -771,12 +772,14 @@ public class ReaderDetailViewController : UIViewController, UIViewControllerRest
 
 
     private func bumpPageViewsForPost() {
-        guard let readerPost = post where isViewLoaded() && view.window != nil else {
-            return
-        }
         if didBumpPageViews {
             return
         }
+
+        guard let readerPost = post where isViewLoaded() && view.window != nil else {
+            return
+        }
+
         didBumpPageViews = true
         ReaderHelpers.bumpPageViewForPost(readerPost)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1050,12 +1050,14 @@ import WordPressComAnalytics
     /// Bump tracked analytics stats if necessary.
     ///
     func bumpStats() {
-        guard let topic = readerTopic, properties = topicPropertyForStats() where isViewLoaded() && view.window != nil else {
-            return
-        }
         if didBumpStats {
             return
         }
+
+        guard let topic = readerTopic, properties = topicPropertyForStats() where isViewLoaded() && view.window != nil else {
+            return
+        }
+
         didBumpStats = true
         ReaderHelpers.trackLoadedTopic(topic, withProperties: properties)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -606,6 +606,8 @@ import WordPressComAnalytics
         tableViewHandler.refreshTableView()
         syncIfAppropriate()
 
+        bumpStats()
+
         let count = tableViewHandler.resultsController.fetchedObjects?.count ?? 0
 
         // Make sure we're showing the no results view if appropriate
@@ -1048,13 +1050,14 @@ import WordPressComAnalytics
     /// Bump tracked analytics stats if necessary.
     ///
     func bumpStats() {
+        guard let topic = readerTopic, properties = topicPropertyForStats() where isViewLoaded() && view.window != nil else {
+            return
+        }
         if didBumpStats {
             return
         }
-        if let topic = readerTopic, properties = topicPropertyForStats() {
-            didBumpStats = true
-            ReaderHelpers.trackLoadedTopic(topic, withProperties: properties)
-        }
+        didBumpStats = true
+        ReaderHelpers.trackLoadedTopic(topic, withProperties: properties)
     }
 
 


### PR DESCRIPTION
This is a quick follow up to #6116 to remove some forced unwrapping of optionals.  

I noticed a crash reported by hockeyapp that may or may not be related to the changes in #6116 -- the stack trace wasn't clear.  This pr is intended to address the issue (if it was an issue). Regardless its better practice to use a guard to unwrap required optionals.  I've also added additional checks ensuring a controller's view is loaded and assigned to a window (thus visible) before bumping stats.  Also, since both ReaderTopic and ReaderPost instances can be assigned *after* the view controller has appeared, depending on circumstance, we'll try to bump stats when the is configured, and when the view has appeared.

To test: Same instructions as in #6116  

Needs review: @kurzee, care for another quick glance? 

cc @sendhil 
