### PR TITLE
Make UIViewController restoration work again

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -4,7 +4,7 @@ import WordPressComAnalytics
 import Gridicons
 
 class MeViewController: UITableViewController, UIViewControllerRestoration {
-    static var restorationIdentifier = "WPMeRestorationID"
+    static let restorationIdentifier = "WPMeRestorationID"
     var handler: ImmuTableViewHandler!
 
     static func viewController(withRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
@@ -16,7 +16,9 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
     override init(style: UITableViewStyle) {
         super.init(style: style)
         navigationItem.title = NSLocalizedString("Me", comment: "Me page title")
-        MeViewController.restorationIdentifier = type(of: self).restorationIdentifier
+        // Need to use `super` to work around a Swift compiler bug
+        // https://bugs.swift.org/browse/SR-3465
+        super.restorationIdentifier = MeViewController.restorationIdentifier
         restorationClass = type(of: self)
         clearsSelectionOnViewWillAppear = false
     }

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -35,7 +35,7 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
         noResultsView.removeFromSuperview()
     }
 
-    static var restorationIdentifier = "PlanList"
+    static let restorationIdentifier = "PlanList"
     /// Reference to the blog object if initialized with a blog. Used for state restoration only.
     fileprivate var restorationBlogURL: URL? = nil
 
@@ -56,7 +56,9 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
         self.service = service
         super.init(style: .grouped)
         title = NSLocalizedString("Plans", comment: "Title for the plan selector")
-        PlanListViewController.restorationIdentifier = PlanListViewController.restorationIdentifier
+        // Need to use `super` to work around a Swift compiler bug
+        // https://bugs.swift.org/browse/SR-3465
+        super.restorationIdentifier = PlanListViewController.restorationIdentifier
         restorationClass = PlanListViewController.self
         noResultsView.delegate = self
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -8,7 +8,7 @@ import WordPressShared
 @objc class ReaderMenuViewController : UITableViewController, UIViewControllerRestoration
 {
 
-    static var restorationIdentifier = "ReaderMenuViewController"
+    static let restorationIdentifier = "ReaderMenuViewController"
     static let selectedIndexPathRestorationIdentifier = "ReaderMenuSelectedIndexPathKey"
 
     let defaultCellIdentifier = "DefaultCellIdentifier"
@@ -73,8 +73,10 @@ import WordPressShared
 
     override init(style: UITableViewStyle) {
         super.init(style: style)
-        ReaderMenuViewController.restorationIdentifier = type(of: self).restorationIdentifier
-        restorationClass = type(of: self)
+        // Need to use `super` to work around a Swift compiler bug
+        // https://bugs.swift.org/browse/SR-3465
+        super.restorationIdentifier = ReaderMenuViewController.restorationIdentifier
+        restorationClass = ReaderMenuViewController.self
 
         clearsSelectionOnViewWillAppear = false
 


### PR DESCRIPTION
In #6352 @aerych says:

> State restoration appears recently broken in develop on the iPhone (Swift 3 merge maybe?)

And you were right, the Swift 3 migration did some weird things to VC restoration code. And just for fun I hit a [compiler bug](https://bugs.swift.org/browse/SR-3465) while trying to fix this

To test:

Make sure restoration works in

- Me
- Reader
- Plans

Needs review: @aerych 