### PR TITLE
Remove duplicate .DS_Store in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ Icon
 .Trashes
 
 # Xcode
-.DS_Store
 */build/*
 *.pbxuser
 !default.pbxuser


### PR DESCRIPTION
This PR removes the duplicate .DS_Store in .gitignore.