### PR TITLE
Fix #6545: Make sure authorNameForDisplay and blogNameForDisplay getters returns plain text

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -468,7 +468,7 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 
 - (NSString *)authorNameForDisplay
 {
-    return self.author;
+    return [NSString makePlainText:self.author];
 }
 
 - (NSURL *)avatarURLForDisplay
@@ -478,7 +478,7 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 
 - (NSString *)blogNameForDisplay
 {
-    return self.blog.settings.name;
+    return [NSString makePlainText:self.blog.settings.name];
 }
 
 - (NSURL *)blogURL


### PR DESCRIPTION
Fix #6545: Make sure authorNameForDisplay and blogNameForDisplay getters returns plain text. Author and site names can include HTML entities, make sure these are decoded for display.

To test: Change your username to "AT&T" and load your site post list.