### PR TITLE
Improves the title placeholder for the native editor.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -44,7 +44,7 @@ class AztecPostViewController: UIViewController {
         let tv = UITextView()
 
         let toolbar = self.createToolbar(htmlMode: true)
-        let accessibilityLabel = NSLocalizedString("HTML Content", comment: "Post HTML content")
+        let accessibilityLabel = NSLocalizedString("Post content", comment: "Post content")
         self.configureDefaultProperties(for: tv, using: toolbar, accessibilityLabel: accessibilityLabel)
         toolbar.formatter = self
         tv.isHidden = true
@@ -56,7 +56,7 @@ class AztecPostViewController: UIViewController {
     /// Title's TextField
     ///
     fileprivate(set) lazy var titleTextField: UITextField = {
-        let placeholderText = NSLocalizedString("Post title", comment: "Placeholder for the post title.")
+        let placeholderText = NSLocalizedString("Title", comment: "Placeholder for the post title.")
         let tf = UITextField()
 
         tf.accessibilityLabel = NSLocalizedString("Title", comment: "Post title")

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -61,7 +61,7 @@ class AztecPostViewController: UIViewController {
 
         tf.accessibilityLabel = NSLocalizedString("Title", comment: "Post title")
         tf.attributedPlaceholder = NSAttributedString(string: placeholderText,
-                                                      attributes: [NSForegroundColorAttributeName: WPStyleGuide.greyLighten30()])
+                                                      attributes: [NSForegroundColorAttributeName: WPStyleGuide.grey()])
         tf.delegate = self
         tf.font = WPFontManager.merriweatherBoldFont(ofSize: 24.0)
         tf.returnKeyType = .next


### PR DESCRIPTION
Changes the native editor's placeholder text to be darker, and to read "Title" like in Calypso.

Fixes #6693 
Fixes #6687 

To test:

1. Launch the native editor.
2. Make sure the placeholder text for the title field reads "Title".
3. Make sure the placeholder text color for the title field matches the hybrid editor's.