### PR TITLE
Reader: Changes when stale content is cleaned up.

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -411,9 +411,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
         post.inUse = NO;
     }
 
-    [self.managedObjectContext performBlockAndWait:^{
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-    }];
+    [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
 }
 
 - (void)setFollowing:(BOOL)following forPostsFromSiteWithID:(NSNumber *)siteID andURL:(NSString *)siteURL

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -214,9 +214,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
         topic.inUse = NO;
     }
 
-    [self.managedObjectContext performBlockAndWait:^{
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-    }];
+    [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
 }
 
 - (void)deleteAllTopics

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -83,10 +83,9 @@ import WordPressShared
             restorableSelectedIndexPath = defaultIndexPath
         }
 
-        unflagInUseContent()
         setupRefreshControl()
         setupAccountChangeNotificationObserver()
-        setupApplicationDidLaunchNotificationObserver()
+        setupApplicationWillTerminateNotificationObserver()
     }
 
 
@@ -140,9 +139,10 @@ import WordPressShared
     }
 
 
-    func setupApplicationDidLaunchNotificationObserver() {
-        NotificationCenter.default.addObserver(self, selector: #selector(type(of: self).handleApplicationDidLaunch), name: NSNotification.Name.UIApplicationDidFinishLaunching, object: nil)
+    func setupApplicationWillTerminateNotificationObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(type(of: self).handleApplicationWillTerminate), name: NSNotification.Name.UIApplicationWillTerminate, object: nil)
     }
+
 
     func setupAccountChangeNotificationObserver() {
         NotificationCenter.default.addObserver(self, selector: #selector(type(of: self).handleAccountChanged), name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged, object: nil)
@@ -188,12 +188,15 @@ import WordPressShared
     // MARK: - Instance Methods
 
 
-    /// Handle the UIApplicationDidFinishLaunching notification.
+    /// Handle the UIApplicationWillTerminate notification.
     //
-    func handleApplicationDidLaunch(_ notification: Foundation.Notification) {
+    func handleApplicationWillTerminate(_ notification: Foundation.Notification) {
+        // Its important to clean up stale content before unflagging, otherwise
+        // content we want to preserve for state restoration might also be
+        // deleted.
         cleanupStaleContent(removeAllTopics: false)
+        unflagInUseContent()
     }
-
 
     /// When logged out return the nav stack to the menu
     ///


### PR DESCRIPTION
Fixes #6757, see the issue for details.

This PR changes when the Reader's clean up logic is performed.  Instead of cleaning up stale content at launch, it will not clean up stale content just before the app is terminated. 

To test:
The crash this attempts to fix is difficult to reproduce, so for testing, just confirm that content is being successfully cleaned up when the app is terminated. 

- Go to the reader.  Preview a couple of sites and tags so there will be content to clean up
- Double tap the home button (Or cmd+H for the simulator) and swipe to force close the app.
- Inspect the console output. Confirm that the previewed topic(s) were deleted.

Needs review: @kurzee 
