### PR TITLE
Install SwiftLint from binaries when available.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -85,13 +85,33 @@ namespace :dependencies do
       fold("install.swiftlint") do
         puts "Installing SwiftLint #{SWIFTLINT_VERSION} into #{swiftlint_path}"
         Dir.mktmpdir do |tmpdir|
-          sh "git clone --quiet https://github.com/realm/SwiftLint.git #{tmpdir}"
-          Dir.chdir(tmpdir) do
-            sh "git checkout --quiet #{SWIFTLINT_VERSION}"
-            sh "git submodule --quiet update --init --recursive"
-            FileUtils.remove_entry_secure(swiftlint_path) if Dir.exist?(swiftlint_path)
-            FileUtils.mkdir_p(swiftlint_path)
-            sh "make prefix_install PREFIX='#{swiftlint_path}'"
+          # Try first using a binary release
+          pkgfile = "#{tmpdir}/swiftlint-#{SWIFTLINT_VERSION}.pkg"
+          sh "curl --location -o #{pkgfile} https://github.com/realm/SwiftLint/releases/download/#{SWIFTLINT_VERSION}/SwiftLint.pkg"
+          if File.exists?(pkgfile)
+            pkgdir = "#{tmpdir}/swiftlint-#{SWIFTLINT_VERSION}"
+            sh "pkgutil --expand #{pkgfile} #{pkgdir}"
+            Dir.chdir(pkgdir) do
+              binfile = "#{pkgdir}/usr/local/bin/swiftlint"
+              sh "cat Payload | gzip -d | cpio -id"
+              sh "install_name_tool -rpath /Library/Frameworks '@executable_path/../Frameworks' #{binfile}"
+              sh "install_name_tool -rpath /Library/Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks '@executable_path/../Frameworks/SwiftLintFramework.framework/Versions/Current/Frameworks' #{binfile}"
+              puts "Copying SwiftLint #{SWIFTLINT_VERSION} into #{swiftlint_path}"
+              FileUtils.remove_entry_secure(swiftlint_path) if Dir.exist?(swiftlint_path)
+              FileUtils.mkdir_p(swiftlint_path)
+              FileUtils.cp_r("#{pkgdir}/Library/Frameworks", swiftlint_path)
+              FileUtils.mkdir_p("#{swiftlint_path}/bin")
+              FileUtils.cp("#{pkgdir}/usr/local/bin/swiftlint", "#{swiftlint_path}/bin/swiftlint")
+            end
+          else
+            sh "git clone --quiet https://github.com/realm/SwiftLint.git #{tmpdir}"
+            Dir.chdir(tmpdir) do
+              sh "git checkout --quiet #{SWIFTLINT_VERSION}"
+              sh "git submodule --quiet update --init --recursive"
+              FileUtils.remove_entry_secure(swiftlint_path) if Dir.exist?(swiftlint_path)
+              FileUtils.mkdir_p(swiftlint_path)
+              sh "make prefix_install PREFIX='#{swiftlint_path}'"
+            end
           end
         end
       end


### PR DESCRIPTION
To avoid problems when building SwiftLint, and because it's so much faster,
let's install it using the `pkg` from the releases page if available.

To test:

- Make sure `SWIFTLINT_VERSION` in Rakefile is different from the installed version (or `rm -rf vendor`)
- Run `rake dependencies`, no need to change it to `master` anymore
- SwiftLint 0.12.0 should be installed from the pkg file
- Try `rake lint`

Needs review: @astralbodies 