### PR TITLE
Allow to retry failed uploads.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '0.11'
     pod 'WordPress-iOS-Editor', '1.8.1'
     pod 'WordPressCom-Analytics-iOS', '0.1.22'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => 'e474df16708fdf361560227cf33056ca6453bd07'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => 'e13f779c3a7ca6c8beab4d81fac503e8b08410aa'
     pod 'wpxmlrpc', '~> 0.8'
 
     target :WordPressTest do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -178,7 +178,7 @@ DEPENDENCIES:
   - SVProgressHUD (~> 1.1.3)
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `e474df16708fdf361560227cf33056ca6453bd07`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `e13f779c3a7ca6c8beab4d81fac503e8b08410aa`)
   - WordPress-iOS-Editor (= 1.8.1)
   - WordPress-iOS-Shared (= 0.7.2)
   - WordPressCom-Analytics-iOS (= 0.1.22)
@@ -201,7 +201,7 @@ EXTERNAL SOURCES:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: e474df16708fdf361560227cf33056ca6453bd07
+    :commit: e13f779c3a7ca6c8beab4d81fac503e8b08410aa
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -221,7 +221,7 @@ CHECKOUT OPTIONS:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: e474df16708fdf361560227cf33056ca6453bd07
+    :commit: e13f779c3a7ca6c8beab4d81fac503e8b08410aa
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -267,6 +267,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 3bda8ac8cb8939c797fde230c093803c719aaad5
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: ed062111f5d84283afc75dae0ec9c84bdacefa22
+PODFILE CHECKSUM: c1e1b12a1ecdaa4280ff0d2414eceb6b9ecfa26f
 
 COCOAPODS: 1.1.1

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1108,11 +1108,11 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
         let mediaService = MediaService(managedObjectContext:ContextManager.sharedInstance().mainContext)
         var uploadProgress: Progress?
         mediaService.uploadMedia(media, progress: &uploadProgress, success: {[weak self]() in
-            guard let strongSelf = self else {
+            guard let strongSelf = self, let remoteURL = URL(string:media.remoteURL) else {
                 return
             }
             DispatchQueue.main.async {
-                strongSelf.richTextView.update(attachment: attachment, alignment: attachment.alignment, size: attachment.size, url: URL(string:media.remoteURL)!)
+                strongSelf.richTextView.update(attachment: attachment, alignment: attachment.alignment, size: attachment.size, url: remoteURL)
             }
         }, failure: { [weak self](error) in
             guard let strongSelf = self else {

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1169,20 +1169,22 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
     }
 
     func handleError(_ error: NSError?, onAttachment attachment: Aztec.TextAttachment) {
-        var message = NSLocalizedString("Failed to insert media on your post. Please tap to retry.", comment: "Error message to show to use when media insertion on a post fails")
+        let message = NSLocalizedString("Failed to insert media on your post.\n Please tap to retry.", comment: "Error message to show to use when media insertion on a post fails")
         if let error = error {
             if error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {
                 return
             }
-            message = error.localizedDescription
             mediaProgressCoordinator.attach(error: error, toMediaID: attachment.identifier)
         }
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
-        let attributes: [String:Any] = [NSFontAttributeName: Assets.defaultRegularFont,
+        let shadow = NSShadow()
+        shadow.shadowColor = UIColor(white: 0, alpha: 0.6)
+        let attributes: [String:Any] = [NSFontAttributeName: Assets.defaultSemiBoldFont,
                                         NSParagraphStyleAttributeName: paragraphStyle,
-                                        NSForegroundColorAttributeName: UIColor.darkGray]
+                                        NSForegroundColorAttributeName: UIColor.darkGray,
+                                        NSShadowAttributeName: shadow]
         let attributeMessage = NSAttributedString(string: message, attributes: attributes)
         richTextView.update(attachment: attachment, message: attributeMessage)
     }

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1186,7 +1186,8 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
                                         NSForegroundColorAttributeName: UIColor.darkGray,
                                         NSShadowAttributeName: shadow]
         let attributeMessage = NSAttributedString(string: message, attributes: attributes)
-        richTextView.update(attachment: attachment, message: attributeMessage)
+        attachment.message = attributeMessage
+        richTextView.refreshLayoutFor(attachment: attachment)
     }
 
     func refresh(mediaProgressCoordinator: MediaProgressCoordinator, progress: Float) {
@@ -1197,10 +1198,12 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
                 continue
             }
             if progress.fractionCompleted >= 1 {
-                richTextView.update(attachment: attachment, progress: nil)
+                attachment.progress = nil
             } else {
-                richTextView.update(attachment: attachment, progress: progress.fractionCompleted, progressColor: WPStyleGuide.wordPressBlue())
+                attachment.progress = progress.fractionCompleted
+                attachment.progressColor = WPStyleGuide.wordPressBlue()
             }
+            richTextView.refreshLayoutFor(attachment: attachment)
         }
     }
 
