### PR TITLE
Remove Unsaved Changes alert

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -108,7 +108,6 @@ EditImageDetailsViewControllerDelegate
 @property (nonatomic, assign, readwrite) BOOL ownsPost;
 
 #pragma mark - Unsaved changes support
-@property (nonatomic, assign, readwrite) BOOL shouldShowUnsavedChangesAlert;
 @property (nonatomic, assign, readonly) BOOL changedToEditModeDueToUnsavedChanges;
 
 #pragma mark - State restoration
@@ -225,10 +224,6 @@ EditImageDetailsViewControllerDelegate
             [PrivateSiteURLProtocol registerPrivateSiteURLProtocol];
         }
         
-        if (post.postTitle.length > 0 || post.content.length > 0) {
-            _shouldShowUnsavedChangesAlert = [post hasLocalChanges];
-        }
-        
         if ([post isRevision]
             && [post hasLocalChanges]
             && post.original.postTitle.length == 0
@@ -343,11 +338,6 @@ EditImageDetailsViewControllerDelegate
         if (self.isEditing) {
             [self setNeedsStatusBarAppearanceUpdate];
         }
-    }
-
-    if (self.shouldShowUnsavedChangesAlert) {
-        self.shouldShowUnsavedChangesAlert = NO;
-        [self showUnsavedChangesAlert];
     }
 }
 
@@ -577,22 +567,6 @@ EditImageDetailsViewControllerDelegate
 {
     self.mediaInProgress = [NSMutableDictionary dictionary];
     self.mediaProgressView = [[UIProgressView alloc] initWithProgressViewStyle:UIProgressViewStyleBar];
-}
-
-#pragma mark - Alerts
-
-- (void)showUnsavedChangesAlert
-{
-    [self.editorView endEditing];
-
-    NSString *title = NSLocalizedString(@"Unsaved changes.",
-                                        @"Title of the alert that lets the users know there are unsaved changes in a post they're opening.");
-    NSString *message = NSLocalizedString(@"This post has local changes that were not saved. You can now save them or discard them.",
-                                          @"Message of the alert that lets the users know there are unsaved changes in a post they're opening.");
-    
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
-    [alertController addActionWithTitle:NSLocalizedString(@"OK",@"") style:UIAlertActionStyleDefault handler:nil];
-    [self presentViewController:alertController animated:YES completion:nil];
 }
 
 #pragma mark - Actions


### PR DESCRIPTION
While there is some value on letting users know they're editing a post that has
local changes, the alert is very disruptive and causing some issues on
restoration.

Fixes #6367 

To test:

- Create a new post, type some title/content
- Switch to airplane mode and publish
- From the posts list, locate the failed post
- Open the post, no alert should show

Needs review: @diegoreymendez 
