### PR TITLE
Posts: Super secret hidden support for searching remote posts via XML-RPC

### DIFF
--- a/WordPress/Classes/Networking/PostServiceRemoteOptions.h
+++ b/WordPress/Classes/Networking/PostServiceRemoteOptions.h
@@ -69,7 +69,6 @@ typedef NS_ENUM(NSUInteger, PostServiceResultsOrdering) {
 
 /**
  A search query used when requesting posts.
- @attention Not supported in XML-RPC.
  */
 - (NSString *)search;
 

--- a/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteXMLRPC.m
@@ -14,6 +14,7 @@ static NSString * const RemoteOptionKeyOffset = @"offset";
 static NSString * const RemoteOptionKeyOrder = @"order";
 static NSString * const RemoteOptionKeyOrderBy = @"orderby";
 static NSString * const RemoteOptionKeyStatus = @"post_status";
+static NSString * const RemoteOptionKeySearch = @"s";
 
 static NSString * const RemoteOptionValueOrderAscending = @"ASC";
 static NSString * const RemoteOptionValueOrderDescending = @"DESC";
@@ -268,6 +269,11 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     }
     if (orderByStr.length) {
         [remoteParams setObject:orderByStr forKey:RemoteOptionKeyOrderBy];
+    }
+
+    NSString *search = [options search];
+    if (search.length) {
+        [remoteParams setObject:search forKey:RemoteOptionKeySearch];
     }
     
     return remoteParams.count ? [NSDictionary dictionaryWithDictionary:remoteParams] : nil;


### PR DESCRIPTION
Fixes #6392, #6391

Way back in https://github.com/wordpress-mobile/WordPress-iOS/pull/4840 we added support for searching posts via the `PostService`, but at the time XML-RPC was not obviously supported as per the documentation: https://codex.wordpress.org/XML-RPC_WordPress_API/Posts

For whatever mysterious, glorious, hidden reason, the XML-RPC does apparently in-fact support searching/filtering `wp.getPosts` with an `"s"` param under filters. Thus, we now support it in app as well.

To test:
1. Uninstall the app to ensure no posts are cached.
2. Add a self hosted site with more than 40 posts, or lower the default sync count on https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/Services/PostService.m#L23
3. Select the Blog Posts list.
4. Don't scroll down.
5. Search for a known post title that is older and would not have loaded into the initial sync of posts.
6. There should be a brief delay, but the post should load via the new remote search.

Needs review: @aerych thanks for pinging me on this!