### PR TITLE
Adds tests for BlogServiceRemoteXMLRPCAPI Class

### DIFF
--- a/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.h
+++ b/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.h
@@ -2,13 +2,6 @@
 #import "BlogServiceRemote.h"
 #import "ServiceRemoteWordPressXMLRPC.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface BlogServiceRemoteXMLRPC : ServiceRemoteWordPressXMLRPC<BlogServiceRemote>
 
-- (RemotePostType *)remotePostTypeFromXMLRPCDictionary:(NSDictionary *)json;
-- (RemoteBlogSettings *)remoteBlogSettingFromXMLRPCDictionary:(NSDictionary *)json;
-
 @end
-
-NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.h
+++ b/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.h
@@ -2,6 +2,13 @@
 #import "BlogServiceRemote.h"
 #import "ServiceRemoteWordPressXMLRPC.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface BlogServiceRemoteXMLRPC : ServiceRemoteWordPressXMLRPC<BlogServiceRemote>
 
+- (RemotePostType *)remotePostTypeFromXMLRPCDictionary:(NSDictionary *)json;
+- (RemoteBlogSettings *)remoteBlogSettingFromXMLRPCDictionary:(NSDictionary *)json;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Networking/ServiceRemoteWordPressXMLRPC.h
+++ b/WordPress/Classes/Networking/ServiceRemoteWordPressXMLRPC.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import "WordPress-Swift.h"
 
 @class WordPressOrgXMLRPCApi;
 
@@ -6,9 +7,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ServiceRemoteWordPressXMLRPC : NSObject
 
-- (id)initWithApi:(WordPressOrgXMLRPCApi *)api username:(NSString *)username password:(NSString *)password;
+- (id)initWithApi:(id<WordPressOrgXMLRPC>)api username:(NSString *)username password:(NSString *)password;
 
-@property (nonatomic, readonly) WordPressOrgXMLRPCApi *api;
+@property (nonatomic, readonly) id<WordPressOrgXMLRPC> api;
 
 - (NSArray *)defaultXMLRPCArguments;
 - (NSArray *)XMLRPCArgumentsWithExtra:(_Nullable id)extra;

--- a/WordPress/Classes/Networking/ServiceRemoteWordPressXMLRPC.m
+++ b/WordPress/Classes/Networking/ServiceRemoteWordPressXMLRPC.m
@@ -3,7 +3,7 @@
 
 @interface ServiceRemoteWordPressXMLRPC()
 
-@property (nonatomic, strong, readwrite) WordPressOrgXMLRPCApi *api;
+@property (nonatomic, strong, readwrite) id<WordPressOrgXMLRPC> api;
 @property (nonatomic, copy) NSString *username;
 @property (nonatomic, copy) NSString *password;
 
@@ -11,7 +11,7 @@
 
 @implementation ServiceRemoteWordPressXMLRPC
 
-- (id)initWithApi:(WordPressOrgXMLRPCApi *)api username:(NSString *)username password:(NSString *)password
+- (id)initWithApi:(id<WordPressOrgXMLRPC>)api username:(NSString *)username password:(NSString *)password
 {
     NSParameterAssert(api != nil);
     NSParameterAssert(username != nil);

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -122,8 +122,9 @@
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		261FF32C1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */; };
-		263F3FC11DDEBBFA00C209E1 /* MockWordPressOrgXMLRPCApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26161A541DDEB0F5004552D3 /* MockWordPressOrgXMLRPCApi.swift */; };
+		263F3FC81DE3601400C209E1 /* MockWordPressOrgXMLRPCApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26161A541DDEB0F5004552D3 /* MockWordPressOrgXMLRPCApi.swift */; };
 		26A1B5A01DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */; };
+		26CB48311DDE66CB004DFEC5 /* BlogServiceRemoteXMLRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CB48301DDE66CB004DFEC5 /* BlogServiceRemoteXMLRPCTest.swift */; };
 		26CB48331DDEA13C004DFEC5 /* WordPressOrgXMLRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CB48321DDEA13C004DFEC5 /* WordPressOrgXMLRPC.swift */; };
 		28AD73600D9D9599002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD735F0D9D9599002E5188 /* MainWindow.xib */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
@@ -1142,6 +1143,7 @@
 		26165C3E18786662761456D6 /* Pods-WordPress_Base-WordPress.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPress.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPress/Pods-WordPress_Base-WordPress.release-internal.xcconfig"; sourceTree = "<group>"; };
 		261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaServiceRemoteRESTTests.swift; sourceTree = "<group>"; };
 		26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSiteServiceRemoteTests.swift; sourceTree = "<group>"; };
+		26CB48301DDE66CB004DFEC5 /* BlogServiceRemoteXMLRPCTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlogServiceRemoteXMLRPCTest.swift; sourceTree = "<group>"; };
 		26CB48321DDEA13C004DFEC5 /* WordPressOrgXMLRPC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgXMLRPC.swift; sourceTree = "<group>"; };
 		28A0AAE50D9B0CCF005BE974 /* WordPress_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPress_Prefix.pch; sourceTree = "<group>"; };
 		28AD735F0D9D9599002E5188 /* MainWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = MainWindow.xib; path = Resources/MainWindow.xib; sourceTree = "<group>"; };
@@ -2894,6 +2896,7 @@
 				598F86AA1B67BD7600550C9C /* ThemeServiceRemoteTests.m */,
 				FF34EEA81CF473F600F8B38D /* WordPressComServiceRemoteRestTests.swift */,
 				26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */,
+				26CB48301DDE66CB004DFEC5 /* BlogServiceRemoteXMLRPCTest.swift */,
 				261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */,
 			);
 			name = "Remote Services";
