### PR TITLE
Fixing notifications ios10 warnings

### DIFF
--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Mixpanel
 import WordPressComAnalytics
+import UserNotifications
 
 
 
@@ -85,9 +86,15 @@ final public class PushNotificationsManager: NSObject {
 
 
 
-    /// Indicates whether Push Notifications are enabled in Settings.app, or not.
-    func notificationsEnabledInDeviceSettings() -> Bool {
-        return (sharedApplication.currentUserNotificationSettings?.types ?? UIUserNotificationType()) != UIUserNotificationType()
+    /// Checks asynchronously if Notifications are enabled in the Device's Settings, or not.
+    ///
+    func loadAuthorizationStatus(completion: @escaping ((_ authorized: Bool) -> Void)) {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                let enabled = settings.authorizationStatus == .authorized
+                completion(enabled)
+            }
+        }
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -7,7 +7,51 @@ import WordPressComAnalytics
 /// encapsulated in the class NotificationSettings.Stream, and to provide the user a simple interface
 /// to update those settings, as needed.
 ///
-open class NotificationSettingDetailsViewController: UITableViewController {
+class NotificationSettingDetailsViewController: UITableViewController {
+
+    /// Index of the very first tableVIew Section
+    ///
+    private let firstSectionIndex = 0
+
+    /// NotificationSettings being rendered
+    ///
+    private var settings: NotificationSettings?
+
+    /// Notification Stream to be displayed
+    ///
+    private var stream: NotificationSettings.Stream?
+
+    /// TableView Sections to be rendered
+    ///
+    private var sections = [Section]()
+
+    /// Contains all of the updated Stream Settings
+    ///
+    private var newValues = [String: Bool]()
+
+    /// Indicates whether push notifications have been disabled, in the device, or not.
+    ///
+    private var pushNotificationsAuthorized = true {
+        didSet {
+            reloadTable()
+        }
+    }
+
+    /// Returns the name of the current site, if any
+    ///
+    private var siteName: String {
+        switch settings!.channel {
+        case .wordPressCom:
+            return NSLocalizedString("WordPress.com Updates", comment: "WordPress.com Notification Settings Title")
+        case .other:
+            return NSLocalizedString("Other Sites", comment: "Other Sites Notification Settings Title")
+        default:
+            return settings?.blog?.settings?.name ?? NSLocalizedString("Unnamed Site", comment: "Displayed when a site has no name")
+        }
+    }
+
+
+
     // MARK: - Initializers
     public convenience init(settings: NotificationSettings) {
         self.init(settings: settings, stream: settings.streams.first!)
@@ -22,7 +66,7 @@ open class NotificationSettingDetailsViewController: UITableViewController {
 
 
     // MARK: - View Lifecycle
-    open override func viewDidLoad() {
+    override func viewDidLoad() {
         super.viewDidLoad()
         setupTitle()
         setupNotifications()
@@ -30,12 +74,16 @@ open class NotificationSettingDetailsViewController: UITableViewController {
         reloadTable()
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        // iOS +10: Push Notifications Auth is now.. async. Lovely
+        refreshPushAuthorizationStatus()
+
         WPAnalytics.track(.openedNotificationSettingDetails)
     }
 
-    open override func viewWillDisappear(_ animated: Bool) {
+    override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         saveSettingsIfNeeded()
     }
@@ -43,11 +91,11 @@ open class NotificationSettingDetailsViewController: UITableViewController {
 
 
     // MARK: - Setup Helpers
-    fileprivate func setupTitle() {
+    private func setupTitle() {
         title = stream?.kind.description()
     }
 
-    fileprivate func setupNotifications() {
+    private func setupNotifications() {
         // Reload whenever the app becomes active again since Push Settings may have changed in the meantime!
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self,
@@ -56,7 +104,7 @@ open class NotificationSettingDetailsViewController: UITableViewController {
             object:     nil)
     }
 
-    fileprivate func setupTableView() {
+    private func setupTableView() {
         // Register the cells
         tableView.register(SwitchTableViewCell.self, forCellReuseIdentifier: Row.Kind.Setting.rawValue)
         tableView.register(WPTableViewCell.self, forCellReuseIdentifier: Row.Kind.Text.rawValue)
@@ -76,7 +124,7 @@ open class NotificationSettingDetailsViewController: UITableViewController {
 
 
     // MARK: - Private Helpers
-    fileprivate func sectionsForSettings(_ settings: NotificationSettings, stream: NotificationSettings.Stream) -> [Section] {
+    private func sectionsForSettings(_ settings: NotificationSettings, stream: NotificationSettings.Stream) -> [Section] {
         // WordPress.com Channel requires a brief description per row.
         // For that reason, we'll render each row in its own section, with it's very own footer
         let singleSectionMode = settings.channel != .wordPressCom
@@ -110,7 +158,7 @@ open class NotificationSettingDetailsViewController: UITableViewController {
         return sections
     }
 
-    fileprivate func sectionsForDisabledDeviceStream() -> [Section] {
+    private func sectionsForDisabledDeviceStream() -> [Section] {
         let description     = NSLocalizedString("Go to iOS Settings", comment: "Opens WPiOS Settings.app Section")
         let row             = Row(kind: .Text, description: description, key: nil, value: nil)
 
@@ -125,15 +173,15 @@ open class NotificationSettingDetailsViewController: UITableViewController {
 
 
     // MARK: - UITableView Delegate Methods
-    open override func numberOfSections(in tableView: UITableView) -> Int {
+    override func numberOfSections(in tableView: UITableView) -> Int {
         return sections.count
     }
 
-    open override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return sections[section].rows.count
     }
 
-    open override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let section = sections[indexPath.section]
         let row     = section.rows[indexPath.row]
         let cell    = tableView.dequeueReusableCell(withIdentifier: row.kind.rawValue)
@@ -148,26 +196,26 @@ open class NotificationSettingDetailsViewController: UITableViewController {
         return cell!
     }
 
-    open override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard section == firstSectionIndex else {
             return nil
         }
         return siteName
     }
 
-    open override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
-    open override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return sections[section].footerText
     }
 
-    open override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+    override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
         WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
-    open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectSelectedRowWithAnimation(true)
 
         if isDeviceStreamDisabled() {
@@ -178,12 +226,12 @@ open class NotificationSettingDetailsViewController: UITableViewController {
 
 
     // MARK: - UITableView Helpers
-    fileprivate func configureTextCell(_ cell: WPTableViewCell, row: Row) {
+    private func configureTextCell(_ cell: WPTableViewCell, row: Row) {
         cell.textLabel?.text    = row.description
         WPStyleGuide.configureTableViewCell(cell)
     }
 
-    fileprivate func configureSwitchCell(_ cell: SwitchTableViewCell, row: Row) {
+    private func configureSwitchCell(_ cell: SwitchTableViewCell, row: Row) {
         let settingKey          = row.key ?? String()
 
         cell.name               = row.description
@@ -196,19 +244,24 @@ open class NotificationSettingDetailsViewController: UITableViewController {
 
 
     // MARK: - Disabled Push Notifications Handling
-    fileprivate func isDeviceStreamDisabled() -> Bool {
-        return stream?.kind == .Device && !PushNotificationsManager.sharedInstance.notificationsEnabledInDeviceSettings()
+    private func isDeviceStreamDisabled() -> Bool {
+        return stream?.kind == .Device && pushNotificationsAuthorized == false
     }
 
-    fileprivate func openApplicationSettings() {
+    private func openApplicationSettings() {
         let targetURL = URL(string: UIApplicationOpenSettingsURLString)
         UIApplication.shared.open(targetURL!)
     }
 
+    private func refreshPushAuthorizationStatus() {
+        PushNotificationsManager.sharedInstance.loadAuthorizationStatus { authorized in
+            self.pushNotificationsAuthorized = authorized
+        }
+    }
 
 
     // MARK: - Service Helpers
-    fileprivate func saveSettingsIfNeeded() {
+    private func saveSettingsIfNeeded() {
         if newValues.count == 0 || settings == nil {
             return
         }
@@ -228,7 +281,7 @@ open class NotificationSettingDetailsViewController: UITableViewController {
             })
     }
 
-    fileprivate func handleUpdateError() {
+    private func handleUpdateError() {
         let title       = NSLocalizedString("Oops!", comment: "")
         let message     = NSLocalizedString("There has been an unexpected error while updating your Notification Settings",
                                             comment: "Displayed after a failed Notification Settings call")
@@ -249,7 +302,7 @@ open class NotificationSettingDetailsViewController: UITableViewController {
 
 
     // MARK: - Private Nested Class'ess
-    fileprivate class Section {
+    private class Section {
         var rows: [Row]
         var footerText: String?
 
@@ -259,7 +312,7 @@ open class NotificationSettingDetailsViewController: UITableViewController {
         }
     }
 
-    fileprivate class Row {
+    private class Row {
         let description: String
         let kind: Kind
         let key: String?
@@ -277,28 +330,4 @@ open class NotificationSettingDetailsViewController: UITableViewController {
             case Text           = "TextCell"
         }
     }
-
-
-    // MARK: - Computed Properties
-    fileprivate var siteName: String {
-        switch settings!.channel {
-        case .wordPressCom:
-            return NSLocalizedString("WordPress.com Updates", comment: "WordPress.com Notification Settings Title")
-        case .other:
-            return NSLocalizedString("Other Sites", comment: "Other Sites Notification Settings Title")
-        default:
-            return settings?.blog?.settings?.name ?? NSLocalizedString("Unnamed Site", comment: "Displayed when a site has no name")
-        }
-    }
-
-    // MARK: - Private Constants
-    fileprivate let firstSectionIndex = 0
-
-    // MARK: - Private Properties
-    fileprivate var settings: NotificationSettings?
-    fileprivate var stream: NotificationSettings.Stream?
-
-    // MARK: - Helpers
-    fileprivate var sections = [Section]()
-    fileprivate var newValues = [String: Bool]()
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -8,9 +8,42 @@ import WordPressComAnalytics
 /// A Stream represents a possible way in which notifications are communicated.
 /// For instance: Push Notifications / WordPress.com Timeline / Email
 ///
-open class NotificationSettingStreamsViewController: UITableViewController {
+class NotificationSettingStreamsViewController: UITableViewController {
+
+    // MARK: - Private Properties
+
+    /// NotificationSettings being rendered
+    ///
+    private var settings: NotificationSettings?
+
+    /// Notification Streams
+    ///
+    private var sortedStreams: [NotificationSettings.Stream]?
+
+    /// Indicates whether push notifications have been disabled, in the device, or not.
+    ///
+    private var pushNotificationsAuthorized = true {
+        didSet {
+            tableView.reloadData()
+        }
+    }
+
+    /// TableViewCell's Reuse Identifier
+    ///
+    private let reuseIdentifier = WPTableViewCell.classNameWithoutNamespaces()
+
+    /// Number of Sections
+    ///
+    private let emptySectionCount = 0
+
+    /// Number of Rows
+    ///
+    private let rowsCount = 1
+
+
+
     // MARK: - Initializers
-    public convenience init(settings: NotificationSettings) {
+    convenience init(settings: NotificationSettings) {
         self.init(style: .grouped)
         setupWithSettings(settings)
     }
@@ -18,24 +51,28 @@ open class NotificationSettingStreamsViewController: UITableViewController {
 
 
     // MARK: - View Lifecycle
-    open override func viewDidLoad() {
+    override func viewDidLoad() {
         super.viewDidLoad()
         setupNotifications()
         setupTableView()
     }
 
-    open override func viewWillAppear(_ animated: Bool) {
+    override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         // Manually deselect the selected row. This is required due to a bug in iOS7 / iOS8
         tableView.deselectSelectedRowWithAnimation(true)
+
+        // iOS +10: Push Notifications Auth is now.. async. Lovely
+        refreshPushAuthorizationStatus()
+
         WPAnalytics.track(.openedNotificationSettingStreams)
     }
 
 
 
     // MARK: - Setup Helpers
-    fileprivate func setupNotifications() {
+    private func setupNotifications() {
         // Reload whenever the app becomes active again since Push Settings may have changed in the meantime!
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self,
@@ -44,7 +81,7 @@ open class NotificationSettingStreamsViewController: UITableViewController {
             object:     nil)
     }
 
-    fileprivate func setupTableView() {
+    private func setupTableView() {
         // Empty Back Button
         navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
 
@@ -58,7 +95,7 @@ open class NotificationSettingStreamsViewController: UITableViewController {
 
 
     // MARK: - Public Helpers
-    open func setupWithSettings(_ streamSettings: NotificationSettings) {
+    func setupWithSettings(_ streamSettings: NotificationSettings) {
         // Title
         switch streamSettings.channel {
         case let .blog(blogId):
@@ -78,22 +115,22 @@ open class NotificationSettingStreamsViewController: UITableViewController {
         tableView.reloadData()
     }
 
-    open func reloadTable() {
+    func reloadTable() {
         tableView.reloadData()
     }
 
 
 
     // MARK: - UITableView Delegate Methods
-    open override func numberOfSections(in tableView: UITableView) -> Int {
+    override func numberOfSections(in tableView: UITableView) -> Int {
         return sortedStreams?.count ?? emptySectionCount
     }
 
-    open override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return rowsCount
     }
 
-    open override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         var cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier) as? WPTableViewCell
         if cell == nil {
             cell = WPTableViewCell(style: .value1, reuseIdentifier: reuseIdentifier)
@@ -104,29 +141,19 @@ open class NotificationSettingStreamsViewController: UITableViewController {
         return cell!
     }
 
-    open override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return footerForStream(streamAtSection(section))
     }
 
-    open override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+    override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
         WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
 
 
     // MARK: - UITableView Delegate Methods
-    open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // iOS <8: Display the 'Enable Push Notifications Alert', when needed
-        // iOS +8: Go ahead and push the details
-        //
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let stream = streamAtSection(indexPath.section)
-
-        if isDisabledDeviceStream(stream) && !UIDevice.isOS8() {
-            tableView.deselectSelectedRowWithAnimation(true)
-            displayPushNotificationsAlert()
-            return
-        }
-
         let detailsViewController = NotificationSettingDetailsViewController(settings: settings!, stream: stream)
         navigationController?.pushViewController(detailsViewController, animated: true)
     }
@@ -134,9 +161,9 @@ open class NotificationSettingStreamsViewController: UITableViewController {
 
 
     // MARK: - Helpers
-    fileprivate func configureCell(_ cell: UITableViewCell, indexPath: IndexPath) {
+    private func configureCell(_ cell: UITableViewCell, indexPath: IndexPath) {
         let stream                  = streamAtSection(indexPath.section)
-        let disabled                = isDisabledDeviceStream(stream)
+        let disabled                = stream.kind == .Device && pushNotificationsAuthorized == false
 
         cell.imageView?.image       = imageForStreamKind(stream.kind)
         cell.imageView?.tintColor   = WPStyleGuide.greyLighten10()
@@ -147,11 +174,11 @@ open class NotificationSettingStreamsViewController: UITableViewController {
         WPStyleGuide.configureTableViewCell(cell)
     }
 
-    fileprivate func streamAtSection(_ section: Int) -> NotificationSettings.Stream {
+    private func streamAtSection(_ section: Int) -> NotificationSettings.Stream {
         return sortedStreams![section]
     }
 
-    fileprivate func imageForStreamKind(_ streamKind: NotificationSettings.Stream.Kind) -> UIImage? {
+    private func imageForStreamKind(_ streamKind: NotificationSettings.Stream.Kind) -> UIImage? {
         let imageName: String
         switch streamKind {
         case .Email:
@@ -167,11 +194,13 @@ open class NotificationSettingStreamsViewController: UITableViewController {
 
 
     // MARK: - Disabled Push Notifications Helpers
-    fileprivate func isDisabledDeviceStream(_ stream: NotificationSettings.Stream) -> Bool {
-        return stream.kind == .Device && !PushNotificationsManager.sharedInstance.notificationsEnabledInDeviceSettings()
+    private func refreshPushAuthorizationStatus() {
+        PushNotificationsManager.sharedInstance.loadAuthorizationStatus { authorized in
+            self.pushNotificationsAuthorized = authorized
+        }
     }
 
-    fileprivate func displayPushNotificationsAlert() {
+    private func displayPushNotificationsAlert() {
         let title   = NSLocalizedString("Push Notifications have been turned off in iOS Settings",
                                         comment: "Displayed when Push Notifications are disabled (iOS 7)")
         let message = NSLocalizedString("To enable notifications:\n\n" +
@@ -189,7 +218,7 @@ open class NotificationSettingStreamsViewController: UITableViewController {
 
 
     // MARK: - Footers
-    fileprivate func footerForStream(_ stream: NotificationSettings.Stream) -> String {
+    private func footerForStream(_ stream: NotificationSettings.Stream) -> String {
         switch stream.kind {
         case .Device:
             return NSLocalizedString("Settings for push notifications that appear on your mobile device.",
@@ -202,16 +231,4 @@ open class NotificationSettingStreamsViewController: UITableViewController {
                 comment: "Descriptive text for the Notifications Tab Settings")
         }
     }
-
-
-
-
-    // MARK: - Private Constants
-    fileprivate let reuseIdentifier     = WPTableViewCell.classNameWithoutNamespaces()
-    fileprivate let emptySectionCount   = 0
-    fileprivate let rowsCount           = 1
-
-    // MARK: - Private Properties
-    fileprivate var settings: NotificationSettings?
-    fileprivate var sortedStreams: [NotificationSettings.Stream]?
 }

--- a/WordPress/WordPressTest/PushNotificationsManagerTests.m
+++ b/WordPress/WordPressTest/PushNotificationsManagerTests.m
@@ -31,36 +31,6 @@
     XCTAssert([manager.deviceToken isEmpty]);
 }
 
-- (void)testPushNotificationsAreDisabledInDeviceSettingsWhenRegisteredTypeIsNone
-{
-    id mockSettings = OCMPartialMock([[UIApplication sharedApplication] currentUserNotificationSettings]);
-    [OCMStub([mockSettings types]) andReturnValue:OCMOCK_VALUE(UNAuthorizationOptionNone)];
-    
-    id mockApplication = OCMPartialMock([UIApplication sharedApplication]);
-    [OCMStub([mockApplication currentUserNotificationSettings]) andReturn:mockSettings];
-    
-    PushNotificationsManager *manager = [PushNotificationsManager new];
-    id mockManager = OCMPartialMock(manager);
-    [OCMStub([mockManager sharedApplication]) andReturn:mockApplication];
-
-    XCTAssertFalse([mockManager notificationsEnabledInDeviceSettings]);
-}
-
-- (void)testPushNotificationsAreEnabledInDeviceSettingsWhenRegisteredTypeIsAlert
-{
-    id mockSettings = OCMPartialMock([[UIApplication sharedApplication] currentUserNotificationSettings]);
-    [OCMStub([mockSettings types]) andReturnValue:OCMOCK_VALUE(UNAuthorizationOptionAlert)];
-    
-    id mockApplication = OCMPartialMock([UIApplication sharedApplication]);
-    [OCMStub([mockApplication currentUserNotificationSettings]) andReturn:mockSettings];
-    
-    PushNotificationsManager *manager = [PushNotificationsManager new];
-    id mockManager = OCMPartialMock(manager);
-    [OCMStub([mockManager sharedApplication]) andReturn:mockApplication];
-    
-    XCTAssertTrue([mockManager notificationsEnabledInDeviceSettings]);
-}
-
 - (void)testRegisterForRemoteNotificationsCallsSharedApplicationRegisterForRemoteNotifications
 {
     // Note:


### PR DESCRIPTION
### Details:
This PR addresses the pending Build Warnings we've got, related to Notifications.

**Please review / merge this one after #6684 gets approved!**
cc @koke 

### To test:
1. Log into wpios
2. Open `Me` > `Notification Settings`
3. Pick any of your websites
4. Verify that the `Push Notifications` row doesn't say *off*
5. Switch to **Settings.app* and disable wpios's push notifications
6. Switch back to **WPiOS** and verify that the Push Notifications row displays an `Off` legend
7. Press over the Push Notifications Row
8. Verify that there's a single row onscreen, which allows the user to open the Settings.app entry
9. Enable WPiOS's Push Notifications
10. Switch back to WPiOS and verify that the Push Notification (Fine-Grainted) Settings are onscreen

Needs review: @astralbodies 

