### PR TITLE
Fixes an issue where an empty string could cause a crash.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -120,7 +120,12 @@ class WPRichContentView: UITextView
 
                     // Ensure the starting paragraph style is applied to the topMarginAttachment else the
                     // first paragraph might not have the correct line height.
-                    let paraStyle = attrTxt.attribute(NSParagraphStyleAttributeName, atIndex: 0, effectiveRange: nil) as? NSParagraphStyle ?? NSParagraphStyle.defaultParagraphStyle()
+                    var paraStyle = NSParagraphStyle.defaultParagraphStyle()
+                    if attrTxt.length > 0 {
+                        if let pstyle = attrTxt.attribute(NSParagraphStyleAttributeName, atIndex: 0, effectiveRange: nil) as? NSParagraphStyle {
+                            paraStyle = pstyle
+                        }
+                    }
                     mattrTxt.insertAttributedString(NSAttributedString(attachment: topMarginAttachment), atIndex: 0)
                     mattrTxt.addAttributes([NSParagraphStyleAttributeName: paraStyle], range: NSRange(location: 0, length: 1))
                     mattrTxt.appendAttributedString(NSAttributedString(attachment: bottomMarginAttachment))


### PR DESCRIPTION
This PR fixes an issue where a post with an empty string for content would cause a crash trying to retrieve the paragraph style from an attributed string.  Props @kurzee for the find.

To test:
Try viewing a post with an empty string for its content.   Confirm there is no crash.

Needs review: @kurzee 

