### PR TITLE
PingHub wrap up

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -213,7 +213,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Gridicons-iOS.git
     :tag: '0.4'
   Starscream:
-    :commit: 14313df360c12bfa0d760c0bffb9ccbab16f6c43
+    :commit: 60b27a4388bcb1b8b170c645dd19142cfa674f59
     :git: https://github.com/wordpress-mobile/Starscream
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a

--- a/WordPress/Classes/Utility/PingHubManager.swift
+++ b/WordPress/Classes/Utility/PingHubManager.swift
@@ -209,6 +209,7 @@ fileprivate extension PingHubManager {
             return
         }
         state.connected = true
+        DDLogSwift.logInfo("PingHub connecting")
         client?.connect()
     }
 
@@ -221,6 +222,7 @@ fileprivate extension PingHubManager {
 
     func disconnect() {
         delayedRetry?.cancel()
+        DDLogSwift.logInfo("PingHub disconnecting")
         client?.disconnect()
         state.connected = false
     }

--- a/WordPress/Classes/Utility/PingHubManager.swift
+++ b/WordPress/Classes/Utility/PingHubManager.swift
@@ -205,6 +205,9 @@ fileprivate extension PingHubManager {
 // MARK: - Actions
 fileprivate extension PingHubManager {
     func connect() {
+        guard !state.connected else {
+            return
+        }
         state.connected = true
         client?.connect()
     }

--- a/WordPress/Classes/Utility/PingHubManager.swift
+++ b/WordPress/Classes/Utility/PingHubManager.swift
@@ -230,6 +230,8 @@ extension PingHubManager: PinghubClientDelegate {
         DDLogSwift.logInfo("PingHub connected")
         delay.reset()
         state.connected = true
+        // Trigger a full sync, since we might have missed notes while PingHub was disconnected
+        NotificationSyncMediator()?.sync()
     }
 
     func pinghubDidDisconnect(_ client: PinghubClient, error: Error?) {

--- a/WordPress/Classes/Utility/PingHubManager.swift
+++ b/WordPress/Classes/Utility/PingHubManager.swift
@@ -181,13 +181,11 @@ fileprivate extension PingHubManager {
     @objc
     func applicationDidEnterBackground() {
         state.foreground = false
-        client?.disconnect()
     }
 
     @objc
     func applicationWillEnterForeground() {
         state.foreground = true
-        client?.connect()
     }
 
     // MARK: reachability

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -312,8 +312,7 @@ final public class PushNotificationsManager: NSObject {
             return false
         }
 
-        // TODO: JLP Nov.3.2016. Nuke applicationState == .Active once PingHub is in place!
-        guard applicationState == .background || applicationState == .active else {
+        guard applicationState == .background else {
             return false
         }
 


### PR DESCRIPTION
I've combined a bunch of small fixes into this one for the finishing details for PingHub:

- If the application is active, it now ignores push notifications, as we assume we'll get them through pinghub. #5894 might change this in the future though
- Updated Starscream. My [previous patch](https://github.com/daltoniam/Starscream/pull/294) introduced a new bug that meant the delegate/callback wasn't being called correctly on disconnect.
- This, combined with the delayed retry made the state machine confused when coming from the background, and there was a lot of reconnection, since `connect` would `disconnect` the socket if it was already connecting, changing the state again 🙄 I added a `guard` for sanity so we don't call `connect()` if we're connect(ing|ed).
- Besides (dis)connecting from state changes, the application state observers were also calling connect/disconnect on their own, causing more confusion, and even possibly bugs, since they weren't checking if a connection should happen.
- The console messages were even more confusing because you would see 2-3 "disconnected" messages in a row. Which was OK, since it only prints "connected" when successfully connected. To have a clearer picture, now it also logs "connecting" and "disconnecting".
- When PingHub connects, trigger a full sync. Since there might have been changes while PingHub was disconnected, this will ensure consistency. The next step would have been to remove the sync on appear for the notifications list, but I'd rather leave it for now as a sanity check.

Fixes #6164

To test:

- Launch the app
- Check the console and make sure "PingHub connected"
- Generate a new note (like a new post), and verify it appears
- Delete a note (unlike the post), and verify it appears
- Put the app in the background and resume, verify no odd (dis)connects in the console
- Give it a good test ride. This should be the final PingHub implementation for a while, unless there are bugs. 🎉 

Needs review: @jleandroperez 