### PR TITLE
PostViewController: Adds quick Publish / Draft item to options menu.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -49,7 +49,7 @@ abstract_target 'WordPress_Base' do
     pod 'NSURL+IDN', '0.3'
     pod 'WPMediaPicker', '~> 0.10.2'
     pod 'WordPress-iOS-Editor', '1.8.1'
-    pod 'WordPressCom-Analytics-iOS', :git => 'https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git', :branch => 'try/add-quick-save-events'
+    pod 'WordPressCom-Analytics-iOS', '0.1.21'
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => '7d02c77349245c6e4d3bcdf63a878f90eb4a4e39'
     pod 'wpxmlrpc', '~> 0.8'
 

--- a/Podfile
+++ b/Podfile
@@ -49,7 +49,7 @@ abstract_target 'WordPress_Base' do
     pod 'NSURL+IDN', '0.3'
     pod 'WPMediaPicker', '~> 0.10.2'
     pod 'WordPress-iOS-Editor', '1.8.1'
-    pod 'WordPressCom-Analytics-iOS', '0.1.20'
+    pod 'WordPressCom-Analytics-iOS', :git => 'https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git', :branch => 'try/add-quick-save-events'
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => '7d02c77349245c6e4d3bcdf63a878f90eb4a4e39'
     pod 'wpxmlrpc', '~> 0.8'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -146,7 +146,7 @@ PODS:
     - WordPressCom-Analytics-iOS (~> 0.1.0)
   - WordPress-iOS-Shared (0.7.0):
     - CocoaLumberjack (~> 2.2.0)
-  - WordPressCom-Analytics-iOS (0.1.20)
+  - WordPressCom-Analytics-iOS (0.1.21)
   - WordPressCom-Stats-iOS (0.8.0):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
@@ -189,7 +189,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `7d02c77349245c6e4d3bcdf63a878f90eb4a4e39`)
   - WordPress-iOS-Editor (= 1.8.1)
   - WordPress-iOS-Shared (= 0.7.0)
-  - WordPressCom-Analytics-iOS (from `https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git`, branch `try/add-quick-save-events`)
+  - WordPressCom-Analytics-iOS (= 0.1.21)
   - WordPressCom-Stats-iOS (= 0.8.0)
   - WordPressComKit (= 0.0.5)
   - WPMediaPicker (~> 0.10.2)
@@ -208,9 +208,6 @@ EXTERNAL SOURCES:
   WordPress-Aztec-iOS:
     :commit: 7d02c77349245c6e4d3bcdf63a878f90eb4a4e39
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
-  WordPressCom-Analytics-iOS:
-    :branch: try/add-quick-save-events
-    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -225,9 +222,6 @@ CHECKOUT OPTIONS:
   WordPress-Aztec-iOS:
     :commit: 7d02c77349245c6e4d3bcdf63a878f90eb4a4e39
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
-  WordPressCom-Analytics-iOS:
-    :commit: aef9957069eac3702f70cdf5bbe0f94944ed9d77
-    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 00d6f4caae77c19ba33045b8569fbeb9689f0d1d
@@ -263,12 +257,12 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 49c682caa55e69bfbe12545dc1f448207060f6f4
   WordPress-iOS-Editor: 3118f5d6b142b6bf322f3393a7dd98a28bca68cb
   WordPress-iOS-Shared: 4bec543bac6543480b10d904bea122dcba43cc37
-  WordPressCom-Analytics-iOS: a92d9b1e75c14db406b203c7101d20557fabb9c0
+  WordPressCom-Analytics-iOS: ee6cc3a4feb63cebba167ce762c6e12c0b7b6671
   WordPressCom-Stats-iOS: 7c961a7780a695f54db5431537c16615682cdf32
   WordPressComKit: 4dc52eebc508b8e056d8bf8e931a7be95d467e3b
   WPMediaPicker: 9ba8c29a1de4b07696356f541c01eeaa6dd14c47
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: f85f281a27ef394c9bfe2ff050efa3d140fa32f3
+PODFILE CHECKSUM: e55ed7f68c9c856f548d0023166d945a0ac909d6
 
 COCOAPODS: 1.1.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -189,7 +189,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `7d02c77349245c6e4d3bcdf63a878f90eb4a4e39`)
   - WordPress-iOS-Editor (= 1.8.1)
   - WordPress-iOS-Shared (= 0.7.0)
