### PR TITLE
Register for push notifications on launch

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -399,6 +399,11 @@ int ddLogLevel = DDLogLevelInfo;
     [WPFontManager merriweatherRegularFontOfSize:16.0];
 
     [self customizeAppearance];
+
+    // Push notifications
+    // This is silent (the user is prompted) so we can do it on launch.
+    // We'll ask for user notification permission after signin.
+    [[PushNotificationsManager sharedInstance] registerForRemoteNotifications];
     
     // Deferred tasks to speed up app launch
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{


### PR DESCRIPTION
In fixing #1802, we removed code to register for push notifications on launch (#5476). However, if there's a problem registering after sign in, then we'd end up never attempting to register again. Apple's documentation also states that you should attempt to register on every launch of the app. 

Registering for push doesn't prompt the user, so it doesn't affect #1802. We'll still delay asking for _user_ notification permission until sign in.

Targeting 6.7 because we've had one user in testing who had issues at least partially caused by this omission.

**To test:** run the app, ensure you register successfully for push notifications. Of course, it won't do anything on first launch, until you've signed in. Ensure you're not asked for notifications permission until you sign in.

Needs review: @jleandroperez 