### PR TITLE
Fixes a crash when switching between media groups and inserting an image

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -102,8 +102,10 @@
         }
     }];
     id<NSObject> secondKey = [self.mediaLibraryDataSource registerChangeObserverBlock:^(BOOL incrementalChanges, NSIndexSet *removed, NSIndexSet *inserted, NSIndexSet *changed, NSArray<id<WPMediaMove>> *moved) {
-        if (callback) {
-            callback(incrementalChanges, removed, inserted, changed, moved);
+        if (weakSelf.currentDataSource == weakSelf.mediaLibraryDataSource) {
+            if (callback) {
+                callback(incrementalChanges, removed, inserted, changed, moved);
+            }
         }
     }];
     


### PR DESCRIPTION
Fixes: #6030

This should resolve the crashes we've been seeing from the media picker involving section counts not matching. I was able to reliable reproduce the crash through WPiOS (not the media picker project):

## To Test:
1. Select a site that has a lot of remote media (50+ images). It also helps to throttle your connection with network link conditioner or Charles Proxy to simulate slower speeds.
2. Create a new post.
3. Tap the add media button in the post content.
4. Allow access to your photos - make sure you have at least a handful number of images in your camera roll.
5. Tap the group button to switch to Media Library.
6. As soon as the collection view shows the placeholders and starts downloading images, switch back to camera roll (quickly!!).
7. Select any image from the camera roll and tap done.
8. The app should crash shortly.

I suggest testing these steps BEFORE switching to this branch so you get experience reproducing the crash.

## The Fix
This patch adds a check to make sure the media picker callback for updating the data source isn't updating when no longer in the media library group.

Needs Review: @SergioEstevao @kurzee 