### PR TITLE
Switch BasePost.status to a swift enum

### DIFF
--- a/WordPress/Classes/Extensions/NSManagedObject.swift
+++ b/WordPress/Classes/Extensions/NSManagedObject.swift
@@ -1,0 +1,16 @@
+import CoreData
+
+extension NSManagedObject {
+    func setRawValue<ValueType: RawRepresentable>(_ value: ValueType?, forKey key: String) {
+        willChangeValue(forKey: key)
+        setPrimitiveValue(value?.rawValue, forKey: key)
+        didChangeValue(forKey: key)
+    }
+
+    func rawValue<ValueType: RawRepresentable>(forKey key: String) -> ValueType? {
+        willAccessValue(forKey: key)
+        let result = primitiveValue(forKey: key) as? ValueType.RawValue
+        didAccessValue(forKey: key)
+        return result.flatMap({ ValueType(rawValue: $0) })
+    }
+}

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension AbstractPost {
+    class func title(for status: Status) -> String {
+        return AbstractPost.title(forStatus: status.rawValue)
+    }
+}

--- a/WordPress/Classes/Models/BasePost.h
+++ b/WordPress/Classes/Models/BasePost.h
@@ -15,7 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSDate * date_created_gmt;
 @property (nonatomic, strong, nullable) NSString * postTitle;
 @property (nonatomic, strong, nullable) NSString * content;
-@property (nonatomic, strong, nullable) NSString * status;
 @property (nonatomic, strong, nullable) NSString * password;
 @property (nonatomic, strong, nullable) NSString * permaLink;
 @property (nonatomic, strong, nullable) NSString * mt_excerpt;

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -17,7 +17,6 @@ static const NSUInteger PostDerivedSummaryLength = 150;
 @dynamic date_created_gmt;
 @dynamic postID;
 @dynamic postTitle;
-@dynamic status;
 @dynamic password;
 @dynamic remoteStatusNumber;
 @dynamic permaLink;
@@ -100,7 +99,7 @@ static const NSUInteger PostDerivedSummaryLength = 150;
 
 - (NSString *)statusForDisplay
 {
-    return self.status;
+    return [self valueForKey:@"status"];
 }
 
 @end

