### PR TITLE
Feature/6358 related posts ui

### DIFF
--- a/WordPress/Classes/Models/ReaderPost.h
+++ b/WordPress/Classes/Models/ReaderPost.h
@@ -49,7 +49,7 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 @property (nonatomic) BOOL isSiteBlocked;
 @property (nonatomic, strong) SourcePostAttribution *sourceAttribution;
 @property (nonatomic, strong) ReaderPost *relatedPost;
-@property (nonatomic, strong) NSSet *relatedPosts;
+@property (nonatomic, strong) NSSet<ReaderPost *> *relatedPosts;
 
 @property (nonatomic, strong) NSString *primaryTag;
 @property (nonatomic, strong) NSString *primaryTagSlug;

--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -4,6 +4,7 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -706,23 +707,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="b7O-t0-EA1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1484" y="1129"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="DQf-eH-W1U">
-            <objects>
-                <viewController id="A4R-jX-ijH" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="lLN-PE-jd3"/>
-                        <viewControllerLayoutGuide type="bottom" id="yHr-4P-kAs"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="8hd-r1-xUZ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Ydc-0N-yfp" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
         </scene>
     </scenes>
     <resources>

--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -638,7 +638,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="345" height="300"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="CaP-Js-Bfx">
-                                        <rect key="frame" x="0.0" y="0.0" width="345" height="47"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="345" height="37"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VKf-La-zGo">
                                                 <rect key="frame" x="0.0" y="0.0" width="345" height="1"/>
@@ -648,18 +648,18 @@
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MORE IN SITE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UOZ-a8-rsU">
-                                                <rect key="frame" x="0.0" y="17" width="345" height="30"/>
+                                                <rect key="frame" x="0.0" y="17" width="345" height="20"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="kLQ-hy-82P"/>
+                                                    <constraint firstAttribute="height" constant="20" id="kLQ-hy-82P"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" red="0.52941176469999995" green="0.65098039220000004" blue="0.73725490199999999" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="iWe-88-Zql">
-                                        <rect key="frame" x="0.0" y="63" width="345" height="47"/>
+                                        <rect key="frame" x="0.0" y="53" width="345" height="37"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Eh1-Hn-3Y5">
                                                 <rect key="frame" x="0.0" y="0.0" width="345" height="1"/>
@@ -669,18 +669,18 @@
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MORE ON WPCOM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DqU-Qf-LhN">
-                                                <rect key="frame" x="0.0" y="17" width="345" height="30"/>
+                                                <rect key="frame" x="0.0" y="17" width="345" height="20"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="JXn-XM-OV2"/>
+                                                    <constraint firstAttribute="height" constant="20" id="JXn-XM-OV2"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" red="0.52941176470588236" green="0.65098039215686276" blue="0.73725490196078436" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d3Y-ea-8mA">
-                                        <rect key="frame" x="0.0" y="126" width="345" height="174"/>
+                                        <rect key="frame" x="0.0" y="106" width="345" height="194"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     </view>
                                 </subviews>

--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -626,15 +626,103 @@
         <scene sceneID="uVg-vg-oQl">
             <objects>
                 <viewController storyboardIdentifier="RelatedPostsViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="7Pc-dm-R7a" customClass="RelatedPostsViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="8SY-iT-OP4"/>
