### PR TITLE
Reader: Fixes a breaking constraint on the reader detail.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -247,7 +247,7 @@
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="lUA-Mu-a4u" secondAttribute="trailing" id="29T-ZN-CUn"/>
                                             <constraint firstItem="lUA-Mu-a4u" firstAttribute="top" secondItem="UJH-3y-QkU" secondAttribute="top" id="Jbh-tW-3mu"/>
-                                            <constraint firstAttribute="bottom" secondItem="lUA-Mu-a4u" secondAttribute="bottom" constant="16" id="Wvl-3O-WyW"/>
+                                            <constraint firstAttribute="bottom" secondItem="lUA-Mu-a4u" secondAttribute="bottom" priority="999" constant="16" id="Wvl-3O-WyW"/>
                                             <constraint firstItem="lUA-Mu-a4u" firstAttribute="leading" secondItem="UJH-3y-QkU" secondAttribute="leading" id="f82-aL-C6b"/>
                                         </constraints>
                                         <connections>


### PR DESCRIPTION
I noticed a breaking constraint in the reader detail when the attribution footer was not being shown.  This PR changes that view's height constraint priority to 999 to avoid the breakage. 

To test:
View the detail and check in the console that the constraint does not break.

Needs review: @nheagy could I trouble you for this one? 

