### PR TITLE
Preview refactor

### DIFF
--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -140,6 +140,7 @@
 #import "WPWebViewController.h"
 #import "WPTabBarController.h"
 #import "WPWalkthroughTextField.h"
+#import "WPURLRequest.h"
 #import "WPUserAgent.h"
 #import "WordPressComServiceRemote.h"
 #import "WPAndDeviceMediaLibraryDataSource.h"

--- a/WordPress/Classes/Utility/WPURLRequest.h
+++ b/WordPress/Classes/Utility/WPURLRequest.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
 @interface WPURLRequest : NSURLRequest
 
 
@@ -11,7 +12,7 @@
  @return a `NSURLRequest` instance for the specified URL, with a given UserAgent set.
  */
 
-+ (NSURLRequest *)requestWithURL:(NSURL *)url userAgent:(NSString *)userAgent;
++ (NSURLRequest *)requestWithURL:(NSURL *)url userAgent:(nullable NSString *)userAgent;
 
 
 /**
@@ -28,8 +29,9 @@
 + (NSURLRequest *)requestForAuthenticationWithURL:(NSURL *)loginUrl
                                       redirectURL:(NSURL *)redirectURL
                                          username:(NSString *)username
-                                         password:(NSString *)password
-                                      bearerToken:(NSString *)bearerToken
-                                        userAgent:(NSString *)userAgent;
+                                         password:(nullable NSString *)password
+                                      bearerToken:(nullable NSString *)bearerToken
+                                        userAgent:(nullable NSString *)userAgent;
 
 @end
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/ViewRelated/Post/FakePreviewBuilder.swift
+++ b/WordPress/Classes/ViewRelated/Post/FakePreviewBuilder.swift
@@ -41,7 +41,7 @@ class FakePreviewBuilder: NSObject {
 
 private extension FakePreviewBuilder {
     var previewTitle: String {
-        return title?.nonEmptyString() ?? NSLocalizedString("(no title", comment: "")
+        return title?.nonEmptyString() ?? NSLocalizedString("(no title)", comment: "")
     }
 
     var previewContent: String {

--- a/WordPress/Classes/ViewRelated/Post/FakePreviewBuilder.swift
+++ b/WordPress/Classes/ViewRelated/Post/FakePreviewBuilder.swift
@@ -55,7 +55,7 @@ private extension FakePreviewBuilder {
 
     var previewTags: String {
         let tagsLabel = NSLocalizedString("Tags: %@", comment: "")
-        return String(format: tagsLabel, tags.joined(separator: ","))
+        return String(format: tagsLabel, tags.joined(separator: ", "))
     }
 
     var previewCategories: String {
@@ -74,8 +74,13 @@ extension FakePreviewBuilder {
         let tags: [String]
         let categories: [String]
         if let post = apost as? Post {
-            tags = post.tags?.components(separatedBy: ",") ?? []
-            categories = post.categories?.map({ $0.categoryName }) ?? []
+            tags = post.tags?
+                .components(separatedBy: ",")
+                .map({ $0.trim() })
+                ?? []
+            categories = post.categories?
+                .map({ $0.categoryName })
+                ?? []
         } else {
             tags = []
             categories = []

--- a/WordPress/Classes/ViewRelated/Post/FakePreviewBuilder.swift
+++ b/WordPress/Classes/ViewRelated/Post/FakePreviewBuilder.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+class FakePreviewBuilder: NSObject {
+    let title: String?
+    let content: String?
+    let tags: [String]
+    let categories: [String]
+    let message: String?
+
+    init(title: String?, content: String?, tags: [String], categories: [String], message: String?) {
+        self.title = title
+        self.content = content
+        self.tags = tags
+        self.categories = categories
+        self.message = message
+        super.init()
+    }
+
+    func build() -> String {
+        let template = loadTemplate()
+        let messageParagraph = message.map({ "<p>\($0)</p>" }) ?? ""
+        return template
+            .replacingOccurrences(of: "!$title$!", with: previewTitle)
+            .replacingOccurrences(of: "!$text$!", with: previewContent)
+            .replacingOccurrences(of: "!$mt_keywords$!", with: previewTags)
+            .replacingOccurrences(of: "!$categories$!", with: previewCategories)
+            .replacingOccurrences(of: "<div class=\"page\">", with: "<div class=\"page\">\(messageParagraph)")
+    }
+
+    private func loadTemplate() -> String {
+        guard let path = Bundle.main.path(forResource: "defaultPostTemplate", ofType: "html"),
+            let template = try? String(contentsOfFile: path, encoding: .utf8) else {
+                assertionFailure("Unable to load preview template")
+                return ""
+        }
+        return template
+    }
+}
+
+// MARK: - Formatting Fields
+
+private extension FakePreviewBuilder {
+    var previewTitle: String {
+        return title?.nonEmptyString() ?? NSLocalizedString("(no title", comment: "")
+    }
+
+    var previewContent: String {
+        guard var contentText = content?.nonEmptyString() else {
+            let placeholder = NSLocalizedString("No Description available for this Post", comment: "")
+            return "<h1>\(placeholder)</h1>"
+        }
+        contentText = contentText.replacingOccurrences(of: "\n", with: "<br>")
+        return "<p>\(contentText)</p><br />"
+    }
+
+    var previewTags: String {
+        let tagsLabel = NSLocalizedString("Tags: %@", comment: "")
+        return String(format: tagsLabel, tags.joined(separator: ","))
+    }
+
+    var previewCategories: String {
+        let categoriesLabel = NSLocalizedString("Categories: %@", comment: "")
+        return String(format: categoriesLabel, categories.joined(separator: ", "))
+    }
+}
+
+
+// MARK: - Processing AbstractPost
+
+extension FakePreviewBuilder {
+    convenience init(apost: AbstractPost, message: String?) {
+        let title = apost.postTitle
+        let content = apost.content
+        let tags: [String]
+        let categories: [String]
+        if let post = apost as? Post {
+            tags = post.tags?.components(separatedBy: ",") ?? []
+            categories = post.categories?.map({ $0.categoryName }) ?? []
+        } else {
+            tags = []
+            categories = []
+        }
+
+        self.init(title: title, content: content, tags: tags, categories: categories, message: message)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+@objc
+protocol PostPreviewGeneratorDelegate {
+    func preview(_ generator: PostPreviewGenerator, attemptRequest request: URLRequest)
+    func preview(_ generator: PostPreviewGenerator, loadHTML html: String)
+}
+
+class PostPreviewGenerator: NSObject {
+    let post: AbstractPost
+    var delegate: PostPreviewGeneratorDelegate?
+
+    init(post: AbstractPost) {
+        self.post = post
+        super.init()
+    }
+
+    func generate() {
+        guard let link = post.permaLink,
+            let url = URL(string: link),
+            !post.hasLocalChanges() else {
+                showFakePreview()
+                return
+        }
+
+        guard WordPressAppDelegate.sharedInstance().connectionAvailable else {
+            showFakePreview(message:
+                NSLocalizedString("The internet connection appears to be offline.", comment: "") +
+                    " " +
+                NSLocalizedString("A simple preview is shown below.", comment: "")
+            )
+            return
+        }
+
+        if needsLogin() {
+            attemptAuthenticatedRequest(url: url)
+        } else {
+            attemptUnauthenticatedRequest(url: url)
+        }
+    }
+
+    func previewRequestFailed(error: NSError) {
+        showFakePreview(message:
+            NSLocalizedString("There has been an error while trying to reach your site.", comment: "") +
+                " " +
+                NSLocalizedString("A simple preview is shown below.", comment: "")
+        )
+    }
+}
+
+private extension PostPreviewGenerator {
+    func needsLogin() -> Bool {
+        guard let status = post.status else {
+            assertionFailure("A post should always have a status")
+            return false
+        }
+        switch status {
+        case .draft, .publishPrivate, .pending, .scheduled:
+            return true
+        default:
+            return post.blog.isPrivate()
+        }
+    }
+
+    func attemptUnauthenticatedRequest(url: URL) {
+        let request = URLRequest(url: url)
+        delegate?.preview(self, attemptRequest: request)
+    }
+
+    func attemptAuthenticatedRequest(url: URL) {
+        let blog = post.blog
+        guard let loginURL = URL(string: blog.loginUrl()),
+            let username = blog.usernameForSite?.nonEmptyString() else {
+                showFakePreview()
+                return
+        }
+
+        let request: URLRequest
+        if blog.supports(.oAuth2Login) {
+            guard let token = blog.authToken?.nonEmptyString() else {
+                showFakePreview()
+                return
+            }
+            request = WPURLRequest.requestForAuthentication(with: loginURL, redirectURL: url, username: username, password: nil, bearerToken: token, userAgent: nil)
+        } else {
+            guard let password = blog.password?.nonEmptyString() else {
+                showFakePreview()
+                return
+            }
+            request = WPURLRequest.requestForAuthentication(with: loginURL, redirectURL: url, username: username, password: password, bearerToken: nil, userAgent: nil)
+        }
+        delegate?.preview(self, attemptRequest: request)
+    }
+
+    func showFakePreview(message: String? = nil) {
+        let builder = FakePreviewBuilder(apost: post, message: message)
+        delegate?.preview(self, loadHTML: builder.build())
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -9,10 +9,10 @@
 #import "WordPress-Swift.h"
 
 @import Gridicons;
+@import SVProgressHUD;
 @interface PostPreviewViewController ()
 
 @property (nonatomic, strong) UIWebView *webView;
-@property (nonatomic, strong) UIView *loadingView;
 @property (nonatomic, strong) NSMutableData *receivedData;
 @property (nonatomic, strong) AbstractPost *apost;
 @property (nonatomic, strong) UIBarButtonItem *shareBarButtonItem;
@@ -53,7 +53,6 @@
     
     [super viewDidLoad];
     [self setupWebView];
-    [self setupLoadingView];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -87,36 +86,6 @@
         self.webView.delegate = self;
     }
     [self.view addSubview:self.webView];
-}
-
-- (void)setupLoadingView
-{
-    if (!self.loadingView) {
-
-        CGRect frame = self.view.frame;
-        CGFloat sides = 100.0f;
-        CGFloat x = (frame.size.width - sides) / 2.0f;
-        CGFloat y = (frame.size.height - sides) / 2.0f;
-
-        self.loadingView = [[UIView alloc] initWithFrame:CGRectMake(x, y, sides, sides)];
-        self.loadingView.layer.cornerRadius = 10.0f;
-        self.loadingView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:0.8f];
-        self.loadingView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin |
-        UIViewAutoresizingFlexibleBottomMargin |
-        UIViewAutoresizingFlexibleTopMargin |
-        UIViewAutoresizingFlexibleRightMargin;
-
-        UIActivityIndicatorView *activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
-        [activityView startAnimating];
-
-        frame = activityView.frame;
-        frame.origin.x = (sides - frame.size.width) / 2.0f;
-        frame.origin.y = (sides - frame.size.height) / 2.0f;
-        activityView.frame = frame;
-        [self.loadingView addSubview:activityView];
-    }
-
-    [self.view addSubview:self.loadingView];
 }
 
 - (void)showSimplePreviewWithMessage:(NSString *)message
@@ -195,12 +164,12 @@
 
 - (void)startLoading
 {
-    self.loadingView.hidden = NO;
+    [SVProgressHUD show];
 }
 
 - (void)stopLoading
 {
-    self.loadingView.hidden = YES;
+    [SVProgressHUD dismiss];
 }
 
 #pragma mark -

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -191,13 +191,25 @@
     }
 }
 
+#pragma mark - Loading
+
+- (void)startLoading
+{
+    self.loadingView.hidden = NO;
+}
+
+- (void)stopLoading
+{
+    self.loadingView.hidden = YES;
+}
+
 #pragma mark -
 #pragma mark Webkit View Delegate Methods
 
 - (void)refreshWebView
 {
     BOOL edited = [self.apost hasLocalChanges];
-    self.loadingView.hidden = NO;
+    [self startLoading];
 
     if (edited) {
         [self showSimplePreview];
@@ -209,7 +221,7 @@
 - (void)webViewDidFinishLoad:(UIWebView *)awebView
 {
     DDLogMethod();
-    self.loadingView.hidden = YES;
+    [self stopLoading];
 }
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
@@ -224,7 +236,7 @@
         return;
     }
 
-    self.loadingView.hidden = YES;
+    [self stopLoading];
     NSString *errorMessage = [NSString stringWithFormat:@"<div class=\"page\"><p>%@ %@</p>",
                               NSLocalizedString(@"There has been an error while trying to reach your site.", nil),
                               NSLocalizedString(@"A simple preview is shown below.", @"")];

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -119,72 +119,12 @@
     [self.view addSubview:self.loadingView];
 }
 
-- (Post *)post
-{
-    if ([self.apost isKindOfClass:[Post class]]) {
-        return (Post *)self.apost;
-    }
-
-    return nil;
-}
-
-- (NSString *)buildSimplePreview
-{
-    NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
-    NSString *fpath = [NSString stringWithFormat:@"%@/defaultPostTemplate.html", resourcePath];
-    NSString *str = [NSString stringWithContentsOfFile:fpath encoding:NSUTF8StringEncoding error:nil];
-
-    if ([str length]) {
-
-        //Title
-        NSString *title = self.apost.postTitle;
-        title = (title == nil || ([title length] == 0) ? NSLocalizedString(@"(no title)", @"") : title);
-        str = [str stringByReplacingOccurrencesOfString:@"!$title$!" withString:title];
-
-        //Content
-        NSString *desc = self.apost.content;
-        if (!desc) {
-            desc = [NSString stringWithFormat:@"<h1>%@</h1>", NSLocalizedString(@"No Description available for this Post", @"")];
-        } else {
-            desc = [self stringReplacingNewlinesWithBR:desc];
-        }
-        desc = [NSString stringWithFormat:@"<p>%@</p><br />", desc];
-        str = [str stringByReplacingOccurrencesOfString:@"!$text$!" withString:desc];
-
-        //Tags
-        NSString *tags = self.post.tags;
-        tags = (tags == nil ? @"" : tags);
-        tags = [NSString stringWithFormat:NSLocalizedString(@"Tags: %@", @""), tags];
-        str = [str stringByReplacingOccurrencesOfString:@"!$mt_keywords$!" withString:tags];
-
-        //Categories [selObjects count]
-        NSArray *categories = [self.post.categories allObjects];
-        NSString *catStr = @"";
-        NSUInteger i = 0, count = [categories count];
-        for (i = 0; i < count; i++) {
-            PostCategory *category = [categories objectAtIndex:i];
-            catStr = [catStr stringByAppendingString:category.categoryName];
-            if (i < count-1) {
-                catStr = [catStr stringByAppendingString:@", "];
-            }
-        }
-        catStr = [NSString stringWithFormat:NSLocalizedString(@"Categories: %@", @""), catStr];
-        str = [str stringByReplacingOccurrencesOfString:@"!$categories$!" withString:catStr];
-
-    } else {
-        str = @"";
-    }
-
-    return str;
-}
-
 - (void)showSimplePreviewWithMessage:(NSString *)message
 {
     DDLogMethod();
-    NSString *previewPageHTML = [self buildSimplePreview];
-    if (message) {
-        previewPageHTML = [previewPageHTML stringByReplacingOccurrencesOfString:@"<div class=\"page\">" withString:[NSString stringWithFormat:@"<div class=\"page\"><p>%@</p>", message]];
-    }
+    FakePreviewBuilder *builder = [[FakePreviewBuilder alloc] initWithApost:self.apost message:message];
+    NSString *previewPageHTML = [builder build];
+    previewPageHTML = [builder build];
     [self.webView loadHTMLString:previewPageHTML baseURL:nil];
 }
 
@@ -359,14 +299,6 @@
     } else{
         [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
     }
-}
-
-#pragma mark -
-
-- (NSString *)stringReplacingNewlinesWithBR:(NSString *)surString
-{
-    NSArray *comps = [surString componentsSeparatedByString:@"\n"];
-    return [comps componentsJoinedByString:@"<br>"];
 }
 
 @end

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -735,6 +735,7 @@
 		E1C545801C6C79BB001CEB0E /* MediaSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5457F1C6C79BB001CEB0E /* MediaSettingsTests.swift */; };
 		E1C9AA511C10419200732665 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA501C10419200732665 /* Math.swift */; };
 		E1C9AA561C10427100732665 /* MathTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA551C10427100732665 /* MathTest.swift */; };
