### PR TITLE
Fix post-post causing unresponsive app

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -89,8 +89,6 @@ class PostPostViewController: UIViewController {
         viewButtonWidth.constant = shareButton.frame.size.width * animationScaleBegin
         view.layoutIfNeeded()
 
-        revealPost = false
-
         guard let transitionCoordinator = transitionCoordinator else {
             return
         }
@@ -166,12 +164,10 @@ class PostPostViewController: UIViewController {
 
     @IBAction func editTapped() {
         reshowEditor?()
-        revealPost = true
     }
 
     @IBAction func viewTapped() {
         preview?()
-        revealPost = true
     }
 
     @IBAction func doneTapped() {


### PR DESCRIPTION
Fixes #6544 

Sharing could cause post-post to make the app unresponsive. There may have been other undiscovered cases that caused this which will be fixed as well.

To test:
_On an iPhone:_
1. Create a new post and publish it, to get the post-post screen
2. Tap Share
3. Tap Message or Mail
4. Don't share, instead tap Cancel

The post-post should reappear, and be completely functional

Needs review: @frosty 
Got time for this one?
