### PR TITLE
Posts: Fixes issue with post updating and status changes

### DIFF
--- a/WordPress/Classes/Networking/PostServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.m
@@ -372,10 +372,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     parameters[@"password"] = post.password ? post.password : @"";
     parameters[@"type"] = post.type;
 
-    if ([post.date isEqualToDate:post.dateModified]) {
-        // publish immediately when date created matches date modified
-        parameters[@"date"] = [[NSDate date] WordPressComJSONString];
-    } else if (post.date) {
+    if (post.date) {
         parameters[@"date"] = [post.date WordPressComJSONString];
     } else if (existingPost) {
         // safety net. An existing post with no create date should publish immediately

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -933,11 +933,19 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         return blog.account?.userID
     }
 
+    // MARK - Filtering
+
     func refreshAndReload() {
         recentlyTrashedPostObjectIDs.removeAll()
         updateFilterTitle()
         resetTableViewContentOffset()
         updateAndPerformFetchRequestRefreshingResults()
+    }
+
+    func updateFilterWithPostStatus(status: String) {
+        filterSettings.setFilterWithPostStatus(status)
+        refreshAndReload()
+        WPAnalytics.track(.PostListStatusFilterChanged, withProperties: propertiesForAnalytics())
     }
 
     func updateFilterTitle() {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -386,8 +386,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         postViewController.onClose = { [weak self] (viewController, changesSaved) in
             if changesSaved {
                 if let postStatus = viewController.post.status {
-                    self?.filterSettings.setFilterWithPostStatus(postStatus)
-                    WPAnalytics.track(.PostListStatusFilterChanged, withProperties: self?.propertiesForAnalytics())
+                    self?.updateFilterWithPostStatus(postStatus)
                 }
             }
 
@@ -443,7 +442,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
 
                 if changesSaved {
                     if let postStatus = viewController.post.status {
-                        self?.filterSettings.setFilterWithPostStatus(postStatus)
+                        self?.updateFilterWithPostStatus(postStatus)
                     }
                 }
 


### PR DESCRIPTION
Fixes #6113, #3973, and partially #5992

This fixes two issues, one we were overriding the `"date"` for a remote post when it's modified date matched the `date`. This looks like it was added to help fix the issues in #5483 but _seems_ unnecessary and actually creates the issues seen in #6113 and #3973.

Second, this fixes an issue with the post filter not updating when opening the editor and changing the status of a post. Which will now select the correct filter, which it was trying to do before but never updated the UI. This addresses part of #5992.

To test:
- Follow the same steps seen in #5483, #6113, #3973, making sure the issues don't reproduce.
- Second, while testing, ensure that the expected filter list is selected when a post's status changes and the editor dismisses.

Needs review: @diegoreymendez can you take a whirl?
cc @aerych 