### PR TITLE
ReplyTextView: Fixing Scroll Position Glitch

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -1,13 +1,19 @@
 import Foundation
 import WordPressShared.WPStyleGuide
 
-@objc public protocol ReplyTextViewDelegate : UITextViewDelegate
+
+
+// MARK: - ReplyTextViewDelegate
+//
+@objc public protocol ReplyTextViewDelegate: UITextViewDelegate
 {
     optional func textView(textView: UITextView, didTypeWord word: String)
 }
 
 
-@objc public class ReplyTextView : UIView, UITextViewDelegate
+// MARK: - ReplyTextView
+//
+@objc public class ReplyTextView: UIView, UITextViewDelegate
 {
     // MARK: - Initializers
     public convenience init(width: CGFloat) {
@@ -142,17 +148,19 @@ import WordPressShared.WPStyleGuide
 
     // MARK: - IBActions
     @IBAction private func btnReplyPressed() {
-        if let handler = onReply {
-            // Load the new text
-            let newText = textView.text
-            textView.resignFirstResponder()
-
-            // Cleanup + Shrink
-            text = String()
-
-            // Hit the handler
-            handler(newText)
+        guard let handler = onReply else {
+            return
         }
+
+        // Load the new text
+        let newText = textView.text
+        textView.resignFirstResponder()
+
+        // Cleanup + Shrink
+        text = String()
+
+        // Hit the handler
+        handler(newText)
     }
 
 
@@ -282,17 +290,10 @@ import WordPressShared.WPStyleGuide
     }
 
     private func refreshScrollPosition() {
-        // FIX: In iOS 8, scrollRectToVisible causes a weird flicker
-        if UIDevice.isOS8() {
-            // FIX: Force layout right away. This prevents the TextView from "Jumping"
-            textView.layoutIfNeeded()
-            textView.scrollRangeToVisible(textView.selectedRange)
-        } else {
-            let selectedRangeStart      = textView.selectedTextRange?.start ?? UITextPosition()
-            var caretRect               = textView.caretRectForPosition(selectedRangeStart)
-            caretRect                   = CGRectIntegral(caretRect)
-            textView.scrollRectToVisible(caretRect, animated: false)
-        }
+        let selectedRangeStart      = textView.selectedTextRange?.start ?? UITextPosition()
+        var caretRect               = textView.caretRectForPosition(selectedRangeStart)
+        caretRect                   = CGRectIntegral(caretRect)
+        textView.scrollRectToVisible(caretRect, animated: false)
     }
 
 


### PR DESCRIPTION
### Details:
ReplyTextView appears to be slightly broken in iOS 10 (just noticed). Details below!

### To test:
1. Launch WPiOS on an iOS 10 device (tested here on the SE / 6s)
2. Open a Comment-Y Notification
3. Type three lines of text (word + newline + word + newline + word)
4. As a result, the first word will end up offscreen.
5. Try to scroll upwards
6. Note that the ReplyTextView won't scroll

Please, verify that iOS 9 doesn't break. This might have been broken for months, i'm afraid!

Needs review: @aerych 
Eric, may i bug you with a review

Thanks in advance!
