### PR TITLE
Reader: Ensure the scroll offset is not affected when traits are updated

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -426,8 +426,10 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
         // Make sure the text view is scrolled to the top the first time after
         // the view is first configured.
-        view.layoutIfNeeded()
-        textView.setContentOffset(CGPoint.zero, animated: false)
+        // TODO: Restore the following when we restore the full screen reader detail.
+        // Aerych 2017-02-09
+        // view.layoutIfNeeded()
+        //textView.setContentOffset(CGPoint.zero, animated: false)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -227,6 +227,22 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         // This is something we do to help with the resizing that can occur with
         // split screen multitasking on the iPad.
         view.layoutIfNeeded()
+
+        // NOTE: On the iPad, when being presented in a splitView, the size of
+        // the view and textView are updated after the view is added to its window.
+        // The traitCollection is updated after the call to viewWillAppear: finally
+        // providing the correct geometry for the view.  At this point the textView's
+        // insets need to be updated and, because updating the insets impacts
+        // the its contentOffset, the offset needs to be reset to zero.
+        // We should be able to remove this bit of code when we start showing
+        // the detail full screen again.
+        // Aerych - 2017-02-09
+        let offset = textView.contentOffset
+        updateContentInsets()
+        updateTextViewMargins()
+        if offset == .zero {
+            textView.setContentOffset(.zero, animated: false)
+        }
     }
 
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
Fixes #6288 (again :p )
I haven't traced this cause of this one back to a specific commit, but I'm guessing its related to reverting the full screen detail. 
The behavior we're seeing currently is the view, and subsequently the textView, do not have their final geometry until after `viewWillAppear:` has been called, and not until a subsequent call to `traitCollectionDidChange:`.  This differs from earlier behavior where the correct geometry was available immediately after the view was loaded. This is problematic for the textView as updating its contentInsets to match readable content margins affects its scroll offset,  hence the reemergence of the glitch.   This PR provides a temporary patch for this behavior until the full screen reader detail is restored.  

To test:
Like the example post provided by @kathrynwp in her latest comment on the issue.
View your liked stream and view the post detail in the split view. 
Confirm that the post loads scrolled to the top and not part way down the page.

Needs review: @frosty would you mind taking a look at this one? 
