### PR TITLE
Reader: Fixes warning about breaking constraint.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -256,7 +256,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
                                                                           options:0
                                                                           metrics:metrics
                                                                             views:views]];
-    [headerWrapper addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(margin)-[headerView(44)]-(>=1)-[borderView(1@1000)]|"
+    [headerWrapper addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(margin)-[headerView(44)]-(>=1@900)-[borderView(1@1000)]|"
                                                                           options:0
                                                                           metrics:metrics
                                                                             views:views]];


### PR DESCRIPTION
Fixes a breaking constraint to do an invalid height value.

To test:
Confirm the bug by viewing a comment notification, then viewing that notification's list of comments. Note that the console logs a warning about the breaking constraint. 
Switch to this branch and repeat the steps above. Note that the warning is gone. 

Needs review: @kurzee 
