### PR TITLE
Removed two duplicate headers from WPPostViewController.h

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -37,8 +37,6 @@
 #import "MediaLibraryPickerDataSource.h"
 #import "WPAndDeviceMediaLibraryDataSource.h"
 #import "WPAppAnalytics.h"
-#import "WordPress-Swift.h"
-#import "WordPressAppDelegate.h"
 
 @import Gridicons;
 


### PR DESCRIPTION
I found that `WPPostViewController.h` was including two headers twice each. That's silly.

To test: Make sure it still compiles. If it doesn't, I'll lose faith in humanity. 

Needs review: @SergioEstevao 