### PR TITLE
Update Stats pod to 0.8.1 to fix rotation crash in graph VC.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ abstract_target 'WordPress_Base' do
   pod 'WordPress-iOS-Shared', '0.7.0'
   ## This pod is only being included to support the share extension ATM - https://github.com/wordpress-mobile/WordPress-iOS/issues/5081
   pod 'WordPressComKit',   '0.0.5'
-  pod 'WordPressCom-Stats-iOS', '0.8.0'
+  pod 'WordPressCom-Stats-iOS', '0.8.1'
 
   target 'WordPress' do
     # ---------------------

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -147,7 +147,7 @@ PODS:
   - WordPress-iOS-Shared (0.7.0):
     - CocoaLumberjack (~> 2.2.0)
   - WordPressCom-Analytics-iOS (0.1.21)
-  - WordPressCom-Stats-iOS (0.8.0):
+  - WordPressCom-Stats-iOS (0.8.1):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
@@ -190,7 +190,7 @@ DEPENDENCIES:
   - WordPress-iOS-Editor (= 1.8.1)
   - WordPress-iOS-Shared (= 0.7.0)
   - WordPressCom-Analytics-iOS (= 0.1.21)
-  - WordPressCom-Stats-iOS (= 0.8.0)
+  - WordPressCom-Stats-iOS (= 0.8.1)
   - WordPressComKit (= 0.0.5)
   - WPMediaPicker (~> 0.10.2)
   - wpxmlrpc (~> 0.8)
@@ -258,11 +258,11 @@ SPEC CHECKSUMS:
   WordPress-iOS-Editor: 3118f5d6b142b6bf322f3393a7dd98a28bca68cb
   WordPress-iOS-Shared: 4bec543bac6543480b10d904bea122dcba43cc37
   WordPressCom-Analytics-iOS: ee6cc3a4feb63cebba167ce762c6e12c0b7b6671
-  WordPressCom-Stats-iOS: 7c961a7780a695f54db5431537c16615682cdf32
+  WordPressCom-Stats-iOS: 07b1796831c31c0c8c8a0f2e314bb2e6636af5df
   WordPressComKit: 4dc52eebc508b8e056d8bf8e931a7be95d467e3b
   WPMediaPicker: 9ba8c29a1de4b07696356f541c01eeaa6dd14c47
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: e55ed7f68c9c856f548d0023166d945a0ac909d6
+PODFILE CHECKSUM: c159c67f1c338d3129a8e985d53a0dd855918c5f
 
 COCOAPODS: 1.1.1


### PR DESCRIPTION
Fixes #6273 

To test:
Try to get the app to crash with rotations, backgrounding, etc. Reproducing this crash is really really hard. I'm fairly certain the fix does resolve the problem and this is really just a sanity check for the pod version bump.

Needs review: @kurzee 

