### PR TITLE
Fixes a bork to properly attach media to uploaded posts.

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -185,6 +185,9 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
 
                 NSPredicate *unattachedMediaPredicate = [NSPredicate predicateWithFormat:@"postID <= 0"];
                 NSArray<Media *> *mediaToUpdate = [[postInContext.media filteredSetUsingPredicate:unattachedMediaPredicate] allObjects];
+                for (Media *media in mediaToUpdate) {
+                    media.postID = post.postID;
+                }
 
                 MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:self.managedObjectContext];
                 [mediaService updateMultipleMedia:mediaToUpdate overallSuccess:^{


### PR DESCRIPTION
Fixes #6372 

I broke-diddy-oke attaching media to posts after they've been published in d707022d57210192da39240abcae5722bbe976b6. This puts back the missing functionality when I batched stuff.

To test:
1. Create a new post.
2. Attach an image (new one).
3. Publish the post.
4. Verify media is attached in wp-admin.

Needs review: @SergioEstevao 
