### PR TITLE
Switch to Merriweather instead of Merriweather-Italic for blockquotes.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -113,7 +113,7 @@ class WPRichContentView: UITextView
             let str = newValue ?? ""
             let style = "<style>" +
                 "body { font-family: Merriweather; font-size:16.0; line-height:1.6875; color: #2e4453; } " +
-                "blockquote { font-size:18.0; font-style: italic; font-family: Merriweather-Italic; color:#4f748e; } " +
+                "blockquote { font-size:18.0; color:#4f748e; } " +
                 "em, i { font-size:18.0; font-style: italic; font-family: Merriweather-Italic; } " +
                 "a { color: #0087be; text-decoration: none; } " +
                 "a:active { color: #005082; } " +


### PR DESCRIPTION
Fixes #6279 

To test:
Check that blockquotes are displayed in the Merriweather font and not Merriweather-Italic

Needs review: @jleandroperez would you mind taking this one? 
