### PR TITLE
Sanitize Email for Gravatar Hash Creation

### DIFF
--- a/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
+++ b/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
@@ -91,7 +91,10 @@ extension UIImageView
     /// - Returns: Gravatar's URL
     ///
     private func gravatarUrlForEmail(email: String, size: NSInteger, rating: String) -> NSURL? {
-        let targetURL = String(format: "%@/%@?d=404&s=%d&r=%@", WPGravatarBaseURL, email.md5(), size, rating)
+        let sanitizedEmail = email
+            .lowercaseString
+            .stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
+        let targetURL = String(format: "%@/%@?d=404&s=%d&r=%@", WPGravatarBaseURL, sanitizedEmail.md5(), size, rating)
         return NSURL(string: targetURL)
     }
 

--- a/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
+++ b/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
@@ -72,9 +72,13 @@ extension UIImageView
 
         let request = NSURLRequest(URL: targetURL)
 
-
+        self.dynamicType.sharedImageDownloader().imageCache?.removeImageforRequest(request, withAdditionalIdentifier: nil)
         self.dynamicType.sharedImageDownloader().imageCache?.addImage(image, forRequest: request, withAdditionalIdentifier: nil)
-        NSURLCache.sharedURLCache().cacheImage(image, forRequest: request)
+
+        // Remove all cached responses - removing an individual response does not work since iOS 7.
+        // This feels hacky to do but what else can we do...
+        let sessionConfiguration = self.dynamicType.sharedImageDownloader().sessionManager.valueForKey("sessionConfiguration") as? NSURLSessionConfiguration
+        sessionConfiguration?.URLCache?.removeAllCachedResponses()
     }
 
 

--- a/WordPress/Classes/Networking/GravatarServiceRemote.swift
+++ b/WordPress/Classes/Networking/GravatarServiceRemote.swift
@@ -3,8 +3,7 @@ import Foundation
 
 /// This ServiceRemote encapsulates all of the interaction with the Gravatar endpoint.
 ///
