### PR TITLE
Issue/6255 Show Publish Now action for self-hosted non-Jetpack sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1282,7 +1282,9 @@ EditImageDetailsViewControllerDelegate
 - (UIAlertAction *)quickSaveAlertAction
 {
     if ([self.post.status isEqualToString:PostStatusDraft]) {
-        if ([self.post.blog isPublishingPostsAllowed]) {
+        // Self-hosted non-Jetpack blogs have no capabilities, so we'll default
+        // to showing Publish Now instead of Submit for Review.
+        if (!self.post.blog.capabilities || [self.post.blog isPublishingPostsAllowed]) {
             return [UIAlertAction actionWithTitle:NSLocalizedString(@"Publish Now", "Title of button allowing the user to immediately publish the post they are editing.")
                                             style:UIAlertActionStyleDestructive
                                           handler:^(UIAlertAction * _Nonnull action) {


### PR DESCRIPTION
Fixes #6255.

The new "quick publish" action (#6207) adds either a Save as Draft, Publish Now, or Submit for Review action to the `...` menu in the editor.

We were determining whether to show Publish Now or Submit for Draft based on the blog's `capabilities` – if it contains `publish_posts` then show Publish Now, otherwise Submit for Draft.

However, self-hosted blogs don't have `capabilities`, and we don't currently seem to have any way to determine user role / permissions. Because of this, we were always showing "Submit for Review". I've updated the logic to default to "Publish Now" if no capabilities are present.

To test:

* Start a new post for a self-hosted non-Jetpack site.
* Save the post as a draft (you can use the quick action in the `...` menu)
* Open the `...` menu and you should see Publish Now as the top option.

Needs review: @kurzee
cc @rachelmcr 