### PR TITLE
Remove tags from post sharing

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -3,7 +3,7 @@ import SVProgressHUD
 
 @objc class PostSharingController: NSObject {
 
-    func shareController(_ title: String?, summary: String?, tags: String?, link: String?) -> UIActivityViewController {
+    func shareController(_ title: String?, summary: String?, link: String?) -> UIActivityViewController {
         var activityItems = [AnyObject]()
         let postDictionary = NSMutableDictionary()
 
@@ -33,11 +33,10 @@ import SVProgressHUD
         return controller
     }
 
-    func sharePost(_ title: String, summary: String, tags: String?, link: String?, fromBarButtonItem anchorBarButtonItem: UIBarButtonItem, inViewController viewController: UIViewController) {
+    func sharePost(_ title: String, summary: String, link: String?, fromBarButtonItem anchorBarButtonItem: UIBarButtonItem, inViewController viewController: UIViewController) {
         let controller = shareController(
             title,
             summary: summary,
-            tags: tags,
             link: link)
 
         if !UIDevice.isPad() {
@@ -54,11 +53,10 @@ import SVProgressHUD
         }
     }
 
-    func sharePost(_ title: String, summary: String, tags: String?, link: String?, fromView anchorView: UIView, inViewController viewController: UIViewController) {
+    func sharePost(_ title: String, summary: String, link: String?, fromView anchorView: UIView, inViewController viewController: UIViewController) {
         let controller = shareController(
             title,
             summary: summary,
-            tags: tags,
             link: link)
 
         if !UIDevice.isPad() {
@@ -81,7 +79,6 @@ import SVProgressHUD
         sharePost(
             post.titleForDisplay(),
             summary: post.contentPreviewForDisplay(),
-            tags: post.tags,
             link: post.permaLink,
             fromBarButtonItem: anchorBarButtonItem,
             inViewController: viewController)
@@ -92,7 +89,6 @@ import SVProgressHUD
         sharePost(
             post.titleForDisplay(),
             summary: post.contentPreviewForDisplay(),
-            tags: post.tags,
             link: post.permaLink,
             fromView: anchorView,
             inViewController: viewController)
@@ -103,14 +99,13 @@ import SVProgressHUD
         sharePost(
             post.titleForDisplay(),
             summary: post.contentPreviewForDisplay(),
-            tags: post.tags,
             link: post.permaLink,
             fromView: anchorView,
             inViewController: viewController)
     }
 
     func shareURL(url: NSURL, fromRect rect: CGRect, inView view: UIView, inViewController viewController: UIViewController) {
-        let controller = shareController("", summary: "", tags: "", link: url.absoluteString)
+        let controller = shareController("", summary: "", link: url.absoluteString)
 
         if !UIDevice.isPad() {
             viewController.present(controller, animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -13,9 +13,6 @@ import SVProgressHUD
         if let str = summary {
             postDictionary["summary"] = str
         }
-        if let str = tags {
-            postDictionary["tags"] = str
-        }
 
         activityItems.append(postDictionary)
         if let urlPath = link, let url = URL(string: urlPath) {

--- a/WordPress/WordPressTest/Posts/PostSharingControllerTests.swift
+++ b/WordPress/WordPressTest/Posts/PostSharingControllerTests.swift
@@ -9,13 +9,13 @@ class PostSharingControllerTests: XCTestCase {
 
         let sharingController = PostSharingController()
 
-        var controller = sharingController.shareController("test", summary: "test", tags: "test", link: "test")
+        var controller = sharingController.shareController("test", summary: "test", link: "test")
         XCTAssertNotNil(controller, "Controller should not be nil")
 
-        controller = sharingController.shareController("", summary: "", tags: "", link: "")
+        controller = sharingController.shareController("", summary: "", link: "")
         XCTAssertNotNil(controller, "Controller should not be nil")
 
-        controller = sharingController.shareController(nil, summary: nil, tags: nil, link: nil)
+        controller = sharingController.shareController(nil, summary: nil, link: nil)
         XCTAssertNotNil(controller, "Controller should not be nil")
     }
 


### PR DESCRIPTION
Fixes #6645 

To test:
- On a device, review a post in the post list
- Tap the share button
- Share to Messages
- Observe that tags aren't included in the Message

Needs review: @aerych 
Hey Eric, trade ya?