### PR TITLE
Linking Device Settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -102,23 +102,20 @@ class AppSettingsViewController: UITableViewController {
     // MARK: - Actions
 
     func mediaSizeChanged() -> Int -> Void {
-        return {
-            value in
+        return { value in
             MediaSettings().maxImageSizeSetting = value
             ShareExtensionService.configureShareExtensionMaximumMediaDimension(value)
         }
     }
 
     func mediaRemoveLocationChanged() -> Bool -> Void {
-        return {
-            value in
+        return { value in
             MediaSettings().removeLocationSetting = value
         }
     }
 
     func visualEditorChanged() -> Bool -> Void {
-        return {
-            enabled in
+        return { enabled in
             if enabled {
                 WPAnalytics.track(.EditorToggledOn)
             } else {
@@ -130,8 +127,7 @@ class AppSettingsViewController: UITableViewController {
     }
 
     func nativeEditorChanged() -> Bool -> Void {
-        return {
-            enabled in
+        return { enabled in
             EditorSettings().nativeEditorEnabled = enabled
         }
     }

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -8,10 +8,6 @@ class AppSettingsViewController: UITableViewController {
     private var handler: ImmuTableViewHandler!
     // MARK: - Initialization
 
-    deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
-    }
-
     override init(style: UITableViewStyle) {
         super.init(style: style)
         navigationItem.title = NSLocalizedString("App Settings", comment: "App Settings Title")
@@ -38,18 +34,6 @@ class AppSettingsViewController: UITableViewController {
         handler.viewModel = tableViewModel()
 
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
-    }
-
-    override func viewWillAppear(animated: Bool) {
-        super.viewWillAppear(animated)
-
-        let nc = NSNotificationCenter.defaultCenter()
-        nc.addObserver(self, selector: #selector(applicationWillEnterForeground), name: UIApplicationWillEnterForegroundNotification, object: nil)
-    }
-
-    override func viewWillDisappear(animated: Bool) {
-        super.viewWillDisappear(animated)
-        NSNotificationCenter.defaultCenter().removeObserver(self)
     }
 
 
@@ -163,19 +147,11 @@ class AppSettingsViewController: UITableViewController {
 
     func openApplicationSettings() -> ImmuTableAction {
         return { row in
-            guard let targetURL = NSURL(string: UIApplicationOpenSettingsURLString) else {
-                NSLog("Error while unwrapping Settings URL")
-                return
-            }
+            let targetURL = NSURL(string: UIApplicationOpenSettingsURLString)
+            precondition(targetURL != nil)
 
-            UIApplication.sharedApplication().openURL(targetURL)
+            self.tableView.deselectSelectedRowWithAnimation(true)
+            UIApplication.sharedApplication().openURL(targetURL!)
         }
-    }
-
-
-    // MARK: - Notification Handlers
-
-    @objc func applicationWillEnterForeground(sender: AnyObject) {
-        tableView.deselectSelectedRowWithAnimation(true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 import WordPressShared
 import WordPressComAnalytics
 
-public class AppSettingsViewController: UITableViewController {
+class AppSettingsViewController: UITableViewController {
 
     private var handler: ImmuTableViewHandler!
     // MARK: - Initialization
@@ -13,15 +13,15 @@ public class AppSettingsViewController: UITableViewController {
         navigationItem.title = NSLocalizedString("App Settings", comment: "App Settings Title")
     }
 
-    public required init?(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public required convenience init() {
+    required convenience init() {
         self.init(style: .Grouped)
     }
 
-    public override func viewDidLoad() {
+    override func viewDidLoad() {
         super.viewDidLoad()
 
         ImmuTable.registerRows([

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -147,11 +147,13 @@ class AppSettingsViewController: UITableViewController {
 
     func openApplicationSettings() -> ImmuTableAction {
         return { row in
-            let targetURL = NSURL(string: UIApplicationOpenSettingsURLString)
-            precondition(targetURL != nil)
+            if let targetURL = NSURL(string: UIApplicationOpenSettingsURLString) {
+                UIApplication.sharedApplication().openURL(targetURL)
+            } else {
+                assertionFailure("Couldn't unwrap Settings URL")
+            }
 
             self.tableView.deselectSelectedRowWithAnimation(true)
-            UIApplication.sharedApplication().openURL(targetURL!)
         }
     }
 }


### PR DESCRIPTION
Fixes #6057

### To test:
1. Log into a dotcom account
2. Open `Me` > `App Settings`
3. Tap over the `Open Device Settings` row

Verify that the OS Settings for WPiOS show up onscreen. Tap the top left button to reopen wpios, and verify that the row gets properly de-highlighted.

Needs review: @aerych 
Sir, may i bug you with a review?

Thanks in advance!
