### PR TITLE
Reader crash while backgrounding

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -18,7 +18,7 @@ import WordPressShared
     var didSyncTopics = false
 
     fileprivate var defaultIndexPath: IndexPath {
-        return viewModel.indexPathOfDefaultMenuItemWithOrder(order: .discover) as IndexPath
+        return viewModel.indexPathOfDefaultMenuItemWithOrder(order: .discover)
     }
 
     fileprivate var restorableSelectedIndexPath: IndexPath?

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -17,7 +17,7 @@ import Gridicons
     @IBOutlet fileprivate weak var label: UILabel!
 
     fileprivate var backgroundTapRecognizer: UITapGestureRecognizer!
-    fileprivate var streamController: ReaderStreamViewController!
+    fileprivate var streamController: ReaderStreamViewController?
     fileprivate let searchBarSearchIconSize = CGFloat(13.0)
     fileprivate var suggestionsController: ReaderSearchSuggestionsViewController?
     fileprivate var restoredSearchTopic: ReaderSearchTopic?
@@ -60,7 +60,6 @@ import Gridicons
 
 
     open override func encodeRestorableState(with coder: NSCoder) {
-        // Optionally check the streamController as it may not be set yet, even though we are using !
         if let topic = streamController?.readerTopic {
             topic.preserveForRestoration = true
             ContextManager.sharedInstance().saveContextAndWait(topic.managedObjectContext)
@@ -184,7 +183,7 @@ import Gridicons
         }
         label.isHidden = true
         searchBar.text = topic.title
-        streamController.readerTopic = topic
+        streamController?.readerTopic = topic
     }
 
 
@@ -200,7 +199,9 @@ import Gridicons
     /// embedded stream to the topic.
     ///
     func performSearch() {
-        assert(streamController != nil)
+        guard let streamController = streamController else {
+            return
+        }
 
         guard let phrase = searchBar.text?.trim(), !phrase.isEmpty else {
             return

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -60,7 +60,8 @@ import Gridicons
 
 
     open override func encodeRestorableState(with coder: NSCoder) {
-        if let topic = streamController.readerTopic {
+        // Optionally check the streamController as it may not be set yet, even though we are using !
+        if let topic = streamController?.readerTopic {
             topic.preserveForRestoration = true
             ContextManager.sharedInstance().saveContextAndWait(topic.managedObjectContext)
             coder.encode(topic.path, forKey: type(of: self).restorableSearchTopicPathKey)


### PR DESCRIPTION
This was interesting one. A crash would occur in Reader when backgrounding the app during NUX, but only if the app is freshly installed.

In this particular scenario the `ReaderSearchViewController` is initiated via `initialDetailViewControllerForSplitView` as the initial controller. This is because the `ReaderTopicService.topicForDiscover()` topic is unavailable on first launch, otherwise discover would be loaded as a `ReaderStreamViewController`.

Since `ReaderSearchViewController` is initialized at first launch, if the user backgrounds the app during NUX, or before they login, the `encodeRestorableState` method will be called which triggers the crash at `if let topic = streamController.readerTopic` by unwrapping `fileprivate var streamController: ReaderStreamViewController!`.

So the fix I added here is simply `if let topic = streamController?.readerTopic`, but I'm not so sure there isn't something else going on here we would want to address? Perhaps we shouldn't default the `ReaderSearchViewController` on split-view initialization? cc @frosty 

You can see the stack of all this play out by adding a breakpoint `ReaderSearchViewController` in:
```
    open class func controller() -> ReaderSearchViewController {
        let storyboard = UIStoryboard(name: "Reader", bundle: Bundle.main)
        let controller = storyboard.instantiateViewController(withIdentifier: "ReaderSearchViewController") as! ReaderSearchViewController
        return controller
    }
```

To test:
1. Delete WPiOS from the simulator or device.
2. Install and launch the app, but don't log in.
3. Background the app.
4. No crashes! 🤞 

Needs review: @aerych can you take a peak? You might also have additional thoughts on how this is handled.