### PR TITLE
Don't show the secondary publish actions when the post has no content.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -236,8 +236,11 @@ public class PostEditorStateContext {
         return editorState.action.isPostPostShown
     }
 
-    // TODO: Replace with a method to bring label and such back for secondary publish button
     var isSecondaryPublishButtonShown: Bool {
+        guard hasContent else {
+            return false
+        }
+
         return editorState.action.secondaryPublishAction != nil
     }
 

--- a/WordPress/WordPressTest/PostEditorStateTests.swift
+++ b/WordPress/WordPressTest/PostEditorStateTests.swift
@@ -172,6 +172,15 @@ extension PostEditorStateTests {
     }
 }
 
+extension PostEditorStateTests {
+    func testPublishSecondaryDisabledNoContent() {
+        context = PostEditorStateContext(originalPostStatus: nil, userCanPublish: true, delegate: self)
+        context.updated(hasContent: false)
+
+        XCTAssertFalse(context.isSecondaryPublishButtonShown, "should return false if post has no content")
+    }
+}
+
 extension PostEditorStateTests: PostEditorStateContextDelegate {
     func context(_ context: PostEditorStateContext, didChangeAction: PostEditorAction) {
 


### PR DESCRIPTION
Fixes #6654 

## To test:
1. Start a new post in Aztec.
2. Verify Save As Draft not available in the ellipsis menu.
3. Type something in the title or content fields.
4. Verify Save As Draft is now available in the ellipsis menu.

Needs review: @jleandroperez 
