### PR TITLE
Add inline reply to comment notifications

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -79,7 +79,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:accountInContext];
 
         [[PushNotificationsManager sharedInstance] registerForRemoteNotifications];
-        [[InteractiveNotificationsManager sharedInstance] registerForUserNotifications];
+        [[InteractiveNotificationsManager sharedInstance] requestAuthorization];
     };
     if ([NSThread isMainThread]) {
         // This is meant to help with testing account observers.

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -122,6 +122,7 @@ int ddLogLevel = DDLogLevelInfo;
     DDLogVerbose(@"didFinishLaunchingWithOptions state: %d", application.applicationState);
     [self.window makeKeyAndVisible];
 
+    [[InteractiveNotificationsManager sharedInstance] registerForUserNotifications];
     [self showWelcomeScreenIfNeededAnimated:NO];
     [self setupLookback];
     [self setupAppbotX];
@@ -446,10 +447,11 @@ int ddLogLevel = DDLogLevelInfo;
 
 - (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier
                                         forRemoteNotification:(NSDictionary *)remoteNotification
+                                             withResponseInfo:(NSDictionary *)responseInfo
                                             completionHandler:(void (^)())completionHandler
 {
-    [[InteractiveNotificationsManager sharedInstance] handleActionWithIdentifier:identifier remoteNotification:remoteNotification];
-    
+    NSString *responseText = responseInfo[UIUserNotificationActionResponseTypedTextKey];
+    [[InteractiveNotificationsManager sharedInstance] handleActionWithIdentifier:identifier remoteNotification:remoteNotification responseText:responseText];
     completionHandler();
 }
 

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -120,7 +120,7 @@ final public class InteractiveNotificationsManager : NSObject
     ///     - siteID: The site identifier
     ///
     private func likeCommentWithCommentID(commentID: NSNumber, siteID: NSNumber) {
-        let context = ContextManager.sharedInstance().newDerivedContext()
+        let context = ContextManager.sharedInstance().mainContext
         let service = CommentService(managedObjectContext: context)
 
         service.likeCommentWithID(commentID, siteID: siteID, success: {
@@ -138,7 +138,7 @@ final public class InteractiveNotificationsManager : NSObject
     ///     - siteID: The site identifier
     ///
     private func approveCommentWithCommentID(commentID: NSNumber, siteID: NSNumber) {
-        let context = ContextManager.sharedInstance().newDerivedContext()
+        let context = ContextManager.sharedInstance().mainContext
         let service = CommentService(managedObjectContext: context)
 
         service.approveCommentWithID(commentID, siteID: siteID, success: {
@@ -166,7 +166,7 @@ final public class InteractiveNotificationsManager : NSObject
     ///     - content: The text for the comment reply
     ///
     private func replyToCommentWithCommentID(commentID: NSNumber, siteID: NSNumber, content: String) {
-        let context = ContextManager.sharedInstance().newDerivedContext()
+        let context = ContextManager.sharedInstance().mainContext
         let service = CommentService(managedObjectContext: context)
 
         service.replyToCommentWithID(commentID, siteID: siteID, content: content, success: {

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -71,7 +71,7 @@ final public class InteractiveNotificationsManager : NSObject
             return
         }
 
-        guard let action = NoteActionDefinition(rawValue: identifier) else {
+        guard let noteId = remoteNotification.objectForKey("note_id") as? NSNumber else {
             return
         }
 
@@ -80,6 +80,17 @@ final public class InteractiveNotificationsManager : NSObject
         }
 
         guard let commentID = remoteNotification.objectForKey("comment_id") as? NSNumber else {
+            return
+        }
+
+        if #available(iOS 10.0, *) {
+            if identifier == UNNotificationDefaultActionIdentifier {
+                showDetailsWithNoteID(noteId)
+                return
+            }
+        }
+
+        guard let action = NoteActionDefinition(rawValue: identifier) else {
             return
         }
 
@@ -136,6 +147,16 @@ final public class InteractiveNotificationsManager : NSObject
             DDLogSwift.logInfo("Couldn't moderate comment from push notification")
         })
     }
+
+
+    /// Opens the details for a given notificationId
+    ///
+    /// - Parameter noteID: The Notification's Identifier
+    ///
+    private func showDetailsWithNoteID(noteId: NSNumber) {
+        WPTabBarController.sharedInstance().showNotificationsTabForNoteWithID(noteId.stringValue)
+    }
+
 
     /// Replies to a comment
     ///

--- a/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
@@ -60,7 +60,7 @@ import UIKit
         NSUserDefaults.standardUserDefaults().setBool(true, forKey: UserDefaultsHelpshiftWasUsed)
 
         PushNotificationsManager.sharedInstance.registerForRemoteNotifications()
-        InteractiveNotificationsManager.sharedInstance.registerForUserNotifications()
+        InteractiveNotificationsManager.sharedInstance.requestAuthorization()
 
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)


### PR DESCRIPTION
Adds inline comment reply to notifications.

Fixes #2036 

## Some design changes

I've split the registration of categories and authorization in two. iOS 9 keeps the old behavior but iOS 10+ will always register notification categories on launch. Otherwise, changes to those categories would only be picked by iOS when we requested authorization (i.e. you had to sign out and back in).

I've reversed the order of actions on `CommentReplyWithLike`. Specially for iOS9, where the first item looks like the primary action (blue vs grey). I personally think we should encourage reply over like, but that's a design decision that's not really related to inline reply, so I could use a second opinion.

## Screenshots

### iOS 9

![img_0027](https://cloud.githubusercontent.com/assets/8739/20793980/fda77314-b7c9-11e6-9409-07cb315bab27.PNG)
![img_0028](https://cloud.githubusercontent.com/assets/8739/20793985/083da500-b7ca-11e6-9cec-24c4e28db142.PNG)

### iOS 10

![screen shot 2016-12-01 at 13 16 09](https://cloud.githubusercontent.com/assets/8739/20793990/104965f4-b7ca-11e6-8406-166d4d0c6388.png)
![screen shot 2016-12-01 at 13 16 13](https://cloud.githubusercontent.com/assets/8739/20793997/13ba53ce-b7ca-11e6-8005-b057dbb31d7c.png)


## Testing

- Run the app. If testing on iOS 9, sign out and back in or do a fresh install so the system picks up the new notification categories.
- Put the app in the background.
- Leave a comment on the site.
- Verify that you can reply from the notification and that the comment is successfully posted.

Needs review: @jleandroperez 