### PR TITLE
Fixes a crash in PostEditorSaveAction

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorSaveAction.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorSaveAction.swift
@@ -14,7 +14,8 @@ import WordPressComAnalytics
 extension WPPostViewController {
     /// What action should be taken when the user taps the editor's save button?
     var currentSaveAction: PostEditorSaveAction {
-        if let status = post.status,
+        if let post = post,
+            let status = post.status,
             let originalStatus = post.original?.status, status != originalStatus || !post.hasRemote() {
             if (post.isScheduled()) {
                 return .schedule


### PR DESCRIPTION
Fixes a crash we've been seeing where the editor is recreated without a post. Obviously this doesn't fix the root cause, but should at least prevent the app from crashing.

The editor's post is implicitly unwrapped, but now we're explicitly unwrapping it.

Needs review: @koke 