### PR TITLE
Editor Preview: Adds css classes for alignment.

### DIFF
--- a/WordPress/Resources/HTML/defaultPostTemplate.html
+++ b/WordPress/Resources/HTML/defaultPostTemplate.html
@@ -68,7 +68,27 @@
         progress.wp_media_indicator {
             display:none;            
         }
-		
+
+        /**
+         * 8.0 - Alignments
+         * Taken and modified from twenty-sixteen theme style.css.
+         */
+        .alignleft {
+            float: left;
+            margin: 0.375em 1.75em 1.75em 0;
+        }
+
+        .alignright {
+            float: right;
+            margin: 0.375em 0 1.75em 1.75em;
+        }
+
+        .aligncenter {
+            clear: both;
+            display: block !important;
+            margin: auto !important;
+        }
+
 	</style>
 </head>
 <body>


### PR DESCRIPTION
Fixes #6384 

To test:
Create or edit a post and add a few images.
Edit each image and set its alignemnt to left, center, right.  Optionally set the image size to thumbnail to help it fit on screen.
Back on the editor screen, tap the menu button and choose Preview from the options. 
Confirm that the images are shown the the correct alignment.

Needs review: @nheagy could I trouble you with this one?