--- a/WordPress/Classes/Models/BasePost.swift
+++ b/WordPress/Classes/Models/BasePost.swift
@@ -1,0 +1,43 @@
+import CoreData
+
+extension BasePost {
+    // We can't use #keyPath on a non-@objc property, and we can't expose
+    // status to Objc-C since it returns an optional enum.
+    // I'd prefer #keyPath over a string constant, but the enum brings way more value.
+    static let statusKeyPath = "status"
+    var status: Status? {
+        get {
+            return rawValue(forKey: BasePost.statusKeyPath)
+        }
+        set {
+            setRawValue(newValue, forKey: BasePost.statusKeyPath)
+        }
+    }
+
+    /// For Obj-C compatibility only
+    @objc(status)
+    var statusString: String? {
+        get {
+            return status?.rawValue
+        }
+        set {
+            status = newValue.flatMap({ Status(rawValue: $0) })
+        }
+    }
+
+    enum Status: String {
+        case draft = "draft"
+        case pending = "pending"
+        case publishPrivate = "private"
+        case publish = "publish"
+        case scheduled = "future"
+        case trash = "trash"
+        case deleted = "deleted" // Returned by wpcom REST API when a post is permanently deleted.
+    }
+}
+
+extension Sequence where Iterator.Element == BasePost.Status {
+    var strings: [String] {
+        return map({ $0.rawValue })
+    }
+}

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -143,7 +143,7 @@ class Post: AbstractPost {
     // MARK: - Sharing
 
     func canEditPublicizeSettings() -> Bool {
-        return !self.hasRemote() || self.status != PostStatusPublish
+        return !self.hasRemote() || self.status != .publish
     }
 
     // MARK: - PublicizeConnections
@@ -265,7 +265,7 @@ class Post: AbstractPost {
     override func statusForDisplay() -> String? {
         var statusString: String?
 
-        if status != PostStatusPublish && status != PostStatusDraft {
+        if status != .publish && status != .draft {
             statusString = statusTitle as String?
         }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -263,7 +263,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
         let page = pageAtIndexPath(indexPath)
 
-        if page.remoteStatus != AbstractPostRemoteStatusPushing && page.status != PostStatusTrash {
+        if page.remoteStatus != AbstractPostRemoteStatusPushing && page.status != .trash {
             editPage(page)
         }
     }
@@ -406,7 +406,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         WPAnalytics.track(.postListDraftAction, withProperties: propertiesForAnalytics())
 
         let previousStatus = apost.status
-        apost.status = PostStatusDraft
+        apost.status = .draft
 
         let contextManager = ContextManager.sharedInstance()
         let postService = PostService(managedObjectContext: contextManager.mainContext)

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -589,7 +589,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         let postService = PostService(managedObjectContext: managedObjectContext())
 
         let options = PostServiceSyncOptions()
-        options.statuses = filter.statuses
+        options.statuses = filter.statuses.strings
         options.authorID = author
         options.number = numberOfPostsPerSync() as NSNumber!
         options.purgesLocalSync = true
@@ -642,7 +642,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         let postService = PostService(managedObjectContext: managedObjectContext())
 
         let options = PostServiceSyncOptions()
-        options.statuses = filter.statuses
+        options.statuses = filter.statuses.strings
         options.authorID = author
         options.number = numberOfPostsPerSync() as NSNumber!
         options.offset = tableViewHandler.resultsController.fetchedObjects?.count as NSNumber!
@@ -798,7 +798,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         let author = filterSettings.shouldShowOnlyMyPosts() ? blogUserID() : nil
         let postService = PostService(managedObjectContext: managedObjectContext())
         let options = PostServiceSyncOptions()
-        options.statuses = filter.statuses
+        options.statuses = filter.statuses.strings
         options.authorID = author
         options.number = 20
         options.purgesLocalSync = false
@@ -821,7 +821,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
     func publishPost(_ apost: AbstractPost) {
         WPAnalytics.track(.postListPublishAction, withProperties: propertiesForAnalytics())
 
-        apost.status = PostStatusPublish
+        apost.status = .publish
         if let date = apost.dateCreated, date == (Date() as NSDate).laterDate(date) {
             apost.dateCreated = Date()
         }
@@ -983,7 +983,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         updateAndPerformFetchRequestRefreshingResults()
     }
 
-    func updateFilterWithPostStatus(_ status: String) {
+    func updateFilterWithPostStatus(_ status: BasePost.Status) {
         filterSettings.setFilterWithPostStatus(status)
         refreshAndReload()
         WPAnalytics.track(.postListStatusFilterChanged, withProperties: propertiesForAnalytics())

--- a/WordPress/Classes/ViewRelated/Post/PostEditorSaveAction.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorSaveAction.swift
@@ -19,7 +19,7 @@ extension WPPostViewController {
             let originalStatus = post.original?.status, status != originalStatus || !post.hasRemote() {
             if (post.isScheduled()) {
                 return .schedule
-            } else if (status == PostStatusPublish) {
+            } else if (status == .publish) {
                 return .post
             } else {
                 return .save

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -1,17 +1,5 @@
 import Foundation
 
-// Taken from AbstractPost.m - this should get a better home than here
-///
-enum PostStatus: String {
-    case draft = "draft"
-    case pending = "pending"
-    case publishPrivate = "private"
-    case publish = "publish"
-    case scheduled = "future"
-    case trash = "trash"
-    case deleted = "deleted" // Returned by wpcom REST API when a post is permanently deleted.
-}
-
 /// The various states of the editor interface and all associated UI values
 ///
 /// None of the associated values should be (nor can be) accessed directly by the UI, only through the `PostEditorStateContext` instance.
@@ -103,7 +91,7 @@ fileprivate protocol PostEditorActionState {
     var action: PostEditorAction { get }
 
     // Actions that change state
-    func updated(postStatus: PostStatus, context: PostEditorStateContext) -> PostEditorActionState
+    func updated(postStatus: BasePost.Status, context: PostEditorStateContext) -> PostEditorActionState
     func updated(publishDate: Date?, context: PostEditorStateContext) -> PostEditorActionState
 }
 
@@ -128,7 +116,7 @@ public class PostEditorStateContext {
         }
     }
 
-    fileprivate var originalPostStatus: PostStatus?
+    fileprivate var originalPostStatus: BasePost.Status?
     fileprivate var userCanPublish: Bool
     private weak var delegate: PostEditorStateContextDelegate?
 
@@ -156,7 +144,7 @@ public class PostEditorStateContext {
     ///   - originalPostStatus: If the post was already published (saved to the server) what is the status
     ///   - userCanPublish: Does the user have permission to publish posts or merely create drafts
     ///   - delegate: Delegate for listening to change in state for the editor
-    init(originalPostStatus: PostStatus? = nil, userCanPublish: Bool = true, delegate: PostEditorStateContextDelegate) {
+    init(originalPostStatus: BasePost.Status? = nil, userCanPublish: Bool = true, delegate: PostEditorStateContextDelegate) {
         self.originalPostStatus = originalPostStatus
         self.userCanPublish = userCanPublish
         self.delegate = delegate
@@ -176,7 +164,7 @@ public class PostEditorStateContext {
 
     /// Call when the post status has changed due to a remote operation
     ///
-    func updated(postStatus: PostStatus) {
+    func updated(postStatus: BasePost.Status) {
         let updatedState = editorState.updated(postStatus: postStatus, context: self)
         guard type(of: editorState) != type(of: updatedState) else {
             return
@@ -274,7 +262,7 @@ fileprivate class PostEditorStatePublish: PostEditorActionState {
         return .publish
     }
 
-    func updated(postStatus: PostStatus, context: PostEditorStateContext) -> PostEditorActionState {
+    func updated(postStatus: BasePost.Status, context: PostEditorStateContext) -> PostEditorActionState {
         switch postStatus {
         case .draft where context.originalPostStatus == .publish:
             // If switching to a draft the post should show Update
@@ -304,7 +292,7 @@ fileprivate class PostEditorStateSave: PostEditorActionState {
         return .save
     }
 
-    func updated(postStatus: PostStatus, context: PostEditorStateContext) -> PostEditorActionState {
+    func updated(postStatus: BasePost.Status, context: PostEditorStateContext) -> PostEditorActionState {
         switch postStatus {
         case .publish:
             // If a draft is published, it should show Update
@@ -331,7 +319,7 @@ fileprivate class PostEditorStateSchedule: PostEditorActionState {
         return .schedule
     }
 
-    func updated(postStatus: PostStatus, context: PostEditorStateContext) -> PostEditorActionState {
+    func updated(postStatus: BasePost.Status, context: PostEditorStateContext) -> PostEditorActionState {
         switch postStatus {
         case .scheduled:
             // When a post is scheduled, button should transition to Update
@@ -358,7 +346,7 @@ fileprivate class PostEditorStateSubmitForReview: PostEditorActionState {
         return .submitForReview
     }
 
-    func updated(postStatus: PostStatus, context: PostEditorStateContext) -> PostEditorActionState {
+    func updated(postStatus: BasePost.Status, context: PostEditorStateContext) -> PostEditorActionState {
         return self
     }
 
@@ -374,7 +362,7 @@ fileprivate class PostEditorStateUpdate: PostEditorActionState {
         return .update
     }
 
-    func updated(postStatus: PostStatus, context: PostEditorStateContext) -> PostEditorActionState {
+    func updated(postStatus: BasePost.Status, context: PostEditorStateContext) -> PostEditorActionState {
         return self
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -13,10 +13,21 @@ import Foundation
     var filterType: Status
     var oldestPostDate: Date?
     var predicateForFetchRequest: NSPredicate
-    var statuses: [String]
+    var statuses: [BasePost.Status]
     var title: String
 
-    init(title: String, filterType: Status, predicate: NSPredicate, statuses: [String]) {
+    /// For Obj-C compatibility only
+    @objc(statuses)
+    var statusesStrings: [String] {
+        get {
+            return statuses.strings
+        }
+        set {
+            statuses = newValue.flatMap({ BasePost.Status(rawValue: $0) })
+        }
+    }
+
+    init(title: String, filterType: Status, predicate: NSPredicate, statuses: [BasePost.Status]) {
         hasMore = true
 
         self.filterType = filterType
@@ -31,8 +42,8 @@ import Foundation
 
     class func publishedFilter() -> PostListFilter {
         let filterType: Status = .published
-        let predicate = NSPredicate(format: "status IN %@", [PostStatusPublish, PostStatusPrivate])
-        let statuses = [PostStatusPublish, PostStatusPrivate]
+        let statuses: [BasePost.Status] = [.publish, .publishPrivate]
+        let predicate = NSPredicate(format: "status IN %@", statuses.strings)
         let title = NSLocalizedString("Published", comment: "Title of the published filter. This filter shows a list of posts that the user has published.")
 
         return PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
@@ -40,8 +51,9 @@ import Foundation
 
     class func draftFilter() -> PostListFilter {
         let filterType: Status = .draft
-        let predicate = NSPredicate(format: "NOT status IN %@", [PostStatusPublish, PostStatusPrivate, PostStatusScheduled, PostStatusTrash])
-        let statuses = [PostStatusDraft, PostStatusPending]
+        let statuses: [BasePost.Status] = [.draft, .pending]
+        let statusesExcluded: [BasePost.Status] = [.publish, .publishPrivate, .scheduled, .trash]
+        let predicate = NSPredicate(format: "NOT status IN %@", statusesExcluded.strings)
         let title = NSLocalizedString("Draft", comment: "Title of the draft filter.  This filter shows a list of draft posts.")
 
         return PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
@@ -49,8 +61,8 @@ import Foundation
 
     class func scheduledFilter() -> PostListFilter {
         let filterType: Status = .scheduled
-        let predicate = NSPredicate(format: "status = %@", PostStatusScheduled)
-        let statuses = [PostStatusScheduled]
+        let statuses: [BasePost.Status] = [.scheduled]
+        let predicate = NSPredicate(format: "status IN %@", statuses.strings)
         let title = NSLocalizedString("Scheduled", comment: "Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date.")
 
         return PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
@@ -58,8 +70,8 @@ import Foundation
 
     class func trashedFilter() -> PostListFilter {
         let filterType: Status = .trashed
-        let predicate = NSPredicate(format: "status = %@", PostStatusTrash)
-        let statuses = [PostStatusTrash]
+        let statuses: [BasePost.Status] = [.trash]
+        let predicate = NSPredicate(format: "status IN %@", statuses.strings)
         let title = NSLocalizedString("Trashed", comment: "Title of the trashed filter. This filter shows posts that have been moved to the trash bin.")
 
         return PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)

--- a/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
@@ -33,12 +33,12 @@ class PostListFilterSettings: NSObject {
         return allPostListFilters!
     }
 
-    func filterThatDisplaysPostsWithStatus(_ postStatus: String) -> PostListFilter {
+    func filterThatDisplaysPostsWithStatus(_ postStatus: BasePost.Status) -> PostListFilter {
         let index = indexOfFilterThatDisplaysPostsWithStatus(postStatus)
         return availablePostListFilters()[index]
     }
 
-    func indexOfFilterThatDisplaysPostsWithStatus(_ postStatus: String) -> Int {
+    func indexOfFilterThatDisplaysPostsWithStatus(_ postStatus: BasePost.Status) -> Int {
         var index = 0
         var found = false
 
@@ -68,7 +68,7 @@ class PostListFilterSettings: NSObject {
         }
     }
 
-    func setFilterWithPostStatus(_ status: String) {
+    func setFilterWithPostStatus(_ status: BasePost.Status) {
         let index = indexOfFilterThatDisplaysPostsWithStatus(status)
         self.setCurrentFilterIndex(index)
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -327,7 +327,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             return
         }
 
-        if post.status == PostStatusTrash {
+        if post.status == .trash {
             // No editing posts that are trashed.
             return
         }
@@ -494,7 +494,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func cell(_ cell: UITableViewCell, handleTrashPost post: AbstractPost) {
-        if (post.status == PostStatusTrash) {
+        if (post.status == .trash) {
 
             let cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
             let deleteText = NSLocalizedString("Delete", comment: "Deletes post permanently")

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -699,6 +699,7 @@
 		E19A10CA1B010AA0006192B0 /* WPURLRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E19A10C91B010AA0006192B0 /* WPURLRequestTest.m */; };
 		E19B17AE1E5C6944007517C6 /* BasePost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19B17AD1E5C6944007517C6 /* BasePost.swift */; };
 		E19B17B01E5C69A5007517C6 /* NSManagedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19B17AF1E5C69A5007517C6 /* NSManagedObject.swift */; };
+		E19B17B21E5C8F36007517C6 /* AbstractPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19B17B11E5C8F36007517C6 /* AbstractPost.swift */; };
 		E19DF741141F7BDD000002F3 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E19DF740141F7BDD000002F3 /* libz.dylib */; };
 		E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A03EE117422DCE0085D192 /* BlogToAccount.m */; };
 		E1A03F48174283E10085D192 /* BlogToJetpackAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A03F47174283E00085D192 /* BlogToJetpackAccount.m */; };
@@ -2069,6 +2070,7 @@
 		E19A10C91B010AA0006192B0 /* WPURLRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPURLRequestTest.m; sourceTree = "<group>"; };
 		E19B17AD1E5C6944007517C6 /* BasePost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasePost.swift; sourceTree = "<group>"; };
 		E19B17AF1E5C69A5007517C6 /* NSManagedObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSManagedObject.swift; sourceTree = "<group>"; };
+		E19B17B11E5C8F36007517C6 /* AbstractPost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AbstractPost.swift; sourceTree = "<group>"; };
 		E19BF8F913CC69E7004753FE /* WordPress 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 3.xcdatamodel"; sourceTree = "<group>"; };
 		E19DF740141F7BDD000002F3 /* libz.dylib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		E1A03EE017422DCD0085D192 /* BlogToAccount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogToAccount.h; sourceTree = "<group>"; };
@@ -2879,6 +2881,7 @@
 				B5176CBF1CDCE14F0083CF2D /* People Management */,
 				5D42A3D6175E7452005CFF05 /* AbstractPost.h */,
 				5D42A3D7175E7452005CFF05 /* AbstractPost.m */,
+				E19B17B11E5C8F36007517C6 /* AbstractPost.swift */,
 				5D42A3D8175E7452005CFF05 /* BasePost.h */,
 				5D42A3D9175E7452005CFF05 /* BasePost.m */,
 				E19B17AD1E5C6944007517C6 /* BasePost.swift */,
@@ -6467,6 +6470,7 @@
 				FF8DDCDF1B5DB1C10098826F /* SettingTableViewCell.m in Sources */,
 				B52D29A51B66BEB70010BD3D /* RemoteNotificationSettings.swift in Sources */,
 				5DF7F7741B22337C003A05C8 /* WordPress-30-31.xcmappingmodel in Sources */,
+				E19B17B21E5C8F36007517C6 /* AbstractPost.swift in Sources */,
 				5D577D361891360900B964C3 /* PostGeolocationView.m in Sources */,
 				E1C9AA511C10419200732665 /* Math.swift in Sources */,
 				FF3DD6BE19F2B6B3003A52CB /* RemoteMedia.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -697,6 +697,8 @@
 		E18EE95119349EC300B0A40C /* ReaderTopicServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = E18EE95019349EC300B0A40C /* ReaderTopicServiceRemote.m */; };
 		E1926C091C779868009F3C2C /* PlanListViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B2FF581C637AE200F6BDEA /* PlanListViewControllerTest.swift */; };
 		E19A10CA1B010AA0006192B0 /* WPURLRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E19A10C91B010AA0006192B0 /* WPURLRequestTest.m */; };
+		E19B17AE1E5C6944007517C6 /* BasePost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19B17AD1E5C6944007517C6 /* BasePost.swift */; };
+		E19B17B01E5C69A5007517C6 /* NSManagedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19B17AF1E5C69A5007517C6 /* NSManagedObject.swift */; };
 		E19DF741141F7BDD000002F3 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E19DF740141F7BDD000002F3 /* libz.dylib */; };
 		E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A03EE117422DCE0085D192 /* BlogToAccount.m */; };
 		E1A03F48174283E10085D192 /* BlogToJetpackAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E1A03F47174283E00085D192 /* BlogToJetpackAccount.m */; };
@@ -1164,7 +1166,7 @@
 		1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForcePopoverPresenter.swift; sourceTree = "<group>"; };
 		1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueDatabase.swift; sourceTree = "<group>"; };
 		1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+StyledHTML.swift"; sourceTree = "<group>"; };
-		17626A8F1DE38FE700140B45 /* PostEditorSaveAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostEditorSaveAction.swift; sourceTree = "<group>"; };
+		17626A8F1DE38FE700140B45 /* PostEditorSaveAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PostEditorSaveAction.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		176579F61C63A40F0000978E /* PurchaseButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseButton.swift; sourceTree = "<group>"; };
 		1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSearchHeaderView.swift; sourceTree = "<group>"; };
 		176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPSplitViewController.swift; sourceTree = "<group>"; };
@@ -1241,7 +1243,7 @@
 		5903AE1A19B60A98009D5354 /* WPButtonForNavigationBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPButtonForNavigationBar.m; sourceTree = "<group>"; usesTabs = 0; };
 		5903AE1C19B60AB9009D5354 /* WPButtonForNavigationBar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WPButtonForNavigationBar.h; sourceTree = "<group>"; usesTabs = 0; };
 		590E873A1CB8205700D1B734 /* PostListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostListViewController.swift; sourceTree = "<group>"; };
-		591232681CCEAA5100B86207 /* AbstractPostListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AbstractPostListViewController.swift; sourceTree = "<group>"; };
+		591232681CCEAA5100B86207 /* AbstractPostListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AbstractPostListViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		591252291A38AE9C00468279 /* TodayWidgetPrefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TodayWidgetPrefix.pch; sourceTree = "<group>"; };
 		591A428A1A6DC1B0003807A6 /* WPBackgroundDimmerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPBackgroundDimmerView.h; sourceTree = "<group>"; };
 		591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPBackgroundDimmerView.m; sourceTree = "<group>"; };
@@ -1261,7 +1263,7 @@
 		5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAppAnalyticsTests.m; sourceTree = "<group>"; };
 		594DB2931AB891A200E2E456 /* WPUserAgent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUserAgent.h; sourceTree = "<group>"; };
 		594DB2941AB891A200E2E456 /* WPUserAgent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUserAgent.m; sourceTree = "<group>"; };
-		595CB3751D2317D50082C7E9 /* PostListFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostListFilter.swift; sourceTree = "<group>"; };
+		595CB3751D2317D50082C7E9 /* PostListFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PostListFilter.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5960967E1CF7959300848496 /* PostTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostTests.swift; sourceTree = "<group>"; };
 		596C035D1B84F21D00899EEB /* ThemeBrowserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserViewController.swift; sourceTree = "<group>"; };
 		596C035F1B84F24000899EEB /* ThemeBrowser.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ThemeBrowser.storyboard; sourceTree = "<group>"; };
@@ -1341,8 +1343,8 @@
 		5D3E334C15EEBB6B005FC6F2 /* ReachabilityUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReachabilityUtils.h; sourceTree = "<group>"; };
 		5D3E334D15EEBB6B005FC6F2 /* ReachabilityUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReachabilityUtils.m; sourceTree = "<group>"; };
 		5D42A3BB175E686F005CFF05 /* WordPress 12.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 12.xcdatamodel"; sourceTree = "<group>"; };
-		5D42A3D6175E7452005CFF05 /* AbstractPost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AbstractPost.h; sourceTree = "<group>"; };
-		5D42A3D7175E7452005CFF05 /* AbstractPost.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AbstractPost.m; sourceTree = "<group>"; };
+		5D42A3D6175E7452005CFF05 /* AbstractPost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = AbstractPost.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		5D42A3D7175E7452005CFF05 /* AbstractPost.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = AbstractPost.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		5D42A3D8175E7452005CFF05 /* BasePost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BasePost.h; sourceTree = "<group>"; };
 		5D42A3D9175E7452005CFF05 /* BasePost.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BasePost.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		5D42A3DC175E7452005CFF05 /* ReaderPost.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReaderPost.h; sourceTree = "<group>"; };
@@ -1582,7 +1584,7 @@
 		93267A6019B896CD00997EB8 /* Info-Internal.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-Internal.plist"; sourceTree = "<group>"; };
 		932AB00A1D526C1400BE486D /* gallery-reader-post-private.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gallery-reader-post-private.json"; sourceTree = "<group>"; };
 		932C6CB21D521DFA006E4A62 /* gallery-reader-post-public.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "gallery-reader-post-public.json"; path = "../gallery-reader-post-public.json"; sourceTree = "<group>"; };
-		93414DE41E2D25AE003143A3 /* PostEditorState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostEditorState.swift; sourceTree = "<group>"; };
+		93414DE41E2D25AE003143A3 /* PostEditorState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PostEditorState.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		93460A36189D5091000E26CE /* WordPress 14.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 14.xcdatamodel"; sourceTree = "<group>"; };
 		934884AC19B78723004028D8 /* WordPressTodayWidget-Internal.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "WordPressTodayWidget-Internal.entitlements"; sourceTree = "<group>"; };
 		934884AE19B7875C004028D8 /* WordPress-Internal.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "WordPress-Internal.entitlements"; sourceTree = "<group>"; };
@@ -2048,7 +2050,6 @@
 		E177807F1C97FA9500FA7E14 /* StoreKit+Debug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StoreKit+Debug.swift"; sourceTree = "<group>"; };
 		E17B98E7171FFB450073E30D /* WordPress 11.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 11.xcdatamodel"; sourceTree = "<group>"; };
 		E17BE7A9134DEC12007285FD /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
-		E17D90CC1E4DBD4800BB1A4B /* WordPress 56.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 56.xcdatamodel"; sourceTree = "<group>"; };
 		E18165FC14E4428B006CE885 /* loader.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = loader.html; path = Resources/HTML/loader.html; sourceTree = "<group>"; };
 		E1823E6B1E42231C00C19F53 /* UIEdgeInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIEdgeInsets.swift; sourceTree = "<group>"; };
 		E183BD7217621D85000B0822 /* WPCookie.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPCookie.h; sourceTree = "<group>"; };
@@ -2066,6 +2067,8 @@
 		E1939C671B15B4D2001AFEF7 /* WordPress 30.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 30.xcdatamodel"; sourceTree = "<group>"; };
 		E19853331755E461001CC6D5 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E19A10C91B010AA0006192B0 /* WPURLRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPURLRequestTest.m; sourceTree = "<group>"; };
+		E19B17AD1E5C6944007517C6 /* BasePost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasePost.swift; sourceTree = "<group>"; };
+		E19B17AF1E5C69A5007517C6 /* NSManagedObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSManagedObject.swift; sourceTree = "<group>"; };
 		E19BF8F913CC69E7004753FE /* WordPress 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 3.xcdatamodel"; sourceTree = "<group>"; };
 		E19DF740141F7BDD000002F3 /* libz.dylib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		E1A03EE017422DCD0085D192 /* BlogToAccount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogToAccount.h; sourceTree = "<group>"; };
@@ -2304,7 +2307,7 @@
 		E6A09BA41C4492DC008626FB /* SharingAuthorizationWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SharingAuthorizationWebViewController.h; sourceTree = "<group>"; };
 		E6A09BA51C4492DC008626FB /* SharingAuthorizationWebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SharingAuthorizationWebViewController.m; sourceTree = "<group>"; };
 		E6A2158D1D10627500DE5270 /* ReaderMenuViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderMenuViewModel.swift; sourceTree = "<group>"; };
-		E6A2158F1D1065F200DE5270 /* AbstractPostTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AbstractPostTest.swift; sourceTree = "<group>"; };
+		E6A2158F1D1065F200DE5270 /* AbstractPostTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AbstractPostTest.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		E6A216921DCE857100E7DF73 /* WPRichTextFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPRichTextFormatterTests.swift; sourceTree = "<group>"; };
 		E6A3384A1BB08E3F00371587 /* ReaderGapMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReaderGapMarker.h; sourceTree = "<group>"; };
 		E6A3384B1BB08E3F00371587 /* ReaderGapMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReaderGapMarker.m; sourceTree = "<group>"; };
@@ -2366,7 +2369,7 @@
 		FDCB9A89134B75B900E5C776 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		FDFB011916B1EA1C00F589A8 /* WordPress 10.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 10.xcdatamodel"; sourceTree = "<group>"; };
 		FF0148E41DFABBC9001AD265 /* NSFileManager+FolderSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSFileManager+FolderSize.swift"; sourceTree = "<group>"; };
-		FF06FFB71D65CB480095CDF7 /* AztecPostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecPostViewController.swift; sourceTree = "<group>"; };
+		FF06FFB71D65CB480095CDF7 /* AztecPostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AztecPostViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		FF0AAE081A1509C50089841D /* WPProgressTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPProgressTableViewCell.h; sourceTree = "<group>"; };
 		FF0AAE091A150A560089841D /* WPProgressTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPProgressTableViewCell.m; sourceTree = "<group>"; };
 		FF0AAE0B1A16550D0089841D /* WPMediaProgressTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPMediaProgressTableViewController.h; sourceTree = "<group>"; };
@@ -2878,6 +2881,7 @@
 				5D42A3D7175E7452005CFF05 /* AbstractPost.m */,
 				5D42A3D8175E7452005CFF05 /* BasePost.h */,
 				5D42A3D9175E7452005CFF05 /* BasePost.m */,
+				E19B17AD1E5C6944007517C6 /* BasePost.swift */,
 				83418AA811C9FA6E00ACF00C /* Comment.h */,
 				83418AA911C9FA6E00ACF00C /* Comment.m */,
 				E14932B4130427B300154804 /* Coordinate.h */,
@@ -4085,6 +4089,7 @@
 				B587796F19B799D800E57C5A /* NSDate+Helpers.swift */,
 				B5DD04731CD3DAB00003DF89 /* NSFetchedResultsController+Helpers.swift */,
 				B587797019B799D800E57C5A /* NSIndexPath+Swift.swift */,
+				E19B17AF1E5C69A5007517C6 /* NSManagedObject.swift */,
 				B574CE141B5E8EA800A84FFD /* NSMutableAttributedString+Helpers.swift */,
 				B5772ACA1C9DAE7C0031F97E /* NSMutableData+Helpers.swift */,
 				B587797119B799D800E57C5A /* NSParagraphStyle+Helpers.swift */,
@@ -6204,6 +6209,7 @@
 				B529069A1DB929D3007121F3 /* NotificationSyncServiceRemote.swift in Sources */,
 				B57AF5FA1ACDC73D0075A7D2 /* NoteBlockActionsTableViewCell.swift in Sources */,
 				85DA8C4418F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m in Sources */,
+				E19B17B01E5C69A5007517C6 /* NSManagedObject.swift in Sources */,
 				E15644EF1CE0E53B00D96E64 /* PlanListViewModel.swift in Sources */,
 				93C1147F18EC5DD500DAC95C /* AccountService.m in Sources */,
 				E6374DBF1C444D8B00F24720 /* KeyringConnection.swift in Sources */,
@@ -6522,6 +6528,7 @@
 				08D345501CD7F50900358E8C /* MenusSelectionDetailView.m in Sources */,
 				591AA5021CEF9BF20074934F /* Post+CoreDataProperties.swift in Sources */,
 				E6D35FFC1C5ABC2700A46303 /* RemoteBlogOptionsHelper.m in Sources */,
+				E19B17AE1E5C6944007517C6 /* BasePost.swift in Sources */,
 				E1EBC36F1C118EA500F638E0 /* ImmuTable.swift in Sources */,
 				B59B18751CC7FB8D0055EB7C /* PersonViewController.swift in Sources */,
 				E1D086E2194214C600F0CC19 /* NSDate+WordPressJSON.m in Sources */,

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -260,52 +260,52 @@ class PostTests: XCTestCase {
     func testThatStatusForDisplayWorksForOriginalPost() {
         let post = newTestPost()
 
-        post.status = PostStatusDraft
+        post.status = .draft
         XCTAssertNil(post.statusForDisplay())
 
-        post.status = PostStatusPending
-        XCTAssertEqual(post.statusForDisplay(), Post.title(forStatus: PostStatusPending))
+        post.status = .pending
+        XCTAssertEqual(post.statusForDisplay(), Post.title(for: .pending))
 
-        post.status = PostStatusPrivate
-        XCTAssertEqual(post.statusForDisplay(), Post.title(forStatus: PostStatusPrivate))
+        post.status = .publishPrivate
+        XCTAssertEqual(post.statusForDisplay(), Post.title(for: .publishPrivate))
 
-        post.status = PostStatusPublish
+        post.status = .publish
         XCTAssertNil(post.statusForDisplay())
 
-        post.status = PostStatusScheduled
-        XCTAssertEqual(post.statusForDisplay(), Post.title(forStatus: PostStatusScheduled))
+        post.status = .scheduled
+        XCTAssertEqual(post.statusForDisplay(), Post.title(for: .scheduled))
 
-        post.status = PostStatusTrash
-        XCTAssertEqual(post.statusForDisplay(), Post.title(forStatus: PostStatusTrash))
+        post.status = .trash
+        XCTAssertEqual(post.statusForDisplay(), Post.title(for: .trash))
 
-        post.status = PostStatusDeleted
-        XCTAssertEqual(post.statusForDisplay(), Post.title(forStatus: PostStatusDeleted))
+        post.status = .deleted
+        XCTAssertEqual(post.statusForDisplay(), Post.title(for: .deleted))
     }
 
     func testThatStatusForDisplayWorksForRevisionPost() {
         let original = newTestPost()
         let revision = original.createRevision()
 
-        revision.status = PostStatusDraft
+        revision.status = .draft
         XCTAssertEqual(revision.statusForDisplay(), "Local")
 
-        revision.status = PostStatusPending
-        XCTAssertEqual(revision.statusForDisplay(), "\(Post.title(forStatus: PostStatusPending)), Local")
+        revision.status = .pending
+        XCTAssertEqual(revision.statusForDisplay(), "\(Post.title(for: .pending)), Local")
 
-        revision.status = PostStatusPrivate
-        XCTAssertEqual(revision.statusForDisplay(), "\(Post.title(forStatus: PostStatusPrivate)), Local")
+        revision.status = .publishPrivate
+        XCTAssertEqual(revision.statusForDisplay(), "\(Post.title(for: .publishPrivate)), Local")
 
-        revision.status = PostStatusPublish
+        revision.status = .publish
         XCTAssertEqual(revision.statusForDisplay(), "Local")
 
-        revision.status = PostStatusScheduled
-        XCTAssertEqual(revision.statusForDisplay(), "\(Post.title(forStatus: PostStatusScheduled)), Local")
+        revision.status = .scheduled
+        XCTAssertEqual(revision.statusForDisplay(), "\(Post.title(for: .scheduled)), Local")
 
-        revision.status = PostStatusTrash
-        XCTAssertEqual(revision.statusForDisplay(), "\(Post.title(forStatus: PostStatusTrash)), Local")
+        revision.status = .trash
+        XCTAssertEqual(revision.statusForDisplay(), "\(Post.title(for: .trash)), Local")
 
-        revision.status = PostStatusDeleted
-        XCTAssertEqual(revision.statusForDisplay(), "\(Post.title(forStatus: PostStatusDeleted)), Local")
+        revision.status = .deleted
+        XCTAssertEqual(revision.statusForDisplay(), "\(Post.title(for: .deleted)), Local")
     }
 
     func testThatHasLocalChangesWorks() {
@@ -377,16 +377,16 @@ class PostTests: XCTestCase {
     func testThatCanEditPublicizeSettingsWorks() {
         let post = newTestPost()
 
-        post.status = PostStatusPublish
+        post.status = .publish
         XCTAssertTrue(post.canEditPublicizeSettings())
 
         post.postID = 2905
         XCTAssertFalse(post.canEditPublicizeSettings())
 
-        post.status = PostStatusScheduled
+        post.status = .scheduled
         XCTAssertTrue(post.canEditPublicizeSettings())
 
-        post.status = PostStatusDraft
+        post.status = .draft
         XCTAssertTrue(post.canEditPublicizeSettings())
     }
 }


### PR DESCRIPTION
I went through the 🐰 🕳 and converted `BasePost.status` into an enum instead of a string, so I didn't have to deal with ugly Obj-C constants in Swift.

Some odd things:
- Added a `NSManagedObject` extension to provide accessors for `RawRepresentable` properties.
- As the `status` accessor is now custom and an optional enum, it can't be `@objc` so you can't do `#keyPath(BasePost.status)`. I added `BasePost.statusKeyPath` as an ugly workaround.
- Added a couple `statusString` helpers. With the help of `@objc`, I didn't need to change any of the Objective-C code using status. I'd rather rewrite that in Swift over time, and remove those helpers when not needed.
- Added an extension on Sequences of PostStatus, so you can access `.strings` and convert them to an array of strings. I would have liked to make it more generic, but I don't think the language allows it yet.

Needs review: @astralbodies 
