### PR TITLE
Issue/4328 Show No Results message when all sites are hidden

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -341,16 +341,24 @@ static NSInteger HideSearchMinSites = 3;
 {
     if (!_headerView) {
         _headerView = [[UIView alloc] initWithFrame:CGRectZero];
+        [_headerView addSubview:self.headerLabel];
+    }
+
+    return _headerView;
+}
+
+- (UILabel *)headerLabel
+{
+    if (!_headerLabel) {
         _headerLabel = [[UILabel alloc] initWithFrame:CGRectZero];
         _headerLabel.numberOfLines = 0;
         _headerLabel.textAlignment = NSTextAlignmentCenter;
         _headerLabel.textColor = [WPStyleGuide allTAllShadeGrey];
         _headerLabel.font = [WPFontManager systemRegularFontOfSize:14.0];
         _headerLabel.text = NSLocalizedString(@"Select which sites will be shown in the site picker.", @"Blog list page edit mode header label");
-        [_headerView addSubview:_headerLabel];
     }
 
-    return _headerView;
+    return _headerLabel;
 }
 
 - (void)updateHeaderSize

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -232,12 +232,15 @@ static NSInteger HideSearchMinSites = 3;
 - (void)updateViewsForCurrentSiteCount
 {
     NSUInteger count = [self countForAllBlogs];
-    if (count == NSNotFound) {
-        count = 0;
-    }
+    NSUInteger visibleSitesCount = [self countForVisibleBlogs];
 
-    [self showNoResultsViewForSiteCount:count];
-    [self updateSplitViewAppearanceForSiteCount:count];
+    // If the user has sites, but they're all hidden...
+    if (count > 0 && visibleSitesCount == 0 && !self.isEditing) {
+        [self showNoResultsViewForAllSitesHidden];
+    } else {
+        [self showNoResultsViewForSiteCount:count];
+        [self updateSplitViewAppearanceForSiteCount:count];
+    }
 }
 
 - (void)showNoResultsViewForSiteCount:(NSUInteger)siteCount
@@ -248,7 +251,30 @@ static NSInteger HideSearchMinSites = 3;
         [self bypassBlogListViewController];
     }
 
-    self.noResultsView.hidden = (siteCount > 0);
+    self.noResultsView.hidden = siteCount > 0;
+
+    if (!self.noResultsView.hidden) {
+        self.noResultsView.titleText = NSLocalizedString(@"You don't have any WordPress sites yet.", @"Title shown when the user has no sites.");
+        self.noResultsView.messageText = NSLocalizedString(@"Would you like to start one?", @"Prompt asking user whether they'd like to create a new site if they don't already have one.");
+        self.noResultsView.buttonTitle = NSLocalizedString(@"Create Site", nil);
+    }
+}
+
+- (void)showNoResultsViewForAllSitesHidden
+{
+    NSUInteger count = [self countForAllBlogs];
+
+    if (count == 1) {
+        self.noResultsView.titleText = NSLocalizedString(@"You have 1 hidden WordPress site.", "Message informing the user that all of their sites are currently hidden (singular)");
+        self.noResultsView.messageText = NSLocalizedString(@"To manage it here, set it to visible.", @"Prompt asking user to make sites visible in order to use them in the app (singular)");
+    } else {
+        self.noResultsView.titleText = [NSString stringWithFormat:NSLocalizedString(@"You have %lu hidden WordPress sites.", "Message informing the user that all of their sites are currently hidden (plural)"), count];
+        self.noResultsView.messageText = NSLocalizedString(@"To manage them here, set them to visible.", @"Prompt asking user to make sites visible in order to use them in the app (plural)");
+    }
+
+    self.noResultsView.buttonTitle = NSLocalizedString(@"Change Visibility", "Button title to edit visibility of sites.");
+
+    self.noResultsView.hidden = NO;
 }
 
 - (void)updateSplitViewAppearanceForSiteCount:(NSUInteger)siteCount
@@ -273,10 +299,26 @@ static NSInteger HideSearchMinSites = 3;
 
 - (NSUInteger)countForAllBlogs
 {
+    return [self countForPredicate:[self fetchRequestPredicateForAllBlogs]];
+}
+
+- (NSUInteger)countForVisibleBlogs
+{
+    return [self countForPredicate:[self fetchRequestPredicateForVisibleBlogs]];
+}
+
+- (NSUInteger)countForPredicate:(NSPredicate *)predicate
+{
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:BlogEntityName];
-    request.predicate = [self fetchRequestPredicateForAllBlogs];
-    return [context countForFetchRequest:request error:nil];
+    request.predicate = predicate;
+
+    NSUInteger count = [context countForFetchRequest:request error:nil];
+    if (count == NSNotFound) {
+        count = 0;
+    }
+
+    return count;
 }
 
 - (void)syncBlogs
