### PR TITLE
Improve RTL support

### DIFF
--- a/WordPress/Classes/Extensions/UIEdgeInsets.swift
+++ b/WordPress/Classes/Extensions/UIEdgeInsets.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+extension UIEdgeInsets {
+    func flippedForRightToLeftLayoutDirection() -> UIEdgeInsets {
+        return UIEdgeInsets(top: top, left: right, bottom: bottom, right: left)
+    }
+}
+
+extension UIButton {
+    func flipInsetsForRightToLeftLayoutDirection() {
+        contentEdgeInsets = contentEdgeInsets.flippedForRightToLeftLayoutDirection()
+        imageEdgeInsets = imageEdgeInsets.flippedForRightToLeftLayoutDirection()
+        titleEdgeInsets = titleEdgeInsets.flippedForRightToLeftLayoutDirection()
+    }
+}
+
+// Hack: Since UIEdgeInsets is a struct in ObjC, you can't have methods on it.
+// You can't also export top level functions from Swift.
+// 🙄
+@objc(InsetsHelper)
+class _InsetsHelper: NSObject {
+    static func flipForRightToLeftLayoutDirection(_ insets: UIEdgeInsets) -> UIEdgeInsets {
+        return insets.flippedForRightToLeftLayoutDirection()
+    }
+}

--- a/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
@@ -220,8 +220,7 @@ private struct WPFullscreenNavigationTransitionViewModel {
 
         // RTL support
 
-        let attribute = transitionContext.containerView.semanticContentAttribute
-        let layoutDirection = UIView.userInterfaceLayoutDirection(for: attribute)
+        let layoutDirection = transitionContext.containerView.userInterfaceLayoutDirection()
         let isRTLLayout = (layoutDirection == .rightToLeft)
 
         // Transforms

--- a/WordPress/Classes/Extensions/UIView+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIView+Helpers.swift
@@ -79,4 +79,8 @@ extension UIView {
             }
         }
     }
+
+    public func userInterfaceLayoutDirection() -> UIUserInterfaceLayoutDirection {
+        return UIView.userInterfaceLayoutDirection(for: semanticContentAttribute)
+    }
 }

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -42,8 +42,8 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
 
 @property (nonatomic,   weak) IBOutlet UIWebView                *webView;
 @property (nonatomic,   weak) IBOutlet UIProgressView           *progressView;
-@property (nonatomic, strong) IBOutlet UIBarButtonItem          *dismissButton;
-@property (nonatomic, strong) IBOutlet UIBarButtonItem          *optionsButton;
+@property (nonatomic, strong) UIBarButtonItem          *dismissButton;
+@property (nonatomic, strong) UIBarButtonItem          *optionsButton;
 
 @property (nonatomic,   weak) IBOutlet UIToolbar                *toolbar;
 @property (nonatomic,   weak) IBOutlet UIBarButtonItem          *backButton;
@@ -75,9 +75,7 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
 
     NSAssert(_webView,                 @"Missing Outlet!");
     NSAssert(_progressView,            @"Missing Outlet!");
-    NSAssert(_dismissButton,           @"Missing Outlet!");
-    NSAssert(_optionsButton,           @"Missing Outlet!");
-    
+
     NSAssert(_toolbar,                 @"Missing Outlet!");
     NSAssert(_backButton,              @"Missing Outlet!");
     NSAssert(_forwardButton,           @"Missing Outlet!");
@@ -90,16 +88,17 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     self.navigationItem.titleView           = self.titleView;
     
     // Buttons
+    self.optionsButton = [[UIBarButtonItem alloc] initWithImage:[Gridicon iconOfType:GridiconTypeShareIOS] style:UIBarButtonItemStylePlain target:self action:@selector(showLinkOptions)];
+    self.dismissButton = [[UIBarButtonItem alloc] initWithImage:[Gridicon iconOfType:GridiconTypeCross] style:UIBarButtonItemStylePlain target:self action:@selector(dismiss)];
+
     self.optionsButton.accessibilityLabel   = NSLocalizedString(@"Share",   @"Spoken accessibility label");
     self.dismissButton.accessibilityLabel   = NSLocalizedString(@"Dismiss", @"Dismiss a view. Verb");
     self.backButton.accessibilityLabel      = NSLocalizedString(@"Back",    @"Previous web page");
     self.forwardButton.accessibilityLabel   = NSLocalizedString(@"Forward", @"Next web page");
     
-    self.optionsButton.image                = [Gridicon iconOfType:GridiconTypeShareIOS];
-    self.dismissButton.image                = [Gridicon iconOfType:GridiconTypeCross];
-    self.backButton.image                   = [Gridicon iconOfType:GridiconTypeChevronLeft];
-    self.forwardButton.image                = [Gridicon iconOfType:GridiconTypeChevronRight];
-    
+    self.backButton.image                   = [[Gridicon iconOfType:GridiconTypeChevronLeft] imageFlippedForRightToLeftLayoutDirection];
+    self.forwardButton.image                = [[Gridicon iconOfType:GridiconTypeChevronRight] imageFlippedForRightToLeftLayoutDirection];
+
     // Toolbar: Hidden by default!
     self.toolbar.barTintColor               = [UIColor whiteColor];
     self.backButton.tintColor               = [WPStyleGuide greyLighten10];

--- a/WordPress/Classes/Utility/WPWebViewController.xib
+++ b/WordPress/Classes/Utility/WPWebViewController.xib
@@ -1,15 +1,17 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="WPWebViewController">
             <connections>
                 <outlet property="backButton" destination="MrE-vk-zRt" id="yms-r2-bmI"/>
-                <outlet property="dismissButton" destination="cwn-cV-SEd" id="0A6-X7-2t3"/>
                 <outlet property="forwardButton" destination="3bZ-k3-0vv" id="aMq-ua-feI"/>
-                <outlet property="optionsButton" destination="51" id="52"/>
                 <outlet property="progressView" destination="KoJ-2F-0M7" id="pbn-M0-taM"/>
                 <outlet property="toolbar" destination="AXg-oh-s2G" id="oAq-hv-8wQ"/>
                 <outlet property="toolbarBottomConstraint" destination="Nlf-af-GR4" id="ogC-wy-f35"/>
@@ -24,18 +26,18 @@
             <subviews>
                 <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="436"/>
-                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <connections>
                         <outlet property="delegate" destination="-1" id="22"/>
                     </connections>
                 </webView>
                 <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progressViewStyle="bar" translatesAutoresizingMaskIntoConstraints="NO" id="KoJ-2F-0M7">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="2.5"/>
-                    <color key="progressTintColor" red="0.023529411764705882" green="0.23921568627450981" blue="0.43137254901960786" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="progressTintColor" red="0.023529411764705882" green="0.23921568627450981" blue="0.43137254901960786" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </progressView>
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AXg-oh-s2G">
                     <rect key="frame" x="0.0" y="436" width="320" height="44"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <items>
                         <barButtonItem id="MrE-vk-zRt" userLabel="BackBarButtonItem">
                             <connections>
@@ -49,11 +51,11 @@
                             </connections>
                         </barButtonItem>
                     </items>
