### PR TITLE
Saving sharing button settings when dismissing view controller

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -74,6 +74,12 @@ import WordPressShared
         tableView.reloadData()
     }
 
+    override func viewWillDisappear(animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        self.saveButtonChanges(true)
+    }
+
 
     // MARK: - Sections Setup and Config
 


### PR DESCRIPTION
Fixes #6136 

To test:

Go to sharing->Manage and enable "Edit sharing buttons" or 'Edit "More" button'.  
Add a button.
Go back to Sharing
Go back to Manage.  With the fix the additional button is appropriately checked.  Without it is not.


Needs review: @rachelmcr
