### PR TITLE
Notifications: fix for broken layout of action buttons

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -632,7 +632,7 @@ private extension NotificationDetailsViewController {
         // Setup: Properties
         // Note: Approve Action is actually a synonym for 'Edit' (Based on Calypso's basecode)
         //
-        cell.isReplyEnabled     = !hasHorizontallyCompactView() && commentBlock.isActionOn(.Reply)
+        cell.isReplyEnabled     = !shouldAttachReplyView && commentBlock.isActionOn(.Reply)
         cell.isLikeEnabled      = commentBlock.isActionEnabled(.Like)
         cell.isApproveEnabled   = commentBlock.isActionEnabled(.Approve)
         cell.isTrashEnabled     = commentBlock.isActionEnabled(.Trash)

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -72,7 +72,7 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
     ///
     var isReplyEnabled: Bool = false {
         didSet {
-            btnReply.isHidden = !isReplyEnabled
+            toggleAction(button: btnReply, hidden: !isReplyEnabled)
         }
     }
 
@@ -80,7 +80,7 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
     ///
     var isLikeEnabled: Bool = false {
         didSet {
-            btnLike.isHidden = !isLikeEnabled
+            toggleAction(button: btnLike, hidden: !isLikeEnabled)
         }
     }
 
@@ -88,7 +88,7 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
     ///
     var isApproveEnabled: Bool = false {
         didSet {
-            btnApprove.isHidden = !isApproveEnabled
+            toggleAction(button: btnApprove, hidden: !isApproveEnabled)
         }
     }
 
@@ -96,7 +96,7 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
     ///
     var isTrashEnabled: Bool = false {
         didSet {
-            btnTrash.isHidden = !isTrashEnabled
+            toggleAction(button: btnTrash, hidden: !isTrashEnabled)
         }
     }
 
@@ -104,7 +104,7 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
     ///
     var isSpamEnabled: Bool = false {
         didSet {
-            btnSpam.isHidden = !isSpamEnabled
+            toggleAction(button: btnSpam, hidden: !isSpamEnabled)
         }
     }
 
@@ -112,7 +112,7 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
     ///
     var isEditEnabled: Bool = false {
         didSet {
-            btnEdit.isHidden = !isEditEnabled
+            toggleAction(button: btnEdit, hidden: !isEditEnabled)
         }
     }
 
@@ -268,9 +268,23 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
 
 
 
-// MARK: - Animation Helpers
+// MARK: - Action Button Helpers
 //
 private extension NoteBlockActionsTableViewCell {
+
+    func toggleAction(button: UIButton, hidden: Bool) {
+        button.isHidden = hidden
+        /*
+         * Since these buttons are in a stackView, and since they are
+         * subclasses of `VerticallyStackedButton`, we need to zero the alpha of the button.
+         * This keeps the custom layout in `VerticallyStackedButton` from breaking out
+         * of the constraint-based layout the stackView sets on the button, once hidden.
+         * Note: ideally, we wouldn't be doing custom layout in `VerticallyStackedButton`.
+         * - Brent Feb 15/2017
+         */
+        button.alpha = hidden ? 0.0 : 1.0
+    }
+
     func animateLikeButton(_ button: UIButton, completion: @escaping (() -> Void)) {
         guard let overlayImageView = overlayForButton(button, state: .selected) else {
             return


### PR DESCRIPTION
This fixes the issue in which a button in `NoteBlockActionsTableViewCell` would break out of its `isHidden` layout when hidden in the stackView.

Since we're doing custom layout on `layoutSubviews` for these buttons with `VerticallyStackedButton`, we need to just go ahead and hide these buttons altogether when hidden, via `alpha`.

Note: I thought about not using alpha, but all alternatives point to a refactor of these buttons/action views. For another day.

To test:
1. On iPad, landscape, open a Notification comment.
2. Pull in a multitasking split that takes up the right third of the screen space.
3. Notice a reply action button is still available.
4. Rotate to portrait, but keep your eye on the reply button. It should disappear with ease and not stick around after the orientation change.
5. ☕️ 

Needs review: @frosty can you give this a spin since you found it? 🕶 And, it should also fix it for your branch as well.
