### PR TITLE
Don't show errors if load more fails on posts.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -668,15 +668,13 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
                 }
 
                 success?(filter.hasMore)
-            }, failure: {[weak self] (error) -> () in
+            }, failure: {(error) -> () in
 
-                guard let strongSelf = self,
-                    let error = error else {
+                guard let error = error else {
                         return
                 }
 
                 failure?(error as NSError)
-                strongSelf.handleSyncFailure(error as NSError)
             })
     }
 


### PR DESCRIPTION
Just as we don't show errors on sync unless it was user initiated, avoid
presenting an alert if infinite scroll was triggered.

The deeper issue is that the infinite scroll code is triggered from
willDisplayCell which doesn't only get called as you scroll, but also whenever
we update the table data (i.e. every core data save).

There is a lot of room for improvement there, but this will at least avoid
presenting the user with countless alerts when trying to write a post while
being offline.

Fixes #4993

To test:

- Launch the app while in Airplane Mode
- Go to a site's post list
- Add a new post 
- Write a title and some content
- No offline alerts should display while editing the post


Needs review: @diegoreymendez 
