### PR TITLE
Adjust up/down buttons for notifications (7.0)

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -70,11 +70,11 @@ class NotificationDetailsViewController: UIViewController {
 
     /// Previous NavBar Navigation Button
     ///
-    var previousNavigationButton: UIBarButtonItem!
+    var previousNavigationButton: UIButton!
 
     /// Next NavBar Navigation Button
     ///
-    var nextNavigationButton: UIBarButtonItem!
+    var nextNavigationButton: UIButton!
 
     /// Arrows Navigation Datasource
     ///
@@ -287,21 +287,55 @@ extension NotificationDetailsViewController {
                                          target: nil,
                                          action: nil)
 
-        let previousButton = UIBarButtonItem(image: Gridicon.iconOfType(.arrowDown),
-                                             style: .plain,
-                                             target: self,
-                                             action: #selector(previousNotificationWasPressed))
+        let next = UIButton(type: .custom)
+        next.setImage(Gridicon.iconOfType(.arrowUp), for: .normal)
+        next.addTarget(self, action: #selector(nextNotificationWasPressed), for: .touchUpInside)
 
-        let nextButton = UIBarButtonItem(image: Gridicon.iconOfType(.arrowUp),
-                                         style: .plain,
-                                         target: self,
-                                         action: #selector(nextNotificationWasPressed))
+        let previous = UIButton(type: .custom)
+        previous.setImage(Gridicon.iconOfType(.arrowDown), for: .normal)
+        previous.addTarget(self, action: #selector(previousNotificationWasPressed), for: .touchUpInside)
+
+        /*
+
+            |                     |           |                     |
+            |-------- 24 ---------|--- 12 ----|--------- 24 --------|
+            |                     |           |                     |
+        --- +---------------------+           +---------------------+
+         |  |                     |           |                     |
+         |  |         |           |           |         /|\         |
+         |  |         |           |           |        / | \        |
+         |  |         |           |           |       /  |  \       |
+         |  |         |           |           |      /   |   \      |
+         |  |         |           |           |     /    |    \     |
+            |         |           |           |          |          |
+         2  |         |           |           |          |          |
+         4  |         |           |           |          |          |
+            |         |           |           |          |          |
+         |  |    \    |    /      |           |          |          |
+         |  |     \   |   /       |           |          |          |
+         |  |      \  |  /        |           |          |          |
+         |  |       \ | /         |           |          |          |
+         |  |        \|/          |           |          |          |
+         |  |                     |           |                     |
+        --- +---------------------+           +---------------------+
+
+         https://github.com/wordpress-mobile/WordPress-iOS/issues/6662#issue-207316186
+         */
+        let buttonSize = CGFloat(24)
+        let buttonSpacing = CGFloat(12)
+
+        let width = buttonSize + buttonSpacing + buttonSize
+        let height = buttonSize
+        let buttons = UIStackView(arrangedSubviews: [previous, next])
+        buttons.axis = .horizontal
+        buttons.spacing = buttonSpacing
+        buttons.frame = CGRect(x: 0, y: 0, width: width, height: height)
 
         navigationItem.backBarButtonItem = backButton
-        navigationItem.rightBarButtonItems = [nextButton, previousButton]
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: buttons)
 
-        previousNavigationButton = previousButton
-        nextNavigationButton = nextButton
+        previousNavigationButton = previous
+        nextNavigationButton = next
     }
 
     func setupMainView() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -295,32 +295,7 @@ extension NotificationDetailsViewController {
         previous.setImage(Gridicon.iconOfType(.arrowDown), for: .normal)
         previous.addTarget(self, action: #selector(previousNotificationWasPressed), for: .touchUpInside)
 
-        /*
-
-            |                     |           |                     |
-            |-------- 24 ---------|--- 12 ----|--------- 24 --------|
-            |                     |           |                     |
-        --- +---------------------+           +---------------------+
-         |  |                     |           |                     |
-         |  |         |           |           |         /|\         |
-         |  |         |           |           |        / | \        |
-         |  |         |           |           |       /  |  \       |
-         |  |         |           |           |      /   |   \      |
-         |  |         |           |           |     /    |    \     |
-            |         |           |           |          |          |
-         2  |         |           |           |          |          |
-         4  |         |           |           |          |          |
-            |         |           |           |          |          |
-         |  |    \    |    /      |           |          |          |
-         |  |     \   |   /       |           |          |          |
-         |  |      \  |  /        |           |          |          |
-         |  |       \ | /         |           |          |          |
-         |  |        \|/          |           |          |          |
-         |  |                     |           |                     |
-        --- +---------------------+           +---------------------+
-
-         https://github.com/wordpress-mobile/WordPress-iOS/issues/6662#issue-207316186
-         */
+        // https://github.com/wordpress-mobile/WordPress-iOS/issues/6662#issue-207316186
         let buttonSize = CGFloat(24)
         let buttonSpacing = CGFloat(12)
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -326,7 +326,7 @@ extension NotificationDetailsViewController {
 
         let width = buttonSize + buttonSpacing + buttonSize
         let height = buttonSize
-        let buttons = UIStackView(arrangedSubviews: [previous, next])
+        let buttons = UIStackView(arrangedSubviews: [next, previous])
         buttons.axis = .horizontal
         buttons.spacing = buttonSpacing
         buttons.frame = CGRect(x: 0, y: 0, width: width, height: height)


### PR DESCRIPTION
Fixes #6662

As requested, making the spacing between the arrows a bit tighter, and changed the order of buttons (now it's ⬆️ ⬇️ )

![updown](https://cloud.githubusercontent.com/assets/8739/22924154/613041b2-f2a4-11e6-89bd-58162342da01.png)



Needs review: @jleandroperez @mattmiklic 
