### PR TITLE
Aztec: Fixing Retain Cycle

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -73,7 +73,7 @@ fileprivate protocol PostEditorActionState {
     func updated(publishDate: Date?, context: PostEditorStateContext) -> PostEditorActionState
 }
 
-public protocol PostEditorStateContextDelegate {
+public protocol PostEditorStateContextDelegate: class {
     func context(_ context: PostEditorStateContext, didChangeAction: PostEditorAction)
     func context(_ context: PostEditorStateContext, didChangeActionAllowed: Bool)
 }
@@ -96,7 +96,7 @@ public class PostEditorStateContext {
 
     fileprivate var originalPostStatus: PostStatus?
     fileprivate var userCanPublish: Bool
-    private var delegate: PostEditorStateContextDelegate?
+    private weak var delegate: PostEditorStateContextDelegate?
 
     fileprivate var hasContent = false {
         didSet {


### PR DESCRIPTION
### Details:
In this PR we're fixing a retain cycle: just marking a delegate as `weak`. 

Please, note that **AztecPostViewController** won't get deinitialized after dismissal, not even after applying this patch, since there's yet another Retain Cycle affecting Aztec's Format Bar (shipping a PR to get that one fixed right away).

Please, verify that the app builds correctly.

Thanks in advance!
Needs review: @astralbodies 

