### PR TITLE
Support publicize on posting

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -3,6 +3,11 @@
 This file documents changes in the data model. Please explain any changes to the
 data model as well as any custom migrations.
 
+## WordPress56
+- @elibud 2011-02-02
+- `Post` added optional `disabledPublicizeConnections` transformable property.
+- `Post` added optional `publicizeMessage` and `publicizeMessageID` string properties.
+
 ## WordPress55
 - @aerych 2016-12-21
 - `ReaderPost` renamed `preserveForRestoration` to "inUse"

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -126,6 +126,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 // Readonly Properties
 @property (nonatomic,   weak,  readonly, nullable) NSArray *sortedPostFormatNames;
 @property (nonatomic,   weak,  readonly, nullable) NSArray *sortedPostFormats;
+@property (nonatomic,   weak,  readonly, nullable) NSArray *sortedConnections;
 @property (nonatomic, strong,  readonly, nullable) WordPressOrgXMLRPCApi *xmlrpcApi;
 @property (nonatomic,   weak,  readonly, nullable) NSString       *version;
 @property (nonatomic, strong,  readonly, nullable) NSString       *authToken;

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -263,7 +263,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
 {
     NSSortDescriptor *sortServiceDescriptor = [[NSSortDescriptor alloc] initWithKey:@"service"
                                                                           ascending:YES
-                                                                           selector:@selector(caseInsensitiveCompare:)];
+                                                                           selector:@selector(localizedCaseInsensitiveCompare:)];
     NSSortDescriptor *sortExternalNameDescriptor = [[NSSortDescriptor alloc] initWithKey:@"externalName"
                                                                                ascending:YES
                                                                                 selector:@selector(caseInsensitiveCompare:)];

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -259,6 +259,18 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
     }];
 }
 
+- (NSArray *)sortedConnections
+{
+    NSSortDescriptor *sortServiceDescriptor = [[NSSortDescriptor alloc] initWithKey:@"service"
+                                                                          ascending:YES
+                                                                           selector:@selector(caseInsensitiveCompare:)];
+    NSSortDescriptor *sortExternalNameDescriptor = [[NSSortDescriptor alloc] initWithKey:@"externalName"
+                                                                               ascending:YES
+                                                                                selector:@selector(caseInsensitiveCompare:)];
+    NSArray *sortDescriptors = [[NSArray alloc] initWithObjects:sortServiceDescriptor, sortExternalNameDescriptor, nil];
+    return [[self.connections allObjects] sortedArrayUsingDescriptors:sortDescriptors];
+}
+
 - (NSString *)defaultPostFormatText
 {
     return [self postFormatTextFromSlug:self.settings.defaultPostFormat];

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -267,7 +267,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
     NSSortDescriptor *sortExternalNameDescriptor = [[NSSortDescriptor alloc] initWithKey:@"externalName"
                                                                                ascending:YES
                                                                                 selector:@selector(caseInsensitiveCompare:)];
-    NSArray *sortDescriptors = [[NSArray alloc] initWithObjects:sortServiceDescriptor, sortExternalNameDescriptor, nil];
+    NSArray *sortDescriptors = @[sortServiceDescriptor, sortExternalNameDescriptor];
     return [[self.connections allObjects] sortedArrayUsingDescriptors:sortDescriptors];
 }
 