@@ -5952,6 +5955,7 @@
 				B5C7D7B81BC6B5A3008E668A /* UIAlertController+Helpers.swift in Sources */,
 				B54866CA1A0D7042004AC79D /* NSAttributedString+Helpers.swift in Sources */,
 				834CAEA0122D56B1003DDF49 /* UIImage+RoundedCorner.m in Sources */,
+				263F3FC81DE3601400C209E1 /* MockWordPressOrgXMLRPCApi.swift in Sources */,
 				B5176CC31CDCE1C30083CF2D /* ManagedPerson+CoreDataProperties.swift in Sources */,
 				08D345531CD7F50900358E8C /* MenusSelectionView.m in Sources */,
 				E18EE95119349EC300B0A40C /* ReaderTopicServiceRemote.m in Sources */,
@@ -6421,6 +6425,7 @@
 				E1926C091C779868009F3C2C /* PlanListViewControllerTest.swift in Sources */,
 				59ECF87B1CB7061D00E68F25 /* PostSharingControllerTests.swift in Sources */,
 				E157D5E01C690A6C00F04FB9 /* ImmuTableTestUtils.swift in Sources */,
+				26CB48311DDE66CB004DFEC5 /* BlogServiceRemoteXMLRPCTest.swift in Sources */,
 				E1C9AA561C10427100732665 /* MathTest.swift in Sources */,
 				93A379EC19FFBF7900415023 /* KeychainTest.m in Sources */,
 				59E2AAEC1B20E5CE0051DC06 /* PostServiceRemoteRESTTests.m in Sources */,
@@ -6439,7 +6444,6 @@
 				B58CE5DA1DC1271B004AA81D /* RemoteNotificationTests.swift in Sources */,
 				93E9050719E6F3D8005513C9 /* TestContextManager.m in Sources */,
 				5D2BEB4919758102005425F7 /* PhotonImageURLHelperTest.m in Sources */,
-				263F3FC11DDEBBFA00C209E1 /* MockWordPressOrgXMLRPCApi.swift in Sources */,
 				08A2AD751CCEBDBD00E84454 /* TaxonomyServiceRemoteRESTTests.m in Sources */,
 				5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */,
 				85D239C01AE5A7020074768D /* LoginFacadeTests.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -122,7 +122,9 @@
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		261FF32C1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */; };
+		263F3FC11DDEBBFA00C209E1 /* MockWordPressOrgXMLRPCApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26161A541DDEB0F5004552D3 /* MockWordPressOrgXMLRPCApi.swift */; };
 		26A1B5A01DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */; };
+		26CB48331DDEA13C004DFEC5 /* WordPressOrgXMLRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CB48321DDEA13C004DFEC5 /* WordPressOrgXMLRPC.swift */; };
 		28AD73600D9D9599002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD735F0D9D9599002E5188 /* MainWindow.xib */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
 		296526FE105810E100597FA3 /* NSString+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 296526FD105810E100597FA3 /* NSString+Helpers.m */; };
@@ -1136,9 +1138,11 @@
 		1D3623240D0F684500981E51 /* WordPressAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressAppDelegate.h; sourceTree = "<group>"; };
 		1D3623250D0F684500981E51 /* WordPressAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = WordPressAppDelegate.m; sourceTree = "<group>"; usesTabs = 0; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		1D6058910D05DD3D006BFB54 /* WordPress.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordPress.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		26161A541DDEB0F5004552D3 /* MockWordPressOrgXMLRPCApi.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockWordPressOrgXMLRPCApi.swift; sourceTree = "<group>"; };
 		26165C3E18786662761456D6 /* Pods-WordPress_Base-WordPress.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPress.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPress/Pods-WordPress_Base-WordPress.release-internal.xcconfig"; sourceTree = "<group>"; };
 		261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaServiceRemoteRESTTests.swift; sourceTree = "<group>"; };
 		26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSiteServiceRemoteTests.swift; sourceTree = "<group>"; };
+		26CB48321DDEA13C004DFEC5 /* WordPressOrgXMLRPC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgXMLRPC.swift; sourceTree = "<group>"; };
 		28A0AAE50D9B0CCF005BE974 /* WordPress_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPress_Prefix.pch; sourceTree = "<group>"; };
 		28AD735F0D9D9599002E5188 /* MainWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = MainWindow.xib; path = Resources/MainWindow.xib; sourceTree = "<group>"; };
 		2906F80F110CDA8900169D56 /* EditCommentViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditCommentViewController.h; sourceTree = "<group>"; };
@@ -3497,6 +3501,7 @@
 			children = (
 				59E2AAE91B20E3FB0051DC06 /* Remote Services */,
 				FFB7CFFD1CEC8A9A00143C09 /* MockWordPressComRestApi.swift */,
+				26161A541DDEB0F5004552D3 /* MockWordPressOrgXMLRPCApi.swift */,
 				E61084C31B9DC09C008050C5 /* ReaderPostServiceRemoteTests.m */,
 				E66969C91B9E0C4F00EC9C00 /* ReaderTopicServiceRemoteTests.m */,
 				E6374DC81C445ABF00F24720 /* SharingServiceRemoteTests.m */,
@@ -4461,6 +4466,7 @@
 				E1D086E1194214C600F0CC19 /* NSDate+WordPressJSON.m */,
 				FF9839B01CD8B40700E85258 /* WordPressComOAuthClient.swift */,
 				FFB8DCA31CE320F200D4D1B7 /* WordPressComRestApi.swift */,
+				26CB48321DDEA13C004DFEC5 /* WordPressOrgXMLRPC.swift */,
 				FF3EAE9A1D0036E300CC4939 /* WordPressOrgXMLRPCApi.swift */,
 				FF3F1E721D085AA7009AB440 /* HTTPAuthenticationAlertController.swift */,
 			);
