### PR TITLE
Aztec 0.5a5 7.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -51,7 +51,7 @@ abstract_target 'WordPress_Base' do
     pod 'WPMediaPicker', '0.11.1'
     pod 'WordPress-iOS-Editor', '1.9.0'
     pod 'WordPressCom-Analytics-iOS', '0.1.22'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => '21f0d1274aa05db1cb4eea656414dbc7f893ccd4'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :tag => '0.5a5'
     pod 'wpxmlrpc', '~> 0.8'
 
     target :WordPressTest do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -129,7 +129,7 @@ PODS:
   - SVProgressHUD (2.1.2)
   - UIDeviceIdentifier (0.5.0)
   - WordPress-AppbotX (1.0.6)
-  - WordPress-Aztec-iOS (0.5a4):
+  - WordPress-Aztec-iOS (0.5a5):
     - Gridicons (= 0.4)
   - WordPress-iOS-Editor (1.9.0):
     - CocoaLumberjack (~> 2.2.0)
@@ -178,7 +178,7 @@ DEPENDENCIES:
   - SVProgressHUD (~> 2.1.2)
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `21f0d1274aa05db1cb4eea656414dbc7f893ccd4`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, tag `0.5a5`)
   - WordPress-iOS-Editor (= 1.9.0)
   - WordPress-iOS-Shared (= 0.8.0)
   - WordPressCom-Analytics-iOS (= 0.1.22)
@@ -198,8 +198,8 @@ EXTERNAL SOURCES:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: 21f0d1274aa05db1cb4eea656414dbc7f893ccd4
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
+    :tag: 0.5a5
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -215,8 +215,8 @@ CHECKOUT OPTIONS:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: 21f0d1274aa05db1cb4eea656414dbc7f893ccd4
     :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
+    :tag: 0.5a5
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -252,7 +252,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: c404a55d78acbeb7ebb78b76d3faf986475a6994
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
-  WordPress-Aztec-iOS: af5f5eb608cf0d0013a158491f46182db7e08371
+  WordPress-Aztec-iOS: 834cc790b55bf26750d1bc426a8cc8544f34d5a8
   WordPress-iOS-Editor: 69c5d1e83aaa6e5ab6c80e067f1858de8dab4017
   WordPress-iOS-Shared: 4d073fb8efa96f3c902d1e1ac2557bb720f416d7
   WordPressCom-Analytics-iOS: 66b890823ffd54aee871fbba3ed0278d4ae1aa0a
@@ -261,6 +261,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: f5b1c20a25abc9ed710747f7019dbf43f03caa4f
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: c7b84c445f7a30a738d6b460d9d589756afe9a2b
+PODFILE CHECKSUM: 95379ef4488618e3b64a53f59a2fe0474469b637
 
 COCOAPODS: 1.1.1

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -943,26 +943,28 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
     func handleActionForIdentifier(_ identifier: FormattingIdentifier) {
 
         switch identifier {
-            case .bold:
-                toggleBold()
-            case .italic:
-                toggleItalic()
-            case .underline:
-                toggleUnderline()
-            case .strikethrough:
-                toggleStrikethrough()
-            case .blockquote:
-                toggleBlockquote()
-            case .unorderedlist:
-                toggleUnorderedList()
-            case .orderedlist:
-                toggleOrderedList()
-            case .link:
-                toggleLink()
-            case .media:
-                showImagePicker()
-            case .sourcecode:
-                toggleEditingMode()
+        case .bold:
+            toggleBold()
+        case .italic:
+            toggleItalic()
+        case .underline:
+            toggleUnderline()
+        case .strikethrough:
+            toggleStrikethrough()
+        case .blockquote:
+            toggleBlockquote()
+        case .unorderedlist:
+            toggleUnorderedList()
+        case .orderedlist:
+            toggleOrderedList()
+        case .link:
+            toggleLink()
+        case .media:
+            showImagePicker()
+        case .sourcecode:
+            toggleEditingMode()
+        default:
+            return
         }
         updateFormatBar()
     }

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -963,7 +963,7 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
             showImagePicker()
         case .sourcecode:
             toggleEditingMode()
-        default:
+        case .header:
             return
         }
         updateFormatBar()


### PR DESCRIPTION
Brings Aztec 0.5a5 to WPiOS 7.1 mostly matching #6787 which only made it into develop.
