### PR TITLE
Issue/6158 Splitview Dimming with Multitasking

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -61,6 +61,12 @@ class WPSplitViewController: UISplitViewController {
         extendedLayoutIncludesOpaqueBars = true
     }
 
+    override func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+
+        updateDimmingViewFrame()
+    }
+
     override func encodeRestorableStateWithCoder(coder: NSCoder) {
         super.encodeRestorableStateWithCoder(coder)
 


### PR DESCRIPTION
Fixes #6158. @hoverduck reported an issue (with reproduction steps) where the 'dimming' view could become misplaced when switching between multitasking sizes. This PR just ensures that the frame is correct when a splitview appears.

To test: Follow the reproduction steps in the original issue, and ensure it doesn't happen again!

Needs review: @kurzee 