### PR TITLE
Reader: Make sure view is properly laid out before setting content offset

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -402,6 +402,7 @@ public class ReaderDetailViewController: UIViewController, UIViewControllerResto
 
         // Make sure the text view is scrolled to the top the first time after
         // the view is first configured.
+        view.layoutIfNeeded()
         textView.setContentOffset(CGPoint.zero, animated: false)
     }
 


### PR DESCRIPTION
Fixes #6288
The previous fix did not work for long posts with no featured image displayed on the iPad.  For these posts, the geometry of the text view was not yet finalized by the time the offset was set (its width was too narrow). When the view received its final geometry the offset was adjusted to compensate for the change in size. This patch ensures the view is properly laid out before setting the offset.

To test:
Confirm the glitch in an iPad simulator.  DM me for sample posts, or find one of your own.  A long text post with no featured image should do the trick. 
Switch to this branch and confirm the fix. The post should load scrolled to the top.

Needs review: @bummytime would you be game to review this one?
