### PR TITLE
Issues/6459 prevent stat spamming

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1228,6 +1228,7 @@ import WordPressComAnalytics
 
         footerView.showSpinner(true)
 
+        let properties = topicPropertyForStats()
         let earlierThan = post.sortDate
         let syncContext = ContextManager.sharedInstance().newDerivedContext()
         let service =  ReaderPostService(managedObjectContext: syncContext)
@@ -1255,10 +1256,10 @@ import WordPressComAnalytics
             } else {
                 service?.fetchPosts(for: topicInContext, earlierThan: earlierThan, success: successBlock, failure: failureBlock)
             }
-        }
 
-        if let properties = topicPropertyForStats() {
-            WPAppAnalytics.track(.readerInfiniteScroll, withProperties: properties)
+            if let properties = properties {
+                WPAppAnalytics.track(.readerInfiniteScroll, withProperties: properties)
+            }
         }
     }
 


### PR DESCRIPTION
Closes #6459 

Ugh.  This is a defensive patch for an issue where the infinite scroll stat is being spammed.  There appears to be a specific set of circumstances that causes the post list to repeatedly trigger the load more feature.  The issue was introduced with the [changes in release/6.7](https://github.com/wordpress-mobile/WordPress-iOS/compare/release/6.6...release/6.7), yet nothing in that release directly changed the way the infinite scroll stat is bumped, or the operation of load more feature.  The best guess is that changes with the WPTableViewHandler are somehow involved.  It might be the call to `scrollToRowAtIndexPath:`, or to get visibleCells when the cells have never been rendered (due to state restoration) is involved.  However attempts to reproduce the glitch have been unsuccessful indicating some other factor is also involved. 

Since the exact cause remains unknown this patch attempts to address the issue by checking whether a refresh is in process before triggering a load more action.

To test:
The cause of the stats glitch and how to reproduce it remains illusive, so just test that the load more feature continues to function as expected after the patch.

Needs review: @kurzee would you take a look since you're familiar with the issue? 
