### PR TITLE
NotificationsViewController: Minimum PTR delay

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -632,8 +632,16 @@ extension NotificationsViewController
             return
         }
 
+        let start = NSDate()
+
         service.sync { _ in
-            self.refreshControl?.endRefreshing()
+
+            let delta = max(Syncing.minimumPullToRefreshDelay + start.timeIntervalSinceNow, 0)
+            let delay = dispatch_time(DISPATCH_TIME_NOW, Int64(delta * Double(NSEC_PER_SEC)))
+
+            dispatch_after(delay, dispatch_get_main_queue()) { _ in
+                self.refreshControl?.endRefreshing()
+            }
         }
     }
 }
@@ -1094,6 +1102,7 @@ private extension NotificationsViewController
     }
 
     enum Syncing {
+        static let minimumPullToRefreshDelay = NSTimeInterval(1.5)
         static let pushMaxWait = NSTimeInterval(1.5)
         static let syncTimeout = NSTimeInterval(10)
         static let undoTimeout = NSTimeInterval(4)


### PR DESCRIPTION
### Details:
On fast connections, the pull to refresh gesture's spinner might get dismissed nearly instantly. In this PR we're implementing a "Minimum Delay" mechanism, so that the manual refresh doesn't feel broken.

Closes #6177

### To test:
1. Log into a WordPress.com account
2. Open the Notifications tab
3. Perform a Pull to Refresh gesture

Make sure that the minimum delay is ~1.5 seconds, before the spinner goes away. Optionally, toggle the Network Link Conditioner and verify everything works as expected.

Needs review: @nheagy 
Nate, may i bug you with a review?

Thanks in advance sir!
