### PR TITLE
Editor: Fixes status HUD being dismissed too early after posting

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1497,7 +1497,7 @@ EditImageDetailsViewControllerDelegate
                         } else {
                             hudText = NSLocalizedString(@"Saved!", @"Text displayed in HUD after a post was successfully saved as a draft.");
                         }
-                        [SVProgressHUD dismiss];
+
                         [SVProgressHUD showSuccessWithStatus:hudText];
                         [WPNotificationFeedbackGenerator notificationOccurred:WPNotificationFeedbackTypeSuccess];
 
@@ -1512,7 +1512,7 @@ EditImageDetailsViewControllerDelegate
                         } else {
                             hudText = NSLocalizedString(@"Error occurred\nduring saving", @"Text displayed in HUD after attempting to save a draft post and an error occurred.");
                         }
-                        [SVProgressHUD dismiss];
+
                         [SVProgressHUD showErrorWithStatus:hudText];
                         [WPNotificationFeedbackGenerator notificationOccurred:WPNotificationFeedbackTypeError];
 


### PR DESCRIPTION
After publishing a post, we should show a "Published!" status after the "Publishing..." HUD appears if the post was published successfully. If the publish fails, we should show an error stating that something went wrong.

It seems like these final statuses weren't being displayed because we were calling `dismiss` on the HUD just before we tried to show them. I've removed the calls to dismiss, and it seems to work as expected now:

![post-post-hud](https://cloud.githubusercontent.com/assets/4780/20833850/9993530a-b889-11e6-8bc2-4af8d1613c6c.gif)

To test:

* Publish a post and ensure you see the "Published!" status.
* Attempt to publish a post resulting in a failure (you could tweak `-[PostService uploadPost:success:failure]` to call failure instead of success) and ensure you see an error status.

Needs review: @astralbodies looks like you touched this code recently – would you mind?