### PR TITLE
Add analytics properties for editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -2,6 +2,12 @@ import UIKit
 
 class EditPostViewController: UIViewController {
 
+    enum editor: String {
+        case hybridVisual = "HybridVisualEditor"
+        case nativeVisual = "NativeVisualEditor"
+        case text = "TextEditor"
+    }
+    
     /// appear instantly, without animations
     var showImmediately: Bool = false
     /// appear with the media picker open
@@ -112,24 +118,39 @@ class EditPostViewController: UIViewController {
         } else {
             let context = ContextManager.sharedInstance().mainContext
             let postService = PostService(managedObjectContext: context)
-            let newPost = postService?.createDraftPost(for: blog)!
+            let newPost = (postService?.createDraftPost(for: blog))!
             post = newPost
-            return newPost!
+            return newPost
         }
     }
 
     // MARK: show the editor
 
-    fileprivate func showEditor() {
+    fileprivate func editorToUse() -> editor {
         let editorSettings = EditorSettings()
-        let editor: UIViewController
         if editorSettings.visualEditorEnabled {
             if editorSettings.nativeEditorEnabled {
-                editor = editPostInNativeVisualEditor()
+                return .nativeVisual
             } else {
-                editor = editPostInHybridVisualEditor()
+                return .hybridVisual
             }
         } else {
+            return .text
+        }
+    }
+
+    public func editorType() -> String {
+        return editorToUse().rawValue
+    }
+
+    fileprivate func showEditor() {
+        let editor: UIViewController
+        switch editorToUse() {
+        case .nativeVisual:
+            editor = editPostInNativeVisualEditor()
+        case .hybridVisual:
+            editor = editPostInHybridVisualEditor()
+        case .text:
             editor = editPostInTextEditor()
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -393,7 +393,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         }
         editor.modalPresentationStyle = .fullScreen
         present(editor, animated: false, completion: nil)
-        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "posts_view"], with: blog)
+        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "posts_view", "editor": editor.editorType()], with: blog)
     }
 
     private func editPost(apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -418,7 +418,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     editor.modalPresentationStyle = UIModalPresentationFullScreen;
     editor.showImmediately = !animated;
     editor.openWithMediaPicker = openToMedia;
-    [WPAppAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar"} withBlog:editor.blog];
+    [WPAppAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar", @"editor": [editor editorType]} withBlog:editor.blog];
     [self presentViewController:editor animated:NO completion:nil];
     return;
 }


### PR DESCRIPTION
As the app has three editors, it'd be useful to know how often each is being used. This PR adds analytics for that each time a new post is created.

To test: create a new post and either inspect the properties using the debugger, or find them in the analytics data.

Needs review: @astralbodies 
Also: @catehstn, I know data is one of your fortés, want to take a look?

Thanks!
