### PR TITLE
Allow direct copy of image or video from capture to WP media library.

### DIFF
--- a/WordPress/Classes/Extensions/NSURL+Exporters.swift
+++ b/WordPress/Classes/Extensions/NSURL+Exporters.swift
@@ -32,7 +32,7 @@ extension NSURL: ExportableAsset {
         default:
             errorHandler(error: errorForCode(.UnsupportedAssetType,
                 failureReason: NSLocalizedString("This media type is not supported on WordPress.",
-                                                 comment: "Error reason to display when exporting an unknow asset type from the device library")))
+                                                 comment: "Error reason to display when exporting an unknown asset type.")))
         }
     }
 
@@ -56,7 +56,7 @@ extension NSURL: ExportableAsset {
               let scaledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, scaleOptions)
         else {
             errorHandler(error: errorForCode(.FailedToExport,
-                failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of a image from device library fails")
+                failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of a image fails.")
                 ))
             return
         }
@@ -106,7 +106,7 @@ extension NSURL: ExportableAsset {
         let asset = AVURLAsset(URL: self)
         guard let track = asset.tracksWithMediaType(AVMediaTypeVideo).first else {
             errorHandler(error: errorForCode(.FailedToExport,
-                failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of a image from device library fails")
+                failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of an media asset fails")
                 ))
             return
         }
@@ -119,7 +119,7 @@ extension NSURL: ExportableAsset {
         else {
 
             errorHandler(error: errorForCode(.FailedToExport,
-                failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of a image from device library fails")
+                failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of an media asset fails")
                 ))
             return
         }

--- a/WordPress/Classes/Extensions/NSURL+Exporters.swift
+++ b/WordPress/Classes/Extensions/NSURL+Exporters.swift
@@ -1,0 +1,325 @@
+import Foundation
+import Photos
+import MobileCoreServices
+import AVFoundation
+
+extension NSURL: ExportableAsset {
+
+    func exportToURL(url: NSURL,
+        targetUTI: String,
+        maximumResolution: CGSize,
+        stripGeoLocation: Bool,
+        synchronous: Bool,
+        successHandler: SuccessHandler,
+        errorHandler: ErrorHandler) {
+
+        switch assetMediaType {
+        case .Image:
+            exportImageToURL(url,
+                targetUTI: targetUTI,
+                maximumResolution: maximumResolution,
+                stripGeoLocation: stripGeoLocation,
+                synchronous: synchronous,
+                successHandler: successHandler,
+                errorHandler: errorHandler)
+        case .Video:
+            exportVideoToURL(url,
+                targetUTI: targetUTI,
+                maximumResolution: maximumResolution,
+                stripGeoLocation: stripGeoLocation,
+                successHandler: successHandler,
+                errorHandler: errorHandler)
+        default:
+            errorHandler(error: errorForCode(.UnsupportedAssetType,
+                failureReason: NSLocalizedString("This media type is not supported on WordPress.",
+                                                 comment: "Error reason to display when exporting an unknow asset type from the device library")))
+        }
+    }
+
+    func exportImageToURL(url: NSURL,
+        targetUTI: String,
+        maximumResolution: CGSize,
+        stripGeoLocation: Bool,
+        synchronous: Bool,
+        successHandler: SuccessHandler,
+        errorHandler: ErrorHandler)
+    {
+
+        let requestedSize = maximumResolution.clamp(min: CGSizeZero, max: pixelSize)
+        let metadataOptions: [NSString:NSObject] = [kCGImageSourceShouldCache: false]
+        let scaleOptions: [NSString: NSObject] = [
+            kCGImageSourceThumbnailMaxPixelSize: max(requestedSize.width, requestedSize.height),
+            kCGImageSourceCreateThumbnailFromImageAlways: true
+        ]
+        guard let imageSource = CGImageSourceCreateWithURL(self, nil),
+              let imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, metadataOptions),
+              let scaledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, scaleOptions)
+        else {
+            errorHandler(error: errorForCode(.FailedToExport,
+                failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of a image from device library fails")
+                ))
+            return
+        }
+        let image = UIImage(CGImage: scaledImage)
+        var exportMetadata : [String:AnyObject]? = nil
+        if let metadata = imageProperties as NSDictionary as? [String:AnyObject] {
+            exportMetadata = metadata
+            if stripGeoLocation {
+                let attributesToRemove = [kCGImagePropertyGPSDictionary as String]
+                exportMetadata = removeAttributes(attributesToRemove, fromMetadata: metadata)
+            }
+        }
+
+        do {
+            try image.writeToURL(url, type: targetUTI, compressionQuality: 0.9, metadata: exportMetadata)
+            successHandler(resultingSize: image.size)
+        } catch let error as NSError {
+            errorHandler(error: error)
+        } catch {
+            errorHandler(error: errorForCode(.FailedToExport,
+                                                  failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of a image from device library fails")
+            ))
+        }
+    }
+
+    func exportOriginalImage(toURL: NSURL, successHandler: SuccessHandler, errorHandler: ErrorHandler) {
+        let fileManager = NSFileManager.defaultManager()
+        do {
+            try fileManager.copyItemAtURL(self, toURL: toURL)
+        } catch let error as NSError {
+            errorHandler(error: error)
+        } catch {
+            errorHandler(error: errorForCode(.FailedToExport,
+                                                  failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of a image from device library fails")
+            ))
+        }
+        successHandler(resultingSize: pixelSize)
+    }
+
+    func exportVideoToURL(url: NSURL,
+        targetUTI: String,
+        maximumResolution: CGSize,
+        stripGeoLocation: Bool,
+        successHandler: SuccessHandler,
+        errorHandler: ErrorHandler) {
+
+        let asset = AVURLAsset(URL: self)
+        guard let track = asset.tracksWithMediaType(AVMediaTypeVideo).first else {
+            errorHandler(error: errorForCode(.FailedToExport,
+                failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of a image from device library fails")
+                ))
+            return
+        }
+        let size = CGSizeApplyAffineTransform(track.naturalSize, track.preferredTransform)
+        let pixelWidth = fabs(size.width)
+        let pixelHeight = fabs(size.height)
+
+        guard
+            let exportSession = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetPassthrough)
+        else {
+
+            errorHandler(error: errorForCode(.FailedToExport,
+                failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of a image from device library fails")
+                ))
+            return
+        }
+        exportSession.outputFileType = targetUTI
+        exportSession.shouldOptimizeForNetworkUse = true
+        exportSession.outputURL = url
+        exportSession.exportAsynchronouslyWithCompletionHandler({ () -> Void in
+            guard exportSession.status == .Completed else {
+                if let error = exportSession.error {
+                    errorHandler(error: error)
+                }
+                return
+            }
+            successHandler(resultingSize: CGSize(width: pixelWidth, height: pixelHeight))
+        })
+    }
+
+    func exportThumbnailToURL(url: NSURL,
+        targetSize: CGSize,
+        synchronous: Bool,
+        successHandler: SuccessHandler,
+        errorHandler: ErrorHandler) {
+        if isImage {
+            exportToURL(url,
+                        targetUTI: defaultThumbnailUTI,
+                        maximumResolution: targetSize,
+                        stripGeoLocation: true,
+                        synchronous: synchronous,
+                        successHandler: successHandler,
+                        errorHandler: errorHandler)
+        } else if isVideo {
+            do {
+                let asset = AVURLAsset(URL: self, options: nil)
+                let imgGenerator = AVAssetImageGenerator(asset: asset)
+                imgGenerator.maximumSize = targetSize
+                imgGenerator.appliesPreferredTrackTransform = true
+                let cgImage = try imgGenerator.copyCGImageAtTime(CMTimeMake(0, 1), actualTime: nil)
+                let uiImage = UIImage(CGImage: cgImage)
+                try uiImage.writeJPEGToURL(url)
+                successHandler(resultingSize: uiImage.size)
+            } catch let error as NSError {
+                errorHandler(error: error)
+            } catch {
+                errorHandler(error: errorForCode(.FailedToExport,
+                    failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of a image from device library fails")
+                    ))
+            }
+        } else {
+            errorHandler(error: errorForCode(.FailedToExport,
+                failureReason: NSLocalizedString("Unknown asset export error", comment: "Error reason to display when the export of a image from device library fails")
+                ))
+        }
+    }
+
+    func originalUTI() -> String? {
+        return typeIdentifier
+    }
+
+    var defaultThumbnailUTI: String {
+        get {
+            return kUTTypeJPEG as String
+        }
+    }
+
+    var assetMediaType: MediaType {
+        get {
+            if isImage {
+                return .Image
+            } else if (isVideo) {
+                return .Video
+            }
+            return .Document
+        }
+    }
+
+    //MARK: - Helper methods
+
+    var pixelSize: CGSize {
+        get {
+            if isVideo {
+                let asset = AVAsset(URL: self)
+                guard let track = asset.tracksWithMediaType(AVMediaTypeVideo).first else {
+                    return CGSizeZero
+                }
+                let size = CGSizeApplyAffineTransform(track.naturalSize, track.preferredTransform)
+                return size
+            } else if isImage {
+                let options: [NSString:NSObject] = [kCGImageSourceShouldCache: false]
+                guard
+                    let imageSource = CGImageSourceCreateWithURL(self, nil),
+                    let imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, options)
+                    else {
+                        return CGSizeZero
+                }
+
+                let imageDictionary = imageProperties as NSDictionary
+                guard
+                    let pixelWidth = imageDictionary[kCGImagePropertyPixelWidth as NSString] as? Int,
+                    let pixelHeight = imageDictionary[kCGImagePropertyPixelHeight as NSString] as? Int
+                    else {
+                        return CGSizeZero
+                }
+
+                return CGSize(width: pixelWidth, height: pixelHeight)
+            } else {
+                return CGSizeZero
+            }
+        }
+    }
+
+    var typeIdentifier: String? {
+        guard fileURL else { return nil }
+        do {
+            let data = try bookmarkDataWithOptions(NSURLBookmarkCreationOptions.MinimalBookmark, includingResourceValuesForKeys:[NSURLTypeIdentifierKey], relativeToURL: nil)
+            guard
+                let resourceValues = NSURL.resourceValuesForKeys([NSURLTypeIdentifierKey], fromBookmarkData:data),
+                let typeIdentifier = resourceValues[NSURLTypeIdentifierKey] as? String else {
+                    return nil
+            }
+            return typeIdentifier
+        } catch {
+            return nil
+        }
+    }
+
+    var mimeType: String {
+        guard let uti = typeIdentifier,
+            let mimeType = UTTypeCopyPreferredTagWithClass(uti as CFString, kUTTagClassMIMEType)?.takeUnretainedValue() as? String
+            else {
+                return "application/octet-stream"
+        }
+
+        return mimeType
+    }
+
+    var isVideo: Bool {
+        guard let uti = typeIdentifier else {
+            return false
+        }
+
+        return UTTypeConformsTo(uti as CFString, kUTTypeMovie)
+    }
+
+    var isImage: Bool {
+        guard let uti = typeIdentifier else {
+            return false
+        }
+
+        return UTTypeConformsTo(uti as CFString, kUTTypeImage)
+    }
+
+
+    func removeAttributes(attributes: [String], fromMetadata: [String:AnyObject]) -> [String:AnyObject]{
+        var resultingMetadata = fromMetadata
+        for attribute in attributes {
+            resultingMetadata.removeValueForKey(attribute)
+            if attribute == kCGImagePropertyOrientation as String{
+                if let tiffMetadata = resultingMetadata[kCGImagePropertyTIFFDictionary as String] as? [String:AnyObject]{
+                    var newTiffMetadata = tiffMetadata
+                    newTiffMetadata.removeValueForKey(kCGImagePropertyTIFFOrientation as String)
+                    resultingMetadata[kCGImagePropertyTIFFDictionary as String] = newTiffMetadata
+                }
+            }
+        }
+        return resultingMetadata
+    }
+
+    /// Makes sure the metadata of the image is matching the attributes in the Image.
+    ///
+    /// - Parameters:
+    ///     - metadata: The original metadata of the image.
+    ///     - image: The current image.
+    ///
+    /// - Returns: A new metadata object where the values match the values on the UIImage
+    ///
+    func matchMetadata(metadata: [String:AnyObject], image: UIImage) -> [String:AnyObject] {
+        var resultingMetadata = metadata
+        let correctOrientation = image.metadataOrientation
+        resultingMetadata[kCGImagePropertyOrientation as String] = Int(correctOrientation.rawValue)
+        if var tiffMetadata = resultingMetadata[kCGImagePropertyTIFFDictionary as String] as? [String:AnyObject]{
+            tiffMetadata[kCGImagePropertyTIFFOrientation as String] = Int(correctOrientation.rawValue)
+            resultingMetadata[kCGImagePropertyTIFFDictionary as String] = tiffMetadata
+        }
+
+        return resultingMetadata
+    }
+
+    // MARK: - Error Handling
+
+    enum ErrorCode : Int {
+        case UnsupportedAssetType = 1
+        case FailedToExport = 2
+        case FailedToExportMetadata = 3
+    }
+
+    private func errorForCode(errorCode: ErrorCode, failureReason: String) -> NSError {
+        let userInfo = [NSLocalizedFailureReasonErrorKey: failureReason]
+        let error = NSError(domain: "NSURL+ExporterExtensions", code: errorCode.rawValue, userInfo: userInfo)
+
+        return error
+    }
+
+}

