### PR TITLE
Issues/6112 add user to restricted list

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -207,7 +207,7 @@ import Mixpanel
     ///
     class func isUsernameReserved(username: String) -> Bool {
         let name = username.lowercaseString.trim()
-        return ["admin", "administrator", "root"].contains(name)
+        return ["admin", "administrator", "root", "user"].contains(name)
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -207,7 +207,7 @@ import Mixpanel
     ///
     class func isUsernameReserved(username: String) -> Bool {
         let name = username.lowercaseString.trim()
-        return ["admin", "administrator", "root", "user"].contains(name)
+        return ["admin", "administrator", "invite", "main", "root", "web", "www"].contains(name)
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -207,7 +207,7 @@ import Mixpanel
     ///
     class func isUsernameReserved(username: String) -> Bool {
         let name = username.lowercaseString.trim()
-        return ["admin", "administrator", "invite", "main", "root", "web", "www"].contains(name)
+        return ["admin", "administrator", "invite", "main", "root", "web", "www"].contains(name) || name.containsString("wordpress")
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -253,6 +253,7 @@ import Mixpanel
         alertController.addCancelActionWithTitle(NSLocalizedString("OK", comment: "OK Button Title"), handler: {(action) in
             callback()
         })
+        alertController.presentFromRootViewController()
     }
 
 


### PR DESCRIPTION
Closes #6112 

Adds ~~`user`~~ more names to the list of reserved wpcom usernames: www, web, main, invite, and names containing "wordpress"

Also, since somehow we missed actually showing the reserved name prompt when a user tries to sign into wpcom after _already_ being signed in with a self-hosted blog, now we do that too. :P 

To test: 
Scenario 1:
- Be completely signed out of the app. 
- On the sign in screen enter ~~"user"~~ the new names for the username and click "Next"
- Confirm you are advanced to the self-hosted sign in screen. 

Scenario 2:
- Be signed into a self-hosted blog. 
- From the Me tab, tap to connect to wpcom. 
- Enter ~~"user"~~ the new names for the user name and click "Next".
- Confirm you are prompted that "user" is a reserved username on wpcom. 

Needs review: @kwonye, would you please? 

Edit:  Turns out that "user" and "username" are valid screen names on wpcom.  Props @aforcier and @rachelmcr for the sleuth work. 
