### PR TITLE
Update to media picker 0.12

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -48,7 +48,7 @@ abstract_target 'WordPress_Base' do
     pod 'Gridicons', '0.4'
     pod 'NSObject-SafeExpectations', '0.0.2'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS', :commit => 'e6c13a5'
+    pod 'WPMediaPicker', '0.12'
     pod 'WordPress-iOS-Editor', '1.9.0'
     pod 'WordPressCom-Analytics-iOS', '0.1.22'
     pod 'WordPress-Aztec-iOS', '0.5a5'

--- a/Podfile
+++ b/Podfile
@@ -48,7 +48,7 @@ abstract_target 'WordPress_Base' do
     pod 'Gridicons', '0.4'
     pod 'NSObject-SafeExpectations', '0.0.2'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', '0.11.1'
+    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS', :commit => 'e6c13a5'
     pod 'WordPress-iOS-Editor', '1.9.0'
     pod 'WordPressCom-Analytics-iOS', '0.1.22'
     pod 'WordPress-Aztec-iOS', '0.5a5'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -146,7 +146,7 @@ PODS:
     - WordPressCom-Analytics-iOS (~> 0.1.4)
   - WordPressComKit (0.0.6):
     - Alamofire (= 4.0.1)
-  - WPMediaPicker (0.11.1)
+  - WPMediaPicker (0.11.3)
   - wpxmlrpc (0.8.2)
 
 DEPENDENCIES:
@@ -184,7 +184,7 @@ DEPENDENCIES:
   - WordPressCom-Analytics-iOS (= 0.1.22)
   - WordPressCom-Stats-iOS (= 0.9.0)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
-  - WPMediaPicker (= 0.11.1)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS`, commit `e6c13a5`)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -200,6 +200,9 @@ EXTERNAL SOURCES:
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
+  WPMediaPicker:
+    :commit: e6c13a5
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -214,6 +217,9 @@ CHECKOUT OPTIONS:
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
+  WPMediaPicker:
+    :commit: e6c13a5
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS
 
 SPEC CHECKSUMS:
   1PasswordExtension: 00d6f4caae77c19ba33045b8569fbeb9689f0d1d
@@ -252,9 +258,9 @@ SPEC CHECKSUMS:
   WordPressCom-Analytics-iOS: 66b890823ffd54aee871fbba3ed0278d4ae1aa0a
   WordPressCom-Stats-iOS: cf78f0dd05ba586fd7b3c01b6cdcd5ca12e032ea
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
-  WPMediaPicker: f5b1c20a25abc9ed710747f7019dbf43f03caa4f
+  WPMediaPicker: 24a218bcd70cc9620c894129d8bc9d5e1935bd23
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: bf98c40c4017d6124229fa0872f80569f87c5368
+PODFILE CHECKSUM: be46b2151ad34840eea71122efc3864b99b8aed8
 
 COCOAPODS: 1.1.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -146,7 +146,7 @@ PODS:
     - WordPressCom-Analytics-iOS (~> 0.1.4)
   - WordPressComKit (0.0.6):
     - Alamofire (= 4.0.1)
-  - WPMediaPicker (0.11.3)
+  - WPMediaPicker (0.12)
   - wpxmlrpc (0.8.2)
 
 DEPENDENCIES:
@@ -184,7 +184,7 @@ DEPENDENCIES:
   - WordPressCom-Analytics-iOS (= 0.1.22)
   - WordPressCom-Stats-iOS (= 0.9.0)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS`, commit `e6c13a5`)
+  - WPMediaPicker (= 0.12)
   - wpxmlrpc (~> 0.8)
 
 EXTERNAL SOURCES:
@@ -200,9 +200,6 @@ EXTERNAL SOURCES:
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
-  WPMediaPicker:
-    :commit: e6c13a5
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -217,9 +214,6 @@ CHECKOUT OPTIONS:
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
-  WPMediaPicker:
-    :commit: e6c13a5
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS
 
 SPEC CHECKSUMS:
   1PasswordExtension: 00d6f4caae77c19ba33045b8569fbeb9689f0d1d
@@ -258,9 +252,9 @@ SPEC CHECKSUMS:
   WordPressCom-Analytics-iOS: 66b890823ffd54aee871fbba3ed0278d4ae1aa0a
   WordPressCom-Stats-iOS: cf78f0dd05ba586fd7b3c01b6cdcd5ca12e032ea
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
-  WPMediaPicker: 24a218bcd70cc9620c894129d8bc9d5e1935bd23
+  WPMediaPicker: d4ce8e9db98b60ab44e7154151dbad135f8e7ff6
   wpxmlrpc: 38623cc415117914d6ab5bf2ab8a57a4076cc469
 
-PODFILE CHECKSUM: be46b2151ad34840eea71122efc3864b99b8aed8
+PODFILE CHECKSUM: e4930a9b8830946f509fd0494b672c86fc0b1663
 
 COCOAPODS: 1.1.1

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -564,7 +564,7 @@ int ddLogLevel = DDLogLevelInfo;
     [barButtonItem setTitleTextAttributes:@{NSForegroundColorAttributeName: [UIColor whiteColor], NSFontAttributeName : [WPFontManager systemSemiBoldFontOfSize:16.0]} forState:UIControlStateNormal];
     [barButtonItem setTitleTextAttributes:@{NSForegroundColorAttributeName: [UIColor whiteColor], NSFontAttributeName : [WPFontManager systemSemiBoldFontOfSize:16.0]} forState:UIControlStateDisabled];
     [[UICollectionView appearanceWhenContainedInInstancesOfClasses:@[ [WPMediaPickerViewController class] ]] setBackgroundColor:[WPStyleGuide greyLighten30]];
