### PR TITLE
Fixes #6202: Dismiss keyboard when showing unsaved changes alert.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -582,6 +582,8 @@ EditImageDetailsViewControllerDelegate
 
 - (void)showUnsavedChangesAlert
 {
+    [self.editorView endEditing];
+
     NSString *title = NSLocalizedString(@"Unsaved changes.",
                                         @"Title of the alert that lets the users know there are unsaved changes in a post they're opening.");
     NSString *message = NSLocalizedString(@"This post has local changes that were not saved. You can now save them or discard them.",


### PR DESCRIPTION
Fixes #6202. See the original issue for a brief summary.

To test:

* Open the editor to start a new post. Enter a title and ensure the keyboard is visible onscreen.
* Background the app.
* Quit the app in Xcode (so that state restoration is used).
* Relaunch the app. The 'unsaved changes' alert should be displayed, but the keyboard should not be visible.

Needs review: @nheagy Would you mind?