### PR TITLE
Notifications: reload the tableView after nuking notifications

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1049,6 +1049,7 @@ private extension NotificationsViewController {
             let helper = CoreDataHelper<Notification>(context: mainContext)
             helper.deleteAllObjects()
             try mainContext.save()
+            tableView.reloadData()
         } catch {
             DDLogSwift.logError("Error while trying to nuke Notifications Collection: [\(error)]")
         }


### PR DESCRIPTION
Fixes #6517 

This was a peculiar bug that I took a crack at after @frosty wanted a second set of eyes on it for his split-view implementation.

It wasn't super clear what was going on with the issue, but it did replicate every time. I guessed that after we nuke the notifications objects and save the context in `resetNotifications`, we need to go ahead and do a hard `reloadData` to wipe out the tableView, before subsequently pinging the `resultsController` afterwards during the account transitions.

Not 100% confident in this, but I am decently confident in it 😎 

To test:
1. Repeat the steps in the original issue, and also try with a different account when logging back in.

Needs review: @aerych can you take a spin since you found the original issue? Also, cc @jleandroperez for any obvious red flags you might see here.