### PR TITLE
Add RTL support to WPSplitViewController dimming

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -187,7 +187,14 @@ class WPSplitViewController: UISplitViewController {
     private func updateDimmingViewFrame() {
         if dimmingView.superview != nil {
             dimmingView.frame = view.frame
-            dimmingView.frame.origin.x = primaryColumnWidth
+
+            let attribute = view.semanticContentAttribute
+            let layoutDirection = UIView.userInterfaceLayoutDirectionForSemanticContentAttribute(attribute)
+            if layoutDirection == .LeftToRight {
+                dimmingView.frame.origin.x = primaryColumnWidth
+            } else {
+                dimmingView.frame.size.width = dimmingView.frame.size.width - primaryColumnWidth
+            }
         }
     }
 


### PR DESCRIPTION
`WPSplitViewController`'s 'dimming view' didn't position itself correctly for right-to-left layouts:

![simulator screen shot 13 dec 2016 17 23 37](https://cloud.githubusercontent.com/assets/4780/21151246/b22cc68e-c159-11e6-966d-49709f2097c3.png)

This PR fixes the issue by adjusting the placement of the dimming view based on the current interface layout direction:

![simulator screen shot 13 dec 2016 17 27 07](https://cloud.githubusercontent.com/assets/4780/21151525/c162c2a6-c15a-11e6-86ed-2bf9d1be610c.png)

To test:

* On iPad...
* Set your scheme's application language to "Right to Left Pseudolanguage", build and run
* On My Sites, navigate back to the Blog List, and you should see the detail pane dimmed out. Ensure the dimming view stays in the right place when rotating the device.

Needs review: @kurzee 