-                    <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                    <color key="barTintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="tintColor" red="0.33333333333333331" green="0.33333333333333331" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="barTintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </toolbar>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="KoJ-2F-0M7" secondAttribute="trailing" id="ISH-w3-feS"/>
                 <constraint firstAttribute="bottom" secondItem="AXg-oh-s2G" secondAttribute="bottom" id="Nlf-af-GR4"/>
@@ -69,17 +71,10 @@
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
         </view>
-        <barButtonItem id="cwn-cV-SEd" userLabel="DismissBarButtonItem">
-            <inset key="imageInsets" minX="-12" minY="0.0" maxX="0.0" maxY="0.0"/>
-            <connections>
-                <action selector="dismiss" destination="-1" id="8vH-rJ-oZS"/>
-            </connections>
-        </barButtonItem>
-        <barButtonItem enabled="NO" id="51" userLabel="OptionsBarButtonItem">
-            <inset key="imageInsets" minX="-10" minY="0.0" maxX="10" maxY="0.0"/>
-            <connections>
-                <action selector="showLinkOptions" destination="-1" id="53"/>
-            </connections>
-        </barButtonItem>
     </objects>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
+    </simulatedMetricsContainer>
 </document>

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -557,7 +557,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:row.identifier];
     cell.accessoryType = [self splitViewControllerIsHorizontallyCompact] ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
     cell.accessoryView = nil;
-    cell.textLabel.textAlignment = NSTextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentNatural;
     cell.imageView.tintColor = [WPStyleGuide greyLighten10];
     [WPStyleGuide configureTableViewCell:cell];
     [self configureCell:cell atIndexPath:indexPath];

