### PR TITLE
Site Management > Start Over: readability and autosizing

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
@@ -48,6 +48,10 @@ open class StartOverViewController: UITableViewController {
 
         title = NSLocalizedString("Start Over", comment: "Title of Start Over settings page")
 
+        tableView.cellLayoutMarginsFollowReadableWidth = true
+        tableView.estimatedSectionHeaderHeight = 100.0
+        tableView.sectionHeaderHeight = UITableViewAutomaticDimension
+
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
     }
 
@@ -73,13 +77,6 @@ open class StartOverViewController: UITableViewController {
 
     override open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         return headerView
-    }
-
-    override open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        headerView.layoutWidth = tableView.frame.width
-        let height = headerView.intrinsicContentSize.height
-
-        return height
     }
 
     // MARK: - Actions

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/TableViewHeaderDetailView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/TableViewHeaderDetailView.swift
@@ -26,22 +26,6 @@ open class TableViewHeaderDetailView: UITableViewHeaderFooterView {
         }
     }
 
-    /// layoutWidth may be set from heightForHeaderInSection then intrinsicSize queried for height
-    ///
-    open var layoutWidth: CGFloat = 0 {
-        didSet {
-            layoutWidth = Style.layoutWidthFitting(layoutWidth)
-            if layoutWidth != oldValue {
-                let labelWidth = max(layoutWidth - stackView.layoutMargins.left - stackView.layoutMargins.right, 0)
-                titleLabel.preferredMaxLayoutWidth = labelWidth
-                detailLabel.preferredMaxLayoutWidth = labelWidth
-
-                stackWidthConstraint?.constant = layoutWidth
-                setNeedsUpdateConstraints()
-            }
-        }
-    }
-
     // MARK: - Private Aliases
 
     fileprivate typealias Style = WPStyleGuide.TableViewHeaderDetailView
@@ -77,13 +61,9 @@ open class TableViewHeaderDetailView: UITableViewHeaderFooterView {
         stackView.alignment = .fill
         stackView.distribution = .fill
         stackView.spacing = Style.headerDetailSpacing
-        stackView.layoutMargins = Style.layoutMargins
-        stackView.isLayoutMarginsRelativeArrangement = true
 
         return stackView
     }()
-
-    fileprivate var stackWidthConstraint: NSLayoutConstraint?
 
     // MARK: - Initializers
 
@@ -112,34 +92,20 @@ open class TableViewHeaderDetailView: UITableViewHeaderFooterView {
     }
 
     fileprivate func stackSubviews() {
+
         contentView.addSubview(stackView)
         stackView.addArrangedSubview(titleLabel)
         stackView.addArrangedSubview(detailLabel)
 
-        stackView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
-        stackWidthConstraint = stackView.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width)
-        stackWidthConstraint?.isActive = true
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: contentView.readableContentGuide.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: contentView.readableContentGuide.bottomAnchor),
+            ])
     }
 
     // MARK: - View Lifecycle
-
-    override open func layoutSubviews() {
-        super.layoutSubviews()
-
-        layoutWidth = frame.size.width
-    }
-
-    override open var intrinsicContentSize: CGSize {
-        guard layoutWidth > 0 else {
-            return CGSize.zero
-        }
-
-        let titleSize = titleLabel.intrinsicContentSize
-        let detailSize = detailLabel.intrinsicContentSize
-        let height = stackView.layoutMargins.top + titleSize.height + stackView.spacing + detailSize.height + stackView.layoutMargins.bottom
-
-        return CGSize(width: layoutWidth, height: height)
-    }
 
     override open func prepareForReuse() {
         super.prepareForReuse()
@@ -162,20 +128,6 @@ extension WPStyleGuide {
         public static let detailColor = WPStyleGuide.greyDarken10()
 
         // MARK: - Metrics
-
-        public static func layoutWidthFitting(_ width: CGFloat) -> CGFloat {
-            var result = max(width, sideMargin * 2)
-            if UIDevice.isPad() {
-                result = min(result, WPTableViewFixedWidth)
-            }
-            return result
-        }
-
-        public static let topMargin: CGFloat = 21
-        public static let bottomMargin: CGFloat = 8
-        public static let sideMargin: CGFloat = 16
-        public static let layoutMargins = UIEdgeInsets(top: topMargin, left: sideMargin, bottom: bottomMargin, right: sideMargin)
-
         public static let headerDetailSpacing: CGFloat = 8
     }
 }


### PR DESCRIPTION
This PR reworks our custom `TableViewHeaderDetailView` for readability and autosizing, which is currently only used in `StartOverViewController`.

Particularly, we really just wanted to get away from its use of custom margins and `WPTableViewFixedWidth`, and rely on readable margins instead. We also autosize it via automatic dimension.

To test:
1. Open up Site Settings on a .COM site.
2. Scroll down, open up the Start Over selection.
3. Check that the header view with labels is loaded correctly and aligned with the expected readable margins.
4. Check on iPad, iPhone and iPhone Plus.

Needs review: @frosty can you take a look? (no rush)