### PR TITLE
Notifications: use readable width for maxMediaWidth in comments.

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -950,11 +950,8 @@ private extension NotificationDetailsViewController {
     }
 
     var maxMediaEmbedWidth: CGFloat {
-        let textPadding = NoteBlockTextTableViewCell.defaultLabelPadding
-        let portraitWidth = hasHorizontallyCompactView() ? view.bounds.width : WPTableViewFixedWidth
-        let maxWidth = portraitWidth - (textPadding.left + textPadding.right)
-
-        return maxWidth
+        let readableWidth = view.readableContentGuide.layoutFrame.size.width
+        return readableWidth > 0 ? readableWidth : view.frame.size.width
     }
 }
 


### PR DESCRIPTION
This is a leftover Notifications readability change, which I didn't notice before.

I reworked our `maxMediaWidth` calculation to instead rely on the `readableContentGuide.layoutFrame` for an expected max width. This allows wide images to correctly size up for our expected readable width, vs the ole fixed width or view width it used before.

To test:
1. Add a wide image (like a desktop wallpaper) to a comment on a site. You can easily add an image by editing the comment in WP-Admin.
2. In the app, log into the account which would have the corresponding comment notification with the insert image.
3. Open the detail notification view of that comment notification.
4. Ensure the maxWidth is as expected for an image that's wide enough to fill.
5. Check on iPad, iPhone and iPhone Plus.
6. Also check on landscape and portrait orientations for each.

Needs review: @frosty can you take this for a spin? 🕺 
