### PR TITLE
Issues/6324 fix attribute parsing

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
@@ -354,7 +354,7 @@ class ListTagProcessor: HtmlTagProcessor
 class AttachmentTagProcessor: HtmlTagProcessor
 {
     let textAttachmentIdentifier = "WPTEXTATTACHMENTIDENTIFIER"
-    static let attributeRegex = try! NSRegularExpression(pattern: "([a-zA-Z-]+)=(?:\"|')([^\"']+)(?:\"|')", options: .CaseInsensitive)
+    static let attributeRegex = try! NSRegularExpression(pattern: "([a-z-]+)=(?:\"|')([^\"']+)(?:\"|')", options: .CaseInsensitive)
 
     /// Replaces extracted tags with markers.
     ///

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
@@ -429,7 +429,7 @@ class AttachmentTagProcessor: HtmlTagProcessor
             let keyRange = match.rangeAtIndex(1)
             let valueRange = match.rangeAtIndex(2)
 
-            let key = tag!.substringWithRange(keyRange)
+            let key = tag!.substringWithRange(keyRange).lowercaseString
             let value = tag!.substringWithRange(valueRange)
 
             attrs.updateValue(value, forKey: key)

--- a/WordPress/WordPressTest/WPRichTextFormatterTests.swift
+++ b/WordPress/WordPressTest/WPRichTextFormatterTests.swift
@@ -89,4 +89,18 @@ class WPRichTextFormatterTests: XCTestCase {
         XCTAssert(pStyle.headIndent == formatter.blockquoteIndentation)
     }
 
+
+    func testAttributesFromTag() {
+
+        let str = "<img src=\"http://example.com\" class=\"classname\"alt='alttext'>"
+
+        let processor = AttachmentTagProcessor(tagName: "img", includesEndTag: false)
+
+        let attributes = processor.attributesFromTag(str)
+        XCTAssert(attributes.count == 3)
+        XCTAssert(attributes["src"] != nil)
+        XCTAssert(attributes["alt"] != nil)
+        XCTAssert(attributes["class"] != nil)
+    }
+
 }

--- a/WordPress/WordPressTest/WPRichTextFormatterTests.swift
+++ b/WordPress/WordPressTest/WPRichTextFormatterTests.swift
@@ -92,15 +92,16 @@ class WPRichTextFormatterTests: XCTestCase {
 
     func testAttributesFromTag() {
 
-        let str = "<img src=\"http://example.com\" class=\"classname\"alt='alttext'>"
+        let str = "<img src=\"http://example.com\" class=\"classname1 classname2\"alt='alt😀text' TITLE=\"Example\">"
 
         let processor = AttachmentTagProcessor(tagName: "img", includesEndTag: false)
 
         let attributes = processor.attributesFromTag(str)
-        XCTAssert(attributes.count == 3)
-        XCTAssert(attributes["src"] != nil)
-        XCTAssert(attributes["alt"] != nil)
-        XCTAssert(attributes["class"] != nil)
+        XCTAssert(attributes.count == 4)
+        XCTAssert(attributes["src"] == "http://example.com")
+        XCTAssert(attributes["class"] == "classname1 classname2")
+        XCTAssert(attributes["alt"] == "alt😀text")
+        XCTAssert(attributes["title"] == "Example")
     }
 
 }


### PR DESCRIPTION
Fixes #6324 
Its disappointing, but the attribute retrieval using NSScanner isn't going to be robust enough to handle different possible ways attributes can be written in a tag.  This PR switch to regex, using capture groups to retrieve attribute key/value pairs. Less code and less parsing FTW.

To test: 
Follow `flightpathblog.com` and view its stream in the reader.
Confirm the bug by viewing one of the affected photo posts, such as the one titled "Shoes".
Switch to this branch and confirm the fix. 

Needs review: @nheagy could I trouble you with this one? 
