### PR TITLE
Fix Optional string in copyright year

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
@@ -187,8 +187,7 @@ open class AboutViewController: UITableViewController {
 
     // MARK: - Private Properties
     fileprivate lazy var footerTitleText: String = {
-        let calendar = Calendar.current
-        let year = (calendar as NSCalendar).components(.year, from: Date()).year
+        let year = Calendar.current.component(.year, from: Date())
         return NSLocalizedString("© \(year) Automattic, Inc.", comment: "About View's Footer Text")
     }()
 


### PR DESCRIPTION
Fixes #6533 

To test:

- Go to Me > App Settings > About WordPress for iOS
- Verify that the copyright footer shows correctly

Needs review: @frosty 
