### PR TITLE
Disable helpshift while in debug mode

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -386,8 +386,12 @@ int ddLogLevel = DDLogLevelInfo;
     [KeychainTools processKeychainDebugArguments];
 #endif
 
+    // Don't set up helpshift if we are debugging.
+    // Allows testing of the app without helpshift credentials.
+#if !DEBUG
     [HelpshiftUtils setup];
-    
+#endif
+
     // Networking setup
     [[AFNetworkActivityIndicatorManager sharedManager] setEnabled:YES];
     [WPUserAgent useWordPressUserAgentInUIWebViews];

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -386,11 +386,8 @@ int ddLogLevel = DDLogLevelInfo;
     [KeychainTools processKeychainDebugArguments];
 #endif
 
-    // Don't set up helpshift if we are debugging.
-    // Allows testing of the app without helpshift credentials.
-#if !DEBUG
+
     [HelpshiftUtils setup];
-#endif
 
     // Networking setup
     [[AFNetworkActivityIndicatorManager sharedManager] setEnabled:YES];

--- a/WordPress/Classes/Utility/HelpshiftUtils.m
+++ b/WordPress/Classes/Utility/HelpshiftUtils.m
@@ -34,6 +34,15 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
 
 + (void)setup
 {
+    // Don't set up helpshift if we are debugging and there is not a valid API Key.
+    // Allows testing of the app without helpshift credentials.
+#if !DEBUG
+    NSString *apiKey = [ApiCredentials helpshiftAPIKey];
+    if (apiKey == nil || [apiKey isEqualToString:@""]) {
+        return;
+    }
+#endif
+
     [HelpshiftCore initializeWithProvider:[HelpshiftSupport sharedInstance]];
     [[HelpshiftSupport sharedInstance] setDelegate:[HelpshiftUtils sharedInstance]];
     [HelpshiftCore installForApiKey:[ApiCredentials helpshiftAPIKey] domainName:[ApiCredentials helpshiftDomainName] appID:[ApiCredentials helpshiftAppId]];


### PR DESCRIPTION
Fixes #6162 

To test:
Run the app in debug mode without helpshift credentials. It should not crash.

This enables testing of the app without helpshift credentials.