@@ -412,14 +454,14 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)configureNoResultsView
 {
-    self.noResultsView = [WPNoResultsView noResultsViewWithTitle:NSLocalizedString(@"You don't have any WordPress sites yet.", @"Title shown when the user has no sites.")
-                                                         message:NSLocalizedString(@"Would you like to start one?", @"Prompt asking user whether they'd like to create a new site if they don't already have one.")
+    self.noResultsView = [WPNoResultsView noResultsViewWithTitle:nil
+                                                         message:nil
                                                    accessoryView:[[UIImageView alloc] initWithImage:[UIImage imageNamed:@"theme-empty-results"]]
-                                                     buttonTitle:NSLocalizedString(@"Create Site", nil)];
-    [self.view addSubview:self.noResultsView];
+                                                     buttonTitle:nil];
+    [self.tableView addSubview:self.noResultsView];
     [self.noResultsView setTranslatesAutoresizingMaskIntoConstraints:NO];
 
-    [self.view pinSubviewAtCenter:self.noResultsView];
+    [self.tableView pinSubviewAtCenter:self.noResultsView];
     [self.noResultsView layoutIfNeeded];
 
     self.noResultsView.hidden = YES;
@@ -629,7 +671,7 @@ static NSInteger HideSearchMinSites = 3;
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
-    return (self.tableView.isEditing) ? CGFLOAT_MIN : UITableViewAutomaticDimension;
+    return UITableViewAutomaticDimension;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
@@ -660,7 +702,7 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)setSelectedBlog:(Blog *)selectedBlog animated:(BOOL)animated
 {
-    if (selectedBlog != _selectedBlog) {
+    if (selectedBlog != _selectedBlog || !_blogDetailsViewController) {
         _selectedBlog = selectedBlog;
 
         self.blogDetailsViewController = [[BlogDetailsViewController alloc] init];
@@ -714,9 +756,11 @@ static NSInteger HideSearchMinSites = 3;
 
         self.firstHide = nil;
         self.hideCount = 0;
+        self.noResultsView.hidden = YES;
     }
     else {
         self.tableView.tableHeaderView = self.searchController.searchBar;
+        [self updateViewsForCurrentSiteCount];
     }
 
     // Animate view to editing mode
@@ -979,23 +1023,18 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)didTapNoResultsView:(WPNoResultsView *)noResultsView
 {
-    // Find the button in the NoResultsView
-    UIButton *button = nil;
-    for (UIView *subview in noResultsView.subviews) {
-        if ([subview isKindOfClass:[UIButton class]]) {
-            button = (UIButton *)subview;
-            break;
-        }
+    if ([self countForAllBlogs] == 0) {
+        UIAlertController *addSiteAlertController = [self makeAddSiteAlertController];
+        addSiteAlertController.popoverPresentationController.sourceView = self.view;
+        addSiteAlertController.popoverPresentationController.sourceRect = [self.view convertRect:noResultsView.button.frame
+                                                                                        fromView:noResultsView];
+        addSiteAlertController.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
+
+        [self presentViewController:addSiteAlertController animated:YES completion:nil];
+        self.addSiteAlertController = addSiteAlertController;
+    } else if ([self countForVisibleBlogs] == 0) {
+        [self setEditing:YES animated:YES];
     }
-
-    UIAlertController *addSiteAlertController = [self makeAddSiteAlertController];
-    addSiteAlertController.popoverPresentationController.sourceView = self.view;
-    addSiteAlertController.popoverPresentationController.sourceRect = [self.view convertRect:noResultsView.button.frame
-                                                                                    fromView:noResultsView];
-    addSiteAlertController.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
-
-    [self presentViewController:addSiteAlertController animated:YES completion:nil];
-    self.addSiteAlertController = addSiteAlertController;
 }
 
 #pragma mark - WPSplitViewControllerDetailProvider


### PR DESCRIPTION
Fixes #4328. I've added a variation on the no results view when all sites are hidden. The messaging should match Calypso's in the same situation.

![simulator screen shot 17 nov 2016 18 49 53](https://cloud.githubusercontent.com/assets/4780/20402930/a79df43a-acf6-11e6-9d77-3f77742b8002.png)

To test:

* Hide all sites, exit Edit mode and check the message appears as expected.
* Check the message disappears when you re-show a site.
* Check the existing 'no sites' message still appears when you have no sites whatsoever.

Needs review: @aerych 