### PR TITLE
Makes Tracks anonymous ID a bit more persistent

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -32,7 +32,8 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
 
 @implementation WPAnalyticsTrackerAutomatticTracks
 
-NSString *_loggedInID, *_anonymousID;
+@synthesize loggedInID = _loggedInID;
+@synthesize anonymousID = _anonymousID;
 
 + (NSString *)eventNameForStat:(WPAnalyticsStat)stat
 {


### PR DESCRIPTION
Fixes #6388 

Currently the anonymous ID sticks around as long as the app isn't evicted from memory and the user ID property in `TracksService` isn't wiped. Technically the anonymous ID would be replaced every time the app is backgrounded (not on purpose) but isn't wiped due to it being stored in the `TracksService` instance.

This PR makes the randomly-generated anonymous ID for users not logged into WordPress.com a little more sticky. The anonymous ID, after being generated, is stored in user defaults. When the user logs in as a .com user the appropriate alias event is sent to Tracks and the anonymous ID is wiped out. If the user logs out from a .com account and then logs back in to another the anonymous ID is created for a brief moment to prevent aliasing in Tracks.

To test:
1. Set a breakpoint in `TracksServiceRemote` `sendBatchOfEvents:withSharedProperties:completionHandler:` to inspect the contents of `dataToSend` when Tracks fires out the queued events.
2. Launch the app.
3. Wait up to 10 seconds for Tracks to fire. Verify `_ui` is a random-looking user ID (a UUID).
4. Log in as a .com user.
5. Verify alias event is sent with .com username and the random ID from step 3.
6. Log out.
7. Verify at least one of the log out events has a new random UUID. Make a note of this for step 9.
8. Kill the app. Restart.
9. Verify the app opened event has the UUID from step 7.

You could go further into testing switching .com accounts but the timing is super tricky and not really important in the grand scheme.


Needs review: @frosty 

cc: @catehstn @daniloercoli @sendhil 
