### PR TITLE
Update README to mention the workaround for helpshift.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ In order to use these details, you'll need to create a credential file in your b
 
 Then edit the ~/.wpcom_app_credentials file and change the WPCOM_APP_ID and WPCOM_APP_SECRET fields to the values you got for your app.
 
+To run the app on device or simulator, you will also need to specify a dummy value for the HELPSHIFT_API_KEY field. The value you specify here doesn't matter as long as it is non-empty.
+
 Then you can compile and run the app on a device or an emulator and login with a WordPress.com account.
 
 **Remember the only account you will be able to login in with is the one affiliated with your developer account.** 


### PR DESCRIPTION
Fixes #6162 

The app will crash on launch if there is not a value specified for the
HELPSHIFT_API_KEY in the credentials file. 

This PR adds a workaround to the README so that new developers can get set up without running in to this issue.

A potential alternative to this could be to guard against a missing or invalid API key in the helpshift utils. I have not gone with this approach as it could potentially introduce a bug if the key were to be missing in the released app (It would silently fail). Potentially this guard could be run in debug configurations only?