### PR TITLE
ReaderComments: extend replyTextView layout to leading/trailing edges.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -389,8 +389,8 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
                                                                         views:views]];
 
     // ReplyTextView Constraints
-    [[self.replyTextView.leftAnchor constraintEqualToAnchor:self.tableView.layoutMarginsGuide.leftAnchor constant:-16] setActive:YES];
-    [[self.replyTextView.rightAnchor constraintEqualToAnchor:self.tableView.layoutMarginsGuide.rightAnchor constant:16] setActive:YES];
+    [[self.replyTextView.leftAnchor constraintEqualToAnchor:self.tableView.leftAnchor] setActive:YES];
+    [[self.replyTextView.rightAnchor constraintEqualToAnchor:self.tableView.rightAnchor] setActive:YES];
 
     self.replyTextViewBottomConstraint = [NSLayoutConstraint constraintWithItem:self.view
                                                                       attribute:NSLayoutAttributeBottom


### PR DESCRIPTION
On iPad, the Reply textview bar was centered and not extended to the screen edges, as I'd expect:

![screen shot 2017-01-31 at 2 55 43 pm](https://cloud.githubusercontent.com/assets/1873422/22484058/5fb21d90-e7c5-11e6-986b-cf25591fbd90.png)

For now, we'll just go ahead and extend the margins to match the tableview's leading and trailing edges. Soon though, as I work on Notifications, I'll ensure we're following all readable margins on this VC.

To test:
1. On iPad, open up Notifications, hit the Comments segment.
2. Select a comment, hit the header to load the thread.
3. Ensure that the reply textview bar extends to the edges.

![screen shot 2017-01-31 at 2 52 47 pm](https://cloud.githubusercontent.com/assets/1873422/22484169/caffb76a-e7c5-11e6-9779-9d0536de6afd.png)

Needs review: @aerych another one for you kind sir.