### PR TITLE
Issues/6346 format pre tags

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -177,7 +177,9 @@ class ReaderCommentCell : UITableViewCell
         }
 
         textView.isPrivate = comment.isPrivateContent()
-        textView.content = comment.contentForDisplay()
+        // Use `content` vs `contentForDisplay`. Hierarchcial comments are already
+        // correctly formatted during the sync process.
+        textView.content = comment.content
     }
 
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
@@ -17,6 +17,7 @@ class WPRichTextFormatter
     lazy var tags:[HtmlTagProcessor] = {
         return [
             BlockquoteTagProcessor(),
+            PreTagProcessor(),
             ListTagProcessor(tagName: "ol", includesEndTag: true),
             ListTagProcessor(tagName: "ul", includesEndTag: true),
             AttachmentTagProcessor(tagName: "img", includesEndTag: false),
@@ -321,6 +322,30 @@ class BlockquoteTagProcessor: HtmlTagProcessor
             str += marker
         }
         parsedString = str
+
+        return (parsedString, nil)
+    }
+}
+
+
+/// Encapsulates the logic for processing pre tags.
+///
+class PreTagProcessor: HtmlTagProcessor
+{
+
+    init() {
+        super.init(tagName: "pre", includesEndTag: true)
+    }
+
+
+    /// Adds a new line after the end of the pre tag.
+    ///
+    override func process(_ scanner: Scanner) -> (String, WPTextAttachment?) {
+        var (matched, parsedString) = extractTag(scanner)
+
+        if matched && !parsedString.contains("\n\n</pre>") {
+            parsedString += "<br>"
+        }
 
         return (parsedString, nil)
     }

--- a/WordPress/WordPressTest/WPRichTextFormatterTests.swift
+++ b/WordPress/WordPressTest/WPRichTextFormatterTests.swift
@@ -31,6 +31,21 @@ class WPRichTextFormatterTests: XCTestCase {
         XCTAssert(str.contains("<blockquote><p>\(WPRichTextFormatter.blockquoteIdentifier)Hi</p><p>\(WPRichTextFormatter.blockquoteIdentifier)Hi</p></blockquote>"))
     }
 
+    func testPreTagProcessor() {
+        let processor = PreTagProcessor()
+
+        var html = "<pre>\n\nHi\n\n</pre>"
+        var scanner = Scanner(string: html)
+        var (result, _) = processor.process(scanner)
+        XCTAssert(result == html)
+
+        html = "<pre>\nexample\nexample\n</pre>"
+        scanner = Scanner(string: html)
+        (result, _) = processor.process(scanner)
+
+        let expectedResult = html + "<br>"
+        XCTAssert(result == expectedResult)
+    }
 
     func testImageTagProcessor() {
         let processor = AttachmentTagProcessor(tagName: "img", includesEndTag: false)


### PR DESCRIPTION
Fixes #6346 
This PR adds a new line after a closing `pre` tag, provided that a new line is required.

To test:
Like the post mentioned in the issue and confirm that there is now an empty line after the pre tags. 
Create a new comment with multiple carriage returns (two or more) before the closing tag. Confirm that a new line is *not* added.

Needs review: @jleandroperez would you be game for this one? 
