### PR TITLE
Reader: Wait to autosync while stream is hidden.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -228,7 +228,6 @@ import WordPressComAnalytics
     }
 
 
-
     public override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
 
@@ -1061,12 +1060,6 @@ import WordPressComAnalytics
     /// - The controller must be the active controller.
     /// - The app must have a internet connection.
     /// - The current time must be greater than the last sync interval.
-    ///
-    /// NOTE: Until we have more robust content wrangling, we want to delay a
-    /// background sync until the controller is the active controller.
-    /// This helps avoid an issue where content being used
-    /// by the user gets cleaned up or deleted by the sync process.
-    /// See: https://github.com/wordpress-mobile/WordPress-iOS/issues/6297
     ///
     func syncIfAppropriate() {
         guard UIApplication.sharedApplication().isRunningTestSuite() == false else {


### PR DESCRIPTION
Fixes #6297 
The crash in #6297 occurs when the reader stream kicks off its auto sync while the detail is being viewed, and then the post shown in the detail is cleaned up by the sync.  This patch avoids the crash by deferring the auto sync until the stream is the visible controller.

It would be nice if at some point we could A) completely decouple syncing from the controller and B) have a nice way of making sure "active" content is not deleted while its needed. Maybe a separate persistent store.  For now this patch will avoid the crash until we can build out a more robust solution.

To test:
Follow the steps outlined in the issue.  Confirm there is no crash

Needs review: @koke 

