### PR TITLE
Fix transition between Post and Save buttons in editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1397,6 +1397,7 @@ EditImageDetailsViewControllerDelegate
                    changesSaved:(BOOL)changesSaved
 {
     [WPAppAnalytics track:WPAnalyticsStatEditorClosed withBlog:self.post.blog];
+    [self removePostObserver];
 
     if (self.onClose) {
         self.onClose(self, changesSaved);
@@ -1596,7 +1597,7 @@ EditImageDetailsViewControllerDelegate
 
 - (void)setupPostObserver
 {
-     [self.post addObserver:self forKeyPath:@"dateCreated" options:NSKeyValueObservingOptionNew context:DateChangeObserverContext];
+    [self.post addObserver:self forKeyPath:@"dateCreated" options:NSKeyValueObservingOptionNew context:DateChangeObserverContext];
     [self.post addObserver:self forKeyPath:@"status" options:NSKeyValueObservingOptionNew context:DateChangeObserverContext];
 }
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1597,12 +1597,14 @@ EditImageDetailsViewControllerDelegate
 - (void)setupPostObserver
 {
      [self.post addObserver:self forKeyPath:@"dateCreated" options:NSKeyValueObservingOptionNew context:DateChangeObserverContext];
+    [self.post addObserver:self forKeyPath:@"status" options:NSKeyValueObservingOptionNew context:DateChangeObserverContext];
 }
 
 - (void)removePostObserver
 {
     @try {
         [self.post removeObserver:self forKeyPath:@"dateCreated"];
+        [self.post removeObserver:self forKeyPath:@"status"];
     } @catch (NSException *exception) {}
 }
 


### PR DESCRIPTION
Just like #6275 but now for the Drafts/Save button transition!

![post_save_after](https://cloud.githubusercontent.com/assets/517257/20945908/9d1793a4-bbce-11e6-9ccd-176b82ac3f70.gif)

We like small, focused PRs, right?

To test:

- Make a new post, change it draft status, watch the top right button as it transitions back to the editor
- Also, try the new "Save as Draft" option in the `…` menu to make sure nothing is broken 😉

Needs review: @jleandroperez 
Jorge, mind looking over this one for me?