### PR TITLE
Add source tag arg to NUX error screens

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
@@ -148,11 +148,11 @@ class NUXAbstractViewController: UIViewController {
     ///
     /// - Parameter error: An NSError instance
     ///
-    func displayError(_ error: NSError) {
+    func displayError(_ error: NSError, sourceTag: SupportSourceTag) {
         let presentingController = navigationController ?? self
         let controller = SigninErrorViewController.controller()
         controller.presentFromController(presentingController)
-        controller.displayError(error, loginFields: loginFields, delegate: self)
+        controller.displayError(error, loginFields: loginFields, delegate: self, sourceTag: sourceTag)
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/Signin2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Signin2FAViewController.swift
@@ -255,6 +255,6 @@ extension Signin2FAViewController: LoginFacadeDelegate {
     func displayRemoteError(_ error: Error!) {
         configureStatusLabel("")
         configureViewLoading(false)
-        displayError(error as NSError)
+        displayError(error as NSError, sourceTag: sourceTag)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
@@ -321,8 +321,11 @@ import WordPressShared
             },
             failure: { [weak self] (error: Error) in
                 DDLogSwift.logError(error.localizedDescription)
-                self?.configureViewLoading(false)
-                self?.displayError(error as NSError)
+                guard let strongSelf = self else {
+                    return
+                }
+                strongSelf.configureViewLoading(false)
+                strongSelf.displayError(error as NSError, sourceTag: strongSelf.sourceTag)
             })
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
@@ -141,7 +141,7 @@ class SigninErrorViewController: UIViewController {
     ///
     /// - Parameter error: An NSError instance
     ///
-    func displayError(_ error: NSError, loginFields: LoginFields, delegate: SigninErrorViewControllerDelegate) {
+    func displayError(_ error: NSError, loginFields: LoginFields, delegate: SigninErrorViewControllerDelegate, sourceTag: SupportSourceTag) {
         self.loginFields = loginFields
         self.delegate = delegate
 
@@ -151,10 +151,10 @@ class SigninErrorViewController: UIViewController {
 
         if error.domain != WPXMLRPCFaultErrorDomain && error.code != NSURLErrorBadURL {
             if HelpshiftUtils.isHelpshiftEnabled() {
-                displayGenericErrorMessageWithHelpshiftButton(message)
+                displayGenericErrorMessageWithHelpshiftButton(message, sourceTag: sourceTag)
 
             } else {
-                displayGenericErrorMessage(message)
+                displayGenericErrorMessage(message, sourceTag: sourceTag)
             }
             return
         }
@@ -168,11 +168,11 @@ class SigninErrorViewController: UIViewController {
         }
 
         if error.code == 405 {
-            displayErrorMessageForXMLRPC(message)
+            displayErrorMessageForXMLRPC(message, sourceTag: sourceTag)
         } else  if error.code == NSURLErrorBadURL {
             displayErrorMessageForBadURL(message)
         } else {
-            displayGenericErrorMessage(message)
+            displayGenericErrorMessage(message, sourceTag: sourceTag)
         }
     }
 
@@ -181,10 +181,10 @@ class SigninErrorViewController: UIViewController {
     ///
     /// - Parameter message: The error message to show.
     ///
-    func displayGenericErrorMessage(_ message: String) {
+    func displayGenericErrorMessage(_ message: String, sourceTag: SupportSourceTag) {
         let callback: SigninErrorCallback = { [unowned self] in
             self.dismiss()
-            self.delegate?.displaySupportViewController(sourceTag: SupportSourceTag.generalLogin)
+            self.delegate?.displaySupportViewController(sourceTag: sourceTag)
         }
 
         configureView(message,
@@ -200,11 +200,12 @@ class SigninErrorViewController: UIViewController {
     /// is configured so the user can open Helpshift for assistance.
     ///
     /// - Parameter message: The error message to show.
+    /// - Parameter sourceTag: tag of the source of the error
     ///
-    func displayGenericErrorMessageWithHelpshiftButton(_ message: String) {
+    func displayGenericErrorMessageWithHelpshiftButton(_ message: String, sourceTag: SupportSourceTag) {
         let callback: SigninErrorCallback = { [unowned self] in
             self.dismiss()
-            self.delegate?.displayHelpshiftConversationView(sourceTag: SupportSourceTag.wpComLogin)
+            self.delegate?.displayHelpshiftConversationView(sourceTag: sourceTag)
         }
 
         configureView(message,
@@ -220,7 +221,7 @@ class SigninErrorViewController: UIViewController {
     ///
     /// - Parameter message: The error message to show.
     ///
-    func displayErrorMessageForXMLRPC(_ message: String) {
+    func displayErrorMessageForXMLRPC(_ message: String, sourceTag: SupportSourceTag) {
         let firstCallback: SigninErrorCallback = { [unowned self] in
             self.dismiss()
 
@@ -245,7 +246,7 @@ class SigninErrorViewController: UIViewController {
 
         let secondCallback: SigninErrorCallback = { [unowned self] in
             self.dismiss()
-            self.delegate?.displaySupportViewController(sourceTag: SupportSourceTag.wpOrgLogin)
+            self.delegate?.displaySupportViewController(sourceTag: sourceTag)
         }
 
         configureView(message,

--- a/WordPress/Classes/ViewRelated/NUX/SigninLinkRequestViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninLinkRequestViewController.swift
@@ -102,8 +102,11 @@ class SigninLinkRequestViewController: NUXAbstractViewController {
 
             }, failure: { [weak self] (error: Error) in
                 WPAppAnalytics.track(.loginMagicLinkFailed)
-                self?.displayError(error as NSError)
-                self?.configureLoading(false)
+                guard let strongSelf = self else {
+                    return
+                }
+                strongSelf.displayError(error as NSError, sourceTag: strongSelf.sourceTag)
+                strongSelf.configureLoading(false)
             })
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
@@ -315,7 +315,7 @@ extension SigninSelfHostedViewController: LoginFacadeDelegate {
     func displayRemoteError(_ error: Error!) {
         displayLoginMessage("")
         configureViewLoading(false)
-        displayError(error as NSError)
+        displayError(error as NSError, sourceTag: sourceTag)
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninWPComSyncHandler.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninWPComSyncHandler.swift
@@ -9,7 +9,7 @@ protocol SigninWPComSyncHandler: class {
     func configureViewLoading(_ loading: Bool)
     func configureStatusLabel(_ message: String)
     func dismiss()
-    func displayError(_ error: NSError)
+    func displayError(_ error: NSError, sourceTag: SupportSourceTag)
     func updateSafariCredentialsIfNeeded()
 
     func syncWPCom(_ username: String, authToken: String, requiredMultifactor: Bool)

--- a/WordPress/Classes/ViewRelated/NUX/SigninWPComViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninWPComViewController.swift
@@ -331,7 +331,7 @@ extension SigninWPComViewController: LoginFacadeDelegate {
     func displayRemoteError(_ error: Error!) {
         configureStatusLabel("")
         configureViewLoading(false)
-        displayError(error as NSError)
+        displayError(error as NSError, sourceTag: sourceTag)
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -271,7 +271,7 @@ import WordPressShared
         let controller = SigninErrorViewController.controller()
         controller.delegate = self
         controller.presentFromController(presentingController)
-        controller.displayGenericErrorMessage(message)
+        controller.displayGenericErrorMessage(message, sourceTag: sourceTag)
     }
 
 
@@ -345,7 +345,7 @@ import WordPressShared
             self.displayLoginMessage("")
             self.configureLoading(false)
             if let error = error as? NSError {
-                self.displayError(error)
+                self.displayError(error, sourceTag: self.sourceTag)
             }
         }
 


### PR DESCRIPTION
Fixes #6510 

To test:
- intentionally encounter an error while signing up for WordPress.com (a single letter password works)
- on the error screen, tap "Contact Us"
- Enter some text
- Check the created Helpshift issue to ensure it has the proper tag of `origin:signup-screen`

Needs review: @kurzee 