### PR TITLE
Issue/6928: Remove Plans menu item for non-Admin users

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -430,7 +430,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
         case BlogFeatureMentions:
         case BlogFeatureOAuth2Login:
         case BlogFeaturePlans:
-            return [self isHostedAtWPcom];
+            return [self isHostedAtWPcom] && [self isAdmin];
         case BlogFeaturePushNotifications:
             return [self supportsPushNotifications];
         case BlogFeatureThemeBrowsing:


### PR DESCRIPTION
Fixes #6928.

The Plans menu item in `BlogDetailsViewController` will now only appear if the user is an Admin of the blog.

To test:

* Add yourself to a site with a user level of Author or Contributor.
* Start the app, select the site, and check that the Plans menu item isn't visible.

Needs review: @koke 
