### PR TITLE
Adds class to fetch cached ReaderPost objects

### DIFF
--- a/WordPress/Classes/Models/ReaderCrossPostMeta.swift
+++ b/WordPress/Classes/Models/ReaderCrossPostMeta.swift
@@ -1,8 +1,10 @@
 import Foundation
 import CoreData
 
-@objc public class ReaderCrossPostMeta : NSManagedObject
+@objc public class ReaderCrossPostMeta : NSManagedObject, ManagedObject
 {
+    static let entityName = "ReaderCrossPostMeta"
+
     // Relations
     @NSManaged public var post: ReaderPost
 

--- a/WordPress/Classes/Models/ReaderPost+ManagedObject.swift
+++ b/WordPress/Classes/Models/ReaderPost+ManagedObject.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension ReaderPost: ManagedObject {
+    @nonobjc static let entityName = "ReaderPost"
+}

--- a/WordPress/Classes/Models/SourcePostAttribution+ManagedObject.swift
+++ b/WordPress/Classes/Models/SourcePostAttribution+ManagedObject.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension SourcePostAttribution: ManagedObject {
+    @nonobjc static let entityName = "SourcePostAttribution"
+}

--- a/WordPress/Classes/Utility/ReaderPostCacheProvider.swift
+++ b/WordPress/Classes/Utility/ReaderPostCacheProvider.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+@objc class ReaderPostCacheProvider: NSObject {
+
+    private enum ReaderPostType {
+
+        case normal
+        case cross
+        case attribution
+
+        static let allTypes = [normal, cross, attribution]
+    }
+
+    let context: NSManagedObjectContext
+    init(context: NSManagedObjectContext) {
+        self.context = context
+    }
+
+    func getPostByID(postID: Int, siteID: Int) -> ReaderPost? {
+
+        for type in ReaderPostType.allTypes {
+            if let post = getPostByID(postID, siteID: siteID, type: type) {
+                return post
+            }
+        }
+
+        return nil
+    }
+
+    private func getPostByID(postID: Int, siteID: Int, type: ReaderPostType) -> ReaderPost? {
+
+        let fetchRequest = searchPostRequestForID(postID, siteID: siteID, type: type)
+        var post: ReaderPost? = nil
+
+        do {
+
+            let results = try context.executeFetchRequest(fetchRequest)
+            post = results.first as? ReaderPost
+
+        } catch {
+            DDLogSwift.logError("Error fetching post from database")
+        }
+
+        return post
+    }
+
+    private func searchPostRequestForID(postID: Int, siteID: Int, type: ReaderPostType) -> NSFetchRequest {
+        let fetchRequest = NSFetchRequest(entityName: "ReaderPost")
+        fetchRequest.predicate = searchPostPredicateForID(postID, siteID: siteID, type: type)
+        return fetchRequest
+    }
+
+    private func searchPostPredicateForID(postID: Int, siteID: Int, type: ReaderPostType) -> NSPredicate {
+
+        var predicateFormat: String
+        switch type {
+        case .normal:
+            predicateFormat = "postID = %d AND siteID = %d"
+        case .cross:
+            predicateFormat = "sourceAttribution.postID = %d AND sourceAttribution.blogID = %d"
+        case .attribution:
+            predicateFormat = "crossPostMeta.postID = %d AND crossPostMeta.siteID = %d"
+        }
+
+        let predicate = NSPredicate(format:predicateFormat, postID, siteID)
+        return predicate
+    }
+}

--- a/WordPress/Classes/Utility/ReaderPostCacheProvider.swift
+++ b/WordPress/Classes/Utility/ReaderPostCacheProvider.swift
@@ -56,9 +56,9 @@ import Foundation
         switch type {
         case .normal:
             predicateFormat = "postID = %d AND siteID = %d"
-        case .cross:
-            predicateFormat = "sourceAttribution.postID = %d AND sourceAttribution.blogID = %d"
         case .attribution:
+            predicateFormat = "sourceAttribution.postID = %d AND sourceAttribution.blogID = %d"
+        case .cross:
             predicateFormat = "crossPostMeta.postID = %d AND crossPostMeta.siteID = %d"
         }
 

--- a/WordPress/Classes/Utility/ReaderPostCacheProvider.swift
+++ b/WordPress/Classes/Utility/ReaderPostCacheProvider.swift
@@ -16,6 +16,16 @@ import Foundation
         self.context = context
     }
 
