### PR TITLE
Fix that unrelated warning that stares me to death when I try to compile a risky block of code

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -19,6 +19,7 @@
 #import "MenusViewController.h"
 #import <Reachability/Reachability.h>
 
+@import WordPressComStatsiOS;
 @import Gridicons;
 
 static NSString *const BlogDetailsCellIdentifier = @"BlogDetailsCell";

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.h
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.h
@@ -1,7 +1,7 @@
 #import <UIKit/UIKit.h>
-#import <WordPressComStatsiOS/WPStatsViewController.h>
 
 @class Blog;
+@class WPStatsService;
 
 @interface StatsViewController : UIViewController
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -14,6 +14,8 @@
 #import "WPAppAnalytics.h"
 #import "WPWebViewController.h"
 
+@import WordPressComStatsiOS;
+
 static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 @interface StatsViewController () <WPStatsViewControllerDelegate>


### PR DESCRIPTION
Fixes a warning for a "duplicate" category definition from the stats pod. Really, we just needed to import in .m files and not the .h files for Xcode 8.

To test:
- Build, make sure there's no warnings.

Needs review: @aerych can you take a gander?

