### PR TITLE
BlogService: Refactor for syncing a blog, settings, and options

### DIFF
--- a/WordPress/Classes/Networking/BlogServiceRemote.h
+++ b/WordPress/Classes/Networking/BlogServiceRemote.h
@@ -27,7 +27,7 @@ typedef void (^SuccessHandler)();
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)syncPostTypesWithSuccess:(PostTypesHandler)success
-                           failure:(void (^)(NSError *error))failure;
+                         failure:(void (^)(NSError *error))failure;
 
 /**
  *  @brief      Synchronizes a blog's post formats.

--- a/WordPress/Classes/Networking/BlogServiceRemote.h
+++ b/WordPress/Classes/Networking/BlogServiceRemote.h
@@ -4,9 +4,6 @@
 @class RemoteBlogSettings;
 @class RemotePostType;
 
-typedef void (^SettingsHandler)(RemoteBlogSettings *settings);
-typedef void (^OptionsHandler)(NSDictionary *options);
-typedef void (^SiteDetailsHandler)(RemoteBlog *remoteBlog);
 typedef void (^PostTypesHandler)(NSArray <RemotePostType *> *postTypes);
 typedef void (^PostFormatsHandler)(NSDictionary *postFormats);
 typedef void (^MultiAuthorCheckHandler)(BOOL isMultiAuthor);
@@ -39,46 +36,6 @@ typedef void (^SuccessHandler)();
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)syncPostFormatsWithSuccess:(PostFormatsHandler)success
-                           failure:(void (^)(NSError *error))failure;
-
-
-/**
- *  @brief      Synchronizes a blog's settings.
- *
- *  @param      success     The block that will be executed on success.  Can be nil.
- *  @param      failure     The block that will be executed on failure.  Can be nil.
- */
-- (void)syncSettingsWithSuccess:(SettingsHandler)success
-                        failure:(void (^)(NSError *error))failure;
-
-/**
- *  @brief      Updates the blog settings.
- *
- *  @param      success     The block that will be executed on success.  Can be nil.
- *  @param      failure     The block that will be executed on failure.  Can be nil.
- */
-- (void)updateBlogSettings:(RemoteBlogSettings *)remoteBlogSettings
-                   success:(SuccessHandler)success
-                   failure:(void (^)(NSError *error))failure;
-
-@optional
-
-/**
- *  @brief      Synchronizes a blog's options.
- *
- *  @param      success     The block that will be executed on success.  Can be nil.
- *  @param      failure     The block that will be executed on failure.  Can be nil.
- */
-- (void)syncOptionsWithSuccess:(OptionsHandler)success
-                       failure:(void (^)(NSError *error))failure;
-
-/**
- *  @brief      Synchronizes a blog's top-level details.
- *
- *  @param      success     The block that will be executed on success.  Can be nil.
- *  @param      failure     The block that will be executed on failure.  Can be nil.
- */
-- (void)syncSiteDetailsWithSuccess:(SiteDetailsHandler)success
                            failure:(void (^)(NSError *error))failure;
 
 @end

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.h
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.h
@@ -2,5 +2,43 @@
 #import "BlogServiceRemote.h"
 #import "SiteServiceRemoteWordPressComREST.h"
 
+typedef void (^BlogDetailsHandler)(RemoteBlog *remoteBlog);
+typedef void (^SettingsHandler)(RemoteBlogSettings *settings);
+
 @interface BlogServiceRemoteREST : SiteServiceRemoteWordPressComREST <BlogServiceRemote>
