### PR TITLE
Add Helpshift tags to Start Over conversations

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
@@ -111,9 +111,11 @@ public class StartOverViewController: UITableViewController
     }
 
     private func helpshiftMetadata(blog: Blog) -> [NSObject: AnyObject] {
-        let options: [String: String] = [
+        let tags = blog.account.map({ HelpshiftUtils.planTagsForAccount($0) }) ?? []
+        let options: [String: AnyObject] = [
             "Source": "Start Over",
             "Blog": blog.logDescription(),
+            HelpshiftSupportTagsKey: tags
             ]
 
         return [HelpshiftSupportCustomMetadataKey: options]


### PR DESCRIPTION
I missed the Start Over controller in #6061, and paid users who contacted us from there didn't have their conversations tagged accordingly

Cc: @rachelmcr 
Needs review: @sendhil 

