### PR TITLE
Strip html from post title in post-post

### DIFF
--- a/WordPress/Classes/Extensions/String+Helpers.swift
+++ b/WordPress/Classes/Extensions/String+Helpers.swift
@@ -27,13 +27,6 @@ extension String {
         copy.remove(at: index)
         return copy
     }
-
-    func stripHtmlTags() -> String {
-        let data = self.data(using: String.Encoding.utf8)!
-        guard let html = try? NSAttributedString(data: data, options: [NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType], documentAttributes: nil) else {return self}
-        return html.string
-    }
-
 }
 
 // MARK: - Prefix removal

--- a/WordPress/Classes/Extensions/String+Helpers.swift
+++ b/WordPress/Classes/Extensions/String+Helpers.swift
@@ -28,6 +28,12 @@ extension String {
         return copy
     }
 
+    func stripHtmlTags() -> String {
+        let data = self.data(using: String.Encoding.utf8)!
+        guard let html = try? NSAttributedString(data: data, options: [NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType], documentAttributes: nil) else {return self}
+        return html.string
+    }
+
 }
 
 // MARK: - Prefix removal

--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -130,7 +130,7 @@ class PostPostViewController: UIViewController {
         }
         self.post = post
 
-        titleLabel.text = post.titleForDisplay().stripHtmlTags()
+        titleLabel.text = post.titleForDisplay().strippingHTML()
 
         if post.isScheduled() {
             let format = NSLocalizedString("Scheduled for %@ on", comment: "Precedes the name of the blog a post was just scheduled on. Variable is the date post was scheduled for.")

--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -130,7 +130,8 @@ class PostPostViewController: UIViewController {
         }
         self.post = post
 
-        titleLabel.text = post.titleForDisplay()
+        titleLabel.text = post.titleForDisplay().stripHtmlTags()
+
         if post.isScheduled() {
             let format = NSLocalizedString("Scheduled for %@ on", comment: "Precedes the name of the blog a post was just scheduled on. Variable is the date post was scheduled for.")
             postStatusLabel.text = String(format: format, post.dateStringForDisplay())

--- a/WordPress/WordPressTest/Extensions/StringHelperTests.swift
+++ b/WordPress/WordPressTest/Extensions/StringHelperTests.swift
@@ -20,12 +20,6 @@ class StringHelperTests: XCTestCase {
         XCTAssert(trimmedString == sourceString.trim())
     }
 
-    func testStripHtmlTags() {
-        let strippedHtmlString = "And here?"
-        let sourceString = "And <em>here?</em>"
-        XCTAssert(strippedHtmlString == sourceString.stripHtmlTags())
-    }
-
     func testRemovePrefix() {
         let string = "X-Post: This is a test"
         XCTAssertEqual("This is a test", string.removingPrefix("X-Post: "))

--- a/WordPress/WordPressTest/Extensions/StringHelperTests.swift
+++ b/WordPress/WordPressTest/Extensions/StringHelperTests.swift
@@ -20,6 +20,12 @@ class StringHelperTests: XCTestCase {
         XCTAssert(trimmedString == sourceString.trim())
     }
 
+    func testStripHtmlTags() {
+        let strippedHtmlString = "And here?"
+        let sourceString = "And <em>here?</em>"
+        XCTAssert(strippedHtmlString == sourceString.stripHtmlTags())
+    }
+
     func testRemovePrefix() {
         let string = "X-Post: This is a test"
         XCTAssertEqual("This is a test", string.removingPrefix("X-Post: "))


### PR DESCRIPTION
Fixes #6435 

To test: Create a new post with title: And <em>here?</em>
The html tags are stripped in post post view


Needs review: @nheagy 
