### PR TITLE
Fix encoding in TOS footer

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -137,8 +137,9 @@ import WordPressShared
     func configureTermsButtonText() {
         let string = NSLocalizedString("By creating an account you agree to the fascinating <u>Terms of Service</u>.",
                                        comment: "Message displayed when a verification code is needed")
-        let options = [
-            NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType
+        let options: [String: Any] = [
+            NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType,
+            NSCharacterEncodingDocumentAttribute: String.Encoding.utf8.rawValue
         ]
 
         let styledString = "<style>body {font-family: -apple-system, sans-serif; font-size:13px; color: #ffffff; text-align:center;}</style>" + string


### PR DESCRIPTION

![tos-encoding](https://cloud.githubusercontent.com/assets/8739/22786127/8c4588c4-eed7-11e6-80a6-6d0e345ce6d5.gif)


Much better:

![tos-encoding-after](https://cloud.githubusercontent.com/assets/8739/22786134/95d32540-eed7-11e6-8538-2bc9039cc1b9.png)


Needs review: @aerych 
