### PR TITLE
Issue/6215 Tapping on the current tab now pops to its root

### DIFF
--- a/WordPress/Classes/Extensions/UINavigationController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+Helpers.swift
@@ -7,8 +7,16 @@ extension UINavigationController {
         if let topViewController = topViewController as? WPScrollableViewController {
             topViewController.scrollViewToTop()
         } else if let scrollView = topViewController?.view as? UIScrollView {
+            // If the view controller's view is a scrollview
             let offset = CGPoint(x: 0, y: -scrollView.contentInset.top)
             scrollView.setContentOffset(offset, animated: animated)
+        } else if let scrollViews = topViewController?.view.subviews.filter({ $0 is UIScrollView }) as? [UIScrollView] {
+            // If one of the top level views of the view controller's view
+            // is a scrollview
+            if let scrollView = scrollViews.first {
+                let offset = CGPoint(x: 0, y: -scrollView.contentInset.top)
+                scrollView.setContentOffset(offset, animated: animated)
+            }
         }
     }
 }

--- a/WordPress/Classes/Extensions/UINavigationController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+Helpers.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+extension UINavigationController {
+    func scrollContentToTopAnimated(_ animated: Bool) {
+        guard viewControllers.count == 1 else { return }
+
+        if let topViewController = topViewController as? WPScrollableViewController {
+            topViewController.scrollViewToTop()
+        } else if let scrollView = topViewController?.view as? UIScrollView {
+            let offset = CGPoint(x: 0, y: -scrollView.contentInset.top)
+            scrollView.setContentOffset(offset, animated: animated)
+        }
+    }
+}

--- a/WordPress/Classes/Extensions/UINavigationController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+Helpers.swift
@@ -4,18 +4,21 @@ extension UINavigationController {
     func scrollContentToTopAnimated(_ animated: Bool) {
         guard viewControllers.count == 1 else { return }
 
+        let scrollToTop = { (scrollView: UIScrollView) in
+            let offset = CGPoint(x: 0, y: -scrollView.contentInset.top)
+            scrollView.setContentOffset(offset, animated: animated)
+        }
+
         if let topViewController = topViewController as? WPScrollableViewController {
             topViewController.scrollViewToTop()
         } else if let scrollView = topViewController?.view as? UIScrollView {
             // If the view controller's view is a scrollview
-            let offset = CGPoint(x: 0, y: -scrollView.contentInset.top)
-            scrollView.setContentOffset(offset, animated: animated)
+            scrollToTop(scrollView)
         } else if let scrollViews = topViewController?.view.subviews.filter({ $0 is UIScrollView }) as? [UIScrollView] {
             // If one of the top level views of the view controller's view
             // is a scrollview
             if let scrollView = scrollViews.first {
-                let offset = CGPoint(x: 0, y: -scrollView.contentInset.top)
-                scrollView.setContentOffset(offset, animated: animated)
+                scrollToTop(scrollView)
             }
         }
     }

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -128,6 +128,7 @@
 #import "WPNUXMainButton.h"
 #import "WPNUXSecondaryButton.h"
 #import "WPPostViewController.h"
+#import "WPScrollableViewController.h"
 #import "WPStyleGuide+Posts.h"
 #import "WPStyleGuide+ReadableMargins.h"
 #import "WPTableImageSource.h"

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -350,6 +350,28 @@ class WPSplitViewController: UISplitViewController {
             updateDisplayMode()
         }
     }
+
+    /// Pops both the primary and detail navigation controllers (if present)
+    /// to their roots.
+    ///
+    func popToRootViewControllersAnimated(_ animated: Bool) {
+        let popOrScrollToTop = { (navigationController: UINavigationController) in
+            if navigationController.viewControllers.count > 1 {
+                navigationController.popToRootViewController(animated: animated)
+            } else {
+                navigationController.scrollContentToTopAnimated(animated)
+            }
+        }
+
+        if let primaryNavigationController = viewControllers.first as? UINavigationController {
+            popOrScrollToTop(primaryNavigationController)
+
+            if let detailNavigationController = viewControllers.last as? UINavigationController,
+                primaryNavigationController != detailNavigationController {
+                popOrScrollToTop(detailNavigationController)
+            }
+        }
+    }
 }
 
 // MARK: - UISplitViewControllerDelegate

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		177CBE501DA3A3AC009F951E /* CollectionType+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177CBE4F1DA3A3AC009F951E /* CollectionType+Helpers.swift */; };
 		177E7DAD1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */; };
 		178EDE701C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178EDE6F1C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift */; };
+		1790A4531E28F0ED00AE54C2 /* UINavigationController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1790A4521E28F0ED00AE54C2 /* UINavigationController+Helpers.swift */; };
 		17AD36D51D36C1A60044B10D /* WPStyleGuide+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */; };
 		17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */; };
 		17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */; };
@@ -1163,6 +1164,7 @@
 		177CBE4F1DA3A3AC009F951E /* CollectionType+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionType+Helpers.swift"; sourceTree = "<group>"; };
 		177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+SplitViewFullscreen.swift"; sourceTree = "<group>"; };
 		178EDE6F1C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PlanPostPurchaseViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		1790A4521E28F0ED00AE54C2 /* UINavigationController+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Helpers.swift"; sourceTree = "<group>"; };
 		17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Search.swift"; sourceTree = "<group>"; };
 		17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogSiteVisibilityHelperTest.m; sourceTree = "<group>"; };
 		17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanComparisonViewController.swift; sourceTree = "<group>"; };
@@ -4020,6 +4022,7 @@
 				E67B30291DD2428B00F2F47B /* UIImage+Tint.swift */,
 				B57F010D1CB6931900B761B3 /* UIImageView+Gravatar.swift */,
 				B587797419B799D800E57C5A /* UIImageView+Networking.swift */,
+				1790A4521E28F0ED00AE54C2 /* UINavigationController+Helpers.swift */,
 				B53FDF6C19B8C336000723B6 /* UIScreen+Helpers.swift */,
 				B587797519B799D800E57C5A /* UITableView+Helpers.swift */,
 				B587797619B799D800E57C5A /* UITableViewCell+Helpers.swift */,
@@ -6019,6 +6022,7 @@
 				B5899ADE1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift in Sources */,
 				FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */,
 				B57B99D519A2C20200506504 /* NoteTableHeaderView.swift in Sources */,
+				1790A4531E28F0ED00AE54C2 /* UINavigationController+Helpers.swift in Sources */,
 				08D345561CD7FBA900358E8C /* MenuHeaderViewController.m in Sources */,
 				B5120B381D47CC6C0059361A /* NotificationDetailsViewController.swift in Sources */,
 				83418AAA11C9FA6E00ACF00C /* Comment.m in Sources */,


### PR DESCRIPTION
Fixes #6215. Default behaviour for the tab bar should be that if the user taps the currently selected item, the current navigation controller should pop back up to the root. This functionality broke when adding in UISplitViewController, so this PR restores it. 

If the current view controller is already at the root, we instead scroll its content back up to the top of possible / applicable.

I also took the opportunity to tidy up / refactor a little bit of code in `WPTabBarController`.

To test:

* Check that for each of the tabs in the app, with the split view both collapsed and expanded, that both the primary and detail navigation controllers pop back to the root if you reselect the current tab.

Needs review: @kurzee 