### PR TITLE
Menus: avoid selecting and enabling a save for the default menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -211,6 +211,13 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
 
 - (void)setSelectedMenu:(Menu *)menu
 {
+    if (menu == self.selectedMenuLocation.menu) {
+        /* Ignore, already selected this menu at this point.
+         * Note: we may arrive at this condition after a discard has occurred for
+         * a previously selected menu that was unsaved.
+         */
+        return;
+    }
     Menu *defaultMenu = [Menu defaultMenuForBlog:self.blog];
     if (menu == defaultMenu) {
         /*


### PR DESCRIPTION
Fixes #6483

This resolves the issue in #6483, nice find @hoverduck!

Since the newly created Menu object was never saved, it was never persisted beyond our context's undo manager for Menus. Thus, once discarding the changes and calling `undo` on the context's `undoManager`, we lost the need for saving the originally selected Menu since we ended up at the currently selected Menu, anyways.

To test:
1. Follow the steps in the original issue.

Bonus steps:

1. Open Menus.
2. Add a new Menu by selecting from the Menus drop down, hit "+ Add New Menu".
3. Save that menu, back out of Menus.
4. Go back to Menus, should now see your custom Menu in place.
5. Add a new menu, don't save it.
6. Re-select your previous menu.
7. Discard changes.
8. Save should be disabled.

Needs review: @aerych  can you take a test of this?
