### PR TITLE
Aztec: Preventing Double Restoration

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -78,7 +78,7 @@ class EditPostViewController: UIViewController {
 
         // show postpost, which will be transparent
         view.isOpaque = false
-        view.backgroundColor = UIColor.clear
+        view.backgroundColor = .clear
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -144,8 +144,14 @@ class EditPostViewController: UIViewController {
             strongSelf.closeEditor(changesSaved)
         }
 
+        // Neutralize iOS's Restoration:
+        // We'll relaunch the editor on our own, on viewDidAppear. Why: Because we need to set up the callbacks!
+        // This effectively prevents double editor instantiation!
+        //
+        postViewController.restorationClass = nil
+        postViewController.restorationIdentifier = nil
+
         let navController = UINavigationController(rootViewController: postViewController)
-        navController.restorationIdentifier = AztecPostViewController.Restoration.navigationIdentifier
         navController.modalPresentationStyle = .fullScreen
 
         return navController
@@ -165,9 +171,14 @@ class EditPostViewController: UIViewController {
             strongSelf.closeEditor(changesSaved)
         }
 
+        // Neutralize iOS's Restoration:
+        // We'll relaunch the editor on our own, on viewDidAppear. Why: Because we need to set up the callbacks!
+        // This effectively prevents double editor instantiation!
+        //
+        postViewController?.restorationClass = nil
+        postViewController?.restorationIdentifier = nil
+
         let navController = UINavigationController(rootViewController: postViewController!)
-        navController.restorationIdentifier = WPEditorNavigationRestorationID
-        navController.restorationClass = WPPostViewController.self
         navController.isToolbarHidden = false // Fixes incorrect toolbar animation.
         navController.modalPresentationStyle = .fullScreen
 


### PR DESCRIPTION
### Details:
We've implemented State Restoration in Aztec in #6582. In this PR we're shipping a minor fix that prevents a double instantiation of our editors, upon state restoration.

### Background: 
iOS itself takes care of reinstantiating all of the view controllers that carry a **restorationIdentifier** and **restorationClass**.

On the other hand, **EditPostViewController** always instantiates the active editor in it's **viewDidAppear** method. Meaning that upon state restoration, the Active Editor would get alloc'ated twice: once by the OS, and the second time, by ourselves.

In this PR we're addressing this dual instantiation.

Closes #6700

### Scenario: New Post
1. Make sure Aztec is **enabled**
2. Log into a dotcom account
3. Press the `+` button to add a new post
4. Send the app to BG
5. From Xcode, stop execution
6. Relaunch WPiOS

As a result, Aztec should be back onscreen, and the **Dismiss Button** (top left) should display an `X`.

### Scenario: New Page
1. Make sure Aztec is **enabled**
2. Log into a dotcom account
3. Select **My Sites** > **Any Site** > **Pages**
4. Press the top right `+` button
5. Send the app to BG
6. From Xcode, stop execution
7. Relaunch WPiOS

As a result, Aztec should be back onscreen, and the **Dismiss Button** (top left) should display an `X`.

### Scenario: Edit Page
1. Make sure Aztec is **enabled**
2. Log into a dotcom account
3. Select **My Sites** > **Any Site** > **Pages**
4. Pick any random page, and tap its row, to launch the editor
5. Send the app to BG
6. From Xcode, stop execution
7. Relaunch WPiOS

As a result, Aztec should be back onscreen, the **Dismiss Button** (top left) should display a Chevron Left `<`, and the Blog Picker should not be enabled.

### Scenario: Edit Post
1. Make sure Aztec is **enabled**
2. Log into a dotcom account
3. Select **My Sites** > **Any Site** > **Posts**
4. Pick any random page, and press the **Edit** button, to launch Aztec
5. Send the app to BG
6. From Xcode, stop execution
7. Relaunch WPiOS

As a result, Aztec should be back onscreen, the **Dismiss Button** (top left) should display an `X`, and the Blog Picker should not be enabled.

**PLEASE** Repeat the 4 test scenarios with the Hybrid Editor.

Needs review: @diegoreymendez 
Thank you!!