--- a/WordPress/Classes/Models/Post+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/Post+CoreDataProperties.swift
@@ -4,7 +4,7 @@ import CoreData
 extension Post {
 
     @NSManaged var commentCount: NSNumber?
-    @NSManaged var disabledPublicizeConnections: Dictionary<NSNumber, Dictionary<String, String>>?
+    @NSManaged var disabledPublicizeConnections: [NSNumber: [String: String]]?
     @NSManaged var geolocation: Coordinate?
     @NSManaged var latitudeID: String?
     @NSManaged var likeCount: NSNumber?

--- a/WordPress/Classes/Models/Post+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/Post+CoreDataProperties.swift
@@ -4,6 +4,7 @@ import CoreData
 extension Post {
 
     @NSManaged var commentCount: NSNumber?
+    @NSManaged var disabledPublicizeConnections: Dictionary<NSNumber, Dictionary<String, String>>?
     @NSManaged var geolocation: Coordinate?
     @NSManaged var latitudeID: String?
     @NSManaged var likeCount: NSNumber?
@@ -11,6 +12,8 @@ extension Post {
     @NSManaged var postFormat: String?
     @NSManaged var postType: String?
     @NSManaged var publicID: String?
+    @NSManaged var publicizeMessage: String?
+    @NSManaged var publicizeMessageID: String?
     @NSManaged var tags: String?
     @NSManaged var categories: Set<PostCategory>?
 

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -31,6 +31,13 @@ class Post: AbstractPost {
     static let entityName = "Post"
     static let typeDefaultIdentifier = "post"
 
+    struct Constants {
+        static let publicizeIdKey = "id"
+        static let publicizeValueKey = "value"
+        static let publicizeDisabledValue = "1"
+        static let publicizeEnabledValue = "0"
+    }
+
     // MARK: - Properties
 
     fileprivate var storedContentPreviewForDisplay = ""
@@ -142,17 +149,12 @@ class Post: AbstractPost {
     // MARK: - PublicizeConnections
 
     func publicizeConnectionDisabledForKeyringID(_ keyringID: NSNumber) -> Bool {
-        if let disabled = disabledPublicizeConnections?[keyringID]?["value"],
-            disabled == "1" {
-            return true
-        } else {
-            return false
-        }
+        return disabledPublicizeConnections?[keyringID]?[Constants.publicizeValueKey] == Constants.publicizeDisabledValue
     }
 
     func enablePublicizeConnectionWithKeyringID(_ keyringID: NSNumber) {
-        if let _ = disabledPublicizeConnections?[keyringID]?["id"] {
-            disabledPublicizeConnections![keyringID]!["value"] = "0"
+        if let _ = disabledPublicizeConnections?[keyringID]?[Constants.publicizeIdKey] {
+            disabledPublicizeConnections![keyringID]![Constants.publicizeValueKey] = Constants.publicizeEnabledValue
         } else {
             _ = disabledPublicizeConnections?.removeValue(forKey: keyringID)
         }
@@ -160,12 +162,12 @@ class Post: AbstractPost {
 
     func disablePublicizeConnectionWithKeyringID(_ keyringID: NSNumber) {
         if let _ = disabledPublicizeConnections?[keyringID] {
-            disabledPublicizeConnections![keyringID]!["value"] = "1"
+            disabledPublicizeConnections![keyringID]![Constants.publicizeValueKey] = Constants.publicizeDisabledValue
         } else {
             if disabledPublicizeConnections == nil {
                 disabledPublicizeConnections = [NSNumber: [String: String]]()
             }
-            disabledPublicizeConnections?[keyringID] = ["value": "1"]
+            disabledPublicizeConnections?[keyringID] = [Constants.publicizeValueKey: Constants.publicizeDisabledValue]
         }
     }
 

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -133,6 +133,12 @@ class Post: AbstractPost {
         categories = newCategories
     }
 
+    // MARK: - Sharing
+
+    func canEditPublicizeSettings() -> Bool {
+        return !self.hasRemote() || self.status != PostStatusPublish
+    }
+
     // MARK: - PublicizeConnections
 
     func publicizeConnectionDisabledForKeyringID(_ keyringID: NSNumber) -> Bool {

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -133,6 +133,38 @@ class Post: AbstractPost {
         categories = newCategories
     }
 
+    // MARK: - PublicizeConnections
+
+    func publicizeConnectionDisabledForKeyringID(_ keyringID: NSNumber) -> Bool {
+        if let disabled = disabledPublicizeConnections?[keyringID]?["value"],
+            disabled == "1" {
+            return true
+        } else {
+            return false
+        }
+    }
+
+    func enablePublicizeConnectionWithKeyringID(_ keyringID: NSNumber) {
+        if let _ = disabledPublicizeConnections?[keyringID] {
+            if let _ = disabledPublicizeConnections?[keyringID]?["id"] {
+                disabledPublicizeConnections?[keyringID]!["value"] = "0"
+            } else {
+                _ = disabledPublicizeConnections?.removeValue(forKey: keyringID)
+            }
+        }
+    }
+
+    func disablePublicizeConnectionWithKeyringID(_ keyringID: NSNumber) {
+        if let _ = disabledPublicizeConnections?[keyringID] {
+            disabledPublicizeConnections![keyringID]!["value"] = "1"
+        } else {
+            if disabledPublicizeConnections == nil {
+                disabledPublicizeConnections = [NSNumber: [String: String]]()
+            }
+            disabledPublicizeConnections?[keyringID] = ["value": "1"]
+        }
+    }
+
     // MARK: - Comments
 
     func numberOfComments() -> Int {
@@ -202,6 +234,15 @@ class Post: AbstractPost {
             if let coord1 = geolocation?.coordinate,
                 let coord2 = originalPost.geolocation?.coordinate, coord1.latitude != coord2.latitude || coord1.longitude != coord2.longitude {
 
+                return true
+            }
+
+            if publicizeMessage ?? "" != originalPost.publicizeMessage ?? "" {
+                return true
+            }
+
+            if (!NSDictionary(dictionary: disabledPublicizeConnections ?? [:])
+                             .isEqual(to: originalPost.disabledPublicizeConnections ?? [:])) {
                 return true
             }
         }

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -151,12 +151,10 @@ class Post: AbstractPost {
     }
 
     func enablePublicizeConnectionWithKeyringID(_ keyringID: NSNumber) {
-        if let _ = disabledPublicizeConnections?[keyringID] {
-            if let _ = disabledPublicizeConnections?[keyringID]?["id"] {
-                disabledPublicizeConnections?[keyringID]!["value"] = "0"
-            } else {
-                _ = disabledPublicizeConnections?.removeValue(forKey: keyringID)
-            }
+        if let _ = disabledPublicizeConnections?[keyringID]?["id"] {
+            disabledPublicizeConnections![keyringID]!["value"] = "0"
+        } else {
+            _ = disabledPublicizeConnections?.removeValue(forKey: keyringID)
         }
     }
 

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -153,11 +153,17 @@ class Post: AbstractPost {
     }
 
     func enablePublicizeConnectionWithKeyringID(_ keyringID: NSNumber) {
-        if let _ = disabledPublicizeConnections?[keyringID]?[Constants.publicizeIdKey] {
-            disabledPublicizeConnections![keyringID]![Constants.publicizeValueKey] = Constants.publicizeEnabledValue
-        } else {
-            _ = disabledPublicizeConnections?.removeValue(forKey: keyringID)
+        guard var connection = disabledPublicizeConnections?[keyringID] else {
+            return
         }
+
+        guard connection[Constants.publicizeIdKey] != nil else {
+            _ = disabledPublicizeConnections?.removeValue(forKey: keyringID)
+            return
+        }
+
+        connection[Constants.publicizeValueKey] = Constants.publicizeEnabledValue
+        disabledPublicizeConnections?[keyringID] = connection
     }
 
     func disablePublicizeConnectionWithKeyringID(_ keyringID: NSNumber) {

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -272,6 +272,17 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
                                        dispatch_group_leave(syncGroup);
                                    }];
 
+    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    dispatch_group_enter(syncGroup);
+    [sharingService syncPublicizeConnectionsForBlog:blog
+                                            success:^{
+                                                dispatch_group_leave(syncGroup);
+                                            }
+                                            failure:^(NSError *error) {
+                                                DDLogError(@"Failed syncing publicize connections for blog %@: %@", blog.url, error);
+                                                dispatch_group_leave(syncGroup);
+                                            }];
+
     dispatch_group_enter(syncGroup);
     [remote checkMultiAuthorWithSuccess:^(BOOL isMultiAuthor) {
         [self updateMultiAuthor:isMultiAuthor forBlog:blogObjectID];

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -554,6 +554,9 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         NSString *latitudeID = nil;
         NSString *longitudeID = nil;
         NSString *publicID = nil;
+        NSString *publicizeMessage = nil;
+        NSString *publicizeMessageID = nil;
+        NSMutableDictionary *disabledPublicizeConnections = [NSMutableDictionary dictionary];
         if (remotePost.metadata) {
             NSDictionary *latitudeDictionary = [self dictionaryWithKey:@"geo_latitude" inMetadata:remotePost.metadata];
             NSDictionary *longitudeDictionary = [self dictionaryWithKey:@"geo_longitude" inMetadata:remotePost.metadata];
@@ -569,11 +572,27 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
                 longitudeID = [longitudeDictionary stringForKey:@"id"];
                 publicID = [geoPublicDictionary stringForKey:@"id"];
             }
+            NSDictionary *publicizeMessageDictionary = [self dictionaryWithKey:@"_wpas_mess" inMetadata:remotePost.metadata];
+            publicizeMessage = [publicizeMessageDictionary stringForKey:@"value"];
+            publicizeMessageID = [publicizeMessageDictionary stringForKey:@"id"];
+
+            NSArray *disabledPublicizeConnectionsArray = [self entriesWithKeyLike:@"_wpas_skip_*" inMetadata:remotePost.metadata];
+            for (NSDictionary *disabledConnectionDictionary in disabledPublicizeConnectionsArray) {
+                NSString *dictKey = [disabledConnectionDictionary stringForKey:@"key"];
+                NSNumber *keyringConnectionID = @([[dictKey stringByReplacingOccurrencesOfString:@"_wpas_skip_" withString:@""]integerValue]);
+                NSMutableDictionary *keyringConnectionData = [NSMutableDictionary dictionaryWithCapacity:2];
+                keyringConnectionData[@"id"] = [disabledConnectionDictionary stringForKey:@"id"];
+                keyringConnectionData[@"value"] = [disabledConnectionDictionary stringForKey:@"value"];
+                disabledPublicizeConnections[keyringConnectionID] = keyringConnectionData;
+            }
         }
         postPost.geolocation = geolocation;
         postPost.latitudeID = latitudeID;
         postPost.longitudeID = longitudeID;
         postPost.publicID = publicID;
+        postPost.publicizeMessage = publicizeMessage;
+        postPost.publicizeMessageID = publicizeMessageID;
+        postPost.disabledPublicizeConnections = disabledPublicizeConnections;
     }
 }
 
@@ -671,6 +690,21 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         }
         [metadata addObject:publicDictionary];
     }
+    if (post.publicizeMessageID || post.publicizeMessage.length) {
+        NSMutableDictionary *publicizeMessageDictionary = [NSMutableDictionary dictionaryWithCapacity:3];
+        if (post.publicizeMessageID) {
+            publicizeMessageDictionary[@"id"] = post.publicizeMessageID;
+        }
+        publicizeMessageDictionary[@"key"] = @"_wpas_mess";
+        publicizeMessageDictionary[@"value"] = post.publicizeMessage.length ? post.publicizeMessage : @"";
+        [metadata addObject:publicizeMessageDictionary];
+    }
+    for (NSNumber *keyringConnectionId in post.disabledPublicizeConnections.allKeys) {
+        NSMutableDictionary *disabledConnectionsDictionary = [NSMutableDictionary dictionaryWithCapacity: 3];
+        disabledConnectionsDictionary[@"key"] = [NSString stringWithFormat:@"_wpas_skip_%@", keyringConnectionId];
+        [disabledConnectionsDictionary addEntriesFromDictionary:post.disabledPublicizeConnections[keyringConnectionId]];
+        [metadata addObject:disabledConnectionsDictionary];
+    }
     return metadata;
 }
 
@@ -704,6 +738,11 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     // In theory, there shouldn't be duplicated fields, but I've seen some bugs where there's more than one geo_* value
     // In any case, they should be sorted by id, so `lastObject` should have the newer value
     return [matchingEntries lastObject];
+}
+
+- (NSArray *)entriesWithKeyLike:(NSString *)key inMetadata:(NSArray *)metadata
+{
+    return [metadata filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"key like %@", key]];
 }
 
 - (id<PostServiceRemote>)remoteForBlog:(Blog *)blog {

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -579,7 +579,9 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
             NSArray *disabledPublicizeConnectionsArray = [self entriesWithKeyLike:@"_wpas_skip_*" inMetadata:remotePost.metadata];
             for (NSDictionary *disabledConnectionDictionary in disabledPublicizeConnectionsArray) {
                 NSString *dictKey = [disabledConnectionDictionary stringForKey:@"key"];
-                NSNumber *keyringConnectionID = @([[dictKey stringByReplacingOccurrencesOfString:@"_wpas_skip_" withString:@""]integerValue]);
+                // We only want to keep the keyringID value from the key
+                NSNumber *keyringConnectionID = @([[dictKey stringByReplacingOccurrencesOfString:@"_wpas_skip_"
+                                                                                      withString:@""]integerValue]);
                 NSMutableDictionary *keyringConnectionData = [NSMutableDictionary dictionaryWithCapacity:2];
                 keyringConnectionData[@"id"] = [disabledConnectionDictionary stringForKey:@"id"];
                 keyringConnectionData[@"value"] = [disabledConnectionDictionary stringForKey:@"value"];
@@ -702,7 +704,9 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     }
     for (NSNumber *keyringConnectionId in post.disabledPublicizeConnections.allKeys) {
         NSMutableDictionary *disabledConnectionsDictionary = [NSMutableDictionary dictionaryWithCapacity: 3];
-        disabledConnectionsDictionary[@"key"] = [NSString stringWithFormat:@"_wpas_skip_%@", keyringConnectionId];
+        // We need to compose back the key
+        disabledConnectionsDictionary[@"key"] = [NSString stringWithFormat:@"_wpas_skip_%@",
+                                                                           keyringConnectionId];
         [disabledConnectionsDictionary addEntriesFromDictionary:post.disabledPublicizeConnections[keyringConnectionId]];
         [metadata addObject:disabledConnectionsDictionary];
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -780,7 +780,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 - (UITableViewCell *)configureShareCellForIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell *cell;
-    BOOL canEditSharing = ![self.apost.status isEqualToString:PostStatusPublish];
+    BOOL canEditSharing = [self.post canEditPublicizeSettings];
 
     if (indexPath.row < self.publicizeConnections.count) {
         cell = [self getWPTableViewImageAndAccessoryCell];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -439,7 +439,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         return 1;
 
     } else if (sec == PostSettingsSectionShare) {
-        return self.apost.blog.supportsPublicize && self.publicizeConnections.count ? (self.publicizeConnections.count + 1) : 0;
+        return [self numberOfRowsForShareSection];
 
     } else if (sec == PostSettingsSectionGeolocation) {
         return 1;
@@ -463,7 +463,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     } else if (sec == PostSettingsSectionFeaturedImage) {
         return NSLocalizedString(@"Featured Image", @"Label for the Featured Image area in post settings.");
 
-    } else if (sec == PostSettingsSectionShare) {
+    } else if (sec == PostSettingsSectionShare && [self numberOfRowsForShareSection] > 0) {
         return NSLocalizedString(@"Sharing", @"Label for the Sharing section in post Settings. Should be the same as WP core.");
 
     } else if (sec == PostSettingsSectionGeolocation) {
@@ -476,6 +476,24 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 - (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
     [WPStyleGuide configureTableViewSectionHeader:view];
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    if ([self tableView:tableView numberOfRowsInSection:section] == 0) {
+        return 0.01f;
+    } else {
+        return UITableViewAutomaticDimension;
+    }
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+{
+    if ([self tableView:tableView numberOfRowsInSection:section] == 0) {
+        return 0.01f;
+    } else {
+        return UITableViewAutomaticDimension;
+    }
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -556,6 +574,15 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         [self showEditShareMessageController];
     } else if (cell.tag == PostSettingsRowGeolocation) {
         [self showPostGeolocationSelector];
+    }
+}
+
+- (NSInteger)numberOfRowsForShareSection
+{
+    if (self.apost.blog.supportsPublicize && self.publicizeConnections.count > 0) {
+        return self.publicizeConnections.count + 1;
+    } else {
+        return 0;
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -766,14 +766,18 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 - (UITableViewCell *)configureShareCellForIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell *cell;
+    BOOL canEditSharing = ![self.apost.status isEqualToString:PostStatusPublish];
 
     if (indexPath.row < self.publicizeConnections.count) {
         cell = [self getWPTableViewImageAndAccessoryCell];
         PublicizeConnection *connection = self.publicizeConnections[indexPath.row];
         UIImage *image = [WPStyleGuide iconForService: connection.service];
         [cell.imageView setImage:image];
-        cell.imageView.tintColor = [WPStyleGuide tintColorForConnectedService: connection.service];
+        if (canEditSharing) {
+            cell.imageView.tintColor = [WPStyleGuide tintColorForConnectedService: connection.service];
+        }
         cell.textLabel.text = connection.externalDisplay;
+        cell.textLabel.enabled = canEditSharing;
         if (connection.isBroken) {
             cell.accessoryView = [WPStyleGuide sharingCellWarningAccessoryImageView];
         } else {
@@ -781,6 +785,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
             switchAccessory.tag = indexPath.row;
             [switchAccessory addTarget:self action:@selector(handleShareConnectionCellSwitchChanged:) forControlEvents:UIControlEventValueChanged];
             switchAccessory.on = ![self.post publicizeConnectionDisabledForKeyringID:connection.keyringConnectionID];
+            switchAccessory.enabled = canEditSharing;
             cell.accessoryView = switchAccessory;
         }
         cell.tag = PostSettingsRowShareConnection;
@@ -788,10 +793,13 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     } else {
         cell = [self getWPTableViewDisclosureCell];
         cell.textLabel.text = NSLocalizedString(@"Message", @"Label for the share message field on the post settings.");
+        cell.textLabel.enabled = canEditSharing;
         cell.detailTextLabel.text = self.post.publicizeMessage ? self.post.publicizeMessage : self.post.titleForDisplay;
+        cell.detailTextLabel.enabled = canEditSharing;
         cell.tag = PostSettingsRowShareMessage;
         cell.accessibilityIdentifier = @"Customize the message";
     }
+    cell.userInteractionEnabled = canEditSharing;
     return cell;
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1131,7 +1131,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 - (void)showEditShareMessageController
 {
     SettingsMultiTextViewController *vc = [[SettingsMultiTextViewController alloc] initWithText:self.post.publicizeMessage
-                                                                                    placeholder:self.post.titleForDisplay
+                                                                                    placeholder:nil
                                                                                            hint:NSLocalizedString(@"Customize the message you want to share.", @"Hint displayed when the user is customizing the share message.")
                                                                                      isPassword:NO];
     vc.title = NSLocalizedString(@"Customize the message", @"Title for the edition of the share message.");

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -593,6 +593,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 - (NSInteger)numberOfRowsForShareSection
 {
     if (self.apost.blog.supportsPublicize && self.publicizeConnections.count > 0) {
+        // One row per publicize connection plus an extra row for the publicze message
         return self.publicizeConnections.count + 1;
     } else {
         return 0;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -592,7 +592,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
     if (indexPath.row == PostSettingsRowCategories) {
         // Categories
-        cell = [self getWPTableViewCell];
+        cell = [self getWPTableViewDisclosureCell];
         cell.textLabel.text = NSLocalizedString(@"Categories", @"Label for the categories field. Should be the same as WP core.");
         cell.detailTextLabel.text = [NSString decodeXMLCharactersIn:[self.post categoriesText]];
         cell.tag = PostSettingsRowCategories;
@@ -600,7 +600,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
     } else if (indexPath.row == PostSettingsRowTags) {
         // Tags
-        WPTextFieldTableViewCell *textCell = [self getTextFieldCell];
+        WPTextFieldTableViewCell *textCell = [self getWPTableViewTextFieldCell];
         textCell.textLabel.text = NSLocalizedString(@"Tags", @"Label for the tags field. Should be the same as WP core.");
         textCell.textField.text = self.post.tags;
         textCell.textField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:(NSLocalizedString(@"Comma separated", @"Placeholder text for the tags field. Should be the same as WP core.")) attributes:(@{NSForegroundColorAttributeName: [WPStyleGuide textFieldPlaceholderGrey]})];
@@ -621,7 +621,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     UITableViewCell *cell;
     if (indexPath.row == 0 && !self.datePicker) {
         // Publish date
-        cell = [self getWPTableViewCell];
+        cell = [self getWPTableViewDisclosureCell];
         if (self.apost.dateCreated && ![self.apost shouldPublishImmediately]) {
             if ([self.apost hasFuturePublishDate]) {
                 cell.textLabel.text = NSLocalizedString(@"Scheduled for", @"Scheduled for [date]");
@@ -640,7 +640,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         cell = [self getWPTableViewDatePickerCell];
     } else if (indexPath.row == 1) {
         // Publish Status
-        cell = [self getWPTableViewCell];
+        cell = [self getWPTableViewDisclosureCell];
         cell.textLabel.text = NSLocalizedString(@"Status", @"The status of the post. Should be the same as in core WP.");
         cell.accessibilityIdentifier = @"Status";
         cell.detailTextLabel.text = self.apost.statusTitle;
@@ -655,7 +655,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
     } else if (indexPath.row == 2) {
         // Visibility
-        cell = [self getWPTableViewCell];
+        cell = [self getWPTableViewDisclosureCell];
         cell.textLabel.text = NSLocalizedString(@"Visibility", @"The visibility settings of the post. Should be the same as in core WP.");
         cell.detailTextLabel.text = [self titleForVisibility];
         cell.tag = PostSettingsRowVisibility;
@@ -671,7 +671,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 - (UITableViewCell *)configurePasswordCell
 {
     // Password
-    WPTextFieldTableViewCell *textCell = [self getTextFieldCell];
+    WPTextFieldTableViewCell *textCell = [self getWPTableViewTextFieldCell];
     textCell.textLabel.text = NSLocalizedString(@"Password", @"Label for the tags field. Should be the same as WP core.");
     textCell.textField.text = self.apost.password;
     textCell.textField.attributedPlaceholder = nil;
@@ -702,8 +702,8 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
 - (UITableViewCell *)configurePostFormatCellForIndexPath:(NSIndexPath *)indexPath
 {
-    UITableViewCell *cell = [self getWPTableViewCell];
-    
+    UITableViewCell *cell = [self getWPTableViewDisclosureCell];
+
     cell.textLabel.text = NSLocalizedString(@"Post Format", @"The post formats available for the post. Should be the same as in core WP.");
     
     if (self.post.postFormatText.length > 0) {
@@ -723,7 +723,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     UITableViewCell *cell;
 
     if (!self.apost.post_thumbnail && !self.isUploadingMedia) {
-        WPTableViewActivityCell *activityCell = [self getWPActivityTableViewCell];
+        WPTableViewActivityCell *activityCell = [self getWPTableViewActivityCell];
         activityCell.textLabel.text = NSLocalizedString(@"Set Featured Image", @"");
         activityCell.tag = PostSettingsRowFeaturedImageAdd;
 
@@ -765,9 +765,10 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
 - (UITableViewCell *)configureShareCellForIndexPath:(NSIndexPath *)indexPath
 {
-    UITableViewCell *cell = [self getWPTableViewCell];
+    UITableViewCell *cell;
 
     if (indexPath.row < self.publicizeConnections.count) {
+        cell = [self getWPTableViewImageAndAccessoryCell];
         PublicizeConnection *connection = self.publicizeConnections[indexPath.row];
         UIImage *image = [WPStyleGuide iconForService: connection.service];
         [cell.imageView setImage:image];
@@ -785,6 +786,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         cell.tag = PostSettingsRowShareConnection;
         cell.accessibilityIdentifier = [NSString stringWithFormat:@"%@ %@", connection.service, connection.externalDisplay];
     } else {
+        cell = [self getWPTableViewDisclosureCell];
         cell.textLabel.text = NSLocalizedString(@"Message", @"Label for the share message field on the post settings.");
         cell.detailTextLabel.text = self.post.publicizeMessage ? self.post.publicizeMessage : self.post.titleForDisplay;
         cell.tag = PostSettingsRowShareMessage;
@@ -855,27 +857,39 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     return cell;
 }
 
-- (WPTableViewCell *)getWPTableViewCell
+- (WPTableViewCell *)getWPTableViewDisclosureCell
 {
-    static NSString *wpTableViewCellIdentifier = @"wpTableViewCellIdentifier";
-    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:wpTableViewCellIdentifier];
+    static NSString *wpTableViewDisclosureCellIdentifier = @"wpTableViewDisclosureCellIdentifier";
+    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:wpTableViewDisclosureCellIdentifier];
     if (!cell) {
-        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:wpTableViewCellIdentifier];
+        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:wpTableViewDisclosureCellIdentifier];
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         [WPStyleGuide configureTableViewCell:cell];
     }
     cell.tag = 0;
+    return cell;
+}
+
+- (WPTableViewCell *)getWPTableViewImageAndAccessoryCell
+{
+    static NSString *wpTableViewImageAndAccesoryCellIdentifier = @"wpTableViewImageAndAccesoryCellIdentifier";
+    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:wpTableViewImageAndAccesoryCellIdentifier];
+    if (!cell) {
+        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:wpTableViewImageAndAccesoryCellIdentifier];
+        [WPStyleGuide configureTableViewCell:cell];
+    }
     cell.accessoryView = nil;
     cell.imageView.image = nil;
+    cell.tag = 0;
     return cell;
 }
 
 - (WPTableViewCell *)getWPTableViewDatePickerCell
 {
-    static NSString *wpTableViewCellIdentifier = @"wpTableViewDatePickerCellIdentifier";
-    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:wpTableViewCellIdentifier];
+    static NSString *wpTableViewDatePickerCellIdentifier = @"wpTableViewDatePickerCellIdentifier";
+    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:wpTableViewDatePickerCellIdentifier];
     if (!cell) {
-        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:wpTableViewCellIdentifier];
+        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:wpTableViewDatePickerCellIdentifier];
         cell.accessoryType = UITableViewCellAccessoryNone;
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         [WPStyleGuide configureTableViewCell:cell];
@@ -888,7 +902,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     return cell;
 }
 
-- (WPTableViewActivityCell *)getWPActivityTableViewCell
+- (WPTableViewActivityCell *)getWPTableViewActivityCell
 {
     WPTableViewActivityCell *cell = [self.tableView dequeueReusableCellWithIdentifier:TableViewActivityCellIdentifier];
     cell.accessoryType = UITableViewCellAccessoryNone;
@@ -899,7 +913,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     return cell;
 }
 
-- (WPTextFieldTableViewCell *)getTextFieldCell
+- (WPTextFieldTableViewCell *)getWPTableViewTextFieldCell
 {
     static NSString *textFieldCellIdentifier = @"textFieldCellIdentifier";
     WPTextFieldTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:textFieldCellIdentifier];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -490,7 +490,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
     if ([self tableView:tableView numberOfRowsInSection:section] == 0) {
-        return 0.01f;
+        return CGFLOAT_MIN;
     } else {
         return UITableViewAutomaticDimension;
     }
@@ -499,7 +499,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
 {
     if ([self tableView:tableView numberOfRowsInSection:section] == 0) {
-        return 0.01f;
+        return CGFLOAT_MIN;
     } else {
         return UITableViewAutomaticDimension;
     }
@@ -595,9 +595,8 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     if (self.apost.blog.supportsPublicize && self.publicizeConnections.count > 0) {
         // One row per publicize connection plus an extra row for the publicze message
         return self.publicizeConnections.count + 1;
-    } else {
-        return 0;
     }
+    return 0;
 }
 
 - (UITableViewCell *)configureTaxonomyCellForIndexPath:(NSIndexPath *)indexPath
@@ -891,10 +890,10 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
 - (WPTableViewCell *)getWPTableViewDisclosureCell
 {
-    static NSString *wpTableViewDisclosureCellIdentifier = @"wpTableViewDisclosureCellIdentifier";
-    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:wpTableViewDisclosureCellIdentifier];
+    static NSString *WPTableViewDisclosureCellIdentifier = @"WPTableViewDisclosureCellIdentifier";
+    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:WPTableViewDisclosureCellIdentifier];
     if (!cell) {
-        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:wpTableViewDisclosureCellIdentifier];
+        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:WPTableViewDisclosureCellIdentifier];
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         [WPStyleGuide configureTableViewCell:cell];
     }
@@ -904,10 +903,10 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
 - (WPTableViewCell *)getWPTableViewImageAndAccessoryCell
 {
-    static NSString *wpTableViewImageAndAccesoryCellIdentifier = @"wpTableViewImageAndAccesoryCellIdentifier";
-    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:wpTableViewImageAndAccesoryCellIdentifier];
+    static NSString *WPTableViewImageAndAccesoryCellIdentifier = @"WPTableViewImageAndAccesoryCellIdentifier";
+    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:WPTableViewImageAndAccesoryCellIdentifier];
     if (!cell) {
-        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:wpTableViewImageAndAccesoryCellIdentifier];
+        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:WPTableViewImageAndAccesoryCellIdentifier];
         [WPStyleGuide configureTableViewCell:cell];
     }
     cell.accessoryView = nil;
@@ -918,10 +917,10 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
 - (WPTableViewCell *)getWPTableViewDatePickerCell
 {
-    static NSString *wpTableViewDatePickerCellIdentifier = @"wpTableViewDatePickerCellIdentifier";
-    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:wpTableViewDatePickerCellIdentifier];
+    static NSString *WPTableViewDatePickerCellIdentifier = @"WPTableViewDatePickerCellIdentifier";
+    WPTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:WPTableViewDatePickerCellIdentifier];
     if (!cell) {
-        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:wpTableViewDatePickerCellIdentifier];
+        cell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleValue1 reuseIdentifier:WPTableViewDatePickerCellIdentifier];
         cell.accessoryType = UITableViewCellAccessoryNone;
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         [WPStyleGuide configureTableViewCell:cell];
@@ -947,10 +946,10 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
 - (WPTextFieldTableViewCell *)getWPTableViewTextFieldCell
 {
-    static NSString *textFieldCellIdentifier = @"textFieldCellIdentifier";
-    WPTextFieldTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:textFieldCellIdentifier];
+    static NSString *WPTextFieldCellIdentifier = @"WPTextFieldCellIdentifier";
+    WPTextFieldTableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:WPTextFieldCellIdentifier];
     if (!cell) {
-        cell = [[WPTextFieldTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:textFieldCellIdentifier];
+        cell = [[WPTextFieldTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:WPTextFieldCellIdentifier];
         cell.textField.returnKeyType = UIReturnKeyDone;
         cell.textField.delegate = self;
         [WPStyleGuide configureTableViewTextCell:cell];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController_Internal.h
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController_Internal.h
@@ -5,6 +5,7 @@ typedef enum {
     PostSettingsSectionMeta,
     PostSettingsSectionFormat,
     PostSettingsSectionFeaturedImage,
+    PostSettingsSectionShare,
     PostSettingsSectionGeolocation
 } PostSettingsSection;
 

--- a/WordPress/Classes/WordPress.xcdatamodeld/.xccurrentversion
+++ b/WordPress/Classes/WordPress.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>WordPress 55.xcdatamodel</string>
+	<string>WordPress 56.xcdatamodel</string>
 </dict>
 </plist>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 56.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 56.xcdatamodel/contents
@@ -1,0 +1,664 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="11759" systemVersion="16D32" minimumToolsVersion="Xcode 7.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+    <entity name="AbstractPost" representedClassName="AbstractPost" isAbstract="YES" parentEntity="BasePost">
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="metaIsLocal" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="metaPublishImmediately" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="posts" inverseEntity="Blog" indexed="YES" syncable="YES"/>
+        <relationship name="media" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Media" inverseName="posts" inverseEntity="Media" indexed="YES" syncable="YES"/>
+        <relationship name="original" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPost" inverseName="revision" inverseEntity="AbstractPost" indexed="YES" syncable="YES"/>
+        <relationship name="revision" optional="YES" minCount="1" maxCount="1" deletionRule="Cascade" destinationEntity="AbstractPost" inverseName="original" inverseEntity="AbstractPost" indexed="YES" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Account" representedClassName="WPAccount" syncable="YES">
+        <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="userID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blogs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Blog" inverseName="account" inverseEntity="Blog" indexed="YES" syncable="YES"/>
+        <relationship name="defaultBlog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="accountForDefaultBlog" inverseEntity="Blog" syncable="YES"/>
+        <relationship name="jetpackBlogs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Blog" inverseName="jetpackAccount" inverseEntity="Blog" indexed="YES" syncable="YES"/>
+        <relationship name="settings" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="AccountSettings" inverseName="account" inverseEntity="AccountSettings" syncable="YES"/>
+    </entity>
+    <entity name="AccountSettings" representedClassName=".ManagedAccountSettings" syncable="YES">
+        <attribute name="aboutMe" attributeType="String" syncable="YES"/>
+        <attribute name="displayName" attributeType="String" syncable="YES"/>
+        <attribute name="email" attributeType="String" syncable="YES"/>
+        <attribute name="emailPendingAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="emailPendingChange" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="firstName" attributeType="String" syncable="YES"/>
+        <attribute name="language" attributeType="String" syncable="YES"/>
+        <attribute name="lastName" attributeType="String" syncable="YES"/>
+        <attribute name="primarySiteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+        <attribute name="webAddress" attributeType="String" syncable="YES"/>
+        <relationship name="account" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="settings" inverseEntity="Account" syncable="YES"/>
+    </entity>
+    <entity name="BasePost" representedClassName="BasePost" isAbstract="YES">
+        <attribute name="author" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="authorAvatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="content" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="date_created_gmt" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="mt_excerpt" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="mt_text_more" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="password" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="pathForDisplayImage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="permaLink" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="post_thumbnail" optional="YES" attributeType="Integer 32" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="postTitle" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="remoteStatusNumber" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="status" optional="YES" attributeType="String" defaultValueString="publish">
+            <userInfo/>
+        </attribute>
+        <attribute name="wp_slug" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="comments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Comment" inverseName="post" inverseEntity="Comment" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Blog" representedClassName="Blog">
+        <attribute name="apiKey" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="blogID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="capabilities" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="currentThemeId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="hasOlderPages" transient="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="hasOlderPosts" transient="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isActivated" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isAdmin" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isHostedAtWPcom" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isMultiAuthor" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastCommentsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastPagesSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastPostsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastStatsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastUpdateWarning" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="options" optional="YES" attributeType="Transformable">
+            <userInfo/>
+        </attribute>
+        <attribute name="planID" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="planTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="postFormats" optional="YES" attributeType="Transformable">
+            <userInfo/>
+        </attribute>
+        <attribute name="url" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="username" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="visible" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="xmlrpc" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="account" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="blogs" inverseEntity="Account" indexed="YES" syncable="YES"/>
+        <relationship name="accountForDefaultBlog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="defaultBlog" inverseEntity="Account" syncable="YES"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Category" inverseName="blog" inverseEntity="Category" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="comments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Comment" inverseName="blog" inverseEntity="Comment" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="connections" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PublicizeConnection" inverseName="blog" inverseEntity="PublicizeConnection" syncable="YES"/>
+        <relationship name="domains" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Domain" inverseName="blog" inverseEntity="Domain" syncable="YES"/>
+        <relationship name="jetpackAccount" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="jetpackBlogs" inverseEntity="Account" indexed="YES" syncable="YES"/>
+        <relationship name="media" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Media" inverseName="blog" inverseEntity="Media" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="menuLocations" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="MenuLocation" inverseName="blog" inverseEntity="MenuLocation" syncable="YES"/>
+        <relationship name="menus" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Menu" inverseName="blog" inverseEntity="Menu" syncable="YES"/>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="AbstractPost" inverseName="blog" inverseEntity="AbstractPost" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="postTypes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PostType" inverseName="blog" inverseEntity="PostType" syncable="YES"/>
+        <relationship name="settings" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BlogSettings" inverseName="blog" inverseEntity="BlogSettings" syncable="YES"/>
+        <relationship name="sharingButtons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SharingButton" inverseName="blog" inverseEntity="SharingButton" syncable="YES"/>
+        <relationship name="tags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PostTag" inverseName="blog" inverseEntity="PostTag">
+            <userInfo/>
+        </relationship>
+        <relationship name="themes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Theme" inverseName="blog" inverseEntity="Theme" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="BlogSettings" representedClassName=".BlogSettings" syncable="YES">
+        <attribute name="commentsAllowed" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsBlacklistKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="commentsCloseAutomatically" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsCloseAutomaticallyAfterDays" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsFromKnownUsersWhitelisted" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsMaximumLinks" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsModerationKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="commentsPageSize" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsPagingEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsRequireManualModeration" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsRequireNameAndEmail" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsRequireRegistration" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsSortOrder" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsThreadingDepth" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsThreadingEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="defaultCategoryID" optional="YES" attributeType="Integer 32" defaultValueString="1" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="defaultPostFormat" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="geolocationEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="languageID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="pingbackInboundEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="pingbackOutboundEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="privacy" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="relatedPostsAllowed" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="relatedPostsEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="relatedPostsShowHeadline" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="relatedPostsShowThumbnails" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="sharingButtonStyle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="sharingCommentLikesEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="sharingDisabledLikes" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="sharingDisabledReblogs" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="sharingLabel" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="sharingTwitterName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tagline" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="settings" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <entity name="Category" representedClassName="PostCategory">
+        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="categoryName" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="parentID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="categories" inverseEntity="Blog" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Post" inverseName="categories" inverseEntity="Post" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
+    </entity>
+    <entity name="Comment" representedClassName="Comment">
+        <attribute name="author" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="author_email" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="author_ip" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="author_url" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="authorAvatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="commentID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="content" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="depth" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="hierarchy" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isLiked" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="likeCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="link" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="parentID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="postID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="postTitle" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="status" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="type" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="comments" inverseEntity="Blog" syncable="YES"/>
+        <relationship name="post" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BasePost" inverseName="comments" inverseEntity="BasePost" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Domain" representedClassName=".ManagedDomain" syncable="YES">
+        <attribute name="domainName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="domainType" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isPrimary" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="domains" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <entity name="Media" representedClassName="Media">
+        <attribute name="caption" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="desc" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="filename" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="filesize" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="height" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="length" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="localThumbnailURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="localURL" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="mediaID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="mediaTypeString" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="orientation" optional="YES" attributeType="String" defaultValueString="portrait">
+            <userInfo/>
+        </attribute>
+        <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="progress" optional="YES" transient="YES" attributeType="Float" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="remoteStatusNumber" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="remoteThumbnailURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="remoteURL" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="shortcode" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="title" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="videopressGUID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="width" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="media" inverseEntity="Blog" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AbstractPost" inverseName="media" inverseEntity="AbstractPost" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
+    </entity>
+    <entity name="Menu" representedClassName="Menu" syncable="YES">
+        <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="menuID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="menus" inverseEntity="Blog" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="MenuItem" inverseName="menu" inverseEntity="MenuItem" syncable="YES"/>
+        <relationship name="locations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MenuLocation" inverseName="menu" inverseEntity="MenuLocation" syncable="YES"/>
+    </entity>
+    <entity name="MenuItem" representedClassName="MenuItem" syncable="YES">
+        <attribute name="contentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="itemID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="linkTarget" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="linkTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="typeFamily" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="typeLabel" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="urlStr" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="children" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MenuItem" inverseName="parent" inverseEntity="MenuItem" syncable="YES"/>
+        <relationship name="menu" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Menu" inverseName="items" inverseEntity="Menu" syncable="YES"/>
+        <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MenuItem" inverseName="children" inverseEntity="MenuItem" syncable="YES"/>
+    </entity>
+    <entity name="MenuLocation" representedClassName="MenuLocation" syncable="YES">
+        <attribute name="defaultState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="menuLocations" inverseEntity="Blog" syncable="YES"/>
+        <relationship name="menu" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Menu" inverseName="locations" inverseEntity="Menu" syncable="YES"/>
+    </entity>
+    <entity name="Notification" representedClassName="Notification" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="header" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="meta" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="noticon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="notificationHash" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="notificationId" optional="YES" attributeType="String" elementID="simperiumKey" syncable="YES"/>
+        <attribute name="read" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="subject" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="timestamp" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Page" representedClassName="Page" parentEntity="AbstractPost">
+        <attribute name="parentID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <userInfo/>
+    </entity>
+    <entity name="Person" representedClassName=".ManagedPerson" syncable="YES">
+        <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="displayName" attributeType="String" syncable="YES"/>
+        <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isSuperAdmin" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="kind" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="linkedUserID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="role" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="userID" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Post" representedClassName="Post" parentEntity="AbstractPost">
+        <attribute name="commentCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="disabledPublicizeConnections" optional="YES" attributeType="Transformable">
+            <userInfo/>
+        </attribute>
+        <attribute name="geolocation" optional="YES" attributeType="Transformable">
+            <userInfo/>
+        </attribute>
+        <attribute name="latitudeID" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="likeCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="longitudeID" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="postFormat" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="postType" attributeType="String" defaultValueString="post" syncable="YES"/>
+        <attribute name="publicID" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="publicizeMessage" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="publicizeMessageID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tags" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Category" inverseName="posts" inverseEntity="Category" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
+    </entity>
+    <entity name="PostTag" representedClassName="PostTag">
+        <attribute name="name" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tagID" optional="YES" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="tags" inverseEntity="Blog" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="PostType" representedClassName="PostType" syncable="YES">
+        <attribute name="apiQueryable" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="postTypes" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <entity name="PublicizeConnection" representedClassName="WordPress.PublicizeConnection" syncable="YES">
+        <attribute name="connectionID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateExpires" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateIssued" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="externalDisplay" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="externalFollowerCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="externalID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="externalName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="externalProfilePicture" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="externalProfileURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="keyringConnectionID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="keyringConnectionUserID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="refreshURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="service" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shared" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="status" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="userID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="connections" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <entity name="PublicizeService" representedClassName="WordPress.PublicizeService" syncable="YES">
+        <attribute name="connectURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="detail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="jetpackModuleRequired" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="jetpackSupport" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="multipleExternalUserIDSupport" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="serviceID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="ReaderAbstractTopic" representedClassName="WordPress.ReaderAbstractTopic" isAbstract="YES" syncable="YES">
+        <attribute name="algorithm" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="following" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="inUse" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="lastSynced" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="path" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="showInMenu" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ReaderPost" inverseName="topic" inverseEntity="ReaderPost" syncable="YES"/>
+    </entity>
+    <entity name="ReaderCrossPostMeta" representedClassName="WordPress.ReaderCrossPostMeta" syncable="YES">
+        <attribute name="commentURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="postURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="siteURL" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="post" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ReaderPost" inverseName="crossPostMeta" inverseEntity="ReaderPost" syncable="YES"/>
+    </entity>
+    <entity name="ReaderDefaultTopic" representedClassName="WordPress.ReaderDefaultTopic" parentEntity="ReaderAbstractTopic" syncable="YES"/>
+    <entity name="ReaderGapMarker" representedClassName="ReaderGapMarker" parentEntity="ReaderPost" syncable="YES"/>
+    <entity name="ReaderListTopic" representedClassName="WordPress.ReaderListTopic" parentEntity="ReaderAbstractTopic" syncable="YES">
+        <attribute name="isOwner" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isPublic" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="listDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="listID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="owner" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="ReaderPost" representedClassName="ReaderPost" parentEntity="BasePost" syncable="YES">
+        <attribute name="authorDisplayName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="commentCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsOpen" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateSynced" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="featuredImage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="feedID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="feedItemID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="globalID" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="inUse" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="isBlogPrivate" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isExternal" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isFollowing" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isJetpack" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isLiked" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isLikesEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isReblogged" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isSharingEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isSiteBlocked" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="isWPCom" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="likeCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="postAvatar" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="primaryTag" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="primaryTagSlug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="railcar" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="readingTime" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="score" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="siteIconURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="sortDate" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="sortRank" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="summary" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tags" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="wordCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="crossPostMeta" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ReaderCrossPostMeta" inverseName="post" inverseEntity="ReaderCrossPostMeta" syncable="YES"/>
+        <relationship name="sourceAttribution" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="SourcePostAttribution" inverseName="post" inverseEntity="SourcePostAttribution" syncable="YES"/>
+        <relationship name="topic" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ReaderAbstractTopic" inverseName="posts" inverseEntity="ReaderAbstractTopic" syncable="YES"/>
+    </entity>
+    <entity name="ReaderSearchSuggestion" representedClassName="WordPress.ReaderSearchSuggestion" syncable="YES">
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="searchPhrase" attributeType="String" indexed="YES" syncable="YES"/>
+    </entity>
+    <entity name="ReaderSearchTopic" representedClassName="WordPress.ReaderSearchTopic" parentEntity="ReaderAbstractTopic" syncable="YES"/>
+    <entity name="ReaderSiteTopic" representedClassName="WordPress.ReaderSiteTopic" parentEntity="ReaderAbstractTopic" syncable="YES">
+        <attribute name="feedID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="feedURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isJetpack" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isPrivate" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isVisible" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="postCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="siteBlavatar" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="siteURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subscriberCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+    </entity>
+    <entity name="ReaderTagTopic" representedClassName="WordPress.ReaderTagTopic" parentEntity="ReaderAbstractTopic" syncable="YES">
+        <attribute name="isRecommended" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tagID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+    </entity>
+    <entity name="ReaderTeamTopic" representedClassName="WordPress.ReaderTeamTopic" parentEntity="ReaderAbstractTopic" syncable="YES">
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="SharingButton" representedClassName="WordPress.SharingButton" syncable="YES">
+        <attribute name="buttonID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="custom" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="enabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="shortname" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="visibility" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="sharingButtons" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <entity name="SourcePostAttribution" representedClassName="SourcePostAttribution" syncable="YES">
+        <attribute name="attributionType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="blogName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="commentCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="likeCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="permalink" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="post" maxCount="1" deletionRule="Nullify" destinationEntity="ReaderPost" inverseName="sourceAttribution" inverseEntity="ReaderPost" syncable="YES"/>
+    </entity>
+    <entity name="Theme" representedClassName="Theme" syncable="YES">
+        <attribute name="author" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="demoUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="launchDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="popularityRank" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="premium" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="previewUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="purchased" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="screenshotUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="stylesheet" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="themeId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="trendingRank" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="version" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="themes" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="AbstractPost" positionX="0" positionY="0" width="128" height="150"/>
+        <element name="Account" positionX="0" positionY="0" width="128" height="210"/>
+        <element name="AccountSettings" positionX="18" positionY="153" width="128" height="225"/>
+        <element name="BasePost" positionX="0" positionY="0" width="128" height="300"/>
+        <element name="Blog" positionX="0" positionY="0" width="128" height="645"/>
+        <element name="BlogSettings" positionX="18" positionY="153" width="128" height="570"/>
+        <element name="Category" positionX="0" positionY="0" width="128" height="120"/>
+        <element name="Comment" positionX="0" positionY="0" width="128" height="343"/>
+        <element name="Domain" positionX="27" positionY="153" width="128" height="105"/>
+        <element name="Media" positionX="0" positionY="0" width="128" height="390"/>
+        <element name="Menu" positionX="63" positionY="198" width="128" height="135"/>
+        <element name="MenuItem" positionX="45" positionY="180" width="128" height="240"/>
+        <element name="MenuLocation" positionX="54" positionY="189" width="128" height="120"/>
+        <element name="Notification" positionX="18" positionY="162" width="128" height="240"/>
+        <element name="Page" positionX="0" positionY="0" width="128" height="60"/>
+        <element name="Person" positionX="18" positionY="153" width="128" height="30"/>
+        <element name="Post" positionX="0" positionY="0" width="128" height="240"/>
+        <element name="PostTag" positionX="27" positionY="153" width="128" height="105"/>
+        <element name="PostType" positionX="27" positionY="153" width="128" height="105"/>
+        <element name="PublicizeConnection" positionX="27" positionY="162" width="128" height="330"/>
+        <element name="PublicizeService" positionX="18" positionY="153" width="128" height="195"/>
+        <element name="ReaderAbstractTopic" positionX="9" positionY="153" width="128" height="180"/>
+        <element name="ReaderCrossPostMeta" positionX="18" positionY="153" width="128" height="135"/>
+        <element name="ReaderDefaultTopic" positionX="18" positionY="162" width="128" height="45"/>
+        <element name="ReaderGapMarker" positionX="18" positionY="153" width="128" height="45"/>
+        <element name="ReaderListTopic" positionX="45" positionY="189" width="128" height="135"/>
+        <element name="ReaderPost" positionX="0" positionY="0" width="128" height="660"/>
+        <element name="ReaderSearchSuggestion" positionX="36" positionY="162" width="128" height="75"/>
+        <element name="ReaderSearchTopic" positionX="27" positionY="153" width="128" height="45"/>
+        <element name="ReaderSiteTopic" positionX="36" positionY="180" width="128" height="210"/>
+        <element name="ReaderTagTopic" positionX="27" positionY="171" width="128" height="90"/>
+        <element name="ReaderTeamTopic" positionX="27" positionY="153" width="128" height="60"/>
+        <element name="SharingButton" positionX="27" positionY="153" width="128" height="165"/>
+        <element name="SourcePostAttribution" positionX="9" positionY="153" width="128" height="225"/>
+        <element name="Theme" positionX="9" positionY="153" width="128" height="330"/>
+    </elements>
+</model>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1452,6 +1452,7 @@
 		74D5FFD519ACDF6700389E8F /* WPLegacyEditPostViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPLegacyEditPostViewController.m; sourceTree = "<group>"; usesTabs = 0; };
 		7C6F750E97E2AB9DC065FD21 /* Pods-WordPress_Base-WordPressTodayWidget.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPressTodayWidget.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPressTodayWidget/Pods-WordPress_Base-WordPressTodayWidget.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		819A057DA017AF1774BD318A /* Pods-WordPressTest.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		82270C8E1E3FBF72005F697D /* WordPress 56.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 56.xcdatamodel"; sourceTree = "<group>"; };
 		83043E54126FA31400EC9953 /* MessageUI.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		833AF259114575A50016DE8F /* PostAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostAnnotation.h; sourceTree = "<group>"; };
 		833AF25A114575A50016DE8F /* PostAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostAnnotation.m; sourceTree = "<group>"; };
@@ -8463,6 +8464,7 @@
 		E125443B12BF5A7200D87A0A /* WordPress.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				82270C8E1E3FBF72005F697D /* WordPress 56.xcdatamodel */,
 				E66D155A1E0AE3C4003759A1 /* WordPress 55.xcdatamodel */,
 				E626E0C31DF8BB2F0073C0DE /* WordPress 54.xcdatamodel */,
 				B5F94DBF1DB8035200DD505D /* WordPress 53.xcdatamodel */,
@@ -8519,7 +8521,7 @@
 				8350E15911D28B4A00A7B073 /* WordPress.xcdatamodel */,
 				E125443D12BF5A7200D87A0A /* WordPress 2.xcdatamodel */,
 			);
-			currentVersion = E66D155A1E0AE3C4003759A1 /* WordPress 55.xcdatamodel */;
+			currentVersion = 82270C8E1E3FBF72005F697D /* WordPress 56.xcdatamodel */;
 			name = WordPress.xcdatamodeld;
 			path = Classes/WordPress.xcdatamodeld;
 			sourceTree = "<group>";

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -310,6 +310,7 @@ class PostTests: XCTestCase {
 
     func testThatHasLocalChangesWorks() {
         let original = newTestPost()
+        original.disablePublicizeConnectionWithKeyringID(8888)
         let revision = original.createRevision() as! Post
 
         XCTAssertFalse(original.hasLocalChanges())
@@ -319,5 +320,36 @@ class PostTests: XCTestCase {
 
         revision.tags = original.tags
         XCTAssertFalse(revision.hasLocalChanges())
+
+        revision.publicizeMessage = ""
+        XCTAssertFalse(revision.hasLocalChanges())
+
+        revision.publicizeMessage = "Make it notorious"
+        XCTAssertTrue(revision.hasLocalChanges())
+
+        revision.publicizeMessage = original.publicizeMessage
+        XCTAssertFalse(revision.hasLocalChanges())
+
+        revision.disablePublicizeConnectionWithKeyringID(1234)
+        XCTAssertTrue(revision.hasLocalChanges())
+
+        revision.enablePublicizeConnectionWithKeyringID(1234)
+        XCTAssertFalse(revision.hasLocalChanges())
+
+        revision.enablePublicizeConnectionWithKeyringID(8888)
+        XCTAssertTrue(revision.hasLocalChanges())
+
+        revision.disablePublicizeConnectionWithKeyringID(8888)
+        XCTAssertFalse(revision.hasLocalChanges())
+    }
+
+    func testThatEnablingDisablingPublicizeConnectionsWorks() {
+        let post = newTestPost()
+
+        post.disablePublicizeConnectionWithKeyringID(1234)
+        XCTAssertTrue(post.publicizeConnectionDisabledForKeyringID(1234))
+
+        post.enablePublicizeConnectionWithKeyringID(1234)
+        XCTAssertFalse(post.publicizeConnectionDisabledForKeyringID(1234))
     }
 }

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -373,4 +373,20 @@ class PostTests: XCTestCase {
         post.enablePublicizeConnectionWithKeyringID(1234)
         XCTAssertFalse(post.publicizeConnectionDisabledForKeyringID(1234))
     }
+
+    func testThatCanEditPublicizeSettingsWorks() {
+        let post = newTestPost()
+
+        post.status = PostStatusPublish
+        XCTAssertTrue(post.canEditPublicizeSettings())
+
+        post.postID = 2905
+        XCTAssertFalse(post.canEditPublicizeSettings())
+
+        post.status = PostStatusScheduled
+        XCTAssertTrue(post.canEditPublicizeSettings())
+
+        post.status = PostStatusDraft
+        XCTAssertTrue(post.canEditPublicizeSettings())
+    }
 }


### PR DESCRIPTION
Fixes #2698 

To test:

1 - Configure at least one Publicize Connection for a Blog
2 - Create a new Post
3 - Navigate to the Post Settings
4 - Edit the Publicize Message
5 - Enable/Disable some connections for the Post
6 - Publish the Post and check that it's shared to the selected Publicize Connections with the correct message

When sharing is not supported or there are no Connections setup the Sharing section is completely hidden.
If the Post has been published the Sharing section and its items are disabled.

Needs review:  @jleandroperez @kurzee @koke 
CC: @sendhil 

### **Some background to understand the implementation**
How the API handles enabling/disabling Publicize Connections:

**_Fetching disabled connections_**
Disabled publicize connections are returned for every post in the metadata section:

```
...
"metadata": [ 
    {
        "id": "270",
        "key": "_wpas_skip_16508268",
        "value": "1"
    }
],
....
```

The previous excerpt shows that the connection with connectinoKeyringID = 16508268 is disabled for that post.

**_Updating disabled connections_**

This is done in the same way as with any other metadata entry.

POST data to *disable a connection*

```
...
"metadata": [ 
    {
        "key": "_wpas_skip_16508268",
        "value": "1",
        "operation": "add"
    }
],
....
```

POST data to *enable a connection*

```
...
"metadata": [ 
    {
        "id": "270",
        "key": "_wpas_skip_16508268",
        "value": "0",
        "operation": "update"
    }
],
....
```

Please note that in order to re-enable a connection it is necessary to issue an update operation with the previously retrieved id and "0" as the value. This is why it is not enough to just store the disabled connection keyringIDs.
Calypso currently issues a delete operation to accomplish this and it does not work (https://github.com/Automattic/wp-calypso/issues/11099).
