### PR TITLE
Issue/6494 Notifications: Fix disappearing navigation items

### DIFF
--- a/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
@@ -13,7 +13,7 @@ fileprivate let fadeAnimationDuration: TimeInterval = 0.1
 // UIKit glitch.
 extension UINavigationController {
     func pushFullscreenViewController(_ viewController: UIViewController, animated: Bool) {
-        if splitViewController?.preferredDisplayMode != .primaryHidden {
+        if let splitViewController = splitViewController, splitViewController.preferredDisplayMode != .primaryHidden {
             if !splitViewControllerIsHorizontallyCompact {
                 navigationBar.fadeOutNavigationItems(animated: animated)
             }


### PR DESCRIPTION
Fixes #6494. 

This was caused by the first half of the Reader fullscreen transition happening when selecting a post in Notifications. Normally, the split view controller (acting as navigation controller delegate) completes the transition when the push finishes. I've tweaked the fullscreen push so it'll only trigger the transition if we're actually running in a split view controller.

To test: follow the steps in the original issue, ensure that the navigation items stay visible!

Needs review: @kurzee 

Thanks for spotting this!