+    /**
+     Gets an stored ReaderPost from the local database, it searches for a Normal Post, 
+     a SourceAttribution Post or a Cross Post.
+     
+     - Parameters:
+        - postID: the postID of the post to fetch
+        - siteID: the siteID of the post to fetch, can be a blogID if it has source attribution information
+     
+     - Returns: A ReaderPost object if it is cached localy or nil if not found
+     */
     func getPostByID(postID: Int, siteID: Int) -> ReaderPost? {
 
         for type in ReaderPostType.allTypes {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -124,6 +124,8 @@
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		261FF32C1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */; };
 		26A1B5A01DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */; };
+		26AE46241DE891B400043CC9 /* ReaderPostCacheProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AE46231DE891B400043CC9 /* ReaderPostCacheProvider.swift */; };
+		26AE46261DE89FBF00043CC9 /* ReaderPostCacheProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AE46251DE89FBF00043CC9 /* ReaderPostCacheProviderTests.swift */; };
 		28AD73600D9D9599002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD735F0D9D9599002E5188 /* MainWindow.xib */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
 		296526FE105810E100597FA3 /* NSString+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 296526FD105810E100597FA3 /* NSString+Helpers.m */; };
@@ -814,10 +816,10 @@
 		E66969E41B9E68B200EC9C00 /* ReaderPostToReaderPost37to38.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66969E31B9E68B200EC9C00 /* ReaderPostToReaderPost37to38.swift */; };
 		E66EB6F91C1B7A76003DABC5 /* ReaderSpacerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66EB6F81C1B7A76003DABC5 /* ReaderSpacerView.swift */; };
 		E678FC151C76241000F55F55 /* WPStyleGuide+ApplicationStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E678FC141C76241000F55F55 /* WPStyleGuide+ApplicationStyles.swift */; };
+		E67B302A1DD2428B00F2F47B /* UIImage+Tint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B30291DD2428B00F2F47B /* UIImage+Tint.swift */; };
 		E6805D301DCD399600168E4F /* WPRichTextEmbed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6805D2D1DCD399600168E4F /* WPRichTextEmbed.swift */; };
 		E6805D311DCD399600168E4F /* WPRichTextImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6805D2E1DCD399600168E4F /* WPRichTextImage.swift */; };
 		E6805D321DCD399600168E4F /* WPRichTextMediaAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6805D2F1DCD399600168E4F /* WPRichTextMediaAttachment.swift */; };
-		E67B302A1DD2428B00F2F47B /* UIImage+Tint.swift in Sources */ = {isa = PBXBuildFile; fileRef = E67B30291DD2428B00F2F47B /* UIImage+Tint.swift */; };
 		E691D62E1CA4B0C9005C91ED /* SigninErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E691D62D1CA4B0C9005C91ED /* SigninErrorViewController.swift */; };
 		E69551F61B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69551F51B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift */; };
 		E69B125E1CE23A8E00594C73 /* SignupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69B125D1CE23A8E00594C73 /* SignupService.swift */; };
