### PR TITLE
Respect "Reduce Motion" accessibility setting for fullscreen transition

### DIFF
--- a/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
@@ -29,7 +29,10 @@ extension UINavigationController {
         }
 
         if UIAccessibilityIsReduceMotionEnabled() {
-            splitViewController.view.hideWithBlankingSnapshot(afterScreenUpdates: true)
+            // We only actual see the transition if we're in a regular size class
+            if !self.splitViewControllerIsHorizontallyCompact {
+                splitViewController.view.hideWithBlankingSnapshot(afterScreenUpdates: true)
+            }
             performTransition(false)
         } else {
             performTransition(animated)

--- a/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
@@ -28,11 +28,8 @@ extension UINavigationController {
             self.pushViewController(viewController, animated: animated)
         }
 
-        if UIAccessibilityIsReduceMotionEnabled() {
-            // We only actual see the transition if we're in a regular size class
-            if !self.splitViewControllerIsHorizontallyCompact {
-                splitViewController.view.hideWithBlankingSnapshot(afterScreenUpdates: true)
-            }
+        if UIAccessibilityIsReduceMotionEnabled() && !self.splitViewControllerIsHorizontallyCompact {
+            splitViewController.view.hideWithBlankingSnapshot(afterScreenUpdates: true)
             performTransition(false)
         } else {
             performTransition(animated)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -305,10 +305,13 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     /// Composes the views for the post header and Discover attribution.
     fileprivate func setupContentHeaderAndFooter() {
+        // Add the footer first so its behind the header. This way the header
+        // obscures the footer until its properly positioned.
+        textView.addSubview(textFooterStackView)
         textView.addSubview(textHeaderStackView)
+
         textHeaderStackView.topAnchor.constraint(equalTo: textView.topAnchor).isActive = true
 
-        textView.addSubview(textFooterStackView)
         textFooterTopConstraint = NSLayoutConstraint(item: textFooterStackView,
                                                      attribute: .top,
                                                      relatedBy: .equal,

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1683,7 +1683,11 @@ extension ReaderStreamViewController : WPTableViewHandlerDelegate {
 
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: false)
+        if !UIAccessibilityIsReduceMotionEnabled() {
+            // This can conflict with the reduce motion fullscreen push animation
+            tableView.deselectRow(at: indexPath, animated: false)
+        }
+
         guard let posts = tableViewHandler.resultsController.fetchedObjects as? [ReaderPost] else {
             DDLogSwift.logError("[ReaderStreamViewController tableView:didSelectRowAtIndexPath:] fetchedObjects was nil.")
             return

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1683,11 +1683,6 @@ extension ReaderStreamViewController : WPTableViewHandlerDelegate {
 
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if !UIAccessibilityIsReduceMotionEnabled() {
-            // This can conflict with the reduce motion fullscreen push animation
-            tableView.deselectRow(at: indexPath, animated: false)
-        }
-
         guard let posts = tableViewHandler.resultsController.fetchedObjects as? [ReaderPost] else {
             DDLogSwift.logError("[ReaderStreamViewController tableView:didSelectRowAtIndexPath:] fetchedObjects was nil.")
             return
@@ -1734,6 +1729,8 @@ extension ReaderStreamViewController : WPTableViewHandlerDelegate {
         }
 
         navigationController?.pushFullscreenViewController(controller, animated: true)
+
+        tableView.deselectRow(at: indexPath, animated: false)
     }
 
 

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -527,10 +527,19 @@ extension WPSplitViewController: UINavigationControllerDelegate {
         // left in the navigation stack that prefer to be fullscreen, then
         // animate back to a standard split view.
         if isCurrentlyFullscreen && !hasFullscreenViewControllersInStack {
-            setPrimaryViewControllerHidden(false, animated: animated)
+            let performTransition = { (animated: Bool) in
+                self.setPrimaryViewControllerHidden(false, animated: animated)
 
-            if animated && !isViewHorizontallyCompact() {
-                navigationController.navigationBar.fadeOutNavigationItems(animated: true)
+                if animated && !self.isViewHorizontallyCompact() {
+                    navigationController.navigationBar.fadeOutNavigationItems(animated: true)
+                }
+            }
+
+            if UIAccessibilityIsReduceMotionEnabled() {
+                view.hideWithBlankingSnapshot(afterScreenUpdates: false)
+                performTransition(false)
+            } else {
+                performTransition(animated)
             }
         }
     }
@@ -552,6 +561,10 @@ extension WPSplitViewController: UINavigationControllerDelegate {
             // we can set the delegate to nil (see: http://stackoverflow.com/a/38859457/570547)
             navigationController.interactivePopGestureRecognizer?.delegate = nil
             navigationController.interactivePopGestureRecognizer?.isEnabled = allowInteractiveBackGesture
+
+            if UIAccessibilityIsReduceMotionEnabled() {
+                view.fadeOutAndRemoveBlankingSnapshot()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #6478. Reopening #6557 against `develop`.

@kurzee, I think I've fixed up the couple of issues you were seeing: I've disabled the automatic cell deselection in the reader list when reduce motion is on (which should hopefully fix the flicker – I don't see any on my device), and I've fixed the broken cell selection when collapsed.

Make sure you test on a device, as the transition won't look right on some simulators, and check when the split view is both expanded and collapsed. Thanks!

Needs review: @kurzee 