+		E1CECE021E6EC7A8009C6695 /* FakePreviewBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CECE011E6EC7A8009C6695 /* FakePreviewBuilder.swift */; };
 		E1CFC1571E0AC8FF001DF9E9 /* Pattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CFC1561E0AC8FF001DF9E9 /* Pattern.swift */; };
 		E1D04D7E19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D04D7D19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m */; };
 		E1D04D8419374F2C002FADD7 /* BlogServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D04D8319374F2C002FADD7 /* BlogServiceRemoteREST.m */; };
@@ -2156,6 +2157,7 @@
 		E1C807471696F72E00E545A6 /* WordPress 9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 9.xcdatamodel"; sourceTree = "<group>"; };
 		E1C9AA501C10419200732665 /* Math.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Math.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		E1C9AA551C10427100732665 /* MathTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MathTest.swift; sourceTree = "<group>"; };
+		E1CECE011E6EC7A8009C6695 /* FakePreviewBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakePreviewBuilder.swift; sourceTree = "<group>"; };
 		E1CFC1561E0AC8FF001DF9E9 /* Pattern.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pattern.swift; sourceTree = "<group>"; };
 		E1D04D7C19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogServiceRemoteXMLRPC.h; sourceTree = "<group>"; };
 		E1D04D7D19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogServiceRemoteXMLRPC.m; sourceTree = "<group>"; };
@@ -3072,6 +3074,7 @@
 				595CB3751D2317D50082C7E9 /* PostListFilter.swift */,
 				43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */,
 				17626A8F1DE38FE700140B45 /* PostEditorSaveAction.swift */,
