### PR TITLE
Fixing Build Warnings

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -236,9 +236,12 @@ import Gridicons
         controller.delegate = self
         addChildViewController(controller)
 
-        let autoView = controller.view
-        autoView?.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(autoView!)
+        guard let autoView = controller.view, let searchBar = searchBar else {
+            fatalError("Unexpected")
+        }
+
+        autoView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(autoView)
 
         let views = [
             "searchBar": searchBar,
@@ -257,7 +260,7 @@ import Gridicons
             views: views))
         // Center on the search bar.
         view.addConstraint(NSLayoutConstraint(
-            item: autoView!,
+            item: autoView,
             attribute: .centerX,
             relatedBy: .equal,
             toItem: searchBar,

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -273,16 +273,20 @@ class WPSplitViewController: UISplitViewController {
     /// first view controller after the last `WPSplitViewControllerDetailProvider`
     /// in the primary stack if the split view is collapsed).
     var rootDetailViewController: UIViewController? {
-        if isCollapsed {
-            if let navigationController = viewControllers.first as? UINavigationController,
-                let index = navigationController.viewControllers.lastIndex(where: { $0 is WPSplitViewControllerDetailProvider }), navigationController.viewControllers.count > index+1  {
-                return navigationController.viewControllers[index+1]
-            }
-        } else {
+        guard isCollapsed else {
             return (viewControllers.last as? UINavigationController)?.viewControllers.first
         }
 
-        return nil
+        guard let navigationController = viewControllers.first as? UINavigationController else {
+            return nil
+        }
+
+        guard let index = navigationController.viewControllers.lastIndex(where: { $0 is WPSplitViewControllerDetailProvider }),
+            navigationController.viewControllers.count > index + 1 else {
+            return nil
+        }
+
+        return navigationController.viewControllers[index + 1]
     }
 
     /** Sets the primary view controller of the split view as specified, and


### PR DESCRIPTION
### Details:
In this (small!) PR we're addressing few of the new compiler warnings we're getting. Don't worry, we'll get to zero in #6425.

### To test:
- Verify that the app builds correctly
- Verify that ReaderSearch works as expected (cc @aerych)
- Verify that WPSplitViewController works correctly as well (cc @frosty)


Needs review: Invoking my personal friends, @aerych, for **ReaderSearchViewController**, and @frosty for **WPSplitViewController**.

Thanks in advance!

