### PR TITLE
Posts/Pages Lists: calculate correct oldestPostDate from synced posts.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -556,12 +556,16 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
     func updateFilter(_ filter: PostListFilter, withSyncedPosts posts: [AbstractPost], syncOptions options: PostServiceSyncOptions) {
 
-        guard let oldestPost = posts.last else {
+        guard posts.count > 0 else {
             assertionFailure("This method should not be called with no posts.")
             return
         }
 
-        // Reset the filter to only show the latest sync point.
+        // Reset the filter to only show the latest sync point, based on the oldest post date in the posts just synced.
+        // Note: sorting manually to ensure we grab the oldest date as the API may return results out of order if there are
+        // differing time offsets in the created dates.
+        let sortedPosts = posts.sorted {$0.date_created_gmt > $1.date_created_gmt}
+        let oldestPost = sortedPosts.last!
         filter.oldestPostDate = oldestPost.dateCreated()
         filter.hasMore = posts.count >= options.number.intValue
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -555,18 +555,15 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
     }
 
     func updateFilter(_ filter: PostListFilter, withSyncedPosts posts: [AbstractPost], syncOptions options: PostServiceSyncOptions) {
-
         guard posts.count > 0 else {
             assertionFailure("This method should not be called with no posts.")
             return
         }
-
         // Reset the filter to only show the latest sync point, based on the oldest post date in the posts just synced.
-        // Note: sorting manually to ensure we grab the oldest date as the API may return results out of order if there are
+        // Note: Getting oldest date manually as the API may return results out of order if there are
         // differing time offsets in the created dates.
-        let sortedPosts = posts.sorted {$0.date_created_gmt > $1.date_created_gmt}
-        let oldestPost = sortedPosts.last!
-        filter.oldestPostDate = oldestPost.dateCreated()
+        let oldestPost = posts.min {$0.date_created_gmt < $1.date_created_gmt}
+        filter.oldestPostDate = oldestPost?.date_created_gmt
         filter.hasMore = posts.count >= options.number.intValue
 
         updateAndPerformFetchRequestRefreshingResults()


### PR DESCRIPTION
Fixes #6000 

This was an interesting one, thanks to @aerych for the really nice find a while back! As seen in #6000, some times the API may return posts out of the order from which they were requested with, such as asc/dsc dates, when the created date offset differs between posts.

I've fixed this by not relying on the direct order returned from the API and instead calculating our `oldestPostDate` with a manual compute on the returned results.

**To test:**
1. Open a site with a large amount of posts.
2. Scroll to the bottom and page through a series of pages of posts.
3. Ensure the paging is loading the correct posts as expected, compared with the list on the web or wp-admin.

**To test the original offset issue:**
1. Open up wp-admin for a test site with a few pages.
2. Find the two oldest pages in the list.
3. Set both of the two oldest pages to the same date and time using quick edit.
4. The two posts will now order based on the same offset, but maybe differently based on the seconds in the timestamp.
5. Open General Settings for the site in wp-admin.
6. Change the timezone with an offset that would produce a date older than the currently set timezone.
7. Go back to the two oldest posts.
8. Select quick edit on the second from oldest post in the list.
9. Hit the update button without changing the time.
10. The post will now have the same time with the newly set offset, which should be an older date.
11. Open the app, go to Pages, refresh if needed.
12. The newly oldest post should be ordered last in the list, while it lists second from last on wp-admin. Without this fix, the post wouldn't show up at all.

Needs review: @aerych can you take a gander? No pressure to tackle the second test case of the original offset issue 😄 
