### PR TITLE
Reader: Unfollow deleted site by URL.

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -505,7 +505,17 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
         if (newFollowValue) {
             [siteService followSiteWithID:[topic.siteID integerValue] success:successBlock failure:failureBlock];
         } else {
-            [siteService unfollowSiteWithID:[topic.siteID integerValue] success:successBlock failure:failureBlock];
+            // Try to unfollow by ID as its the most reliable method.
+            // Note that if the site has been deleted, attempting to unfollow by ID
+            // results in an HTTP 403 on the v1.1 endpoint.  If this happens try
+            // unfollowing via the less reliable URL method.
+            [siteService unfollowSiteWithID:[topic.siteID integerValue] success:successBlock failure:^(NSError *error) {
+                if (error.code == WordPressComRestApiErrorAuthorizationRequired) {
+                    [siteService unfollowSiteAtURL:topic.siteURL success:successBlock failure:failureBlock];
+                    return;
+                }
+                failureBlock(error);
+            }];
         }
     }
 }


### PR DESCRIPTION
Fixes #6457 

To test:
Follow the steps outlined in the issue and confirm you can no unfollow the deleted blog.

Needs review: @jleandroperez would you do the honors?

cc @nbradbury 
