### PR TITLE
My Sites: Stats cell highlighted on iPhone after opening site dashboard

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -573,7 +573,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     if (row.showsSelectionState) {
         self.restorableSelectedIndexPath = indexPath;
-    } else {
+    } else if (![self splitViewControllerIsHorizontallyCompact]) {
         // Reselect the previous row
         [tableView selectRowAtIndexPath:self.restorableSelectedIndexPath
                                animated:YES


### PR DESCRIPTION
Reselecting the previously selected row when the row currently been selected shouldn’t show the selected state and the split view controller is horizontally compact.

Fixes #6176

To test:
1. Cells remain selected on split view mode
2. Cells don't remain selected in horizontally compact mode (no detail view visible)


Needs review: @
