### PR TITLE
Blog Settings: Limit discussion settings to admins.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -153,7 +153,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         [sections addObject:@(SiteSettingsSectionWriting)];
     }
 
-    if ([self.blog supports:BlogFeatureWPComRESTAPI]) {
+    if ([self.blog supports:BlogFeatureWPComRESTAPI] && self.blog.isAdmin) {
         [sections addObject:@(SiteSettingsSectionDiscussion)];
     }
 


### PR DESCRIPTION
Fixes #4755 

To test:
Confirm the issue by viewing My Sites > Blog Details > Settings > Discussion for a blog where you are not an admin user.  Notice there is an error message in the console stating you don't have permission to make changes.
Confirm the fix by switching to this branch and confirming that the Discussion option is no longer present under blog settings.

Needs review: @bummytime would you mind taking a quick peek at this one? 