+
+/**
+ *  @brief      Synchronizes a blog's top-level details.
+ *
+ *  @note       Requires WPCOM/Jetpack APIs.
+ *
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)syncBlogDetailsWithSuccess:(BlogDetailsHandler)success
+                           failure:(void (^)(NSError *error))failure;
+
+/**
+ *  @brief      Synchronizes a blog's settings.
+ *
+ *  @note       Requires WPCOM/Jetpack APIs.
+ *
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)syncBlogSettingsWithSuccess:(SettingsHandler)success
+                            failure:(void (^)(NSError *error))failure;
+
+/**
+ *  @brief      Updates the blog settings.
+ *
+ *  @note       Requires WPCOM/Jetpack APIs.
+ *
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)updateBlogSettings:(RemoteBlogSettings *)remoteBlogSettings
+                   success:(SuccessHandler)success
+                   failure:(void (^)(NSError *error))failure;
+
 @end

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.h
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.h
@@ -8,15 +8,15 @@ typedef void (^SettingsHandler)(RemoteBlogSettings *settings);
 @interface BlogServiceRemoteREST : SiteServiceRemoteWordPressComREST <BlogServiceRemote>
 
 /**
- *  @brief      Synchronizes a blog's top-level details.
+ *  @brief      Synchronizes a blog and its top-level details.
  *
  *  @note       Requires WPCOM/Jetpack APIs.
  *
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
-- (void)syncBlogDetailsWithSuccess:(BlogDetailsHandler)success
-                           failure:(void (^)(NSError *error))failure;
+- (void)syncBlogWithSuccess:(BlogDetailsHandler)success
+                    failure:(void (^)(NSError *error))failure;
 
 /**
  *  @brief      Synchronizes a blog's settings.

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -85,28 +85,6 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
           }];
 }
 
-- (void)syncSiteDetailsWithSuccess:(SiteDetailsHandler)success
-                           failure:(void (^)(NSError *))failure
-{
-    NSString *path = [self pathForOptions];
-    NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
-    
-    [self.wordPressComRestApi GET:requestUrl
-       parameters:nil
-          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-              NSDictionary *responseDict = (NSDictionary *)responseObject;
-              RemoteBlog *remoteBlog = [[RemoteBlog alloc] initWithJSONDictionary:responseDict];
-              if (success) {
-                  success(remoteBlog);
-              }
-          } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
-              if (failure) {
-                  failure(error);
-              }
-          }];
-}
-
 - (void)syncPostTypesWithSuccess:(PostTypesHandler)success
                          failure:(void (^)(NSError *error))failure
 {
@@ -158,7 +136,29 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
           }];
 }
 
-- (void)syncSettingsWithSuccess:(SettingsHandler)success
+- (void)syncBlogDetailsWithSuccess:(BlogDetailsHandler)success
+                           failure:(void (^)(NSError *))failure
+{
+    NSString *path = [self pathForOptions];
+    NSString *requestUrl = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+
+    [self.wordPressComRestApi GET:requestUrl
+                       parameters:nil
+                          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+                              NSDictionary *responseDict = (NSDictionary *)responseObject;
+                              RemoteBlog *remoteBlog = [[RemoteBlog alloc] initWithJSONDictionary:responseDict];
+                              if (success) {
+                                  success(remoteBlog);
+                              }
+                          } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+                              if (failure) {
+                                  failure(error);
+                              }
+                          }];
+}
+
+- (void)syncBlogSettingsWithSuccess:(SettingsHandler)success
                         failure:(void (^)(NSError *error))failure
 {
     NSString *path = [self pathForSettings];

--- a/WordPress/Classes/Networking/BlogServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/BlogServiceRemoteREST.m
@@ -136,10 +136,10 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
           }];
 }
 
-- (void)syncBlogDetailsWithSuccess:(BlogDetailsHandler)success
-                           failure:(void (^)(NSError *))failure
+- (void)syncBlogWithSuccess:(BlogDetailsHandler)success
+                    failure:(void (^)(NSError *))failure
 {
-    NSString *path = [self pathForOptions];
+    NSString *path = [self pathForSite];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
@@ -225,7 +225,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     return [NSString stringWithFormat:@"sites/%@/users", self.siteID];
 }
 
-- (NSString *)pathForOptions
+- (NSString *)pathForSite
 {
     return [NSString stringWithFormat:@"sites/%@", self.siteID];
 }

--- a/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.h
+++ b/WordPress/Classes/Networking/BlogServiceRemoteXMLRPC.h
@@ -2,6 +2,31 @@
 #import "BlogServiceRemote.h"
 #import "ServiceRemoteWordPressXMLRPC.h"
 
+typedef void (^OptionsHandler)(NSDictionary *options);
+
 @interface BlogServiceRemoteXMLRPC : ServiceRemoteWordPressXMLRPC<BlogServiceRemote>
+
+/**
+ *  @brief      Synchronizes a blog's options.
+ *
+ *  @note       Available in XML-RPC only.
+ *
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)syncBlogOptionsWithSuccess:(OptionsHandler)success
+                           failure:(void (^)(NSError *error))failure;
+
+/**
+ *  @brief      Update a blog's options.
+ *
+ *  @note       Available in XML-RPC only.
+ *
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)updateBlogOptionsWith:(NSDictionary *)remoteBlogOptions
+                      success:(SuccessHandler)success
+                      failure:(void (^)(NSError *error))failure;
 
 @end

--- a/WordPress/Classes/Networking/RemoteBlogOptionsHelper.h
+++ b/WordPress/Classes/Networking/RemoteBlogOptionsHelper.h
@@ -1,7 +1,15 @@
 #import <Foundation/Foundation.h>
 
+@class RemoteBlogSettings;
+
 @interface RemoteBlogOptionsHelper : NSObject
 
 + (NSDictionary *)mapOptionsFromResponse:(NSDictionary *)response;
+
+// Helper methods for converting between XMLRPC dictionaries and RemoteBlogSettings
+// Currently, we are only ever updating the blog title or tagline through XMLRPC
+// Brent - Jan 7, 2017
++ (NSDictionary *)remoteOptionsForUpdatingBlogTitleAndTagline:(RemoteBlogSettings *)blogSettings;
++ (RemoteBlogSettings *)remoteBlogSettingsFromXMLRPCDictionaryOptions:(NSDictionary *)json;
 
 @end

--- a/WordPress/Classes/Networking/RemoteBlogOptionsHelper.m
+++ b/WordPress/Classes/Networking/RemoteBlogOptionsHelper.m
@@ -1,4 +1,6 @@
 #import "RemoteBlogOptionsHelper.h"
+#import "NSMutableDictionary+Helpers.h"
+#import "WordPress-Swift.h"
 
 @implementation RemoteBlogOptionsHelper
 
@@ -39,6 +41,25 @@
     }];
 
     return [NSDictionary dictionaryWithDictionary:valueOptions ];
+}
+
++ (NSDictionary *)remoteOptionsForUpdatingBlogTitleAndTagline:(RemoteBlogSettings *)blogSettings
+{
+    NSMutableDictionary *options = [NSMutableDictionary dictionary];
+    [options setValueIfNotNil:blogSettings.name forKey:@"blog_title"];
+    [options setValueIfNotNil:blogSettings.tagline forKey:@"blog_tagline"];
+    return options;
+}
+
++ (RemoteBlogSettings *)remoteBlogSettingsFromXMLRPCDictionaryOptions:(NSDictionary *)options
+{
+    RemoteBlogSettings *remoteSettings = [RemoteBlogSettings new];
+    remoteSettings.name = [[options stringForKeyPath:@"blog_title.value"] stringByDecodingXMLCharacters];
+    remoteSettings.tagline = [[options stringForKeyPath:@"blog_tagline.value"] stringByDecodingXMLCharacters];
+    if (options[@"blog_public"]) {
+        remoteSettings.privacy = [options numberForKeyPath:@"blog_public.value"];
+    }
+    return remoteSettings;
 }
 
 @end

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -54,7 +54,7 @@ extern NSString *const WordPressMinimumVersion;
  *  Sync all available blogs for an acccount
  *
  *  @param account the account for the associated blogs.
- *  @param success a block that is invoked when the sync is sucessfull.
+ *  @param success a block that is invoked when the sync is successful.
  *  @param failure a block that in invoked when the sync fails.
  */
 - (void)syncBlogsForAccount:(WPAccount *)account
