### PR TITLE
Issues/6288 text view scroll offset

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -290,7 +290,7 @@ public class ReaderDetailViewController: UIViewController, UIViewControllerResto
                                                      multiplier: 1.0,
                                                      constant: 0.0)
         textView.addConstraint(textFooterTopConstraint)
-        textFooterTopConstraint.constant = textView.contentSize.height - textFooterStackView.frame.height
+        textFooterTopConstraint.constant = textFooterYOffset()
         textView.setContentOffset(CGPoint.zero, animated: false)
     }
 
@@ -380,6 +380,10 @@ public class ReaderDetailViewController: UIViewController, UIViewControllerResto
             selector: #selector(ReaderDetailViewController.handleBlockSiteNotification(_:)),
             name: ReaderPostMenu.BlockSiteNotification,
             object: nil)
+
+        // Make sure the text view is scrolled to the top the first time after
+        // the view is first configured.
+        textView.setContentOffset(CGPoint.zero, animated: false)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -216,9 +216,20 @@ public class ReaderDetailViewController: UIViewController, UIViewControllerResto
 
     public override func viewWillTransitionToSize(size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransitionToSize(size, withTransitionCoordinator: coordinator)
-        coordinator.animateAlongsideTransition(nil, completion: { (_) in
-            self.updateContentInsets()
-            self.updateTextViewMargins()
+
+        let y = textView.contentOffset.y
+        let position = textView.closestPositionToPoint(CGPoint(x:0.0, y: y))
+
+        coordinator.animateAlongsideTransition(
+            { (_) in
+                if let position = position, let textRange = self.textView.textRangeFromPosition(position, toPosition: position) {
+                    let rect = self.textView.firstRectForRange(textRange)
+                    self.textView.setContentOffset(CGPoint(x: 0.0, y: rect.origin.y), animated: false)
+                }
+            },
+            completion: { (_) in
+                self.updateContentInsets()
+                self.updateTextViewMargins()
         })
 
         // Make sure that the bars are visible after switching from landscape


### PR DESCRIPTION
Refs #6288 
Refs #6293

This PR addresses some unwanted scrolling in the reader detail.  

First, when the view is configured the `contentOffset` is deliberately set to zero.  This is to address the issue reported in #6288.  I've been unable to reproduce this behavior when testing on the device, or simulator, even when using the same post so setting the offset is a best guess.

Second, there we've had a [known issue](https://github.com/wordpress-mobile/WordPress-iOS/pull/6170#issuecomment-261659938) with `WPRichContentView` where the scroll offset might dramatically change when rotating. While thinking about #6293 I realized how we might capture the visible character position, and set the `contentOffset` accordingly when the view's size changes.  This seems to fix our issue with a changing offset and will most likely resolve #6293 as well. 

To test:
First, confirm that the scroll offset changes dramatically when rotating the reader detail on an iPhone.
Switch to this branch and repeat the test.  Confirm that the text you were reading (top line) remains visible when rotating.

Needs review: @frosty would you be game for this one? 
cc @kurzee 