### PR TITLE
7.1: Cherry-picked ContextManager crash fixes

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -106,6 +106,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)obtainPermanentIDForObject:(NSManagedObject *)managedObject;
 
 /**
+ Merge changes for a given context with a fault-protection, on the context's queue.
+
+ @param context a NSManagedObject context instance
+ @return notification NSNotification from a NSManagedObjectContextDidSaveNotification.
+ */
+- (void)mergeChanges:(NSManagedObjectContext *)context fromContextDidSaveNotification:(NSNotification *)notification;
+
+/**
   Verify if the Core Data model migration failed.
  
   @return YES if there were any errors during the migration: the PSC instance is mapping to a fresh database.

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -195,9 +195,10 @@ static ContextManager *_override;
         // Based on old solution referenced here: http://www.mlsite.net/blog/?p=518
         NSSet* updates = [notification.userInfo objectForKey:NSUpdatedObjectsKey];
         for (NSManagedObject *object in updates) {
-            if ([object isFault]) {
+            NSManagedObject *objectInContext = [context existingObjectWithID:object.objectID error:nil];
+            if ([objectInContext isFault]) {
                 // Force a fault-in of the object's key-values
-                [[context objectWithID:[object objectID]] willAccessValueForKey:nil];
+                [objectInContext willAccessValueForKey:nil];
             }
         }
         // Continue with the merge

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -188,6 +188,23 @@ static ContextManager *_override;
     return YES;
 }
 
+- (void)mergeChanges:(NSManagedObjectContext *)context fromContextDidSaveNotification:(NSNotification *)notification
+{
+    [context performBlock:^{
+        // Fault-in updated objects before a merge to avoid any internal inconsistency errors later.
+        // Based on old solution referenced here: http://www.mlsite.net/blog/?p=518
+        NSSet* updates = [notification.userInfo objectForKey:NSUpdatedObjectsKey];
+        for (NSManagedObject *object in updates) {
+            if ([object isFault]) {
+                // Force a fault-in of the object's key-values
+                [[context objectWithID:[object objectID]] willAccessValueForKey:nil];
+            }
+        }
+        // Continue with the merge
+        [context mergeChangesFromContextDidSaveNotification:notification];
+    }];
+}
+
 - (BOOL)didMigrationFail
 {
     return _migrationFailed;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1368,7 +1368,7 @@ import WordPressComAnalytics
 
 
     func handleContextDidSaveNotification(_ notification: Foundation.Notification) {
-        displayContext.mergeChanges(fromContextDidSave: notification)
+        ContextManager.sharedInstance().mergeChanges(displayContext, fromContextDidSave: notification)
     }
 
 


### PR DESCRIPTION
Bringing these from https://github.com/wordpress-mobile/WordPress-iOS/pull/6768 to 7.1 so we can knock out our top crash.

Needs review: @astralbodies 