--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
@@ -319,7 +319,7 @@ static CGFloat BlogCellRowHeight = 74.0;
 
 - (void)configureCell:(UITableViewCell *)cell atIndexPath:(NSIndexPath *)indexPath
 {
-    cell.textLabel.textAlignment = NSTextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentNatural;
     cell.accessoryType = UITableViewCellAccessoryNone;
     cell.accessoryView = nil;
 

--- a/WordPress/Classes/ViewRelated/Cells/WPReusableTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/WPReusableTableViewCells.swift
@@ -8,7 +8,7 @@ class WPReusableTableViewCell: WPTableViewCell {
         super.prepareForReuse()
 
         textLabel?.text = nil
-        textLabel?.textAlignment = .left
+        textLabel?.textAlignment = .natural
         textLabel?.adjustsFontSizeToFitWidth = false
         detailTextLabel?.text = nil
         detailTextLabel?.textColor = UIColor.black

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,11 +15,11 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="70"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="69.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="69"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AUn-YX-qnu" userLabel="Layout View">
-                        <rect key="frame" x="15" y="0.0" width="290" height="70"/>
+                        <rect key="frame" x="15" y="0.0" width="290" height="69"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="12" width="46" height="46"/>
@@ -24,27 +28,27 @@
                                     <constraint firstAttribute="width" constant="46" id="pBo-eH-W4J"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq">
-                                <rect key="frame" x="56" y="8" width="234" height="20.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq">
+                                <rect key="frame" x="56" y="8" width="234" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reader-postaction-time" translatesAutoresizingMaskIntoConstraints="NO" id="rcg-tb-060">
-                                <rect key="frame" x="56" y="30" width="16" height="16"/>
+                                <rect key="frame" x="56" y="31" width="16" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="16" id="YZR-zM-ndp"/>
                                     <constraint firstAttribute="height" constant="16" id="xwF-CO-6ZI"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
-                                <rect key="frame" x="76" y="28.5" width="214" height="20.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
+                                <rect key="frame" x="76" y="29" width="214" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="AUn-YX-qnu" secondAttribute="top" constant="12" id="8ks-PZ-pXh"/>
                             <constraint firstItem="bDl-id-9M7" firstAttribute="centerY" secondItem="rcg-tb-060" secondAttribute="centerY" id="DOj-EN-RRl"/>

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
@@ -81,6 +81,6 @@ extension WPStyleGuide {
         fileprivate static let titleParagraph       = NSMutableParagraphStyle(minLineHeight: titleLineSize,
                                                     maxLineHeight:  titleLineSize,
                                                     lineBreakMode:  .byWordWrapping,
-                                                    alignment:      .left)
+                                                    alignment:      .natural)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.m
+++ b/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.m
@@ -1,6 +1,7 @@
 #import "WPWalkthroughTextField.h"
 #import "Constants.h"
 #import "WPNUXUtility.h"
+#import "WordPress-Swift.h"
 
 @import Gridicons;
 
@@ -108,10 +109,19 @@
 
     self.secureTextEntryToggle.hidden = !self.showSecureTextEntryToggle;
     if (self.showSecureTextEntryToggle) {
-        self.secureTextEntryToggle.frame = CGRectIntegral(CGRectMake(CGRectGetWidth(self.bounds) - CGRectGetWidth(self.secureTextEntryToggle.frame),
-                                                                     (CGRectGetHeight(self.bounds) - CGRectGetHeight(self.secureTextEntryToggle.frame)) / 2.0,
-                                                                     CGRectGetWidth(self.secureTextEntryToggle.frame),
-                                                                     CGRectGetHeight(self.secureTextEntryToggle.frame)));
+        CGRect frame = self.secureTextEntryToggle.frame;
+        if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight) {
+            frame = CGRectIntegral(CGRectMake(CGRectGetWidth(self.bounds) - CGRectGetWidth(self.secureTextEntryToggle.frame),
+                                              (CGRectGetHeight(self.bounds) - CGRectGetHeight(self.secureTextEntryToggle.frame)) / 2.0,
+                                              CGRectGetWidth(self.secureTextEntryToggle.frame),
+                                              CGRectGetHeight(self.secureTextEntryToggle.frame)));
+        } else {
+            frame = CGRectIntegral(CGRectMake(CGRectGetMinX(self.bounds),
+                                              (CGRectGetHeight(self.bounds) - CGRectGetHeight(self.secureTextEntryToggle.frame)) / 2.0,
+                                              CGRectGetWidth(self.secureTextEntryToggle.frame),
+                                              CGRectGetHeight(self.secureTextEntryToggle.frame)));
+        }
+        self.secureTextEntryToggle.frame = frame;
         [self bringSubviewToFront:self.secureTextEntryToggle];
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -215,7 +215,7 @@ open class NotificationSettingsViewController: UIViewController {
         // Pagination Rows don't really have a Settings entity
         if isPaginationRow(indexPath) {
             cell.textLabel?.text            = paginationRowDescription(indexPath)
-            cell.textLabel?.textAlignment   = .left
+            cell.textLabel?.textAlignment   = .natural
             cell.accessoryType              = .none
             WPStyleGuide.configureTableViewCell(cell)
             return
@@ -239,7 +239,7 @@ open class NotificationSettingsViewController: UIViewController {
 
         default:
             cell.textLabel?.text            = settings.channel.description()
-            cell.textLabel?.textAlignment   = .left
+            cell.textLabel?.textAlignment   = .natural
             cell.accessoryType              = .disclosureIndicator
             WPStyleGuide.configureTableViewCell(cell)
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -221,22 +221,22 @@ extension WPStyleGuide {
 
         // ParagraphStyle's
         fileprivate static let sectionHeaderParagraph   = NSMutableParagraphStyle(
-            minLineHeight: headerLineSize, maxLineHeight: headerLineSize, lineBreakMode: .byWordWrapping, alignment: .left
+            minLineHeight: headerLineSize, maxLineHeight: headerLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
         )
         fileprivate static let subjectParagraph         = NSMutableParagraphStyle(
-            minLineHeight: subjectLineSize, maxLineHeight: subjectLineSize, lineBreakMode: .byWordWrapping, alignment: .left
+            minLineHeight: subjectLineSize, maxLineHeight: subjectLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
         )
         fileprivate static let snippetParagraph         = NSMutableParagraphStyle(
-            minLineHeight: snippetLineSize, maxLineHeight: snippetLineSize, lineBreakMode: .byWordWrapping, alignment: .left
+            minLineHeight: snippetLineSize, maxLineHeight: snippetLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
         )
         fileprivate static let headerTitleParagraph     = NSMutableParagraphStyle(
-            minLineHeight: blockLineSize, lineBreakMode: .byTruncatingTail, alignment: .left
+            minLineHeight: blockLineSize, lineBreakMode: .byTruncatingTail, alignment: .natural
         )
         fileprivate static let blockParagraph           = NSMutableParagraphStyle(
-            minLineHeight: blockLineSize, lineBreakMode: .byWordWrapping, alignment: .left
+            minLineHeight: blockLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
         )
         fileprivate static let contentBlockParagraph     = NSMutableParagraphStyle(
-            minLineHeight: contentBlockLineSize, lineBreakMode: .byWordWrapping, alignment: .left
+            minLineHeight: contentBlockLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
         )
         fileprivate static let badgeParagraph           = NSMutableParagraphStyle(
             minLineHeight: blockLineSize, maxLineHeight: blockLineSize, lineBreakMode: .byWordWrapping, alignment: .center

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,7 +14,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="100"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zZv-EA-ZPR" id="GbU-dc-vAM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="99.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="99"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="254" verticalHuggingPriority="254" translatesAutoresizingMaskIntoConstraints="NO" id="B30-uC-0a3" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -40,7 +40,7 @@
                             </mask>
                         </variation>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J2Y-Yo-5I1">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J2Y-Yo-5I1">
                         <rect key="frame" x="59" y="10" width="249" height="18"/>
                         <constraints>
                             <constraint firstAttribute="height" priority="750" constant="18" id="TnG-1t-sH0"/>
@@ -49,7 +49,7 @@
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="749" text="Details" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0nV-U0-dRc">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="749" text="Details" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0nV-U0-dRc">
                         <rect key="frame" x="59" y="28" width="249" height="18"/>
                         <constraints>
                             <constraint firstAttribute="height" priority="750" constant="18" id="suV-Ve-xon"/>

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="ipad12_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -14,7 +14,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="xVO-JJ-7hX" id="VpH-7p-vak">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="55.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="55"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6Fx-cw-9OG" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -40,13 +40,13 @@
                             </mask>
                         </variation>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rnJ-hn-LCK">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rnJ-hn-LCK">
                         <rect key="frame" x="59" y="7" width="249" height="15"/>
                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Snippet" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wLG-3c-VUY">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Snippet" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wLG-3c-VUY">
                         <rect key="frame" x="59" y="22" width="249" height="15"/>
                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.xib
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -40,13 +40,13 @@
                             </mask>
                         </variation>
                     </imageView>
-                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name Lastname" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBR-jy-KRp" userLabel="NameLabel">
+                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name Lastname" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBR-jy-KRp" userLabel="NameLabel">
                         <rect key="frame" x="78" y="8" width="230" height="14"/>
                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="12"/>
                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog URL" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lsp-ya-PNI" userLabel="BlogUrlLabel">
+                    <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog URL" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lsp-ya-PNI" userLabel="BlogUrlLabel">
                         <rect key="frame" x="78" y="19" width="230" height="15"/>
                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                         <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
@@ -1,8 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NoteTableHeaderView">
@@ -28,21 +31,18 @@
                                 <constraint firstAttribute="height" constant="16" id="G7c-hu-Hc6"/>
                             </constraints>
                         </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zK2-Ta-Z1W" userLabel="Title">
-                            <rect key="frame" x="30" y="4.5" width="660" height="16"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zK2-Ta-Z1W" userLabel="Title">
+                            <rect key="frame" x="30" y="5" width="660" height="16"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="16" id="YxS-jB-T4A"/>
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                             <size key="shadowOffset" width="0.0" height="0.0"/>
-                            <variation key="heightClass=regular-widthClass=regular" misplaced="YES">
-                                <rect key="frame" x="30" y="4" width="660" height="16"/>
-                            </variation>
                         </label>
                     </subviews>
-                    <color key="backgroundColor" red="0.90196079015731812" green="0.90196079015731812" blue="0.90196079015731812" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.90196079015731812" green="0.90196079015731812" blue="0.90196079015731812" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="600" id="7xv-xJ-X6P"/>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" priority="250" constant="600" id="E56-KE-cpo"/>
@@ -65,7 +65,7 @@
                     </variation>
                 </view>
             </subviews>
-            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="AjL-Ni-9e0" firstAttribute="leading" secondItem="v2Z-s3-Kgc" secondAttribute="leading" priority="750" id="KBr-LI-hk5"/>
                 <constraint firstAttribute="trailing" secondItem="AjL-Ni-9e0" secondAttribute="trailing" priority="750" id="SCN-H1-mER"/>

--- a/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -13,14 +17,14 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nJ3-Q4-QJM">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="1"/>
-                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="hXv-IA-XbK"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bJd-dp-RN2">
                     <rect key="frame" x="0.0" y="23" width="320" height="1"/>
-                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="fhB-Qm-C4L"/>
                     </constraints>
@@ -32,14 +36,14 @@
                         <constraint firstAttribute="width" constant="16" id="drN-3K-RBH"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T0w-kY-8uW">
-                    <rect key="frame" x="29" y="3.5" width="283" height="17"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T0w-kY-8uW">
+                    <rect key="frame" x="29" y="4" width="283" height="17"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="Ai0-Ac-pOc" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="64x-dU-a3c"/>
                 <constraint firstItem="Ai0-Ac-pOc" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" constant="-1" id="7Wu-6v-QcC"/>

--- a/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
+++ b/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Pages-->
@@ -14,17 +18,17 @@
                         <viewControllerLayoutGuide type="bottom" id="njG-x9-YTM"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="MiP-YM-poS">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LM5-dj-tFF">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <connections>
                                     <segue destination="54R-UA-mAH" kind="embed" id="f4C-M8-QGj"/>
                                 </connections>
                             </containerView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="LM5-dj-tFF" firstAttribute="leading" secondItem="MiP-YM-poS" secondAttribute="leading" id="5cl-1d-1tg"/>
                             <constraint firstAttribute="trailing" secondItem="LM5-dj-tFF" secondAttribute="trailing" id="AVm-wb-6M1"/>
@@ -48,10 +52,10 @@
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="hOV-1Y-S1G" customClass="NavBarTitleDropdownButton">
                     <rect key="frame" x="0.0" y="0.0" width="77" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <inset key="imageEdgeInsets" minX="4" minY="0.0" maxX="0.0" maxY="0.0"/>
                     <state key="normal" title="Button" image="icon-nav-chevron">
-                        <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                     <connections>
                         <action selector="didTapFilterButton:" destination="RgW-to-XfM" eventType="touchUpInside" id="YoR-fu-Crp"/>
@@ -61,10 +65,13 @@
                     <rect key="frame" x="0.0" y="0.0" width="80" height="44"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AUi-GI-97s">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AUi-GI-97s">
                             <rect key="frame" x="40" y="0.0" width="40" height="44"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="40" id="csV-Ow-Cyb"/>
+                            </constraints>
                             <state key="normal" image="icon-post-add">
-                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <state key="highlighted" image="icon-post-add-highlight"/>
                             <connections>
@@ -72,6 +79,11 @@
                             </connections>
                         </button>
                     </subviews>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="AUi-GI-97s" secondAttribute="trailing" id="BBb-fa-dJF"/>
+                        <constraint firstAttribute="bottom" secondItem="AUi-GI-97s" secondAttribute="bottom" id="cqe-SB-jlh"/>
+                        <constraint firstItem="AUi-GI-97s" firstAttribute="top" secondItem="eMR-fX-0uB" secondAttribute="top" id="hWW-a3-5U0"/>
+                    </constraints>
                 </view>
             </objects>
             <point key="canvasLocation" x="519" y="318"/>
@@ -81,9 +93,9 @@
             <objects>
                 <tableViewController id="54R-UA-mAH" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="47" sectionHeaderHeight="24" sectionFooterHeight="1" id="y3a-Ok-AN1">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <sections/>
                         <connections>
                             <outlet property="dataSource" destination="54R-UA-mAH" id="mDP-Tv-HsW"/>

--- a/WordPress/Classes/ViewRelated/Post/NavBarTitleDropdownButton.m
+++ b/WordPress/Classes/ViewRelated/Post/NavBarTitleDropdownButton.m
@@ -1,4 +1,5 @@
 #import "NavBarTitleDropdownButton.h"
+#import "WordPress-Swift.h"
 #import <WordPressShared/WPFontManager.h>
 
 @implementation NavBarTitleDropdownButton
@@ -17,6 +18,7 @@
 {
     [super awakeFromNib];
     [self setupStyle];
+    [self adjustInsetsForTextDirection];
 }
 
 - (void)setupStyle
@@ -28,17 +30,33 @@
     [self setImage:[UIImage imageNamed:@"icon-nav-chevron-highlight"] forState:UIControlStateHighlighted];
 }
 
+- (void)adjustInsetsForTextDirection
+{
+    if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight) {
+        return;
+    }
+    [self flipInsetsForRightToLeftLayoutDirection];
+}
+
 - (CGRect)imageRectForContentRect:(CGRect)contentRect
 {
     CGRect frame = [super imageRectForContentRect:contentRect];
-    frame.origin.x = CGRectGetMaxX(contentRect) - CGRectGetWidth(frame) -  self.imageEdgeInsets.right + self.imageEdgeInsets.left;
+    if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight) {
+        frame.origin.x = CGRectGetMaxX(contentRect) - CGRectGetWidth(frame) -  self.imageEdgeInsets.right + self.imageEdgeInsets.left;
+    } else {
+        frame.origin.x = CGRectGetMinX(contentRect);
+    }
     return frame;
 }
 
 - (CGRect)titleRectForContentRect:(CGRect)contentRect
 {
     CGRect frame = [super titleRectForContentRect:contentRect];
-    frame.origin.x = CGRectGetMinX(frame) - CGRectGetWidth([self imageRectForContentRect:contentRect]);
+    if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight) {
+        frame.origin.x = CGRectGetMinX(frame) - CGRectGetWidth([self imageRectForContentRect:contentRect]);
+    } else {
+        frame.origin.x = CGRectGetMaxX([self imageRectForContentRect:contentRect]) + self.imageEdgeInsets.right - self.imageEdgeInsets.left;
+    }
     return frame;
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -12,26 +15,31 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="448"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="CUK-Fg-fJ5" id="lmn-sx-Q9M">
-                <frame key="frameInset" width="320" height="447.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="447"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b5E-yQ-veP">
+                        <rect key="frame" x="6" y="10" width="308" height="425.5"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rIp-IY-Ng4">
+                                <rect key="frame" x="16" y="15" width="276" height="34"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="DWo-S7-Yu2">
+                                        <rect key="frame" x="0.0" y="1" width="32" height="32"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="32" id="MkS-EF-k5K"/>
                                             <constraint firstAttribute="height" constant="32" id="y6f-IQ-yFt"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LUv-id-3Yc">
+                                        <rect key="frame" x="42" y="0.0" width="234" height="17"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbp-gj-1hE">
+                                        <rect key="frame" x="42" y="18.5" width="234" height="14.5"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -52,9 +60,11 @@
                                 </constraints>
                             </view>
                             <view clipsSubviews="YES" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Kf-3e-Bni" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="64" width="308" height="196"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Y9d-Yk-F4X">
+                                <rect key="frame" x="0.0" y="64" width="308" height="196"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="196" id="0wl-TX-0Ed">
                                         <variation key="heightClass=regular-widthClass=regular" constant="226"/>
@@ -62,26 +72,31 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="E9Y-IT-TUt">
+                                <rect key="frame" x="16" y="274" width="276" height="24"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Cbe-bm-gnv">
+                                <rect key="frame" x="16" y="307" width="276" height="17.5"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zle-VU-ygo">
+                                <rect key="frame" x="16" y="333.5" width="196" height="18"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="ed0-E7-1lw">
+                                        <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="18" id="Ief-ts-XAf"/>
                                             <constraint firstAttribute="width" constant="18" id="ci3-JD-GRl"/>
                                         </constraints>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xhs-nZ-clP">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xhs-nZ-clP">
+                                        <rect key="frame" x="21" y="2" width="175" height="14.5"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -101,14 +116,17 @@
                                 </constraints>
                             </view>
                             <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="2OR-ox-Csb">
+                                <rect key="frame" x="16" y="357.5" width="276" height="18"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="WhA-sd-qfz">
+                                        <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="18" id="Jyn-II-qDA"/>
                                             <constraint firstAttribute="width" constant="18" id="VrZ-Fl-jC7"/>
                                         </constraints>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mYl-tz-yRu">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mYl-tz-yRu">
+                                        <rect key="frame" x="21" y="2" width="255" height="14.5"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -128,8 +146,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U6E-MB-03K">
+                                <rect key="frame" x="212" y="333.5" width="80" height="18"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U4X-fn-9uf" customClass="PostMetaButton">
+                                        <rect key="frame" x="50" y="0.0" width="30" height="18"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="18" id="YVF-bx-Qxo"/>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="bog-Fu-vOf"/>
@@ -141,6 +161,7 @@
                                         </state>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f2K-8g-nnA" customClass="PostMetaButton">
+                                        <rect key="frame" x="4" y="0.0" width="30" height="18"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="18" id="GFc-LE-9Ao"/>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="tYz-rL-6ud"/>
@@ -165,6 +186,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pkq-mO-MBJ" customClass="PostCardActionBar">
+                                <rect key="frame" x="0.0" y="388.5" width="308" height="37"/>
                                 <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="37" id="WGi-rg-iHS"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -384,6 +384,9 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     [metaButton setImage:image forState:UIControlStateHighlighted];
     metaButton.selected = NO;
     metaButton.hidden = NO;
+    if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionRightToLeft) {
+        [metaButton flipInsetsForRightToLeftLayoutDirection];
+    }
 }
 
 
@@ -411,6 +414,11 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     }
     self.currentActionBarMode = ActionBarModePublish;
 
+    UIEdgeInsets imageInsets = ActionbarButtonImageInsets;
+    if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionRightToLeft) {
+        imageInsets = [InsetsHelper flipForRightToLeftLayoutDirection:imageInsets];
+    }
+
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *items = [NSMutableArray array];
     PostCardActionBarItem *item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"Edit", @"Label for the edit post button. Tapping displays the editor.")