--- a/WordPress/Classes/Extensions/NSURL+Exporters.swift
+++ b/WordPress/Classes/Extensions/NSURL+Exporters.swift
@@ -212,32 +212,21 @@ extension NSURL: ExportableAsset {
         get {
             if isVideo {
                 let asset = AVAsset(URL: self)
-                guard let track = asset.tracksWithMediaType(AVMediaTypeVideo).first else {
-                    return CGSizeZero
+                if let track = asset.tracksWithMediaType(AVMediaTypeVideo).first {
+                    return CGSizeApplyAffineTransform(track.naturalSize, track.preferredTransform)
                 }
-                let size = CGSizeApplyAffineTransform(track.naturalSize, track.preferredTransform)
-                return size
             } else if isImage {
                 let options: [NSString:NSObject] = [kCGImageSourceShouldCache: false]
-                guard
+                if
                     let imageSource = CGImageSourceCreateWithURL(self, nil),
-                    let imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, options)
-                    else {
-                        return CGSizeZero
+                    let imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, options) as NSDictionary?,
+                    let pixelWidth = imageProperties[kCGImagePropertyPixelWidth as NSString] as? Int,
+                    let pixelHeight = imageProperties[kCGImagePropertyPixelHeight as NSString] as? Int
+                {
+                        return CGSize(width: pixelWidth, height: pixelHeight)
                 }
-
-                let imageDictionary = imageProperties as NSDictionary
-                guard
-                    let pixelWidth = imageDictionary[kCGImagePropertyPixelWidth as NSString] as? Int,
-                    let pixelHeight = imageDictionary[kCGImagePropertyPixelHeight as NSString] as? Int
-                    else {
-                        return CGSizeZero
-                }
-
-                return CGSize(width: pixelWidth, height: pixelHeight)
-            } else {
-                return CGSizeZero
             }
+            return CGSizeZero
         }
     }
 

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -9,6 +9,19 @@
 @interface MediaService : LocalCoreDataService
 
 /**
+ Create a media object using the url provided as the source of media.
+
+ @param url a file url pointing to a file with the media data
+ @param postObjectID the post object ID to associate the media
+ @param thumbnailCallback a block that will be invoked when the thumbail for the media object is ready
+ @param completion a block that will be invoked when the media is created, on success it will return a valid Media object, on failure it will return a nil Media and an error object with the details.
+ */
+- (void)createMediaWithURL:(NSURL *)url
+           forPostObjectID:(NSManagedObjectID *)postObjectID
+         thumbnailCallback:(void (^)(NSURL *thumbnailURL))thumbnailCallback
+                completion:(void (^)(Media *media, NSError *error))completion;
+
+/**
  Create a Media object using the asset as the source and making it a child of the post with postObjectId.
  
  @param asset

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -16,6 +16,22 @@
 
 @implementation MediaService
 
+- (void)createMediaWithURL:(NSURL *)url
+           forPostObjectID:(NSManagedObjectID *)postObjectID
+         thumbnailCallback:(void (^)(NSURL *thumbnailURL))thumbnailCallback
+                completion:(void (^)(Media *media, NSError *error))completion
+{
+
+    NSString *mediaName = [[url pathComponents] lastObject];
+
+    [self createMediaWith:url
+          forPostObjectID:postObjectID
+                mediaName:mediaName
+        thumbnailCallback:thumbnailCallback
+               completion:completion
+     ];
+}
+
 - (void)createMediaWithImage:(UIImage *)image
                  withMediaID:(NSString *)mediaID
              forPostObjectID:(NSManagedObjectID *)postObjectID

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -169,7 +169,7 @@
             [self addMediaFromURL:fileURL completionBlock:completionBlock];
         } else {
             if (completionBlock) {
-                completionBlock(nil, error);;
+                completionBlock(nil, error);
             }
         }
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -814,10 +814,10 @@
 		E66969E41B9E68B200EC9C00 /* ReaderPostToReaderPost37to38.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66969E31B9E68B200EC9C00 /* ReaderPostToReaderPost37to38.swift */; };
 		E66EB6F91C1B7A76003DABC5 /* ReaderSpacerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66EB6F81C1B7A76003DABC5 /* ReaderSpacerView.swift */; };
 		E678FC151C76241000F55F55 /* WPStyleGuide+ApplicationStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E678FC141C76241000F55F55 /* WPStyleGuide+ApplicationStyles.swift */; };