-  - WordPressCom-Analytics-iOS (= 0.1.20)
+  - WordPressCom-Analytics-iOS (from `https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git`, branch `try/add-quick-save-events`)
   - WordPressCom-Stats-iOS (= 0.8.0)
   - WordPressComKit (= 0.0.5)
   - WPMediaPicker (~> 0.10.2)
@@ -208,6 +208,9 @@ EXTERNAL SOURCES:
   WordPress-Aztec-iOS:
     :commit: 7d02c77349245c6e4d3bcdf63a878f90eb4a4e39
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
+  WordPressCom-Analytics-iOS:
+    :branch: try/add-quick-save-events
+    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -222,6 +225,9 @@ CHECKOUT OPTIONS:
   WordPress-Aztec-iOS:
     :commit: 7d02c77349245c6e4d3bcdf63a878f90eb4a4e39
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
+  WordPressCom-Analytics-iOS:
+    :commit: aef9957069eac3702f70cdf5bbe0f94944ed9d77
+    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 00d6f4caae77c19ba33045b8569fbeb9689f0d1d
@@ -263,6 +269,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 9ba8c29a1de4b07696356f541c01eeaa6dd14c47
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 886887e9e707c41aa2da8cf72bb29f8e84bc3f5e
+PODFILE CHECKSUM: f85f281a27ef394c9bfe2ff050efa3d140fa32f3
 
 COCOAPODS: 1.1.1

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -247,7 +247,7 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 - (void)deleteRevision
 {
     if (self.revision) {
-        [self.managedObjectContext performBlock:^{
+        [self.managedObjectContext performBlockAndWait :^{
             [self.managedObjectContext deleteObject:self.revision];
             [self willChangeValueForKey:@"revision"];
             [self setPrimitiveValue:nil forKey:@"revision"];

--- a/WordPress/Classes/Models/Blog+Capabilities.swift
+++ b/WordPress/Classes/Models/Blog+Capabilities.swift
@@ -37,4 +37,10 @@ extension Blog
     public func isListingUsersAllowed() -> Bool {
         return isUserCapableOf(.ListUsers)
     }
+
+    /// Returns true if the current user is allowed to publish to the Blog
+    ///
+    public func isPublishingPostsAllowed() -> Bool {
+        return isUserCapableOf(.PublishPosts)
+    }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -251,6 +251,12 @@ NSString *const TracksUserDefaultsAnonymousUserIDKey = @"TracksAnonymousUserID";
         case WPAnalyticsStatEditorPublishedPost:
             eventName = @"editor_post_published";
             break;
+        case WPAnalyticsStatEditorQuickPublishedPost:
+            eventName = @"editor_quick_post_published";
+            break;
+        case WPAnalyticsStatEditorQuickSavedDraft:
+            eventName = @"editor_quick_draft_saved";
+            break;
         case WPAnalyticsStatEditorTappedBlockquote:
             eventName = @"editor_button_tapped";
             eventProperties = @{ TracksEventPropertyButtonKey : @"blockquote" };

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -515,6 +515,11 @@ NSString *const SessionCount = @"session_count";
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_editor_published_post"];
             [instructions setCurrentDateForPeopleProperty:@"last_time_published_post"];
             break;
+        case WPAnalyticsStatEditorQuickPublishedPost:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Quick Published Post"];
+            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_editor_published_post"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_published_post"];
+            break;
         case WPAnalyticsStatGravatarCropped:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Me - Gravatar Cropped"];
             break;
@@ -611,6 +616,11 @@ NSString *const SessionCount = @"session_count";
             break;
         case WPAnalyticsStatEditorSavedDraft:
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Saved Draft"];
+            [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_editor_saved_draft"];
+            [instructions setCurrentDateForPeopleProperty:@"last_time_saved_draft"];
+            break;
+        case WPAnalyticsStatEditorQuickSavedDraft:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Editor - Quick Saved Draft"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_editor_saved_draft"];
             [instructions setCurrentDateForPeopleProperty:@"last_time_saved_draft"];
             break;

--- a/WordPress/Classes/ViewRelated/Post/PostEditorSaveAction.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorSaveAction.swift
@@ -1,0 +1,55 @@
+import Foundation
+import WordPressComAnalytics
+
+/// Encapsulates the current save action of the editor, based on its
+/// post status, whether it's already been saved, is scheduled, etc.
+@objc enum PostEditorSaveAction: Int {
+    case Schedule
+    case Post
+    case Save
+    case Update
+}
+
+/// Some utility methods to help keep track of the current post action
+extension WPPostViewController {
+    /// What action should be taken when the user taps the editor's save button?
+    var currentSaveAction: PostEditorSaveAction {
+        if let status = post.status,
+            let originalStatus = post.original?.status
+            where status != originalStatus || !post.hasRemote() {
+            if (post.isScheduled()) {
+                return .Schedule
+            } else if (status == PostStatusPublish) {
+                return .Post
+            } else {
+                return .Save
+            }
+        } else {
+            return .Update
+        }
+    }
+
+    /// The title for the Save button, based on the current save action
+    var saveBarButtonItemTitle: String {
+        switch currentSaveAction {
+        case .Schedule:
+            return NSLocalizedString("Schedule", comment: "Schedule button, this is what the Publish button changes to in the Post Editor if the post has been scheduled for posting later.")
+        case .Post:
+            return NSLocalizedString("Post", comment: "Publish button label.")
+        case .Save:
+            return NSLocalizedString("Save", comment: "Save button label (saving content, ex: Post, Page, Comment).")
+        case .Update:
+            return NSLocalizedString("Update", comment: "Update button label (saving content, ex: Post, Page, Comment).")
+        }
+    }
+
+    /// The analytics stat to post when the user saves, based on the current post action
+    func analyticsStatForSaveAction(action: PostEditorSaveAction) -> WPAnalyticsStat {
+        switch action {
+        case .Post:     return .EditorPublishedPost
+        case .Schedule: return .EditorScheduledPost
+        case .Save:     return .EditorSavedDraft
+        case .Update:   return .EditorUpdatedPost
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1285,6 +1285,7 @@ EditImageDetailsViewControllerDelegate
                                             style:UIAlertActionStyleDestructive
                                           handler:^(UIAlertAction * _Nonnull action) {
                                               self.post.status = PostStatusPublish;
+                                              self.post.dateCreated = [NSDate date];
                                               [self saveAction:action];
                                           }];
         } else {
@@ -1292,6 +1293,7 @@ EditImageDetailsViewControllerDelegate
                                             style:UIAlertActionStyleDestructive
                                           handler:^(UIAlertAction * _Nonnull action) {
                                               self.post.status = PostStatusPending;
+                                              self.post.dateCreated = [NSDate date];
                                               [self saveAction:action];
                                           }];
         }

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1284,16 +1284,14 @@ EditImageDetailsViewControllerDelegate
             return [UIAlertAction actionWithTitle:NSLocalizedString(@"Publish Now", "Title of button allowing the user to immediately publish the post they are editing.")
                                             style:UIAlertActionStyleDestructive
                                           handler:^(UIAlertAction * _Nonnull action) {
-                                              self.post.status = PostStatusPublish;
-                                              self.post.dateCreated = [NSDate date];
+                                              [self.post publishImmediately];
                                               [self saveAction:action];
                                           }];
         } else {
             return [UIAlertAction actionWithTitle:NSLocalizedString(@"Submit for Review", "Title of button allowing a contributor to a site to submit the post they are editing for review.")
                                             style:UIAlertActionStyleDestructive
                                           handler:^(UIAlertAction * _Nonnull action) {
-                                              self.post.status = PostStatusPending;
-                                              self.post.dateCreated = [NSDate date];
+                                              [self.post publishImmediately];
                                               [self saveAction:action];
                                           }];
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		1751E5911CE0E552000CA08D /* KeyValueDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */; };
 		1751E5931CE23801000CA08D /* NSAttributedString+StyledHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */; };
 		175DBCD61DAE41A6003CBFBE /* WPFeedbackGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175DBCD51DAE41A6003CBFBE /* WPFeedbackGeneratorTests.swift */; };
+		17626A901DE38FE700140B45 /* PostEditorSaveAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17626A8F1DE38FE700140B45 /* PostEditorSaveAction.swift */; };
 		176579F71C63A40F0000978E /* PurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176579F61C63A40F0000978E /* PurchaseButton.swift */; };
 		1767494E1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */; };
 		176DEEE91D4615FE00331F30 /* WPSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */; };