@@ -419,7 +427,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     item.callback = ^{
         [weakSelf editPostAction];
     };
-    item.imageInsets = ActionbarButtonImageInsets;
+    item.imageInsets = imageInsets;
     [items addObject:item];
 
     item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"View", @"Label for the view post button. Tapping displays the post as it appears on the web.")
@@ -428,7 +436,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     item.callback = ^{
         [weakSelf viewPostAction];
     };
-    item.imageInsets = ActionbarButtonImageInsets;
+    item.imageInsets = imageInsets;
     [items addObject:item];
 
     if ([self.post supportsStats]) {
@@ -438,7 +446,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
         item.callback = ^{
             [weakSelf statsPostAction];
         };
-        item.imageInsets = ActionbarButtonImageInsets;
+        item.imageInsets = imageInsets;
         [items addObject:item];
     }
 
@@ -448,7 +456,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     item.callback = ^{
         [weakSelf trashPostAction];
     };
-    item.imageInsets = ActionbarButtonImageInsets;
+    item.imageInsets = imageInsets;
     [items addObject:item];
 
     [self.actionBar setItems:items];
@@ -461,6 +469,11 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     }
     self.currentActionBarMode = ActionBarModeDraft;
 
+    UIEdgeInsets imageInsets = ActionbarButtonImageInsets;
+    if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionRightToLeft) {
+        imageInsets = [InsetsHelper flipForRightToLeftLayoutDirection:imageInsets];
+    }
+
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *items = [NSMutableArray array];
     PostCardActionBarItem *item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"Edit", @"Label for the edit post button. Tapping displays the editor.")
