### PR TITLE
Issues/6281 gravatar xml entities crash

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -231,9 +231,11 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate
     ///
     func imageForAttachment(attachment: WPTextAttachment) -> WPRichTextImage {
         let img = WPRichTextImage(frame: CGRect.zero)
-        img.addTarget(self, action: #selector(self.dynamicType.handleImageTapped(_:)), forControlEvents: .TouchUpInside)
+        guard let url = NSURL(string: attachment.src) else {
+            return img
+        }
 
-        let url = NSURL(string: attachment.src)
+        img.addTarget(self, action: #selector(self.dynamicType.handleImageTapped(_:)), forControlEvents: .TouchUpInside)
         img.contentURL = url
         img.linkURL = linkURLForImageAttachment(attachment)
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
@@ -381,7 +381,8 @@ class AttachmentTagProcessor: HtmlTagProcessor
 
         let attrs = attributesFromTag(html)
 
-        let src = attrs["src"] ?? ""
+        var src = attrs["src"] ?? ""
+        src = src.stringByDecodingXMLCharacters()
         let textAttachment = WPTextAttachment(tagName: tagName, identifier: identifier, src: src)
         textAttachment.attributes = attrs
         textAttachment.html = html


### PR DESCRIPTION
Fixes #6281

To test:
Like the example post in the issue.
View the post in our liked feed in the reader and confirm that it loads without crashing.

Needs review: @nheagy could I trouble you with this one? 
