### PR TITLE
Notifications Crash: when resetting notifications, nil the selectedNotification

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1226,6 +1226,7 @@ private extension NotificationsViewController {
 
     func resetNotifications() {
         do {
+            selectedNotification = nil
             let helper = CoreDataHelper<Notification>(context: mainContext)
             helper.deleteAllObjects()
             try mainContext.save()


### PR DESCRIPTION
Fixes a crash that occurs after the newly merged split-view implementation.

Basically, we just needed to `nil` the `selectedNotification` when we call `resetNotifications`. Otherwise the object is no longer valid when we try to use it, after being nuked.

To test:
1. Open Notifications, select a notification to view the detail.
2. Switch to Me tab.
3. Log out
4. Log back in.
5. Don't crash.
6. Everything loads as expected.

Needs review: @frosty another one for ya 😃 