### PR TITLE
Rich Text: Removes different font-size for blockquote and italics.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -113,7 +113,7 @@ class WPRichContentView: UITextView
             let str = newValue ?? ""
             let style = "<style>" +
                 "body { font-family: Merriweather; font-size:16.0; line-height:1.6875; color: #2e4453; } " +
-                "blockquote { font-size:18.0; color:#4f748e; } " +
+                "blockquote { color:#4f748e; } " +
                 "em, i { font-size:18.0; font-style: italic; font-family: Merriweather-Italic; } " +
                 "a { color: #0087be; text-decoration: none; } " +
                 "a:active { color: #005082; } " +


### PR DESCRIPTION
In #6285 we removed the custom font for blockquotes but neglected to remove the custom font size used for Merriweather-Light.  This PR corrects that oversight. 

To test:
Confirm the incorrect font size by comparing a blockquote text to regular paragraph text.  Switch to this branch and confirm that blockquotes are displayed in the correct font size.

Needs review: @jleandroperez could I trouble you again?