@@ -62,10 +62,10 @@ extern NSString *const WordPressMinimumVersion;
                     failure:(void (^)(NSError *error))failure;
 
 /**
- *  Sync the blog and it's top-level details such as the 'options' data and any jetpack configuration.
+ *  Sync the blog and its top-level details such as the 'options' data and any jetpack configuration.
  *
  *  @param blog    the blog from where to read the information from
- *  @param success a block that is invoked when the sync is sucessfull.
+ *  @param success a block that is invoked when the sync is successful.
  *  @param failure a block that in invoked when the sync fails.
  */
 - (void)syncBlog:(Blog *)blog
@@ -78,27 +78,28 @@ extern NSString *const WordPressMinimumVersion;
  *  @note Used for instances where the entire blog should be refreshed or initially downloaded.
  *
  *  @param blog    the blog from where to read the information from
- *  @param success a block that is invoked when the sync is sucessfull.
+ *  @param success a block that is invoked when the sync is successful.
  *  @param failure a block that in invoked when the sync fails.
  */
-- (void)syncBlogAndAllMetadata:(Blog *)blog completionHandler:(void (^)())completionHandler;
+- (void)syncBlogAndAllMetadata:(Blog *)blog
+             completionHandler:(void (^)())completionHandler;
 
 /**
  *  Sync the available postTypes configured for the blog.
  *
  *  @param blog    the blog from where to read the information from
- *  @param success a block that is invoked when the sync is sucessfull.
+ *  @param success a block that is invoked when the sync is successful.
  *  @param failure a block that in invoked when the sync fails.
  */
 - (void)syncPostTypesForBlog:(Blog *)blog
