### PR TITLE
Issue/6478: Respect "Reduce Motion" accessibility setting for fullscreen transition

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -305,10 +305,13 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     /// Composes the views for the post header and Discover attribution.
     fileprivate func setupContentHeaderAndFooter() {
+        // Add the footer first so its behind the header. This way the header
+        // obscures the footer until its properly positioned.
+        textView.addSubview(textFooterStackView)
         textView.addSubview(textHeaderStackView)
+
         textHeaderStackView.topAnchor.constraint(equalTo: textView.topAnchor).isActive = true
 
-        textView.addSubview(textFooterStackView)
         textFooterTopConstraint = NSLayoutConstraint(item: textFooterStackView,
                                                      attribute: .top,
                                                      relatedBy: .equal,

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -529,10 +529,19 @@ extension WPSplitViewController: UINavigationControllerDelegate {
         // left in the navigation stack that prefer to be fullscreen, then
         // animate back to a standard split view.
         if isCurrentlyFullscreen && !hasFullscreenViewControllersInStack {
-            setPrimaryViewControllerHidden(false, animated: animated)
+            let performTransition = { (animated: Bool) in
+                self.setPrimaryViewControllerHidden(false, animated: animated)
 
-            if animated && !isViewHorizontallyCompact() {
-                navigationController.navigationBar.fadeOutNavigationItems(animated: true)
+                if animated && !self.isViewHorizontallyCompact() {
+                    navigationController.navigationBar.fadeOutNavigationItems(animated: true)
+                }
+            }
+
+            if UIAccessibilityIsReduceMotionEnabled() {
+                view.hideWithBlankingSnapshot(afterScreenUpdates: false)
+                performTransition(false)
+            } else {
+                performTransition(animated)
             }
         }
     }
@@ -554,6 +563,10 @@ extension WPSplitViewController: UINavigationControllerDelegate {
             // we can set the delegate to nil (see: http://stackoverflow.com/a/38859457/570547)
             navigationController.interactivePopGestureRecognizer?.delegate = nil
             navigationController.interactivePopGestureRecognizer?.isEnabled = allowInteractiveBackGesture
+
+            if UIAccessibilityIsReduceMotionEnabled() {
+                view.fadeOutAndRemoveBlankingSnapshot()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #6478. If the user has Reduce Motion enabled, we now do a simple cross fade instead of the standard fullscreen transition. 

This requires snapshotting the view before it's updated to its new layout, updating the layout in the background, and then fading out the snapshot afterwards.

To test:

* In Settings on your device or the simulator, go into General > Accessibility and enable Reduce Motion.
* In WPiOS, go to the Reader and tap a post to enter full screen.
* Also verify: popping back to not-full-screen, and accessing full screen from further down the stack (i.e. tap into comments first, then a stream, then a post).

Needs review: @kurzee 