### PR TITLE
Fix SwiftLint installation if release not found on github

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -87,7 +87,7 @@ namespace :dependencies do
         Dir.mktmpdir do |tmpdir|
           # Try first using a binary release
           pkgfile = "#{tmpdir}/swiftlint-#{SWIFTLINT_VERSION}.pkg"
-          sh "curl --location -o #{pkgfile} https://github.com/realm/SwiftLint/releases/download/#{SWIFTLINT_VERSION}/SwiftLint.pkg"
+          sh "curl --fail --location -o #{pkgfile} https://github.com/realm/SwiftLint/releases/download/#{SWIFTLINT_VERSION}/SwiftLint.pkg || true"
           if File.exists?(pkgfile)
             pkgdir = "#{tmpdir}/swiftlint-#{SWIFTLINT_VERSION}"
             sh "pkgutil --expand #{pkgfile} #{pkgdir}"


### PR DESCRIPTION
Currently, if SwiftLint release is not found on github a `.pkg` file is created with `{"error":"Not Found"}` content and failing to expand the `.pkg` file.