### PR TITLE
NUX: use weak self for fetching Safari/1Password credentials.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
@@ -204,8 +204,8 @@ import WordPressShared
     ///
     func fetchSharedWebCredentialsIfAvailable() {
         didRequestSafariSharedCredentials = true
-        SigninHelpers.requestSharedWebCredentials { [unowned self] (found, username, password) in
-            self.handleFetchedWebCredentials(found, username: username, password: password)
+        SigninHelpers.requestSharedWebCredentials { [weak self] (found, username, password) in
+            self?.handleFetchedWebCredentials(found, username: username, password: password)
         }
     }
 
@@ -346,9 +346,9 @@ import WordPressShared
     func handleOnePasswordButtonTapped(_ sender: UIButton) {
         view.endEditing(true)
 
-        SigninHelpers.fetchOnePasswordCredentials(self, sourceView: sender, loginFields: loginFields) { [unowned self] (loginFields) in
-            self.emailTextField.text = loginFields.username
-            self.signinWithUsernamePassword(true)
+        SigninHelpers.fetchOnePasswordCredentials(self, sourceView: sender, loginFields: loginFields) { [weak self] (loginFields) in
+            self?.emailTextField.text = loginFields.username
+            self?.signinWithUsernamePassword(true)
         }
     }
 


### PR DESCRIPTION
Fixes #6776

I'm _fairly_ sure we can fix this crash by using `weak self` versus `unowned` self. I'm also generally sure we should be using `weak` here anyways.

To test:
1. Log out.
2. Test Safari credentials, fills, no crashes.
3. On device, test 1Password, fills, no crashes.

Needs review: @aerych 🥇 
