### PR TITLE
PersonViewController: Updates Interface Messages

### DIFF
--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -186,7 +186,8 @@ private extension PersonViewController {
     }
 
     func removeWasPressed() {
-        let title = NSLocalizedString("Remove", comment: "Remove Alert Title") + " " + person.username
+        let titleFormat = NSLocalizedString("Remove %@", comment: "Remove Person Alert Title")
+        let titleText = String(format: titleFormat, person.username)
 
         let name = person.firstName?.nonEmptyString() ?? person.username
         let messageFirstLine = NSLocalizedString(
@@ -202,7 +203,7 @@ private extension PersonViewController {
         let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel Action")
         let removeTitle = NSLocalizedString("Remove", comment: "Remove Action")
 
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .Alert)
+        let alert = UIAlertController(title: titleText, message: message, preferredStyle: .Alert)
 
         alert.addCancelActionWithTitle(cancelTitle)
 
@@ -305,8 +306,9 @@ private extension PersonViewController {
     }
 
     func setupRemoveCell() {
-        let removeText = NSLocalizedString("Remove", comment: "Remove. Verb")
-        removeCell.textLabel?.text = removeText + " " + person.username
+        let removeFormat = NSLocalizedString("Remove %@", comment: "Remove User. Verb")
+        let removeText = String(format: removeFormat, person.username)
+        removeCell.textLabel?.text = removeText as String
         WPStyleGuide.configureTableViewDestructiveActionCell(removeCell)
     }
 }

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -255,8 +255,8 @@ private extension PersonViewController {
         let retryTitle          = NSLocalizedString("Retry", comment: "Retry updating User's Role")
         let cancelTitle         = NSLocalizedString("Cancel", comment: "Cancel updating User's Role")
         let title               = NSLocalizedString("Sorry!", comment: "Update User Failed Title")
-        let localizedError      = NSLocalizedString("There was an error updating @", comment: "Updating Role failed error message")
-        let messageText         = localizedError + person.username
+        let localizedError      = NSLocalizedString("There was an error updating @%@", comment: "Updating Role failed error message")
+        let messageText         = String(format: localizedError, person.username)
 
         let alertController = UIAlertController(title: title, message: messageText, preferredStyle: .Alert)
 

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -186,7 +186,7 @@ private extension PersonViewController {
     }
 
     func removeWasPressed() {
-        let titleFormat = NSLocalizedString("Remove %@", comment: "Remove Person Alert Title")
+        let titleFormat = NSLocalizedString("Remove @%@", comment: "Remove Person Alert Title")
         let titleText = String(format: titleFormat, person.username)
 
         let name = person.firstName?.nonEmptyString() ?? person.username
@@ -306,7 +306,7 @@ private extension PersonViewController {
     }
 
     func setupRemoveCell() {
-        let removeFormat = NSLocalizedString("Remove %@", comment: "Remove User. Verb")
+        let removeFormat = NSLocalizedString("Remove @%@", comment: "Remove User. Verb")
         let removeText = String(format: removeFormat, person.username)
         removeCell.textLabel?.text = removeText as String
         WPStyleGuide.configureTableViewDestructiveActionCell(removeCell)

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -186,8 +186,9 @@ private extension PersonViewController {
     }
 
     func removeWasPressed() {
+        let title = NSLocalizedString("Remove", comment: "Remove Alert Title") + " " + person.username
+
         let name = person.firstName?.nonEmptyString() ?? person.username
-        let title = NSLocalizedString("Remove User", comment: "Remove User Alert Title")
         let messageFirstLine = NSLocalizedString(
             "If you remove " + name + ", that user will no longer be able to access this site, " +
             "but any content that was created by " + name + " will remain on the site.",
@@ -250,11 +251,13 @@ private extension PersonViewController {
     }
 
     func retryUpdatingRole(newRole: Role) {
-        let retryTitle      = NSLocalizedString("Retry", comment: "Retry updating User's Role")
-        let cancelTitle     = NSLocalizedString("Cancel", comment: "Cancel updating User's Role")
-        let title           = NSLocalizedString("Sorry!", comment: "Update User Failed Title")
-        let message         = NSLocalizedString("Something went wrong while updating the User's Role.", comment: "Updating Role failed error message")
-        let alertController = UIAlertController(title: title, message: message, preferredStyle: .Alert)
+        let retryTitle          = NSLocalizedString("Retry", comment: "Retry updating User's Role")
+        let cancelTitle         = NSLocalizedString("Cancel", comment: "Cancel updating User's Role")
+        let title               = NSLocalizedString("Sorry!", comment: "Update User Failed Title")
+        let localizedError      = NSLocalizedString("There was an error updating @", comment: "Updating Role failed error message")
+        let messageText         = localizedError + person.username
+
+        let alertController = UIAlertController(title: title, message: messageText, preferredStyle: .Alert)
 
         alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
         alertController.addDefaultActionWithTitle(retryTitle) { action in
@@ -302,7 +305,8 @@ private extension PersonViewController {
     }
 
     func setupRemoveCell() {
-        removeCell.textLabel?.text = NSLocalizedString("Remove User", comment: "Remove User. Verb")
+        let removeText = NSLocalizedString("Remove", comment: "Remove. Verb")
+        removeCell.textLabel?.text = removeText + " " + person.username
         WPStyleGuide.configureTableViewDestructiveActionCell(removeCell)
     }
 }
@@ -383,13 +387,13 @@ private extension PersonViewController {
         return isUser == false
     }
 
-    var isPromoteEnabled : Bool {
+    var isPromoteEnabled: Bool {
         // Note: *Only* users can be promoted.
         //
         return blog.isUserCapableOf(.PromoteUsers) && isMyself == false && isUser == true
     }
 
-    var isRemoveEnabled : Bool {
+    var isRemoveEnabled: Bool {
         // Notes:
         //  -   YES, ListUsers. Brought from Calypso's code
         //  -   Followers, for now, cannot be deleted.
@@ -397,11 +401,11 @@ private extension PersonViewController {
         return blog.isUserCapableOf(.ListUsers) && isMyself == false && isUser == true
     }
 
-    var isUser : Bool {
+    var isUser: Bool {
         return user != nil
     }
 
-    var user : User? {
+    var user: User? {
         return person as? User
     }
 }


### PR DESCRIPTION
Fixes #5670

### To test:
1. Set up a site with two users: the site owner and a second account you are using in the app
2. Open the app (logged in to the second account)
3. Go to My Site > People
4. Select the site owner in the list of users
4. Try to change the user's role. 
5. Verify that an alert shows up, with the following text: `There was an error updating @[username]`
6. Verify that the Remove User row now reads `Remove @[username]` instead of `Remove User`


Needs review: @frosty 
Sir, may i bug you with a quick review?. Thanks in advance!

Thanks @rachelmcr for spotting this one!!

