### PR TITLE
Copy paste link to link dialog if a link is available.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -790,7 +790,15 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
     func showLinkDialog(forURL url: URL?, title: String?, range: NSRange) {
 
         let isInsertingNewLink = (url == nil)
-        // TODO: grab link from pasteboard if available
+        var urlToUse = url
+
+        if isInsertingNewLink {
+            let pasteboard = UIPasteboard.general
+            if let pastedURL = pasteboard.value(forPasteboardType:String(kUTTypeURL)) as? URL {
+                urlToUse = pastedURL
+            }
+        }
+
 
         let insertButtonTitle = isInsertingNewLink ? NSLocalizedString("Insert Link", comment: "Label action for inserting a link on the editor") : NSLocalizedString("Update Link", comment: "Label action for updating a link on the editor")
         let removeButtonTitle = NSLocalizedString("Remove Link", comment: "Label action for removing a link from the editor")
@@ -804,7 +812,7 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
             textField.clearButtonMode = UITextFieldViewMode.always
             textField.placeholder = NSLocalizedString("URL", comment: "URL text field placeholder")
 
-            textField.text = url?.absoluteString
+            textField.text = urlToUse?.absoluteString
 
             textField.addTarget(self,
                 action: #selector(AztecPostViewController.alertTextFieldDidChange),


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/250
How to test:

- Open Safari and open a site
- Tap on share icon on Safary and select the option Copy
- Jump to the Aztec demo app
- tap on the link button in a area where a link doesn't exist
- check that the link URL is pre-filled with the link copied from Safari

Needs review: @jleandroperez  