### PR TITLE
NUX: use the right controller for bad token modal.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -77,8 +77,7 @@ import Mixpanel
     class func showSigninForWPComFixingAuthToken() {
         let controller = signinForWPComFixingAuthToken(nil)
         let presenter = UIApplication.shared.keyWindow?.rootViewController
-        let navController = NUXNavigationController(rootViewController: controller)
-        presenter?.present(navController, animated: true, completion: nil)
+        presenter?.present(controller, animated: true, completion: nil)
 
         trackOpenedLogin()
     }


### PR DESCRIPTION
Brings in crash fix for last iOS 9 release from https://github.com/wordpress-mobile/WordPress-iOS/pull/6774

Needs review: @frosty 🔆 