### PR TITLE
PostList: Improves filter update when switching post statuses.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -933,11 +933,19 @@ class AbstractPostListViewController : UIViewController, WPContentSyncHelperDele
         return blog.account?.userID
     }
 
+    // MARK - Filtering
+
     func refreshAndReload() {
         recentlyTrashedPostObjectIDs.removeAll()
         updateFilterTitle()
         resetTableViewContentOffset()
         updateAndPerformFetchRequestRefreshingResults()
+    }
+
+    func updateFilterWithPostStatus(status: String) {
+        filterSettings.setFilterWithPostStatus(status)
+        refreshAndReload()
+        WPAnalytics.track(.PostListStatusFilterChanged, withProperties: propertiesForAnalytics())
     }
 
     func updateFilterTitle() {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -387,8 +387,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         postViewController.onClose = { [weak self] (viewController, changesSaved) in
             if changesSaved {
                 if let postStatus = viewController.post.status {
-                    self?.filterSettings.setFilterWithPostStatus(postStatus)
-                    WPAnalytics.track(.PostListStatusFilterChanged, withProperties: self?.propertiesForAnalytics())
+                    self?.updateFilterWithPostStatus(postStatus)
                 }
             }
 
@@ -444,7 +443,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
 
                 if changesSaved {
                     if let postStatus = viewController.post.status {
-                        self?.filterSettings.setFilterWithPostStatus(postStatus)
+                        self?.updateFilterWithPostStatus(postStatus)
                     }
                 }
 


### PR DESCRIPTION
Breaks off from https://github.com/wordpress-mobile/WordPress-iOS/pull/6147 to partially fix #5992.

To test, on Blog Posts:

1. Select a post from "Published" and edit it to become a draft.
2. The filter selection should update to "Drafts" and drafts should be displayed.
##
3. Select a post from "Drafts" and edit to publish it.
4. The filter selection should update to "Published" and published posts should be displayed.
##
5. Select a post from "Scheduled" and edit it to become a draft.
6. The filter selection should update to "Drafts"  and drafts should be displayed.
##
7. Select a post from "Drafts" and edit it to become scheduled.
8. The filter selection should update to "Scheduled"  and scheduled posts should be displayed.
##
9. Select a post from "Scheduled" and edit it to post immediately.
10. The filter selection should update to "Published"  and posts should be displayed.

Needs review: @diegoreymendez can you take a second look at this from the previous PR? I know there's some nuances in here between changing scheduled/draft/immediately, but we'll just make sure the filter lands on the right spot for now.
