### PR TITLE
Refresh Post list after author filter is changed.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -217,6 +217,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
             authorFilter = .Mine
         }
         filterSettings.setCurrentPostAuthorFilter(authorFilter)
+        refreshAndReload()
     }
 
     // MARK: - Data Model Interaction


### PR DESCRIPTION
Fixes #6109 

To test:
 - Open the app
 - Select a blog with multiple authors
 - Go to post list
 - Tap on the segment control that allows to select my posts, and everyone
 - Check if the list gets updated.

Needs review: @astralbodies 