### PR TITLE
Fixes an issue where post list filters didn't appear as a popover on 7+

### DIFF
--- a/WordPress/Classes/ViewRelated/System/ForcePopoverPresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/ForcePopoverPresenter.swift
@@ -24,7 +24,7 @@ class ForcePopoverPresenter: NSObject, UIPopoverPresentationControllerDelegate {
         controller.view.sizeToFit()
     }
 
-    func adaptivePresentationStyleForPresentationController(controller: UIPresentationController) -> UIModalPresentationStyle {
+    func adaptivePresentationStyleForPresentationController(controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         return .None
     }
 }


### PR DESCRIPTION
On the iPhones Plus in landscape orientation, the post list filters popover was appearing as a form sheet modal instead of a popover.

This PR uses a different `UIAdaptivePresentationControllerDelegate` method in `ForcePopoverPresenter`, which fixes the problem.

Before:

![simulator screen shot 22 nov 2016 17 29 53](https://cloud.githubusercontent.com/assets/4780/20534515/5ecf0f3c-b0d9-11e6-82bb-3567bc32e0b6.png)

After:

![simulator screen shot 22 nov 2016 17 30 51](https://cloud.githubusercontent.com/assets/4780/20534530/72210996-b0d9-11e6-89a1-9bcdd4cef4af.png)

To test:

* Check that the Post List filters popover (Published / Drafts / etc) appears as a popover in all orientations on all devices (particularly iPhones Plus).

Needs review: @nheagy  