### PR TITLE
Issue/5308 login source tags

### DIFF
--- a/WordPress/Classes/Utility/HelpshiftUtils.h
+++ b/WordPress/Classes/Utility/HelpshiftUtils.h
@@ -13,6 +13,6 @@ extern NSString *const HelpshiftUnreadCountUpdatedNotification;
 + (void)refreshUnreadNotificationCount;
 + (NSArray<NSString *> *)planTagsForAccount:(WPAccount *)account;
 
-+ (NSDictionary<NSString *, NSObject *> *)helpshiftMetadata;
++ (NSDictionary<NSString *, NSObject *> *)helpshiftMetadataWithTags:(NSArray<NSString *> *)extraTags;
 
 @end

--- a/WordPress/Classes/Utility/HelpshiftUtils.m
+++ b/WordPress/Classes/Utility/HelpshiftUtils.m
@@ -139,7 +139,7 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
     return [tags allObjects];
 }
 
-+ (NSDictionary<NSString *, NSObject *> *)helpshiftMetadata
++ (NSDictionary<NSString *, NSObject *> *)helpshiftMetadataWithTags:(NSArray<NSString *> *)extraTags;
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
     AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
@@ -148,7 +148,8 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
 
     NSString *isWPCom = (defaultAccount != nil) ? @"Yes" : @"No";
     NSMutableDictionary *metaData = [NSMutableDictionary dictionaryWithDictionary:@{ @"isWPCom" : isWPCom }];
-
+    NSMutableArray *tags = [NSMutableArray arrayWithArray:extraTags];
+    
     NSArray *allBlogs = [blogService blogsForAllAccounts];
     for (int i = 0; i < allBlogs.count; i++) {
         Blog *blog = allBlogs[i];
@@ -159,12 +160,14 @@ CGFloat const HelpshiftFlagCheckDelay = 10.0;
 
         if (defaultAccount) {
             [metaData addEntriesFromDictionary:@{@"WPCom Username": defaultAccount.username}];
-            NSArray *tags = [HelpshiftUtils planTagsForAccount:defaultAccount];
-            if (tags) {
-                [metaData setObject:tags forKey:HelpshiftSupportTagsKey];
+            NSArray *planTags = [HelpshiftUtils planTagsForAccount:defaultAccount];
+            if (planTags) {
+                [tags addObjectsFromArray:planTags];
             }
         }
     }
+    
+    [metaData setObject:tags forKey:HelpshiftSupportTagsKey];
 
     return [metaData copy];
 }

--- a/WordPress/Classes/Utility/WPError.h
+++ b/WordPress/Classes/Utility/WPError.h
@@ -4,6 +4,8 @@ typedef NS_ENUM(NSUInteger, WordPressAppErrorCode) {
     WordPressAppErrorCodeInvalidVersion = 5000
 };
 
+extern NSString * const WPErrorSupportSourceKey;
+
 @interface WPError : NSObject
 
 

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -8,7 +8,8 @@
 #import <WPXMLRPC/WPXMLRPC.h>
 
 NSInteger const SupportButtonIndex = 0;
-NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
+NSString * const WordPressAppErrorDomain = @"org.wordpress.iphone";
+NSString * const WPErrorSupportSourceKey = @"helpshift-support-source";
 
 @interface WPError ()
 
@@ -104,15 +105,17 @@ NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
             title = customTitle;
         }
     }
+    
+    NSString *sourceTag = [error.userInfo stringForKey:WPErrorSupportSourceKey];
 
