### PR TITLE
Stats: Fixes state restoration.

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -18,7 +18,7 @@
 
 static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
-@interface StatsViewController () <WPStatsViewControllerDelegate>
+@interface StatsViewController () <WPStatsViewControllerDelegate, UIViewControllerRestoration>
 
 @property (nonatomic, assign) BOOL showingJetpackLogin;
 @property (nonatomic, strong) UINavigationController *statsNavVC;


### PR DESCRIPTION
Fixes #5946 

To test:
In the iPhone simulator, browse to the stats screen and background/restore the app.
Stop the debug session, then relaunch the app in the simulator. 
Confirm that the app launches and restores the stats screen.

Needs review: @astralbodies 
