### PR TITLE
Menus: Added taptic feedback for reordering

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
@@ -33,6 +33,8 @@ static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
 @property (nonatomic, strong) MenuItemView *itemViewForOrdering;
 @property (nonatomic, strong, readonly) MenuItemsVisualOrderingView *visualOrderingView;
 
+@property (nonatomic, strong) UISelectionFeedbackGenerator *orderingFeedbackGenerator;
+
 @end
 
 @implementation MenuItemsViewController
@@ -321,6 +323,8 @@ static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
 
 - (void)updateWithTouchesStarted:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
+    [self prepareOrderingFeedbackGenerator];
+
     CGPoint location = [[touches anyObject] locationInView:self.view];
 
     self.touchesBeganLocation = location;
@@ -414,6 +418,11 @@ static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
         self.showingTouchesOrdering = YES;
         [self showVisualOrderingView];
         [self toggleOrderingPlaceHolder:YES forItemViewsWithSelectedItemView:self.itemViewForOrdering];
+
+        // Apple's documentation says not to trigger on initial selection,
+        // but the built-in taptics for UITableView *does* trigger when you first
+        // start reordering. So, let's match that behavior.
+        [self triggerOrderingFeedbackGenerator];
     }
 }
 
@@ -431,6 +440,7 @@ static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
     [self hideOrdering];
     self.itemViewForOrdering = nil;
     [self.delegate itemsViewController:self prefersScrollingEnabled:YES];
+    [self cleanUpOrderingFeedbackGenerator];
 }
 
 - (void)orderingTouchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event vector:(CGPoint)vector
@@ -530,6 +540,7 @@ static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
     // update the views based on the model changes
     if (modelUpdated) {
         [self updateParentChildIndentationForItemViews];
+        [self triggerOrderingFeedbackGenerator];
         [self.visualOrderingView updateForVisualOrderingMenuItemsModelChange];
         [self.delegate itemsViewController:self didUpdateMenuItemsOrdering:self.menu];
     }
@@ -862,6 +873,25 @@ static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
         // Inform the delegate to begin editing the new item.
         [self.delegate itemsViewController:self createdNewItemForEditing:newItem];
     });
+}
+
+#pragma mark - Ordering Taptic Feedback
+
+- (void)prepareOrderingFeedbackGenerator
+{
+    self.orderingFeedbackGenerator = [UISelectionFeedbackGenerator new];
+    [self.orderingFeedbackGenerator prepare];
+}
+
+- (void)triggerOrderingFeedbackGenerator
+{
+    [self.orderingFeedbackGenerator selectionChanged];
+    [self.orderingFeedbackGenerator prepare];
+}
+
+- (void)cleanUpOrderingFeedbackGenerator
+{
+    self.orderingFeedbackGenerator = nil;
 }
 
 @end


### PR DESCRIPTION
Just for fun, I added taptic feedback to the menu reordering in Menus so that it behaves like a `UITableView`.

To test:

* Go to Details > Menus for a site
* Reorder items in a menu
* Check that you can feel taptic feedback when the selection begins or changes

Needs review: @kurzee 