### PR TITLE
Cleanup WPAvatarSource private test method use.

### DIFF
--- a/WordPress/Classes/Utility/WPAvatarSource.h
+++ b/WordPress/Classes/Utility/WPAvatarSource.h
@@ -137,3 +137,12 @@ typedef NS_ENUM(NSUInteger, WPAvatarSourceType) {
 - (WPAvatarSourceType)parseURL:(NSURL *)url forAvatarHash:(NSString **)avatarHash;
 
 @end
+
+/**
+ Exposed interface for private unit testing methods.
+ */
+@protocol WPAvatarSourceTesting <NSObject>
+
+- (void)purgeCaches;
+
+@end

--- a/WordPress/Classes/Utility/WPAvatarSource.m
+++ b/WordPress/Classes/Utility/WPAvatarSource.m
@@ -7,6 +7,10 @@ static CGSize BlavatarMaxSize = {60, 60};
 static CGSize GravatarMaxSize = {92, 92};
 static NSString *const GravatarBaseUrl = @"http://gravatar.com";
 
+@interface WPAvatarSource () <WPAvatarSourceTesting>
+
+@end
+
 @implementation WPAvatarSource {
     NSCache *_gravatarCache;
     NSCache *_blavatarCache;
@@ -196,13 +200,6 @@ static NSString *const GravatarBaseUrl = @"http://gravatar.com";
     [cache setObject:image forKey:cacheKey];
 }
 
-// For unit testing
-- (void)purgeCaches
-{
-    [_gravatarCache removeAllObjects];
-    [_blavatarCache removeAllObjects];
-}
-
 #pragma mark - Size helpers
 
 - (CGSize)maxSizeForType:(WPAvatarSourceType)type
@@ -236,6 +233,14 @@ static NSString *const GravatarBaseUrl = @"http://gravatar.com";
 
     url = [url stringByAppendingFormat:@"%@?s=%d&d=identicon", hash, (int)(size.width * [[UIScreen mainScreen] scale])];
     return [NSURL URLWithString:url];
+}
+
+#pragma mark - WPAvatarSourceTesting
+
+- (void)purgeCaches
+{
+    [_gravatarCache removeAllObjects];
+    [_blavatarCache removeAllObjects];
 }
 
 @end

--- a/WordPress/WordPressTest/WPAvatarSourceTest.m
+++ b/WordPress/WordPressTest/WPAvatarSourceTest.m
@@ -28,7 +28,7 @@
 
 - (void)tearDown
 {
-    [_source performSelector:@selector(purgeCaches)];
+    [(WPAvatarSource <WPAvatarSourceTesting> *)_source purgeCaches];
     _source = nil;
 
     [OHHTTPStubs removeAllStubs];


### PR DESCRIPTION
Fixes a warning when running tests, an undeclared selector for `purgeCaches`. The warning is justified as we're just forcing a call there, without protection.

This revises our use of a private method and exposes it explicitly for testing.

To test:

1. Run the tests for `WPAvatarSourceTest` and ensure no warnings pop up.
2. 🍰 

Needs review: @diegoreymendez can you take a peak?