@@ -1148,6 +1150,8 @@
 		26165C3E18786662761456D6 /* Pods-WordPress_Base-WordPress.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPress.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPress/Pods-WordPress_Base-WordPress.release-internal.xcconfig"; sourceTree = "<group>"; };
 		261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaServiceRemoteRESTTests.swift; sourceTree = "<group>"; };
 		26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSiteServiceRemoteTests.swift; sourceTree = "<group>"; };
+		26AE46231DE891B400043CC9 /* ReaderPostCacheProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostCacheProvider.swift; sourceTree = "<group>"; };
+		26AE46251DE89FBF00043CC9 /* ReaderPostCacheProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostCacheProviderTests.swift; sourceTree = "<group>"; };
 		28A0AAE50D9B0CCF005BE974 /* WordPress_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPress_Prefix.pch; sourceTree = "<group>"; };
 		28AD735F0D9D9599002E5188 /* MainWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = MainWindow.xib; path = Resources/MainWindow.xib; sourceTree = "<group>"; };
 		2906F80F110CDA8900169D56 /* EditCommentViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditCommentViewController.h; sourceTree = "<group>"; };
@@ -2169,10 +2173,10 @@
 		E66EB6F81C1B7A76003DABC5 /* ReaderSpacerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSpacerView.swift; sourceTree = "<group>"; };
 		E677A0001D3ECBD500536CF2 /* WordPress 51.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 51.xcdatamodel"; sourceTree = "<group>"; };
 		E678FC141C76241000F55F55 /* WPStyleGuide+ApplicationStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+ApplicationStyles.swift"; sourceTree = "<group>"; };
+		E67B30291DD2428B00F2F47B /* UIImage+Tint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Tint.swift"; sourceTree = "<group>"; };
 		E6805D2D1DCD399600168E4F /* WPRichTextEmbed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPRichTextEmbed.swift; path = WPRichText/WPRichTextEmbed.swift; sourceTree = "<group>"; };
 		E6805D2E1DCD399600168E4F /* WPRichTextImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPRichTextImage.swift; path = WPRichText/WPRichTextImage.swift; sourceTree = "<group>"; };
 		E6805D2F1DCD399600168E4F /* WPRichTextMediaAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPRichTextMediaAttachment.swift; path = WPRichText/WPRichTextMediaAttachment.swift; sourceTree = "<group>"; };
-		E67B30291DD2428B00F2F47B /* UIImage+Tint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Tint.swift"; sourceTree = "<group>"; };
 		E691D62D1CA4B0C9005C91ED /* SigninErrorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SigninErrorViewController.swift; sourceTree = "<group>"; };
 		E69551F51B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ReaderStreamViewController+Helper.swift"; sourceTree = "<group>"; };
 		E69B125D1CE23A8E00594C73 /* SignupService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupService.swift; sourceTree = "<group>"; };
@@ -3334,6 +3338,7 @@
 				E19A10C91B010AA0006192B0 /* WPURLRequestTest.m */,
 				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
 				175DBCD51DAE41A6003CBFBE /* WPFeedbackGeneratorTests.swift */,
+				26AE46251DE89FBF00043CC9 /* ReaderPostCacheProviderTests.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -3433,6 +3438,7 @@
 				E12E6E321C21BA170033C5D0 /* FeatureFlag.swift */,
 				FFB0DEA91D38061B00DD4A50 /* WPImageURLHelper.swift */,
 				17D33ADF1D9E9C6900FBB621 /* WPFeedbackGenerators.swift */,
+				26AE46231DE891B400043CC9 /* ReaderPostCacheProvider.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -5850,6 +5856,7 @@
 				B535209B1AF7BBB800B33BA8 /* PushAuthenticationManager.swift in Sources */,
 				319D6E8119E44C680013871C /* SuggestionsTableView.m in Sources */,
 				ACBAB6860E1247F700F38795 /* PostPreviewViewController.m in Sources */,
+				26AE46241DE891B400043CC9 /* ReaderPostCacheProvider.swift in Sources */,
 				5D2FB2861AE98C6600F1D4ED /* RestorePostTableViewCell.m in Sources */,
 				E1BEEC651C4E3978000B4FA0 /* PaddedLabel.swift in Sources */,
 				E6417B991CA07B9C0084050A /* WPStyleGuide+NUX.swift in Sources */,
@@ -6480,6 +6487,7 @@
 				93E9050719E6F3D8005513C9 /* TestContextManager.m in Sources */,
 				5D2BEB4919758102005425F7 /* PhotonImageURLHelperTest.m in Sources */,
 				08A2AD751CCEBDBD00E84454 /* TaxonomyServiceRemoteRESTTests.m in Sources */,
