### PR TITLE
WPError: dispatch alert and presentation on main queue.

### DIFF
--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -149,37 +149,39 @@ NSString * const WPErrorSupportSourceKey = @"helpshift-support-source";
 
 + (void)showAlertWithTitle:(NSString *)title message:(NSString *)message withSupportButton:(BOOL)showSupport fromSource:(NSString *)sourceTag okPressedBlock:(void (^)(UIAlertController *))okBlock
 {
-    if ([WPError internalInstance].alertShowing) {
-        return;
-    }
-    [WPError internalInstance].alertShowing = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([WPError internalInstance].alertShowing) {
+            return;
+        }
+        [WPError internalInstance].alertShowing = YES;
 
-    DDLogInfo(@"Showing alert with title: %@ and message %@", title, message);
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
-                                                                             message:[message stringByStrippingHTML]
-                                                                      preferredStyle:UIAlertControllerStyleAlert];
+        DDLogInfo(@"Showing alert with title: %@ and message %@", title, message);
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:title
+                                                                                 message:[message stringByStrippingHTML]
+                                                                          preferredStyle:UIAlertControllerStyleAlert];
 
-    UIAlertAction *action = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
-                                                     style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                                                         if (okBlock) {
-                                                             okBlock(alertController);
-                                                         }
-                                                         [WPError internalInstance].alertShowing = NO;
-                                                     }];
-    [alertController addAction:action];
-    if (showSupport) {
-        NSString *supportText = NSLocalizedString(@"Need Help?", @"'Need help?' button label, links off to the WP for iOS FAQ.");
-        UIAlertAction *action = [UIAlertAction actionWithTitle:supportText
-                                                         style:UIAlertActionStyleCancel
-                                                       handler:^(UIAlertAction * _Nonnull action) {
-                                                           SupportViewController *supportVC = [SupportViewController new];
-                                                           supportVC.sourceTag = sourceTag;
-                                                           [supportVC showFromTabBar];
-                                                           [WPError internalInstance].alertShowing = NO;
-                                                       }];
+        UIAlertAction *action = [UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                         style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                                                             if (okBlock) {
+                                                                 okBlock(alertController);
+                                                             }
+                                                             [WPError internalInstance].alertShowing = NO;
+                                                         }];
         [alertController addAction:action];
-    }
-    [alertController presentFromRootViewController];
+        if (showSupport) {
+            NSString *supportText = NSLocalizedString(@"Need Help?", @"'Need help?' button label, links off to the WP for iOS FAQ.");
+            UIAlertAction *action = [UIAlertAction actionWithTitle:supportText
+                                                             style:UIAlertActionStyleCancel
+                                                           handler:^(UIAlertAction * _Nonnull action) {
+                                                               SupportViewController *supportVC = [SupportViewController new];
+                                                               supportVC.sourceTag = sourceTag;
+                                                               [supportVC showFromTabBar];
+                                                               [WPError internalInstance].alertShowing = NO;
+                                                           }];
+            [alertController addAction:action];
+        }
+        [alertController presentFromRootViewController];
+    });
 }
 
 @end


### PR DESCRIPTION
This fixes a recurring crash we've had for a while now in which _something_ is amiss down the line when presenting alertcontrollers via `WPError`.

```
UIAlertController+Helpers.swift line 0
UIAlertController.presentFromRootViewController() -> ()
```

I've dug into this for quite some time and still can't nail exactly where this is occurring. Generally any time a `WPError.showAlertWithTitle ` call is made within an `NSOperationQueue`, things get crazy and `UIAlertController` winds up on a thread != the main thread.

That said, while a bit sloppy, wrapping our `showAlertWithTitle:message:withSupportButton:fromSource:okPressedBlock` block of code within an async dispatch to the main queue will prevent any crashes arising from `WPError` being called in questionable areas.

Ideally we would never call `WPError` methods within something that's not already wrapped into the main thread, but it's easy to make this mistake and it's best we go ahead and wrap a big ole fluffy dispatch safety blanket across our alert controller.

To test:
1. Build, generate an error.
2. Such as adding a featured image, media, logging into Jetpack connection, etc, without an internet connection.

