### PR TITLE
Force layout before requesting Gravatar size

### DIFF
--- a/WordPress/Classes/Utility/Gravatar.swift
+++ b/WordPress/Classes/Utility/Gravatar.swift
@@ -73,6 +73,12 @@ extension UIImageView {
             return
         }
 
+        // Starting with iOS 10, it seems `initWithCoder` uses a default size
+        // of 1000x1000, which was messing with our size calculations for gravatars
+        // on newly created table cells.
+        // Calling `layoutIfNeeded()` forces UIKit to calculate the actual size.
+        layoutIfNeeded()
+
         let size = Int(ceil(frame.width * contentScaleFactor))
         let url = gravatar.urlWithSize(size)
 


### PR DESCRIPTION
Fixes #6320 

Make sure we're downloading the right sizes for the Gravatars

As mentioned in #6320, I think large Gravatar requests is what was causing them to fail in the first place. I haven't tackled the issue of retrying to load gravatars if they failed, but it seems like it'd take a major refactor of how we load images. So, for now, I believe this will be good enough until we can devote some time to improve image loading.

To test:

Browse around the app all views that show gravatars, and ensure we're fetching the right size. What I did was to set a breakpoint in Gravatar.swift:

![screen shot 2017-01-20 at 09 33 17](https://cloud.githubusercontent.com/assets/8739/22141732/ae0425ea-def3-11e6-8675-005702c7a540.png)

```Downloading avatar of size @size@: @gravatar.canonicalURL.lastPathComponent@```

Needs review: @kwonye 