### PR TITLE
Fix logic error.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -581,7 +581,7 @@ extension AztecPostViewController {
 
         // Button: Save Draft/Update Draft
         if post.hasLocalChanges() {
-            if post.hasRemote() {
+            if !post.hasRemote() {
                 // The post is a local draft or an autosaved draft: Discard or Save
                 alertController.addDefaultActionWithTitle(NSLocalizedString("Save Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")) { _ in
                     self.post.status = PostStatusDraft


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-Aztec-iOS/issues/295

To test:
 - Using Aztec do
 - Create new post
 - Write some thing on it
 - Tap on the X (close) button
 - Check if you get the option to Save Draft.

Needs review: @astralbodies 