### PR TITLE
Update media picker version to 0.10.3

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -48,7 +48,7 @@ abstract_target 'WordPress_Base' do
     pod 'Gridicons', :git => "https://github.com/Automattic/Gridicons-iOS.git", :commit => "8bd04e18eddaaf36810887c94837571e68f7cc24"
     pod 'NSObject-SafeExpectations', '0.0.2'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', '~> 0.10.2'
+    pod 'WPMediaPicker', '~> 0.10.3'
     pod 'WordPress-iOS-Editor', '1.8.1'
     pod 'WordPressCom-Analytics-iOS', '0.1.21'
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => '7d02c77349245c6e4d3bcdf63a878f90eb4a4e39'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -156,7 +156,7 @@ PODS:
     - WordPressCom-Analytics-iOS (~> 0.1.4)
   - WordPressComKit (0.0.5):
     - Alamofire (~> 3.0)
-  - WPMediaPicker (0.10.2)
+  - WPMediaPicker (0.10.3)
   - wpxmlrpc (0.8.2)
 
 DEPENDENCIES:
@@ -194,7 +194,7 @@ DEPENDENCIES:
   - WordPressCom-Analytics-iOS (= 0.1.21)
   - WordPressCom-Stats-iOS (= 0.8.1)
   - WordPressComKit (= 0.0.5)
-  - WPMediaPicker (~> 0.10.2)
+  - WPMediaPicker (~> 0.10.3)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -263,9 +263,9 @@ SPEC CHECKSUMS:
   WordPressCom-Analytics-iOS: ee6cc3a4feb63cebba167ce762c6e12c0b7b6671
   WordPressCom-Stats-iOS: 07b1796831c31c0c8c8a0f2e314bb2e6636af5df
   WordPressComKit: 4dc52eebc508b8e056d8bf8e931a7be95d467e3b
-  WPMediaPicker: 9ba8c29a1de4b07696356f541c01eeaa6dd14c47
+  WPMediaPicker: 1ae6c4658d47cccf5f913350886ff69abefb81f1
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 57f04330257ed997a91c0766a2f7d08545a924d8
+PODFILE CHECKSUM: 71447e338438a8b061b9131b2f7a877e7ec02931
 
 COCOAPODS: 1.1.1


### PR DESCRIPTION
Fixes crash on gravatar change on an iPhone 4s.

To test:
 - On a iPhone 4s
 - Go to Me section
 - Tap on the gravatar image
 - Check if the app doesn't crash.

 - Check on another device to see if it's working ok.

Needs review: @astralbodies 