@@ -469,7 +482,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     item.callback = ^{
         [weakSelf editPostAction];
     };
-    item.imageInsets = ActionbarButtonImageInsets;
+    item.imageInsets = imageInsets;
     [items addObject:item];
 
     item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"Preview", @"Label for the preview post button. Tapping shows a preview of the post.")
@@ -478,7 +491,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     item.callback = ^{
         [weakSelf viewPostAction];
     };
-    item.imageInsets = ActionbarButtonImageInsets;
+    item.imageInsets = imageInsets;
     [items addObject:item];
 
     item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"Publish", @"Label for the publish button. Tapping publishes a draft post.")
@@ -487,7 +500,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     item.callback = ^{
         [weakSelf publishPostAction];
     };
-    item.imageInsets = ActionbarButtonImageInsets;
+    item.imageInsets = imageInsets;
     [items addObject:item];
 
     item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"Trash", @"Label for the trash post button. Tapping moves a post to the trash bin.")
@@ -496,7 +509,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     item.callback = ^{
         [weakSelf trashPostAction];
     };
-    item.imageInsets = ActionbarButtonImageInsets;
+    item.imageInsets = imageInsets;
     [items addObject:item];
 
     [self.actionBar setItems:items];
@@ -509,6 +522,11 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     }
     self.currentActionBarMode = ActionBarModeTrash;
 
+    UIEdgeInsets imageInsets = ActionbarButtonImageInsets;
+    if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionRightToLeft) {
+        imageInsets = [InsetsHelper flipForRightToLeftLayoutDirection:imageInsets];
+    }
+
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *items = [NSMutableArray array];
     PostCardActionBarItem *item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"Restore", @"Label for restoring a trashed post.")
@@ -517,7 +535,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     item.callback = ^{
         [weakSelf restorePostAction];
     };
-    item.imageInsets = ActionbarButtonImageInsets;
+    item.imageInsets = imageInsets;
     [items addObject:item];
 
     item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"Delete", @"Label for the delete post buton. Tapping permanently deletes a post.")
@@ -526,7 +544,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     item.callback = ^{
         [weakSelf trashPostAction];
     };
-    item.imageInsets = ActionbarButtonImageInsets;
+    item.imageInsets = imageInsets;
     [items addObject:item];
 
     [self.actionBar setItems:items];

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,11 +15,11 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="238"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="sqZ-hd-ibO" id="MWK-lj-FaS">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="237.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="237"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lk7-nZ-b0t">
-                        <rect key="frame" x="6" y="10" width="308" height="216"/>
+                        <rect key="frame" x="6" y="10" width="308" height="215"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OuO-i7-2Ds">
                                 <rect key="frame" x="16" y="15" width="276" height="34"/>
@@ -29,20 +33,20 @@
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Glg-dS-0y2">
                                         <rect key="frame" x="42" y="0.0" width="234" height="17"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l4E-Qn-Vgl">
                                         <rect key="frame" x="42" y="18" width="234" height="15"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="l4E-Qn-Vgl" firstAttribute="leading" secondItem="tB9-qp-pdv" secondAttribute="trailing" constant="10" id="ONX-Wv-JNt"/>
                                     <constraint firstAttribute="height" constant="34" id="XPo-Pz-YMq"/>
@@ -57,20 +61,20 @@
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="xIT-FJ-g43">
                                 <rect key="frame" x="16" y="61" width="276" height="24"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="POV-pe-wu8">
-                                <rect key="frame" x="16" y="90" width="276" height="25"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="16" y="90" width="276" height="24"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z3W-ou-g2J">
-                                <rect key="frame" x="16" y="124" width="196" height="18"/>
+                                <rect key="frame" x="16" y="123" width="196" height="18"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="38V-Vw-GfJ">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -79,15 +83,15 @@
                                             <constraint firstAttribute="height" constant="18" id="oYP-3y-IxP"/>
                                         </constraints>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q5D-nc-yvr">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q5D-nc-yvr">
                                         <rect key="frame" x="21" y="2" width="175" height="15"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="18" id="9jY-pA-EoJ">
                                         <variation key="heightClass=regular-widthClass=regular" constant="22"/>
@@ -100,7 +104,7 @@
                                 </constraints>
                             </view>
                             <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="O28-fP-tpX">
-                                <rect key="frame" x="16" y="148" width="276" height="18"/>
+                                <rect key="frame" x="16" y="147" width="276" height="18"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="8Cs-fq-wSe">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -109,15 +113,15 @@
                                             <constraint firstAttribute="height" constant="18" id="tUS-Dc-Ofc"/>
                                         </constraints>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbu-l3-L8G">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbu-l3-L8G">
                                         <rect key="frame" x="21" y="2" width="255" height="15"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="Dbu-l3-L8G" secondAttribute="trailing" id="JHG-At-nZk"/>
                                     <constraint firstAttribute="centerY" secondItem="8Cs-fq-wSe" secondAttribute="centerY" id="Mli-g3-zHk"/>
