### PR TITLE
Fix delayed transition in Post/Schedule button

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -65,6 +65,7 @@ static NSDictionary *DisabledButtonBarStyle;
 static NSDictionary *EnabledButtonBarStyle;
 
 static void *ProgressObserverContext = &ProgressObserverContext;
+static void *DateChangeObserverContext = &DateChangeObserverContext;
 
 @interface WPEditorViewController ()
 @property (nonatomic, strong, readwrite) WPEditorFormatbarView *toolbarView;
@@ -129,6 +130,7 @@ EditImageDetailsViewControllerDelegate
 - (void)dealloc
 {
     [_mediaGlobalProgress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted))];
+    [self.post removeObserver:self forKeyPath:@"dateCreated"];
     [PrivateSiteURLProtocol unregisterPrivateSiteURLProtocol];
 }
 
@@ -804,6 +806,8 @@ EditImageDetailsViewControllerDelegate
     PostSettingsViewController *vc = [[[self classForSettingsViewController] alloc] initWithPost:post];
 	vc.hidesBottomBarWhenPushed = YES;
     [self.navigationController pushViewController:vc animated:YES];
+
+    [self.post addObserver:self forKeyPath:@"dateCreated" options:NSKeyValueObservingOptionNew context:DateChangeObserverContext];
 }
 
 - (void)showPreview
@@ -1062,7 +1066,7 @@ EditImageDetailsViewControllerDelegate
         NSMutableArray* rightBarButtons = [[NSMutableArray alloc] initWithArray:@[self.moreBarButtonItem,
                                                                                   self.editBarButtonItem]];
 
-		[self.navigationItem setRightBarButtonItems:rightBarButtons animated:YES];
+		[self.navigationItem setRightBarButtonItems:rightBarButtons animated:NO];
 	}
 }
 
@@ -2167,6 +2171,8 @@ EditImageDetailsViewControllerDelegate
         [[NSOperationQueue mainQueue] addOperationWithBlock:^{
             [self refreshNavigationBarButtons:NO];
         }];
+    } else if (context == DateChangeObserverContext) {
+        [self refreshNavigationBarButtons:NO];
     } else {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
     }


### PR DESCRIPTION
Fixes the transition between **Post** and **Scheduled** buttons to happen before the settings view dismisses, instead of after the animation has completed.

**Before:**
![post_schedule_before](https://cloud.githubusercontent.com/assets/517257/20905240/9d858e84-bb08-11e6-9797-c2bc0c8f7a32.gif)

**After:**
![post_schedule_after](https://cloud.githubusercontent.com/assets/517257/20905243/a38854d8-bb08-11e6-9185-2426b2e7fdc4.gif)

To test:
1. Create or edit a post
2. Open the options, and change the post to be scheduled for a future date
3. Go back to the editor
4. Observe that the button has changed to 'Scheduled' without animation.

Needs review: @astralbodies 

