### PR TITLE
Issue/6030 fixing media library sync

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -12,6 +12,7 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #import "WordPress-swift.h"
 #import "WPXMLRPCDecoder.h"
+#import "PhotonImageURLHelper.h"
 
 @implementation MediaService
 
@@ -415,10 +416,13 @@
             remoteURL = [NSURL URLWithString:media.remoteThumbnailURL];
         } else if (media.mediaType == MediaTypeImage) {
             NSString *remote = media.remoteURL;
-            if ([media.blog isHostedAtWPcom]) {
-                remote = [NSString stringWithFormat:@"%@?w=%ld",remote, (long)size.width];
-            }
             remoteURL = [NSURL URLWithString:remote];
+            if (!media.blog.isPrivate) {
+                remoteURL = [PhotonImageURLHelper photonURLWithSize:size forImageURL:remoteURL];
+            } else {
+                remoteURL = [WPImageURLHelper imageURLWithSize:size forImageURL:remoteURL];
+            }
+
         }
         if (!remoteURL) {
             if (failure) {

--- a/WordPress/Classes/Utility/WPImageURLHelper.swift
+++ b/WordPress/Classes/Utility/WPImageURLHelper.swift
@@ -25,8 +25,8 @@ public class WPImageURLHelper: NSObject
                 }
             }
         }
-        let height = size.height
-        let width = size.width
+        let height = Int(size.height)
+        let width = Int(size.width)
         if height != 0 {
             let heightItem = NSURLQueryItem(name:"h", value:"\(height)")
             newQueryItems.append(heightItem)

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -336,6 +336,12 @@
 
 
 - (void)controllerDidChangeContent:(NSFetchedResultsController *)controller {
+    if (self.mediaRemoved.count == 0 && self.mediaInserted.count == 0) {
+        //if it's not a removal or insertion we can ignore. We do this because
+        // every time we request get a new thumbnail beside getting it from the internet we
+            // are saving a reference to the database/coredata and triggering another fetch result controller udpate
+        return;
+    }
     [self notifyObserversWithIncrementalChanges:YES
                                         removed:self.mediaRemoved
                                        inserted:self.mediaInserted

--- a/WordPress/WordPressTest/ReaderPostServiceRemoteTests.m
+++ b/WordPress/WordPressTest/ReaderPostServiceRemoteTests.m
@@ -442,7 +442,7 @@
 
     XCTAssertTrue([content rangeOfString:@"src=\"https://picklessaltyporkvonhausen.files.wordpress.com/2016/07/img_8961.jpg?w=181&#038;h=135&#038;crop=1\""].length > 0);
     XCTAssertTrue([resultContent rangeOfString:@"src=\"https://picklessaltyporkvonhausen.files.wordpress.com/2016/07/img_8961.jpg?w=181&#038;h=135&#038;crop=1\""].length == 0);
-    NSString *expectedURL = [NSString stringWithFormat:@"src=\"https://picklessaltyporkvonhausen.files.wordpress.com/2016/07/img_8961.jpg?h=%.1f&w=%.1f\"", scaledSize.height, scaledSize.width];
+    NSString *expectedURL = [NSString stringWithFormat:@"src=\"https://picklessaltyporkvonhausen.files.wordpress.com/2016/07/img_8961.jpg?h=%ld&w=%ld\"", (long)(scaledSize.height), (long)(scaledSize.width)];
     XCTAssertTrue([resultContent rangeOfString:expectedURL].length > 0);
 }
 


### PR DESCRIPTION
Fixes #6030 

To test:
 - Select a blog ( try with WP.com and self-hosted)
 - Create a  new post
 - Tap on add image 
 - Select on the the WordPress Library group
 - Check if the refresh happens without issues.

Needs review: @kurzee 