### PR TITLE
AztecPostViewController: Sheet Passthru Fix

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -484,6 +484,27 @@ class AztecPostViewController: UIViewController {
 }
 
 
+// MARK: - SDK Workarounds!
+//
+extension AztecPostViewController {
+
+    /// Note:
+    /// When presenting an UIAlertController using a navigationBarButton as a source, the entire navigationBar
+    /// gets set as a passthru view, allowing invalid scenarios, such as: pressing the Dismiss Button, while there's
+    /// an ActionSheet onscreen.
+    ///
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        super.present(viewControllerToPresent, animated: flag) {
+            if let alert = viewControllerToPresent as? UIAlertController, alert.preferredStyle == .actionSheet {
+                alert.popoverPresentationController?.passthroughViews = nil
+            }
+
+            completion?()
+        }
+    }
+}
+
+
 // MARK: - Actions
 extension AztecPostViewController {
     @IBAction func publishButtonTapped(sender: UIBarButtonItem) {


### PR DESCRIPTION
Fixes #6656

### To test:
0. Launch WPiOS on an iPad Device
1. Open Aztec and type some content
2. Press the top right `...` button to display the **More** action sheet
3. Verify that pressing the top left `x` button dismisses the popover
4. Press the top left `x` button to display the **Dismiss** action sheet
5. Verify that pressing the top right `...` button dismisses the popover
6. Add an image to the post
7. Double tap over the asset to trigger the Image Actions popover
8. Verify that pressing over the top left button (`x`) or top right (`...`) dismisses the popover

Needs review: @astralbodies 
Thanks for helping me out @SergioEstevao!!!

Closes #6656
@astralbodies ain't this an (extra) evil PR? 6666!