### PR TITLE
AztecPostViewController: Dismissing the keyboard before dismissing Aztec

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -870,7 +870,7 @@ extension AztecPostViewController {
     }
 
     fileprivate func switchToHTML() {
-        view.endEditing(true)
+        stopEditing()
 
         htmlTextView.text = richTextView.getHTML()
         htmlTextView.isHidden = false
@@ -879,7 +879,7 @@ extension AztecPostViewController {
     }
 
     fileprivate func switchToRichText() {
-        view.endEditing(true)
+        stopEditing()
 
         richTextView.setHTML(htmlTextView.text)
         richTextView.isHidden = false
@@ -1236,6 +1236,8 @@ fileprivate extension AztecPostViewController {
     }
 
     func dismissOrPopView(didSave: Bool) {
+        stopEditing()
+
         if let onClose = onClose {
             onClose(didSave)
         } else if isModal() {


### PR DESCRIPTION
Closes #6682

### To test:
1. Launch Aztec
2. Publish a dummy post (random content!)
3. Verify that the keyboard gets dismissed immediately once the post OP completes.

As a result, the keyboard dismiss animation should be half way (or fully complete) once the Post Post screen shows up.

Note that without this PR, the keyboard was fully visible whenever the Post Post interface became visible.

Needs review: @astralbodies 
Thanks in advance sir!