@@ -130,7 +134,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YwV-AJ-Nvl">
-                                <rect key="frame" x="212" y="124" width="80" height="18"/>
+                                <rect key="frame" x="212" y="123" width="80" height="18"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ovg-ci-Pfb" customClass="PostMetaButton">
                                         <rect key="frame" x="50" y="0.0" width="30" height="18"/>
@@ -141,7 +145,7 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
                                         <state key="normal" title="0" image="icon-postmeta-like">
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uDE-AO-Rii" customClass="PostMetaButton">
@@ -153,11 +157,11 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
                                         <state key="normal" title="0" image="icon-postmeta-comment">
-                                            <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                     </button>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="Ovg-ci-Pfb" firstAttribute="leading" secondItem="uDE-AO-Rii" secondAttribute="trailing" constant="16" id="I0b-Dk-6Hj"/>
                                     <constraint firstAttribute="height" constant="18" id="L5g-Oq-HvR">
@@ -170,14 +174,14 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BlB-Gp-P6A" customClass="PostCardActionBar">
-                                <rect key="frame" x="0.0" y="179" width="308" height="37"/>
-                                <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="0.0" y="178" width="308" height="37"/>
+                                <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="37" id="tqV-2T-l9Q"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="BlB-Gp-P6A" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="0LN-fC-xEM"/>
                             <constraint firstItem="OuO-i7-2Ds" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="2pB-iJ-nFa">
@@ -231,7 +235,7 @@
                         </constraints>
                     </view>
                 </subviews>
-                <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="calibratedRGB"/>
+                <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 <constraints>
                     <constraint firstItem="Lk7-nZ-b0t" firstAttribute="trailing" secondItem="MWK-lj-FaS" secondAttribute="trailingMargin" priority="999" constant="2" id="2At-kP-Urm">
                         <variation key="widthClass=regular" constant="0.0"/>

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -814,7 +814,11 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         cell.textField.returnKeyType = UIReturnKeyDone;
         cell.textField.delegate = self;
         [WPStyleGuide configureTableViewTextCell:cell];
-        cell.textField.textAlignment = NSTextAlignmentRight;
+        if ([self.view userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight) {
+            cell.textField.textAlignment = NSTextAlignmentRight;
+        } else {
+            cell.textField.textAlignment = NSTextAlignmentLeft;
+        }
     }
     cell.tag = 0;
     return cell;

--- a/WordPress/Classes/ViewRelated/Post/Posts.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Posts.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Posts-->
@@ -14,17 +18,17 @@
                         <viewControllerLayoutGuide type="bottom" id="AIH-s0-RTt"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Zhd-4n-wcm">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="cnu-9z-5GZ">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <connections>
                                     <segue destination="zOz-bT-2ph" kind="embed" id="m8J-kl-Bnz"/>
                                 </connections>
                             </containerView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="cnu-9z-5GZ" firstAttribute="top" secondItem="Zhd-4n-wcm" secondAttribute="topMargin" id="142-xs-2mp"/>
                             <constraint firstAttribute="bottomMargin" secondItem="cnu-9z-5GZ" secondAttribute="bottom" id="CxD-qt-v2d"/>
@@ -52,10 +56,10 @@
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="qr8-Nf-Mwl" customClass="NavBarTitleDropdownButton">
                     <rect key="frame" x="0.0" y="0.0" width="77" height="25"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <inset key="imageEdgeInsets" minX="4" minY="0.0" maxX="0.0" maxY="0.0"/>
                     <state key="normal" title="Button" image="icon-nav-chevron">
-                        <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </state>
                     <connections>
                         <action selector="didTapFilterButton:" destination="VTO-0U-HpP" eventType="touchUpInside" id="B6R-YT-dc3"/>
@@ -64,10 +68,13 @@
                 <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Ph-e4-iOe">
                     <rect key="frame" x="0.0" y="0.0" width="80" height="44"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Az-zB-Hwe">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Az-zB-Hwe">
                             <rect key="frame" x="40" y="0.0" width="40" height="44"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="40" id="Moj-01-1lI"/>
+                            </constraints>
                             <state key="normal" image="icon-post-add">
-                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
                             <state key="highlighted" image="icon-post-add-highlight"/>
                             <connections>
@@ -75,6 +82,11 @@
                             </connections>
                         </button>
                     </subviews>
+                    <constraints>
+                        <constraint firstItem="9Az-zB-Hwe" firstAttribute="top" secondItem="8Ph-e4-iOe" secondAttribute="top" id="Hjj-Ra-6M9"/>
+                        <constraint firstAttribute="trailing" secondItem="9Az-zB-Hwe" secondAttribute="trailing" id="STW-Iw-FBG"/>
+                        <constraint firstAttribute="bottom" secondItem="9Az-zB-Hwe" secondAttribute="bottom" id="Usu-ZA-zoK"/>
+                    </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" id="PF5-eU-KAv">
                     <rect key="frame" x="0.0" y="0.0" width="600" height="88"/>
@@ -82,14 +94,14 @@
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sFK-WP-z2Z" customClass="SearchWrapperView" customModule="WordPress" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9at-tM-m4A">
                             <rect key="frame" x="0.0" y="44" width="600" height="44"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESQ-oX-ZqN">
                                     <rect key="frame" x="0.0" y="43" width="600" height="1"/>
-                                    <color key="backgroundColor" red="0.82352941176470584" green="0.87058823529411766" blue="0.90196078431372551" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="backgroundColor" red="0.82352941176470584" green="0.87058823529411766" blue="0.90196078431372551" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="4Sy-We-JMj"/>
                                     </constraints>
@@ -127,9 +139,9 @@
             <objects>
                 <tableViewController id="zOz-bT-2ph" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="300" sectionHeaderHeight="22" sectionFooterHeight="22" id="srU-rF-GC6">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>
                             <outlet property="dataSource" destination="zOz-bT-2ph" id="lbh-fP-TC8"/>
                             <outlet property="delegate" destination="zOz-bT-2ph" id="xw7-aO-PKI"/>
@@ -137,6 +149,7 @@
                     </tableView>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="yaY-3g-ZFU">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </refreshControl>
                 </tableViewController>

--- a/WordPress/Classes/ViewRelated/Post/WPButtonForNavigationBar.m
+++ b/WordPress/Classes/ViewRelated/Post/WPButtonForNavigationBar.m
@@ -1,4 +1,5 @@
 #import "WPButtonForNavigationBar.h"
+#import "WordPress-Swift.h"
 
 static CGFloat kDefaultAnimationDuration = 0.3;
 static CGFloat kHighlightedAlpha = 0.2f;
@@ -55,7 +56,11 @@ static CGFloat kNormalAlpha = 1.0f;
 	if (self.removeDefaultRightSpacing) {
 		insets = UIEdgeInsetsMake(0, 0, 0, kDefaultSpacing - self.rightSpacing);
 	}
