### PR TITLE
Updating Aztec Dependency

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '0.11'
     pod 'WordPress-iOS-Editor', '1.8.1'
     pod 'WordPressCom-Analytics-iOS', '0.1.22'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => '2829e11af539e1c7c1cb449bb318a344aa8fc191'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => '9c389f5069e9c1aa8957b74fc3a06f61e75f5bbb'
     pod 'wpxmlrpc', '~> 0.8'
 
     target :WordPressTest do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -176,7 +176,7 @@ DEPENDENCIES:
   - SVProgressHUD (~> 1.1.3)
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `2829e11af539e1c7c1cb449bb318a344aa8fc191`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `9c389f5069e9c1aa8957b74fc3a06f61e75f5bbb`)
   - WordPress-iOS-Editor (= 1.8.1)
   - WordPress-iOS-Shared (= 0.7.2)
   - WordPressCom-Analytics-iOS (= 0.1.22)
@@ -199,7 +199,7 @@ EXTERNAL SOURCES:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: 2829e11af539e1c7c1cb449bb318a344aa8fc191
+    :commit: 9c389f5069e9c1aa8957b74fc3a06f61e75f5bbb
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -219,7 +219,7 @@ CHECKOUT OPTIONS:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: 2829e11af539e1c7c1cb449bb318a344aa8fc191
+    :commit: 9c389f5069e9c1aa8957b74fc3a06f61e75f5bbb
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -264,6 +264,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 3bda8ac8cb8939c797fde230c093803c719aaad5
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 9f130ea78280a6c77f7af5df6ec24f9995216029
+PODFILE CHECKSUM: 9b23024ce1abd7ef23946540d402d73ad9317566
 
 COCOAPODS: 1.1.1


### PR DESCRIPTION
### Details:
This PR updates the Aztec's Dependency, to the latest commit. The crash outlined in #6502 has been [fixed in this Aztec PR](https://github.com/wordpress-mobile/WordPress-Aztec-iOS/pull/231).

Closes #6502

### To test:
Please, give it a smoke test, and make sure everything looks fine.

Needs review: @astralbodies 
Thanks in advance!!
