### PR TITLE
Aztec Media upload cancel

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '0.11'
     pod 'WordPress-iOS-Editor', '1.8.1'
     pod 'WordPressCom-Analytics-iOS', '0.1.22'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => '7b4caa9bee964061bf33f86fda29d8d26d032720'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => 'e474df16708fdf361560227cf33056ca6453bd07'
     pod 'wpxmlrpc', '~> 0.8'
 
     target :WordPressTest do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -178,7 +178,7 @@ DEPENDENCIES:
   - SVProgressHUD (~> 1.1.3)
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `7b4caa9bee964061bf33f86fda29d8d26d032720`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `e474df16708fdf361560227cf33056ca6453bd07`)
   - WordPress-iOS-Editor (= 1.8.1)
   - WordPress-iOS-Shared (= 0.7.2)
   - WordPressCom-Analytics-iOS (= 0.1.22)
@@ -201,7 +201,7 @@ EXTERNAL SOURCES:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: 7b4caa9bee964061bf33f86fda29d8d26d032720
+    :commit: e474df16708fdf361560227cf33056ca6453bd07
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -221,7 +221,7 @@ CHECKOUT OPTIONS:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: 7b4caa9bee964061bf33f86fda29d8d26d032720
+    :commit: e474df16708fdf361560227cf33056ca6453bd07
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -267,6 +267,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 3bda8ac8cb8939c797fde230c093803c719aaad5
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: bfce0ccdec8c9f4931e08746812fc259d1e709a6
+PODFILE CHECKSUM: ed062111f5d84283afc75dae0ec9c84bdacefa22
 
 COCOAPODS: 1.1.1

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1178,9 +1178,8 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
         if let error = error {
             if error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
                 return
-            } else {
-                message = error.localizedDescription
             }
+            message = error.localizedDescription
         }
 
         let paragraphStyle = NSMutableParagraphStyle()
@@ -1210,8 +1209,7 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
     func displayActions(forAttachment attachment: TextAttachment, position: CGPoint) {
         let mediaID = attachment.identifier
         let title: String = NSLocalizedString("Media Options", comment: "Title for action sheet with media options.")
-        let message: String? = nil
-        let alertController = UIAlertController(title: title, message:message, preferredStyle: .actionSheet)
+        let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
         alertController.addActionWithTitle(NSLocalizedString("Dismiss", comment: "User action to dismiss media options."),
                                            style: .cancel,
                                            handler: { (action) in
@@ -1234,7 +1232,6 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
         }
 
         alertController.title = title
-        alertController.message = message
         alertController.popoverPresentationController?.sourceView = richTextView
         alertController.popoverPresentationController?.sourceRect = CGRect(origin: richTextView.center, size: CGSize(width: 1, height: 1))
         alertController.popoverPresentationController?.permittedArrowDirections = .up
@@ -1334,6 +1331,9 @@ extension AztecPostViewController: UIGestureRecognizerDelegate {
     }
 
     func richTextViewWasPressed(_ recognizer: UIGestureRecognizer) {
+        guard recognizer.state == .began else {
+            return
+        }
         let locationInTextView = recognizer.location(in: richTextView)
         guard let attachment = richTextView.attachmentAtPoint(locationInTextView) else {
             return


### PR DESCRIPTION
This PR allows to cancel ongoing media uploads on aztec and/or remove media objects

To test:
 - Start a new Post using Aztec
 - Insert media on the post
 - While the media is uploading, long press on the media object.
 - An action sheet should show with two options: Dismiss and Cancel Upload
 - Tap on Cancel Upload and see if media gets remove and upload is cancelled
 - Double check on server to see if no media showed up there
 - Repeat but only press after upload finished
 - Check if instead of Cancel Upload it shows Remove Media
 - Tap on Remove Media and confirm that media is removed.
 - Next insert media again and remove it using the backspace
 - Check if media stop uploading and doesn't go to the server

Needs review: @jleandroperez 