-	
+
+    if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionRightToLeft) {
+        insets = [InsetsHelper flipForRightToLeftLayoutDirection:insets];
+    }
+
 	return insets;
 }
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1088,7 +1088,7 @@ EditImageDetailsViewControllerDelegate
         return _cancelChevronButton;
     }
     
-    UIImage *image = [UIImage imageNamed:@"icon-posts-editor-chevron"];
+    UIImage *image = [[UIImage imageNamed:@"icon-posts-editor-chevron"] imageFlippedForRightToLeftLayoutDirection];
     image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     
     WPButtonForNavigationBar* cancelButton = [WPStyleGuide buttonForBarWithImage:image

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -389,6 +389,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         configureTag()
         configureActionButtons()
         configureFooterIfNeeded()
+        adjustInsetsForTextDirection()
 
         bumpStats()
         bumpPageViewsForPost()
@@ -759,6 +760,19 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             footerViewHeightConstraint.constant = 0
         }
         footerViewHeightConstraintConstant = footerViewHeightConstraint.constant
+    }
+
+    fileprivate func adjustInsetsForTextDirection() {
+        guard view.userInterfaceLayoutDirection() == .rightToLeft else {
+            return
+        }
+
+        let buttonsToAdjust: [UIButton] = [
+            likeButton,
+            commentButton]
+        for button in buttonsToAdjust {
+            button.flipInsetsForRightToLeftLayoutDirection()
+        }
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
@@ -31,7 +31,7 @@ import WordPressShared.WPStyleGuide
         titleLabel.textColor = WPStyleGuide.darkGrey()
         titleLabel.text = NSLocalizedString("Manage", comment: "Button title. Tapping lets the user manage the sites they follow.")
 
-        disclosureIcon.image = Gridicon.iconOfType(.chevronRight, withSize: disclosureIcon.frame.size)
+        disclosureIcon.image = Gridicon.iconOfType(.chevronRight, withSize: disclosureIcon.frame.size).imageFlippedForRightToLeftLayoutDirection()
         disclosureIcon.tintColor = WPStyleGuide.accessoryDefaultTintColor()
 
         imageView.image = Gridicon.iconOfType(.cog)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -145,6 +145,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         setupAttributionView()
         setupCommentActionButton()
         setupLikeActionButton()
+        adjustInsetsForTextDirection()
     }
 
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -215,6 +216,21 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
 
         menuButton.setImage(tintedIcon, for: .normal)
         menuButton.setImage(highlightIcon, for: .highlighted)
+    }
+
+    fileprivate func adjustInsetsForTextDirection() {
+        guard userInterfaceLayoutDirection() == .rightToLeft else {
+            return
+        }
+
+        let buttonsToAdjust: [UIButton] = [
+            visitButton,
+            likeActionButton,
+            commentActionButton,
+            shareButton]
+        for button in buttonsToAdjust {
+            button.flipInsetsForRightToLeftLayoutDirection()
+        }
     }
 
     /**

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -194,7 +194,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 
 - (UIButton *)newDisclosureButton
 {
-    UIImage *chevronImage = [UIImage imageNamed:@"disclosure-chevron"];
+    UIImage *chevronImage = [[UIImage imageNamed:@"disclosure-chevron"] imageFlippedForRightToLeftLayoutDirection];
     UIButton *disclosureButton = [UIButton buttonWithType:UIButtonTypeCustom];
     [disclosureButton setBackgroundImage:chevronImage forState:UIControlStateNormal];
     disclosureButton.translatesAutoresizingMaskIntoConstraints = NO;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -15,6 +15,7 @@ import WordPressShared
         super.awakeFromNib()
 
         applyStyles()
+        adjustInsetsForTextDirection()
     }
 
     func applyStyles() {
@@ -37,6 +38,15 @@ import WordPressShared
         followButton.isHidden = !enable
     }
 
+    fileprivate func adjustInsetsForTextDirection() {
+        guard userInterfaceLayoutDirection() == .rightToLeft else {
+            return
+        }
+
+        followButton.contentEdgeInsets = followButton.contentEdgeInsets.flippedForRightToLeftLayoutDirection()
+        followButton.imageEdgeInsets = followButton.imageEdgeInsets.flippedForRightToLeftLayoutDirection()
+        followButton.titleEdgeInsets = followButton.titleEdgeInsets.flippedForRightToLeftLayoutDirection()
+    }
 
     // MARK: - Actions
 

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogDetailViewController.m
@@ -32,6 +32,7 @@
     textView.text = self.logText;
     textView.font = [WPStyleGuide subtitleFont];
     textView.backgroundColor = [UIColor whiteColor];
+    textView.textAlignment = NSTextAlignmentLeft; // Logs aren't RTL friendly
     [self.view addSubview:textView];
     textView.translatesAutoresizingMaskIntoConstraints = NO;
     

--- a/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/ActivityLogViewController.m
@@ -96,7 +96,7 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
         DDLogFileInfo *logFileInfo = (DDLogFileInfo *)self.logFiles[indexPath.row];
         cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
         cell.textLabel.text = indexPath.row == 0 ? NSLocalizedString(@"Current", @"") : [self.dateFormatter stringFromDate:logFileInfo.creationDate];
-        cell.textLabel.textAlignment = NSTextAlignmentLeft;
+        cell.textLabel.textAlignment = NSTextAlignmentNatural;
         [WPStyleGuide configureTableViewCell:cell];
     } else {
         cell.accessoryType = UITableViewCellAccessoryNone;

--- a/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Settings/SupportViewController.m
@@ -239,7 +239,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
 
 - (void)configureCell:(UITableViewCell *)cell atIndexPath:(NSIndexPath *)indexPath
 {
-    cell.textLabel.textAlignment = NSTextAlignmentLeft;
+    cell.textLabel.textAlignment = NSTextAlignmentNatural;
     [WPStyleGuide configureTableViewCell:cell];
 
     if (indexPath.section == SettingsSectionFAQForums) {
@@ -281,7 +281,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
             }
         }
     } else if (indexPath.section == SettingsSectionSettings) {
-        cell.textLabel.textAlignment = NSTextAlignmentLeft;
+        cell.textLabel.textAlignment = NSTextAlignmentNatural;
 
         if (indexPath.row == SettingsSectionSettingsRowVersion) {
             // App Version

--- a/WordPress/Classes/ViewRelated/System/PagedViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/PagedViewController.swift
@@ -157,7 +157,7 @@ extension PagedViewController: UIScrollViewDelegate {
         // Calculate which plan's VC is at the center of the view
         let pageWidth = scrollView.bounds.width
         let centerX = scrollView.contentOffset.x + (pageWidth / 2)
-        let currentPage = Int(floor(centerX / pageWidth))
+        let currentPage = rtlCorrectedPage(Int(floor(centerX / pageWidth)))
 
         // Keep it within bounds
         return currentPage.clamp(min: 0, max: viewControllers.count - 1)
@@ -168,10 +168,18 @@ extension PagedViewController: UIScrollViewDelegate {
         guard viewControllers.indices.contains(page) else { return false }
 
         let pageWidth = view.bounds.width
-        scrollView.setContentOffset(CGPoint(x: CGFloat(page) * pageWidth, y: 0), animated: animated)
+        scrollView.setContentOffset(CGPoint(x: CGFloat(rtlCorrectedPage(page)) * pageWidth, y: 0), animated: animated)
 
         currentIndex = page
 
         return true
+    }
+
+    fileprivate func rtlCorrectedPage(_ page: Int) -> Int {
+        if view.userInterfaceLayoutDirection() == .leftToRight {
+            return page
+        } else {
+            return viewControllers.count - page - 1
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -233,9 +233,7 @@ class WPSplitViewController: UISplitViewController {
         if dimmingView.superview != nil {
             dimmingView.frame = view.frame
 
-            let attribute = view.semanticContentAttribute
-            let layoutDirection = UIView.userInterfaceLayoutDirection(for: attribute)
-            if layoutDirection == .leftToRight {
+            if view.userInterfaceLayoutDirection() == .leftToRight {
                 dimmingView.frame.origin.x = primaryColumnWidth
             } else {
                 dimmingView.frame.size.width = dimmingView.frame.size.width - primaryColumnWidth

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -706,7 +706,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (void)updateNotificationBadgeIconPosition
 {
-    CGRect notificationsButtonFrame = [self lastTabBarButtonFrame];
+    CGRect notificationsButtonFrame = [self notificationsButtonFrame];
     CGRect rect = self.notificationBadgeIconView.frame;
     rect.origin.y = WPNotificationBadgeIconVerticalOffsetFromTop;
     rect.origin.x = CGRectGetMidX(notificationsButtonFrame) - WPNotificationBadgeIconHorizontalOffsetFromCenter;
@@ -773,6 +773,29 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     return lastButtonRect;
 }
 
+- (CGRect)firstTabBarButtonFrame
+{
+    CGRect firstButtonRect = CGRectInfinite;
+
+    for (UIView *subview in self.tabBar.subviews) {
+        if ([WPTabBarButtonClassname isEqualToString:NSStringFromClass([subview class])]) {
+            if (CGRectGetMaxX(subview.frame) < CGRectGetMaxX(firstButtonRect)) {
+                firstButtonRect = subview.frame;
+            }
+        }
+    }
+
+    return firstButtonRect;
+}
+
+- (CGRect)notificationsButtonFrame
+{
+    if ([self.view userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight) {
+        return [self lastTabBarButtonFrame];
+    } else {
+        return [self firstTabBarButtonFrame];
+    }
+}
 
 #pragma mark - Handling Layout
 

--- a/WordPress/Classes/ViewRelated/Views/WPUploadStatusButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPUploadStatusButton.m
@@ -16,7 +16,7 @@
     [button setTitle:NSLocalizedString(@"Uploading...", @"\"Uploading...\" Status text") forState:UIControlStateNormal];
     [button setAccessibilityHint:NSLocalizedString(@"Tap to select which blog to post to", @"This is the blog picker in the editor")];
     button.titleLabel.numberOfLines = 1;
-    button.titleLabel.textAlignment = NSTextAlignmentLeft;
+    button.titleLabel.textAlignment = NSTextAlignmentNatural;
     button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
     button.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -671,6 +671,7 @@
 		E174F6E6172A73960004F23A /* WPAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E105E9CE1726955600C0D9E7 /* WPAccount.m */; };
 		E17780801C97FA9500FA7E14 /* StoreKit+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = E177807F1C97FA9500FA7E14 /* StoreKit+Debug.swift */; };
 		E18165FD14E4428B006CE885 /* loader.html in Resources */ = {isa = PBXBuildFile; fileRef = E18165FC14E4428B006CE885 /* loader.html */; };
