### PR TITLE
Reader Comments: reloading issues with jumping and no results label

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -714,7 +714,9 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     CommentService *service = [[CommentService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
     [service syncHierarchicalCommentsForPost:self.post page:1 success:^(NSInteger count, BOOL hasMore) {
         if (success) {
-            success(hasMore);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                success(hasMore);
+            });
         }
     } failure:failure];
     [self refreshNoResultsView];
@@ -728,7 +730,9 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     NSInteger page = [service numberOfHierarchicalPagesSyncedforPost:self.post] + 1;
     [service syncHierarchicalCommentsForPost:self.post page:page success:^(NSInteger count, BOOL hasMore) {
         if (success) {
-            success(hasMore);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                success(hasMore);
+            });
         }
     } failure:failure];
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -714,9 +714,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     CommentService *service = [[CommentService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
     [service syncHierarchicalCommentsForPost:self.post page:1 success:^(NSInteger count, BOOL hasMore) {
         if (success) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                success(hasMore);
-            });
+            success(hasMore);
         }
     } failure:failure];
     [self refreshNoResultsView];
@@ -730,9 +728,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     NSInteger page = [service numberOfHierarchicalPagesSyncedforPost:self.post] + 1;
     [service syncHierarchicalCommentsForPost:self.post page:page success:^(NSInteger count, BOOL hasMore) {
         if (success) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                success(hasMore);
-            });
+            success(hasMore);
         }
     } failure:failure];
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -56,6 +56,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 @property (nonatomic) BOOL isLoggedIn;
 @property (nonatomic) BOOL needsUpdateAttachmentsAfterScrolling;
 @property (nonatomic) BOOL needsRefreshTableViewAfterScrolling;
+@property (nonatomic, strong) NSCache *estimatedRowHeights;
 
 @end
 
@@ -282,6 +283,8 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+
+    self.estimatedRowHeights = [[NSCache alloc] init];
 }
 
 - (void)configureTableViewHandler
@@ -815,6 +818,10 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 - (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    NSNumber *cachedHeight = [self.estimatedRowHeights objectForKey:indexPath];
+    if (cachedHeight.doubleValue) {
+        return cachedHeight.doubleValue;
+    }
     return EstimatedCommentRowHeight;
 }
 
@@ -842,6 +849,8 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    [self.estimatedRowHeights setObject:[NSNumber numberWithDouble:cell.frame.size.height] forKey:indexPath];
+
     // Are we approaching the end of the table?
     if ((indexPath.section + 1 == [self.tableViewHandler numberOfSectionsInTableView:tableView]) &&
         (indexPath.row + 4 >= [self.tableViewHandler tableView:tableView numberOfRowsInSection:indexPath.section])) {


### PR DESCRIPTION
This fixes two issues I've noticed with Reader comments while working on Notifications readability.

1. The no results view would hang around after loading a `ReaderCommentsViewController` for the first time.
- This is fixed by async dispatching the `success` block after `syncHierarchicalCommentsForPost` is called. There is a point in which the no results view was checking the `resultsController` for a count before it was actually ready, after syncing.

2. The cells would some times jump or bump in size when reloading a `ReaderCommentsViewController` that already had cached data.
- This is fixed by using the familiar method of caching estimated heights for rows using `UITableViewAutomaticDimension`. This is kind of duplicate code in other multiple VCs, so I'm going to refactor later to share this implementation.

To test:
1. Launch the app, hit the Notifications tab.
2. Hit the Comments segment up top.
3. Select a comment from the notifications list.
4. Let the comments load, ensure the "be the first to comment" no results label doesn't stick around after the table has loaded.

* Note there is still an issue where the no results label will stick around for a split-second while the tableView is loading the layout, separate issue that I couldn't figure out for this round.

To test:
1. Revisit a comments thread that was previously viewed and loaded.
2. Check that the cells don't stretch or jump in height while loading.

Needs review: @aerych can you take a run at this one?