### PR TITLE
Prevent crash by not presenting the editor without a site, allow user to create a site.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.h
@@ -8,6 +8,7 @@
 
 - (void)setSelectedBlog:(Blog *)selectedBlog animated:(BOOL)animated;
 
+- (void)presentInterfaceForAddingNewSite;
 - (void)bypassBlogListViewController;
 - (BOOL)shouldBypassBlogListViewControllerWhenSelectedFromTabBar;
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -372,6 +372,12 @@ static NSInteger HideSearchMinSites = 3;
 
 #pragma mark - Public methods
 
+- (void)presentInterfaceForAddingNewSite
+{
+    [self.navigationController popToRootViewControllerAnimated:YES];
+    [self addSite];
+}
+
 - (BOOL)shouldBypassBlogListViewControllerWhenSelectedFromTabBar
 {
     // Ensure our list of sites is up to date

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -39,6 +39,7 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia;
 - (void)showReaderTabForPost:(NSNumber *)postId onBlog:(NSNumber *)blogId;
 
+- (void)switchMySitesTabToAddNewSite;
 - (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog;
 - (void)switchMySitesTabToCustomizeViewForBlog:(Blog *)blog;
 - (void)switchMySitesTabToThemesViewForBlog:(Blog *)blog;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -410,7 +410,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     // Ignore taps on the post tab and instead show the modal.
-    if ([blogService blogCountVisibleForAllAccounts] == 0) {
+    if ([blogService blogCountForAllAccounts] == 0) {
         [self switchMySitesTabToAddNewSite];
     } else {
         [self showPostTabAnimated:true toMedia:false];

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -407,7 +407,14 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (void)showPostTab
 {
-    [self showPostTabAnimated:true toMedia:false];
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+    // Ignore taps on the post tab and instead show the modal.
+    if ([blogService blogCountVisibleForAllAccounts] == 0) {
+        [self switchMySitesTabToAddNewSite];
+    } else {
+        [self showPostTabAnimated:true toMedia:false];
+    }
 }
 
 - (void)showMeTab
@@ -539,15 +546,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     NSUInteger newIndex = [tabBarController.viewControllers indexOfObject:viewController];
 
     if (newIndex == WPTabNewPost) {
-        NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-
-        // Ignore taps on the post tab and instead show the modal.
-        if ([blogService blogCountVisibleForAllAccounts] == 0) {
-            [[WordPressAppDelegate sharedInstance] showWelcomeScreenAnimated:YES thenEditor:YES];
-        } else {
-            [self showPostTab];
-        }
+        [self showPostTab];
         return NO;
     }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -464,6 +464,12 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     }
 }
 
+- (void)switchMySitesTabToAddNewSite
+{
+    [self showTabForIndex:WPTabMySites];
+    [self.blogListViewController presentInterfaceForAddingNewSite];
+}
+
 - (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog
 {
     [self switchMySitesTabToBlogDetailsForBlog:blog];


### PR DESCRIPTION
Fixes #6736

This fixes the primary issue of the crash created in #6736, as seen in Fabric, by instead presenting the Create a Site flow via the My Sites tab.

To test:
1. Follow the steps in #6736
2. Instead, you should be presented with the alert controller to create or add a new site.
3. The tab should automatically switch for you, and no crashes.
4. Upon actually creating/adding a site, we won't follow through with the post button action and let the user decided what to do afterwards.

Needs review: @astralbodies this is the most ideal solution to fix this in the wild, but technically a more minimal fix would be to simply ignore taps on the post button instead of trying to do anything, if there aren't any sites. If we want to go that route with `7.0` instead, we totally can.