### PR TITLE
Invite People: Private Sites

### DIFF
--- a/WordPress/Classes/Models/Person.swift
+++ b/WordPress/Classes/Models/Person.swift
@@ -214,7 +214,8 @@ extension Role {
     // MARK: - Static Properties
     //
     static let inviteRoles: [Role] = [.Follower, .Admin, .Editor, .Author, .Contributor]
-    static let inviteRolesForPrivateSite: [Role] = [.Viewer, .Follower, .Admin, .Editor, .Author, .Contributor]
+    static let inviteRolesForPrivateSite: [Role] = [.Viewer, .Admin, .Editor, .Author, .Contributor]
+
 
     // MARK: - Private Properties
     //

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -32,7 +32,7 @@ class InvitePersonViewController : UITableViewController {
 
     /// Invitation Role
     ///
-    private var role : Role = .Follower {
+    private var role: Role = .Follower {
         didSet {
             refreshRoleCell()
             validateInvitation()
@@ -41,7 +41,7 @@ class InvitePersonViewController : UITableViewController {
 
     /// Invitation Message
     ///
-    private var message : String? {
+    private var message: String? {
         didSet {
             refreshMessageTextView()
 
@@ -52,7 +52,7 @@ class InvitePersonViewController : UITableViewController {
 
     /// Last Section Index
     ///
-    private var lastSectionIndex : Int {
+    private var lastSectionIndex: Int {
         return tableView.numberOfSections - 1
     }
 
@@ -65,7 +65,7 @@ class InvitePersonViewController : UITableViewController {
 
     /// Username Cell
     ///
-    @IBOutlet private var usernameCell : UITableViewCell! {
+    @IBOutlet private var usernameCell: UITableViewCell! {
         didSet {
             setupUsernameCell()
             refreshUsernameCell()
@@ -74,7 +74,7 @@ class InvitePersonViewController : UITableViewController {
 
     /// Role Cell
     ///
-    @IBOutlet private var roleCell : UITableViewCell! {
+    @IBOutlet private var roleCell: UITableViewCell! {
         didSet {
             setupRoleCell()
             refreshRoleCell()
@@ -83,7 +83,7 @@ class InvitePersonViewController : UITableViewController {
 
     /// Message Cell
     ///
-    @IBOutlet private var messageTextView : UITextView! {
+    @IBOutlet private var messageTextView: UITextView! {
         didSet {
             setupMessageTextView()
             refreshMessageTextView()

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -50,6 +50,12 @@ class InvitePersonViewController : UITableViewController {
         }
     }
 
+    /// Roles available for the current site
+    ///
+    private var availableRoles: [Role] {
+        return (blog.siteVisibility == .Private) ? Role.inviteRolesForPrivateSite : Role.inviteRoles
+    }
+
     /// Last Section Index
     ///
     private var lastSectionIndex: Int {
@@ -97,6 +103,7 @@ class InvitePersonViewController : UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNavigationBar()
+        setupDefaultRole()
         WPStyleGuide.configureColorsForView(view, andTableView: tableView)
     }
 
@@ -165,9 +172,7 @@ class InvitePersonViewController : UITableViewController {
             return
         }
 
-        let roles = (blog.siteVisibility == .Private) ? Role.inviteRolesForPrivateSite : Role.inviteRoles
-
-        roleViewController.mode = .Static(roles: roles)
+        roleViewController.mode = .Static(roles: availableRoles)
         roleViewController.selectedRole = role
         roleViewController.onChange = { [unowned self] newRole in
             self.role = newRole
@@ -362,6 +367,14 @@ private extension InvitePersonViewController {
 
         // By default, Send is disabled
         navigationItem.rightBarButtonItem?.enabled = false
+    }
+
+    func setupDefaultRole() {
+        guard let firstRole = availableRoles.first else {
+            return
+        }
+
+        role = firstRole
     }
 }
 


### PR DESCRIPTION
### Details:
This PR updates the list of available roles to invite people, whenever the target blog is set to Private.

Fixes #5676 

### To test:
1. Open `My Sites` tab and pick up any of your testing blogs
2. Set its visibility to Private (`Settings` > `Privacy` > `Private`)
3. Open the People Management UI (`My Sites` > `Blog` > `People`)
4. Tap the plus sign in the top right to invite a new user.

Verify that (A) the preselected role is `Viewer`, and (B) if you attempt to change the role, `Follower` doesn't show up in the list.

Needs review: @diegoreymendez 
Diego, may i bug you with a quick PR?

Thanks!

