### PR TITLE
Use current site for new posts

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -298,11 +298,6 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     
     // Setup the Account
     account.defaultBlog = defaultBlog;
-    
-    // DefaultBlog should be flagged as Last Used
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-    [blogService flagBlogAsLastUsed:account.defaultBlog];
 }
 
 - (void)setupAppExtensionsWithDefaultAccount

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -10,11 +10,7 @@ class EditPostViewController: UIViewController {
     fileprivate(set) var post: Post?
     fileprivate var hasShownEditor = false
     fileprivate var editingExistingPost = false
-    fileprivate(set) lazy var blog: Blog = {
-        let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-        return blogService.lastUsedOrFirstBlog()!
-    }()
+    fileprivate let blog: Blog
     fileprivate lazy var postPost: PostPostViewController = {
         return UIStoryboard(name: "PostPost", bundle: nil).instantiateViewController(withIdentifier: "PostPostViewController") as! PostPostViewController
     }()
@@ -48,29 +44,21 @@ class EditPostViewController: UIViewController {
         self.init(post: nil, blog: blog)
     }
 
-    /// Initialize as an editor to create a new post for the last used or default blog
-    convenience init() {
-        self.init(post: nil, blog: nil)
-    }
-
-
     /// Initialize as an editor with a specified post to edit and blog to post too.
     ///
     /// - Parameters:
     ///   - post: the post to edit
     ///   - blog: the blog to create a post for, if post is nil
     /// - Note: it's preferable to use one of the convenience initializers
-    fileprivate init(post: Post?, blog: Blog?) {
+    fileprivate init(post: Post?, blog: Blog) {
         self.post = post
         if let post = post {
             if !post.isDraft() {
                 editingExistingPost = true
             }
         }
+        self.blog = blog
         super.init(nibName: nil, bundle: nil)
-        if let blog = blog {
-            self.blog = blog
-        }
         modalPresentationStyle = .fullScreen
         modalTransitionStyle = .coverVertical
         restorationIdentifier = RestorationKey.viewController.rawValue
@@ -82,7 +70,7 @@ class EditPostViewController: UIViewController {
     }
 
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
+        fatalError("init(coder:) has not been implemented")
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -283,7 +271,7 @@ extension EditPostViewController: UIViewControllerRestoration {
             let post = try? context.existingObject(with: postID),
             let reloadedPost = post as? Post
             else {
-                return EditPostViewController()
+                return nil
         }
 
         return EditPostViewController(post: reloadedPost)

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -426,11 +426,18 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         [self dismissViewControllerAnimated:NO completion:nil];
     }
 
-    EditPostViewController* editor = [EditPostViewController new];
+    Blog *blog = [self currentlyVisibleBlog];
+    if (blog == nil) {
+        NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+        BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+        blog = [blogService lastUsedOrFirstBlog];
+    }
+
+    EditPostViewController* editor = [[EditPostViewController alloc] initWithBlog:blog];
     editor.modalPresentationStyle = UIModalPresentationFullScreen;
     editor.showImmediately = !animated;
     editor.openWithMediaPicker = openToMedia;
-    [WPAppAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar"} withBlog:editor.blog];
+    [WPAppAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar"} withBlog:blog];
     [self presentViewController:editor animated:NO completion:nil];
     return;
 }
@@ -524,6 +531,18 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
             break;
     }
     return currentlySelectedScreen;
+}
+
+- (Blog *)currentlyVisibleBlog
+{
+    if (self.selectedIndex != WPTabMySites) {
+        return nil;
+    }
+
+    BlogDetailsViewController *blogDetailsController = (BlogDetailsViewController *)[[self.blogListNavigationController.viewControllers wp_filter:^BOOL(id obj) {
+        return [obj isKindOfClass:[BlogDetailsViewController class]];
+    }] firstObject];
+    return blogDetailsController.blog;
 }
 
 #pragma mark - UITabBarControllerDelegate methods


### PR DESCRIPTION
As noted in #5480, the previous code had a couple issues:
- We were flagging the primary blog as the "last used" on every account sync (effectively, every time the user visited the Me Tab, contacted support, logged in, or connected to Jetpack).
- The post button in the tab bar would use the "last used" even if the user was on a specific site.

In this PR:
- We don't flag the primary blog as "last used", ever. Since we'd fall back to the primary if there was no "last used", it makes no sense to save it there.
- Tapping the post button will check first if the "My Sites" tab is selected, and if there is a site detail in the navigation stack (i.e. not on the sites list). In that case, it'll create a post in that blog, otherwise it'll default to the primary (or first) blog.
- Moved the blog selection logic to `WPTabBarController`, and make `blog` non-optional for `EditPostController`. 

I think `WPTabBarController` is doing way too much stuff and that this logic shouldn't be in there, but I also think that's out of scope for this bug.

Fixes #5480

To test:

- On a fresh install, log in to an account with multiple sites
- Tapping on new post should create a post for the primary blog
- Use the blog selector and pick a different blog. Close the editor
- Tapping on new post should create a post for the other blog.
- Navigate to the primary blog's posts list.
- Tapping on new post should create a post for the primary blog

Needs review: @nheagy 