+				E1CECE011E6EC7A8009C6695 /* FakePreviewBuilder.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -6520,6 +6523,7 @@
 				B522C4F81B3DA79B00E47B59 /* NotificationSettingsViewController.swift in Sources */,
 				B587797C19B799D800E57C5A /* NSParagraphStyle+Helpers.swift in Sources */,
 				5D6C4B121B604190005E3C43 /* RichTextView.swift in Sources */,
+				E1CECE021E6EC7A8009C6695 /* FakePreviewBuilder.swift in Sources */,
 				171963401D378D5100898E8B /* SearchWrapperView.swift in Sources */,
 				E148362F1C6DF7D8005ACF53 /* Product.swift in Sources */,
 				082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -736,6 +736,7 @@
 		E1C9AA511C10419200732665 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA501C10419200732665 /* Math.swift */; };
 		E1C9AA561C10427100732665 /* MathTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA551C10427100732665 /* MathTest.swift */; };
 		E1CECE021E6EC7A8009C6695 /* FakePreviewBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CECE011E6EC7A8009C6695 /* FakePreviewBuilder.swift */; };
+		E1CECE051E6F01CE009C6695 /* PostPreviewGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CECE041E6F01CE009C6695 /* PostPreviewGenerator.swift */; };
 		E1CFC1571E0AC8FF001DF9E9 /* Pattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CFC1561E0AC8FF001DF9E9 /* Pattern.swift */; };
 		E1D04D7E19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D04D7D19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m */; };
 		E1D04D8419374F2C002FADD7 /* BlogServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = E1D04D8319374F2C002FADD7 /* BlogServiceRemoteREST.m */; };
