### PR TITLE
Fix "optional" X-Post titles

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -116,9 +116,9 @@ open class ReaderCrossPostCell: UITableViewCell {
     fileprivate func configureLabel() {
 
         // Compose the title.
-        var title = contentProvider!.titleForDisplay()
-        if (title?.contains(xPostTitlePrefix))! {
-            title = title?.components(separatedBy: xPostTitlePrefix).last
+        var title = contentProvider!.titleForDisplay() ?? ""
+        if let prefixRange = title.range(of: xPostTitlePrefix) {
+            title.removeSubrange(prefixRange)
         }
         let attrText = NSMutableAttributedString(string: "\(title)\n", attributes: readerCrossPostTitleAttributes)
 


### PR DESCRIPTION
Titles for X-Posts were showing as Optional. This patch adds a default of `""` for nil titles so they show correctly.

![reader-xpost-optional](https://cloud.githubusercontent.com/assets/8739/22281304/80923bf6-e2d6-11e6-976e-38c4863a1c29.png)

Needs review: @aerych 
