### PR TITLE
Issues/6472 lingering no results view

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -350,13 +350,19 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
                                                  if (([parents count] < WPTopLevelHierarchicalCommentsPerPage) || (page > 1 && !includesNewComments)) {
                                                      hasMore = NO;
                                                  }
-                                                 success([comments count], hasMore);
+
+                                                 dispatch_async(dispatch_get_main_queue(), ^{
+                                                     success([comments count], hasMore);
+                                                 });
+
                                              }
                                          }];
                                      } failure:^(NSError *error) {
                                          [self.managedObjectContext performBlock:^{
                                              if (failure) {
-                                                 failure(error);
+                                                 dispatch_async(dispatch_get_main_queue(), ^{
+                                                     failure(error);
+                                                 });
                                              }
                                          }];
                                      }];
@@ -904,7 +910,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
         post.commentCount = @([commentsToKeep count]);
     }
 
-    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+    [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
 
     return newCommentCount > 0;
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -708,7 +708,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 - (void)syncHelper:(WPContentSyncHelper *)syncHelper syncContentWithUserInteraction:(BOOL)userInteraction success:(void (^)(BOOL))success failure:(void (^)(NSError *))failure
 {
-    CommentService *service = [[CommentService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
+    CommentService *service = [[CommentService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] newDerivedContext]];
     [service syncHierarchicalCommentsForPost:self.post page:1 success:^(NSInteger count, BOOL hasMore) {
         if (success) {
             success(hasMore);
@@ -721,7 +721,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 {
     [self.activityFooter startAnimating];
 
-    CommentService *service = [[CommentService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
+    CommentService *service = [[CommentService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] newDerivedContext]];
     NSInteger page = [service numberOfHierarchicalPagesSyncedforPost:self.post] + 1;
     [service syncHierarchicalCommentsForPost:self.post page:page success:^(NSInteger count, BOOL hasMore) {
         if (success) {


### PR DESCRIPTION
Fixes #6472 
Prior to the comment refresh the ReaderCommentsViewController would reset the loading / no results view in response to a core data change, courtesy of the `tableViewDidChangeContent` delete method.  This method and behavior was removed during the refresh, hence the bug.

This PR addresses the issue by (arguably) correcting another issue I'd somehow overlooked. Now a sync uses a derive context so its work is executed on a background queue, saves synchronously, and dispatches its success block on the main queue.  We prefer to do sync operations and saves on a background queue to keep the main queue free and services should *always* dispatch save and failure blocks on the main queue. 

To test: 
Go to a comment notification and view the comment list.  Confirm the no results view is hidden after the comments are loaded. 

Needs review: @kurzee 
