### PR TITLE
Fix UI create account test

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Signin.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Signin.storyboard
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16E163f" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="15G1217" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -140,6 +140,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PCj-nt-T9Y">
                                         <rect key="frame" x="0.0" y="48" width="210" height="28"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="createSiteButton"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="Create a site">
                                             <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -222,6 +223,7 @@
                                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email Address" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="It3-g0-cxp" customClass="WPWalkthroughTextField">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="nuxEmailField"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
                                                         <userDefinedRuntimeAttributes>
@@ -252,6 +254,7 @@
                                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uNv-KX-D1D" customClass="WPWalkthroughTextField">
                                                         <rect key="frame" x="0.0" y="88" width="375" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="nuxPasswordField"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
                                                         <userDefinedRuntimeAttributes>
@@ -267,6 +270,7 @@
                                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Site Address (URL)" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HNy-PM-AgS" customClass="WPWalkthroughTextField">
                                                         <rect key="frame" x="0.0" y="132" width="375" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="nuxUrlField"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
                                                         <userDefinedRuntimeAttributes>
@@ -292,6 +296,7 @@
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b3A-gQ-xPp" customClass="NUXSubmitButton" customModule="WordPress" customModuleProvider="target">
                                                 <rect key="frame" x="124.5" y="287" width="125" height="34"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="nuxCreateAccountButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="34" id="K2q-BG-LM9"/>
                                                 </constraints>

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -49,9 +49,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "LoginTests/testCreateAccount()">
-               </Test>
-               <Test
                   Identifier = "MainNavigationTests">
                </Test>
             </SkippedTests>

