### PR TITLE
Improve performance of Emoji regular expressions.

### DIFF
--- a/WordPress/Classes/Categories/NSString+Helpers.m
+++ b/WordPress/Classes/Categories/NSString+Helpers.m
@@ -202,9 +202,9 @@ static NSString *const Ellipsis =  @"\u2026";
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSError *error;
-        smiliesRegex = [NSRegularExpression regularExpressionWithPattern:@"<img.*?src=['\"].*?wp-includes/images/smilies/(.+?)(?:.gif|.png)[^'\"]*['\"][^//]+/?>" options:NSRegularExpressionCaseInsensitive error:&error];
-        coreEmojiImgRegex = [NSRegularExpression regularExpressionWithPattern:@"<img.*?src=['\"].*?images/core/emoji/[^/]+/.+?.png['\"][^//]+/?>" options:NSRegularExpressionCaseInsensitive error:&error];
-        wpcomSvgSmilies = [NSRegularExpression regularExpressionWithPattern:@"<img.*?src=['\"].*?wp-content/mu-plugins/wpcom-smileys/(.+?).svg['\"][^//]+/?>" options:NSRegularExpressionCaseInsensitive error:&error];
+        smiliesRegex = [NSRegularExpression regularExpressionWithPattern:@"<img[^>]*?src=['\"][^>]*?wp-includes/images/smilies/(.+?)(?:.gif|.png)[^'\"]*['\"][^//]+/?>" options:NSRegularExpressionCaseInsensitive error:&error];
+        coreEmojiImgRegex = [NSRegularExpression regularExpressionWithPattern:@"<img[^>]*?src=['\"][^>]*?images/core/emoji/[^/]+/.+?.png['\"][^//]+/?>" options:NSRegularExpressionCaseInsensitive error:&error];
+        wpcomSvgSmilies = [NSRegularExpression regularExpressionWithPattern:@"<img[^>]*?src=['\"][^>]*?wp-content/mu-plugins/wpcom-smileys/(.+?).svg['\"][^//]+/?>" options:NSRegularExpressionCaseInsensitive error:&error];
 
     });
 

--- a/WordPress/WordPressTest/NSStringHelpersTests.m
+++ b/WordPress/WordPressTest/NSStringHelpersTests.m
@@ -186,6 +186,16 @@
     XCTAssert([emojiString length] == 0, @"Should return an empty string for an invalid file name.");
 }
 
+- (void)testEmojiDoesNotEatUpImages
+{
+    NSString *emoji = @"\U0001F600";
+    NSString *imageTag = @"<img src=\"something.png\"><img src=\"http://s.w.org/images/core/emoji/72x72/1f600.png\" class=\"wp-smiley\" style=\"height: 1em; max-height: 1em;\">";
+    NSString *replacedString = [imageTag stringByReplacingHTMLEmoticonsWithEmoji];
+    NSString *expected = [@"<img src=\"something.png\">" stringByAppendingString:emoji];
+
+    XCTAssertEqualObjects(expected, replacedString, @"The image tag was not replaced with an emoji string");
+}
+
 - (void)testUniqueStringComponentsSeparatedByWhitespaceCorrectlyReturnsASetWithItsWords
 {
     NSString *testString = @"first\nsecond third\nfourth fifth";


### PR DESCRIPTION
The existing regular expressions were way too greedy.

To illustrate what was wrong, imagine you have the following HTML:

```
<img src="1.jpg"><img src="2.jpg"><img src="3.jpg">
```

The regular expression will start matching at the beginning and see a `<img` that matches.

```
<img src="1.jpg"><img src="2.jpg"><img src="3.jpg">
^..^
/<img/
```

Then, it will advance any number of characters (.*) until it finds the next part of the expression (`src=`).

```
<img src="1.jpg"><img src="2.jpg"><img src="3.jpg">
^.........^
/<img.*?src=['\"]/
```

Then it advances again until it finds a `wp-includes/images...`.

```
<img src="1.jpg"><img src="2.jpg"><img src="3.jpg">
^..................................................X
/<img.*?src=['\"].*?wp-includes/
```

Since that doesn't happen, it backtracks to that `<img` and keeps advancing to find another `src=`.

```
<img src="1.jpg"><img src="2.jpg"><img src="3.jpg">
^.........................^
/<img.*?src=['\"]/
```

Then it advances again until it finds a `wp-includes/images...`.

```
<img src="1.jpg"><img src="2.jpg"><img src="3.jpg">
^..................................................X
/<img.*?src=['\"].*?wp-includes/
```

Since that doesn't happen, it backtracks to that `<img` and keeps advancing to find another `src=`.

```
<img src="1.jpg"><img src="2.jpg"><img src="3.jpg">
^..........................................^
/<img.*?src=['\"]/
```

Then it advances again until it finds a `wp-includes/images...`.

```
<img src="1.jpg"><img src="2.jpg"><img src="3.jpg">
^..................................................X
/<img.*?src=['\"].*?wp-includes/
```

Since that doesn't happen, it backtracks to that `<img` and keeps advancing to find another `src=`.

```
<img src="1.jpg"><img src="2.jpg"><img src="3.jpg">
^..................................................X
/<img.*?src=['\"]/
```

We reach the end of the string withouth a match, so we advance and continue looking. Repeat this same process, for every img tag.

And then, there are another two similar regexps to search for smilies.

The scenario where I discovered this was a post with almost 600 images. I killed the app after 10 minutes at 100% CPU trying to replace emoji.

Besides the performance issues, this would also cause another problems, as the existing expression would match this whole string as a smilie.

```
<img src="1.jpg"><img src="wp-includes/images/smilies/mrgreen.gif" />
```

Which effectively means that `stringByReplacingHTMLEmoticonsWithEmoji` would eat up any image tag before a smilie img.

The new regular expression is fairly similar, only instead of using `.*` (any characters) we're using `[^>]` (any characters other than >), to avoid leaving the img tag when looking ahead.

Needs review: @astralbodies 