@@ -5876,6 +5882,7 @@
 				FF54D4641D6F3FA900A0DC4D /* EditorSettings.swift in Sources */,
 				5D9282F91B54697D00066CED /* RemoteReaderSiteInfo.m in Sources */,
 				E6D2E16C1B8B423B0000ED14 /* ReaderStreamHeader.swift in Sources */,
+				26CB48331DDEA13C004DFEC5 /* WordPressOrgXMLRPC.swift in Sources */,
 				5DF6571B1AE6ACAC00AAA8D7 /* DisplayableImageHelper.m in Sources */,
 				E166FA1D1BB0658600374B5B /* Person.swift in Sources */,
 				E60646801CB3133000A3073F /* SigninEditingState.swift in Sources */,
@@ -6432,6 +6439,7 @@
 				B58CE5DA1DC1271B004AA81D /* RemoteNotificationTests.swift in Sources */,
 				93E9050719E6F3D8005513C9 /* TestContextManager.m in Sources */,
 				5D2BEB4919758102005425F7 /* PhotonImageURLHelperTest.m in Sources */,
+				263F3FC11DDEBBFA00C209E1 /* MockWordPressOrgXMLRPCApi.swift in Sources */,
 				08A2AD751CCEBDBD00E84454 /* TaxonomyServiceRemoteRESTTests.m in Sources */,
 				5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */,
 				85D239C01AE5A7020074768D /* LoginFacadeTests.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -122,10 +122,10 @@
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		261FF32C1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */; };
-		263F3FC81DE3601400C209E1 /* MockWordPressOrgXMLRPCApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26161A541DDEB0F5004552D3 /* MockWordPressOrgXMLRPCApi.swift */; };
 		26A1B5A01DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */; };
 		26CB48311DDE66CB004DFEC5 /* BlogServiceRemoteXMLRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CB48301DDE66CB004DFEC5 /* BlogServiceRemoteXMLRPCTest.swift */; };
 		26CB48331DDEA13C004DFEC5 /* WordPressOrgXMLRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CB48321DDEA13C004DFEC5 /* WordPressOrgXMLRPC.swift */; };
+		26D9FA2E1DEF29DE009CFAAE /* MockWordPressOrgXMLRPCApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26161A541DDEB0F5004552D3 /* MockWordPressOrgXMLRPCApi.swift */; };
 		28AD73600D9D9599002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD735F0D9D9599002E5188 /* MainWindow.xib */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
 		296526FE105810E100597FA3 /* NSString+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 296526FD105810E100597FA3 /* NSString+Helpers.m */; };
@@ -5955,7 +5955,7 @@
 				B5C7D7B81BC6B5A3008E668A /* UIAlertController+Helpers.swift in Sources */,
 				B54866CA1A0D7042004AC79D /* NSAttributedString+Helpers.swift in Sources */,
 				834CAEA0122D56B1003DDF49 /* UIImage+RoundedCorner.m in Sources */,
-				263F3FC81DE3601400C209E1 /* MockWordPressOrgXMLRPCApi.swift in Sources */,
+				26D9FA2E1DEF29DE009CFAAE /* MockWordPressOrgXMLRPCApi.swift in Sources */,
 				B5176CC31CDCE1C30083CF2D /* ManagedPerson+CoreDataProperties.swift in Sources */,
 				08D345531CD7F50900358E8C /* MenusSelectionView.m in Sources */,
 				E18EE95119349EC300B0A40C /* ReaderTopicServiceRemote.m in Sources */,

