### PR TITLE
Issue/846: Publish date picker could end up with a zero width

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPickerView.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPickerView.m
@@ -47,12 +47,11 @@ static NSInteger WPPickerToolBarHeight = 44.0f;
 
 - (void)configureView
 {
-    [self configureToolbar];
-
     UIView *picker = [self viewForPicker];
-    picker.frame = CGRectMake(0.0f, CGRectGetMaxY(self.toolbar.frame), CGRectGetWidth(picker.frame), CGRectGetHeight(picker.frame));
-
+    picker.frame = CGRectMake(0.0f, WPPickerToolBarHeight, CGRectGetWidth(picker.frame), CGRectGetHeight(picker.frame));
     self.frame = CGRectMake(0.0f, 0.0f, CGRectGetWidth(picker.frame), CGRectGetMaxY(picker.frame));
+
+    [self configureToolbar];
 
     [self addSubview:picker];
     [self addSubview:self.toolbar];
@@ -61,7 +60,7 @@ static NSInteger WPPickerToolBarHeight = 44.0f;
 - (void)configureToolbar
 {
     self.toolbar = [[UIToolbar alloc] initWithFrame:CGRectMake(0.0f, 0.0f, CGRectGetWidth(self.frame), WPPickerToolBarHeight)];
-    self.toolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin;
+    self.toolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 
     UIBarButtonItem *spacer = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
     UIBarButtonItem *leftSpacer = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];


### PR DESCRIPTION
Fixes #846. On some devices, the publish date picker in post settings could end up with a zero width, making it invisible. This PR moves around some of the date picker view setup code so that it'll always get its width from the picker view.

To test:

* Edit a post, go to Options, and then attempt to set a date. You should always see the blue bar at the top of the picker, and be able to successfully select a date. I was always able to reproduce the original issue on the iPhone 5S simulator, so I'd test there and also ensure other devices look fine.

Needs review: @jleandroperez 
cc @rachelmcr 