+                        <viewControllerLayoutGuide type="bottom" id="QmE-6Y-E2Q"/>
+                    </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="BsZ-Gd-gmn">
-                        <rect key="frame" x="0.0" y="0.0" width="345" height="100"/>
+                        <rect key="frame" x="0.0" y="0.0" width="345" height="300"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="E2m-1H-RWJ">
+                                <rect key="frame" x="0.0" y="0.0" width="345" height="300"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="CaP-Js-Bfx">
+                                        <rect key="frame" x="0.0" y="0.0" width="345" height="47"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VKf-La-zGo">
+                                                <rect key="frame" x="0.0" y="0.0" width="345" height="1"/>
+                                                <color key="backgroundColor" red="0.52941176469999995" green="0.65098039220000004" blue="0.73725490199999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="1" id="Z9C-ax-HC2"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MORE IN SITE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UOZ-a8-rsU">
+                                                <rect key="frame" x="0.0" y="17" width="345" height="30"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="30" id="kLQ-hy-82P"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="iWe-88-Zql">
+                                        <rect key="frame" x="0.0" y="63" width="345" height="47"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Eh1-Hn-3Y5">
+                                                <rect key="frame" x="0.0" y="0.0" width="345" height="1"/>
+                                                <color key="backgroundColor" red="0.52941176469999995" green="0.65098039220000004" blue="0.73725490199999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="1" id="dsg-mq-3a4"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MORE ON WPCOM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DqU-Qf-LhN">
+                                                <rect key="frame" x="0.0" y="17" width="345" height="30"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="30" id="JXn-XM-OV2"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d3Y-ea-8mA">
+                                        <rect key="frame" x="0.0" y="126" width="345" height="174"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </view>
+                                </subviews>
+                            </stackView>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="E2m-1H-RWJ" firstAttribute="top" secondItem="8SY-iT-OP4" secondAttribute="bottom" id="0ut-cE-Qvh"/>
+                            <constraint firstItem="E2m-1H-RWJ" firstAttribute="leading" secondItem="BsZ-Gd-gmn" secondAttribute="leading" id="Dc0-xi-5G0"/>
+                            <constraint firstAttribute="trailing" secondItem="E2m-1H-RWJ" secondAttribute="trailing" id="QOg-wd-ead"/>
+                            <constraint firstItem="QmE-6Y-E2Q" firstAttribute="top" secondItem="E2m-1H-RWJ" secondAttribute="bottom" id="ak9-FV-5sM"/>
+                        </constraints>
                     </view>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="345" height="300"/>
+                    <connections>
+                        <outlet property="relatedSitestackView" destination="CaP-Js-Bfx" id="cXl-pX-UiW"/>
+                        <outlet property="relatedWPComStackView" destination="iWe-88-Zql" id="bQj-bU-gza"/>
+                        <outlet property="siteLabel" destination="UOZ-a8-rsU" id="GCY-yB-LpR"/>
+                        <outlet property="wpcomLabel" destination="DqU-Qf-LhN" id="lQ3-qG-Vh2"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="b7O-t0-EA1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1484" y="1129"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="DQf-eH-W1U">
+            <objects>
+                <viewController id="A4R-jX-ijH" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="lLN-PE-jd3"/>
+                        <viewControllerLayoutGuide type="bottom" id="yHr-4P-kAs"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8hd-r1-xUZ">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ydc-0N-yfp" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
         </scene>
     </scenes>
     <resources>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCard.swift