--- a/WordPress/WordPressApi/WordPressOrgXMLRPC.swift
+++ b/WordPress/WordPressApi/WordPressOrgXMLRPC.swift
@@ -13,10 +13,11 @@ import Foundation
     /**
      Check if username and password are valid credentials for the xmlrpc endpoint.
 
-     - parameter username: username to check
-     - parameter password: password to check
-     - parameter success:  callback block to be invoked if credentials are valid, the object returned in the block is the options dictionary for the site.
-     - parameter failure:  callback block to be invoked is credentials fail
+     - Parameters: 
+        - username: username to check
+        - password: password to check
+        - success:  callback block to be invoked if credentials are valid, the object returned in the block is the options dictionary for the site.
+        - failure:  callback block to be invoked is credentials fail
      */
     func checkCredentials(username: String,
                           password: String,
@@ -26,12 +27,13 @@ import Foundation
     /**
      Executes a XMLRPC call for the method specificied with the arguments provided.
 
-     - parameter method:  the xmlrpc method to be invoked
-     - parameter parameters: the parameters to be encoded on the request
-     - parameter success:    callback to be called on successful request
-     - parameter failure:    callback to be called on failed request
+     - Parameters: 
+        - method:  the xmlrpc method to be invoked
+        - parameters: the parameters to be encoded on the request
+        - success:    callback to be called on successful request
+        - failure:    callback to be called on failed request
 
-     - returns:  a NSProgress object that can be used to track the progress of the request and to cancel the request. If the method
+     - Returns:  a NSProgress object that can be used to track the progress of the request and to cancel the request. If the method
      returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
      will be invoked with the error specificing the serialization issues.
      */
@@ -44,12 +46,13 @@ import Foundation
      Executes a XMLRPC call for the method specificied with the arguments provided, by streaming the request from a file.
      This allows to do requests that can use a lot of memory, like media uploads.
 
-     - parameter method:  the xmlrpc method to be invoked
-     - parameter parameters: the parameters to be encoded on the request
-     - parameter success:    callback to be called on successful request
-     - parameter failure:    callback to be called on failed request
+     - Parameters: 
+        - method:  the xmlrpc method to be invoked
+        - parameters: the parameters to be encoded on the request
+        - success:    callback to be called on successful request
+        - failure:    callback to be called on failed request
 
-     - returns:  a NSProgress object that can be used to track the progress of the request and to cancel the request. If the method
+     - Returns:  a NSProgress object that can be used to track the progress of the request and to cancel the request. If the method
      returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
      will be invoked with the error specificing the serialization issues.
      */

--- a/WordPress/WordPressApi/WordPressOrgXMLRPC.swift
+++ b/WordPress/WordPressApi/WordPressOrgXMLRPC.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+@objc protocol WordPressOrgXMLRPC {
+
+    init(endpoint: NSURL, userAgent: String?)
+
+    /**
+     Cancels all ongoing and makes the session so the object will not fullfil any more request
+     */
+    func invalidateAndCancelTasks()
+
+    //MARK: - Network requests
+    /**
+     Check if username and password are valid credentials for the xmlrpc endpoint.
+
+     - parameter username: username to check
+     - parameter password: password to check
+     - parameter success:  callback block to be invoked if credentials are valid, the object returned in the block is the options dictionary for the site.
+     - parameter failure:  callback block to be invoked is credentials fail
+     */
+    func checkCredentials(username: String,
+                          password: String,
+                          success: SuccessResponseBlock,
+                          failure: FailureReponseBlock)
+
+    /**
+     Executes a XMLRPC call for the method specificied with the arguments provided.
+
+     - parameter method:  the xmlrpc method to be invoked
+     - parameter parameters: the parameters to be encoded on the request
+     - parameter success:    callback to be called on successful request
+     - parameter failure:    callback to be called on failed request
+
+     - returns:  a NSProgress object that can be used to track the progress of the request and to cancel the request. If the method
+     returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
+     will be invoked with the error specificing the serialization issues.
+     */
+    func callMethod(method: String,
+                    parameters: [AnyObject]?,
+                    success: SuccessResponseBlock,
+                    failure: FailureReponseBlock) -> NSProgress?
+
+    /**
+     Executes a XMLRPC call for the method specificied with the arguments provided, by streaming the request from a file.
+     This allows to do requests that can use a lot of memory, like media uploads.
+
+     - parameter method:  the xmlrpc method to be invoked
+     - parameter parameters: the parameters to be encoded on the request
+     - parameter success:    callback to be called on successful request
+     - parameter failure:    callback to be called on failed request
+
+     - returns:  a NSProgress object that can be used to track the progress of the request and to cancel the request. If the method
+     returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
+     will be invoked with the error specificing the serialization issues.
+     */
+
+    func streamCallMethod(method: String,
+                          parameters: [AnyObject]?,
+                          success: SuccessResponseBlock,
+                          failure: FailureReponseBlock) -> NSProgress?
+}
+
+extension WordPressOrgXMLRPC {
+
+    typealias SuccessResponseBlock = (AnyObject, NSHTTPURLResponse?) -> ()
+    typealias FailureReponseBlock = (error: NSError, httpResponse: NSHTTPURLResponse?) -> ()
+}

--- a/WordPress/WordPressApi/WordPressOrgXMLRPC.swift
+++ b/WordPress/WordPressApi/WordPressOrgXMLRPC.swift
@@ -2,8 +2,6 @@ import Foundation
 
 @objc protocol WordPressOrgXMLRPC {
 
-    init(endpoint: NSURL, userAgent: String?)
-
     /**
      Cancels all ongoing and makes the session so the object will not fullfil any more request
      */
@@ -13,7 +11,7 @@ import Foundation
     /**
      Check if username and password are valid credentials for the xmlrpc endpoint.
 
-     - Parameters: 
+     - Parameters:
         - username: username to check
         - password: password to check
         - success:  callback block to be invoked if credentials are valid, the object returned in the block is the options dictionary for the site.
@@ -27,7 +25,7 @@ import Foundation
     /**
      Executes a XMLRPC call for the method specificied with the arguments provided.
 
-     - Parameters: 
+     - Parameters:
         - method:  the xmlrpc method to be invoked
         - parameters: the parameters to be encoded on the request
         - success:    callback to be called on successful request
@@ -46,7 +44,7 @@ import Foundation
      Executes a XMLRPC call for the method specificied with the arguments provided, by streaming the request from a file.
      This allows to do requests that can use a lot of memory, like media uploads.
 
-     - Parameters: 
+     - Parameters:
         - method:  the xmlrpc method to be invoked
         - parameters: the parameters to be encoded on the request
         - success:    callback to be called on successful request

--- a/WordPress/WordPressApi/WordPressOrgXMLRPC.swift
+++ b/WordPress/WordPressApi/WordPressOrgXMLRPC.swift
@@ -19,8 +19,8 @@ import Foundation
      */
     func checkCredentials(username: String,
                           password: String,
-                          success: SuccessResponseBlock,
-                          failure: FailureReponseBlock)
+                          success: (AnyObject, NSHTTPURLResponse?) -> Void,
+                          failure: (NSError, NSHTTPURLResponse?) -> Void)
 
     /**
      Executes a XMLRPC call for the method specificied with the arguments provided.
@@ -37,8 +37,8 @@ import Foundation
      */
     func callMethod(method: String,
                     parameters: [AnyObject]?,
-                    success: SuccessResponseBlock,
-                    failure: FailureReponseBlock) -> NSProgress?
+                    success: (AnyObject, NSHTTPURLResponse?) -> Void,
+                    failure: (NSError, NSHTTPURLResponse?) -> Void) -> NSProgress?
 
     /**
      Executes a XMLRPC call for the method specificied with the arguments provided, by streaming the request from a file.
@@ -57,12 +57,6 @@ import Foundation
 
     func streamCallMethod(method: String,
                           parameters: [AnyObject]?,
-                          success: SuccessResponseBlock,
-                          failure: FailureReponseBlock) -> NSProgress?
-}
-
-extension WordPressOrgXMLRPC {
-
-    typealias SuccessResponseBlock = (AnyObject, NSHTTPURLResponse?) -> ()
-    typealias FailureReponseBlock = (error: NSError, httpResponse: NSHTTPURLResponse?) -> ()
+                          success: (AnyObject, NSHTTPURLResponse?) -> Void,
+                          failure: (NSError, NSHTTPURLResponse?) -> Void) -> NSProgress?
 }

--- a/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
+++ b/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
@@ -1,7 +1,7 @@
 import Foundation
 import wpxmlrpc
 
-public class WordPressOrgXMLRPCApi: NSObject
+public class WordPressOrgXMLRPCApi: NSObject, WordPressOrgXMLRPC
 {
     public typealias SuccessResponseBlock = (AnyObject, NSHTTPURLResponse?) -> ()
     public typealias FailureReponseBlock = (error: NSError, httpResponse: NSHTTPURLResponse?) -> ()
@@ -37,7 +37,7 @@ public class WordPressOrgXMLRPCApi: NSObject
         }
     }
 
-    public init(endpoint: NSURL, userAgent: String? = nil) {
+    required public init(endpoint: NSURL, userAgent: String? = nil) {
         self.endpoint = endpoint
         self.userAgent = userAgent
         super.init()
@@ -50,42 +50,23 @@ public class WordPressOrgXMLRPCApi: NSObject
     /**
      Cancels all ongoing and makes the session so the object will not fullfil any more request
      */
