### PR TITLE
Plans: allow for optional icon URL from plan features

### DIFF
--- a/WordPress/Classes/Models/Plan.swift
+++ b/WordPress/Classes/Models/Plan.swift
@@ -12,8 +12,8 @@ struct Plan {
     let title: String
     let fullTitle: String
     let tagline: String
-    let iconUrl: URL
-    let activeIconUrl: URL
+    let iconUrl: URL?
+    let activeIconUrl: URL?
     let productIdentifier: String?
     let featureGroups: [PlanFeatureGroupPlaceholder]
 }
@@ -59,7 +59,7 @@ struct PlanFeature {
     let slug: String
     let title: String
     let description: String
-    let iconURL: URL
+    let iconURL: URL?
 }
 
 struct PlanFeatureGroupPlaceholder {

--- a/WordPress/Classes/Models/Plan.swift
+++ b/WordPress/Classes/Models/Plan.swift
@@ -12,8 +12,8 @@ struct Plan {
     let title: String
     let fullTitle: String
     let tagline: String
-    let iconUrl: URL?
-    let activeIconUrl: URL?
+    let iconUrl: URL
+    let activeIconUrl: URL
     let productIdentifier: String?
     let featureGroups: [PlanFeatureGroupPlaceholder]
 }

--- a/WordPress/Classes/Networking/PlansFeaturesRemote.swift
+++ b/WordPress/Classes/Networking/PlansFeaturesRemote.swift
@@ -129,7 +129,6 @@ private func mapPlanFeaturesResponse(_ response: AnyObject) throws -> PlanFeatur
             let title = featureDetails["title"] as? String,
             var description = featureDetails["description"] as? String,
             let iconURLString = featureDetails["icon"] as? String,
-            let iconURL = URL(string: iconURLString),
             let planDetails = featureDetails["plans"] as? [String: AnyObject] else { throw PlansRemote.ResponseError.decodingFailure }
 
         for (planID, planInfo) in planDetails {
@@ -144,6 +143,7 @@ private func mapPlanFeaturesResponse(_ response: AnyObject) throws -> PlanFeatur
                 description = planSpecificDescription
             }
 
+            let iconURL = URL(string: iconURLString)
             features[planID]?.append(PlanFeature(slug: slug, title: title, description: description, iconURL: iconURL))
         }
     }

--- a/WordPress/Classes/Networking/PlansFeaturesRemote.swift
+++ b/WordPress/Classes/Networking/PlansFeaturesRemote.swift
@@ -128,7 +128,6 @@ private func mapPlanFeaturesResponse(_ response: AnyObject) throws -> PlanFeatur
         guard let slug = featureDetails["product_slug"] as? String,
             let title = featureDetails["title"] as? String,
             var description = featureDetails["description"] as? String,
-            let iconURLString = featureDetails["icon"] as? String,
             let planDetails = featureDetails["plans"] as? [String: AnyObject] else { throw PlansRemote.ResponseError.decodingFailure }
 
         for (planID, planInfo) in planDetails {
@@ -143,7 +142,10 @@ private func mapPlanFeaturesResponse(_ response: AnyObject) throws -> PlanFeatur
                 description = planSpecificDescription
             }
 
-            let iconURL = URL(string: iconURLString)
+            var iconURL: URL?
+            if let iconURLString = featureDetails["icon"] as? String {
+                iconURL = URL(string: iconURLString)
+            }
             features[planID]?.append(PlanFeature(slug: slug, title: title, description: description, iconURL: iconURL))
         }
     }