--- a/WordPress/WordPressUITests/LoginTests.swift
+++ b/WordPress/WordPressUITests/LoginTests.swift
@@ -46,7 +46,7 @@ class LoginTests: XCTestCase {
 
     func testCreateAccount() {
         let username = "\(WordPressTestCredentials.oneStepUser)\(arc4random())"
-        let email = username + WordPressTestCredentials.nuxEmailSuffix
+        let email = WordPressTestCredentials.nuxEmailPrefix + username + WordPressTestCredentials.nuxEmailSuffix
 
         createAccount(email: email, username: username, password: WordPressTestCredentials.oneStepPassword)
         waitForElementToAppear(element: app.tabBars[ elementStringIDs.mainNavigationBar ], timeout: 20)

--- a/WordPress/WordPressUITests/LoginTests.swift
+++ b/WordPress/WordPressUITests/LoginTests.swift
@@ -46,18 +46,9 @@ class LoginTests: XCTestCase {
 
     func testCreateAccount() {
         let username = "\(WordPressTestCredentials.oneStepUser)\(arc4random())"
-        app.buttons["Create Account"].tap()
+        let email = username + WordPressTestCredentials.nuxEmailSuffix
 
-        let emailAddressField = app.textFields["Email Address"]
-        emailAddressField.tap()
-        emailAddressField.typeText("\(username)@gmail.com")
-
-        let usernameField = app.textFields["Username"]
-        usernameField.tap()
-        usernameField.typeText(username)
-
-        let passwordField = app.secureTextFields["Password"]
-        passwordField.tap()
-        passwordField.typeText(WordPressTestCredentials.oneStepPassword)
+        createAccount(email: email, username: username, password: WordPressTestCredentials.oneStepPassword)
+        waitForElementToAppear(element: app.tabBars[ elementStringIDs.mainNavigationBar ], timeout: 20)
     }
 }

--- a/WordPress/WordPressUITests/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/XCTest+Extensions.swift
@@ -13,9 +13,14 @@ public struct elementStringIDs {
     static var loginSubmitButton = "submitButton"
     static var addSelfHostedButton = "addSelfHostedButton"
     static var selfHostedURLField = "selfHostedURL"
+    static var createSiteButton = "createSiteButton"
 
     // Signup page
     static var nuxUsernameField = "nuxUsernameField"
+    static var nuxEmailField = "nuxEmailField"
+    static var nuxPasswordField = "nuxPasswordField"
+    static var nuxUrlField = "nuxUrlField"
+    static var nuxCreateAccountButton = "nuxCreateAccountButton"
 
     // My Sites page
     static var settingsButton = "BlogDetailsSettingsCell"
@@ -25,6 +30,25 @@ public struct elementStringIDs {
 
     // Me tab
     static var disconnectFromWPcomButton = "disconnectFromWPcomButton"
+}
+
+extension XCUIElement {
+    /**
+     Removes any current text in the field before typing in the new value
+     - Parameter text: the text to enter into the field
+     */
+    func clearAndEnterText(text: String) -> Void {
+        let app = XCUIApplication()
+
+        if (self.value as! String).characters.count > 0 {
+            self.press(forDuration: 1.2)
+            app.menuItems["Select All"].tap()
+        } else {
+            self.tap()
+        }
+
+        self.typeText(text)
+    }
 }
 
 extension XCTestCase {
@@ -117,5 +141,35 @@ extension XCTestCase {
         } else {
             app.sheets.buttons.element(boundBy: 0).tap()
         }
+    }
+
+    public func createAccount(email: String, username: String, password: String, url: String? = nil) {
+        let app = XCUIApplication()
+        let createSiteFromLoginScreenButton = app.buttons[ elementStringIDs.createSiteButton ]
+        let emailField = app.textFields[ elementStringIDs.nuxEmailField ]
+        let usernameField = app.textFields[ elementStringIDs.nuxUsernameField ]
+        let passwordField = app.secureTextFields[ elementStringIDs.nuxPasswordField ]
+        let urlField = app.textFields[ elementStringIDs.nuxUrlField ]
+        let createAccountButton = app.buttons[ elementStringIDs.nuxCreateAccountButton ]
+
+        if createSiteFromLoginScreenButton.exists {
+            createSiteFromLoginScreenButton.tap()
+        }
+
+        waitForElementToAppear(element: emailField)
+
+        emailField.tap()
+        emailField.clearAndEnterText(text: email)
+        usernameField.tap()
+        usernameField.clearAndEnterText(text: username)
+        passwordField.tap()
+        passwordField.clearAndEnterText(text: password)
+
+        if ( url != nil ) {
+            urlField.tap()
+            urlField.clearAndEnterText(text: url!)
+        }
+
+        createAccountButton.tap()
     }
 }

--- a/WordPress/WordPressUITests/gencredentials.rb
+++ b/WordPress/WordPressUITests/gencredentials.rb
@@ -8,7 +8,7 @@ static let #{name}Password = "#{password}"
 EOF
 end
 
-def print_class(one_step_user, one_step_password, two_step_user, two_step_password, self_hosted_user, self_hosted_password, self_hosted_site_url, self_hosted_site_name, nux_email_suffix)
+def print_class(one_step_user, one_step_password, two_step_user, two_step_password, self_hosted_user, self_hosted_password, self_hosted_site_url, self_hosted_site_name, nux_email_prefix, nux_email_suffix)
   print <<-EOF
 public class WordPressTestCredentials {
 EOF
@@ -19,6 +19,7 @@ EOF
 static let selfHostedSiteURL = "#{self_hosted_site_url}"
 static let selfHostedSiteName = "#{self_hosted_site_name}"
 static let nuxEmailSuffix = "#{nux_email_suffix}"
+static let nuxEmailPrefix = "#{nux_email_prefix}"
 
 }
 EOF
@@ -45,6 +46,7 @@ self_hosted_password = nil
 self_hosted_site_url = nil
 self_hosted_site_name = nil
 nux_email_suffix = nil
+nux_email_prefix = nil
 File.open(path) do |f|
   f.each_line do |l|
     (k,v) = l.split("=")
@@ -65,11 +67,13 @@ File.open(path) do |f|
     elsif k == "selfHostedSiteName"
       self_hosted_site_name = v.chomp
     elsif k == "nuxEmailSuffix"
-      nux_email_suffix = v.chomp
+    nux_email_suffix = v.chomp
+    elsif k == "nuxEmailPrefix"
+    nux_email_prefix = v.chomp
     else
       $stderr.puts "warning: Unknown key #{k}"
     end
   end
 end
 
-print_class(one_step_user, one_step_password, two_step_user, two_step_password, self_hosted_user, self_hosted_password, self_hosted_site_url, self_hosted_site_name, nux_email_suffix)
+print_class(one_step_user, one_step_password, two_step_user, two_step_password, self_hosted_user, self_hosted_password, self_hosted_site_url, self_hosted_site_name, nux_email_prefix, nux_email_suffix)

--- a/WordPress/WordPressUITests/gencredentials.rb
+++ b/WordPress/WordPressUITests/gencredentials.rb
@@ -8,7 +8,7 @@ static let #{name}Password = "#{password}"
 EOF
 end
 
-def print_class(one_step_user, one_step_password, two_step_user, two_step_password, self_hosted_user, self_hosted_password, self_hosted_site_url, self_hosted_site_name)
+def print_class(one_step_user, one_step_password, two_step_user, two_step_password, self_hosted_user, self_hosted_password, self_hosted_site_url, self_hosted_site_name, nux_email_suffix)
   print <<-EOF
 public class WordPressTestCredentials {
 EOF
@@ -18,6 +18,7 @@ EOF
   print <<-EOF
 static let selfHostedSiteURL = "#{self_hosted_site_url}"
 static let selfHostedSiteName = "#{self_hosted_site_name}"
+static let nuxEmailSuffix = "#{nux_email_suffix}"
 
 }
 EOF
@@ -43,6 +44,7 @@ self_hosted_user = nil
 self_hosted_password = nil
 self_hosted_site_url = nil
 self_hosted_site_name = nil
+nux_email_suffix = nil
 File.open(path) do |f|
   f.each_line do |l|
     (k,v) = l.split("=")
@@ -62,10 +64,12 @@ File.open(path) do |f|
       self_hosted_site_url = v.chomp
     elsif k == "selfHostedSiteName"
       self_hosted_site_name = v.chomp
+    elsif k == "nuxEmailSuffix"
+      nux_email_suffix = v.chomp
     else
       $stderr.puts "warning: Unknown key #{k}"
     end
   end
 end
 
-print_class(one_step_user, one_step_password, two_step_user, two_step_password, self_hosted_user, self_hosted_password, self_hosted_site_url, self_hosted_site_name)
+print_class(one_step_user, one_step_password, two_step_user, two_step_password, self_hosted_user, self_hosted_password, self_hosted_site_url, self_hosted_site_name, nux_email_suffix)


### PR DESCRIPTION
Fixes the testCreateAccount test in the WordPressUITest target.  Needs two new fields added to the ~/.wp_test_credentials file:

```
nuxEmailPrefix=***
nuxEmailSuffix=***
```

These will be appended to either end of the randomly generated username to build a dynamic e-mail address for the new account.  This supports doing something like `username+RANDOM@gmail.com` or `RANDOM@youremailserver.com`