### PR TITLE
Share Extension: Prevent images from being squished.

### DIFF
--- a/WordPress/WordPressShareExtension/MediaView.swift
+++ b/WordPress/WordPressShareExtension/MediaView.swift
@@ -29,7 +29,12 @@ class MediaView: UIView {
 
     /// Internal imageView Instance
     ///
-    fileprivate let imageView = UIImageView()
+    fileprivate lazy var imageView: UIImageView = {
+        let view = UIImageView()
+        view.clipsToBounds = true
+        view.contentMode = .scaleAspectFill
+        return view
+    }()
 
     /// Internal Width Constraint
     ///


### PR DESCRIPTION
Fixes #5689 

To test:
Prep: Make sure you have a photo with a visually distinct aspect ratio (4:1 or the like) for easier testing.
Confirm the bug by using the share extension with the photo and observe the photo is squished in the thumbnail. 
Run this test branch and confirm that the photo preserves its aspect ratio while being cropped to the bounds of the media view.

Needs review: @astralbodies 
