### PR TITLE
Issue/6448: Fix auto selection of newly added self hosted sites

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
@@ -288,6 +288,12 @@ extension SigninSelfHostedViewController: LoginFacadeDelegate {
         BlogSyncFacade().syncBlog(withUsername: username, password: password, xmlrpc: xmlrpc, options: options) { [weak self] in
             self?.configureViewLoading(false)
 
+            let context = ContextManager.sharedInstance().mainContext
+            if let service = BlogService(managedObjectContext: context),
+                let blog = service.findBlog(withXmlrpc: xmlrpc, andUsername: username) {
+                service.flagBlog(asLastUsed: blog)
+            }
+
             NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: SigninHelpers.WPSigninDidFinishNotification), object: nil)
 
             self?.dismiss()


### PR DESCRIPTION
Fixes #6448 

When the user signs into a self-hosted site, we now mark it as the 'last used' site so that it'll get auto selected in the blog list view controller.

To test, follow the steps outlined in the original issue and ensure the new blog gets selected.

Needs review: @koke 