### PR TITLE
Update WordPressCom-Stats-iOS pod to 0.9.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ abstract_target 'WordPress_Base' do
   pod 'WordPress-iOS-Shared', '0.7.2'
   ## This pod is only being included to support the share extension ATM - https://github.com/wordpress-mobile/WordPress-iOS/issues/5081
   pod 'WordPressComKit', :git => 'https://github.com/Automattic/WordPressComKit.git', :tag => '0.0.6'
-  pod 'WordPressCom-Stats-iOS', '0.8.1'
+  pod 'WordPressCom-Stats-iOS', '0.9.0'
 
   target 'WordPress' do
     # ---------------------

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -138,7 +138,7 @@ PODS:
   - WordPress-iOS-Shared (0.7.2):
     - CocoaLumberjack (~> 2.2.0)
   - WordPressCom-Analytics-iOS (0.1.22)
-  - WordPressCom-Stats-iOS (0.8.1):
+  - WordPressCom-Stats-iOS (0.9.0):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
@@ -182,7 +182,7 @@ DEPENDENCIES:
   - WordPress-iOS-Editor (= 1.8.1)
   - WordPress-iOS-Shared (= 0.7.2)
   - WordPressCom-Analytics-iOS (= 0.1.22)
-  - WordPressCom-Stats-iOS (= 0.8.1)
+  - WordPressCom-Stats-iOS (= 0.9.0)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.11.1)
   - wpxmlrpc (~> 0.8)
@@ -250,11 +250,11 @@ SPEC CHECKSUMS:
   WordPress-iOS-Editor: 3118f5d6b142b6bf322f3393a7dd98a28bca68cb
   WordPress-iOS-Shared: c989e2760e64736dd5de10b932bb4fccdd9f9695
   WordPressCom-Analytics-iOS: 66b890823ffd54aee871fbba3ed0278d4ae1aa0a
-  WordPressCom-Stats-iOS: 07b1796831c31c0c8c8a0f2e314bb2e6636af5df
+  WordPressCom-Stats-iOS: cf78f0dd05ba586fd7b3c01b6cdcd5ca12e032ea
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: f5b1c20a25abc9ed710747f7019dbf43f03caa4f
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: 4c1d0edbe1fb389def103b6838a6991eb51275f9
+PODFILE CHECKSUM: ca191d14f5aa6bb795f87ce537699d8f817edee7
 
 COCOAPODS: 1.1.1


### PR DESCRIPTION
Closes #6728

To test:
1. `pod repo update`.
2. `pod install`.
3. Run the app and verify stats loads properly.

Needs review: @koke 