-                       success:(void (^)())success
-                       failure:(void (^)(NSError *error))failure;
+                     success:(void (^)())success
+                     failure:(void (^)(NSError *error))failure;
 
 /**
  *  Sync the available postFormats configured for the blog.
  *
  *  @param blog    the blog from where to read the information from
- *  @param success a block that is invoked when the sync is sucessfull.
+ *  @param success a block that is invoked when the sync is successful.
  *  @param failure a block that in invoked when the sync fails.
  */
 - (void)syncPostFormatsForBlog:(Blog *)blog
@@ -109,23 +110,23 @@ extern NSString *const WordPressMinimumVersion;
  *  Sync blog settings from the server
  *
  *  @param blog    the blog from where to read the information from
- *  @param success a block that is invoked when the sync is sucessfull
+ *  @param success a block that is invoked when the sync is successful
  *  @param failure a block that in invoked when the sync fails.
  */
 - (void)syncSettingsForBlog:(Blog *)blog
-                   success:(void (^)())success
-                   failure:(void (^)(NSError *error))failure;
+                    success:(void (^)())success
+                    failure:(void (^)(NSError *error))failure;
 
 /**
- *  Update blog settings to server
+ *  Update blog settings to the server
  *
  *  @param blog    the blog to update
- *  @param success a block that is invoked when the update is sucessfull
+ *  @param success a block that is invoked when the update is successful
  *  @param failure a block that in invoked when the update fails.
  */
 - (void)updateSettingsForBlog:(Blog *)blog
-                     success:(nullable void (^)())success
-                     failure:(nullable void (^)(NSError *error))failure;
+                      success:(nullable void (^)())success
+                      failure:(nullable void (^)(NSError *error))failure;
 
 
 /**
@@ -187,7 +188,7 @@ extern NSString *const WordPressMinimumVersion;
  @return the blog if one was found, otherwise it returns nil
  */
 - (nullable Blog *)findBlogWithXmlrpc:(NSString *)xmlrpc