Needs review: @astralbodies can you give this a spin? Also, it would be great if we dropped it into `7.0`.

```
Fatal Exception: NSInternalInconsistencyException
0  CoreFoundation                 0x185aa21c0 __exceptionPreprocess
1  libobjc.A.dylib                0x1844dc55c objc_exception_throw
2  CoreFoundation                 0x185aa2094 +[NSException raise:format:]
3  Foundation                     0x18652f79c -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:]
4  UIKit                          0x18b929328 -[UIKeyboardTaskQueue waitUntilAllTasksAreFinished]
5  UIKit                          0x18b929d7c -[UIKeyboardImpl setDelegate:force:]
6  UIKit                          0x18b923678 -[UIPeripheralHost(UIKitInternal) _reloadInputViewsForResponder:]
7  UIKit                          0x18bffb3bc -[UIPeripheralHost(UIKitInternal) _preserveInputViewsWithId:animated:reset:]
8  UIKit                          0x18bc67860 -[UIViewController _presentViewController:modalSourceViewController:presentationController:animationController:interactionController:completion:]
9  UIKit                          0x18bc69328 -[UIViewController _presentViewController:withAnimationController:completion:]
10 UIKit                          0x18bc6be5c -[UIViewController _performCoordinatedPresentOrDismiss:animated:]
11 UIKit                          0x18b9efb54 -[UIViewController presentViewController:animated:completion:]
12 WordPress                      0x10039de04 UIAlertController.presentFromRootViewController() -> () (UIAlertController+Helpers.swift)
13 WordPress                      0x10039de50 @objc UIAlertController.presentFromRootViewController() -> () (UIAlertController+Helpers.swift)
14 WordPress                      0x1001b8384 +[WPError showAlertWithTitle:message:withSupportButton:okPressedBlock:] (WPError.m:173)
15 WordPress                      0x1001b7ffc +[WPError showAlertWithTitle:message:] (WPError.m:134)
16 WordPress                      0x1001b7f84 +[WPError showXMLRPCErrorAlert:] (WPError.m:129)
17 WordPress                      0x1001417f8 __51-[WPAddPostCategoryViewController saveAddCategory:]_block_invoke.102 (WPAddPostCategoryViewController.m:127)
18 WordPress                      0x1002358ac __81-[TaxonomyServiceRemoteXMLRPC createTaxonomyWithType:parameters:success:failure:]_block_invoke.129 (TaxonomyServiceRemoteXMLRPC.m:165)
19 WordPress                      0x1004c0a20 partial apply for thunk (WordPressOrgXMLRPCApi.swift)
20 WordPress                      0x1004bd5b8 WordPressOrgXMLRPCApi.(callMethod(String, parameters : [AnyObject]?, success : (AnyObject, NSHTTPURLResponse?) -> (), failure : (error : NSError, httpResponse : NSHTTPURLResponse?) -> ()) -> NSProgress?).(closure #1) (WordPressOrgXMLRPCApi.swift:106)
21 CFNetwork                      0x1860a2a40 __75-[__NSURLSessionLocal taskForClass:request:uploadFile:bodyData:completion:]_block_invoke
22 CFNetwork                      0x1860ba960 __49-[__NSCFLocalSessionTask _task_onqueue_didFinish]_block_invoke
23 Foundation                     0x186566754 __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__
24 Foundation                     0x1864ab2c8 -[NSBlockOperation main]
25 Foundation                     0x18649b8c4 -[__NSOperationInternal _start:]
26 Foundation                     0x186568b00 __NSOQSchedule_f
27 libdispatch.dylib              0x18492d1c0 _dispatch_client_callout
28 libdispatch.dylib              0x18493b444 _dispatch_queue_serial_drain
29 libdispatch.dylib              0x1849309a8 _dispatch_queue_invoke
30 libdispatch.dylib              0x18493d38c _dispatch_root_queue_drain
31 libdispatch.dylib              0x18493d0ec _dispatch_worker_thread3
32 libsystem_pthread.dylib        0x184b362b8 _pthread_wqthread
33 libsystem_pthread.dylib        0x184b35da4 start_wqthread
```