### PR TITLE
NUX: Instead, present shared credentials when tapping the text field.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Signin.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Signin.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11760" systemVersion="16B2657" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11755"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -58,6 +58,7 @@
                                                 <connections>
                                                     <action selector="handleSubmitForm" destination="fwZ-QE-5et" eventType="primaryActionTriggered" id="8l9-uh-Gyz"/>
                                                     <action selector="handleTextFieldDidChange:" destination="fwZ-QE-5et" eventType="editingChanged" id="LoF-5Q-Yw5"/>
+                                                    <action selector="handleTextFieldEditingDidBegin:" destination="fwZ-QE-5et" eventType="editingDidBegin" id="Ff8-SJ-F9U"/>
                                                     <outlet property="delegate" destination="fwZ-QE-5et" id="Urv-t1-Fui"/>
                                                 </connections>
                                             </textField>

--- a/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
@@ -79,11 +79,6 @@ import WordPressShared
 
         registerForKeyboardEvents(keyboardWillShowAction: #selector(SigninEmailViewController.handleKeyboardWillShow(_:)),
                                   keyboardWillHideAction: #selector(SigninEmailViewController.handleKeyboardWillHide(_:)))
-
-
-        if !didRequestSafariSharedCredentials {
-            fetchSharedWebCredentialsIfAvailable()
-        }
     }
 
 
@@ -372,6 +367,11 @@ import WordPressShared
         configureSubmitButton()
     }
 
+    @IBAction func handleTextFieldEditingDidBegin(_ sender: UITextField) {
+        if !didRequestSafariSharedCredentials {
+            fetchSharedWebCredentialsIfAvailable()
+        }
+    }
 
     // MARK: - Keyboard Notifications
 


### PR DESCRIPTION
Instead of presenting shared credentials as soon as the view appears for `SigninEmailViewController`, or as soon as a user opens the app, now present the credentials when they tap on the username/email textfield.

When discussing this with @mattmiklic, the idea I had here was to get away from instantly presenting the credentials picker and instead allowing a user to soak up the actual first NUX view. This also allows a user to instead add a self-hosted site or choose the 1Password option, without having to dismiss the credentials picker each time (if they had some available).

I think this cleans the experience up a bit for our users to not be so surprised by the picker immediately every time the app is opened, without being logged in.

Any additional thoughts or concerns @mattmiklic?

To test:
1. Uninstall the app.
2. Open the app, the credentials alert should not automatically present as before.
3. Tap the text field to begin editing, the shared credentials should appear.
4. Stop editing.
5. Begin editing again, the credentials should not reappear, only the one time.

Needs review: @aerych can you give this a test? Also, you may have additional thoughts on the matter since you've touched a lot of NUX.