### PR TITLE
Add media downloading for image already existing in a post.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -984,7 +984,7 @@ extension AztecPostViewController: TextViewMediaDelegate {
     }
 
     func textView(_ textView: TextView, urlForImage image: UIImage) -> URL {
-
+        //TODO: add support for saving images that result from a copy/paste to the editor, this should save locally to file, and import to the media library.
         return URL(string:"")!
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 import Aztec
 import Gridicons
 import WordPressShared
+import AFNetworking
 
 
 // MARK: - Aztec's Native Editor!
@@ -29,6 +30,7 @@ class AztecPostViewController: UIViewController {
         tv.textColor = UIColor.darkText
         tv.translatesAutoresizingMaskIntoConstraints = false
         tv.keyboardDismissMode = .interactive
+        tv.mediaDelegate = self
 
         return tv
     }()
@@ -156,6 +158,7 @@ class AztecPostViewController: UIViewController {
         }
     }
 
+    fileprivate var activeMediaRequests = [AFImageDownloadReceipt]()
 
     // MARK: - Lifecycle Methods
 
@@ -170,6 +173,7 @@ class AztecPostViewController: UIViewController {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+        cancelAllPendingMediaRequests()
     }
 
 
@@ -945,6 +949,52 @@ private extension AztecPostViewController {
     }
 }
 
+extension AztecPostViewController: TextViewMediaDelegate {
+
+    func textView(_ textView: TextView, imageAtUrl url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) -> UIImage {
+        var requestURL = url
+        let imageMaxDimension = max(UIScreen.main.nativeBounds.size.width, UIScreen.main.nativeBounds.size.height)
+        let size = CGSize(width: imageMaxDimension, height: imageMaxDimension)
+        let request: URLRequest
+        if self.post.blog.isPrivate() {
+            // private wpcom image needs special handling.
+            requestURL = WPImageURLHelper.imageURLWithSize(size, forImageURL: requestURL)
+            request = PrivateSiteURLProtocol.requestForPrivateSite(from: requestURL)
+        } else {
+            requestURL = PhotonImageURLHelper.photonURL(with: size, forImageURL: requestURL)
+            request = URLRequest(url: requestURL)
+        }
+
+        let imageDownloader = AFImageDownloader.defaultInstance()
+        let receipt = imageDownloader.downloadImage(for: request, success: { (request, response, image) in
+            DispatchQueue.main.async(execute: {
+                success(image)
+            })
+        }) { (request, response, error) in
+            DispatchQueue.main.async(execute: {
+                failure()
+            })
+        }
+
+        if let receipt = receipt {
+            activeMediaRequests.append(receipt)
+        }
+
+        return Gridicon.iconOfType(.image)
+    }
+
+    func textView(_ textView: TextView, urlForImage image: UIImage) -> URL {
+
+        return URL(string:"")!
+    }
+
+    func cancelAllPendingMediaRequests() {
+        let imageDownloader = AFImageDownloader.defaultInstance()
+        for receipt in activeMediaRequests {
+            imageDownloader.cancelTask(for: receipt)
+        }
+    }
+}
 
 // MARK: - Constants
 fileprivate extension AztecPostViewController {


### PR DESCRIPTION
This PR adds media downloading for the Aztec editor.

This use the AFNetworking Image download cache mechanism to manage the requests.

To test:
 - Open a post that is already published and has images on it.
 - Check if the images are dowloaded a displayed correctly.
 - Check if while images are being downloaded a placeholder is show.

Check this on wp.com sites and wp.org sites and on private wp.com sites. 

Needs review: @jleandroperez 