### PR TITLE
Add wp.getPost call after creating new post with XMLRPC

### DIFF
--- a/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
@@ -91,14 +91,22 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
                  success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                      if ([responseObject respondsToSelector:@selector(numericValue)]) {
                          post.postID = [responseObject numericValue];
-                         // TODO: fetch individual post
+
                          if (!post.date) {
                              // Set the temporary date until we get it from the server so it sorts properly on the list
                              post.date = [NSDate date];
                          }
-                         if (success) {
-                             success(post);
-                         }
+
+                         [self getPostWithID:post.postID success:^(RemotePost *fetchedPost) {
+                             if (success) {
+                                 success(fetchedPost);
+                             }
+                         } failure:^(NSError *error) {
+                             // update failed, and that sucks, but creating the post succeeded… so, let's just act like everything is ok!
+                             if (success) {
+                                 success(post);
+                             }
+                         }];
                      } else if (failure) {
                          NSDictionary *userInfo = @{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Invalid value returned for new post: %@", responseObject]};
                          NSError *error = [NSError errorWithDomain:WordPressAppErrorDomain code:0 userInfo:userInfo];


### PR DESCRIPTION
Fixes #6307

When creating a new post using the `XMLRPC` api, the service will now immediately fetch the post to get its metadata, such as `permalink`.  This allows the post-post view to show a live preview. 

Hopefully there are no unwanted side-effects…

### To test:
1. Create a new post on a self-hosted site
2. Tap "View Post" from the post-post screen
3. Enjoy a live preview of the post

Needs review: @koke 
_This was all your idea_