-                   inAccount:(WPAccount *)account;
+                            inAccount:(WPAccount *)account;
 
 /**
  Searches for a `Blog` object for this account with the given username
@@ -197,7 +198,7 @@ extern NSString *const WordPressMinimumVersion;
  @return the blog if one was found, otherwise it returns nil
  */
 - (nullable Blog *)findBlogWithXmlrpc:(NSString *)xmlrpc
-                 andUsername:(NSString *)username;
+                          andUsername:(NSString *)username;
 
 /**
  Creates a blank `Blog` object for this account

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -50,18 +50,57 @@ extern NSString *const WordPressMinimumVersion;
  */
 - (nullable Blog *)primaryBlog;
 
+/**
+ *  Sync all available blogs for an acccount
+ *
+ *  @param account the account for the associated blogs.
+ *  @param success a block that is invoked when the sync is sucessfull.
+ *  @param failure a block that in invoked when the sync fails.
+ */
 - (void)syncBlogsForAccount:(WPAccount *)account
                     success:(void (^)())success
                     failure:(void (^)(NSError *error))failure;
 
-- (void)syncOptionsForBlog:(Blog *)blog
-                   success:(void (^)())success
-                   failure:(void (^)(NSError *error))failure;
+/**
+ *  Sync the blog and it's top-level details such as the 'options' data and any jetpack configuration.
+ *
+ *  @param blog    the blog from where to read the information from
+ *  @param success a block that is invoked when the sync is sucessfull.
+ *  @param failure a block that in invoked when the sync fails.
+ */
+- (void)syncBlog:(Blog *)blog
+         success:(void (^)())success
+         failure:(void (^)(NSError *error))failure;
 
+/**
+ *  Sync the blog and all available metadata or configuration. Such as top-level details, postTypes, postFormats, categories, multi-author and jetpack configuration.
+ *
+ *  @note Used for instances where the entire blog should be refreshed or initially downloaded.
+ *
+ *  @param blog    the blog from where to read the information from
+ *  @param success a block that is invoked when the sync is sucessfull.
+ *  @param failure a block that in invoked when the sync fails.
+ */
+- (void)syncBlogAndAllMetadata:(Blog *)blog completionHandler:(void (^)())completionHandler;
+
+/**
+ *  Sync the available postTypes configured for the blog.
+ *
+ *  @param blog    the blog from where to read the information from
+ *  @param success a block that is invoked when the sync is sucessfull.
+ *  @param failure a block that in invoked when the sync fails.
+ */
 - (void)syncPostTypesForBlog:(Blog *)blog
                        success:(void (^)())success
                        failure:(void (^)(NSError *error))failure;
 
+/**
+ *  Sync the available postFormats configured for the blog.
+ *
+ *  @param blog    the blog from where to read the information from
+ *  @param success a block that is invoked when the sync is sucessfull.
+ *  @param failure a block that in invoked when the sync fails.
+ */
 - (void)syncPostFormatsForBlog:(Blog *)blog
                        success:(void (^)())success
                        failure:(void (^)(NSError *error))failure;
@@ -100,13 +139,6 @@ extern NSString *const WordPressMinimumVersion;
 - (void)updatePassword:(NSString *)password forBlog:(Blog *)blog;
 
 - (void)migrateJetpackBlogsToXMLRPCWithCompletion:(void (^)())success;
-
-/**
- Syncs an blog "meta data" including post formats, blog options, and categories. 
- Also checks if the blog is multi-author.
- Used for instances where the entire blog should be refreshed or initially downloaded.
- */
-- (void)syncBlog:(Blog *)blog completionHandler:(void (^)())completionHandler;
 
 - (BOOL)hasVisibleWPComAccounts;
 

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -193,9 +193,9 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
                                          failure:failure];
     } else if ([remote isKindOfClass:[BlogServiceRemoteREST class]]) {
         BlogServiceRemoteREST *restRemote = remote;
-        [restRemote syncBlogDetailsWithSuccess:[self blogDetailsHandlerWithBlogObjectID:blog.objectID
-                                                                      completionHandler:success]
-                                       failure:failure];
+        [restRemote syncBlogWithSuccess:[self blogDetailsHandlerWithBlogObjectID:blog.objectID
+                                                               completionHandler:success]
+                                failure:failure];
     }
 }
 