@@ -2158,6 +2159,7 @@
 		E1C9AA501C10419200732665 /* Math.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Math.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		E1C9AA551C10427100732665 /* MathTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MathTest.swift; sourceTree = "<group>"; };
 		E1CECE011E6EC7A8009C6695 /* FakePreviewBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakePreviewBuilder.swift; sourceTree = "<group>"; };
+		E1CECE041E6F01CE009C6695 /* PostPreviewGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostPreviewGenerator.swift; sourceTree = "<group>"; };
 		E1CFC1561E0AC8FF001DF9E9 /* Pattern.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pattern.swift; sourceTree = "<group>"; };
 		E1D04D7C19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogServiceRemoteXMLRPC.h; sourceTree = "<group>"; };
 		E1D04D7D19374CFE002FADD7 /* BlogServiceRemoteXMLRPC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogServiceRemoteXMLRPC.m; sourceTree = "<group>"; };
@@ -3075,6 +3077,7 @@
 				43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */,
 				17626A8F1DE38FE700140B45 /* PostEditorSaveAction.swift */,
 				E1CECE011E6EC7A8009C6695 /* FakePreviewBuilder.swift */,
+				E1CECE041E6F01CE009C6695 /* PostPreviewGenerator.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -6405,6 +6408,7 @@
 				B5DBE4FE1D21A700002E81D3 /* NotificationsViewController.swift in Sources */,
 				B5772AC91C9C859D0031F97E /* GravatarServiceRemote.swift in Sources */,
 				E1B84F001E02E94D00BF6434 /* PingHubManager.swift in Sources */,
+				E1CECE051E6F01CE009C6695 /* PostPreviewGenerator.swift in Sources */,
 				E61084C11B9B47BA008050C5 /* ReaderSiteTopic.swift in Sources */,
 				5DAE40AD19EC70930011A0AE /* ReaderPostHeaderView.m in Sources */,
 				FFB0DEAA1D38061B00DD4A50 /* WPImageURLHelper.swift in Sources */,


### PR DESCRIPTION
For #5693 I have to introduce quite a bit of logic to support multiple authentication mechanisms (nonce, cookie, no auth), and in the future also autosave drafts so we can show a real preview.

This first PR takes all the preview generation logic out of PostPreviewViewController, leaving it only to handle the UI.

I know there's plenty to improve in this code, but for this first pass I wanted to keep the exact same behavior, with just better separation of responsibilities (and Swift migration).

The one behavior change I did was to get rid of the custom loading indicator and use `SVProgressHUD` instead.

I'm having some trouble running the test suite, so I'm leaving unit tests for a future PR.

Needs review: @aerych 