### PR TITLE
Issues/1466 – New sites are now selected / highlighted in the blog list after creation

### DIFF
--- a/WordPress/Classes/Extensions/UITableView+Helpers.swift
+++ b/WordPress/Classes/Extensions/UITableView+Helpers.swift
@@ -40,6 +40,41 @@ extension UITableView
         }
     }
 
+    /// Flashes the specified row (selecting and then deselecting), and optionally scrolls to the specified position.
+    /// This method uses a default 'flash length' (time between selection and deselection) of 0.7 seconds.
+    /// Use `flashRowAtIndexPath(indexPath: NSIndexPath, scrollPosition: UITableViewScrollPosition = default, flashLength: NSTimeInterval, completion: (() -> Void)?)`
+    /// to specify a custom length.
+    ///
+    // - Parameters:
+    ///     - indexPath:        The indexPath of the row to flash.
+    ///     - scrollPosition:   The position in the table view to scroll the specified row. Use `.None` for no scrolling. Defaults to `.Middle`.
+    ///     - completion:       A block to call after the row has been deselected.
+    ///
+    public func flashRowAtIndexPath(indexPath: NSIndexPath, scrollPosition: UITableViewScrollPosition = .Middle, completion: (() -> Void)?) {
+        flashRowAtIndexPath(indexPath, scrollPosition: scrollPosition, flashLength: self.dynamicType.defaultFlashLength, completion: completion)
+    }
+
+    /// Flashes the specified row (selecting and then deselecting), and optionally scrolls to the specified position.
+    ///
+    // - Parameters:
+    ///     - indexPath:        The indexPath of the row to flash.
+    ///     - scrollPosition:   The position in the table view to scroll the specified row. Use `.None` for no scrolling.
+    ///     - flashLength:      The length of time (in seconds) to wait between selecting and deselecting the row.
+    ///     - completion:       A block to call after the row has been deselected.
+    ///
+    func flashRowAtIndexPath(indexPath: NSIndexPath, scrollPosition: UITableViewScrollPosition = .Middle, flashLength: NSTimeInterval, completion: (() -> Void)?) {
+        selectRowAtIndexPath(indexPath, animated: true, scrollPosition: scrollPosition)
+
+        let time = dispatch_time(DISPATCH_TIME_NOW, Int64(flashLength * Double(NSEC_PER_SEC)))
+
+        dispatch_after(time, dispatch_get_main_queue()) { [weak self] in
+            self?.deselectSelectedRowWithAnimation(true)
+            completion?()
+        }
+    }
+
+    private static let defaultFlashLength: NSTimeInterval = 0.7
+
     /// Disables Editing after a specified delay.
     ///
     /// -   Parameter delay: milliseconds to elapse before edition will be disabled.

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -195,27 +195,8 @@ static NSString * const UserDictionaryDateKey = @"date";
 {
     NSArray *blogs = jsonBlogs;
     return [blogs wp_map:^id(NSDictionary *jsonBlog) {
-        return [self remoteBlogFromJSONDictionary:jsonBlog];
+        return [[RemoteBlog alloc] initWithJSONDictionary:jsonBlog];
     }];
-}
-
-- (RemoteBlog *)remoteBlogFromJSONDictionary:(NSDictionary *)jsonBlog
-{
-    RemoteBlog *blog = [RemoteBlog new];
-    blog.blogID =  [jsonBlog numberForKey:@"ID"];
-    blog.name = [jsonBlog stringForKey:@"name"];
-    blog.tagline = [jsonBlog stringForKey:@"description"];
-    blog.url = [jsonBlog stringForKey:@"URL"];
-    blog.xmlrpc = [jsonBlog stringForKeyPath:@"meta.links.xmlrpc"];
-    blog.jetpack = [[jsonBlog numberForKey:@"jetpack"] boolValue];
-    blog.icon = [jsonBlog stringForKeyPath:@"icon.img"];
-    blog.capabilities = [jsonBlog dictionaryForKey:@"capabilities"];
-    blog.isAdmin = [[jsonBlog numberForKeyPath:@"capabilities.manage_options"] boolValue];
-    blog.visible = [[jsonBlog numberForKey:@"visible"] boolValue];
-    blog.options = [RemoteBlogOptionsHelper mapOptionsFromResponse:jsonBlog];
-    blog.planID = [jsonBlog numberForKeyPath:@"plan.product_id"];
-    blog.planTitle = [jsonBlog stringForKeyPath:@"plan.product_name_short"];
-    return blog;
 }
 
 @end

