### PR TITLE
Pod bump WPMediaPicker 0.11.3, crash fix.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -48,7 +48,7 @@ abstract_target 'WordPress_Base' do
     pod 'Gridicons', '0.4'
     pod 'NSObject-SafeExpectations', '0.0.2'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', '0.11.1'
+    pod 'WPMediaPicker', '0.11.3'
     pod 'WordPress-iOS-Editor', '1.9.0'
     pod 'WordPressCom-Analytics-iOS', '0.1.22'
     pod 'WordPress-Aztec-iOS', '0.5a5'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -146,7 +146,7 @@ PODS:
     - WordPressCom-Analytics-iOS (~> 0.1.4)
   - WordPressComKit (0.0.6):
     - Alamofire (= 4.0.1)
-  - WPMediaPicker (0.11.1)
+  - WPMediaPicker (0.11.3)
   - wpxmlrpc (0.8.2)
 
 DEPENDENCIES:
@@ -184,7 +184,7 @@ DEPENDENCIES:
   - WordPressCom-Analytics-iOS (= 0.1.22)
   - WordPressCom-Stats-iOS (= 0.9.0)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
-  - WPMediaPicker (= 0.11.1)
+  - WPMediaPicker (= 0.11.3)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -252,9 +252,9 @@ SPEC CHECKSUMS:
   WordPressCom-Analytics-iOS: 66b890823ffd54aee871fbba3ed0278d4ae1aa0a
   WordPressCom-Stats-iOS: cf78f0dd05ba586fd7b3c01b6cdcd5ca12e032ea
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
-  WPMediaPicker: f5b1c20a25abc9ed710747f7019dbf43f03caa4f
+  WPMediaPicker: 24a218bcd70cc9620c894129d8bc9d5e1935bd23
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: bf98c40c4017d6124229fa0872f80569f87c5368
+PODFILE CHECKSUM: 837ab774b45ff9a5a879748c63ff60b683d2b2a0
 
 COCOAPODS: 1.1.1


### PR DESCRIPTION
Reopened from https://github.com/wordpress-mobile/WordPress-iOS/pull/6813, on develop.

Fixes #wordpress-mobile/MediaPicker-iOS#128 (MediaPicker-iOS)

This brings in the updated pod to resolve the crash seen in the original issue.

For sanity's sake, test by:

1. Build and run on device.
2. Open Media collection picker, Camera Roll.
3. Take a photo, ensure it shows up.
4. Background app, delete the same photo in Photos.
5. Take another photo with Camera.
6. Open app again, ensure the deleted photo disappears and the newly added photo appears.

Needs review: @frosty 🛡