+		E67B302A1DD2428B00F2F47B /* UIImage+Tint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B30291DD2428B00F2F47B /* UIImage+Tint.swift */; };
 		E6805D301DCD399600168E4F /* WPRichTextEmbed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6805D2D1DCD399600168E4F /* WPRichTextEmbed.swift */; };
 		E6805D311DCD399600168E4F /* WPRichTextImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6805D2E1DCD399600168E4F /* WPRichTextImage.swift */; };
 		E6805D321DCD399600168E4F /* WPRichTextMediaAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6805D2F1DCD399600168E4F /* WPRichTextMediaAttachment.swift */; };
-		E67B302A1DD2428B00F2F47B /* UIImage+Tint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B30291DD2428B00F2F47B /* UIImage+Tint.swift */; };
 		E691D62E1CA4B0C9005C91ED /* SigninErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E691D62D1CA4B0C9005C91ED /* SigninErrorViewController.swift */; };
 		E69551F61B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69551F51B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift */; };
 		E69B125E1CE23A8E00594C73 /* SignupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69B125D1CE23A8E00594C73 /* SignupService.swift */; };
@@ -881,6 +881,7 @@
 		FF2716921CAAC87B0006E2D4 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2716911CAAC87B0006E2D4 /* LoginTests.swift */; };
 		FF27169F1CAAF5060006E2D4 /* WordPressTestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF27169E1CAAF5060006E2D4 /* WordPressTestCredentials.swift */; };
 		FF2716A11CABC7D40006E2D4 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2716A01CABC7D40006E2D4 /* XCTest+Extensions.swift */; };
