### PR TITLE
Fix improper header on EditPostViewController.swift

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -1,11 +1,3 @@
-//
-//  EdiPostViewController.swift
-//  WordPress
-//
-//  Created by Nate Heagy on 2016-11-10.
-//  Copyright © 2016 WordPress. All rights reserved.
-//
-
 import UIKit
 
 class EditPostViewController: UIViewController {


### PR DESCRIPTION
I didn't remove Xcode's autogenerated header before merging. Oops.

Needs review: @kurzee 
_You found it, so you can review it_ ;)