### PR TITLE
RichText: Better handling for optionals relating to embeds.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -227,7 +227,7 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
 
         attachment.maxSize = CGSize(width: width, height: height)
 
-        if let url = URL(string: attachment.src.stringByDecodingXMLCharacters()), attachment.tagName == "iframe" {
+        if attachment.tagName == "iframe", let url = URL(string: attachment.src.stringByDecodingXMLCharacters()) {
             embed.loadContentURL(url)
         } else {
             let html = attachment.html ?? ""

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -227,10 +227,11 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
 
         attachment.maxSize = CGSize(width: width, height: height)
 
-        if attachment.tagName == "iframe" {
-            embed.loadContentURL(URL(string: attachment.src.stringByDecodingXMLCharacters())!)
+        if let url = URL(string: attachment.src.stringByDecodingXMLCharacters()), attachment.tagName == "iframe" {
+            embed.loadContentURL(url)
         } else {
-            embed.loadHTMLString(attachment.html! as NSString)
+            let html = attachment.html ?? ""
+            embed.loadHTMLString(html as NSString)
         }
 
         embed.success = { [weak self] embedView in


### PR DESCRIPTION
Fixes #6772 
This PR improves some optional handling which *should* resolve the crash reported in 6722. 

To test:
- Create a post on a blog you follow, where the post contains an iframe with an empty string for its `src` tag. For example: ```<iframe src="" width="300" height"200"></iframe>```
- Confirm the crash by viewing the post in the reader detail.
- Switch to this branch.
- View the post in the reader detail again and confirm there is no longer a crash. 

While this will prevent a crash, the exact markup involved remains unknown. Since the embed's HTML will be passed in its expected that we'll receive some reports of embedded content looking wrong in the reader.  We can use these reports to zero in on the exact circumstances and improve the fix once the exact mark up is known. 

Needs review: @kurzee would you mind another sir? 
