### PR TITLE
AztecPostViewController: Updates draft removal logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1034,10 +1034,7 @@ fileprivate extension AztecPostViewController {
     }
 
     func shouldRemoveOnDismiss(post: AbstractPost) -> Bool {
-        let originalTitleIsEmpty = post.original?.postTitle?.isEmpty ?? true
-        let originalContentIsEmpty = post.original?.content?.isEmpty ?? true
-
-        return post.isRevision() && post.hasLocalChanges() && originalTitleIsEmpty && originalContentIsEmpty
+        return post.isRevision() && post.hasLocalChanges() || post.hasNeverAttemptedToUpload()
     }
 }
 


### PR DESCRIPTION
### Details:
This PR updates Aztec's Post Removal logic. Apologies about the misunderstanding, this bug is also present in the Hybrid Editor (and i was replicating precisely that!).

Fixes #6587

### To test:
1. Launch WordPress iOS and enable **Aztec**
2. Open **My Sites** > **Any Site**
3. Open the Post List
4. Press the top right `+` button to create a post
5. Dismiss the editor
6. Verify that the draft gets effectively nuked
7. Try editing a post from the list
8. Dismiss Aztec
9. Verify that the post you've just edited does not get nuked from CoreData

Needs review: @diegoreymendez 
Thanks Diego!!
