### PR TITLE
Split view: Ensure nav bar is visible when popping to root.

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -370,6 +370,8 @@ class WPSplitViewController: UISplitViewController {
             } else {
                 navigationController.scrollContentToTopAnimated(animated)
             }
+
+            navigationController.setNavigationBarHidden(false, animated: animated)
         }
 
         if let primaryNavigationController = viewControllers.first as? UINavigationController {

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -367,11 +367,15 @@ class WPSplitViewController: UISplitViewController {
         let popOrScrollToTop = { (navigationController: UINavigationController) in
             if navigationController.viewControllers.count > 1 {
                 navigationController.popToRootViewController(animated: animated)
+
+                // Ensure navigation bars are visible – otherwise if we popped
+                // back from e.g. a Reader Detail screen which had hidden its
+                // bars, they'd stay hidden.
+                navigationController.setNavigationBarHidden(false, animated: animated)
             } else {
                 navigationController.scrollContentToTopAnimated(animated)
             }
 
-            navigationController.setNavigationBarHidden(false, animated: animated)
         }
 
         if let primaryNavigationController = viewControllers.first as? UINavigationController {


### PR DESCRIPTION
Fixes #6670.

Note that the reproduction steps are slightly incorrect in the original issue. See 'to test' below for replication steps.

I wanted to fix this in the Reader detail VC, as that's the one that hides the bar in the first place. But it turns out that its `navigationController` gets set to `nil` as soon as `popToRootViewController` is called. I also could've set it in the navigation controller delegate, but I didn't want to presume to update the bars for any and every navigation controller. 

So I've opted to just set it in the method that takes care of popping to the root when you tap on the currently-selected tab bar item.

To test:

1. Open a post in the Reader
2. Scroll down to cause the top bar to hide
3. **Tap the Reader tab bar item to pop back to the Reader menu**
4. Navigation bar has gone.

Needs review: @aerych