### PR TITLE
Refresh the list after setting the author filter.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -215,6 +215,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
             authorFilter = .Mine
         }
         filterSettings.setCurrentPostAuthorFilter(authorFilter)
+        refreshAndReload()
     }
 
     // MARK: - Data Model Interaction


### PR DESCRIPTION
Fixes #6109 

To test:
 - Open the app
 - Select a blog with multiple authors
 - Go to post list
 - Tap on the segment control that allows to select my posts, and everyone
 - Check if the list gets updated.

Needs review: @sendhil 