### PR TITLE
Reader: avoid broken header layout for streams

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -485,7 +485,7 @@ import WordPressComAnalytics
         }
 
         header.enableLoggedInFeatures(isLoggedIn)
-        header.configureHeader(readerTopic!)
+        header.configureHeader(topic)
         header.delegate = self
 
         tableView.tableHeaderView = header as? UIView
@@ -495,11 +495,11 @@ import WordPressComAnalytics
     // Refresh the header of a site topic when returning in case the
     // topic's following status changed.
     func refreshTableHeaderIfNeeded() {
-        guard let siteTopic = readerTopic as? ReaderSiteTopic,
+        guard let topic = readerTopic as? ReaderSiteTopic,
             header = tableView.tableHeaderView as? ReaderStreamHeader else {
             return
         }
-        header.configureHeader(siteTopic)
+        header.configureHeader(topic)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -532,6 +532,8 @@ import WordPressComAnalytics
         configureStreamHeader()
         tableView.setContentOffset(CGPointZero, animated: false)
         tableViewHandler.refreshTableView()
+        refreshTableViewHeaderLayout()
+
         syncIfAppropriate()
 
         bumpStats()


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-iOS/issues/6291

Fixes an issue seen recently when loading a stream with a header topic description for the first time caused the layout to incorrectly compute its bounds.

![simulator screen shot dec 9 2016 1 11 31 pm](https://cloud.githubusercontent.com/assets/1873422/21062058/a77081a6-be14-11e6-9ce7-b6c86c5bf026.png)

The fix here now refreshes the header layout after we've configured for a topic. Also added a bit of cleanup.

To test:
1. Fresh install.
2. Sign in, open Reader Discover stream.
3. Tap on a card's header to open that card's topic stream.
4. The topic will fetch from the network and take a second to load.
5. Once loaded ensure the layout with text is as expected.
6. Go back and repeat with the cached stream.
7. Ensure the layout is still as expected.
8. ✌️ 

Needs review: @aerych can you take a quick stroll?