### PR TITLE
Reader: Fixes an issue where text could vanish for some posts.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -58,7 +58,7 @@ class WPRichContentView: UITextView
 
         set {
             var bounds = topMarginAttachment.bounds
-            bounds.size.height = newValue
+            bounds.size.height = max(1, newValue)
             bounds.size.width = textContainer.size.width
             topMarginAttachment.bounds = bounds
 
@@ -70,6 +70,9 @@ class WPRichContentView: UITextView
         }
     }
 
+    // NOTE: Avoid setting attachment bounds with a zero height. A zero height
+    // for an attachment at the end of a text run can glitch TextKit's layout
+    // causing glyphs to not be drawn.
     var bottomMargin: CGFloat {
         get {
             return bottomMarginAttachment.bounds.height
@@ -77,7 +80,7 @@ class WPRichContentView: UITextView
 
         set {
             var bounds = bottomMarginAttachment.bounds
-            bounds.size.height = newValue
+            bounds.size.height = max(1, newValue)
             bounds.size.width = textContainer.size.width
             bottomMarginAttachment.bounds = bounds
 


### PR DESCRIPTION
We've received several reports about posts in the reader displaying correctly at first, but then the text vanishes when scrolling. Props @rachelmcr @roundhill and @ebinnion for the reports. 

The cause appears to be when the NSTextAttachment used to reserve space for a footer view has a height of zero. It only seems to happen on certain posts, but on those posts it happens consistently.  The posts are on private blogs so ping me for the URLs. 

To test:
Confirm the glitch in the release/6.8 branch on any of the affected posts.  
Switch to the branch in this PR and confirm that

Needs review: @jleandroperez would you mind taking a look at this one? 

