### PR TITLE
Show search options on initial help shift talk.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
@@ -232,7 +232,7 @@ extension NUXAbstractViewController : SigninErrorViewControllerDelegate
             "Username": loginFields.username,
             "SiteURL": loginFields.siteUrl
         ]
-        HelpshiftSupport.showConversation(self, withOptions: [HelpshiftSupportCustomMetadataKey: metaData])
+        HelpshiftSupport.showConversation(self, withOptions: [HelpshiftSupportCustomMetadataKey: metaData, "showSearchOnNewConversation": "YES"])
         WPAppAnalytics.track(.SupportOpenedHelpshiftScreen)
     }
 


### PR DESCRIPTION
Fixes #6216

To test:
 - Try to login in the app with invalid login details
 - On the error screen tap on the Contact US option
 - See if you ask something like "login" a screen shows up with possible solutions in the FAQ
 - Do the same by tapping on the ? icon on the top right.

Note: if you used the app before, and used helpshift you may need to reset the Simulator in order to start a conversation from the beginning.

Needs review: @aerych 
