### PR TITLE
WPAddPostCategoryViewController: Thread Safety makes us Happy

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Categories/WPAddPostCategoryViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Categories/WPAddPostCategoryViewController.m
@@ -112,18 +112,20 @@ static const CGFloat HorizontalMargin = 15.0f;
                                         [self removeProgressIndicator];
                                         [self dismissWithCategory:category];
                                     } failure:^(NSError *error) {
-                                        [self removeProgressIndicator];
+                                        dispatch_async(dispatch_get_main_queue(), ^{
+                                            [self removeProgressIndicator];
 
-                                        if ([error code] == 403) {
-                                            [WPError showAlertWithTitle:NSLocalizedString(@"Couldn't Connect", @"") message:NSLocalizedString(@"The username or password stored in the app may be out of date. Please re-enter your password in the settings and try again.", @"") withSupportButton:NO];
+                                            if ([error code] == 403) {
+                                                [WPError showAlertWithTitle:NSLocalizedString(@"Couldn't Connect", @"") message:NSLocalizedString(@"The username or password stored in the app may be out of date. Please re-enter your password in the settings and try again.", @"") withSupportButton:NO];
 
-                                            // bad login/pass combination
-                                            SiteSettingsViewController *editSiteViewController = [[SiteSettingsViewController alloc] initWithBlog:self.blog];
-                                            [self.navigationController pushViewController:editSiteViewController animated:YES];
+                                                // bad login/pass combination
+                                                SiteSettingsViewController *editSiteViewController = [[SiteSettingsViewController alloc] initWithBlog:self.blog];
+                                                [self.navigationController pushViewController:editSiteViewController animated:YES];
 
-                                        } else {
-                                            [WPError showXMLRPCErrorAlert:error];
-                                        }
+                                            } else {
+                                                [WPError showXMLRPCErrorAlert:error];
+                                            }
+                                        });
                                     }];
 }
 


### PR DESCRIPTION
Fixes #6266

### To test:
1. Comment out [this snippet](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/Networking/TaxonomyServiceRemoteXMLRPC.m#L33) (`TaxonomyServiceRemoteXMLRPC. createCategory`, `extraParameters` initialization) in order to force a "Create Category Remote Error"
2. Fresh install the app
3. Log into a self hosted blog
4. Launch the Post Editor
5. Tap over the top right actions button, and pick `Options`
6. Tap over the `Categories` row
7. Press the `+` button and try adding a new category

As a result, the app is expected not to crash anymore.

Needs review: @kurzee 
Sir, may i bug you with a crashfix check?

Thanks!!

