### PR TITLE
Posts: Set the title of the preview controller for consistency.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -836,6 +836,9 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         let post = apost.hasRevision() ? apost.revision : apost
 
         let controller = PostPreviewViewController(post: post)
+        // NOTE: We'll set the title to match the title of the View action button.
+        // If the button title changes we should also update the title here.
+        controller?.navigationItem.title = NSLocalizedString("View", comment: "Verb. The screen title shown when viewing a post inside the app.")
         controller?.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(controller!, animated: true)
     }


### PR DESCRIPTION
Fixes #6394 

To test:
Tap the View button on a post in the post list. 
Confirm the title of the preview controller is "View"
Tap to edit the post
Tap the menu button and choose the Preview option.
Confirm the title of the preview controller is "Preview"

Needs review: @diegoreymendez do you have time for a quick review?
