### PR TITLE
Aztec: Navbar Actions

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -72,6 +72,11 @@ class AztecPostViewController: UIViewController {
         return v
     }()
 
+    private lazy var closeBarButtonItem: UIBarButtonItem = {
+        let image = Gridicon.iconOfType(.cross)
+        return UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(cancelEditingAction))
+    }()
+
     private lazy var moreBarButtonItem: UIBarButtonItem = {
         let image = Gridicon.iconOfType(.ellipsis)
         return UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(displayMoreSheet))
@@ -147,11 +152,6 @@ class AztecPostViewController: UIViewController {
         configureNavigationBar()
 
         title = NSLocalizedString("Aztec Native Editor", comment: "")
-        navigationItem.leftBarButtonItem = UIBarButtonItem(
-            title: NSLocalizedString("Cancel", comment: "Action button to close editor and cancel changes or insertion of post"),
-            style: .done,
-            target: self,
-            action: #selector(AztecPostViewController.cancelEditingAction(_:)))
         view.backgroundColor = .white
     }
 
@@ -217,6 +217,7 @@ class AztecPostViewController: UIViewController {
     }
 
     func configureNavigationBar() {
+        navigationItem.leftBarButtonItem = closeBarButtonItem
         navigationItem.rightBarButtonItem = moreBarButtonItem
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -72,30 +72,15 @@ class AztecPostViewController: UIViewController {
         return v
     }()
 
-    private lazy var closeBarButtonItem: UIBarButtonItem = {
+    fileprivate lazy var closeBarButtonItem: UIBarButtonItem = {
         let image = Gridicon.iconOfType(.cross)
         return UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(cancelEditingAction))
     }()
 
-    private lazy var moreBarButtonItem: UIBarButtonItem = {
+    fileprivate lazy var moreBarButtonItem: UIBarButtonItem = {
         let image = Gridicon.iconOfType(.ellipsis)
         return UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(displayMoreSheet))
     }()
-
-    private var switchHTMLAlertAction: UIAlertAction {
-        let title = NSLocalizedString("Switch to HTML", comment: "Switches the Editor to HTML Mode")
-        return UIAlertAction(title: title, style: .default, handler: { _ in
-            self.mode = .html
-        })
-    }
-
-    private var switchRichAlertAction: UIAlertAction {
-        let title = NSLocalizedString("Switch to Rich Text", comment: "Switches the Editor to Rich Text Mode")
-        return UIAlertAction(title: title, style: .default, handler: { _ in
-            self.mode = .richText
-        })
-    }
-
 
     fileprivate(set) var mode = EditionMode.richText {
         didSet {
@@ -221,27 +206,6 @@ class AztecPostViewController: UIViewController {
         navigationItem.rightBarButtonItem = moreBarButtonItem
     }
 
-
-    // MARK: - Helpers
-
-    @IBAction func displayMoreSheet() {
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-
-        switch mode {
-        case .richText:
-            alertController.addAction(switchHTMLAlertAction)
-        case .html:
-            alertController.addAction(switchRichAlertAction)
-        }
-
-        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Dismisses the Alert from Screen"))
-        alertController.popoverPresentationController?.barButtonItem = moreBarButtonItem
-
-        view.endEditing(true)
-        present(alertController, animated: true, completion: nil)
-    }
-
-
     // MARK: - Keyboard Handling
 
     func keyboardWillShow(_ notification: Foundation.Notification) {
@@ -284,6 +248,41 @@ class AztecPostViewController: UIViewController {
         let range = richTextView.selectedRange
         let identifiers = richTextView.formatIdentifiersSpanningRange(range)
         toolbar.selectItemsMatchingIdentifiers(identifiers)
+    }
+}
+
+
+// MARK: - More Sheet
+extension AztecPostViewController {
+    @IBAction func displayMoreSheet() {
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+        switch mode {
+        case .richText:
+            alertController.addAction(switchHTMLAlertAction())
+        case .html:
+            alertController.addAction(switchRichAlertAction())
+        }
+
+        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Dismisses the Alert from Screen"))
+        alertController.popoverPresentationController?.barButtonItem = moreBarButtonItem
+
+        view.endEditing(true)
+        present(alertController, animated: true, completion: nil)
+    }
+
+    private func switchHTMLAlertAction() -> UIAlertAction {
+        let title = NSLocalizedString("Switch to HTML", comment: "Switches the Editor to HTML Mode")
+        return UIAlertAction(title: title, style: .default, handler: { _ in
+            self.mode = .html
+        })
+    }
+
+    private func switchRichAlertAction() -> UIAlertAction {
+        let title = NSLocalizedString("Switch to Rich Text", comment: "Switches the Editor to Rich Text Mode")
+        return UIAlertAction(title: title, style: .default, handler: { _ in
+            self.mode = .richText
+        })
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -72,6 +72,24 @@ class AztecPostViewController: UIViewController {
         return v
     }()
 
+    private lazy var moreBarButtonItem: UIBarButtonItem = {
+        let image = Gridicon.iconOfType(.ellipsis)
+        return UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(displayMoreSheet))
+    }()
+
+    private var switchHTMLAlertAction: UIAlertAction {
+        let title = NSLocalizedString("Switch to HTML", comment: "Switches the Editor to HTML Mode")
+        return UIAlertAction(title: title, style: .default, handler: { _ in
+            self.mode = .html
+        })
+    }
+
+    private var switchRichAlertAction: UIAlertAction {
+        let title = NSLocalizedString("Switch to Rich Text", comment: "Switches the Editor to Rich Text Mode")
+        return UIAlertAction(title: title, style: .default, handler: { _ in
+            self.mode = .richText
+        })
+    }
 
 
     fileprivate(set) var mode = EditionMode.richText {
@@ -199,18 +217,26 @@ class AztecPostViewController: UIViewController {
     }
 
     func configureNavigationBar() {
-        let title = NSLocalizedString("HTML", comment: "HTML!")
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: title,
-                                                            style: .plain,
-                                                            target: self,
-                                                            action: #selector(switchEditionMode))
+        navigationItem.rightBarButtonItem = moreBarButtonItem
     }
 
 
     // MARK: - Helpers
 
-    @IBAction func switchEditionMode() {
-        mode.toggle()
+    @IBAction func displayMoreSheet() {
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+        switch mode {
+        case .richText:
+            alertController.addAction(switchHTMLAlertAction)
+        case .html:
+            alertController.addAction(switchRichAlertAction)
+        }
+
+        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Dismisses the Alert from Screen"))
+        alertController.popoverPresentationController?.barButtonItem = moreBarButtonItem
+
+        present(alertController, animated: true, completion: nil)
     }
 
 
@@ -296,7 +322,6 @@ extension AztecPostViewController {
     }
 
     fileprivate func switchToHTML() {
-        navigationItem.rightBarButtonItem?.title = NSLocalizedString("Native", comment: "Rich Edition!")
         view.endEditing(true)
 
         htmlTextView.text = richTextView.getHTML()
@@ -305,7 +330,6 @@ extension AztecPostViewController {
     }
 
     fileprivate func switchToRichText() {
-        navigationItem.rightBarButtonItem?.title = NSLocalizedString("HTML", comment: "HTML!")
         view.endEditing(true)
 
         richTextView.setHTML(htmlTextView.text)

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -236,6 +236,7 @@ class AztecPostViewController: UIViewController {
         alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Dismisses the Alert from Screen"))
         alertController.popoverPresentationController?.barButtonItem = moreBarButtonItem
 
+        view.endEditing(true)
         present(alertController, animated: true, completion: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -293,33 +293,22 @@ extension AztecPostViewController {
     enum EditionMode {
         case richText
         case html
-
-        mutating func toggle() {
-            switch self {
-            case .html:
-                self = .richText
-            case .richText:
-                self = .html
-            }
-        }
     }
 
     fileprivate func switchToHTML() {
         navigationItem.rightBarButtonItem?.title = NSLocalizedString("Native", comment: "Rich Edition!")
+        view.endEditing(true)
 
         htmlTextView.text = richTextView.getHTML()
-
-        view.endEditing(true)
         htmlTextView.isHidden = false
         richTextView.isHidden = true
     }
 
     fileprivate func switchToRichText() {
         navigationItem.rightBarButtonItem?.title = NSLocalizedString("HTML", comment: "HTML!")
+        view.endEditing(true)
 
         richTextView.setHTML(htmlTextView.text)
-
-        view.endEditing(true)
         richTextView.isHidden = false
         htmlTextView.isHidden = true
     }


### PR DESCRIPTION
### Details:
This PR updates the navigationBar, so that the Switch **HTML <> Rich** toggle is moved to an Action Sheet button.

This matches the Hybrid Editor, and makes room for `Settings` // `Post` actions.

### Testing:
1. Launch the Aztec Editor
2. Verify that the top right corner has a three dots button
3. Press over the `ellipsis` button
4. Press the Switch action
5. Please, verify that everything works as expected. 
6. Press the Cancel action
7. Verify that the Editor gets closed

Needs review: @astralbodies 
Thanks in advance!

