### PR TITLE
Me: Show selfies album by default when picking image for Gravatar

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
@@ -11,6 +11,16 @@ class GravatarPickerViewController : UIViewController, WPMediaPickerViewControll
 
     var onCompletion : (UIImage? -> Void)?
 
+    // MARK: - Private Properties
+
+    private lazy var mediaPickerAssetDataSource: WPPHAssetDataSource? = {
+        let collectionsFetchResult = PHAssetCollection.fetchAssetCollectionsWithType(.SmartAlbum, subtype: .SmartAlbumSelfPortraits, options: nil)
+        guard let assetCollection = collectionsFetchResult.firstObject as? PHAssetCollection else { return nil }
+
+        let dataSource = WPPHAssetDataSource()
+        dataSource.setSelectedGroup(PHAssetCollectionForWPMediaGroup(collection: assetCollection, mediaType: .Image))
+        return dataSource
+    }()
 
     // MARK: - View Lifecycle Methods
 
@@ -76,7 +86,7 @@ class GravatarPickerViewController : UIViewController, WPMediaPickerViewControll
         pickerViewController.allowMultipleSelection = false
         pickerViewController.filter = .Image
         pickerViewController.preferFrontCamera = true
-
+        pickerViewController.dataSource = mediaPickerAssetDataSource
         return pickerViewController
     }
 


### PR DESCRIPTION
Fixes #6017 

To test:
Navigate to the **Me** tab and tap the current avatar and the view should be different based on the images on the device:

| No selfies on the device | At least one selfie on the device |
|:----------:|:-------------------:|
| ![without selfies](https://cloud.githubusercontent.com/assets/1046917/19954056/7c02e972-a1af-11e6-8d1c-288c81d29837.PNG) | ![with selfies](https://cloud.githubusercontent.com/assets/1046917/19954057/7c065eea-a1af-11e6-8e61-1a6ff5904119.PNG) |

<hr>
And thanks for building this awesome app.

This is my first step contributing to this project, would love to 👂  your thoughts on this!
Thank you 😃 
