### PR TITLE
Posts: Remove API override of dateCreated when equal to dateModified

### DIFF
--- a/WordPress/Classes/Networking/PostServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.m
@@ -369,10 +369,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     parameters[@"password"] = post.password ? post.password : @"";
     parameters[@"type"] = post.type;
 
-    if ([post.date isEqualToDate:post.dateModified]) {
-        // publish immediately when date created matches date modified
-        parameters[@"date"] = [[NSDate date] WordPressComJSONString];
-    } else if (post.date) {
+    if (post.date) {
         parameters[@"date"] = [post.date WordPressComJSONString];
     } else if (existingPost) {
         // safety net. An existing post with no create date should publish immediately


### PR DESCRIPTION
Fixes #6113 (mostly), https://github.com/wordpress-mobile/WordPress-iOS/issues/3973#issuecomment-245332447

This was previously an attempted fix on https://github.com/wordpress-mobile/WordPress-iOS/pull/6147, but we soon realized we weren't sure of any greater implications from the change.

After much thought, testing, and seeing new user reports of the same issues, I've decided it would be in our best interest to ship the fix as seen here. The side affects of the original bug are more consequential than the potential edge cases this fix may create. I would find myself afraid to use our editor if I experienced the issues users have reported based on the original bug.

That said, the only real edge case I can seem to find from this fix are that previously saved drafts which are later changed from a `draft` to `publish` status are instead posted with the original `dateCreated` from when the draft was created, rather than the "now" date they would be expected to be published with.

However, this behavior is actually indicative of our UX, in which changing the status from `draft` to `publish` doesn't also update the `dateCreated` to "now" as one might think, without hitting the "Publish Immediately" button on the date selector. So this edge case behavior actually works as our current UX implies, with showing the original creation date. What is happening without the change in this PR was that our API remote was itself deciding that the draft should be published "now", despite what date was actually shown in the editor options to the user. Which of course lead to other instances of the date being overridden in the linked issues above.... in far less expected ways.

In addition to this fix, there is a new UX that can actually solve our edge case behavior for us. Courtesy of @frosty on https://github.com/wordpress-mobile/WordPress-iOS/pull/6207, we will now present a user with a quick-action for "Publish Now" when hitting the ••• button on a draft. We could go a step further  to _also_ update a draft's `dateCreated` to "now" when the "Publish Now" action is selected. This would match the user's expectations more closely and avoid our behavior mis-match. We would keep same UX behavior as outlined above in the Post Options, but the more obvious button of "Publish Now" is a clear path for us to ignore the original `dateCreated` and override it, without predicting when to override it ourselves.

I think this is the best fix for a fairly urgent issue, barring any crazy scenarios created by this small change I may have completely overlooked.

To test:

1. Follow the steps in https://github.com/wordpress-mobile/WordPress-iOS/issues/6113
2. Follow the steps in https://github.com/wordpress-mobile/WordPress-iOS/issues/3973#issuecomment-245332447
3. Follow the steps on https://github.com/wordpress-mobile/WordPress-iOS/pull/5483

Needs review: @diegoreymendez can you take a dive into this? Sorry to revisit this again, but I hope we've found a good path to finally resolve it. (no rush to review this weekend or anything, can wait until Monday for `6.8`)

cc @aerych, @rachelmcr, @frosty 