### PR TITLE
Fix Helpshift tag problems

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
@@ -33,7 +33,7 @@ import WordPressShared
 
     override var sourceTag: SupportSourceTag {
         get {
-            return .generalLogin
+            return .wpComLogin
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
@@ -385,7 +385,10 @@ class JetpackLoginViewController: UIViewController {
 
     fileprivate func handleSignInError(_ error: Error) {
         let error = error as NSError
-        WPError.showNetworkingAlertWithError(error)
+        var userInfo = error.userInfo
+        userInfo[WPErrorSupportSourceKey] = SupportSourceTag.jetpackLogin
+        let errorWithSource = NSError(domain: error.domain, code: error.code, userInfo: userInfo)
+        WPError.showNetworkingAlertWithError(errorWithSource)
         updateControls()
     }
 


### PR DESCRIPTION
Fixes #6797 

To test:
1. attempt to login to jetpack
2. use help button to contact support
3. verify the created Helpshift issue has the correct tag

1. launch fresh install of app
2. on very first screen, use `?` button to contact support
3. verify the created Helpshift issue has the correct tag

Needs review: @bummytime 
_I touched your new swift code. does it meet your standards?_
