### PR TITLE
Feature/6358 fetch related posts

### DIFF
--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.h
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.h
@@ -52,7 +52,7 @@
 
 
 /**
- Fetche related posts for the specified post on the specified site.
+ Fetches related posts for the specified post on the specified site.
 
  @param postID the ID of the post to fetch
  @param siteID the ID of the site the post belongs to

--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.h
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.h
@@ -50,6 +50,24 @@
           success:(void (^)(RemoteReaderPost *post))success
           failure:(void (^)(NSError *error))failure;
 
+
+/**
+ Fetche related posts for the specified post on the specified site.
+
+ @param postID the ID of the post to fetch
+ @param siteID the ID of the site the post belongs to
+ @param localCount the number of related posts to fetch from the specified site
+ @param globalCount the number of related posts to fetch from other sites
+ @param success block called on a successful fetch.
+ @param failure block called if there is any error. `error` can be any underlying network error.
+ */
+- (void)fetchRelatedPostFor:(NSUInteger)postID
+                   fromSite:(NSUInteger)siteID
+                 localCount:(NSUInteger)localCount
+                globalCount:(NSUInteger)globalCount
+                    success:(void (^)(NSArray<RemoteReaderPost *> *posts))success
+                    failure:(void (^)(NSError *error))failure;
+
 /**
  Mark a post as liked by the user.
 

--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -75,6 +75,16 @@ extern NSString * const ReaderPostServiceErrorDomain;
           success:(void (^)(ReaderPost *post))success
           failure:(void (^)(NSError *error))failure;
 
+/**
+ Fetches related posts for the specified post.
+
+ @param post The reader post for which to fetch related posts.
+ @param success block called on a successful fetch.
+ @param failure block called if there is any error. `error` can be any underlying network error.
+ */
+- (void)fetchRelatedPostsForPost:(ReaderPost *)post
+                         success:(void (^)())success
+                         failure:(void (^)(NSError *error))failure;
 
 /**
  Silently refresh posts for the followed sites topic.

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -23,6 +23,7 @@ NSUInteger const ReaderPostServiceNumberToSync = 40;
 NSUInteger const ReaderPostServiceNumberToSyncForSearch = 10;
 NSUInteger const ReaderPostServiceMaxSearchPosts = 200;
 NSUInteger const ReaderPostServiceMaxPosts = 300;
+NSUInteger const ReaderRelatedPostsCount = 2;
 NSString * const ReaderPostServiceErrorDomain = @"ReaderPostServiceErrorDomain";
 
 static NSString * const ReaderPostGlobalIDKey = @"globalID";
@@ -178,7 +179,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
 
     NSUInteger postID = [post.postID integerValue];
     NSUInteger siteID = [post.siteID integerValue];
-    NSUInteger count = 2;
+    NSUInteger count = ReaderRelatedPostsCount;
     [remoteService fetchRelatedPostFor:postID
                               fromSite:siteID
                             localCount:count

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -170,6 +170,37 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     }];
 }
 
+- (void)fetchRelatedPostsForPost:(ReaderPost *)post
+                         success:(void (^)())success
+                         failure:(void (^)(NSError *error))failure
+{
+    ReaderPostServiceRemote *remoteService = [[ReaderPostServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
+
+    NSUInteger postID = [post.postID integerValue];
+    NSUInteger siteID = [post.siteID integerValue];
+    NSUInteger count = 2;
+    [remoteService fetchRelatedPostFor:postID
+                              fromSite:siteID
+                            localCount:count
+                           globalCount:count
+                               success:^(NSArray<RemoteReaderPost *> *remotePosts) {
+
+                                   NSMutableArray *posts = [NSMutableArray array];
+                                   for (RemoteReaderPost *remotePost in remotePosts) {
+                                       ReaderPost *post = [self createOrReplaceFromRemotePost:remotePost forTopic:nil];
+                                       [posts addObject:post];
+                                   }
+                                   if (success) {
+                                       success();
+                                   }
+
+                               } failure:^(NSError *error) {
+                                   if (failure){
+                                       failure(error);
+                                   }
+                               }];
+}
+
 - (void)refreshPostsForFollowedTopic
 {
     ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:self.managedObjectContext];


### PR DESCRIPTION
Refs #6358

This is the first of a series of prs to add support for related posts to the reader's post detail.
In this patch, support for fetching related posts is added to the networking and service layers.  Support for saving the retrieved posts to core data and actually performing the calls will be added in subsequent PRs.
As code is reviewed we'll merge to a feature branch, which will be merged to develop when the feature is complete.

Needs review: @kwonye would you be game for a review?
