### PR TITLE
Share Extension: Uploads image first, then creates post. Avoids gallery.

### DIFF
--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -249,13 +249,42 @@ private extension ShareViewController {
 ///
 private extension ShareViewController {
     func uploadPostWithSubject(_ subject: String, body: String, status: String, siteID: Int, attachedImageData: Data?, requestEqueued: @escaping (Void) -> ()) {
-        let configuration = URLSessionConfiguration.backgroundSessionConfigurationWithRandomizedIdentifier()
-        let service = PostService(configuration: configuration)
+        if let data = attachedImageData {
+            uploadImageAttachment(data, forPostWithSubject: subject, body: body, status: status, siteID: siteID, requestEqueued: requestEqueued)
+        } else {
+            uploadPostWithSubject(subject, body: body, status: status, siteID: siteID, requestEqueued: requestEqueued)
+        }
+    }
 
-        service.createPost(siteID: siteID, status: status, title: subject, body: body, attachedImageJPEGData: attachedImageData, requestEqueued: {
+    func uploadImageAttachment(_ attachedImageData: Data, forPostWithSubject subject: String, body: String, status: String, siteID: Int, requestEqueued: @escaping (Void) -> ()) {
+        let configuration = URLSessionConfiguration.backgroundSessionConfigurationWithRandomizedIdentifier()
+
+        let mediaService = MediaService(configuration: configuration)
+        mediaService.createMedia(attachedImageData, siteID: siteID) { (media, error) in
+            guard let media = media else {
+                print("Media was nil. Error \(error)")
+                return
+            }
+
+            let width = Int(media.size.width)
+            let height = Int(media.size.height)
+            let mediaID = media.mediaID
+            let src = media.remoteURL
+            let content = "<img class=\"alignnone size-full wp-image-\(mediaID)\" src=\"\(src)\" width=\"\(width)\" height=\"\(height)\" /><br><br>" + body
+
+            self.uploadPostWithSubject(subject, body: content, status: status, siteID: siteID, requestEqueued: requestEqueued)
+        }
+    }
+
+    func uploadPostWithSubject(_ subject: String, body: String, status: String, siteID: Int, requestEqueued: @escaping (Void) -> ()) {
+        let configuration = URLSessionConfiguration.backgroundSessionConfigurationWithRandomizedIdentifier()
+
+        let service = PostService(configuration: configuration)
+        service.createPost(siteID: siteID, status: status, title: subject, body: body, attachedImageJPEGData: nil, requestEqueued: {
             requestEqueued()
         }, completion: { (post, error) in
             print("Post \(post) Error \(error)")
         })
     }
+
 }


### PR DESCRIPTION
Fixes #6393 
This PR updates the Share Extension to upload an image first, then compose an image tag to include in the post body and publish the post.  This resolves an issue where uploading the image data with the post would cause the REST API endpoint to present the image as a gallery.

To test:
Share an image from the Photo app to your blog.  
Confirm that it uploads correctly.  
Confirm that the post contains your title, content, and an image tag inserted above the content.

Share a URL from Safari to your blog.
Confirm that it still shares correctly without a photo.

Needs review: @jleandroperez or @astralbodies  would either of you be free to take a look at this one?  I think you're both pretty familiar with the share extension, yah? 
