### PR TITLE
Make plan feature icon optional

### DIFF
--- a/WordPress/Classes/Models/Plan.swift
+++ b/WordPress/Classes/Models/Plan.swift
@@ -59,7 +59,7 @@ struct PlanFeature {
     let slug: String
     let title: String
     let description: String
-    let iconURL: URL
+    let iconURL: URL?
 }
 
 struct PlanFeatureGroupPlaceholder {

--- a/WordPress/Classes/Networking/PlansFeaturesRemote.swift
+++ b/WordPress/Classes/Networking/PlansFeaturesRemote.swift
@@ -128,9 +128,10 @@ private func mapPlanFeaturesResponse(_ response: AnyObject) throws -> PlanFeatur
         guard let slug = featureDetails["product_slug"] as? String,
             let title = featureDetails["title"] as? String,
             var description = featureDetails["description"] as? String,
-            let iconURLString = featureDetails["icon"] as? String,
-            let iconURL = URL(string: iconURLString),
             let planDetails = featureDetails["plans"] as? [String: AnyObject] else { throw PlansRemote.ResponseError.decodingFailure }
+
+        let iconURLString = featureDetails["icon"] as? String
+        let iconURL = iconURLString.flatMap({ URL(string: $0) })
 
         for (planID, planInfo) in planDetails {
             guard let planID = Int(planID) else { throw PlansRemote.ResponseError.decodingFailure }

--- a/WordPress/Classes/ViewRelated/Plans/FeatureItemRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/FeatureItemRow.swift
@@ -6,7 +6,7 @@ struct FeatureItemRow: ImmuTableRow {
 
     let title: String
     let description: String
-    let iconURL: URL
+    let iconURL: URL?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -18,7 +18,11 @@ struct FeatureItemRow: ImmuTableRow {
             cell.featureDescriptionLabel?.attributedText = attributedDescriptionText(description, font: featureDescriptionLabel.font)
         }
 
-        cell.featureIconImageView?.setImageWith(iconURL, placeholderImage: nil)
+        if let iconURL = iconURL {
+            cell.featureIconImageView?.setImageWith(iconURL, placeholderImage: nil)
+        } else {
+            cell.featureIconImageView?.image = nil
+        }
 
         cell.featureTitleLabel.textColor = WPStyleGuide.darkGrey()
         cell.featureDescriptionLabel.textColor = WPStyleGuide.grey()


### PR DESCRIPTION
Instead of throwing a decode error, make the feature icon optional. From what I've seen, the new features without icon are not even used in current plans 😬 

I tested forcing a `nil` icon for `support` just to check that it would render correctly:

![simulator screen shot 27 jan 2017 09 50 42](https://cloud.githubusercontent.com/assets/8739/22365516/3720a496-e478-11e6-9c4b-b8e8079c10ee.png)

Fixes #6480 

Needs review: @frosty 
