### PR TITLE
Include locale when creating account

### DIFF
--- a/WordPress/Classes/Networking/WordPressComServiceRemote.h
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.h
@@ -21,12 +21,14 @@ typedef void(^WordPressComServiceFailureBlock)(NSError *error);
  *  @param      email       The email to use for the new account.  Cannot be nil.
  *  @param      username    The username of the new account.  Cannot be nil.
  *  @param      password    The password of the new account.  Cannot be nil.
+ *  @param      locale      The locale for the new account.  Cannot be nil.
  *  @param      success     The block to execute on success.  Can be nil.
  *  @param      failure     The block to execute on failure.  Can be nil.
  */
 - (void)createWPComAccountWithEmail:(NSString *)email
                         andUsername:(NSString *)username
                         andPassword:(NSString *)password
+                          andLocale:(NSString *)locale
                             success:(WordPressComServiceSuccessBlock)success
                             failure:(WordPressComServiceFailureBlock)failure;
 

--- a/WordPress/Classes/Networking/WordPressComServiceRemote.m
+++ b/WordPress/Classes/Networking/WordPressComServiceRemote.m
@@ -8,6 +8,7 @@
 - (void)createWPComAccountWithEmail:(NSString *)email
                         andUsername:(NSString *)username
                         andPassword:(NSString *)password
+                          andLocale:(NSString *)locale
                             success:(WordPressComServiceSuccessBlock)success
                             failure:(WordPressComServiceFailureBlock)failure
 {
@@ -18,6 +19,7 @@
     [self createWPComAccountWithEmail:email
                           andUsername:username
                           andPassword:password
+                            andLocale:locale
                              validate:NO
                               success:success
                               failure:failure];
@@ -26,6 +28,7 @@
 - (void)createWPComAccountWithEmail:(NSString *)email
                         andUsername:(NSString *)username
                         andPassword:(NSString *)password
+                          andLocale:(NSString *)locale
                            validate:(BOOL)validate
                             success:(WordPressComServiceSuccessBlock)success
                             failure:(WordPressComServiceFailureBlock)failure
@@ -45,11 +48,12 @@
     
     NSDictionary *params = @{
                              @"email": email,
-                             @"username" : username,
-                             @"password" : password,
-                             @"validate" : @(validate),
-                             @"client_id" : [ApiCredentials client],
-                             @"client_secret" : [ApiCredentials secret]
+                             @"username": username,
+                             @"password": password,
+                             @"validate": @(validate),
+                             @"locale": locale,
+                             @"client_id": [ApiCredentials client],
+                             @"client_secret": [ApiCredentials secret]
                              };
     
     NSString *requestUrl = [self pathForEndpoint:@"users/new"

--- a/WordPress/Classes/Services/SignupService.swift
+++ b/WordPress/Classes/Services/SignupService.swift
@@ -135,10 +135,12 @@ open class SignupService: LocalCoreDataService {
                                    failure: @escaping SignupFailureBlock) {
 
         status(.creatingUser)
+        let locale = WordPressComLanguageDatabase().deviceLanguage.slug
         let remote = WordPressComServiceRemote(wordPressComRestApi: self.anonymousApi())
         remote?.createWPComAccount(withEmail: params.email,
                                             andUsername: params.username,
                                             andPassword: params.password,
+                                            andLocale: locale,
                                             success: { (responseDictionary) in
                                                 // Note: User creation is deferred until we have a WPCom auth token.
                                                 success()

--- a/WordPress/WordPressTest/WordPressComServiceRemoteRestTests.swift
+++ b/WordPress/WordPressTest/WordPressComServiceRemoteRestTests.swift
@@ -53,6 +53,7 @@ class WordPressComServiceRemoteRestTests: XCTestCase {
         service.createWPComAccount(withEmail: "fakeEmail",
                                             andUsername: "fakeUsername",
                                             andPassword: "fakePassword",
+                                            andLanguage: "en",
                                             success: { (responseObject) in
                                                 expect.fulfill()
                                                 XCTFail("This call should fail")

--- a/WordPress/WordPressTest/WordPressComServiceRemoteRestTests.swift
+++ b/WordPress/WordPressTest/WordPressComServiceRemoteRestTests.swift
@@ -53,7 +53,7 @@ class WordPressComServiceRemoteRestTests: XCTestCase {
         service.createWPComAccount(withEmail: "fakeEmail",
                                             andUsername: "fakeUsername",
                                             andPassword: "fakePassword",
-                                            andLanguage: "en",
+                                            andLocale: "en",
                                             success: { (responseObject) in
                                                 expect.fulfill()
                                                 XCTFail("This call should fail")


### PR DESCRIPTION
Fixes #5244 

To test:

- Switch phone to a non-English language (or change language in scheme editor)
- Run the app and sign up for a new site/account
- Verify that both the account and site language are set to the device language


Needs review: @aerych 