@@ -224,14 +224,14 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     if ([remote isKindOfClass:[BlogServiceRemoteREST class]]) {
         dispatch_group_enter(syncGroup);
         BlogServiceRemoteREST *restRemote = remote;
-        [restRemote syncBlogDetailsWithSuccess:[self blogDetailsHandlerWithBlogObjectID:blogObjectID
-                                                                      completionHandler:^{
-                                                                          dispatch_group_leave(syncGroup);
-                                                                      }]
-                                       failure:^(NSError *error) {
-                                           DDLogError(@"Failed syncing site details for blog %@: %@", blog.url, error);
-                                           dispatch_group_leave(syncGroup);
-                                       }];
+        [restRemote syncBlogWithSuccess:[self blogDetailsHandlerWithBlogObjectID:blogObjectID
+                                                               completionHandler:^{
+                                                                   dispatch_group_leave(syncGroup);
+                                                               }]
+                                failure:^(NSError *error) {
+                                    DDLogError(@"Failed syncing site details for blog %@: %@", blog.url, error);
+                                    dispatch_group_leave(syncGroup);
+                                }];
 
         dispatch_group_enter(syncGroup);
         [restRemote syncBlogSettingsWithSuccess:^(RemoteBlogSettings *settings) {

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -189,12 +189,12 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     if ([remote isKindOfClass:[BlogServiceRemoteXMLRPC class]]) {
         BlogServiceRemoteXMLRPC *xmlrpcRemote = remote;
         [xmlrpcRemote syncBlogOptionsWithSuccess:[self optionsHandlerWithBlogObjectID:blog.objectID
-                                                          completionHandler:success]
+                                                                    completionHandler:success]
                                          failure:failure];
     } else if ([remote isKindOfClass:[BlogServiceRemoteREST class]]) {
         BlogServiceRemoteREST *restRemote = remote;
         [restRemote syncBlogDetailsWithSuccess:[self blogDetailsHandlerWithBlogObjectID:blog.objectID
-                                                                  completionHandler:success]
+                                                                      completionHandler:success]
                                        failure:failure];
     }
 }
