### PR TITLE
Posts: sync when changing filter author

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -218,6 +218,7 @@ class PostListViewController : AbstractPostListViewController, UIViewControllerR
         }
         filterSettings.setCurrentPostAuthorFilter(authorFilter)
         refreshAndReload()
+        syncItemsWithUserInteraction(false)
     }
 
     // MARK: - Data Model Interaction


### PR DESCRIPTION
We lost the original re-sync call when changing authors via: https://github.com/wordpress-mobile/WordPress-iOS/commit/dadde8f9e73354b3627ee5c8fd27c090cedebc4a#diff-56d3ee28947d056476717395cb71f4d7L584.

Adding it back now to address an issue where posts would not sync or page correctly when switching authors. This also helps alleviate some of the issues on https://github.com/wordpress-mobile/WordPress-iOS/issues/6151.

To test:
- Fresh install.
- Log in, Open "Blog Posts" for a site that has many posts and multiple authors.
- The `PostListViewController` will start on "Only Me", switch to "Everyone".
- The `PostListViewController` should reload and resync.
- Scroll to the bottom of the list, more posts should page in as expected.

Needs review: @nheagy 