### PR TITLE
Reader: Improves the silent followed posts refresh.

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -78,6 +78,8 @@ extern NSString * const ReaderPostServiceErrorDomain;
 
 /**
  Silently refresh posts for the followed sites topic.
+ Note that calling this method creates a new service instance that performs
+ all its work on a derived managed object context, and background queue.
  */
 - (void)refreshPostsForFollowedTopic;
 

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -172,10 +172,13 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
 
 - (void)refreshPostsForFollowedTopic
 {
-    ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    // Do all of this work on a background thread.
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
+    ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:context];
     ReaderAbstractTopic *topic = [topicService topicForFollowedSites];
     if (topic) {
-        [self fetchPostsForTopic:topic earlierThan:[NSDate date] deletingEarlier:YES success:nil failure:nil];
+        ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context];
+        [service fetchPostsForTopic:topic earlierThan:[NSDate date] deletingEarlier:YES success:nil failure:nil];
     }
 }
 


### PR DESCRIPTION
Fixes #6404 

The reason cells were inactive after following a site is because the managed object context was being reset.  When the context is reset, the post object referenced by the cells is dealloced, which in turn means the guard checks on the cells cause certain actions to fail silently.  Scrolling away and back retrieves a fresh instance of the post from the context which is why everything works again. 

The reset is intentional, and necessary for the correct operation of the reader list. However its intended that a table view using a results controller backed by a managed object context that is reset, should in turn reload its data.  Since we silently fetch new posts for the followed sites topic whenever a post is followed or unfollowed, the table view was never reloaded. 

The meat of the matter is the refresh operation was being performed on a child main queue concurrency managed object context (which touches the UI), rather than a derived context using a background queue.  The issue can be neatly resolved by making sure the operation is performed using a derived context, which is really more proper for a silent background operation anyway.

To test:
Follow the steps specified in the issue and confirm that after following or unfollowing a site from a card you can still interact with the other buttons on the card (like, comment, follow, etc.)

Needs review: @kurzee care to take a peek since you discovered the glitch? 
