### PR TITLE
Reader Cards: Adjusts line spacing.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -331,7 +331,7 @@ extension WPStyleGuide
         public static let titleFontSize:CGFloat = WPDeviceIdentification.isiPad() ? 28.0 : 18.0
         public static let titleLineSpacing:CGFloat = WPDeviceIdentification.isiPad() ? 4.0 : 2.0
         public static let contentFontSize:CGFloat = 16.0
-        public static let contentLineSpacing:CGFloat = WPDeviceIdentification.isiPad() ? 4.0 : 2.0
+        public static let contentLineSpacing:CGFloat = 6.5
         public static let buttonFontSize:CGFloat = 14.0
         public static let subtextFontSize:CGFloat = 12.0
         public static let loadMoreButtonFontSize:CGFloat = 15.0


### PR DESCRIPTION
Fixes #6282 

For the fix I'm just increasing the lineSpacing.  I thought it might be better to set the lineHeightMultiplier to match the line height set in the detail (1.6875), but when I tried it the line spacing was significantly larger than desired.  Best I can tell this is due to a difference between how the detail computes its line height via css. 

Also, since the same font size is used on the iPad and iPhone I've made the spacing the same as well.

To test: 
Compare the line spacing in the cells and in the detail.  They should be nearly indistinguishable, with only a pixel or two difference at three lines of text.  

Needs review: @kurzee Could I trouble you again sir? 