+				26AE46261DE89FBF00043CC9 /* ReaderPostCacheProviderTests.swift in Sources */,
 				5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */,
 				85D239C01AE5A7020074768D /* LoginFacadeTests.m in Sources */,
 				E63C897C1CB9A0D700649C8F /* UITextFieldTextHelperTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -123,6 +123,8 @@
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		261FF32C1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */; };
+		268D5DAC1DEE35E300CBEAB3 /* ReaderPost+ManagedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268D5DAB1DEE35E300CBEAB3 /* ReaderPost+ManagedObject.swift */; };
+		268D5DB01DEE367A00CBEAB3 /* SourcePostAttribution+ManagedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268D5DAF1DEE367A00CBEAB3 /* SourcePostAttribution+ManagedObject.swift */; };
 		26A1B5A01DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */; };
 		26AE46241DE891B400043CC9 /* ReaderPostCacheProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AE46231DE891B400043CC9 /* ReaderPostCacheProvider.swift */; };
 		26AE46261DE89FBF00043CC9 /* ReaderPostCacheProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AE46251DE89FBF00043CC9 /* ReaderPostCacheProviderTests.swift */; };
@@ -1149,6 +1151,8 @@
 		1D6058910D05DD3D006BFB54 /* WordPress.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordPress.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		26165C3E18786662761456D6 /* Pods-WordPress_Base-WordPress.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPress.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPress/Pods-WordPress_Base-WordPress.release-internal.xcconfig"; sourceTree = "<group>"; };
 		261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaServiceRemoteRESTTests.swift; sourceTree = "<group>"; };
+		268D5DAB1DEE35E300CBEAB3 /* ReaderPost+ManagedObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ReaderPost+ManagedObject.swift"; sourceTree = "<group>"; };
+		268D5DAF1DEE367A00CBEAB3 /* SourcePostAttribution+ManagedObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SourcePostAttribution+ManagedObject.swift"; sourceTree = "<group>"; };
 		26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSiteServiceRemoteTests.swift; sourceTree = "<group>"; };
 		26AE46231DE891B400043CC9 /* ReaderPostCacheProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostCacheProvider.swift; sourceTree = "<group>"; };
 		26AE46251DE89FBF00043CC9 /* ReaderPostCacheProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostCacheProviderTests.swift; sourceTree = "<group>"; };
@@ -2800,6 +2804,7 @@
 				E6374DBE1C444D8B00F24720 /* PublicizeService.swift */,
 				5D42A3DC175E7452005CFF05 /* ReaderPost.h */,
 				5D42A3DD175E7452005CFF05 /* ReaderPost.m */,
+				268D5DAB1DEE35E300CBEAB3 /* ReaderPost+ManagedObject.swift */,
 				E6C09B3D1BF0FDEB003074CB /* ReaderCrossPostMeta.swift */,
 				5DE471B71B4C710E00665C44 /* ReaderPostContentProvider.h */,
 				E6A3384A1BB08E3F00371587 /* ReaderGapMarker.h */,
@@ -2815,6 +2820,7 @@
 				E6E27D611C6144DB0063F821 /* SharingButton.swift */,
 				5DED0E161B432E0400431FCD /* SourcePostAttribution.h */,
 				5DED0E171B432E0400431FCD /* SourcePostAttribution.m */,
+				268D5DAF1DEE367A00CBEAB3 /* SourcePostAttribution+ManagedObject.swift */,
 				319D6E7919E447500013871C /* Suggestion.h */,
 				319D6E7A19E447500013871C /* Suggestion.m */,
 				5DA5BF3318E32DCF005F11F9 /* Theme.h */,
@@ -5811,6 +5817,7 @@
 				B587798619B799EB00E57C5A /* Notification+Interface.swift in Sources */,
 				5D1D9C50198837D0009D13B7 /* RemoteReaderPost.m in Sources */,
 				5D1D9C51198837D0009D13B7 /* RemoteReaderSite.m in Sources */,
