### PR TITLE
NUX: use the right controller for showSigninForWPComFixingAuthToken()

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -77,8 +77,7 @@ import Mixpanel
     class func showSigninForWPComFixingAuthToken() {
         let controller = signinForWPComFixingAuthToken(nil)
         let presenter = UIApplication.shared.keyWindow?.rootViewController
-        let navController = NUXNavigationController(rootViewController: controller)
-        presenter?.present(navController, animated: true, completion: nil)
+        presenter?.present(controller, animated: true, completion: nil)
 
         trackOpenedLogin()
     }


### PR DESCRIPTION
Fixes #6773

Just needed to not instantiate with another `UINavigationController`.

To test:

1. Add the following block of code to `WordPressAppDelegate.didFinishLaunchingWithOptions:`.
2. Make sure the modal presents as expected, no crash.

```
    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
        [SigninHelpers showSigninForWPComFixingAuthToken];
    });
```

Needs review: @nheagy 
