### PR TITLE
Reader: Fixes placement of attachment subviews after updating margins.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -66,6 +66,7 @@ class WPRichContentView: UITextView
                 let rng = NSRange(location: 0, length: 1)
                 layoutManager.invalidateLayoutForCharacterRange(rng, actualCharacterRange: nil)
                 layoutManager.ensureLayoutForCharacterRange(rng)
+                attachmentManager.layoutAttachmentViews()
             }
         }
     }
@@ -85,6 +86,7 @@ class WPRichContentView: UITextView
                 let rng = NSRange(location: textStorage.length - 2, length: 1)
                 layoutManager.invalidateLayoutForCharacterRange(rng, actualCharacterRange: nil)
                 layoutManager.ensureLayoutForCharacterRange(rng)
+                attachmentManager.layoutAttachmentViews()
             }
         }
     }


### PR DESCRIPTION
Fixes an issue where subviews associated with text attachments were not correctly re-positioned after changing margin height.  This is most noticeable when multitasking on the iPad. Props @frosty for the find.  

To test:
View the post detail on the iPad Pro. 
Swipe to open the multitasking window and enter side by side mode. 
Drag the app separator to switch between 50/50 and 1/4 split screen. 
Confirm that images are correctly positioned after changing split screen size.

Needs review: @frosty would you do the honors? 