+		FF286C761DE70A4500383A62 /* NSURL+Exporters.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF286C751DE70A4500383A62 /* NSURL+Exporters.swift */; };
 		FF28B3F11AEB251200E11AAE /* InfoPListTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = FF28B3F01AEB251200E11AAE /* InfoPListTranslator.m */; };
 		FF34EEA91CF473F600F8B38D /* WordPressComServiceRemoteRestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF34EEA81CF473F600F8B38D /* WordPressComServiceRemoteRestTests.swift */; };
 		FF34EEAB1CF480F100F8B38D /* WordPressComRestApiFailThrottled.json in Resources */ = {isa = PBXBuildFile; fileRef = FF34EEAA1CF480F100F8B38D /* WordPressComRestApiFailThrottled.json */; };
@@ -2169,10 +2170,10 @@
 		E66EB6F81C1B7A76003DABC5 /* ReaderSpacerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSpacerView.swift; sourceTree = "<group>"; };
 		E677A0001D3ECBD500536CF2 /* WordPress 51.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 51.xcdatamodel"; sourceTree = "<group>"; };
 		E678FC141C76241000F55F55 /* WPStyleGuide+ApplicationStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+ApplicationStyles.swift"; sourceTree = "<group>"; };
+		E67B30291DD2428B00F2F47B /* UIImage+Tint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Tint.swift"; sourceTree = "<group>"; };
 		E6805D2D1DCD399600168E4F /* WPRichTextEmbed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPRichTextEmbed.swift; path = WPRichText/WPRichTextEmbed.swift; sourceTree = "<group>"; };
 		E6805D2E1DCD399600168E4F /* WPRichTextImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPRichTextImage.swift; path = WPRichText/WPRichTextImage.swift; sourceTree = "<group>"; };
 		E6805D2F1DCD399600168E4F /* WPRichTextMediaAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPRichTextMediaAttachment.swift; path = WPRichText/WPRichTextMediaAttachment.swift; sourceTree = "<group>"; };
-		E67B30291DD2428B00F2F47B /* UIImage+Tint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Tint.swift"; sourceTree = "<group>"; };
 		E691D62D1CA4B0C9005C91ED /* SigninErrorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SigninErrorViewController.swift; sourceTree = "<group>"; };
 		E69551F51B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ReaderStreamViewController+Helper.swift"; sourceTree = "<group>"; };
 		E69B125D1CE23A8E00594C73 /* SignupService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupService.swift; sourceTree = "<group>"; };
@@ -2255,6 +2256,7 @@
 		FF27169B1CAAF3190006E2D4 /* gencredentials.rb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.ruby; path = gencredentials.rb; sourceTree = "<group>"; };
 		FF27169E1CAAF5060006E2D4 /* WordPressTestCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressTestCredentials.swift; sourceTree = "<group>"; };
 		FF2716A01CABC7D40006E2D4 /* XCTest+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTest+Extensions.swift"; sourceTree = "<group>"; };
+		FF286C751DE70A4500383A62 /* NSURL+Exporters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSURL+Exporters.swift"; sourceTree = "<group>"; };
 		FF28B3EF1AEB251200E11AAE /* InfoPListTranslator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InfoPListTranslator.h; sourceTree = "<group>"; };
 		FF28B3F01AEB251200E11AAE /* InfoPListTranslator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InfoPListTranslator.m; sourceTree = "<group>"; };
 		FF34EEA81CF473F600F8B38D /* WordPressComServiceRemoteRestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressComServiceRemoteRestTests.swift; sourceTree = "<group>"; };
@@ -3958,6 +3960,7 @@
 				B5A9B7C21BFA6F3100FC30A5 /* NSString+Helpers.swift */,
 				B5BE31C31CB825A100BDF770 /* NSURLCache+Helpers.swift */,
 				FFB1FA9F1BF0EC4E0090C761 /* PHAsset+Exporters.swift */,
