### PR TITLE
Remove title from login error screens

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Signin.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Signin.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16E163f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -985,7 +986,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Vx6-Eq-ho8">
-                                <rect key="frame" x="43" y="231.5" width="289" height="116"/>
+                                <rect key="frame" x="43" y="249.5" width="289" height="80.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-alert" translatesAutoresizingMaskIntoConstraints="NO" id="v7t-tc-0qh">
                                         <rect key="frame" x="113.5" y="0.0" width="62" height="52"/>
@@ -994,15 +995,9 @@
                                             <constraint firstAttribute="height" constant="52" id="toG-vl-LrL"/>
                                         </constraints>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="99N-tl-1Nv">
-                                        <rect key="frame" x="121.5" y="60" width="46" height="30"/>
-                                        <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
-                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WGk-iP-Ea8">
-                                        <rect key="frame" x="105" y="98" width="79" height="18"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <rect key="frame" x="100.5" y="60" width="88" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
@@ -1049,7 +1044,6 @@
                         <outlet property="icon" destination="v7t-tc-0qh" id="6A6-lC-f2N"/>
                         <outlet property="primaryButton" destination="1qa-33-ovF" id="gqu-30-5dP"/>
                         <outlet property="secondaryButton" destination="JxF-Rn-MsR" id="WsO-Gi-kiz"/>
-                        <outlet property="titleLabel" destination="99N-tl-1Nv" id="faA-gH-Rtj"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="k2v-Vb-eUr" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninErrorViewController.swift
@@ -11,7 +11,6 @@ class SigninErrorViewController: UIViewController {
     typealias SigninErrorCallback = (() -> Void)
 
     @IBOutlet weak var icon: UIImageView!
-    @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var primaryButton: UIButton!
     @IBOutlet weak var secondaryButton: UIButton!
@@ -59,7 +58,6 @@ class SigninErrorViewController: UIViewController {
     func configureView(_ message: String, firstButtonText: String?, firstButtonCallback: SigninErrorCallback?, secondButtonText: String?, secondButtonCallback: @escaping SigninErrorCallback, accessibilityIdentifier: String?) {
         assert(!message.isEmpty)
 
-        titleLabel.text = NSLocalizedString("Sorry, we can't log you in.", comment: "")
         descriptionLabel.text = message
         primaryButton.setTitle(NSLocalizedString("OK", comment: ""), for: UIControlState())
         secondaryButton.setTitle(NSLocalizedString("Need Help?", comment: ""), for: UIControlState())
@@ -98,7 +96,7 @@ class SigninErrorViewController: UIViewController {
         controller.definesPresentationContext = true
         controller.present(self, animated: false, completion: {
             if (UIAccessibilityIsVoiceOverRunning()) {
-                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, self.titleLabel)
+                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, self.descriptionLabel)
             }
         })
     }

--- a/WordPress/WordPressUITests/LoginTests.swift
+++ b/WordPress/WordPressUITests/LoginTests.swift
@@ -36,6 +36,8 @@ class LoginTests: XCTestCase {
 
         app.buttons["Log In"].tap()
 
+        // TODO: this will be broken now as this text has been removed from the error.
+        // however, since all UI tests are currently broken, this is staying as-is for now.
         self.waitForElementToAppear(app.staticTexts["Sorry, we can't log you in."])
 
         app.buttons["OK"].tap()


### PR DESCRIPTION
Fixes #4717

The generic "Sorry, we can't log you in" title has been removed from login error screens in favour of the description which contains information on the specific problem encountered.

### Before/After:
![login error before and after](https://cloud.githubusercontent.com/assets/517257/23228838/9e401d74-f903-11e6-9eaa-a92eb7ad738b.png)

To test:
1. Attempt to login to either a WordPress.com or self-hosted site
2. Enter the wrong password or username
3. Observe that the error no longer has the title text.

Needs review: @bummytime 