### PR TITLE
Reader: Hide the details textView while loading the post.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -272,6 +272,7 @@ public class ReaderDetailViewController: UIViewController, UIViewControllerResto
     public func setupWithPostID(postID:NSNumber, siteID:NSNumber) {
         let title = NSLocalizedString("Loading Post...", comment:"Text displayed while loading a post.")
         WPNoResultsView.displayAnimatedBoxWithTitle(title, message: nil, view: view)
+        textView.alpha = 0.0
 
         let context = ContextManager.sharedInstance().mainContext
         let service = ReaderPostService(managedObjectContext: context)
@@ -280,8 +281,9 @@ public class ReaderDetailViewController: UIViewController, UIViewControllerResto
             postID.unsignedIntegerValue,
             forSite: siteID.unsignedIntegerValue,
             success: {[weak self] (post:ReaderPost!) in
-                self?.post = post
                 WPNoResultsView.removeFromView(self?.view)
+                self?.textView.alpha = 1.0
+                self?.post = post
             },
             failure: {[weak self] (error:NSError!) in
                 DDLogSwift.logError("Error fetching post for detail: \(error.localizedDescription)")


### PR DESCRIPTION
I've noticed the no-results/loading view overlapping the loaded post content a couple of times now.  It only happens momentarily and is quick to correct itself so it can be tough to spot.  Best case to observe it is loading a post via a notification and hope it occurs while the view controller is transitioning. 

This pr sets the textView's opacity to 0 until the post content is loaded. This seems to prevent the overlap during the transition animation.  Opacity is set vs making the view hidden to avoid conflicts with updating constraints when the view is hidden.

To test:
Try to confirm the bug via the method stated above. Look sharp or you'll miss it.
Switch to this branch and try to reproduce the bug.  Confirm that the loading/no-results view does not overlap the text content.

Needs review: @jleandroperez would you do the honors? 