@@ -212,9 +212,9 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
         dispatch_group_enter(syncGroup);
         BlogServiceRemoteXMLRPC *xmlrpcRemote = remote;
         [xmlrpcRemote syncBlogOptionsWithSuccess:[self optionsHandlerWithBlogObjectID:blogObjectID
-                                                              completionHandler:^{
-                                                                  dispatch_group_leave(syncGroup);
-                                                              }]
+                                                                    completionHandler:^{
+                                                                        dispatch_group_leave(syncGroup);
+                                                                    }]
                                          failure:^(NSError *error) {
                                              DDLogError(@"Failed syncing options for blog %@: %@", blog.url, error);
                                              dispatch_group_leave(syncGroup);

--- a/WordPress/Classes/Services/SignupService.swift
+++ b/WordPress/Classes/Services/SignupService.swift
@@ -267,7 +267,7 @@ open class SignupService: LocalCoreDataService {
         let blogService = BlogService(managedObjectContext: managedObjectContext)
 
         status(.syncing)
-        blogService?.syncBlog(blog, completionHandler: {
+        blogService?.syncBlogAndAllMetadata(blog, completionHandler: {
             // The final step
             accountService!.updateUserDetails(for: blog.account!, success: success, failure: failure)
         })

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -214,10 +214,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     __weak __typeof(self) weakSelf = self;
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     self.blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-    [self.blogService syncBlog:_blog completionHandler:^() {
-        [weakSelf configureTableViewData];
-        [weakSelf reloadTableViewPreservingSelection];
-    }];
+    [self.blogService syncBlogAndAllMetadata:_blog
+                           completionHandler:^{
+                               [weakSelf configureTableViewData];
+                               [weakSelf reloadTableViewPreservingSelection];
+                           }];
     if (self.blog.account && !self.blog.account.userID) {
         // User's who upgrade may not have a userID recorded.
         AccountService *acctService = [[AccountService alloc] initWithManagedObjectContext:context];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -837,7 +837,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
 
     NSSet *updatedObjects = note.userInfo[NSUpdatedObjectsKey];
-    if ([updatedObjects containsObject:self.blog]) {
+    if ([updatedObjects containsObject:self.blog] || [updatedObjects containsObject:self.blog.settings]) {
         self.navigationItem.title = self.blog.settings.name;
         [self reloadTableViewPreservingSelection];
     }

--- a/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
@@ -527,13 +527,14 @@ static UIEdgeInsets const CreateBlogCancelButtonPaddingPad  = {1.0, 13.0, 0.0, 0
                 }];
             };
 
-            [blogService syncBlog:blog completionHandler:^{
-                [accountService updateUserDetailsForAccount:defaultAccount
-                                                    success:completion
-                                                    failure:^(NSError * _Nonnull error) {
-                                                        completion();
-                                                    }];
-            }];
+            [blogService syncBlogAndAllMetadata:blog
+                              completionHandler:^{
+                                  [accountService updateUserDetailsForAccount:defaultAccount
+                                                                      success:completion
+                                                                      failure:^(NSError * _Nonnull error) {
+                                                                          completion();
+                                                                      }];
+                              }];
         };
 
         WordPressComServiceFailureBlock createBlogFailure = ^(NSError *error) {

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -463,7 +463,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     if (blogChanged) {
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
         BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-        [blogService syncBlog:blog completionHandler:nil];
+        [blogService syncBlogAndAllMetadata:blog completionHandler:nil];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -973,7 +973,7 @@ EditImageDetailsViewControllerDelegate
     if (blogChanged) {
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
         BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-        [blogService syncBlog:blog completionHandler:nil];
+        [blogService syncBlogAndAllMetadata:blog completionHandler:nil];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
@@ -459,12 +459,13 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
         // Ensure options are up to date after connecting Jetpack as there may
         // now be new info.
         BlogService *service = [[BlogService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
-        [service syncBlog:self.blog completionHandler:^() {
-            [self setAuthenticating:NO];
-            if (self.completionBlock) {
-                self.completionBlock(YES);
-            }
-        }];
+        [service syncBlogAndAllMetadata:self.blog
+                      completionHandler:^{
+                          [self setAuthenticating:NO];
+                          if (self.completionBlock) {
+                              self.completionBlock(YES);
+                          }
+                      }];
     };
 
     void (^failureBlock)(NSError *error) = ^(NSError *error) {
@@ -696,14 +697,15 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-    [blogService syncOptionsForBlog:self.blog success:^{
-        if (self.blog.jetpack.isInstalled) {
-            [self updateForm];
-        }
-        [self reloadInterface];
-    } failure:^(NSError *error) {
-        [WPError showNetworkingAlertWithError:error];
-    }];
+    [blogService syncBlog:self.blog
+                  success:^{
+                      if (self.blog.jetpack.isInstalled) {
+                          [self updateForm];
+                      }
+                      [self reloadInterface];
+                  } failure:^(NSError * _Nonnull error) {
+                      [WPError showNetworkingAlertWithError:error];
+                  }];
 }
 
 

--- a/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
@@ -65,8 +65,8 @@ static NSTimeInterval const TestExpectationTimeout = 5;
 
     XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithWordPressComRestApi:api siteID:blog.dotComID]);
 
-    [service syncSiteDetailsWithSuccess:^(RemoteBlog *remoteBlog) {}
-                            failure:^(NSError *error) {}];
+    [service syncBlogDetailsWithSuccess:^(RemoteBlog *remoteBlog) {}
+                                failure:^(NSError *error) {}];
 }
 
 #pragma mark - Synchronizing post types for a blog
@@ -132,7 +132,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
 
     XCTestExpectation *expectation = [self expectationWithDescription:@"Site Settings"];
     
-    [service syncSettingsWithSuccess:^(RemoteBlogSettings *settings) {
+    [service syncBlogSettingsWithSuccess:^(RemoteBlogSettings *settings) {
         // General
         XCTAssertEqualObjects(settings.name, @"My Epic Blog", @"");
         XCTAssertEqualObjects(settings.tagline, @"Definitely, the best blog out there", @"");

--- a/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/BlogServiceRemoteRESTTests.m
@@ -65,8 +65,8 @@ static NSTimeInterval const TestExpectationTimeout = 5;
 
     XCTAssertNoThrow(service = [[BlogServiceRemoteREST alloc] initWithWordPressComRestApi:api siteID:blog.dotComID]);
 
-    [service syncBlogDetailsWithSuccess:^(RemoteBlog *remoteBlog) {}
-                                failure:^(NSError *error) {}];
+    [service syncBlogWithSuccess:^(RemoteBlog *remoteBlog) {}
+                         failure:^(NSError *error) {}];
 }
 
 #pragma mark - Synchronizing post types for a blog


### PR DESCRIPTION
Fixes #6120 

This refactor largely started to address the issue seen in #6120. However while working through the issue and where a sync can occur, it was quickly apparent we have a decent size of tech debt surrounding the different methods of syncing a blog, syncing it's settings, or options or details. I've run into this area of confusion before but never within the right context to take a moment and refactor.

The bulk of this PR moves around code, renames methods and updates code documentation comments. The primary goal was to better separate the concerns and paths between the `BlogServiceRemoteREST` and the `BlogServiceRemoteXMLRPC` and which remote can handle which type of sync or update.

Particularly, methods were moved out of the top-level `BlogServiceRemote` protocol and more clearly included/written into the respective remote classes. For example, the XMLRPC remote handles the bulks of it's syncing through the `options` fields on the site while the REST remote handles syncing through a site endpoint itself, or a settings endpoint. The separation and translation here is now handled within `BlogService` to have better type-safety and clear implementation requirements.

Lastly, to finally resolved the issue in #6120, we run a settings sync on the "sync all" method now named as `syncBlogAndAllMetadata` to ensure that a site's settings are synced regularly. Particularly, this allows us to know the default category and post format without ever visiting the settings controller.

To test:
1. Uninstall the app.
2. Add a self-hosted site.
3. Ensure the editor options has all categories and post formats available for selection.
4. Go to the Blog Details > Settings view.
5. Ensure the settings are as expected from the site.
6. Update the Site name and tagline, check that the web reflects the update made in the app.
7. Quit the app.
8. Change the site name and tagline on the web.
9. Launch the app, check that the name and tagline are updated once the Blog Details is visited and also the Settings view.

To test:
1. Uninstall the app.
2. Log into a .com site.
3. Open the editor, then the options.
4. Ensure that the default category (blank if uncategorized) is set, as well as the post format.
5. Open the Blog Details > Settings view.
6. Ensure that the default category (or uncategorized) is set, as well as the post format.
7. Change the default category and post format.
8. Check that the change is reflected on the web.
9. Quite the app.
10. On the web, change the default category and post format.
11. Launch the app.
12. Open the editor, then the options.
13. Ensure that the default category you selected on the web is set, as well as the post format.
14. Open the Blog Details > Settings view.
15. Ensure that the default category is set, as well as the post format.

Needs review: @frosty can you take a stroll through this refactor and fix? My apologies that this and the diff may look a bit crazy. A fair amount of the code was simply moved for ideal positioning relative to the logic of the method.