### PR TITLE
Correct the requested size of images.

### DIFF
--- a/WordPress/Classes/Utility/PhotonImageURLHelper.h
+++ b/WordPress/Classes/Utility/PhotonImageURLHelper.h
@@ -10,8 +10,9 @@
  The source image is resized and the URL is constructed with a
  default 80% quality as a speed/size optimization.
 
- @param size The desired "points" size of the photon image. The scale of the screen will be multiplied to this value. If height is set to zero the
- returned image will have a height proportional to the requested width.
+ @param size The desired "points" size of the photon image. The scale of the screen will be
+        multiplied to this value. If height is set to zero the returned image will have a
+        height proportional to the requested width.
  @param url The URL to the source image.
  
  @return A URL to the photon service with the source image as its subject.
@@ -22,8 +23,9 @@
 /**
  Create a "photonized" URL from the passed arguments.
 
- @param size The desired "points" size of the photon image. The scale of the screen will be multiplied to this value. If height is set to zero the
-        returned image will have a height proportional to the requested width.
+ @param size The desired "points" size of the photon image. The scale of the screen will be
+        multiplied to this value. If height is set to zero the returned image will have a height
+        proportional to the requested width.
  @param url The URL to the source image.
  @param forceResize By default Photon does not upscale beyond a certain percentage. 
         Setting this to YES forces the returned image to match the specified size.

--- a/WordPress/Classes/Utility/PhotonImageURLHelper.h
+++ b/WordPress/Classes/Utility/PhotonImageURLHelper.h
@@ -10,7 +10,8 @@
  The source image is resized and the URL is constructed with a
  default 80% quality as a speed/size optimization.
 
- @param size The desired size of the photon image. 
+ @param size The desired "points" size of the photon image. The scale of the screen will be multiplied to this value. If height is set to zero the
+ returned image will have a height proportional to the requested width.
  @param url The URL to the source image.
  
  @return A URL to the photon service with the source image as its subject.
@@ -21,7 +22,7 @@
 /**
  Create a "photonized" URL from the passed arguments.
 
- @param size The desired size of the photon image. If height is set to zero the
+ @param size The desired "points" size of the photon image. The scale of the screen will be multiplied to this value. If height is set to zero the
         returned image will have a height proportional to the requested width.
  @param url The URL to the source image.
  @param forceResize By default Photon does not upscale beyond a certain percentage. 

--- a/WordPress/Classes/Utility/WPImageURLHelper.swift
+++ b/WordPress/Classes/Utility/WPImageURLHelper.swift
@@ -6,7 +6,7 @@ open class WPImageURLHelper: NSObject {
      Adds to the provided url width and height parameters to allow the image to be resized on the server
 
      - parameter size: the required pixel size for the image.  If height is set to zero the
-     returned image will have a height proportional to the requested width and vice versa.
+                       returned image will have a height proportional to the requested width and vice versa.
      - parameter url:  the original url for the image
 
      - returns: an URL with the added query parameters.

--- a/WordPress/Classes/Utility/WPImageURLHelper.swift
+++ b/WordPress/Classes/Utility/WPImageURLHelper.swift
@@ -5,7 +5,8 @@ open class WPImageURLHelper: NSObject {
     /**
      Adds to the provided url width and height parameters to allow the image to be resized on the server
 
-     - parameter size: the required size for the image
+     - parameter size: the required pixel size for the image.  If height is set to zero the
+     returned image will have a height proportional to the requested width and vice versa.
      - parameter url:  the original url for the image
 
      - returns: an URL with the added query parameters.

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1324,16 +1324,20 @@ extension AztecPostViewController: TextViewMediaDelegate {
 
     func textView(_ textView: TextView, imageAtUrl url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Void) -> Void) -> UIImage {
         var requestURL = url
-        let imageMaxDimension = max(UIScreen.main.nativeBounds.size.width, UIScreen.main.nativeBounds.size.height)
-        let size = CGSize(width: imageMaxDimension, height: imageMaxDimension)
+        let imageMaxDimension = max(UIScreen.main.bounds.size.width, UIScreen.main.bounds.size.height)
+        //use height zero to maintain the aspect ratio when fetching
+        var size = CGSize(width: imageMaxDimension, height: 0)
         let request: URLRequest
         if url.isFileURL {
             request = URLRequest(url: url)
         } else if self.post.blog.isPrivate() {
             // private wpcom image needs special handling.
+            // the size that WPImageHelper expects is pixel size
+            size.width = size.width * UIScreen.main.scale
             requestURL = WPImageURLHelper.imageURLWithSize(size, forImageURL: requestURL)
             request = PrivateSiteURLProtocol.requestForPrivateSite(from: requestURL)
         } else {
+            // the size that PhotonImageURLHelper expects is points size
             requestURL = PhotonImageURLHelper.photonURL(with: size, forImageURL: requestURL)
             request = URLRequest(url: requestURL)
         }


### PR DESCRIPTION
This PR fixes an issue where images where being fetched on Aztec using incorrect dimension causing crop of images.

To test:
 - Create a post in Aztec
 - Insert an image on it
 - Check that after the upload is finished the image stays with the same aspect ratio and no crop is applied.
 - Check on wp.com and .org sites.


Needs review: @nheagy 