+				268D5DB01DEE367A00CBEAB3 /* SourcePostAttribution+ManagedObject.swift in Sources */,
 				591AA5011CEF9BF20074934F /* Post.swift in Sources */,
 				5D1D9C52198837D0009D13B7 /* RemoteReaderTopic.m in Sources */,
 				C545E0A21811B9880020844C /* ContextManager.m in Sources */,
@@ -6297,6 +6304,7 @@
 				931D26FE19EDA10D00114F17 /* ALIterativeMigrator.m in Sources */,
 				E1F8E1231B0B411E0073E628 /* JetpackService.m in Sources */,
 				5DA3EE161925090A00294E0B /* MediaService.m in Sources */,
+				268D5DAC1DEE35E300CBEAB3 /* ReaderPost+ManagedObject.swift in Sources */,
 				E65219FB1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift in Sources */,
 				43AB7C5E1D3E70510066CB6A /* PostListFilterSettings.swift in Sources */,
 				E64E17661CA8518800BE7744 /* NUXSubmitButton.swift in Sources */,

--- a/WordPress/WordPressTest/ReaderPostCacheProviderTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCacheProviderTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import XCTest
+import CoreData
+@testable import WordPress
+
+extension ReaderPost: ManagedObject {
+    @nonobjc static let entityName = "ReaderPost"
+}
+
+extension SourcePostAttribution: ManagedObject {
+    @nonobjc static let entityName = "SourcePostAttribution"
+}
+
+class ReaderPostCacheProviderTests: XCTestCase {
+
+    var context: NSManagedObjectContext!
+    var postHelper: CoreDataHelper<ReaderPost>!
+    var cacheProvider: ReaderPostCacheProvider!
+
+    override func setUp() {
+
+        super.setUp()
+        context = TestContextManager.sharedInstance().mainContext
+        postHelper = CoreDataHelper<ReaderPost>(context: context)
+        cacheProvider = ReaderPostCacheProvider(context: context)
+    }
+
+    func testCouldntFindNormalPost() {
+
+        let cachedPost = cacheProvider.getPostByID(9999, siteID: 10000)
+        XCTAssertNil(cachedPost)
+    }
+
+    func testGetNormalPost() {
+
+        let insertedPost = insertNormalPostWithID(1, siteID: 2)
+        let cachedPost = cacheProvider.getPostByID(1, siteID: 2)
+        XCTAssertEqual(insertedPost, cachedPost)
+    }
+
+    func testGetCrossPost() {
+
+        let insertedPost = insertCrossPostWithID(10, siteID: 20)
+        let cachedPost = cacheProvider.getPostByID(10, siteID: 20)
+        XCTAssertEqual(insertedPost, cachedPost)
+    }
+
+    func testGetAttributionPost() {
+
+        let insertedPost = insertAttributionPostWithID(20, siteID: 30)
+        let cachedPost = cacheProvider.getPostByID(20, siteID: 30)
+        XCTAssertEqual(insertedPost, cachedPost)
+    }
+
+    func insertNormalPostWithID(postID: Int, siteID: Int) -> ReaderPost {
+
+        let post = postHelper.insertNewObject()
+        post.postID = postID
+        post.siteID = siteID
+        _ = try? context.save()
+        return post
+    }
+
+    func insertAttributionPostWithID(postID: Int, siteID: Int) -> ReaderPost {
+
+        let attributionHelper = CoreDataHelper<SourcePostAttribution>(context: context)
+        let attribution = attributionHelper.insertNewObject()
+        attribution.postID = postID
+        attribution.blogID = siteID
+
+        let post = postHelper.insertNewObject()
+        post.sourceAttribution = attribution
+
+        _ = try? context.save()
+        return post
+    }
+
+    func insertCrossPostWithID(postID: Int, siteID: Int) -> ReaderPost {
+
+        let crossHelper = CoreDataHelper<ReaderCrossPostMeta>(context: context)
+        let cross = crossHelper.insertNewObject()
+        cross.postID = postID
+        cross.siteID = siteID
+
+        let post = postHelper.insertNewObject()
+        post.crossPostMeta = cross
+
+        _ = try? context.save()
+        return post
+    }
+}

