### PR TITLE
Issues/6499 status bar style

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -3,7 +3,7 @@ import WordPressShared
 import WordPressComAnalytics
 
 
-open class ReaderDetailViewController: UIViewController, UIViewControllerRestoration, DefinesVariableStatusBarStyle {
+open class ReaderDetailViewController: UIViewController, UIViewControllerRestoration {
 
     static let restorablePostObjectURLhKey: String = "RestorablePostObjectURLKey"
 
@@ -1102,3 +1102,6 @@ extension ReaderDetailViewController : UIScrollViewDelegate {
 
 // Expand this view controller to full screen if possible
 extension ReaderDetailViewController: PrefersFullscreenDisplay {}
+
+// Let's the split view know this vc changes the status bar style.
+extension ReaderDetailViewController: DefinesVariableStatusBarStyle {}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -3,7 +3,7 @@ import WordPressShared
 import WordPressComAnalytics
 
 
-open class ReaderDetailViewController: UIViewController, UIViewControllerRestoration {
+open class ReaderDetailViewController: UIViewController, UIViewControllerRestoration, DefinesVariableStatusBarStyle {
 
     static let restorablePostObjectURLhKey: String = "RestorablePostObjectURLKey"
 
@@ -65,6 +65,16 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     fileprivate var footerViewHeightConstraintConstant = CGFloat(0.0)
 
     fileprivate let sharingController = PostSharingController()
+
+    var currentPreferredStatusBarStyle = UIStatusBarStyle.lightContent {
+        didSet {
+            setNeedsStatusBarAppearanceUpdate()
+        }
+    }
+
+    override open var preferredStatusBarStyle: UIStatusBarStyle {
+        return currentPreferredStatusBarStyle
+    }
 
     open var post: ReaderPost? {
         didSet {
@@ -787,7 +797,6 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         WPAppAnalytics.track(.readerSitePreviewed, withProperties: properties)
     }
 
-
     func setBarsHidden(_ hidden: Bool) {
         if (navigationController?.isNavigationBarHidden == hidden) {
             return
@@ -796,6 +805,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         if (hidden) {
             // Hides the navbar and footer view
             navigationController?.setNavigationBarHidden(true, animated: true)
+            currentPreferredStatusBarStyle = .default
             footerViewHeightConstraint.constant = 0.0
             UIView.animate(withDuration: 0.3,
                 delay: 0.0,
@@ -809,6 +819,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             let pinToBottom = isScrollViewAtBottom()
 
             navigationController?.setNavigationBarHidden(false, animated: true)
+            currentPreferredStatusBarStyle = .lightContent
             footerViewHeightConstraint.constant = footerViewHeightConstraintConstant
             UIView.animate(withDuration: 0.3,
                 delay: 0.0,

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -102,6 +102,13 @@ class WPSplitViewController: UISplitViewController {
         return .lightContent
     }
 
+    override var childViewControllerForStatusBarStyle: UIViewController? {
+        if let _ = topDetailViewController as? DefinesVariableStatusBarStyle {
+            return topDetailViewController
+        }
+        return nil
+    }
+
     var overrideTraitCollection: UITraitCollection? = nil
 
     override var traitCollection: UITraitCollection {
@@ -597,6 +604,10 @@ extension UIViewController {
 /// delegate method detects that there are no fullscreen view controllers left
 /// in the stack.
 protocol PrefersFullscreenDisplay: class {}
+
+/// Used to indicate whether a view controller varies its preferred status bar style.
+///
+protocol DefinesVariableStatusBarStyle: class {}
 
 // MARK: - WPSplitViewControllerDetailProvider Protocol
 


### PR DESCRIPTION
Fixes #6499 

To test:
Confirm the bug by viewing a detail post in the reader and scrolling down to hide its bars. Notice that there appears to be a gap at the top of the screen because the status bar text is still white.
Switch to this branch and repeat the steps above.  Confirm that the status bar text changes to black when bars are hidden and back to white when bars are visible. 

Needs review: @frosty would you mind having a peek at this one?
