### PR TITLE
Sharing: Allow publicize for authors and editors.

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -449,13 +449,17 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
 
 -(BOOL)supportsSharing
 {
-    return ([self supportsPublicize] || [self supportsShareButtons]) && [self isAdmin];
+    return [self supportsPublicize] || [self supportsShareButtons];
 }
 
 - (BOOL)supportsPublicize
 {
-    // Publicize is only supported via REST, and for admins
+    // Publicize is only supported via REST
     if (![self supports:BlogFeatureWPComRESTAPI]) {
+        return NO;
+    }
+
+    if (![self isPublishingPostsAllowed]) {
         return NO;
     }
 
@@ -472,7 +476,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
 - (BOOL)supportsShareButtons
 {
     // Share Button settings are only supported via REST, and for admins
-    if (![self supports:BlogFeatureWPComRESTAPI]) {
+    if (![self isAdmin] || ![self supports:BlogFeatureWPComRESTAPI]) {
         return NO;
     }
 


### PR DESCRIPTION
Fixes #6396 

We we want administrators, editors, and author user roles to be able to use publicize, so we can just check for the `publish_posts` [capability](https://codex.wordpress.org/Roles_and_Capabilities) and we should be good to go. 

To test:
#### Scenario 1 and 2
Repeat the follow steps with an account that has an editor role, and and account that has an author role.
Sign into the app.
Confirm the blog details screen shows the Sharing option.
Confirm the sharing screen shows publicize options but not the sharing button management option.

#### Scenario 3
Confirm that a user with an administrator role has access to both the publicize and button management feature. 

#### Scenario 4
Confirm that a user with a contributor role does not have access to the Sharing feature under Blog Details.

Needs review: @kwonye would you mind taking a look at this one since you're also familiar with sharing from the Android side of things?