@@ -1236,8 +1239,9 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
                                                     //retry upload
                                                     if let media = self.mediaProgressCoordinator.object(forMediaID: mediaID) as? Media,
                                                         let attachment = self.richTextView.attachment(withId: mediaID) {
-                                                        self.richTextView.update(attachment: attachment, message: nil)
-                                                        self.richTextView.update(attachment: attachment, progress: 0)
+                                                        attachment.message = nil
+                                                        attachment.progress = 0
+                                                        self.richTextView.refreshLayoutFor(attachment: attachment)
                                                         self.mediaProgressCoordinator.track(numberOfItems: 1)
                                                         self.upload(media: media, mediaID: mediaID)
                                                     }

--- a/WordPress/WordPressTest/ViewControllers/MediaProgressCoordinatorTest.swift
+++ b/WordPress/WordPressTest/ViewControllers/MediaProgressCoordinatorTest.swift
@@ -18,7 +18,7 @@ class MediaProgressCoordinatorTest: XCTestCase {
     func testAddToMediaProgress() {
         let totalItems = 10
 
-        mediaProgressCoordinator.addToMediaProgress(numberOfItems: totalItems)
+        mediaProgressCoordinator.track(numberOfItems: totalItems)
         XCTAssertNotNil(mediaProgressCoordinator.mediaUploadingProgress, "Progress should exist")
 
         XCTAssertTrue(mediaProgressCoordinator.mediaUploadingProgress!.totalUnitCount == Int64(totalItems), "There should a total number of 10 items")
@@ -27,7 +27,7 @@ class MediaProgressCoordinatorTest: XCTestCase {
 
         for index in 1...totalItems {
             let progress = Progress.discreteProgress(totalUnitCount: 1)
-            mediaProgressCoordinator.track(progress: progress, ofMediaID: "/(index)")
+            mediaProgressCoordinator.track(progress: progress, ofObject:index , withMediaID: "/(index)")
             progress.completedUnitCount = 1
             XCTAssertTrue(mediaProgressCoordinator.mediaUploadingProgress!.completedUnitCount == Int64(index))
         }
@@ -37,13 +37,13 @@ class MediaProgressCoordinatorTest: XCTestCase {
 
     func testMediaProgressThatFails() {
 
-        mediaProgressCoordinator.addToMediaProgress(numberOfItems: 1)
+        mediaProgressCoordinator.track(numberOfItems: 1)
         XCTAssertNotNil(mediaProgressCoordinator.mediaUploadingProgress, "Progress should exist")
 
         XCTAssertTrue(mediaProgressCoordinator.mediaUploadingProgress!.totalUnitCount == Int64(1), "There should 1 item")
 
         let progress = Progress.discreteProgress(totalUnitCount: 1)
-        mediaProgressCoordinator.track(progress: progress, ofMediaID: "1")
+        mediaProgressCoordinator.track(progress: progress, ofObject:1 , withMediaID: "/(index)")
 
         XCTAssertTrue(mediaProgressCoordinator.isRunning())
         // simulate a failed request
@@ -57,13 +57,13 @@ class MediaProgressCoordinatorTest: XCTestCase {
 
     func testMediaProgressThatIsCanceled() {
 
-        mediaProgressCoordinator.addToMediaProgress(numberOfItems: 1)
+        mediaProgressCoordinator.track(numberOfItems: 1)
         XCTAssertNotNil(mediaProgressCoordinator.mediaUploadingProgress, "Progress should exist")
 
         XCTAssertTrue(mediaProgressCoordinator.mediaUploadingProgress!.totalUnitCount == Int64(1), "There should 1 item")
 
         let progress = Progress.discreteProgress(totalUnitCount: 1)
-        mediaProgressCoordinator.track(progress: progress, ofMediaID: "1")
+        mediaProgressCoordinator.track(progress: progress, ofObject:1 , withMediaID: "/(index)")
 
         XCTAssertTrue(mediaProgressCoordinator.isRunning())
 


### PR DESCRIPTION
This PR implements to retry failed upload of media.

To test:

 - Create a new post using Aztec
 - Turn on Airplane mode
 - Add media to the post
 - check if error message shows overlaying the image.
 - Long press on the image
 - Turn off Airplane mode
 - On the action sheet choose retry upload
 - see if upload finishes correctly.


Needs review: @jleandroperez 