### PR TITLE
Fixes bug with changes detection for Post Tags

### DIFF
--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -195,7 +195,7 @@ class Post: AbstractPost {
 
         if let originalPost = original as? Post {
 
-            if tags?.characters.count != originalPost.tags?.characters.count && tags != originalPost.tags {
+            if tags ?? "" != originalPost.tags ?? "" {
                 return true
             }
 

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -310,9 +310,18 @@ class PostTests: XCTestCase {
 
     func testThatHasLocalChangesWorks() {
         let original = newTestPost()
-        let revision = original.createRevision() as! Post
+        var revision = original.createRevision() as! Post
 
-        XCTAssertFalse(original.hasLocalChanges())
+        XCTAssertFalse(revision.hasLocalChanges())
+
+        revision.tags = "Ahoi"
+        XCTAssertTrue(revision.hasLocalChanges())
+
+        original.deleteRevision()
+        original.tags = "ioha"
+        revision = original.createRevision() as! Post
+
+        XCTAssertFalse(revision.hasLocalChanges())
 
         revision.tags = "Ahoi"
         XCTAssertTrue(revision.hasLocalChanges())

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -312,6 +312,7 @@ class PostTests: XCTestCase {
         let original = newTestPost()
         var revision = original.createRevision() as! Post
 
+        XCTAssertFalse(original.hasLocalChanges())
         XCTAssertFalse(revision.hasLocalChanges())
 
         revision.tags = "Ahoi"


### PR DESCRIPTION
Fixes #6522

To test:
- Edit a Post
- Enter a simple Tag (remember how many characters it has)
- Save the Post
- Edit the Post, changing the Tag to something that has the same number of characters as before
- The Update button on the Post edition screen should be enabled

Needs review: @kurzee @diegoreymendez 
CC: @sendhil 