--- a/WordPress/WordPressTest/ReaderPostCacheProviderTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCacheProviderTests.swift
@@ -3,14 +3,6 @@ import XCTest
 import CoreData
 @testable import WordPress
 
-extension ReaderPost: ManagedObject {
-    @nonobjc static let entityName = "ReaderPost"
-}
-
-extension SourcePostAttribution: ManagedObject {
-    @nonobjc static let entityName = "SourcePostAttribution"
-}
-
 class ReaderPostCacheProviderTests: XCTestCase {
 
     var context: NSManagedObjectContext!

--- a/WordPress/WordPressTest/ReaderPostCacheProviderTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCacheProviderTests.swift
@@ -25,15 +25,15 @@ class ReaderPostCacheProviderTests: XCTestCase {
         cacheProvider = ReaderPostCacheProvider(context: context)
     }
 
-    func testCouldntFindNormalPost() {
+    func testCouldntFindOriginalPost() {
 
         let cachedPost = cacheProvider.getPostByID(9999, siteID: 10000)
         XCTAssertNil(cachedPost)
     }
 
-    func testGetNormalPost() {
+    func testGetOriginalPost() {
 
-        let insertedPost = insertNormalPostWithID(1, siteID: 2)
+        let insertedPost = insertOriginalPostWithID(1, siteID: 2)
         let cachedPost = cacheProvider.getPostByID(1, siteID: 2)
         XCTAssertEqual(insertedPost, cachedPost)
     }
@@ -52,7 +52,15 @@ class ReaderPostCacheProviderTests: XCTestCase {
         XCTAssertEqual(insertedPost, cachedPost)
     }
 
-    func insertNormalPostWithID(postID: Int, siteID: Int) -> ReaderPost {
+    func testGetOriginalPostFromMultiplePosts() {
+
+        let originalPost = insertOriginalPostWithID(2, siteID: 3)
+        _ = insertAttributionPostWithID(2, siteID: 3)
+        let cachedPost = cacheProvider.getPostByID(2, siteID: 3)
+        XCTAssertEqual(originalPost, cachedPost)
+    }
+
+    func insertOriginalPostWithID(postID: Int, siteID: Int) -> ReaderPost {
 
         let post = postHelper.insertNewObject()
         post.postID = postID

--- a/WordPress/WordPressTest/WordPressTest-Bridging-Header.h
+++ b/WordPress/WordPressTest/WordPressTest-Bridging-Header.h
@@ -12,6 +12,7 @@
 #import "RemoteMedia.h"
 #import "RemoteReaderSite.h"
 #import "MediaServiceRemote.h"
+#import "SourcePostAttribution.h"
 #import "MediaServiceRemoteREST.h"
 #import "ReaderSiteServiceRemote.h"
 #import "UIAlertControllerProxy.h"


### PR DESCRIPTION
Retales to #6240 

This class will be hooked in a later PR to the `ReaderPostService` class.
It's only responsibility is to retrieve a cached `ReaderPost` based on a `postID` and a `siteID`

Which is the information passed on `ReaderStreamViewController`

```swift
var controller: ReaderDetailViewController
        if post.sourceAttributionStyle() == .Post &&
            post.sourceAttribution.postID != nil &&
            post.sourceAttribution.blogID != nil {

            controller = ReaderDetailViewController.controllerWithPostID(post.sourceAttribution.postID!, siteID: post.sourceAttribution.blogID!)

        } else if post.isCrossPost() {
            controller = ReaderDetailViewController.controllerWithPostID(post.crossPostMeta.postID, siteID: post.crossPostMeta.siteID)

        } else {
            controller = ReaderDetailViewController.controllerWithPost(post)

        }
```
[Source](https://github.com/wordpress-mobile/WordPress-iOS/blob/9d1bf0eb6a6eb00f92df8ab06bb1116506b5c01c/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift#L1702)

@aerych would you mind to review to see if this is the right direction? 😬