### PR TITLE
Fix preview done button

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -61,7 +61,7 @@
     [super viewWillAppear:animated];
     [self refreshWebView];
     NSMutableArray *rightButtons = [NSMutableArray new];
-    if (self.isBeingPresented || self.navigationController.isBeingPresented) {
+    if (self.isModal) {
         [rightButtons addObject:[self doneBarButtonItem]];
     }
     if ([self.apost isKindOfClass:[Post class]]) {


### PR DESCRIPTION
Fixes #6604

The post preview's Done button should now always appear when presented modally, which is how the post-post screen presents it.

To test:
1. Publish a new post
2. Tap "View Post" on post-post screen
3. Tap the share button
4. Tap Messages
5. Hit Cancel
6. Ensure that the preview can still be dismissed via the Done button

Needs review: @kurzee  
Brent, have time for this one?
