### PR TITLE
Media tests: change name of method to fix test, for whatever reason.

### DIFF
--- a/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
+++ b/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
@@ -29,7 +29,7 @@ class MediaLibraryPickerDataSourceTests: XCTestCase {
         ContextManager.overrideSharedInstance(nil)
     }
 
-    func testPixelSize() {
+    func testMediaPixelSize() {
         guard let media = newImageMedia() else {
             XCTFail("Media should be created without error")
             return


### PR DESCRIPTION
Dancing a bit on the insane side of things...

The test `testPixelSize` on `MediaLibraryPickerDataSourceTests` was crashing when you ran _all_ tests for our WordPressTests project. However, the test class itself would _not_ crash and would pass if you simply ran `MediaLibraryPickerDataSourceTests` by themselves, or even the individual test `testPixelSize` by itself.

So seemingly, you can fix this by simply renaming the test method from `testPixelSize` to anything else, such as `testMediaPixelSize` in this PR, for example. Why? I'm not sure. Swizzling issue? Maybe namespace collision with our other uses of `pixelSize`? Not clear to my eyes at the moment.

To test:
1. First run all tests on `develop` to see the original crash.
2. Switch to this branch `issue/media-broken-test-method` with the new method name.
3. Run all tests again, ensure the test class passes, no crash, no failures.
4. Question everything....

Needs review: @SergioEstevao you're far more familiar with these tests and Media methods in general, can you take a peak and double check there's not a larger issue here?