### PR TITLE
Initialize PingHub with the actual reachability

### DIFF
--- a/WordPress/Classes/Utility/PingHubManager.swift
+++ b/WordPress/Classes/Utility/PingHubManager.swift
@@ -92,7 +92,7 @@ class PingHubManager: NSObject {
     override init() {
         let foreground = (UIApplication.shared.applicationState != .background)
         let authToken = defaultAccountToken()
-        state = State(connected: false, reachable: true, foreground: foreground, authToken: authToken)
+        state = State(connected: false, reachable: reachability.isReachable(), foreground: foreground, authToken: authToken)
         super.init()
 
         guard enabled else {


### PR DESCRIPTION
For some reason, I had this idea that `isReachable` could return the wrong value initially and that we had to wait for a reachability changed notification. Maybe that was the case in an older iOS version. So I initialized the state with `reachable = true`.

TIL that `isReachable` (through `SCNetworkReachabilityGetFlags`) is synchronous, so you can call it whenever you want.

Fixes #6487 

To test:

- Switch on airplane mode
- Launch the app
- Look at the console and make sure PingHub doesn't try to connect

Needs review: @jleandroperez 