-    [[WPMediaCollectionViewCell appearanceWhenContainedInInstancesOfClasses:@[ [WPMediaCollectionViewController class] ]] setBackgroundColor:[WPStyleGuide lightGrey]];
+    [[WPMediaCollectionViewCell appearanceWhenContainedInInstancesOfClasses:@[ [WPMediaPickerViewController class] ]] setBackgroundColor:[WPStyleGuide lightGrey]];
 
     [[WPLegacyEditorFormatToolbar appearance] setBarTintColor:[UIColor colorWithHexString:@"F9FBFC"]];
     [[WPLegacyEditorFormatToolbar appearance] setTintColor:[WPStyleGuide greyLighten10]];

--- a/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
@@ -12,6 +12,8 @@ class GravatarPickerViewController: UIViewController, WPMediaPickerViewControlle
 
     // MARK: - Private Properties
 
+    fileprivate var mediaPickerViewController: WPNavigationMediaPickerViewController!
+
     fileprivate lazy var mediaPickerAssetDataSource: WPPHAssetDataSource? = {
         let collectionsFetchResult = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumSelfPortraits, options: nil)
         guard let assetCollection = collectionsFetchResult.firstObject else { return nil }
@@ -53,7 +55,7 @@ class GravatarPickerViewController: UIViewController, WPMediaPickerViewControlle
 
             // Proceed Cropping
             let imageCropViewController = self.newImageCropViewController(rawGravatar)
-            picker.show(after: imageCropViewController)
+            self.mediaPickerViewController.show(after: imageCropViewController)
         }
     }
 
@@ -74,12 +76,14 @@ class GravatarPickerViewController: UIViewController, WPMediaPickerViewControlle
         view.addSubview(pickerViewController.view)
         addChildViewController(pickerViewController)
         pickerViewController.didMove(toParentViewController: self)
+
+        mediaPickerViewController = pickerViewController
     }
 
     // Returns a new WPMediaPickerViewController instance.
     //
-    fileprivate func newMediaPickerViewController() -> WPMediaPickerViewController {
-        let pickerViewController = WPMediaPickerViewController()
+    fileprivate func newMediaPickerViewController() -> WPNavigationMediaPickerViewController {
+        let pickerViewController = WPNavigationMediaPickerViewController()
         pickerViewController.delegate = self
         pickerViewController.showMostRecentFirst = true
         pickerViewController.allowMultipleSelection = false

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1125,7 +1125,7 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
 
     func showImagePicker() {
 
-        let picker = WPMediaPickerViewController()
+        let picker = WPNavigationMediaPickerViewController()
         picker.dataSource = mediaLibraryDataSource
         picker.showMostRecentFirst = true
         picker.filter = WPMediaType.image

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1211,7 +1211,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
 - (void)showMediaPicker
 {
-    WPMediaPickerViewController *picker = [[WPMediaPickerViewController alloc] init];
+    WPNavigationMediaPickerViewController *picker = [[WPNavigationMediaPickerViewController alloc] init];
     self.mediaDataSource = [[WPAndDeviceMediaLibraryDataSource alloc] initWithPost:self.apost];
     picker.dataSource = self.mediaDataSource;
     picker.filter = WPMediaTypeImage;

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -377,7 +377,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
 
 - (void)showMediaPicker
 {
-    WPMediaPickerViewController *picker = [[WPMediaPickerViewController alloc] init];
+    WPNavigationMediaPickerViewController *picker = [[WPNavigationMediaPickerViewController alloc] init];
     picker.delegate = self;
     if (!self.mediaLibraryDataSource) {
         self.mediaLibraryDataSource = [[WPAndDeviceMediaLibraryDataSource alloc] initWithPost:self.post];

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -802,7 +802,7 @@ EditImageDetailsViewControllerDelegate
 - (void)showMediaPickerAnimated:(BOOL)animated
 {
     self.mediaLibraryDataSource = [[WPAndDeviceMediaLibraryDataSource alloc] initWithPost:self.post];
-    WPMediaPickerViewController *picker = [[WPMediaPickerViewController alloc] init];
+    WPNavigationMediaPickerViewController *picker = [[WPNavigationMediaPickerViewController alloc] init];
     picker.dataSource = self.mediaLibraryDataSource;
     picker.showMostRecentFirst = YES;
     picker.delegate = self;


### PR DESCRIPTION
Updates the app to use MediaPicker 0.12

The media picker had a couple of high-level architecture changes in this release, which required a few changes to WPiOS. `WPMediaCollectionViewController` has now become `WPMediaPickerViewController`, and `WPMediaPickerViewController` has now become `WPNavigationMediaPickerViewController` (wrapping the collection view in a navigation controller.

**To test:**

Check that all of the editors show the media picker correctly, that it's styled correctly, and that you can select images.

Needs review: @kurzee 