### PR TITLE
Resolves crash upon upload of media when remote errors happen

### DIFF
--- a/WordPress/Classes/Networking/MediaServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteREST.m
@@ -131,7 +131,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
                                                      fileParts:@[filePart]
                                                        success:^(id  _Nonnull responseObject, NSHTTPURLResponse * _Nullable httpResponse) {
         NSDictionary *response = (NSDictionary *)responseObject;
-        NSArray * errorList = response[@"error"];
+        NSArray * errorList = response[@"errors"];
         NSArray * mediaList = response[@"media"];
         if (mediaList.count > 0){
             RemoteMedia * remoteMedia = [self remoteMediaFromJSONDictionary:mediaList[0]];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3015,17 +3015,17 @@
 			children = (
 				591CFB051B28A960009E61B3 /* AccountServiceRemoteRESTTests.m */,
 				591CFB081B28AC8C009E61B3 /* BlogServiceRemoteRESTTests.m */,
-				FA9E74471C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift */,
-				B5BC259F1CFCB91800F7D8B9 /* PeopleRemoteTests.swift */,
+				261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */,
 				0859DCFC1CB8488400EB4069 /* MenusServiceRemoteTests.m */,
 				B532ACD01DC3ABF600FFFA57 /* NotificationSyncServiceRemoteTests.swift */,
+				B5BC259F1CFCB91800F7D8B9 /* PeopleRemoteTests.swift */,
 				59E2AAEB1B20E5CE0051DC06 /* PostServiceRemoteRESTTests.m */,
+				26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */,
 				59E2AAE71B20E3EA0051DC06 /* ServiceRemoteRESTTests.m */,
+				FA9E74471C50382D00C6B1D2 /* SiteManagementServiceRemoteTests.swift */,
 				08A2AD741CCEBDBD00E84454 /* TaxonomyServiceRemoteRESTTests.m */,
 				598F86AA1B67BD7600550C9C /* ThemeServiceRemoteTests.m */,
 				FF34EEA81CF473F600F8B38D /* WordPressComServiceRemoteRestTests.swift */,
-				26A1B59F1DDB6FC1007BDAC0 /* ReaderSiteServiceRemoteTests.swift */,
-				261FF32B1DDCF58900695BD5 /* MediaServiceRemoteRESTTests.swift */,
 			);
 			name = "Remote Services";
 			sourceTree = "<group>";
@@ -4636,24 +4636,24 @@
 		E1239B7B176A2E0F00D37220 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				FF7C89A11E3A1029000472A8 /* MediaPicker */,
-				E6A216911DCE851000E7DF73 /* WPRichText */,
-				FF9839A71CD3960600E85258 /* WordPressAPI */,
-				BEA0E4821BD8353B000AEE81 /* System */,
-				E1C9AA541C1041E600732665 /* Extensions */,
-				59B48B601B99E0B0008EBB84 /* TestUtilities */,
 				B5AEEC7F1ACAD099008BF2A4 /* Categories */,
 				B5AEEC731ACACF3B008BF2A4 /* Core Data */,
+				E1C9AA541C1041E600732665 /* Extensions */,
+				FF7C89A11E3A1029000472A8 /* MediaPicker */,
 				5D7A577D1AFBFD7C0097C028 /* Models */,
 				85F8E1991B017A8E000859BB /* Networking */,
+				B5416CF81C17542900006DD8 /* Notifications */,
 				85D239BD1AE5A6EE0074768D /* NUX */,
 				59ECF8791CB705EB00E68F25 /* Posts */,
 				E6B9B8AB1B94EA710001B92F /* Reader */,
-				B5416CF81C17542900006DD8 /* Notifications */,
 				B5AEEC7E1ACAD088008BF2A4 /* Services */,
+				BEA0E4821BD8353B000AEE81 /* System */,
+				59B48B601B99E0B0008EBB84 /* TestUtilities */,
 				852416D01A12ED2D0030700C /* Utility */,
 				B5AEEC801ACAD0A5008BF2A4 /* ViewControllers */,
 				BE20F5E11B2F738E0020694C /* ViewRelated */,
+				FF9839A71CD3960600E85258 /* WordPressAPI */,
+				E6A216911DCE851000E7DF73 /* WPRichText */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -5332,7 +5332,7 @@
 					};
 					932225A61C7CE50300443B02 = {
 						CreatedOnToolsVersion = 7.2.1;
-						DevelopmentTeam = 99KV9Z6BKV;
+						DevelopmentTeam = PZYM8XX95Q;
 						LastSwiftMigration = 0820;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {

--- a/WordPress/WordPressTest/MediaServiceRemoteRESTTests.swift
+++ b/WordPress/WordPressTest/MediaServiceRemoteRESTTests.swift
@@ -70,7 +70,7 @@ class MediaServiceRemoteRESTTests: XCTestCase {
 
     func testCreateMediaError() {
 
-        let response = ["error": ["some error"]]
+        let response = ["errors": ["some error"]]
         let media = mockRemoteMedia()
         var progress: Progress? = nil
         var errorDescription = ""
@@ -78,7 +78,7 @@ class MediaServiceRemoteRESTTests: XCTestCase {
             errorDescription = ($0?.localizedDescription)!
         })
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
-        XCTAssertEqual(errorDescription, response["error"]![0])
+        XCTAssertEqual(errorDescription, response["errors"]![0])
     }
 
     func testUpdateMediaPath() {


### PR DESCRIPTION
Fixes #6360 

Errors returned by the media endpoint have two dictionary keys - `media` and `errors`. In code the errors key was misspelled as `error`. The unit test also made this assumption.

https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/media/new/#apidoc-response

## To test:
I can't figure out the best way to test this remotely because it's difficult to get the API side to return an error on media upload. Specifically the user who reported this has some Jetpack connectivity issues which is causing media upload to fail.

I did update the unit test with the right key and verified that the tests do cause the same crash when it's not the right key.

Needs review: @koke, @SergioEstevao 