--- a/WordPress/Classes/Networking/BlogServiceRemote.h
+++ b/WordPress/Classes/Networking/BlogServiceRemote.h
@@ -1,10 +1,12 @@
 #import <Foundation/Foundation.h>
 
+@class RemoteBlog;
 @class RemoteBlogSettings;
 @class RemotePostType;
 
 typedef void (^SettingsHandler)(RemoteBlogSettings *settings);
 typedef void (^OptionsHandler)(NSDictionary *options);
+typedef void (^SiteDetailsHandler)(RemoteBlog *remoteBlog);
 typedef void (^PostTypesHandler)(NSArray <RemotePostType *> *postTypes);
 typedef void (^PostFormatsHandler)(NSDictionary *postFormats);
 typedef void (^MultiAuthorCheckHandler)(BOOL isMultiAuthor);
@@ -20,15 +22,6 @@ typedef void (^SuccessHandler)();
  */
 - (void)checkMultiAuthorWithSuccess:(MultiAuthorCheckHandler)success
                             failure:(void (^)(NSError *error))failure;
-
-/**
- *  @brief      Synchronizes a blog's options.
- *
- *  @param      success     The block that will be executed on success.  Can be nil.
- *  @param      failure     The block that will be executed on failure.  Can be nil.
- */
-- (void)syncOptionsWithSuccess:(OptionsHandler)success
-                       failure:(void (^)(NSError *error))failure;
 
 /**
  *  @brief      Synchronizes a blog's post types.
@@ -67,5 +60,25 @@ typedef void (^SuccessHandler)();
 - (void)updateBlogSettings:(RemoteBlogSettings *)remoteBlogSettings
                    success:(SuccessHandler)success
                    failure:(void (^)(NSError *error))failure;
+
+@optional
+
+/**
+ *  @brief      Synchronizes a blog's options.
+ *
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)syncOptionsWithSuccess:(OptionsHandler)success
+                       failure:(void (^)(NSError *error))failure;
+
+/**
+ *  @brief      Synchronizes a blog's top-level details.
+ *
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)syncSiteDetailsWithSuccess:(SiteDetailsHandler)success
+                           failure:(void (^)(NSError *error))failure;
 
 @end

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -1,6 +1,7 @@
 #import "BlogServiceRemoteREST.h"
 #import "NSMutableDictionary+Helpers.h"
 #import "WordPress-Swift.h"
+#import "RemoteBlog.h"
 #import "RemoteBlogOptionsHelper.h"
 #import "RemotePostType.h"
 
@@ -84,8 +85,8 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
           }];
 }
 
-- (void)syncOptionsWithSuccess:(OptionsHandler)success
-                       failure:(void (^)(NSError *))failure
+- (void)syncSiteDetailsWithSuccess:(SiteDetailsHandler)success
+                           failure:(void (^)(NSError *))failure
 {
     NSString *path = [self pathForOptions];
     NSString *requestUrl = [self pathForEndpoint:path
@@ -95,9 +96,9 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
        parameters:nil
           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
               NSDictionary *responseDict = (NSDictionary *)responseObject;
-              NSDictionary *options = [RemoteBlogOptionsHelper mapOptionsFromResponse:responseDict];
+              RemoteBlog *remoteBlog = [[RemoteBlog alloc] initWithJSONDictionary:responseDict];
               if (success) {
-                  success(options);
+                  success(remoteBlog);
               }
           } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
               if (failure) {

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
@@ -74,7 +74,7 @@
 @property (nonatomic, strong) NSDictionary *capabilities;
 
 /**
- * @details Parses details from a JSON dictionary.
+ * @details Parses details from a JSON dictionary, as returned by the WordPress.com REST API.
  */
 - (instancetype)initWithJSONDictionary:(NSDictionary *)json;
 

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlog.h
@@ -73,4 +73,9 @@
  */
 @property (nonatomic, strong) NSDictionary *capabilities;
 
