### PR TITLE
Blogs: Synchronous context save when creating a blog managed object

### DIFF
--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -56,7 +56,7 @@
     if ([blog.options numberForKeyPath:@"blog_title.readonly"]) {
         blog.isAdmin = ![[blog.options numberForKeyPath:@"blog_title.readonly"] boolValue];
     }
-    [[ContextManager sharedInstance] saveContext:context];
+    [[ContextManager sharedInstance] saveContextAndWait:context];
 
     if (blog.jetpack.isInstalled) {
         if (blog.jetpack.isConnected) {

--- a/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/CreateNewBlog/CreateNewBlogViewController.m
@@ -508,10 +508,7 @@ static UIEdgeInsets const CreateBlogCancelButtonPaddingPad  = {1.0, 13.0, 0.0, 0
             blog.url = blogOptions[@"url"];
             blog.settings.name = [[blogOptions stringForKey:@"blogname"] stringByDecodingXMLCharacters];
 
-            [[ContextManager sharedInstance] saveContext:context];
-
-            // syncBlog will need a permanent ID so it can fetch and update the blog in its request completion blocks 
-            [[ContextManager sharedInstance] obtainPermanentIDForObject:blog];
+            [[ContextManager sharedInstance] saveContextAndWait:context];
 
             __weak __typeof(self) weakSelf = self;
 


### PR DESCRIPTION
@frosty originally discovered this issue when adding a self-hosted site in https://github.com/wordpress-mobile/WordPress-iOS/pull/6407, in which the categories failed to sync after login.

The source of the issue was that after creating a blog, the context was being saved via an asynchronous block as `performBlock:` in `[[ContextManager sharedInstance] saveContext:context]` which did not call and obtain permanent objectIDs in time for the blog object to actually be used right after being created.

The fix is to instead perform a synchronous save via `[[ContextManager sharedInstance] saveContextAndWait:context]` which will obtain permanent objectIDs and save the context before moving forward with the blog object. Thus allowing the blog to be fetched and used correctly later.

I also went ahead and updated the .com code path in `CreateNewBlogViewController` to use `saveContextAndWait:` as well since this same problem was addressed differently in https://github.com/wordpress-mobile/WordPress-iOS/commit/b4173cdb403a539e19aef00c570a0c39fd843c74.

To test:
1. Uninstall the app.
2. Add a self-hosted site.
3. Ensure no console warnings appear for a failed sync of categories or post formats.
4. Open the Editor, Options, check that categories and post formats are available.

To test:
1. Repeat the steps for a .com site as well since I touched the equivalent code.

Needs review: @frosty can you give this a shot on your site? (I was also able to reproduce on my own)