### PR TITLE
Updates Invalid Password Message

### DIFF
--- a/WordPress/Classes/Networking/WordPressComServiceRemote.m
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.m
@@ -241,7 +241,7 @@
     } else if ([errorCode isEqualToString:@"blog_name_reserved_but_may_be_available"]) {
         return NSLocalizedString(@"That site is currently reserved but may be available in a couple days.", nil);
     } else if ([errorCode isEqualToString:@"password_invalid"]) {
-        return NSLocalizedString(@"Sorry, that password does not meet our security guidelines. Please choose a password with a mix of uppercase letters, lowercase letters, numbers and symbols.", @"This error message occurs when a user tries to create an account with a weak password.");
+        return NSLocalizedString(@"Sorry, that password does not meet our security guidelines. Please choose a password with a minimum length of six characters, mixing uppercase letters, lowercase letters, numbers and symbols.", @"This error message occurs when a user tries to create an account with a weak password.");
     } else if ([errorCode isEqualToString:@"blog_title_invalid"]) {
         return NSLocalizedString(@"Invalid Site Title", @"");
     } else if ([errorCode isEqualToString:@"username_illegal_wpcom"]) {


### PR DESCRIPTION
### Details:
We recently got a support request via Helpshift, regarding issues creating an account. After a brief check, we've noticed the minimum password length isn't being adviced anywhere.

In this PR we're just updating the `Invalid Password` message, to indicate that the minimum required length is 6 characters.

### To Test:
1. Fresh install the app
2. Attempt to create a new account, with a 1 character password
3. Verify that the Error message reads as follows:

```
Sorry, that password does not meet our security guidelines. Please choose a password with a minimum length of six characters, mixing uppercase letters, lowercase letters, numbers and symbols.
```

Needs review: @nheagy 
Nate, may i bug you with a quick review?

Thanks!!!

cc @mzorz @oguzkocer 