@@ -1122,6 +1123,7 @@
 		1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueDatabase.swift; sourceTree = "<group>"; };
 		1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+StyledHTML.swift"; sourceTree = "<group>"; };
 		175DBCD51DAE41A6003CBFBE /* WPFeedbackGeneratorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPFeedbackGeneratorTests.swift; sourceTree = "<group>"; };
+		17626A8F1DE38FE700140B45 /* PostEditorSaveAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostEditorSaveAction.swift; sourceTree = "<group>"; };
 		176579F61C63A40F0000978E /* PurchaseButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseButton.swift; sourceTree = "<group>"; };
 		1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSearchHeaderView.swift; sourceTree = "<group>"; };
 		176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPSplitViewController.swift; sourceTree = "<group>"; };
@@ -2941,6 +2943,7 @@
 			children = (
 				595CB3751D2317D50082C7E9 /* PostListFilter.swift */,
 				43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */,
+				17626A8F1DE38FE700140B45 /* PostEditorSaveAction.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -6120,6 +6123,7 @@
 				FF9839B11CD8B40700E85258 /* WordPressComOAuthClient.swift in Sources */,
 				37EAAF4D1A11799A006D6306 /* CircularImageView.swift in Sources */,
 				E1DF5DFD19E7CFAE004E70D5 /* TaxonomyServiceRemoteREST.m in Sources */,
+				17626A901DE38FE700140B45 /* PostEditorSaveAction.swift in Sources */,
 				E6396E1F1BED91E00058B374 /* RemoteReaderCrossPostMeta.swift in Sources */,
 				E69551F61B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift in Sources */,
 				E61084BE1B9B47BA008050C5 /* ReaderAbstractTopic.swift in Sources */,


### PR DESCRIPTION
Fixes #6121. 

Adds Publish Now / Submit for Review / Save as Draft options to the options menu in the editor.

* If the post is new and the status is currently set to Publish, then the options menu will contain a "Save as Draft" option. This toggles the post status and updates the content of the local post.
* If the post's status is currently set to Draft and the user has permission to publish posts, the options 
menu will contain a "Publish Now" option.
* If the post's status is currently set to Draft and the user does not have permission to publish posts, the options menu will contain a "Submit for Review" option.

To test:

* Try the above scenarios out in the editor, and others besides to ensure it's not appearing when it shouldn't (and is appearing when it should)!
* Ensure that the Post / Update / Save button in the navigation bar updates accordingly when saving as draft.

Needs review: @kurzee 

@rachelmcr @mattmiklic Would you two also care to take a look?