+				FF286C751DE70A4500383A62 /* NSURL+Exporters.swift */,
 				B5C7D7B71BC6B5A3008E668A /* UIAlertController+Helpers.swift */,
 				B587797219B799D800E57C5A /* UIDevice+Helpers.swift */,
 				FFB1FA9D1BF0EB840090C761 /* UIImage+Exporters.swift */,
@@ -6321,6 +6324,7 @@
 				B58CE5E11DC139A0004AA81D /* Dictionary+Helpers.swift in Sources */,
 				E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */,
 				E6431DE71C4E892900FD8D90 /* SharingViewController.m in Sources */,
+				FF286C761DE70A4500383A62 /* NSURL+Exporters.swift in Sources */,
 				E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */,
 				5D44EB381986D8BA008B7175 /* ReaderSiteService.m in Sources */,
 				B518E1651CCAA19200ADFE75 /* Blog+Capabilities.swift in Sources */,


### PR DESCRIPTION
Fixes #5560

To test:
- Go to the settings app and block the access to Photo Library for the WordPress app
 - Start a new post or edit an old one
 - Tap on add media
 - Tap on the media capture on the top
 - Check if the new media is added to the WordPress media library
 - Tap on Done
 - See if media is correctly added
 - Go to App setting and change media related settings (maximum image size and geo-location) and check if all works correctly.

Needs review: @frosty 
