### PR TITLE
Issue/aztec media interaction

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '0.11'
     pod 'WordPress-iOS-Editor', '1.8.1'
     pod 'WordPressCom-Analytics-iOS', '0.1.22'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => '297cb09fec269ab0168e3a7ced641d54cd258cc0'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => 'f682b3b2ca111875372781e1c55e1c28e2a1ce2b'
     pod 'wpxmlrpc', '~> 0.8'
 
     target :WordPressTest do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -178,7 +178,7 @@ DEPENDENCIES:
   - SVProgressHUD (~> 1.1.3)
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `297cb09fec269ab0168e3a7ced641d54cd258cc0`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `f682b3b2ca111875372781e1c55e1c28e2a1ce2b`)
   - WordPress-iOS-Editor (= 1.8.1)
   - WordPress-iOS-Shared (= 0.7.2)
   - WordPressCom-Analytics-iOS (= 0.1.22)
@@ -198,7 +198,7 @@ EXTERNAL SOURCES:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: 297cb09fec269ab0168e3a7ced641d54cd258cc0
+    :commit: f682b3b2ca111875372781e1c55e1c28e2a1ce2b
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -215,7 +215,7 @@ CHECKOUT OPTIONS:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: 297cb09fec269ab0168e3a7ced641d54cd258cc0
+    :commit: f682b3b2ca111875372781e1c55e1c28e2a1ce2b
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -261,6 +261,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 3bda8ac8cb8939c797fde230c093803c719aaad5
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: cca1110e59bc784c6da5e95ba5b5f4230048c176
+PODFILE CHECKSUM: bd59d46581226e9542778a6dceb472a2528c097e
 
 COCOAPODS: 1.1.1

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1252,8 +1252,8 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
         alertController.title = title
         alertController.message = message
         alertController.popoverPresentationController?.sourceView = richTextView
-        alertController.popoverPresentationController?.sourceRect = CGRect(origin: richTextView.center, size: CGSize(width: 1, height: 1))
-        alertController.popoverPresentationController?.permittedArrowDirections = .up
+        alertController.popoverPresentationController?.sourceRect = CGRect(origin: position, size: CGSize(width: 1, height: 1))
+        alertController.popoverPresentationController?.permittedArrowDirections = .any
         present(alertController, animated:true, completion: { () in
             UIMenuController.shared.setMenuVisible(false, animated: false)
         })


### PR DESCRIPTION
This PR improved the interaction with media by replacing the long press gesture for a double tap on image. First tap makes the image go to selection mode and second tap on it shows the related options.

How to test:
 - Start or edit a  post using Aztec
 - Add two images to it
 - Tap on a image ( see if image get an overlay saying tap to edit)
 - Tap on the image ( see if image displays the action sheet)
 - Tap outside the image to see if overlay goes away.

Needs review: @jleandroperez 