### PR TITLE
Fixes number picker's height in Site Settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/PickerTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/PickerTableViewCell.swift
@@ -73,10 +73,12 @@ public class PickerTableViewCell : WPTableViewCell, UIPickerViewDelegate, UIPick
         picker.backgroundColor = UIColor.whiteColor()
         contentView.addSubview(picker)
 
-        // ContentView: Pin to Left + Right edges
+        // ContentView: Pin to Left + Right + Top + Bottom edges
         contentView.translatesAutoresizingMaskIntoConstraints = false
         contentView.leadingAnchor.constraintEqualToAnchor(leadingAnchor).active = true
         contentView.trailingAnchor.constraintEqualToAnchor(trailingAnchor).active = true
+        contentView.topAnchor.constraintEqualToAnchor(topAnchor).active = true
+        contentView.bottomAnchor.constraintEqualToAnchor(bottomAnchor).active = true
 
         // Picker: Pin to Top + Bottom + CenterX edges
         picker.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Fixes #6226

To test:
- Open the My Sites tab in the app
- Open a site's Settings
- Open the Discussion settings
- Open a setting with a picker, e.g. Paging

Needs review: @frosty 

Bare in mind that I haven't fully digested the project, just wanted to take a look on what Automatticians do in iOS development 😉 

That's how it looks with the fix:
![simulator screen shot 28 nov 2016 14 00 56](https://cloud.githubusercontent.com/assets/2648910/20669400/45a3e830-b574-11e6-93cc-68169e5550cd.png)
