### PR TITLE
Don't sort by publish immediately on drafts.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -381,6 +381,9 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         let sortDescriptorLocal = NSSortDescriptor(key: "metaIsLocal", ascending: false)
         let sortDescriptorImmediately = NSSortDescriptor(key: "metaPublishImmediately", ascending: false)
         let sortDescriptorDate = dateSortDescriptor()
+        if filterSettings.currentPostListFilter().filterType == .draft {
+            return [sortDescriptorLocal, sortDescriptorDate]
+        }
         return [sortDescriptorLocal, sortDescriptorImmediately, sortDescriptorDate]
     }
 


### PR DESCRIPTION
As reported by @rachelmcr:

> 1. I start a new post.I save the post as a draft (I generally do this with the quick action in the ellipsis menu).
> 2. I edit the post further.I save the draft again (either by tapping “Update” or by saving when I exit the editor).
> 3. The post disappears from the top of my list of posts. I thought it was gone, but it (and any other drafts where I do these steps) is showing up between drafts from May and August 2016, 8th in the list of drafts. On other blogs the same thing happens but the date/placement in the list isn’t consistent.

The changes in #6477 meant that we were now sorting drafts on local status, “publish immediately” first, then by date modified. Previously, we only sorted drafts on local status, then by date modified. So this effectively put all the “publish immediately” drafts above the last, recently edited but with a date set, draft.

This PR restores that behavior from before #6477, as that change wasn't intended. I'm adding the check here as a hotfix for 7.0, but I plan to refactor and add tests for develop later.

I've considered reverting #6477 but that fixed an issue where pages were completely gone (#6476). I think this is worth getting into 7.0: while there's no actual data loss, it can be perceived as such and cause some panic.

To test:

- Create a post, save as draft and close the editor
- Create a second post, save as draft using the ellipsis menu, add some more content and tap Update.
- The second post should be the first on the drafts list as it's the most recently edited.

Needs review: @astralbodies 