### PR TITLE
Refactor of posts/pages sorting

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -1,0 +1,19 @@
+extension AbstractPost {
+    /// Represent the supported properties used to sort posts.
+    ///
+    enum SortField {
+        case dateCreated
+        case dateModified
+
+        /// The keyPath to access the underlying property.
+        ///
+        var keyPath: String {
+            switch self {
+            case .dateCreated:
+                return #keyPath(AbstractPost.date_created_gmt)
+            case .dateModified:
+                return #keyPath(AbstractPost.dateModified)
+            }
+        }
+    }
+}

--- a/WordPress/Classes/Models/Page.swift
+++ b/WordPress/Classes/Models/Page.swift
@@ -16,4 +16,17 @@ class Page: AbstractPost {
         let date = dateModified ?? Date()
         return date.toStringForPageSections()
     }
+
+    /// Returns the selector string to use as a sectionNameKeyPath, depending on the given keyPath.
+    ///
+    static func sectionIdentifier(dateKeyPath: String) -> String {
+        switch dateKeyPath {
+        case #keyPath(AbstractPost.date_created_gmt):
+            return NSStringFromSelector(#selector(Page.sectionIdentifierWithDateCreated))
+        case #keyPath(AbstractPost.dateModified):
+            return NSStringFromSelector(#selector(Page.sectionIdentifierWithDateModified))
+        default:
+            preconditionFailure("Invalid key path for a section identifier")
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -220,12 +220,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     // MARK: - Table View Handling
 
     func sectionNameKeyPath() -> String {
-        switch sortField() {
-        case .dateCreated:
-            return NSStringFromSelector(#selector(Page.sectionIdentifierWithDateCreated))
-        case .dateModified:
-            return NSStringFromSelector(#selector(Page.sectionIdentifierWithDateModified))
-        }
+        let sortField = filterSettings.currentPostListFilter().sortField
+        return Page.sectionIdentifier(dateKeyPath: sortField.keyPath)
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -381,6 +381,9 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         let sortDescriptorLocal = NSSortDescriptor(key: "metaIsLocal", ascending: false)
         let sortDescriptorImmediately = NSSortDescriptor(key: "metaPublishImmediately", ascending: false)
         let sortDescriptorDate = dateSortDescriptor()
+        if filterSettings.currentPostListFilter().filterType == .draft {
+            return [sortDescriptorLocal, sortDescriptorDate]
+        }
         return [sortDescriptorLocal, sortDescriptorImmediately, sortDescriptorDate]
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -378,13 +378,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
     }
 
     func sortDescriptorsForFetchRequest() -> [NSSortDescriptor] {
-        let sortDescriptorLocal = NSSortDescriptor(key: "metaIsLocal", ascending: false)
-        let sortDescriptorImmediately = NSSortDescriptor(key: "metaPublishImmediately", ascending: false)
-        let sortDescriptorDate = dateSortDescriptor()
-        if filterSettings.currentPostListFilter().filterType == .draft {
-            return [sortDescriptorLocal, sortDescriptorDate]
-        }
-        return [sortDescriptorLocal, sortDescriptorImmediately, sortDescriptorDate]
+        return filterSettings.currentPostListFilter().sortDescriptors
     }
 
     func updateAndPerformFetchRequest() {
@@ -720,28 +714,6 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         }
     }
 
-    // MARK: - Sorting
-
-    enum SortField: String {
-        case dateCreated = "date_created_gmt"
-        case dateModified = "dateModified"
-    }
-
-    func sortField() -> SortField {
-        if filterSettings.currentPostListFilter().filterType == .draft {
-            return .dateModified
-        } else {
-            return .dateCreated
-        }
-    }
-
-    func dateSortDescriptor() -> NSSortDescriptor {
-        let field = sortField()
-        // Ascending only for scheduled posts/pages.
-        let ascending = filterSettings.currentPostListFilter().filterType == .scheduled
-
-        return NSSortDescriptor(key: field.rawValue, ascending: ascending)
-    }
 
     // MARK: - Searching
 

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -25,6 +25,29 @@ import Foundation
         self.title = title
     }
 
+    var sortField: AbstractPost.SortField {
+        switch filterType {
+        case .draft:
+            return .dateModified
+        default:
+            return .dateCreated
+        }
+    }
+
+    var sortAscending: Bool {
+        switch filterType {
+        case .scheduled:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var sortDescriptors: [NSSortDescriptor] {
+        let dateDescriptor = NSSortDescriptor(key: sortField.keyPath, ascending: sortAscending)
+        return [dateDescriptor]
+    }
+
     class func postListFilters() -> [PostListFilter] {
         return [publishedFilter(), draftFilter(), scheduledFilter(), trashedFilter()]
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -602,6 +602,8 @@
 		E10B3652158F2D3F00419A93 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E10B3651158F2D3F00419A93 /* QuartzCore.framework */; };
 		E10B3654158F2D4500419A93 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E10B3653158F2D4500419A93 /* UIKit.framework */; };
 		E10B3655158F2D7800419A93 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834CE7371256D0F60046A4A3 /* CoreGraphics.framework */; };
+		E10F3D9F1E5C2C20008FAADA /* AbstractPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10F3D9E1E5C2C20008FAADA /* AbstractPost.swift */; };
+		E10F3DA11E5C2CE0008FAADA /* PostListFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10F3DA01E5C2CE0008FAADA /* PostListFilterTests.swift */; };
 		E11000991CDB5F1E00E33887 /* KeychainTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11000981CDB5F1E00E33887 /* KeychainTools.swift */; };
 		E11330511A13BAA300D36D84 /* me-sites-with-jetpack.json in Resources */ = {isa = PBXBuildFile; fileRef = E11330501A13BAA300D36D84 /* me-sites-with-jetpack.json */; };
 		E11450DF1C4E47E600A6BD0F /* NoticeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11450DE1C4E47E600A6BD0F /* NoticeAnimator.swift */; };
