### PR TITLE
Aztec: First Responder Handling

### DIFF
--- a/WordPress/Classes/Extensions/UIView+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIView+Helpers.swift
@@ -2,23 +2,8 @@ import Foundation
 
 
 extension UIView {
-    // MARK: - Public Methods
-    public func pinSubview(_ subview: UIView, aboveSubview: UIView) {
-        let constraint = NSLayoutConstraint(item: subview, attribute: .bottom, relatedBy: .equal, toItem: aboveSubview, attribute: .top, multiplier: 1, constant: 0)
-        addConstraint(constraint)
-    }
 
-    public func pinSubviewAtBottom(_ subview: UIView) {
-        let newConstraints = [
-            NSLayoutConstraint(item: self, attribute: .leading,  relatedBy: .equal, toItem: subview, attribute: .leading,  multiplier: 1, constant: 0),
-            NSLayoutConstraint(item: self, attribute: .trailing, relatedBy: .equal, toItem: subview, attribute: .trailing, multiplier: 1, constant: 0),
-            NSLayoutConstraint(item: self, attribute: .bottom,   relatedBy: .equal, toItem: subview, attribute: .bottom,   multiplier: 1, constant: 0),
-        ]
-
-        addConstraints(newConstraints)
-    }
-
-    public func pinSubviewAtCenter(_ subview: UIView) {
+    func pinSubviewAtCenter(_ subview: UIView) {
         let newConstraints = [
             NSLayoutConstraint(item: self, attribute: .centerX,  relatedBy: .equal, toItem: subview, attribute: .centerX,  multiplier: 1, constant: 0),
             NSLayoutConstraint(item: self, attribute: .centerY,  relatedBy: .equal, toItem: subview, attribute: .centerY,  multiplier: 1, constant: 0)
@@ -27,7 +12,7 @@ extension UIView {
         addConstraints(newConstraints)
     }
 
-    public func pinSubviewToAllEdges(_ subview: UIView) {
+    func pinSubviewToAllEdges(_ subview: UIView) {
         let newConstraints = [
             NSLayoutConstraint(item: self, attribute: .leading,  relatedBy: .equal, toItem: subview, attribute: .leading,  multiplier: 1, constant: 0),
             NSLayoutConstraint(item: self, attribute: .trailing, relatedBy: .equal, toItem: subview, attribute: .trailing, multiplier: 1, constant: 0),
@@ -38,49 +23,21 @@ extension UIView {
         addConstraints(newConstraints)
     }
 
-    public func pinSubviewToAllEdgeMargins(_ subview: UIView) {
+    func pinSubviewToAllEdgeMargins(_ subview: UIView) {
         subview.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor).isActive = true
         subview.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor).isActive = true
         subview.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor).isActive = true
         subview.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor).isActive = true
     }
 
-    public func constraintForAttribute(_ attribute: NSLayoutAttribute) -> CGFloat? {
-        for constraint in constraints {
-            if constraint.firstItem as! NSObject == self {
-                if constraint.firstAttribute == attribute || constraint.secondAttribute == attribute {
-                    return constraint.constant
-                }
-            }
         }
-        return nil
-    }
 
-    public func updateConstraint(_ attribute: NSLayoutAttribute, constant: CGFloat) {
-        updateConstraintWithFirstItem(self, attribute: attribute, constant: constant)
-    }
-
-    public func updateConstraintWithFirstItem(_ firstItem: NSObject!, attribute: NSLayoutAttribute, constant: CGFloat) {
-        for constraint in constraints {
-            if constraint.firstItem as! NSObject == firstItem {
-                if constraint.firstAttribute == attribute || constraint.secondAttribute == attribute {
-                    constraint.constant = constant
-                }
             }
+
         }
     }
 
-    public func updateConstraintWithFirstItem(_ firstItem: NSObject!, secondItem: NSObject!, firstItemAttribute: NSLayoutAttribute, secondItemAttribute: NSLayoutAttribute, constant: CGFloat) {
-        for constraint in constraints {
-            if (constraint.firstItem as! NSObject == firstItem) && (constraint.secondItem as? NSObject == secondItem) {
-                if constraint.firstAttribute == firstItemAttribute && constraint.secondAttribute == secondItemAttribute {
-                    constraint.constant = constant
-                }
-            }
-        }
-    }
-
-    public func userInterfaceLayoutDirection() -> UIUserInterfaceLayoutDirection {
+    func userInterfaceLayoutDirection() -> UIUserInterfaceLayoutDirection {
         return UIView.userInterfaceLayoutDirection(for: semanticContentAttribute)
     }
 }

--- a/WordPress/Classes/Extensions/UIView+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIView+Helpers.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 
+// MARK: - UIView Helpers
+//
 extension UIView {
 
     func pinSubviewAtCenter(_ subview: UIView) {
@@ -30,11 +32,20 @@ extension UIView {
         subview.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor).isActive = true
     }
 
+    func findFirstResponder() -> UIView? {
+        if isFirstResponder {
+            return self
         }
 
+        for subview in subviews {
+            guard let responder = subview.findFirstResponder() else {
+                continue
             }
 
+            return responder
         }
+
+        return nil
     }
 
     func userInterfaceLayoutDirection() -> UIUserInterfaceLayoutDirection {

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1162,10 +1162,6 @@ fileprivate extension AztecPostViewController {
     }
 
     func stopEditing() {
-        if titleTextField.isFirstResponder {
-            titleTextField.resignFirstResponder()
-        }
-
         view.endEditing(true)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -298,17 +298,13 @@ class AztecPostViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        // We can only configure the dismiss button, when we know the way this VC will be presented
         configureDismissButton()
-
-        // Wire Notification Listeners!
         startListeningToNotifications()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        // Bring back the keyboard on the last known Responder
         restoreFirstResponder()
     }
 
@@ -316,10 +312,7 @@ class AztecPostViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        // Notifications Listeners Cleanup
         stopListeningToNotifications()
-
-        // Remember the current First Responder
         rememberFirstResponder()
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -167,6 +167,7 @@ class AztecPostViewController: UIViewController {
         }
     }
 
+
     /// Post being currently edited
     ///
     fileprivate(set) var post: AbstractPost {
@@ -196,6 +197,8 @@ class AztecPostViewController: UIViewController {
     }()
 
 
+    /// Media Progress Coordinator
+    ///
     fileprivate lazy var mediaProgressCoordinator: MediaProgressCoordinator = {
         let coordinator = MediaProgressCoordinator()
         coordinator.delegate = self
@@ -203,6 +206,8 @@ class AztecPostViewController: UIViewController {
     }()
 
 
+    /// Media Progress View
+    ///
     fileprivate lazy var mediaProgressView: UIProgressView = {
         let progressView = UIProgressView(progressViewStyle: .bar)
         progressView.backgroundColor = WPStyleGuide.wordPressBlue()
@@ -212,6 +217,9 @@ class AztecPostViewController: UIViewController {
         return progressView
     }()
 
+
+    /// Selected Text Attachment
+    ///
     fileprivate var currentSelectedAttachment: TextAttachment?
 
     /// Maintainer of state for editor - like for post button
@@ -230,6 +238,7 @@ class AztecPostViewController: UIViewController {
 
         return context
     }()
+
 
 
     // MARK: - Lifecycle Methods

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -222,6 +222,12 @@ class AztecPostViewController: UIViewController {
     ///
     fileprivate var currentSelectedAttachment: TextAttachment?
 
+
+    /// Last Interface Element that was a First Responder
+    ///
+    fileprivate var lastFirstResponder: UIView?
+
+
     /// Maintainer of state for editor - like for post button
     ///
     fileprivate(set) lazy var postEditorStateContext: PostEditorStateContext = {
@@ -299,11 +305,22 @@ class AztecPostViewController: UIViewController {
         startListeningToNotifications()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // Bring back the keyboard on the last known Responder
+        restoreFirstResponder()
+    }
+
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
+        // Notifications Listeners Cleanup
         stopListeningToNotifications()
+
+        // Remember the current First Responder
+        rememberFirstResponder()
     }
 
 
@@ -319,6 +336,7 @@ class AztecPostViewController: UIViewController {
         //    [self.titleToolbar configureForHorizontalSizeClass:newCollection.horizontalSizeClass];
 
     }
+
 
     // MARK: - Configuration Methods
 
@@ -408,6 +426,15 @@ class AztecPostViewController: UIViewController {
         let notificationCenter = NotificationCenter.default
         notificationCenter.removeObserver(self, name: .UIKeyboardWillShow, object: nil)
         notificationCenter.removeObserver(self, name: .UIKeyboardWillHide, object: nil)
+    }
+
+    func rememberFirstResponder() {
+        lastFirstResponder = view.findFirstResponder()
+    }
+
+    func restoreFirstResponder() {
+        let nextFirstResponder = lastFirstResponder ?? titleTextField
+        nextFirstResponder.becomeFirstResponder()
     }
 
     func refreshInterface() {
@@ -694,7 +721,6 @@ private extension AztecPostViewController {
         alert.addCancelActionWithTitle(MoreSheetAlert.cancelTitle)
         alert.popoverPresentationController?.barButtonItem = moreBarButtonItem
 
-        view.endEditing(true)
         present(alert, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
### Details:
- By default, the Title TextField will become the first responder
- Whenever Aztec is about to disappear, we'll store the previous First Responder
- On viewWillAppear, we'll restore the previous first responder
- Did some cleanup in `UIView+Helpers`!

Closes #6673

### To test:
1. Launch Aztec
2. Verify that the Title TextField is the First Responder
3. Press the TextView
4. Open `More` (Top Right navBar button) > `Options`
5. Return to Aztec
6. Verify that the TextView becomes first responder, again.

Needs review: @astralbodies 
cc @diegoreymendez 
