### PR TITLE
Post Preview: Prevent spinner from flickering.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -266,12 +266,6 @@
     }
 }
 
-- (void)webViewDidStartLoad:(UIWebView *)webView
-{
-    DDLogMethod();
-    self.loadingView.hidden = NO;
-}
-
 - (void)webViewDidFinishLoad:(UIWebView *)awebView
 {
     DDLogMethod();


### PR DESCRIPTION
Fixes #4079 

When showing a post preview, the loading view can reappear for every request made by the webview to fetch content.  This PR limits the spinner to appearing for just the initial page load. 

Before:
https://cloudup.com/ipfjb-ASyqx

After:
https://cloudup.com/i8mlQrpM9Lg

To test:
Preview a post that has a lot of remote content.  Embedding some video links and images should do the trick.
Ensure that the spinner does not flicker. 

Needs review: @bummytime would you mind taking a peek at this one?
