### PR TITLE
Reader Comments: Fixes stackview alignment setting so label isn't cropped

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.xib
@@ -21,11 +21,11 @@
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="YXw-gg-IAV">
                         <rect key="frame" x="15" y="11" width="345" height="125"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PBm-HG-IYD">
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PBm-HG-IYD">
                                 <rect key="frame" x="0.0" y="0.0" width="345" height="39.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="XPU-fY-7js" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
+                                        <rect key="frame" x="0.0" y="4" width="32" height="32"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="32" id="28l-JO-bUu"/>
@@ -33,7 +33,7 @@
                                         </constraints>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="OsT-Wk-2aG">
-                                        <rect key="frame" x="40" y="0.0" width="305" height="36.5"/>
+                                        <rect key="frame" x="40" y="1.5" width="305" height="36.5"/>
                                         <subviews>
                                             <button contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wUR-85-LXr">
                                                 <rect key="frame" x="0.0" y="0.0" width="305" height="22"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.xib
@@ -15,14 +15,14 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="147"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="byi-Wo-fAK" id="9mZ-R9-DZW">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="146"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="146.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="YXw-gg-IAV">
                         <rect key="frame" x="15" y="11" width="345" height="125"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PBm-HG-IYD">
-                                <rect key="frame" x="0.0" y="0.0" width="345" height="32"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="PBm-HG-IYD">
+                                <rect key="frame" x="0.0" y="0.0" width="345" height="39.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="XPU-fY-7js" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
@@ -33,7 +33,7 @@
                                         </constraints>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="OsT-Wk-2aG">
-                                        <rect key="frame" x="40" y="0.0" width="305" height="32"/>
+                                        <rect key="frame" x="40" y="0.0" width="305" height="36.5"/>
                                         <subviews>
                                             <button contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wUR-85-LXr">
                                                 <rect key="frame" x="0.0" y="0.0" width="305" height="22"/>
@@ -53,7 +53,7 @@
                                                 </connections>
                                             </button>
                                             <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="srn-Fn-Of7">
-                                                <rect key="frame" x="0.0" y="22" width="305" height="10"/>
+                                                <rect key="frame" x="0.0" y="22" width="305" height="14.5"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.6588235294117647" green="0.74509803921568629" blue="0.80784313725490198" alpha="1" colorSpace="calibratedRGB"/>
@@ -64,7 +64,7 @@
                                 </subviews>
                             </stackView>
                             <textView clipsSubviews="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Lorem ipsum dolor sit er elit lamet, " textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="MZj-2b-1Xd" customClass="WPRichContentView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="32" width="345" height="43"/>
+                                <rect key="frame" x="0.0" y="39.5" width="345" height="35.5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>


### PR DESCRIPTION
Fixes #6567 
The stackview for the header had its alignment set to fill which ended up cropping the label.  This PR changes that setting to `top` allowing the stackview to accommodate the full label height. 

To test:
View reader comments and confirm that the date label is no longer cropped

Needs review: @frosty would you do the honors?