@@ -1912,6 +1914,8 @@
 		E10675C9183FA78E00E5CE5C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		E10B3651158F2D3F00419A93 /* QuartzCore.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E10B3653158F2D4500419A93 /* UIKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		E10F3D9E1E5C2C20008FAADA /* AbstractPost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AbstractPost.swift; sourceTree = "<group>"; };
+		E10F3DA01E5C2CE0008FAADA /* PostListFilterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostListFilterTests.swift; sourceTree = "<group>"; };
 		E11000981CDB5F1E00E33887 /* KeychainTools.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeychainTools.swift; sourceTree = "<group>"; };
 		E11330501A13BAA300D36D84 /* me-sites-with-jetpack.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "me-sites-with-jetpack.json"; sourceTree = "<group>"; };
 		E11450DE1C4E47E600A6BD0F /* NoticeAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoticeAnimator.swift; sourceTree = "<group>"; };
@@ -2875,6 +2879,7 @@
 				B5176CBF1CDCE14F0083CF2D /* People Management */,
 				5D42A3D6175E7452005CFF05 /* AbstractPost.h */,
 				5D42A3D7175E7452005CFF05 /* AbstractPost.m */,
+				E10F3D9E1E5C2C20008FAADA /* AbstractPost.swift */,
 				5D42A3D8175E7452005CFF05 /* BasePost.h */,
 				5D42A3D9175E7452005CFF05 /* BasePost.m */,
 				83418AA811C9FA6E00ACF00C /* Comment.h */,
@@ -3674,6 +3679,7 @@
 			isa = PBXGroup;
 			children = (
 				937E3AB51E3EBE1600CDA01A /* PostEditorStateTests.swift */,
+				E10F3DA01E5C2CE0008FAADA /* PostListFilterTests.swift */,
 			);
 			name = Post;
 			sourceTree = "<group>";
@@ -6222,6 +6228,7 @@
 				B5772ACB1C9DAE7C0031F97E /* NSMutableData+Helpers.swift in Sources */,
 				E1D04D8419374F2C002FADD7 /* BlogServiceRemoteREST.m in Sources */,
 				B5066D031BEBFAA900355819 /* RemoteBlogSettings.swift in Sources */,
+				E10F3D9F1E5C2C20008FAADA /* AbstractPost.swift in Sources */,
 				5926E1E31AC4468300964783 /* WPCrashlytics.m in Sources */,
 				E16273E11B2ACEB600088AF7 /* BlogToBlog32to33.swift in Sources */,
 				E678FC151C76241000F55F55 /* WPStyleGuide+ApplicationStyles.swift in Sources */,
