### PR TITLE
Aztec: Force Load Merryweather Fonts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -259,6 +259,9 @@ class AztecPostViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        // TODO: Fix the warnings triggered by this one!
+        WPFontManager.loadMerriweatherFontFamily()
+
         createRevisionOfPost()
 
         configureNavigationBar()


### PR DESCRIPTION
### Details:
In this PR we're bringing back the Force-Load Merryweather Fonts call. This is known to be triggering a warning, whenever a font was already preloaded.

We've nuked this call, not long ago, but definitely missed the crash!!

### To test:
1. Launch Aztec
2. Toggle Italics
3. Verify that the app doesn't break

Needs review: @astralbodies / @diegoreymendez 
Thanks in advance!