+/**
+ * @details Parses details from a JSON dictionary.
+ */
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json;
+
 @end

--- a/WordPress/Classes/Networking/Remote Objects/RemoteBlog.m
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteBlog.m
@@ -1,6 +1,28 @@
 #import "RemoteBlog.h"
+#import "RemoteBlogOptionsHelper.h"
 
 @implementation RemoteBlog
+
+- (instancetype)initWithJSONDictionary:(NSDictionary *)json
+{
+    if (self = [super init]) {
+        _blogID =  [json numberForKey:@"ID"];
+        _name = [json stringForKey:@"name"];
+        _tagline = [json stringForKey:@"description"];
+        _url = [json stringForKey:@"URL"];
+        _xmlrpc = [json stringForKeyPath:@"meta.links.xmlrpc"];
+        _jetpack = [[json numberForKey:@"jetpack"] boolValue];
+        _icon = [json stringForKeyPath:@"icon.img"];
+        _capabilities = [json dictionaryForKey:@"capabilities"];
+        _isAdmin = [[json numberForKeyPath:@"capabilities.manage_options"] boolValue];
+        _visible = [[json numberForKey:@"visible"] boolValue];
+        _options = [RemoteBlogOptionsHelper mapOptionsFromResponse:json];
+        _planID = [json numberForKeyPath:@"plan.product_id"];
+        _planTitle = [json stringForKeyPath:@"plan.product_name_short"];
+    }
+
+    return self;
+}
 
 - (NSString *)description
 {

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -189,6 +189,10 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
         [remote syncOptionsWithSuccess:[self optionsHandlerWithBlogObjectID:blog.objectID
                                                           completionHandler:success]
                                failure:failure];
+    } else if ([remote respondsToSelector:@selector(syncSiteDetailsWithSuccess:failure:)]) {
+        [remote syncSiteDetailsWithSuccess:[self siteDetailsHandlerWithBlogObjectID:blog.objectID
+                                                                  completionHandler:success]
+                                   failure:failure];
     }
 }
 