+		E1823E6C1E42231C00C19F53 /* UIEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1823E6B1E42231C00C19F53 /* UIEdgeInsets.swift */; };
 		E183BD7417621D87000B0822 /* WPCookie.m in Sources */ = {isa = PBXBuildFile; fileRef = E183BD7317621D86000B0822 /* WPCookie.m */; };
 		E183EC9C16B215FE00C2EB11 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A01C542D0E24E88400D411F2 /* SystemConfiguration.framework */; };
 		E183EC9D16B2160200C2EB11 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D67D11D13EAD00A61362 /* MobileCoreServices.framework */; };
@@ -2010,6 +2011,7 @@
 		E17B98E7171FFB450073E30D /* WordPress 11.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 11.xcdatamodel"; sourceTree = "<group>"; };
 		E17BE7A9134DEC12007285FD /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E18165FC14E4428B006CE885 /* loader.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = loader.html; path = Resources/HTML/loader.html; sourceTree = "<group>"; };
+		E1823E6B1E42231C00C19F53 /* UIEdgeInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIEdgeInsets.swift; sourceTree = "<group>"; };
 		E183BD7217621D85000B0822 /* WPCookie.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPCookie.h; sourceTree = "<group>"; };
 		E183BD7317621D86000B0822 /* WPCookie.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPCookie.m; sourceTree = "<group>"; };
 		E1845F581BFF75D200B69421 /* AccountSettingsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsRemote.swift; sourceTree = "<group>"; };
@@ -4005,6 +4007,7 @@
 				FF286C751DE70A4500383A62 /* NSURL+Exporters.swift */,
 				B5C7D7B71BC6B5A3008E668A /* UIAlertController+Helpers.swift */,
 				B587797219B799D800E57C5A /* UIDevice+Helpers.swift */,
+				E1823E6B1E42231C00C19F53 /* UIEdgeInsets.swift */,
 				FFB1FA9D1BF0EB840090C761 /* UIImage+Exporters.swift */,
 				E6F66D411E00966000F875A5 /* UIImage+Rotation.swift */,
 				E67B30291DD2428B00F2F47B /* UIImage+Tint.swift */,
@@ -6335,6 +6338,7 @@
 				E6374DC71C44550700F24720 /* RemotePublicizeService.swift in Sources */,
 				B5899AE41B422D990075A3D6 /* NotificationSettings.swift in Sources */,
 				FFB1FAA01BF0EC4E0090C761 /* PHAsset+Exporters.swift in Sources */,
+				E1823E6C1E42231C00C19F53 /* UIEdgeInsets.swift in Sources */,
 				5D18FE9F1AFBB17400EFEED0 /* RestorePageTableViewCell.m in Sources */,
 				FFB1FA9E1BF0EB840090C761 /* UIImage+Exporters.swift in Sources */,
 				E1556CF2193F6FE900FC52EA /* CommentService.m in Sources */,


### PR DESCRIPTION
This is a first pass at #6432. There are still some known issues (I haven't touched NUX mostly) and more testing to do, but I think this was already a huge improvement, and the PR was getting large.

To test:

Switch to Arab/Hebrew, or run from Xcode with "Right to Left Pseudolanguage" for an easier time.
Then test all the things `¯\_(ツ)_/¯`

For reference, here's a screen comparison of the fixes I've noticed, which might not be all, since I did a bunch of find/replace for text alignments, and I might have missed some other in the comparison.

![rtl-before-after](https://cloud.githubusercontent.com/assets/8739/22546531/c3ee26e0-e93d-11e6-94c9-f9808c754975.png)

Needs review: @aerych @rachelmcr 