### PR TITLE
SigninHelpers: Fixing 1Password Crash

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -365,8 +365,8 @@ import Mixpanel
 
         let loginURL = loginFields.userIsDotCom ? "wordpress.com" : loginFields.siteUrl
 
-        let onePasswordFacade = OnePasswordFacade()
-        onePasswordFacade.findLogin(forURLString: loginURL, viewController: controller, sender: sourceView, completion: { (username: String?, password: String?, oneTimePassword: String?, error: NSError?) in
+
+        let completion: OnePasswordFacadeCallback = { (username, password, oneTimePassword, error) in
             if let error = error {
                 DDLogSwift.logError("OnePassword Error: \(error.localizedDescription)")
                 WPAppAnalytics.track(.onePasswordFailed)
@@ -391,8 +391,10 @@ import Mixpanel
             WPAppAnalytics.track(.onePasswordLogin)
 
             success(loginFields)
-        } as! OnePasswordFacadeCallback)
+        }
 
+        let onePasswordFacade = OnePasswordFacade()
+        onePasswordFacade.findLogin(forURLString: loginURL, viewController: controller, sender: sourceView, completion: completion)
     }
 
 


### PR DESCRIPTION
### Details:
I've been experiencing a crash, in develop, after trying to launch 1Password (see screenshot below!).
(For some unknown reason!) the forced cast of the closure isn't working anymore // now it's breaking.

<img width="1220" alt="screen shot 2017-01-23 at 09 42 23" src="https://cloud.githubusercontent.com/assets/1195260/22197248/6ff4858c-e151-11e6-9337-e99549c24a78.png">


### To test:
0. Make sure you've got 1Password Installed!
1. Fresh install the app
2. Press the 1Password button

Verify that nothing breaks!

Needs review: @aerych 
Thanks in advance sir!

