### PR TITLE
Fixes issues with building on a case-sensitive file system

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,12 +32,12 @@ GEM
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
     cocoapods-deintegrate (1.0.1)
-    cocoapods-downloader (1.1.2)
+    cocoapods-downloader (1.1.3)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
     cocoapods-stats (1.0.0)
-    cocoapods-trunk (1.1.1)
+    cocoapods-trunk (1.1.2)
       nap (>= 0.8, < 2.0)
       netrc (= 0.7.8)
     cocoapods-try (1.1.0)
@@ -45,15 +45,15 @@ GEM
     escape (0.0.4)
     fourflusher (2.0.1)
     fuzzy_match (2.0.4)
-    gh_inspector (1.0.2)
+    gh_inspector (1.0.3)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     minitest (5.10.1)
-    molinillo (0.5.2)
+    molinillo (0.5.5)
     nanaimo (0.2.3)
     nap (1.1.0)
     netrc (0.7.8)
-    rake (11.2.2)
+    rake (12.0.0)
     rouge (1.11.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -64,7 +64,7 @@ GEM
       claide (>= 1.0.1, < 2.0)
       colored (~> 1.2)
       nanaimo (~> 0.2.3)
-    xcpretty (0.2.2)
+    xcpretty (0.2.4)
       rouge (~> 1.8)
     xcpretty-travis-formatter (0.0.4)
       xcpretty (~> 0.2, >= 0.0.7)
@@ -78,4 +78,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   1.13.0
+   1.13.7

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -10,7 +10,7 @@
 #import "WPImageSource.h"
 #import "UIImage+Resize.h"
 #import <MobileCoreServices/MobileCoreServices.h>
-#import "WordPress-swift.h"
+#import "WordPress-Swift.h"
 #import "WPXMLRPCDecoder.h"
 #import "PhotonImageURLHelper.h"
 

--- a/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
@@ -1,5 +1,5 @@
 #import "WordPressXMLRPCAPIFacade.h"
-#import <WPXMLRPC/WPXMLRPC.h>
+#import <wpxmlrpc/WPXMLRPC.h>
 #import "WordPress-Swift.h"
 
 

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -5,7 +5,7 @@
 #import "NSString+Helpers.h"
 #import "SupportViewController.h"
 #import "WordPress-Swift.h"
-#import <WPXMLRPC/WPXMLRPC.h>
+#import <wpxmlrpc/WPXMLRPC.h>
 
 NSInteger const SupportButtonIndex = 0;
 NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -18,7 +18,7 @@
 #import "WordPress-Swift.h"
 #import "BlogServiceRemoteXMLRPC.h"
 #import <SVProgressHUD/SVProgressHUD.h>
-#import <WPXMLRPC/WPXMLRPC.h>
+#import <wpxmlrpc/WPXMLRPC.h>
 
 
 NS_ENUM(NSInteger, SiteSettingsGeneral) {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -3,7 +3,7 @@
 #import "MediaService.h"
 #import "Blog.h"
 #import "ContextManager.h"
-#import "WordPress-swift.h"
+#import "WordPress-Swift.h"
 
 @interface  MediaLibraryPickerDataSource() <NSFetchedResultsControllerDelegate>
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -6,7 +6,7 @@
 #import "UIImageView+Gravatar.h"
 #import <WordPressShared/WPStyleGuide.h>
 #import "WPStyleGuide+Posts.h"
-#import "Wordpress-Swift.h"
+#import "WordPress-Swift.h"
 #import "FLAnimatedImage.h"
 
 static const UIEdgeInsets ActionbarButtonImageInsets = {0.0, 0.0, 0.0, 4.0};


### PR DESCRIPTION
1. use https://github.com/rbenv/ruby-build to build and install ruby-2.4.0 $HOME/ruby/
2. export PATH=$HOME/ruby/bin:$PATH
3. gem install bundler
4. rake dependencies ...
5. apply the patch to some *.m as the the compilation run on case sensitive HFS file system.

Fixes # mainly step 5 which import <WPXMLRPC/WPXMLRPC.h> and "WordPress-Swift.h".  Also compile ruby-2.4.0 from source and installed locally to run rake dependencies

To test:  git clone the source to HFS case sensitive filesystem and compile the source



Needs review: @
