### PR TITLE
Guard all the things to prevent a crash case bridging objc.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -166,13 +166,16 @@ import WordPressComAnalytics
             return
         }
 
-        // If the user is an admin on the post's site do not bump the page view unless
-        // the the post is private.
-        if !post.isPrivate() && isUserAdminOnSiteWithID(post.siteID) {
+        guard
+            let siteID = post.siteID,
+            let postID = post.postID,
+            let host = NSURL(string: post.blogURL)?.host else {
             return
         }
 
-        guard let host = NSURL(string: post.blogURL)?.host else {
+        // If the user is an admin on the post's site do not bump the page view unless
+        // the the post is private.
+        if !post.isPrivate() && isUserAdminOnSiteWithID(siteID) {
             return
         }
 
@@ -183,8 +186,8 @@ import WordPressComAnalytics
             "reader=1",
             "ref=\(pixelStatReferrer)",
             "host=\(host)",
-            "blog=\(post.siteID)",
-            "post=\(post.postID)",
+            "blog=\(siteID)",
+            "post=\(postID)",
             NSString(format:"t=%d", arc4random())
         ]
 


### PR DESCRIPTION
Fixes #6265 
I was never able to reproduce the crash.  The stack trace suggests that `isUserAdminOnSiteWithID` was being passed a `nil` value for `post.siteID` so I've opted to `guard` everything to ensure nothing is nil that shouldn't be.  I'm a little worried this is kicking the proverbial can down the road and we'll just end up seeing a new crash with the same root cause.  If we do perhaps the root cause will be more apparent.  Open to other ideas in the meantime.

To test:
Confirm that page views are still bumped when viewing a post.  You can confirm the session task is executed via a breakpoint. Or for a more practical test:  
- Create a new post with a test account. 
- With another test account, like that post.
- Note the page view from the first account.
- With the second account, view your liked feed in the reader, and then view the posts detail.
- Check the stats on the first test account and confirm that you received a page view.

Needs review: @koke would you mind taking a look? 