-    public func invalidateAndCancelTasks() {
+    func invalidateAndCancelTasks() {
         session.invalidateAndCancel()
     }
 
     //MARK: - Network requests
-    /**
-     Check if username and password are valid credentials for the xmlrpc endpoint.
-
-     - parameter username: username to check
-     - parameter password: password to check
-     - parameter success:  callback block to be invoked if credentials are valid, the object returned in the block is the options dictionary for the site.
-     - parameter failure:  callback block to be invoked is credentials fail
-     */
-    public func checkCredentials(username: String,
-                                 password: String,
-                                 success: SuccessResponseBlock,
-                                 failure: FailureReponseBlock) {
+    func checkCredentials(username: String,
+                          password: String,
+                          success: SuccessResponseBlock,
+                          failure: FailureReponseBlock) {
         let parameters:[AnyObject] = [0, username, password]
         callMethod("wp.getOptions", parameters: parameters, success: success, failure: failure)
     }
-    /**
-     Executes a XMLRPC call for the method specificied with the arguments provided.
 
-     - parameter method:  the xmlrpc method to be invoked
-     - parameter parameters: the parameters to be encoded on the request
-     - parameter success:    callback to be called on successful request
-     - parameter failure:    callback to be called on failed request
-
-     - returns:  a NSProgress object that can be used to track the progress of the request and to cancel the request. If the method
-     returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
-     will be invoked with the error specificing the serialization issues.
-     */
-    public func callMethod(method: String,
-                           parameters: [AnyObject]?,
-                           success: SuccessResponseBlock,
-                           failure: FailureReponseBlock) -> NSProgress?
+    func callMethod(method: String,
+                    parameters: [AnyObject]?,
+                    success: SuccessResponseBlock,
+                    failure: FailureReponseBlock) -> NSProgress?
     {
         //Encode request
         let request: NSURLRequest
@@ -110,23 +91,10 @@ public class WordPressOrgXMLRPCApi: NSObject
         return createProgresForTask(task)
     }
 
-    /**
-     Executes a XMLRPC call for the method specificied with the arguments provided, by streaming the request from a file.
-     This allows to do requests that can use a lot of memory, like media uploads.
-
-     - parameter method:  the xmlrpc method to be invoked
-     - parameter parameters: the parameters to be encoded on the request
-     - parameter success:    callback to be called on successful request
-     - parameter failure:    callback to be called on failed request
-
-     - returns:  a NSProgress object that can be used to track the progress of the request and to cancel the request. If the method
-     returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
-     will be invoked with the error specificing the serialization issues.
-     */
-    public func streamCallMethod(method: String,
-                                 parameters: [AnyObject]?,
-                                 success: SuccessResponseBlock,
-                                 failure: FailureReponseBlock) -> NSProgress?
+    func streamCallMethod(method: String,
+                          parameters: [AnyObject]?,
+                          success: SuccessResponseBlock,
+                          failure: FailureReponseBlock) -> NSProgress?
     {
         let fileURL = URLForTemporaryFile()
         //Encode request
@@ -303,8 +271,6 @@ extension WordPressOrgXMLRPCApi: NSURLSessionTaskDelegate, NSURLSessionDelegate 
             completionHandler(.PerformDefaultHandling, nil)
         }
     }
-
-
 }
 
 /**

--- a/WordPress/WordPressTest/BlogServiceRemoteXMLRPCTest.swift
+++ b/WordPress/WordPressTest/BlogServiceRemoteXMLRPCTest.swift
@@ -1,0 +1,271 @@
+import XCTest
+@testable import WordPress
+
+class BlogServiceRemoteXMLRPCTest: XCTestCase {
+
+    let mockApi = MockWordPressOrgXMLRPCApi()
+    var blogServiceRemote: BlogServiceRemoteXMLRPC!
+
+    override func setUp() {
+        super.setUp()
+        blogServiceRemote = BlogServiceRemoteXMLRPC(api: mockApi, username: "", password: "")
+    }
+
+    func testCheckMultiAuthorRequest() {
+
+        let expectedParams = ["who" : "authors"]
+        blogServiceRemote.checkMultiAuthorWithSuccess(nil, failure: nil)
+        XCTAssertEqual(mockApi.methodPassedIn, "wp.getUsers")
+        XCTAssertTrue(checkParametersArray(mockApi.parametersPassedIn, expected: expectedParams),
+                      "\(expectedParams) not found in the parameter list")
+    }
+
+    func testIsMultiAuthor() {
+
+        var isMultiAuthor = false
+        let response = [["ID" : 2], ["ID" : 3]]
+        blogServiceRemote.checkMultiAuthorWithSuccess( {
+                isMultiAuthor = $0
+            }, failure: nil)
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertTrue(isMultiAuthor)
+    }
+
+    func testIsNotMultiAuthor() {
+
+        var isMultiAuthor = true
+        let response = [["ID" : 2]]
+        blogServiceRemote.checkMultiAuthorWithSuccess( {
+            isMultiAuthor = $0
+        }, failure: nil)
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertFalse(isMultiAuthor)
+    }
+
+    func testSyncPostTypesRequest() {
+
+        blogServiceRemote.syncPostTypesWithSuccess(nil, failure: nil)
+        XCTAssertEqual(mockApi.methodPassedIn, "wp.getPostTypes")
+        XCTAssertTrue(checkParametersArray(mockApi.parametersPassedIn, expected: nil),
+                      "Default parameters not found in the parameter list")
+    }
+
+    func testSingleSyncPostTypes() {
+
+        let name = "name"
+        let response = [1 : [name : name]]
+        var remotePost = [RemotePostType]()
+        blogServiceRemote.syncPostTypesWithSuccess({
+            remotePost = $0
+        }, failure: nil)
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertEqual(remotePost.count, 1)
+        XCTAssertEqual(remotePost[0].name, name)
+    }
+
+    func testMultipleSyncPostTypes() {
+
+        let name = "name"
+        let response = ["1" : [name : name], "2" : [ name : name]]
+        var remotePost = [RemotePostType]()
+        blogServiceRemote.syncPostTypesWithSuccess({
+            remotePost = $0
+        }, failure: nil)
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertEqual(remotePost.count, 2)
+        XCTAssertEqual(remotePost[0].name, name)
+        XCTAssertEqual(remotePost[1].name, name)
+    }
+
+    func testSyncPostTypesFailure() {
+
+        let response = [:]
+        var fail = false
+        blogServiceRemote.syncPostTypesWithSuccess(nil, failure: { _ in
+            fail = true
+        })
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertTrue(fail)
+    }
+
+    func testSyncPostFormatsRequest() {
+
+        let expectedParams = ["show-supported" : "1"]
+        blogServiceRemote.syncPostFormatsWithSuccess(nil, failure: nil)
+        XCTAssertEqual(mockApi.methodPassedIn, "wp.getPostFormats")
+        XCTAssertTrue(checkParametersArray(mockApi.parametersPassedIn, expected: expectedParams),
+                      "\(expectedParams) not found in the parameter list")
+    }
+
+    func testSyncPostFormatsAsArray() {
+
+        let response = ["supported" : ["f1", "f2", "f3"],
+                        "all" : ["f1" : "a" , "f2" : "b", "f3" : "c", "f4" : "d", "standard" : "e"]]
+        var responseFormats = [NSObject : NSObject]()
+        blogServiceRemote.syncPostFormatsWithSuccess({
+            if let formats = $0 as? [NSObject : NSObject] {
+                responseFormats = formats
+            }
+        }, failure: nil)
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertEqual(responseFormats["f1"], "a")
+        XCTAssertEqual(responseFormats["f2"], "b")
+        XCTAssertEqual(responseFormats["f3"], "c")
+        XCTAssertEqual(responseFormats.count, 4)
+    }
+
+    func testSyncPostFormatsAsDictionary() {
+
+        let response = ["supported" : [1 : "f1", 2 : "f2", 3 : "f3"],
+                        "all" : ["f1" : "a" , "f2" : "b", "f3" : "c", "f4" : "d", "standard" : "e"]]
+        var responseFormats = [NSObject : NSObject]()
+        blogServiceRemote.syncPostFormatsWithSuccess({
+            if let formats = $0 as? [NSObject : NSObject] {
+                responseFormats = formats
+            }
+            }, failure: nil)
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertEqual(responseFormats["f1"], "a")
+        XCTAssertEqual(responseFormats["f2"], "b")
+        XCTAssertEqual(responseFormats["f3"], "c")
+        XCTAssertEqual(responseFormats.count, 4)
+    }
+
+    func testSyncSettingRequest() {
+
+        blogServiceRemote.syncSettingsWithSuccess(nil, failure: nil)
+        XCTAssertEqual(mockApi.methodPassedIn, "wp.getOptions")
+        XCTAssertTrue(checkParametersArray(mockApi.parametersPassedIn, expected: nil),
+                      "Default parameters not found in the parameter list")
+    }
+
+    func testSyncSetting() {
+
+        let name = "name"
+        let response = ["blog_title" : ["value" : name]]
+        var remoteBlogSettings: RemoteBlogSettings? = nil
+        blogServiceRemote.syncSettingsWithSuccess({
+            remoteBlogSettings = $0
+        }, failure: nil)
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertEqual(remoteBlogSettings?.name, name)
+    }
+
+    func testSyncSettingArrayResponse() {
+
+        let name = "name"
+        let response = [name]
+        var fail = false
+        blogServiceRemote.syncSettingsWithSuccess(nil, failure: { _ in
+            fail = true
+        })
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertTrue(fail)
+    }
+
+    func testUpdateBlogSettingsRequest() {
+
+        let remoteBlogSettings = RemoteBlogSettings()
+        remoteBlogSettings.name = "name"
+        remoteBlogSettings.tagline = "tagline"
+
+        let expectedParams = ["blog_title" : "name", "blog_tagline" : "tagline"]
+        blogServiceRemote.updateBlogSettings(remoteBlogSettings, success: nil, failure: nil)
+        XCTAssertEqual(mockApi.methodPassedIn, "wp.setOptions")
+        XCTAssertTrue(checkParametersArray(mockApi.parametersPassedIn, expected: expectedParams),
+                      "\(expectedParams) not found in the parameter list")
+    }
+
+    func testUpdateBlogSettings() {
+
+        let remoteBlogSettings = RemoteBlogSettings()
+        remoteBlogSettings.name = "name"
+        remoteBlogSettings.tagline = "tagline"
+
+        let response = ["blog_title" : ["value" : "name"]]
+        var success = false
+        blogServiceRemote.updateBlogSettings(remoteBlogSettings, success: {
+            success = true
+        }, failure: nil)
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertTrue(success)
+    }
+
+    func testUpdateBlogSettingsArrayResponse() {
+
+        let remoteBlogSettings = RemoteBlogSettings()
+        remoteBlogSettings.name = "name"
+        remoteBlogSettings.tagline = "tagline"
+
+        let response = [["blog_title" : ["value" : "name"]]]
+        var fail = false
+        blogServiceRemote.updateBlogSettings(remoteBlogSettings, success: nil, failure: { _ in
+            fail = true
+        })
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertTrue(fail)
+    }
+
+    func testSyncOptionsRequest() {
+
+        blogServiceRemote.syncOptionsWithSuccess(nil, failure: nil)
+        XCTAssertEqual(mockApi.methodPassedIn, "wp.getOptions")
+        XCTAssertTrue(checkParametersArray(mockApi.parametersPassedIn, expected: nil),
+                      "Default parameters not found")
+    }
+
+    func testSyncOptions() {
+
+        let response = ["option" : ["a" : "b"]]
+        var remoteOptions = [NSObject : NSObject]()
+        blogServiceRemote.syncOptionsWithSuccess({
+            if let options = $0 as? [NSObject : NSObject] {
+                remoteOptions = options
+            }
+        }, failure: nil)
+        mockApi.successBlockPassedIn?(response, NSHTTPURLResponse())
+        XCTAssertEqual(response, remoteOptions)
+    }
+
+    func testRemotePostFromXMLDictionary() {
+
+        let name = "name"
+        let label = "label"
+        let apiQueryable = NSNumber(integer: 1)
+        let response = [name: name, label: label, "public": apiQueryable]
+        let remotePost = blogServiceRemote.remotePostTypeFromXMLRPCDictionary(response)
+        XCTAssertEqual(remotePost.name, name)
+        XCTAssertEqual(remotePost.label, label)
+        XCTAssertEqual(remotePost.apiQueryable, apiQueryable)
+    }
+
+    func testRemoteBlogFromXMLDictionary() {
+
+        let name = "name"
+        let tagline = "tagline"
+        let privacy = 1
+        let response = ["blog_title" : ["value" : name],
+                        "blog_tagline" : ["value" : tagline],
+                        "blog_public" : ["value" : privacy]]
+        let remoteBlogSettings = blogServiceRemote.remoteBlogSettingFromXMLRPCDictionary(response)
+        XCTAssertEqual(remoteBlogSettings.name, name)
+        XCTAssertEqual(remoteBlogSettings.tagline, tagline)
+        XCTAssertEqual(remoteBlogSettings.privacy, privacy)
+    }
+
+    func checkParametersArray(passedIn: [AnyObject]?, expected: AnyObject?) -> Bool {
+
+        var fullExpectedParams = blogServiceRemote.defaultXMLRPCArguments()
+        if let e = expected {
+            fullExpectedParams.append(e)
+        }
+
+        guard let parametersPassedIn = passedIn as? [NSObject],
+            let parametersExpected = fullExpectedParams as? [NSObject] else {
+                return false
+        }
+
+        let finalSet = Set(parametersPassedIn).subtract(parametersExpected)
+        return finalSet.count == 0
+    }
+}

--- a/WordPress/WordPressTest/MockWordPressOrgXMLRPCApi.swift
+++ b/WordPress/WordPressTest/MockWordPressOrgXMLRPCApi.swift
@@ -1,12 +1,19 @@
 import Foundation
-@testable import WordPress
 
-class MockWordPressOrgXMLRPCApi: WordPressOrgXMLRPC {
+@objc class MockWordPressOrgXMLRPCApi: NSObject, WordPressOrgXMLRPC {
 
     var methodPassedIn: String? = nil
-    var parametersPassedIn: AnyObject? = nil
+    var parametersPassedIn: [AnyObject]? = nil
     var successBlockPassedIn: WordPressOrgXMLRPCApi.SuccessResponseBlock? = nil
     var failureBlockPassedIn: WordPressOrgXMLRPCApi.FailureReponseBlock? = nil
+
+    required init(endpoint: NSURL = NSURL(fileURLWithPath: ""), userAgent: String? = nil) {}
+
+    func invalidateAndCancelTasks() {}
+    func checkCredentials(username: String,
+                          password: String,
+                          success: WordPressOrgXMLRPCApi.SuccessResponseBlock,
+                          failure: WordPressOrgXMLRPCApi.FailureReponseBlock) {}
 
     func callMethod(method: String,
                     parameters: [AnyObject]?,

--- a/WordPress/WordPressTest/MockWordPressOrgXMLRPCApi.swift
+++ b/WordPress/WordPressTest/MockWordPressOrgXMLRPCApi.swift
@@ -1,0 +1,37 @@
+import Foundation
+@testable import WordPress
+
+class MockWordPressOrgXMLRPCApi: WordPressOrgXMLRPC {
+
+    var methodPassedIn: String? = nil
+    var parametersPassedIn: AnyObject? = nil
+    var successBlockPassedIn: WordPressOrgXMLRPCApi.SuccessResponseBlock? = nil
+    var failureBlockPassedIn: WordPressOrgXMLRPCApi.FailureReponseBlock? = nil
+
+    func callMethod(method: String,
+                    parameters: [AnyObject]?,
+                    success: WordPressOrgXMLRPCApi.SuccessResponseBlock,
+                    failure: WordPressOrgXMLRPCApi.FailureReponseBlock) -> NSProgress? {
+
+        return capture(method, parameters: parameters, success: success, failure: failure)
+    }
+
+    func streamCallMethod(method: String,
+                          parameters: [AnyObject]?,
+                          success: WordPressOrgXMLRPCApi.SuccessResponseBlock,
+                          failure: WordPressOrgXMLRPCApi.FailureReponseBlock) -> NSProgress? {
+
+        return capture(method, parameters: parameters, success: success, failure: failure)
+    }
+
+    private func capture(method: String,
+                         parameters: [AnyObject]?,
+                         success: WordPressOrgXMLRPCApi.SuccessResponseBlock,
+                         failure: WordPressOrgXMLRPCApi.FailureReponseBlock) -> NSProgress {
+        methodPassedIn = method
+        parametersPassedIn = parameters
+        successBlockPassedIn = success
+        failureBlockPassedIn = failure
+        return NSProgress()
+    }
+}

--- a/WordPress/WordPressTest/MockWordPressOrgXMLRPCApi.swift
+++ b/WordPress/WordPressTest/MockWordPressOrgXMLRPCApi.swift
@@ -4,37 +4,37 @@ import Foundation
 
     var methodPassedIn: String? = nil
     var parametersPassedIn: [AnyObject]? = nil
-    var successBlockPassedIn: WordPressOrgXMLRPCApi.SuccessResponseBlock? = nil
-    var failureBlockPassedIn: WordPressOrgXMLRPCApi.FailureReponseBlock? = nil
+    var successBlockPassedIn: ((AnyObject, NSHTTPURLResponse?) -> Void)? = nil
+    var failureBlockPassedIn: ((NSError, NSHTTPURLResponse?) -> Void)? = nil
 
     required init(endpoint: NSURL = NSURL(fileURLWithPath: ""), userAgent: String? = nil) {}
 
     func invalidateAndCancelTasks() {}
     func checkCredentials(username: String,
                           password: String,
-                          success: WordPressOrgXMLRPCApi.SuccessResponseBlock,
-                          failure: WordPressOrgXMLRPCApi.FailureReponseBlock) {}
+                          success: (AnyObject, NSHTTPURLResponse?) -> Void,
+                          failure: (NSError, NSHTTPURLResponse?) -> Void) {}
 
     func callMethod(method: String,
                     parameters: [AnyObject]?,
-                    success: WordPressOrgXMLRPCApi.SuccessResponseBlock,
-                    failure: WordPressOrgXMLRPCApi.FailureReponseBlock) -> NSProgress? {
+                    success: (AnyObject, NSHTTPURLResponse?) -> Void,
+                    failure: (NSError, NSHTTPURLResponse?) -> Void) -> NSProgress? {
 
         return capture(method, parameters: parameters, success: success, failure: failure)
     }
 
     func streamCallMethod(method: String,
                           parameters: [AnyObject]?,
-                          success: WordPressOrgXMLRPCApi.SuccessResponseBlock,
-                          failure: WordPressOrgXMLRPCApi.FailureReponseBlock) -> NSProgress? {
+                          success: (AnyObject, NSHTTPURLResponse?) -> Void,
+                          failure: (NSError, NSHTTPURLResponse?) -> Void) -> NSProgress? {
 
         return capture(method, parameters: parameters, success: success, failure: failure)
     }
 
     private func capture(method: String,
                          parameters: [AnyObject]?,
-                         success: WordPressOrgXMLRPCApi.SuccessResponseBlock,
-                         failure: WordPressOrgXMLRPCApi.FailureReponseBlock) -> NSProgress {
+                         success: (AnyObject, NSHTTPURLResponse?) -> Void,
+                         failure: (NSError, NSHTTPURLResponse?) -> Void) -> NSProgress {
         methodPassedIn = method
         parametersPassedIn = parameters
         successBlockPassedIn = success

--- a/WordPress/WordPressTest/WordPressAPI/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPress/WordPressTest/WordPressAPI/WordPressOrgXMLRPCApiTests.swift
@@ -1,6 +1,6 @@
 import XCTest
-import WordPress
 import OHHTTPStubs
+@testable import WordPress
 
 class WordPressOrgXMLRPCApiTests: XCTestCase {
 

--- a/WordPress/WordPressTest/WordPressTest-Bridging-Header.h
+++ b/WordPress/WordPressTest/WordPressTest-Bridging-Header.h
@@ -10,9 +10,12 @@
 #import "AccountService.h"
 #import "ReaderPost.h"
 #import "RemoteMedia.h"
+#import "RemotePostType.h"
 #import "RemoteReaderSite.h"
+#import "BlogServiceRemote.h"
 #import "MediaServiceRemote.h"
 #import "MediaServiceRemoteREST.h"
+#import "BlogServiceRemoteXMLRPC.h"
 #import "ReaderSiteServiceRemote.h"
 #import "UIAlertControllerProxy.h"
 #import <NSObject_SafeExpectations/NSDictionary+SafeExpectations.h>


### PR DESCRIPTION
Relates to #6195 
This PR also make WordPressOrgXMLRPCApi to work under a protocol to make it more easy to inject it in tests.

@koke Sorry but you seem to have worked a fair amount on this class(`BlogServiceRemoteXMLRPC`) would you mind to do a quick review when you have time?
Thanks! 
