### PR TITLE
Properly wraps Reader tab label in NSLocalizedString.

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -228,8 +228,8 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     _readerNavigationController.tabBarItem.image = [readerTabBarImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
     _readerNavigationController.tabBarItem.selectedImage = readerTabBarImage;
     _readerNavigationController.restorationIdentifier = WPReaderNavigationRestorationID;
-    _readerNavigationController.tabBarItem.accessibilityIdentifier = @"Reader";
-    _readerNavigationController.tabBarItem.title = @"Reader";
+    _readerNavigationController.tabBarItem.accessibilityIdentifier = NSLocalizedString(@"Reader", @"The accessibility value of the Reader tab.");
+    _readerNavigationController.tabBarItem.title = NSLocalizedString(@"Reader", @"The accessibility value of the Reader tab.");
 
     return _readerNavigationController;
 }
@@ -246,7 +246,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     _newPostViewController.tabBarItem.image = newPostImage;
     _newPostViewController.tabBarItem.imageInsets = [self tabBarIconImageInsets];
     _newPostViewController.tabBarItem.accessibilityIdentifier = NSLocalizedString(@"New Post", @"The accessibility value of the post tab.");
-    _newPostViewController.tabBarItem.title = @"New Post";
+    _newPostViewController.tabBarItem.title = NSLocalizedString(@"New Post", @"The accessibility value of the post tab.");
     _newPostViewController.tabBarItem.titlePositionAdjustment = UIOffsetMake(0, 20.0);
 
     return _newPostViewController;


### PR DESCRIPTION
Fixes #6154

To test:
Testing this patch is sort of convoluted. It's fairly straightforward but you're welcome to add a localization string and see if it's working properly or not. 😄 


Needs review: @aerych 
