### PR TITLE
Aztec: Fixing Font Load Warning

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -180,8 +180,6 @@ class AztecPostViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        WPFontManager.loadMerriweatherFontFamily()
-
         configureNavigationBar()
         configureView()
         configureSubviews()


### PR DESCRIPTION
### Details:
In this PR we're nuking the call to `loadMerriweatherFontFamily`. Reason why we were getting that warning is:

- `loadMerriweatherFontFamily` actually calls `loadFontResourceNamed` for every single Merryweather font we've got
- Whenever you actually call any of the `merriweather*FontOfSize`, internally, if the font is not available, `loadFontResourceNamed` is executed
- The app is using Merryweather Regular elsewhere. Meaning that the font was already preloaded, way before Aztec gets launched.

In other words, the warning was being printed because Merryweather Regular Font was already loaded.

Fixes #6493

### To test:
Please, just launch the Aztec editor, and verify that the warning is gone.

Needs review: @astralbodies 
Thanks in advance!