--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -97,7 +97,7 @@
 - (void)saveContext:(NSManagedObjectContext *)context withCompletionBlock:(void (^)())completionBlock;
 
 /**
- Get a peranent NSManagedObjectID for the specified NSManagedObject
+ Get a permanent NSManagedObjectID for the specified NSManagedObject
  
  @param managedObject A managedObject with a temporary NSManagedObjectID
  @return YES if the permanentID was successfully obtained, or NO if it failed.

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -147,6 +147,7 @@ static NSInteger HideSearchMinSites = 3;
     [self configureNoResultsView];
 
     [self registerForAccountChangeNotification];
+    [self registerForBlogCreationNotification];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -437,6 +438,14 @@ static NSInteger HideSearchMinSites = 3;
                                                object:nil];
 }
 
+- (void)registerForBlogCreationNotification
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(newWordPressComBlogCreated:)
+                                                 name:NewWPComBlogCreatedNotification
+                                               object:nil];
+}
+
 - (void)registerForKeyboardNotifications
 {
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -506,6 +515,26 @@ static NSInteger HideSearchMinSites = 3;
 {
     [self setEditing:NO];
     [self updateSearchVisibility];
+}
+
+- (void)newWordPressComBlogCreated:(NSNotification *)notification
+{
+    Blog *blog = notification.userInfo[NewWPComBlogCreatedNotificationBlogUserInfoKey];
+
+    if (blog) {
+        NSUInteger index = [self.resultsController.fetchedObjects indexOfObject:blog];
+
+        if (index != NSNotFound) {
+            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:index inSection:0];
+            [self.tableView flashRowAtIndexPath:indexPath
+                                 scrollPosition:UITableViewScrollPositionMiddle
+                                     completion:^{
+                                         if (![self splitViewControllerIsHorizontallyCompact]) {
+                                             [self tableView:self.tableView didSelectRowAtIndexPath:indexPath];
+                                         }
+                                     }];
+        }
+    }
 }
 
 #pragma mark - Table view data source

--- a/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.h
@@ -1,5 +1,8 @@
 #import <UIKit/UIKit.h>
 
+FOUNDATION_EXPORT NSString * const NewWPComBlogCreatedNotification;
+FOUNDATION_EXPORT NSString * const NewWPComBlogCreatedNotificationBlogUserInfoKey;
+
 @interface CreateNewBlogViewController : UIViewController
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
@@ -510,6 +510,9 @@ static UIEdgeInsets const CreateBlogCancelButtonPaddingPad  = {1.0, 13.0, 0.0, 0
 
             [[ContextManager sharedInstance] saveContext:context];
 
+            // syncBlog will need a permanent ID so it can fetch and update the blog in its request completion blocks 
+            [[ContextManager sharedInstance] obtainPermanentIDForObject:blog];
+
             __weak __typeof(self) weakSelf = self;
 
             void (^completion)() = ^{

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -371,15 +371,8 @@ import WordPressShared
         guard let indexPath = viewModel.indexPathOfTag(tag) else {
             return
         }
-        tableView.selectRowAtIndexPath(indexPath, animated: true, scrollPosition: .Middle)
 
-        let time = dispatch_time(
-            DISPATCH_TIME_NOW,
-            Int64(0.7 * Double(NSEC_PER_SEC))
-        )
-        dispatch_after(time, dispatch_get_main_queue()) { [weak self] in
-            self?.tableView.deselectSelectedRowWithAnimation(true)
-        }
+        tableView.flashRowAtIndexPath(indexPath, scrollPosition: .Middle, completion: nil)
     }
 
 

--- a/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
@@ -37,27 +37,26 @@ static NSTimeInterval const TestExpectationTimeout = 5;
                                  failure:^(NSError *error) {}];
 }
 
+#pragma mark - Synchronizing site details for a blog
 
-#pragma mark - Synchronizing options for a blog
-
-- (void)testThatSyncOptionForBlogWorks
+- (void)testThatSyncSiteDetailsForBlogWorks
 {
     Blog *blog = OCMStrictClassMock([Blog class]);
     OCMStub([blog dotComID]).andReturn(@10);
-    
+
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     BlogServiceRemoteREST *service = nil;
-    
+
     NSString* url = [NSString stringWithFormat:@"v1.1/sites/%@", blog.dotComID];
-    
+
     OCMStub([api GET:[OCMArg isEqual:url]
           parameters:[OCMArg isNil]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
-    
+
     XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithWordPressComRestApi:api siteID:blog.dotComID]);
-    
-    [service syncOptionsWithSuccess:^(NSDictionary *options) {}
+
+    [service syncSiteDetailsWithSuccess:^(RemoteBlog *remoteBlog) {}
                             failure:^(NSError *error) {}];
 }
 


### PR DESCRIPTION
Fixes #1466 – when a new .com site is created, it now gets highlighted in the sites list.
- When the app is horizontally regular (so the split view is expanded), the blog is _selected_ and the user is taken to blog details.
- When horizontally compact (so the split view is collapsed), the blog is only _highlighted_ and the user remains on the blog list.

To test:
- On iPad (full screen, no multitasking), create a new site using the + button in the top right of the sites list. After the create site screen is dismissed, the new blog should be highlighted and then you'll be taken to its detail screen.
- On iPad (multitasking either 50/50 landscape or in portrait) or iPhone, create a new site using the + button in the top right of the sites list. The new site should be temporarily highlighted in the list.
- In all cases, if you have a long list of sites and the new site wouldn't be visible in the sites list, the list should scroll to show you the new one.

Needs review: @kwonye 
