### PR TITLE
Aztec: Disabling BlogPicker Button in Single Site Mode

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -210,7 +210,7 @@ class AztecPostViewController: UIViewController {
         super.viewWillTransition(to: size, with: coordinator)
 
         coordinator.animate(alongsideTransition: { _ in
-            self.resizeBlogPickerTitle()
+            self.resizeBlogPickerButton()
         })
 
         // TODO: Update toolbars
@@ -291,9 +291,9 @@ class AztecPostViewController: UIViewController {
     }
 
     func refreshInterface() {
-        reloadBlogPickerTitle()
+        reloadBlogPickerButton()
         reloadEditorContents()
-        resizeBlogPickerTitle()
+        resizeBlogPickerButton()
     }
 
     func reloadEditorContents() {
@@ -303,18 +303,21 @@ class AztecPostViewController: UIViewController {
         richTextView.setHTML(content)
     }
 
-    func reloadBlogPickerTitle() {
+    func reloadBlogPickerButton() {
         var pickerTitle = post.blog.url ?? String()
         if let blogName = post.blog.settings?.name, blogName.isEmpty == false {
             pickerTitle = blogName
         }
 
         let titleText = NSAttributedString(string: pickerTitle, attributes: Constants.blogPickerAttributes)
+        let shouldEnable = !isSingleSiteMode
+
         blogPickerButton.setAttributedTitle(titleText, for: .normal)
-        blogPickerButton.buttonMode = isSingleSiteMode ? .singleSite : .multipleSite
+        blogPickerButton.buttonMode = shouldEnable ? .multipleSite : .singleSite
+        blogPickerButton.isEnabled = shouldEnable
     }
 
-    func resizeBlogPickerTitle() {
+    func resizeBlogPickerButton() {
         // Ensure the BlogPicker gets it's maximum possible size
         blogPickerButton.sizeToFit()
 
@@ -378,11 +381,7 @@ extension AztecPostViewController {
     }
 
     @IBAction func blogPickerWasPressed() {
-        guard isSingleSiteMode == false else {
-            cancelEditing()
-            return
-        }
-
+        assert(isSingleSiteMode == false)
         guard post.hasSiteSpecificChanges() else {
             displayBlogSelector()
             return


### PR DESCRIPTION
Closes #6503

### Scenario: Single Site
1. Log into a dotcom account with a single site
2. Enable Aztec
3. Open the Editor from the **New Post** action / **Edit Published Post** / **Edit Page**

Verify that the Site Picker doesn't display an arrow downwards. Plus, please, verify that pressing over the Blog's Title doesn't result in **any** action at all.

### Scenario: Multiple Sites
1. Log into a dotcom account with multiple sites
2. Enable Aztec
3. Open the Editor from the **New Post** action / **Edit Published Post** / **Edit Page**

Verify that the Site Picker **does** display an arrow downwards. 
Plus, please, verify that pressing over the Blog's Title doesn't trigger an assertion.

Pressing over the Blog's Title, should result in:

A. Blog Picker onscreen, if the post had no changes
B. AlertView indicating the 'Change Site' effects, and asking for confirmation.

--

Needs review: @astralbodies 
cc @diegoreymendez (Thanks for pointing this out Diego, feels much cleaner)

Thanks in advance!!