-    [self showAlertWithTitle:title message:message];
+    [self showAlertWithTitle:title message:message fromSource:sourceTag];
 }
 
 + (void)showXMLRPCErrorAlert:(NSError *)error
 {
     NSString *cleanedErrorMsg = [error localizedDescription];
 
-    if ([error.domain isEqualToString:WPXMLRPCFaultErrorDomain] && error.code == 401){
+    if ([error.domain isEqualToString:WPXMLRPCFaultErrorDomain] && error.code == 401) {
         cleanedErrorMsg = NSLocalizedString(@"Sorry, you cannot access this feature. Please check your User Role on this site.", @"");
     }
 
@@ -129,17 +132,17 @@ NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
     [self showAlertWithTitle:NSLocalizedString(@"Error", @"Generic popup title for any type of error.") message:cleanedErrorMsg];
 }
 
-+ (void)showAlertWithTitle:(NSString *)title message:(NSString *)message
++ (void)showAlertWithTitle:(NSString *)title message:(NSString *)message fromSource:(NSString *)sourceTag
 {
-    [self showAlertWithTitle:title message:message withSupportButton:YES okPressedBlock:nil];
+    [self showAlertWithTitle:title message:message withSupportButton:YES fromSource:sourceTag okPressedBlock:nil];
 }
 
 + (void)showAlertWithTitle:(NSString *)title message:(NSString *)message withSupportButton:(BOOL)showSupport
 {
-    [self showAlertWithTitle:title message:message withSupportButton:showSupport okPressedBlock:nil];
+    [self showAlertWithTitle:title message:message withSupportButton:showSupport fromSource:nil okPressedBlock:nil];
 }
 
-+ (void)showAlertWithTitle:(NSString *)title message:(NSString *)message withSupportButton:(BOOL)showSupport okPressedBlock:(void (^)(UIAlertController *))okBlock
++ (void)showAlertWithTitle:(NSString *)title message:(NSString *)message withSupportButton:(BOOL)showSupport fromSource:(NSString *)sourceTag okPressedBlock:(void (^)(UIAlertController *))okBlock
 {
     if ([WPError internalInstance].alertShowing) {
         return;
@@ -164,7 +167,9 @@ NSString *const WordPressAppErrorDomain = @"org.wordpress.iphone";
         UIAlertAction *action = [UIAlertAction actionWithTitle:supportText
                                                          style:UIAlertActionStyleCancel
                                                        handler:^(UIAlertAction * _Nonnull action) {
-                                                            [SupportViewController showFromTabBar];
+                                                           SupportViewController *supportVC = [SupportViewController new];
+                                                           supportVC.sourceTag = sourceTag;
+                                                           [supportVC showFromTabBar];
                                                            [WPError internalInstance].alertShowing = NO;
                                                        }];
         [alertController addAction:action];

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -108,7 +108,7 @@ NSString * const WPErrorSupportSourceKey = @"helpshift-support-source";
     
     NSString *sourceTag = [error.userInfo stringForKey:WPErrorSupportSourceKey];
 
-    [self showAlertWithTitle:title message:message fromSource:sourceTag];
+    [self showAlertWithTitle:title message:message withSupportButton:YES fromSource:sourceTag okPressedBlock:nil];
 }
 
 + (void)showXMLRPCErrorAlert:(NSError *)error
@@ -132,14 +132,19 @@ NSString * const WPErrorSupportSourceKey = @"helpshift-support-source";
     [self showAlertWithTitle:NSLocalizedString(@"Error", @"Generic popup title for any type of error.") message:cleanedErrorMsg];
 }
 
-+ (void)showAlertWithTitle:(NSString *)title message:(NSString *)message fromSource:(NSString *)sourceTag
++ (void)showAlertWithTitle:(NSString *)title message:(NSString *)message
 {
-    [self showAlertWithTitle:title message:message withSupportButton:YES fromSource:sourceTag okPressedBlock:nil];
+    [self showAlertWithTitle:title message:message withSupportButton:YES okPressedBlock:nil];
 }
 
 + (void)showAlertWithTitle:(NSString *)title message:(NSString *)message withSupportButton:(BOOL)showSupport
 {
-    [self showAlertWithTitle:title message:message withSupportButton:showSupport fromSource:nil okPressedBlock:nil];
+    [self showAlertWithTitle:title message:message withSupportButton:showSupport okPressedBlock:nil];
+}
+
++ (void)showAlertWithTitle:(NSString *)title message:(NSString *)message withSupportButton:(BOOL)showSupport okPressedBlock:(void (^)(UIAlertController *))okBlock
+{
+    [self showAlertWithTitle:title message:message withSupportButton:showSupport fromSource:nil okPressedBlock:okBlock];
 }
 
 + (void)showAlertWithTitle:(NSString *)title message:(NSString *)message withSupportButton:(BOOL)showSupport fromSource:(NSString *)sourceTag okPressedBlock:(void (^)(UIAlertController *))okBlock

--- a/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
@@ -11,6 +11,7 @@ class NUXAbstractViewController: UIViewController {
     var helpBadge: WPNUXHelpBadgeLabel!
     var helpButton: UIButton!
     var loginFields = LoginFields()
+    var sourceTag = SupportSourceTag.generalLogin
 
     let helpButtonMarginSpacerWidth = CGFloat(-8)
     let helpBadgeSize = CGSize(width: 12, height: 10)
@@ -202,7 +203,7 @@ class NUXAbstractViewController: UIViewController {
 
 
     func handleHelpButtonTapped(_ sender: UIButton) {
-        displaySupportViewController()
+        displaySupportViewController(sourceTag: self.sourceTag)
     }
 
 }
@@ -212,8 +213,10 @@ extension NUXAbstractViewController : SigninErrorViewControllerDelegate {
 
     /// Displays the support vc.
     ///
-    func displaySupportViewController() {
+    func displaySupportViewController(sourceTag: SupportSourceTag) {
         let controller = SupportViewController()
+        controller.sourceTag = sourceTag
+
         let navController = UINavigationController(rootViewController: controller)
         navController.navigationBar.isTranslucent = false
         navController.modalPresentationStyle = .formSheet
@@ -224,11 +227,12 @@ extension NUXAbstractViewController : SigninErrorViewControllerDelegate {
 
     /// Displays the Helpshift conversation feature.
     ///
-    func displayHelpshiftConversationView() {
-        let metaData = [
-            "Source": "Failed login",
-            "Username": loginFields.username,
-            "SiteURL": loginFields.siteUrl
+    func displayHelpshiftConversationView(sourceTag: SupportSourceTag) {
+        let metaData: [String: AnyObject] = [
+            "Source": "Failed login" as AnyObject,
+            "Username": loginFields.username as AnyObject,
+            "SiteURL": loginFields.siteUrl as AnyObject,
+            HelpshiftSupportTagsKey: [sourceTag.rawValue]  as AnyObject
         ]
         HelpshiftSupport.showConversation(self, withOptions: [HelpshiftSupportCustomMetadataKey: metaData, "showSearchOnNewConversation": "YES"])
         WPAppAnalytics.track(.supportOpenedHelpshiftScreen)

--- a/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
@@ -201,7 +201,7 @@ class NUXAbstractViewController: UIViewController {
 
 
     func handleHelpButtonTapped(_ sender: UIButton) {
-        displaySupportViewController(sourceTag: self.sourceTag)
+        displaySupportViewController(sourceTag: sourceTag)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
@@ -11,7 +11,6 @@ class NUXAbstractViewController: UIViewController {
     var helpBadge: WPNUXHelpBadgeLabel!
     var helpButton: UIButton!
     var loginFields = LoginFields()
-    var sourceTag = SupportSourceTag.generalLogin
 
     let helpButtonMarginSpacerWidth = CGFloat(-8)
     let helpBadgeSize = CGSize(width: 12, height: 10)
@@ -25,7 +24,6 @@ class NUXAbstractViewController: UIViewController {
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
-
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -210,6 +208,12 @@ class NUXAbstractViewController: UIViewController {
 
 
 extension NUXAbstractViewController : SigninErrorViewControllerDelegate {
+
+    var sourceTag: SupportSourceTag {
+        get {
+            return .generalLogin
+        }
+    }
 
     /// Displays the support vc.
     ///

--- a/WordPress/Classes/ViewRelated/NUX/Signin2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Signin2FAViewController.swift
@@ -41,6 +41,8 @@ import WordPressShared
         configureSendCodeButtonText()
         configureStatusLabel("")
         configureSubmitButton(animating: false)
+        
+        self.sourceTag = SupportSourceTag.wpComLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/Signin2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Signin2FAViewController.swift
@@ -21,6 +21,12 @@ import WordPressShared
         return facade
     }()
 
+    override var sourceTag: SupportSourceTag {
+        get {
+            return .wpComLogin
+        }
+    }
+
 
     /// A convenience method for obtaining an instance of the controller from a storyboard.
     ///
@@ -41,8 +47,6 @@ import WordPressShared
         configureSendCodeButtonText()
         configureStatusLabel("")
         configureSubmitButton(animating: false)
-        
-        self.sourceTag = SupportSourceTag.wpComLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
@@ -53,6 +53,8 @@ import WordPressShared
         setupOnePasswordButtonIfNeeded()
         configureSafariPasswordButton(false)
         configureForWPComOnlyIfNeeded()
+        
+        self.sourceTag = SupportSourceTag.generalLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
@@ -31,6 +31,12 @@ import WordPressShared
         }
     }
 
+    override var sourceTag: SupportSourceTag {
+        get {
+            return .generalLogin
+        }
+    }
+
     /// A convenience method for obtaining an instance of the controller from a storyboard.
     ///
     /// - Parameter loginFields: Optional. A LoginFields instance containing any prefilled credentials.
@@ -53,8 +59,6 @@ import WordPressShared
         setupOnePasswordButtonIfNeeded()
         configureSafariPasswordButton(false)
         configureForWPComOnlyIfNeeded()
-        
-        self.sourceTag = SupportSourceTag.generalLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
@@ -284,7 +284,7 @@ protocol SigninErrorViewControllerDelegate {
     /// The Helpshift tag to track the origin of user conversations
     ///
     var sourceTag: SupportSourceTag { get }
-    
+
     /// Delegates should implement this method and display the support view controller when called.
     ///
     func displaySupportViewController(sourceTag: SupportSourceTag)

--- a/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
@@ -281,6 +281,10 @@ class SigninErrorViewController: UIViewController {
 /// Defines responsibilities for the delegate of a SigninErrorViewController.
 ///
 protocol SigninErrorViewControllerDelegate {
+    /// The Helpshift tag to track the origin of user conversations
+    ///
+    var sourceTag: SupportSourceTag { get }
+    
     /// Delegates should implement this method and display the support view controller when called.
     ///
     func displaySupportViewController(sourceTag: SupportSourceTag)

--- a/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
@@ -184,7 +184,7 @@ class SigninErrorViewController: UIViewController {
     func displayGenericErrorMessage(_ message: String) {
         let callback: SigninErrorCallback = { [unowned self] in
             self.dismiss()
-            self.delegate?.displaySupportViewController()
+            self.delegate?.displaySupportViewController(sourceTag: SupportSourceTag.generalLogin)
         }
 
         configureView(message,
@@ -204,7 +204,7 @@ class SigninErrorViewController: UIViewController {
     func displayGenericErrorMessageWithHelpshiftButton(_ message: String) {
         let callback: SigninErrorCallback = { [unowned self] in
             self.dismiss()
-            self.delegate?.displayHelpshiftConversationView()
+            self.delegate?.displayHelpshiftConversationView(sourceTag: SupportSourceTag.wpComLogin)
         }
 
         configureView(message,
@@ -245,7 +245,7 @@ class SigninErrorViewController: UIViewController {
 
         let secondCallback: SigninErrorCallback = { [unowned self] in
             self.dismiss()
-            self.delegate?.displaySupportViewController()
+            self.delegate?.displaySupportViewController(sourceTag: SupportSourceTag.wpOrgLogin)
         }
 
         configureView(message,
@@ -283,12 +283,12 @@ class SigninErrorViewController: UIViewController {
 protocol SigninErrorViewControllerDelegate {
     /// Delegates should implement this method and display the support view controller when called.
     ///
-    func displaySupportViewController()
+    func displaySupportViewController(sourceTag: SupportSourceTag)
 
 
     /// Delegates should implement this method and display the helpshift conversation when called.
     ///
-    func displayHelpshiftConversationView()
+    func displayHelpshiftConversationView(sourceTag: SupportSourceTag)
 
 
     /// Delegates should implement this method and display the in-app web browser when called.

--- a/WordPress/Classes/ViewRelated/NUX/SigninLinkMailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninLinkMailViewController.swift
@@ -34,6 +34,8 @@ class SigninLinkMailViewController: NUXAbstractViewController {
         }
 
         localizeControls()
+        
+        self.sourceTag = SupportSourceTag.wpComLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninLinkMailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninLinkMailViewController.swift
@@ -10,6 +10,12 @@ class SigninLinkMailViewController: NUXAbstractViewController {
     @IBOutlet var usePasswordButton: UIButton!
     var restrictSigninToWPCom = false
 
+    override var sourceTag: SupportSourceTag {
+        get {
+            return .wpComLogin
+        }
+    }
+
     /// A convenience method for obtaining an instance of the controller from a storyboard.
     ///
     /// - Parameter loginFields: A LoginFields instance containing any prefilled credentials.
@@ -34,8 +40,6 @@ class SigninLinkMailViewController: NUXAbstractViewController {
         }
 
         localizeControls()
-        
-        self.sourceTag = SupportSourceTag.wpComLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninLinkRequestViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninLinkRequestViewController.swift
@@ -35,6 +35,8 @@ class SigninLinkRequestViewController: NUXAbstractViewController {
         if !email.isValidEmail() {
             assert(email.isValidEmail(), "The value of loginFields.username was not a valid email address.")
         }
+        
+        self.sourceTag = SupportSourceTag.wpComLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninLinkRequestViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninLinkRequestViewController.swift
@@ -11,6 +11,12 @@ class SigninLinkRequestViewController: NUXAbstractViewController {
     @IBOutlet var usePasswordButton: UIButton!
     var restrictSigninToWPCom = false
 
+    override var sourceTag: SupportSourceTag {
+        get {
+            return .wpComLogin
+        }
+    }
+
     /// A convenience method for obtaining an instance of the controller from a storyboard.
     ///
     /// - Parameter loginFields: A LoginFields instance containing any prefilled credentials.
@@ -35,8 +41,6 @@ class SigninLinkRequestViewController: NUXAbstractViewController {
         if !email.isValidEmail() {
             assert(email.isValidEmail(), "The value of loginFields.username was not a valid email address.")
         }
-        
-        self.sourceTag = SupportSourceTag.wpComLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
@@ -21,6 +21,11 @@ import WordPressShared
         return facade
     }()
 
+    override var sourceTag: SupportSourceTag {
+        get {
+            return .wpOrgLogin
+        }
+    }
 
     /// A convenience method for obtaining an instance of the controller from a storyboard.
     ///
@@ -43,8 +48,6 @@ import WordPressShared
         localizeControls()
         setupOnePasswordButtonIfNeeded()
         displayLoginMessage("")
-        
-        self.sourceTag = SupportSourceTag.wpOrgLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
@@ -43,6 +43,8 @@ import WordPressShared
         localizeControls()
         setupOnePasswordButtonIfNeeded()
         displayLoginMessage("")
+        
+        self.sourceTag = SupportSourceTag.wpOrgLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninWPComViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninWPComViewController.swift
@@ -58,6 +58,8 @@ import WordPressShared
         setupOnePasswordButtonIfNeeded()
         configureStatusLabel("")
         configureForWPComOnlyIfNeeded()
+        
+        self.sourceTag = SupportSourceTag.wpComLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninWPComViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninWPComViewController.swift
@@ -16,6 +16,12 @@ import WordPressShared
     @IBOutlet weak var verticalCenterConstraint: NSLayoutConstraint!
     var onePasswordButton: UIButton!
 
+    override var sourceTag: SupportSourceTag {
+        get {
+            return .wpComLogin
+        }
+    }
+
     var immediateSignin = false
 
     var restrictSigninToWPCom = false {
@@ -58,8 +64,6 @@ import WordPressShared
         setupOnePasswordButtonIfNeeded()
         configureStatusLabel("")
         configureForWPComOnlyIfNeeded()
-        
-        self.sourceTag = SupportSourceTag.wpComLogin
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -53,6 +53,8 @@ import WordPressShared
         configureTermsButtonText()
         setupOnePasswordButtonIfNeeded()
         displayLoginMessage("")
+        
+        self.sourceTag = SupportSourceTag.wpComSignup
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -33,6 +33,11 @@ import WordPressShared
     let BlogIDKey = "blogid"
     let URLKey = "url"
 
+    override var sourceTag: SupportSourceTag {
+        get {
+            return .wpComSignup
+        }
+    }
 
     /// A convenience method for obtaining an instance of the controller from a storyboard.
     ///
@@ -53,8 +58,6 @@ import WordPressShared
         configureTermsButtonText()
         setupOnePasswordButtonIfNeeded()
         displayLoginMessage("")
-        
-        self.sourceTag = SupportSourceTag.wpComSignup
     }
 
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -110,7 +110,8 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
 
 extension PlanListViewController: WPNoResultsViewDelegate {
     func didTap(_ noResultsView: WPNoResultsView!) {
-        SupportViewController.showFromTabBar()
+        let supportVC = SupportViewController()
+        supportVC.showFromTabBar()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.h
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.h
@@ -10,7 +10,6 @@ extern SupportSourceTag const SupportSourceTagGeneralLogin;
 @interface SupportViewController : UITableViewController
 @property (nonatomic, strong) SupportSourceTag sourceTag;
 
-- (id)initFromSource:(SupportSourceTag)sourceTag;
-+ (void)showFromTabBar;
+- (void)showFromTabBar;
 
 @end

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.h
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.h
@@ -1,7 +1,16 @@
 #import <UIKit/UIKit.h>
 
-@interface SupportViewController : UITableViewController
+typedef NSString * SupportSourceTag NS_EXTENSIBLE_STRING_ENUM;
+extern SupportSourceTag const SupportSourceTagWPComLogin;
+extern SupportSourceTag const SupportSourceTagWPComSignup;
+extern SupportSourceTag const SupportSourceTagWPOrgLogin;
+extern SupportSourceTag const SupportSourceTagJetpackLogin;
+extern SupportSourceTag const SupportSourceTagGeneralLogin;
 
+@interface SupportViewController : UITableViewController
+@property (nonatomic, strong) SupportSourceTag sourceTag;
+
+- (id)initFromSource:(SupportSourceTag)sourceTag;
 + (void)showFromTabBar;
 
 @end

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -20,6 +20,11 @@
 #import "WPLogger.h"
 #import "WPGUIConstants.h"
 
+SupportSourceTag const SupportSourceTagWPComLogin = @"origin:wpcom-login-screen";
+SupportSourceTag const SupportSourceTagWPComSignup = @"origin:signup-screen";
+SupportSourceTag const SupportSourceTagWPOrgLogin = @"origin:wporg-login-screen";
+SupportSourceTag const SupportSourceTagJetpackLogin = @"origin:jetpack-login-screen";
+SupportSourceTag const SupportSourceTagGeneralLogin = @"origin:login-screen";
 
 static NSString *const WPSupportRestorationID = @"WPSupportRestorationID";
 
@@ -142,6 +147,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
 - (void)prepareAndDisplayHelpshiftWindowOfType:(int)helpshiftType
 {
     HelpshiftPresenter *presenter = [HelpshiftPresenter new];
+    presenter.sourceTag = self.sourceTag;
 
     __weak __typeof(self) weakSelf = self;
     void (^completion)() = ^{

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -67,10 +67,9 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
     return [[self alloc] init];
 }
 
-+ (void)showFromTabBar
+- (void)showFromTabBar
 {
-    SupportViewController *supportViewController = [[SupportViewController alloc] init];
-    UINavigationController *aNavigationController = [[UINavigationController alloc] initWithRootViewController:supportViewController];
+    UINavigationController *aNavigationController = [[UINavigationController alloc] initWithRootViewController:self];
     aNavigationController.navigationBar.translucent = NO;
 
     if (IS_IPAD) {

--- a/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackSettingsViewController.m
@@ -505,7 +505,11 @@ static NSInteger const JetpackVerificationCodeNumberOfLines = 2;
         return;
     }
     
-    [WPError showNetworkingAlertWithError:error];
+    NSMutableDictionary *userInfo = error.userInfo.mutableCopy;
+    userInfo[WPErrorSupportSourceKey] = SupportSourceTagJetpackLogin;
+    NSError *errorWithSource = [NSError errorWithDomain:error.domain code:error.code userInfo:userInfo];
+    
+    [WPError showNetworkingAlertWithError:errorWithSource];
 }
 
 

--- a/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
@@ -88,9 +88,11 @@ import UIKit
     }
 
     fileprivate var optionsDictionary: [AnyHashable: Any] {
-        var tags: [String]? = nil
+        let tags: [String]
         if let sourceTag = sourceTag {
             tags = [String(sourceTag.rawValue)]
+        } else {
+            tags = []
         }
         let options: [AnyHashable: Any] = [HelpshiftSupportCustomMetadataKey: HelpshiftUtils.helpshiftMetadata(withTags: tags),
                 HelpshiftPresenter.HelpshiftShowsSearchOnNewConversationKey: true]

--- a/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
@@ -9,7 +9,7 @@ import UIKit
     // a list of possibly related FAQs with matching terms before posting a new conversation.
     fileprivate static let HelpshiftShowsSearchOnNewConversationKey = "showSearchOnNewConversation"
 
-    
+
     /// set the source of the presenter for tagging in Helpshift
     var sourceTag: SupportSourceTag?
 

--- a/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
@@ -9,6 +9,9 @@ import UIKit
     // a list of possibly related FAQs with matching terms before posting a new conversation.
     fileprivate static let HelpshiftShowsSearchOnNewConversationKey = "showSearchOnNewConversation"
 
+    
+    /// set the source of the presenter for tagging in Helpshift
+    var sourceTag: SupportSourceTag?
 
     /// Presents a Helpshift window displaying a specific FAQ.
     ///
@@ -85,7 +88,12 @@ import UIKit
     }
 
     fileprivate var optionsDictionary: [AnyHashable: Any] {
-        return [HelpshiftSupportCustomMetadataKey: HelpshiftUtils.helpshiftMetadata(),
+        var tags: [String]? = nil
+        if let sourceTag = sourceTag {
+            tags = [String(sourceTag.rawValue)]
+        }
+        let options: [AnyHashable: Any] = [HelpshiftSupportCustomMetadataKey: HelpshiftUtils.helpshiftMetadata(withTags: tags),
                 HelpshiftPresenter.HelpshiftShowsSearchOnNewConversationKey: true]
+        return options
     }
 }


### PR DESCRIPTION
Fixes #5308 

Adds tags to helpshift sources within the Login/Signup process. Here's an image of how I've set them up:

![helpshift tag chart mk4](https://cloud.githubusercontent.com/assets/517257/22300977/e538d674-e2ee-11e6-98d6-ba80723b2c52.png)

### To test: 
1. Logout
2. Use the help links or error screens to create new Helpshift issues
3. Find the issue in Helpshift and verify than the correct tag has been added (look at the metadata screen in case the tag itself hasn't been configured. Tags are listed under `hs-tags`).

### Review Notes:

There wasn't a clean way to add a source tag to `WPError`, so a duplicate `NSError` with modified `userInfo` as well as a few renamed method is *probably* the least disruptive way to do it. Certainly rewriting that class to not use class methods would be best…

Needs review: @aerych 
