### PR TITLE
Reload notifications on significant time changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -76,6 +76,7 @@ class NotificationsViewController: UITableViewController {
         //restorationClass = NotificationsViewController.self
 
         startListeningToAccountNotifications()
+        startListeningToTimeChangeNotifications()
     }
 
     override func viewDidLoad() {
@@ -344,6 +345,11 @@ private extension NotificationsViewController {
         nc.addObserver(self, selector: #selector(defaultAccountDidChange), name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged, object: nil)
     }
 
+    func startListeningToTimeChangeNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(significantTimeChange), name: .UIApplicationSignificantTimeChange, object: nil)
+    }
+
     func stopListeningToNotifications() {
         let nc = NotificationCenter.default
         nc.removeObserver(self, name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
@@ -377,6 +383,15 @@ private extension NotificationsViewController {
 
         resetApplicationBadge()
         updateLastSeenTime()
+    }
+
+    @objc func significantTimeChange(_ note: Foundation.Notification) {
+        needsReloadResults = true
+        if UIApplication.shared.applicationState == .active
+            && isViewLoaded == true
+            && view.window != nil {
+            reloadResultsControllerIfNeeded()
+        }
     }
 }
 


### PR DESCRIPTION
I still can't reproduce #6341 so I have no idea if this would fix it, but it seems like a possible fix.

Since the section identifier is based on a relative date and might change at midnight, this would ensure that we reload the results controller in that case, or when the time zone changes.

Needs review: @jleandroperez 