-public class GravatarServiceRemote
-{
+public class GravatarServiceRemote {
     /// Designated Initializer
     ///
     /// - Parameters:

--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -14,6 +14,8 @@ public class GravatarService {
         let mainAccount = AccountService(managedObjectContext: context).defaultWordPressComAccount()
         accountToken    = mainAccount?.authToken
         accountEmail    = mainAccount?.email
+            .stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceCharacterSet())
+            .lowercaseString
 
         guard accountEmail?.isEmpty == false && accountToken?.isEmpty == false else {
             return nil

--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -3,8 +3,7 @@ import Foundation
 
 /// This Service exposes all of the valid operations we can execute, to interact with the Gravatar Service.
 ///
-public class GravatarService
-{
+public class GravatarService {
     /// Designated Initializer
     ///
     /// - Parameter context: The Core Data context that should be used by the service.

--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -29,7 +29,7 @@ public class GravatarService
     ///     - completion: An optional closure to be executed on completion.
     ///
     public func uploadImage(image: UIImage, completion: ((error: NSError?) -> ())? = nil) {
-        let remote = GravatarServiceRemote(accountToken: accountToken, accountEmail: accountEmail)
+        let remote = gravatarServiceRemoteForAccountToken(accountToken, andAccountEmail: accountEmail)
         remote.uploadImage(image) { (error) in
             if let theError = error {
                 DDLogSwift.logError("GravatarService.uploadImage Error: \(theError)")
@@ -41,6 +41,9 @@ public class GravatarService
         }
     }
 
+    func gravatarServiceRemoteForAccountToken(accountToken: String, andAccountEmail accountEmail: String) -> GravatarServiceRemote {
+        return GravatarServiceRemote(accountToken: accountToken, accountEmail: accountEmail)
+    }
 
     // MARK: - Private Properties
     private let accountToken : String!

--- a/WordPress/Classes/Utility/WPAvatarSource.m
+++ b/WordPress/Classes/Utility/WPAvatarSource.m
@@ -58,12 +58,12 @@ static NSString *const GravatarBaseUrl = @"http://gravatar.com";
 
 - (UIImage *)cachedImageForGravatarEmail:(NSString *)email withSize:(CGSize)size
 {
-    return [self cachedImageForAvatarHash:[email md5] ofType:WPAvatarSourceTypeGravatar withSize:size];
+    return [self cachedImageForAvatarHash:[self hashForEmailAddressOrSiteURL:email] ofType:WPAvatarSourceTypeGravatar withSize:size];
 }
 
 - (UIImage *)cachedImageForBlavatarAddress:(NSString *)url withSize:(CGSize)size
 {
-    return [self cachedImageForAvatarHash:[url md5] ofType:WPAvatarSourceTypeBlavatar withSize:size];
+    return [self cachedImageForAvatarHash:[self hashForEmailAddressOrSiteURL:url] ofType:WPAvatarSourceTypeBlavatar withSize:size];
 }
 
 - (UIImage *)cachedImageForAvatarHash:(NSString *)hash ofType:(WPAvatarSourceType)type withSize:(CGSize)size
@@ -88,12 +88,12 @@ static NSString *const GravatarBaseUrl = @"http://gravatar.com";
 
 - (void)fetchImageForGravatarEmail:(NSString *)email withSize:(CGSize)size success:(void (^)(UIImage *image))success
 {
-    [self fetchImageForAvatarHash:[email md5] ofType:WPAvatarSourceTypeGravatar withSize:size success:success];
+    [self fetchImageForAvatarHash:[self hashForEmailAddressOrSiteURL:email] ofType:WPAvatarSourceTypeGravatar withSize:size success:success];
 }
 
 - (void)fetchImageForBlavatarAddress:(NSString *)url withSize:(CGSize)size success:(void (^)(UIImage *image))success
 {
-    [self fetchImageForAvatarHash:[url md5] ofType:WPAvatarSourceTypeBlavatar withSize:size success:success];
+    [self fetchImageForAvatarHash:[self hashForEmailAddressOrSiteURL:url] ofType:WPAvatarSourceTypeBlavatar withSize:size success:success];
 }
 
 - (void)fetchImageForAvatarHash:(NSString *)hash ofType:(WPAvatarSourceType)type withSize:(CGSize)size success:(void (^)(UIImage *image))success
@@ -236,6 +236,12 @@ static NSString *const GravatarBaseUrl = @"http://gravatar.com";
 
     url = [url stringByAppendingFormat:@"%@?s=%d&d=identicon", hash, (int)(size.width * [[UIScreen mainScreen] scale])];
     return [NSURL URLWithString:url];
+}
+
+- (NSString *)hashForEmailAddressOrSiteURL:(NSString *)stringToHash
+{
+    NSString *sanitizedString = [[stringToHash lowercaseString] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    return [sanitizedString md5];
 }
 
 @end

--- a/WordPress/WordPressTest/GravatarServiceTests.swift
+++ b/WordPress/WordPressTest/GravatarServiceTests.swift
@@ -72,7 +72,7 @@ class GravatarServiceTests : XCTestCase {
 
         XCTAssertEqual("email@wordpress.com", gravatarService!.gravatarServiceRemoteMock!.capturedAccountEmail)
     }
-    
+
     func testServiceInitializerSanitizesEmailAddressTrimsSpaces() {
         createTestAccount(username: "some", token: "1234", emailAddress: " email@wordpress.com ")
 
@@ -82,7 +82,7 @@ class GravatarServiceTests : XCTestCase {
 
         XCTAssertEqual("email@wordpress.com", gravatarService!.gravatarServiceRemoteMock!.capturedAccountEmail)
     }
-    
+
     private func createTestAccount(username username: String, token: String, emailAddress: String) {
         let mainContext = contextManager.mainContext
 

--- a/WordPress/WordPressTest/GravatarServiceTests.swift
+++ b/WordPress/WordPressTest/GravatarServiceTests.swift
@@ -5,8 +5,7 @@ import WordPress
 
 /// GravatarService Unit Tests
 ///
-class GravatarServiceTests : XCTestCase
-{
+class GravatarServiceTests : XCTestCase {
     private var contextManager : TestContextManager!
 
     override func setUp() {

--- a/WordPress/WordPressTest/WPAvatarSourceTest.m
+++ b/WordPress/WordPressTest/WPAvatarSourceTest.m
@@ -4,6 +4,12 @@
 
 #import "WPAvatarSource.h"
 
+@interface WPAvatarSource (TestAdditions)
+
+- (void)purgeCaches;
+
+@end
+
 @interface WPAvatarSourceTest : XCTestCase
 
 @end


### PR DESCRIPTION
Fixes #6270 

Gravatar URLs should be constructed with a hash based off of the e-mail address (or URL for Blavatar) with the following sanitization ([per Gravatar documentation](https://en.gravatar.com/site/implement/hash/)):
1. Trim leading and trailing whitespace from an email address
2. Force all characters to lower-case
3. md5 hash the final string

To test (based on @rachelmcr's steps):

1. While logged out of the WordPress app, select "Create a site".
2. Create a new account and site, using an email address with capital letters.
3. On the Me tab, add a new Gravatar.
4. Confirm the Gravatar is added and appears on the Me tab.
5. Swipe to close the app.
6. Reopen the app. Verify the Gravatar is still there.

Needs review: @jleandroperez 
