### PR TITLE
Rich Text: Adds support for horizontal rules.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPHorizontalRuleAttachment.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPHorizontalRuleAttachment.swift
@@ -1,0 +1,34 @@
+import Foundation
+import UIKit
+import WordPressShared
+
+
+/// An NSTextAttachment representing a horizontal rule.
+///
+open class WPHorizontalRuleAttachment: NSTextAttachment
+{
+    /// Designated initializer.
+    ///
+    /// - Parameters:
+    ///     - tagName: The tag name of the HTML element represented by the attachment.
+    ///     - identifier: A string to use as the attachment's identifier. It should be unique in the context of its NSAttributedString.s
+    ///     - src: The URL pointing to the remote content represented by the attachment.
+    ///
+    public init() {
+        super.init(data: nil, ofType: nil)
+    }
+
+
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+
+    /// Adjusts the amount of space for the attachment glyph on a line fragment.
+    /// Used for clearing text trailing an attachment when align equals .None
+    ///
+    open override func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
+        return CGRect(x: 0.0, y: 0.0, width: lineFrag.size.width, height: 1.0)
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
@@ -1,6 +1,6 @@
 import Foundation
 import UIKit
-
+import WordPressShared
 
 /// Responsible for taking an HTML formatted string and parsing/reformatting certain
 /// HTML tags that require special handling before the text is shown in a UITextView.
@@ -12,6 +12,7 @@ class WPRichTextFormatter
     static let blockquoteIdentifier = "WPBLOCKQUOTEIDENTIFIER"
     let blockquoteIndentation = CGFloat(20.0)
     let defaultParagraphSpacing = CGFloat(14.0)
+    var horizontalRuleColor: UIColor = WPStyleGuide.greyLighten30()
 
     /// An array of HTMLTagProcessors
     ///
@@ -100,9 +101,6 @@ class WPRichTextFormatter
         for match: NSTextCheckingResult in matches.reversed() {
             let range = match.range
 
-            // Let the horizontal rule match the text color.
-            let color = attrString.attribute(NSForegroundColorAttributeName, at: range.location, effectiveRange: nil) as? UIColor ?? UIColor.gray
-
             // We want a 1px max line height, and paragraphSpacing matching the fontsize.
             let mParagraphStyle = NSMutableParagraphStyle()
             mParagraphStyle.setParagraphStyle(NSParagraphStyle.default)
@@ -115,7 +113,7 @@ class WPRichTextFormatter
             }
             let attributes: [String: Any] = [
                 NSParagraphStyleAttributeName: mParagraphStyle,
-                NSBackgroundColorAttributeName: color
+                NSBackgroundColorAttributeName: horizontalRuleColor
             ]
 
             let attachment = WPHorizontalRuleAttachment()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -831,6 +831,7 @@
 		E6805D301DCD399600168E4F /* WPRichTextEmbed.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6805D2D1DCD399600168E4F /* WPRichTextEmbed.swift */; };
 		E6805D311DCD399600168E4F /* WPRichTextImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6805D2E1DCD399600168E4F /* WPRichTextImage.swift */; };
 		E6805D321DCD399600168E4F /* WPRichTextMediaAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6805D2F1DCD399600168E4F /* WPRichTextMediaAttachment.swift */; };
+		E68580F61E0D91470090EE63 /* WPHorizontalRuleAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68580F51E0D91470090EE63 /* WPHorizontalRuleAttachment.swift */; };
 		E691D62E1CA4B0C9005C91ED /* SigninErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E691D62D1CA4B0C9005C91ED /* SigninErrorViewController.swift */; };
 		E69551F61B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69551F51B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift */; };
 		E69B125E1CE23A8E00594C73 /* SignupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E69B125D1CE23A8E00594C73 /* SignupService.swift */; };
@@ -2199,6 +2200,7 @@
 		E6805D2D1DCD399600168E4F /* WPRichTextEmbed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPRichTextEmbed.swift; path = WPRichText/WPRichTextEmbed.swift; sourceTree = "<group>"; };
 		E6805D2E1DCD399600168E4F /* WPRichTextImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPRichTextImage.swift; path = WPRichText/WPRichTextImage.swift; sourceTree = "<group>"; };
 		E6805D2F1DCD399600168E4F /* WPRichTextMediaAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPRichTextMediaAttachment.swift; path = WPRichText/WPRichTextMediaAttachment.swift; sourceTree = "<group>"; };
+		E68580F51E0D91470090EE63 /* WPHorizontalRuleAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPHorizontalRuleAttachment.swift; sourceTree = "<group>"; };
 		E691D62D1CA4B0C9005C91ED /* SigninErrorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SigninErrorViewController.swift; sourceTree = "<group>"; };
 		E69551F51B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ReaderStreamViewController+Helper.swift"; sourceTree = "<group>"; };
 		E69B125D1CE23A8E00594C73 /* SignupService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupService.swift; sourceTree = "<group>"; };
@@ -4844,6 +4846,7 @@
 				E62AFB661DC8E593007484FC /* WPRichContentView.swift */,
 				E62AFB671DC8E593007484FC /* WPRichTextFormatter.swift */,
 				E62AFB681DC8E593007484FC /* WPTextAttachment.swift */,
+				E68580F51E0D91470090EE63 /* WPHorizontalRuleAttachment.swift */,
 				E62AFB691DC8E593007484FC /* WPTextAttachmentManager.swift */,
 			);
 			name = WPRichText;
@@ -5902,6 +5905,7 @@
 				E6E27D601C613B3C0063F821 /* RemoteSharingButton.swift in Sources */,
 				E1A6DBE519DC7D230071AC1E /* PostService.m in Sources */,
 				E62AFB6E1DC8E593007484FC /* WPTextAttachmentManager.swift in Sources */,
+				E68580F61E0D91470090EE63 /* WPHorizontalRuleAttachment.swift in Sources */,
 				C58349C51806F95100B64089 /* IOS7CorrectedTextView.m in Sources */,
 				E15644F11CE0E56600D96E64 /* FeatureItemCell.swift in Sources */,
 				E62AFB6B1DC8E593007484FC /* WPRichContentView.swift in Sources */,


### PR DESCRIPTION
Fixes #6278

To test:
Check a post containing horizontal rules. For example: https://wordpress.com/read/blogs/53424024/posts/20733
Ensure the horizontal rules are displayed.

Needs review: @kurzee would you mind?