@@ -6662,6 +6669,7 @@
 				B556EFCB1DCA374200728F93 /* DictionaryHelpersTests.swift in Sources */,
 				F1564E5B18946087009F8F97 /* NSStringHelpersTests.m in Sources */,
 				08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */,
+				E10F3DA11E5C2CE0008FAADA /* PostListFilterTests.swift in Sources */,
 				93EF094C19ED533500C89770 /* ContextManagerTests.swift in Sources */,
 				B5552D821CD1061F00B26DF6 /* StringExtensionsTests.swift in Sources */,
 				08AAD6A11CBEA610002B2418 /* MenusServiceTests.m in Sources */,

--- a/WordPress/WordPressTest/PostListFilterTests.swift
+++ b/WordPress/WordPressTest/PostListFilterTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import WordPress
+
+class PostListFilterTests: XCTestCase {
+
+    func testSortDescriptorForPublished() {
+        let filter = PostListFilter.publishedFilter()
+        let descriptors = filter.sortDescriptors
+        XCTAssertEqual(descriptors.count, 1)
+        XCTAssertEqual(descriptors[0].key, "date_created_gmt")
+        XCTAssertEqual(descriptors[0].ascending, false)
+    }
+
+
+    func testSortDescriptorForDrafs() {
+        let filter = PostListFilter.draftFilter()
+        let descriptors = filter.sortDescriptors
+        XCTAssertEqual(descriptors.count, 1)
+        XCTAssertEqual(descriptors[0].key, "dateModified")
+        XCTAssertEqual(descriptors[0].ascending, false)
+    }
+
+    func testSortDescriptorForScheduled() {
+        let filter = PostListFilter.scheduledFilter()
+        let descriptors = filter.sortDescriptors
+        XCTAssertEqual(descriptors.count, 1)
+        XCTAssertEqual(descriptors[0].key, "date_created_gmt")
+        XCTAssertEqual(descriptors[0].ascending, true)
+    }
+
+    func testSortDescriptorForTrashed() {
+        let filter = PostListFilter.trashedFilter()
+        let descriptors = filter.sortDescriptors
+        XCTAssertEqual(descriptors.count, 1)
+        XCTAssertEqual(descriptors[0].key, "date_created_gmt")
+        XCTAssertEqual(descriptors[0].ascending, false)
+    }
+
+    func testSectionIdentifiersMatchSortDescriptors() {
+        // Every filter must use the same field as the base for the sort
+        // descriptor and the sectionIdentifier.
+        //
+        // See https://github.com/wordpress-mobile/WordPress-iOS/issues/6476 for
+        // more background on the issue.
+        //
+        // This doesn't test anything that the above tests haven't tested before
+        // in theory, but is added as a safeguard, in case we add new filters.
+        for filter in PostListFilter.postListFilters() {
+            let descriptors = filter.sortDescriptors
+            XCTAssertEqual(descriptors.count, 1)
+            XCTAssertEqual(descriptors[0].key, filter.sortField.keyPath)
+        }
+    }
+}


### PR DESCRIPTION
This is the longer version of #6723.

I've simplified the sorting logic, removing the sort descriptors by local status and "publish immediately", and leaving only date created/modified.

Sorting by "Publish Immediately" only made sense on drafts, and not really anymore since we sort them by date modified.

The "Local" sort descriptor was useful to ensure that posts with local changes were kept at the top. But revisiting this, there are two cases for local changes:
- Drafts: Any local draft is likely to be at the top anyway because it was the last modified
- Published: The only scenario where a published post can be "Local" is if the app crashed or was killed in the background while the editor was open. The ideal case is that we restore the editor when the app launches again, but that might not always happen. In that case you could argue it's still interesting to show those local posts first. 

`NSFetchedResultsController` really needs the sections and sorting to be based on the same field, so if we wanted to keep these on top, we'd need a separate section for them. But we're not even doing that for failed post uploads, which I'd guess are more frequent. For now, I'd rather simplify and rethink the UI (there are other ways to warn about local/failed changes) if we see it's a problem.

Also refactored things a bit so this could be testable, and used #keyPath so we gain a bit of build-time safety.


To test:

- Verify the steps at #6476 
- Verify the steps at #6723
- Run the test suite
- Check the order of posts/pages in each filter, and verify the sort as you would expect.

Needs review: @aerych 