### PR TITLE
Reader: Assume no more content when receiving less posts than requested.

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -674,7 +674,16 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
         [self deletePostsInExcessOfMaxAllowedForTopic:readerTopic];
         [self deletePostsFromBlockedSites];
 
-        BOOL hasMore = ((postsCount > 0 ) && ([self numberOfPostsForTopic:readerTopic] < [self maxPostsToSaveForTopic:readerTopic]));
+        BOOL hasMore = NO;
+        BOOL spaceAvailable = ([self numberOfPostsForTopic:readerTopic] < [self maxPostsToSaveForTopic:readerTopic]);
+        if ([ReaderHelpers isTopicTag:readerTopic]) {
+            // For tags, assume there is more content as long as more than zero results are returned.
+            hasMore = (postsCount > 0 ) && spaceAvailable;
+        } else {
+            // For other topics, assume there is more content as long as the number of results requested is returned.
+            hasMore = ([remotePosts count] == [self numberToSyncForTopic:readerTopic]) && spaceAvailable;
+        }
+
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
             // Is called on main queue
             if (success) {


### PR DESCRIPTION
Closes #6459 
Refs: #6546

This is an improved fix for the issue causing our infinite scroll stat to be spammed.  Here we assume that there is no more available content for a topic when the REST API returns fewer results than expected.  Tag topics are excluded as it is expected we'll receive fewer results than requested due to anti-tag spam measures.

To test:
Take the reader for a test drive.  Confirm that the load more feature continues to function as expected for the default lists, tags, and sites. 
Test a site stream known to previously trigger a load-more refresh loop (ping me for an example). Confirm that the loop no longer occurs.

Needs review: @kurzee, I think we finally got it squared away. :)
