### PR TITLE
Disable helpshift if no valid API key is available.

### DIFF
--- a/WordPress/Classes/Utility/HelpshiftUtils.m
+++ b/WordPress/Classes/Utility/HelpshiftUtils.m
@@ -34,9 +34,15 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
 
 + (void)setup
 {
+    if ([[ApiCredentials helpshiftAPIKey] length] == 0) {
+        [[self sharedInstance] disableHelpshift];
+        return;
+    }
     [HelpshiftCore initializeWithProvider:[HelpshiftSupport sharedInstance]];
     [[HelpshiftSupport sharedInstance] setDelegate:[HelpshiftUtils sharedInstance]];
-    [HelpshiftCore installForApiKey:[ApiCredentials helpshiftAPIKey] domainName:[ApiCredentials helpshiftDomainName] appID:[ApiCredentials helpshiftAppId]];
+    [HelpshiftCore installForApiKey:[ApiCredentials helpshiftAPIKey]
+                         domainName:[ApiCredentials helpshiftDomainName]
+                              appID:[ApiCredentials helpshiftAppId]];
     
     // Lets enable Helpshift by default on startup because the time to get data back from Mixpanel
     // can result in users who first launch the app being unable to contact us.
@@ -87,8 +93,13 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
         return;
     }
     
+    [self disableHelpshift];
+}
+
+- (void)disableHelpshift
+{
     DDLogInfo(@"Helpshift Disabled");
-    
+
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     [defaults setBool:NO forKey:UserDefaultsHelpshiftEnabled];
     [defaults synchronize];


### PR DESCRIPTION
Fixes #6162 

To test:
 - Remove the Helpshift credentials from the wpcom_credentials file
 - Recreate the ApiCredentials.m file
 - Build and run the app
 - Go to Me->Help And Support -> WordPress Help Center
 - Check if no crash happens and the app forum webpage opens
 
 - Add the credentials back to the file, and regenerate the ApiCredentials file.
 - Go to Me->Help And Support -> WordPress Help Center 
 - Check if help shift starts.

Needs review: @sendhil 
