### PR TITLE
Aztec: Context now tracks Content Changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -85,7 +85,6 @@ class AztecPostViewController: UIViewController {
         tf.accessibilityLabel = NSLocalizedString("Title", comment: "Post title")
         tf.attributedPlaceholder = NSAttributedString(string: placeholderText,
                                                       attributes: [NSForegroundColorAttributeName: Colors.title])
-        tf.delegate = self
         tf.font = Fonts.title
         tf.returnKeyType = .next
         tf.textColor = UIColor.darkText
@@ -826,24 +825,18 @@ extension AztecPostViewController: PostEditorStateContextDelegate {
         }
     }
 
-
-        super.observeValue(forKeyPath: keyPath,
-                           of: object,
-                           change: change,
-                           context: context)
-    }
-
-    internal func titleTextFieldDidChange(textField: UITextField) {
-        postEditorStateContext.updated(hasContent: editorHasContent)
-    }
-
-    // TODO: We should be tracking hasContent and isDirty separately for enabling button in the state context
     private var editorHasContent: Bool {
-        let contentCharacterCount = post.content?.characters.count ?? 0
-        // Title isn't updated on post until editing is done - this looks at realtime changes
-        let titleCharacterCount = titleTextField.text?.characters.count ?? 0
+        let titleIsEmpty = post.postTitle?.isEmpty ?? true
+        let contentIsEmpty = post.content?.isEmpty ?? true
 
-        return contentCharacterCount + titleCharacterCount > 0
+        return !titleIsEmpty && !contentIsEmpty
+    }
+
+    }
+
+    internal func editorContentWasUpdated() {
+        postEditorStateContext.updated(hasContent: editorHasContent)
+        postEditorStateContext.updated(hasChanges: editorHasChanges)
     }
 
     internal func context(_ context: PostEditorStateContext, didChangeAction: PostEditorAction) {
@@ -884,9 +877,10 @@ extension AztecPostViewController : UITextViewDelegate {
 
 // MARK: - UITextFieldDelegate methods
 //
-extension AztecPostViewController : UITextFieldDelegate {
-    func textFieldDidEndEditing(_ textField: UITextField) {
+extension AztecPostViewController {
+    func titleTextFieldDidChange(_ textField: UITextField) {
         mapUIContentToPostAndSave()
+        editorContentWasUpdated()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -807,19 +807,24 @@ private extension AztecPostViewController {
 //
 extension AztecPostViewController: PostEditorStateContextDelegate {
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        if keyPath == BasePost.statusKeyPath {
+        guard let keyPath = keyPath else {
+            return
+        }
+
+        switch keyPath {
+        case BasePost.statusKeyPath:
             if let status = post.status {
                 postEditorStateContext.updated(postStatus: status)
             }
-            return
-        } else if keyPath == #keyPath(AbstractPost.dateCreated) {
+        case #keyPath(AbstractPost.dateCreated):
             let dateCreated = post.dateCreated ?? Date()
             postEditorStateContext.updated(publishDate: dateCreated)
-            return
-        } else if keyPath == #keyPath(AbstractPost.content) {
-            postEditorStateContext.updated(hasContent: editorHasContent)
-            return
+        case #keyPath(AbstractPost.content):
+            editorContentWasUpdated()
+        default:
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
         }
+    }
 
 
         super.observeValue(forKeyPath: keyPath,

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -832,6 +832,8 @@ extension AztecPostViewController: PostEditorStateContextDelegate {
         return !titleIsEmpty && !contentIsEmpty
     }
 
+    private var editorHasChanges: Bool {
+        return post.hasUnsavedChanges()
     }
 
     internal func editorContentWasUpdated() {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -144,6 +144,7 @@ public class PostEditorStateContext {
     ///   - originalPostStatus: If the post was already published (saved to the server) what is the status
     ///   - userCanPublish: Does the user have permission to publish posts or merely create drafts
     ///   - delegate: Delegate for listening to change in state for the editor
+    ///
     init(originalPostStatus: BasePost.Status? = nil, userCanPublish: Bool = true, delegate: PostEditorStateContextDelegate) {
         self.originalPostStatus = originalPostStatus
         self.userCanPublish = userCanPublish
@@ -196,6 +197,8 @@ public class PostEditorStateContext {
         self.isBeingPublished = isBeingPublished
     }
 
+    /// Call whenever a Media Upload OP is started / stopped
+    ///
     func update(isUploadingMedia: Bool) {
         self.isUploadingMedia = isUploadingMedia
     }
@@ -226,6 +229,8 @@ public class PostEditorStateContext {
         return editorState.action.publishingActionLabel
     }
 
+    /// Returns the Error Text for the current active action
+    ///
     var publishErrorText: String {
         return editorState.action.publishingErrorLabel
     }
@@ -236,6 +241,8 @@ public class PostEditorStateContext {
         return editorState.action.isPostPostShown
     }
 
+    /// Returns whether the secondary publish button should be displayed, or not
+    ///
     var isSecondaryPublishButtonShown: Bool {
         guard hasContent else {
             return false
@@ -244,10 +251,14 @@ public class PostEditorStateContext {
         return editorState.action.secondaryPublishAction != nil
     }
 
+    /// Returns the secondary publish action
+    ///
     var secondaryPublishButtonAction: PostEditorAction? {
         return editorState.action.secondaryPublishAction
     }
 
+    /// Returns the secondary publish button text
+    ///
     var secondaryPublishButtonText: String? {
         return editorState.action.secondaryPublishAction?.secondaryPublishActionLabel
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -126,6 +126,12 @@ public class PostEditorStateContext {
         }
     }
 
+    fileprivate var hasChanges = false {
+        didSet {
+            updatePublishActionAllowed()
+        }
+    }
+
     fileprivate var isBeingPublished = false {
         didSet {
             updatePublishActionAllowed()
@@ -185,10 +191,16 @@ public class PostEditorStateContext {
         editorState = updatedState
     }
 
-    /// Call whenever the post content is changed - title or content body
+    /// Call whenever the post content is not empty - title or content body
     ///
     func updated(hasContent: Bool) {
         self.hasContent = hasContent
+    }
+
+    /// Call whenever the post content was updated - title or content body
+    ///
+    func updated(hasChanges: Bool) {
+        self.hasChanges = hasChanges
     }
 
     /// Call when the post is being published or has finished
@@ -263,9 +275,10 @@ public class PostEditorStateContext {
         return editorState.action.secondaryPublishAction?.secondaryPublishActionLabel
     }
 
-    // TODO: Add isDirty to the state context for enabling/disabling the button
+    /// Indicates whether the Publish Action should be allowed, or not
+    ///
     private func updatePublishActionAllowed() {
-        publishActionAllowed = hasContent && !isBeingPublished && !isUploadingMedia
+        publishActionAllowed = hasContent && hasChanges && !isBeingPublished && !isUploadingMedia
     }
 }
 

--- a/WordPress/WordPressTest/PostEditorStateTests.swift
+++ b/WordPress/WordPressTest/PostEditorStateTests.swift
@@ -141,12 +141,22 @@ extension PostEditorStateTests {
 
 
 
-    func testPublishEnabledHasContentNotPublishing() {
+    func testPublishEnabledHasContentAndChangesNotPublishing() {
         context = PostEditorStateContext(originalPostStatus: .draft, userCanPublish: true, delegate: self)
         context.updated(hasContent: true)
+        context.updated(hasChanges: true)
         context.updated(isBeingPublished: false)
 
         XCTAssertTrue(context.isPublishButtonEnabled, "should return true if form is not publishing and post is not empty")
+    }
+
+    func testPublishDisabledHasContentAndNoChangesNotPublishing() {
+        context = PostEditorStateContext(originalPostStatus: .draft, userCanPublish: true, delegate: self)
+        context.updated(hasContent: true)
+        context.updated(hasChanges: false)
+        context.updated(isBeingPublished: false)
+
+        XCTAssertFalse(context.isPublishButtonEnabled, "should return true if form is not publishing and post is not empty")
     }
 
     // Missing test: should return false if form is not publishing and post is not empty, but user is not verified


### PR DESCRIPTION
Fixes #6766

### To test:
1. Enable Aztec!
2. Open any published post using
3. Tap the "Edit" link.
4. Verify that the top right button (**"Update"**) is disabled
5. Type any character int he post's title
6. Verify that the **Update** button gets enabled
7. Undo the edit performed in (4)
8. Verify that the **Update** button gets disabled
9. Edit the Post's Contents
10. Verify that the **Update** button gets enabled
11. Undo the edition, and verify that the **Update** button gets disabled again

Needs review: @astralbodies 
May i bug you with yet anoooother review?

Thanks!!!
