### PR TITLE
Issues/6317 non latin domains

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -172,7 +172,7 @@ import Mixpanel
     /// - Returns: The base URL or an empty string.
     ///
     class func baseSiteURL(string: String) -> String {
-        guard let siteURL = NSURL(string: NSURL.IDNDecodedURL(string)) else {
+        guard let siteURL = NSURL(string: NSURL.IDNEncodedURL(string)) else {
             return ""
         }
 
@@ -194,7 +194,7 @@ import Mixpanel
             .trimSuffix(regexp: "/wp-admin/?")
             .trimSuffix(regexp: "/?")
 
-        return path
+        return NSURL.IDNDecodedURL(path)
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -172,7 +172,7 @@ import Mixpanel
     /// - Returns: The base URL or an empty string.
     ///
     class func baseSiteURL(string: String) -> String {
-        guard let siteURL = NSURL(string: NSURL.IDNEncodedURL(string)) else {
+        guard let siteURL = NSURL(string: NSURL.IDNEncodedURL(string)) where string.characters.count > 0 else {
             return ""
         }
 

--- a/WordPress/WordPressTest/SigninHelperTests.swift
+++ b/WordPress/WordPressTest/SigninHelperTests.swift
@@ -22,7 +22,7 @@ class SigninHelperTests: XCTestCase {
         url = SigninHelpers.baseSiteURL(baseURL)
         XCTAssert(url == "https://\(baseURL)", "Should force https for a wpcom site without a scheme.")
 
-        baseURL = "www.sefhostedsite.com"
+        baseURL = "www.selfhostedsite.com"
         url = SigninHelpers.baseSiteURL(baseURL)
         XCTAssert((url == "http://\(baseURL)"), "Should add http:\\ for a non wpcom site missing a scheme.")
 
@@ -38,6 +38,13 @@ class SigninHelperTests: XCTestCase {
         url = SigninHelpers.baseSiteURL("\(baseURL)/")
         XCTAssert((url == "http://\(baseURL)"), "Should remove a trailing slash from the url.")
 
+        // Check non-latin characters and puny code
+        baseURL = "http://例.例"
+        let punycode = "http://xn--fsq.xn--fsq"
+        url = SigninHelpers.baseSiteURL(baseURL)
+        XCTAssert(url == baseURL)
+        url = SigninHelpers.baseSiteURL(punycode)
+        XCTAssert(url == baseURL)
     }
 
 


### PR DESCRIPTION
Refs #6317 
While investigating an issue similar to #6317 I noticed that we were calling the IDN decode method when we should have been encoding.  This patch correctly encodes non-latin domains, and adds the relevant test to our test suite.  Sadly, the issue with emoji domains remains.

To test:
Try signing into the app with a blog at a non-latin character domain (ping me for an example).  For the test its fine to provide bogus credentials.  We're just wanting to confirm that the URL will be parsed, and the app can see the blog.  Confirm you get an invalid credentials warning as expected. 

Confirm you can still sign into blogs (self-hosted and wpcom) that have an all latin character domains.

Needs review: @kwonye 

cc @sendhil for the late patch
