### PR TITLE
Aztec: Recreating Posts or Pages as needed

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1228,9 +1228,9 @@ fileprivate extension AztecPostViewController {
 
     // TODO: Rip this and put it into PostService, as well
     func recreatePostRevision(in blog: Blog) {
+        let shouldCreatePage = post is Page
         let postService = PostService(managedObjectContext: mainContext)
-        let newPost = postService.createDraftPost(for: blog)
-
+        let newPost = shouldCreatePage ? postService.createDraftPage(for: blog) : postService.createDraftPost(for: blog)
 
         //  TODO: Strip Media!
         //  NSString *content = oldPost.content;
@@ -1245,8 +1245,8 @@ fileprivate extension AztecPostViewController {
         newPost.dateCreated = post.dateCreated
         newPost.dateModified = post.dateModified
 
-        if let source = post as? Post {
-            newPost.tags = source.tags
+        if let source = post as? Post, let target = newPost as? Post {
+            target.tags = source.tags
         }
 
         discardChanges()

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1228,11 +1228,9 @@ fileprivate extension AztecPostViewController {
 
     // TODO: Rip this and put it into PostService, as well
     func recreatePostRevision(in blog: Blog) {
-        let blogService = BlogService(managedObjectContext: mainContext)
         let postService = PostService(managedObjectContext: mainContext)
         let newPost = postService.createDraftPost(for: blog)
 
-        blogService.flagBlog(asLastUsed: blog)
 
         //  TODO: Strip Media!
         //  NSString *content = oldPost.content;
@@ -1254,9 +1252,15 @@ fileprivate extension AztecPostViewController {
         discardChanges()
         post = newPost
         createRevisionOfPost()
+        markBlogAsLastUsed(blog)
 
         // TODO: Add this snippet, if needed, once we've relocated this helper to PostService
         //[self syncOptionsIfNecessaryForBlog:blog afterBlogChanged:YES];
+    }
+
+    func markBlogAsLastUsed(_ blog: Blog) {
+        let blogService = BlogService(managedObjectContext: mainContext)
+        blogService.flagBlog(asLastUsed: blog)
     }
 
     func cancelEditing() {


### PR DESCRIPTION
Fixes #6765

### To test:
1. Enable Aztec
2. Create a new Page
3. Use the Site Picker and switch the target to another site
4. Hit the publish button

Verify that, as a result, a new Page is uploaded (instead of a post). Note that the original issue mentioned that the button would read `Post`. That's not the case in the latest develop build.

However, upon post recreation, we weren't taking care of regenerating a **Page** draft, when needed.

Needs review: @astralbodies 
Thanks!!