@@ -88,7 +88,7 @@ public class ReaderCard: UIView {
     open var enableLoggedInFeatures = true
     open weak var delegate: ReaderCardDelegate?
 
-    open weak var readerPost: ReaderPost? {
+    open var readerPost: ReaderPost? {
         didSet {
             configureCard()
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCard.swift
@@ -72,6 +72,16 @@ public class ReaderCard: UIView {
     }()
 
 
+    var cardContentMargins: UIEdgeInsets {
+        get {
+            return cardStackView.layoutMargins
+        }
+        set {
+            cardStackView.layoutMargins = newValue
+        }
+    }
+
+
     // MARK: - Public Accessors
     open var hidesFollowButton = false
     open var enableLoggedInFeatures = true

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCard.swift
@@ -83,6 +83,7 @@ public class ReaderCard: UIView {
 
 
     // MARK: - Public Accessors
+
     open var hidesFollowButton = false
     open var enableLoggedInFeatures = true
     open weak var delegate: ReaderCardDelegate?
@@ -107,6 +108,16 @@ public class ReaderCard: UIView {
                     headerAuthorLabel.textColor = WPStyleGuide.readerCardBlogNameLabelDisabledTextColor()
                 }
             }
+        }
+    }
+
+
+    open var hidesActionbar: Bool {
+        get {
+            return actionStackView.isHidden
+        }
+        set {
+            actionStackView.isHidden = newValue
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCard.swift
@@ -149,6 +149,7 @@ public class ReaderCard: UIView {
         contentView.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
         contentView.topAnchor.constraint(equalTo: topAnchor).isActive = true
         contentView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
+        layoutIfNeeded()
 
         // This view only exists to help IB with filling in the bottom space of
         // the cell that is later autosized according to the content's intrinsicContentSize.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCard.swift
@@ -82,6 +82,15 @@ public class ReaderCard: UIView {
     }
 
 
+    override public var preservesSuperviewLayoutMargins: Bool {
+        didSet {
+            // We want subviews to respect this setting
+            contentView.preservesSuperviewLayoutMargins = preservesSuperviewLayoutMargins
+            cardStackView.preservesSuperviewLayoutMargins = preservesSuperviewLayoutMargins
+        }
+    }
+
+
     // MARK: - Public Accessors
 
     open var hidesFollowButton = false

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCard.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCard.xib
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -33,7 +34,7 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB">
+        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="375" height="398"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -271,6 +271,9 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     open override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         relatedPostsController = segue.destination as? RelatedPostsViewController
+        if let relatedView = relatedPostsController?.view {
+            textFooterStackView.addArrangedSubview(relatedView)
+        }
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1212" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,7 +22,7 @@
                         <rect key="frame" x="-1" y="7" width="322" height="469"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2mb-s3-Mab" customClass="ReaderCard" customModule="WordPress" customModuleProvider="target">
+                    <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2mb-s3-Mab" customClass="ReaderCard" customModule="WordPress" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="8" width="320" height="467"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -86,41 +86,7 @@ open class ReaderPostMenu {
 
 
     fileprivate class func toggleFollowingForPost(_ post: ReaderPost) {
-        let generator = UINotificationFeedbackGenerator()
-        generator.prepare()
-
-        var successMessage: String!
-        var errorMessage: String!
-        var errorTitle: String!
-        if post.isFollowing {
-            successMessage = NSLocalizedString("Unfollowed site", comment: "Short confirmation that unfollowing a site was successful")
-            errorTitle = NSLocalizedString("Problem Unfollowing Site", comment: "Title of a prompt")
-            errorMessage = NSLocalizedString("There was a problem unfollowing the site. If the problem persists you can contact us via the Me > Help & Support screen.", comment: "Short notice that there was a problem unfollowing a site and instructions on how to notify us of the problem.")
-        } else {
-            successMessage = NSLocalizedString("Followed site", comment: "Short confirmation that following a site was successful")
-            errorTitle = NSLocalizedString("Problem Following Site", comment: "Title of a prompt")
-            errorMessage = NSLocalizedString("There was a problem following the site.  If the problem persists you can contact us via the Me > Help & Support screen.", comment: "Short notice that there was a problem following a site and instructions on how to notify us of the problem.")
-
-            generator.notificationOccurred(.success)
-        }
-
-        SVProgressHUD.show()
-
-        let postService = ReaderPostService(managedObjectContext: post.managedObjectContext!)
-        postService.toggleFollowing(for: post, success: { () in
-            SVProgressHUD.showSuccess(withStatus: successMessage)
-            }, failure: { (error: Error?) in
-                SVProgressHUD.dismiss()
-
-                generator.notificationOccurred(.error)
-
-                let cancelTitle = NSLocalizedString("OK", comment: "Text of an OK button to dismiss a prompt.")
-                let alertController = UIAlertController(title: errorTitle,
-                    message: errorMessage,
-                    preferredStyle: .alert)
-                alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
-                alertController.presentFromRootViewController()
-        })
+        ReaderHelpers.toggleFollowingForPost(post)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -760,35 +760,7 @@ import WordPressComAnalytics
 
 
     fileprivate func toggleFollowingForPost(_ post: ReaderPost) {
-        var successMessage: String
-        var errorMessage: String
-        var errorTitle: String
-        if post.isFollowing {
-            successMessage = NSLocalizedString("Unfollowed site", comment: "Short confirmation that unfollowing a site was successful")
-            errorTitle = NSLocalizedString("Problem Unfollowing Site", comment: "Title of a prompt")
-            errorMessage = NSLocalizedString("There was a problem unfollowing the site. If the problem persists you can contact us via the Me > Help & Support screen.", comment: "Short notice that there was a problem unfollowing a site and instructions on how to notify us of the problem.")
-        } else {
-            successMessage = NSLocalizedString("Followed site", comment: "Short confirmation that unfollowing a site was successful")
-            errorTitle = NSLocalizedString("Problem Following Site", comment: "Title of a prompt")
-            errorMessage = NSLocalizedString("There was a problem following the site.  If the problem persists you can contact us via the Me > Help & Support screen.", comment: "Short notice that there was a problem following a site and instructions on how to notify us of the problem.")
-        }
-
-        SVProgressHUD.show()
-        let postService = ReaderPostService(managedObjectContext: managedObjectContext())
-        postService.toggleFollowing(for: post,
-                                            success: {
-                                                SVProgressHUD.showSuccess(withStatus: successMessage)
-                                            },
-                                            failure: { (error: Error?) in
-                                                SVProgressHUD.dismiss()
-
-                                                let cancelTitle = NSLocalizedString("OK", comment: "Text of an OK button to dismiss a prompt.")
-                                                let alertController = UIAlertController(title: errorTitle,
-                                                    message: errorMessage,
-                                                    preferredStyle: .alert)
-                                                alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
-                                                alertController.presentFromRootViewController()
-                                        })
+        ReaderHelpers.toggleFollowingForPost(post)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/RelatedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/RelatedPostsViewController.swift
@@ -152,8 +152,17 @@ class RelatedPostsViewController: UIViewController {
 
     // Actions
 
-    func handleCardTapped() {
-        // TODO:
+    func handleCardTapped(sender: UITapGestureRecognizer) {
+        guard let card = sender.view as? ReaderCard else {
+            return
+        }
+
+        guard let post = card.readerPost else {
+            return
+        }
+
+        let controller = ReaderDetailViewController.controllerWithPost(post)
+        navigationController?.pushViewController(controller, animated: true)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/RelatedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/RelatedPostsViewController.swift
@@ -157,6 +157,7 @@ class RelatedPostsViewController: UIViewController {
     }
 
 
+    /// No op
     func handleCardLongPress() {}
 
 
@@ -189,7 +190,9 @@ class RelatedPostsViewController: UIViewController {
 extension RelatedPostsViewController: ReaderCardDelegate {
 
     func readerCard(_ card: ReaderCard, followActionForPost post: ReaderPost) {
-        // TODO:
+        ReaderHelpers.toggleFollowingForPost(post)
+        // Reassigning the post updates the card and the status of the follow button
+        card.readerPost = post
     }
 
     func readerCardImageRequestAuthToken() -> String? {

--- a/WordPress/Classes/ViewRelated/Reader/RelatedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/RelatedPostsViewController.swift
@@ -31,6 +31,7 @@ class RelatedPostsViewController: UIViewController {
 
     // Lifecycle Methods
 
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -72,6 +73,7 @@ class RelatedPostsViewController: UIViewController {
         for post in posts {
             let card = ReaderCard(frame: frame)
             card.readerPost = post
+            card.cardContentMargins = .zero
 
             relatedSitestackView.addArrangedSubview(card)
         }
@@ -100,6 +102,7 @@ class RelatedPostsViewController: UIViewController {
         for post in posts {
             let card = ReaderCard(frame: frame)
             card.readerPost = post
+            card.cardContentMargins = .zero
 
             relatedWPComStackView.addArrangedSubview(card)
         }
@@ -129,6 +132,7 @@ class RelatedPostsViewController: UIViewController {
         }
 
         if post.relatedPosts.count > 0 {
+            configureView()
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/RelatedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/RelatedPostsViewController.swift
@@ -72,8 +72,11 @@ class RelatedPostsViewController: UIViewController {
         let frame = CGRect(x: 0, y: 0, width: 320, height: 100)
         for post in posts {
             let card = ReaderCard(frame: frame)
-            card.readerPost = post
+            card.hidesActionbar = true
+            card.headerButtonIsEnabled = false
             card.cardContentMargins = .zero
+            card.hidesFollowButton = true
+            card.readerPost = post
 
             relatedSitestackView.addArrangedSubview(card)
         }
@@ -101,8 +104,10 @@ class RelatedPostsViewController: UIViewController {
         let frame = CGRect(x: 0, y: 0, width: 320, height: 100)
         for post in posts {
             let card = ReaderCard(frame: frame)
-            card.readerPost = post
+            card.hidesActionbar = true
+            card.headerButtonIsEnabled = false
             card.cardContentMargins = .zero
+            card.readerPost = post
 
             relatedWPComStackView.addArrangedSubview(card)
         }

--- a/WordPress/Classes/ViewRelated/Reader/RelatedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/RelatedPostsViewController.swift
@@ -152,6 +152,7 @@ class RelatedPostsViewController: UIViewController {
         card.hidesActionbar = true
         card.headerButtonIsEnabled = false
         card.cardContentMargins = .zero
+        card.preservesSuperviewLayoutMargins = false
         card.hidesFollowButton = relatedPost.siteID.intValue == post?.siteID.intValue
 
         card.readerPost = relatedPost

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -86,10 +86,12 @@ class WPRichContentView: UITextView {
             bottomMarginAttachment.bounds = bounds
 
             if textStorage.length > 1 {
-                let rng = NSRange(location: textStorage.length - 2, length: 1)
-                layoutManager.invalidateLayout(forCharacterRange: rng, actualCharacterRange: nil)
-                layoutManager.ensureLayout(forCharacterRange: rng)
-                attachmentManager.layoutAttachmentViews()
+                // NOTE: `ranges(forAttachment:)` is part of an Aztec extension on NSAttibutedString
+                if let rng = textStorage.ranges(forAttachment: bottomMarginAttachment).first {
+                    layoutManager.invalidateLayout(forCharacterRange: rng, actualCharacterRange: nil)
+                    layoutManager.ensureLayout(forCharacterRange: rng)
+                    attachmentManager.layoutAttachmentViews()
+                }
             }
         }
     }


### PR DESCRIPTION
Refs #6358 

This is the fourth and finally development PR for adding related posts to the ReaderDetailViewController.  We'll follow up this PR with a final design review before merging to develop.  Since this PR includes model changes, we'll want to try to wrap it up before cutting release/7.1. 

In this PR the RelatedPostsViewController is fleshed out.  Related posts are shown in two sections. One for posts that are from the same blog as the post currently shown in the detail, and one for posts that are from other WordPress.com sites.  Tapping a related post shows that post in a new detail.  Posts from other WPCom sites should display a follow button. 

To test:
View the reader detail for a wpcom post.  Confirm that related posts are loaded and displayed below the post content.
- Confirm the UI updates correctly when changing orientation. 
- Tap to view a related post. Confirm the detail loads and the correct post is shown. 
- Tap to follow a site via a related WPCom post. Tap to unfollow.
- Confirm that the action buttons (likes, comments, etc.) are not shown on the related post cards.
- Confirm that a longpress gesture on the related post cards does not invoke text selection. 

For paranoia, please check posts in a few different streams.  I noticed some layout issues in the post cards (squashed labels) after moving the card out of the cell and into its own view.  It should be resolved with this PR but just in case...

Needs review: @kurzee could I trouble you with this one? 

Examples:

![simulator screen shot feb 20 2017 11 19 18 am](https://cloud.githubusercontent.com/assets/1435271/23135503/95a0339e-f75e-11e6-848d-bb828f9615ef.png)
![simulator screen shot feb 20 2017 11 19 31 am](https://cloud.githubusercontent.com/assets/1435271/23135512/9813242e-f75e-11e6-89b4-4a1ac0aab551.png)