--- a/WordPress/Classes/Networking/PlansRemote.swift
+++ b/WordPress/Classes/Networking/PlansRemote.swift
@@ -51,7 +51,7 @@ private func mapPlansResponse(_ response: AnyObject) throws -> (activePlan: Plan
             let activeIcon = planDetails["icon_active"] as? String,
             let activeIconUrl = URL(string: activeIcon),
             let featureGroupsJson = planDetails["features_highlight"] as? [[String: AnyObject]] else {
-            throw PlansRemote.ResponseError.decodingFailure
+            return result
         }
 
         let productIdentifier = (planDetails["apple_sku"] as? String).flatMap({ $0.nonEmptyString() })

--- a/WordPress/Classes/Networking/PlansRemote.swift
+++ b/WordPress/Classes/Networking/PlansRemote.swift
@@ -46,11 +46,14 @@ private func mapPlansResponse(_ response: AnyObject) throws -> (activePlan: Plan
             let title = planDetails["product_name_short"] as? String,
             let fullTitle = planDetails["product_name"] as? String,
             let tagline = planDetails["tagline"] as? String,
-            let icon = planDetails["icon"] as? String,
+            let featureGroupsJson = planDetails["features_highlight"] as? [[String: AnyObject]] else {
+            throw PlansRemote.ResponseError.decodingFailure
+        }
+
+        guard let icon = planDetails["icon"] as? String,
             let iconUrl = URL(string: icon),
             let activeIcon = planDetails["icon_active"] as? String,
-            let activeIconUrl = URL(string: activeIcon),
-            let featureGroupsJson = planDetails["features_highlight"] as? [[String: AnyObject]] else {
+            let activeIconUrl = URL(string: activeIcon) else {
             return result
         }
 

--- a/WordPress/Classes/ViewRelated/Plans/FeatureItemCell.swift
+++ b/WordPress/Classes/ViewRelated/Plans/FeatureItemCell.swift
@@ -34,6 +34,10 @@ class FeatureItemCell: WPTableViewCell {
         super.prepareForReuse()
 
         separator.isHidden = false
+
+        featureTitleLabel.text = nil
+        featureDescriptionLabel.text = nil
+        featureIconImageView.image = nil
     }
 
     override func layoutSubviews() {

--- a/WordPress/Classes/ViewRelated/Plans/FeatureItemRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/FeatureItemRow.swift
@@ -6,7 +6,7 @@ struct FeatureItemRow: ImmuTableRow {
 
     let title: String
     let description: String
-    let iconURL: URL
+    let iconURL: URL?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -18,7 +18,10 @@ struct FeatureItemRow: ImmuTableRow {
             cell.featureDescriptionLabel?.attributedText = attributedDescriptionText(description, font: featureDescriptionLabel.font)
         }
 
-        cell.featureIconImageView?.setImageWith(iconURL, placeholderImage: nil)
+        cell.featureIconImageView?.image = nil
+        if let iconURL = iconURL {
+            cell.featureIconImageView?.setImageWith(iconURL, placeholderImage: nil)
+        }
 
         cell.featureTitleLabel.textColor = WPStyleGuide.darkGrey()
         cell.featureDescriptionLabel.textColor = WPStyleGuide.grey()

--- a/WordPress/Classes/ViewRelated/Plans/FeatureItemRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/FeatureItemRow.swift
@@ -18,7 +18,6 @@ struct FeatureItemRow: ImmuTableRow {
             cell.featureDescriptionLabel?.attributedText = attributedDescriptionText(description, font: featureDescriptionLabel.font)
         }
 
-        cell.featureIconImageView?.image = nil
         if let iconURL = iconURL {
             cell.featureIconImageView?.setImageWith(iconURL, placeholderImage: nil)
         }

--- a/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
@@ -10,7 +10,7 @@ struct PlanListRow: ImmuTableRow {
     let active: Bool
     let price: String
     let description: String
-    let iconUrl: URL
+    let iconUrl: URL?
 
     let action: ImmuTableAction?
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
@@ -10,7 +10,7 @@ struct PlanListRow: ImmuTableRow {
     let active: Bool
     let price: String
     let description: String
-    let iconUrl: URL?
+    let iconUrl: URL
 
     let action: ImmuTableAction?
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanPostPurchaseViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanPostPurchaseViewController.swift
@@ -276,8 +276,8 @@ class PlanPostPurchasePageViewController: UIViewController {
 
         switch pageType {
         case .PurchaseComplete:
-            if let plan = plan {
-                imageView.setImageWith(plan.activeIconUrl as URL)
+            if let plan = plan, let activeIconUrl = plan.activeIconUrl {
+                imageView.setImageWith(activeIconUrl)
             }
             headingLabel.text = NSLocalizedString("It’s all yours! Way to go!", comment: "Heading displayed after successful purchase of a plan")
             setDescriptionText(NSLocalizedString("Your site is doing somersaults in excitement! Now explore your site’s new features and choose where you’d like to begin.", comment: "Subtitle displayed after successful purchase of a plan"))

--- a/WordPress/Classes/ViewRelated/Plans/PlanPostPurchaseViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanPostPurchaseViewController.swift
@@ -276,8 +276,8 @@ class PlanPostPurchasePageViewController: UIViewController {
 
         switch pageType {
         case .PurchaseComplete:
-            if let plan = plan, let activeIconUrl = plan.activeIconUrl {
-                imageView.setImageWith(activeIconUrl)
+            if let plan = plan {
+                imageView.setImageWith(plan.activeIconUrl)
             }
             headingLabel.text = NSLocalizedString("It’s all yours! Way to go!", comment: "Heading displayed after successful purchase of a plan")
             setDescriptionText(NSLocalizedString("Your site is doing somersaults in excitement! Now explore your site’s new features and choose where you’d like to begin.", comment: "Subtitle displayed after successful purchase of a plan"))


### PR DESCRIPTION
There may be a better solution here, but a plan feature with an empty icon URL string was causing the guard checks to throw out of the try attempting to decode the JSON. In this case it was the Google Analytics feature that had an empty icon string.

Since the Swift `URL(string:)` init method may return `nil`, I thought it might best to go ahead and account for any other empty icon strings, and declare the use of iconURLs as optional. This tweaks the code a bit to account for that.

To test:
1. Open up Plans, tap on a plan.
2. Make sure it loads, as do the other ones.

Needs review: @frosty can you take a look? I believe you're much more familiar with this code and wrote most of it? Let me know if there's something else entirely we should be doing here.
