### PR TITLE
Sign up: Username and site are a-z0-9 only.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -32,6 +32,7 @@ import WordPressShared
     let XMLRPCKey = "xmlrpc"
     let BlogIDKey = "blogid"
     let URLKey = "url"
+    let nonAlphanumericCharacterSet = NSCharacterSet.alphanumerics.inverted
 
 
     /// A convenience method for obtaining an instance of the controller from a storyboard.
@@ -391,6 +392,11 @@ import WordPressShared
 
 
     @IBAction func handleTextFieldDidChange(_ sender: UITextField) {
+        // Ensure that username and site fields are lower cased.
+        if sender == usernameField || sender == siteURLField {
+            sender.text = sender.text?.lowercased()
+        }
+
         loginFields.emailAddress = emailField.nonNilTrimmedText()
         loginFields.username = usernameField.nonNilTrimmedText()
         loginFields.password = passwordField.nonNilTrimmedText()
@@ -511,6 +517,13 @@ extension SignupViewController: UITextFieldDelegate {
         // Disallow spaces except for the password field
         if string == " " && (textField == emailField || textField == usernameField || textField == siteURLField) {
             return false
+        }
+
+        // Disallow punctuation in username and site names
+        if (textField == usernameField || textField == siteURLField) {
+            if (string as NSString).rangeOfCharacter(from: nonAlphanumericCharacterSet).location != NSNotFound {
+                return false
+            }
         }
 
         if textField == siteURLField {


### PR DESCRIPTION
Fixes #5489 
Similar to https://github.com/wordpress-mobile/WordPress-Android/pull/4181, this patch limits the username and site name fields to lowercase alphanumeric characters.

To test:
Repeat the steps outlined in the issue and confirm that capital characters typed are automatically lowercased and that punctuation is not accepted.

Needs review: @frosty could I trouble you with this one?
