### PR TITLE
Media Library #1: Grid and detail views

### DIFF
--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -45,6 +45,7 @@
 #import "LoginFields.h"
 
 #import "Media.h"
+#import "MediaLibraryPickerDataSource.h"
 #import "MediaService.h"
 #import "MeHeaderView.h"
 #import "MixpanelTweaks.h"

--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -2,6 +2,7 @@
 /// different builds.
 @objc
 enum FeatureFlag: Int {
+    case mediaLibrary
     case nativeEditor
     case exampleFeature
 
@@ -10,6 +11,8 @@ enum FeatureFlag: Int {
         switch self {
         case .exampleFeature:
             return true
+        case .mediaLibrary:
+            return build(.debug)
         case .nativeEditor:
             // At the moment this is only active in debug mode
             if build(.alpha, .debug, .internal) {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -436,7 +436,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     if ([Feature enabled:FeatureFlagMediaLibrary]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Media", @"Noun. Title. Links to the blog's Media library.")
-                                                        image:[Gridicon iconOfType:GridiconTypeImageMultiple]
+                                                        image:[Gridicon iconOfType:GridiconTypeImage]
                                                      callback:^{
                                                          [weakSelf showMediaLibrary];
                                                      }]];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -434,6 +434,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                      [weakSelf showPageList];
                                                  }]];
 
+    if ([Feature enabled:FeatureFlagMediaLibrary]) {
+        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Media", @"Noun. Title. Links to the blog's Media library.")
+                                                        image:[Gridicon iconOfType:GridiconTypeImageMultiple]
+                                                     callback:^{
+                                                         [weakSelf showMediaLibrary];
+                                                     }]];
+    }
+
     BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Comments", @"Noun. Title. Links to the blog's Comments screen.")
                                                           image:[Gridicon iconOfType:GridiconTypeComment]
                                                        callback:^{
@@ -728,6 +736,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)showPageList
 {
     [WPAppAnalytics track:WPAnalyticsStatOpenedPages withBlog:self.blog];
+    PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
+    [self showDetailViewController:controller sender:self];
+}
+
+- (void)showMediaLibrary
+{
+    [WPAppAnalytics track:WPAnalyticsStatOpenedMediaLibrary withBlog:self.blog];
     PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -743,7 +743,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)showMediaLibrary
 {
     [WPAppAnalytics track:WPAnalyticsStatOpenedMediaLibrary withBlog:self.blog];
-    PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
+    MediaLibraryViewController *controller = [[MediaLibraryViewController alloc] initWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -1,0 +1,304 @@
+import UIKit
+import WordPressShared
+
+/// Displays an image preview and metadata for a single Media asset.
+///
+class MediaItemViewController: UITableViewController, ImmuTablePresenter {
+    let media: Media
+    var viewModel: ImmuTable!
+
+    init(media: Media) {
+        self.media = media
+
+        super.init(style: .grouped)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = media.title
+
+        WPStyleGuide.configureColors(for: view, andTableView: tableView)
+        ImmuTable.registerRows([TextRow.self, EditableTextRow.self, MediaImageRow.self],
+                               tableView: tableView)
+        setupViewModel()
+    }
+
+    private func setupViewModel() {
+        let presenter = MediaMetadataPresenter(media: media)
+
+        viewModel = ImmuTable(sections: [
+            ImmuTableSection(rows: [
+                MediaImageRow(media: media, action: { [weak self] row in
+                    self?.presentImageViewControllerForMedia()
+                }) ]),
+            ImmuTableSection(headerText: nil, rows: [
+                EditableTextRow(title: NSLocalizedString("Title", comment: "Noun. Label for the title of a media asset (image / video)"), value: media.title, action: nil),
+                EditableTextRow(title: NSLocalizedString("Caption", comment: "Noun. Label for the caption for a media asset (image / video)"), value: media.caption, action: nil),
+                EditableTextRow(title: NSLocalizedString("Description", comment: "Label for the description for a media asset (image / video)"), value: media.desc, action: nil)
+                ], footerText: nil),
+            ImmuTableSection(headerText: NSLocalizedString("Metadata", comment: "Title of section containing image / video metadata such as size and file type"), rows: [
+                TextRow(title: NSLocalizedString("File name", comment: "Label for the file name for a media asset (image / video)"), value: media.filename),
+                TextRow(title: NSLocalizedString("File type", comment: "Label for the file type (.JPG, .PNG, etc) for a media asset (image / video)"), value: presenter.fileType),
+                TextRow(title: NSLocalizedString("Dimensions", comment: "Label for the dimensions in pixels for a media asset (image / video)"), value: presenter.dimensions),
+                TextRow(title: NSLocalizedString("Uploaded", comment: "Label for the date a media asset (image / video) was uploaded"), value: media.creationDate.mediumString())
+                ], footerText: nil)
+            ])
+    }
+
+    private func presentImageViewControllerForMedia() {
+        if let controller = WPImageViewController(media: self.media) {
+            controller.modalTransitionStyle = .crossDissolve
+            controller.modalPresentationStyle = .fullScreen
+
+            self.present(controller, animated: true, completion: nil)
+        }
+    }
+}
+
+// MARK: - UITableViewDataSource
+extension MediaItemViewController {
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return viewModel.sections.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.sections[section].rows.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let row = viewModel.rowAtIndexPath(indexPath)
+        let cell = tableView.dequeueReusableCell(withIdentifier: row.reusableIdentifier, for: indexPath)
+
+        row.configureCell(cell)
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return viewModel.sections[section].headerText
+    }
+}
+
+// MARK: - UITableViewDelegate
+extension MediaItemViewController {
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        let row = viewModel.rowAtIndexPath(indexPath)
+        if let customHeight = type(of: row).customHeight {
+            return CGFloat(customHeight)
+        } else if row is MediaImageRow {
+            return UITableViewAutomaticDimension
+        }
+
+        return tableView.rowHeight
+    }
+
+    override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        let row = viewModel.rowAtIndexPath(indexPath)
+        if row is MediaImageRow {
+            return view.readableContentGuide.layoutFrame.width
+        }
+
+        return tableView.rowHeight
+    }
+
+    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if let row = viewModel.rowAtIndexPath(indexPath) as? MediaImageRow {
+            row.willDisplay(cell)
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionHeader(view)
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let row = viewModel.rowAtIndexPath(indexPath)
+        row.action?(row)
+    }
+}
+
+open class ImageTableViewCell: WPTableViewCell {
+    let customImageView = UIImageView()
+    let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .white)
+    let activityMaskView = UIView()
+
+    // MARK: - Initializers
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    public required override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        commonInit()
+    }
+
+    public convenience init() {
+        self.init(style: .default, reuseIdentifier: nil)
+    }
+
+    func commonInit() {
+        setupImageView()
+        setupLoadingViews()
+    }
+
+    private func setupImageView() {
+        addSubview(customImageView)
+        customImageView.translatesAutoresizingMaskIntoConstraints = false
+        customImageView.contentMode = .scaleAspectFit
+
+        NSLayoutConstraint.activate([
+            customImageView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
+            customImageView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor),
+            customImageView.topAnchor.constraint(equalTo: topAnchor),
+            customImageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            ])
+
+        customImageView.setContentHuggingPriority(UILayoutPriorityDefaultLow, for: .horizontal)
+    }
+
+    private func setupLoadingViews() {
+        addSubview(activityMaskView)
+        activityMaskView.translatesAutoresizingMaskIntoConstraints = false
+        activityMaskView.backgroundColor = .black
+        activityMaskView.alpha = 0.5
+
+        addSubview(activityIndicator)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        activityIndicator.hidesWhenStopped = true
+
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            activityMaskView.leadingAnchor.constraint(equalTo: customImageView.leadingAnchor),
+            activityMaskView.trailingAnchor.constraint(equalTo: customImageView.trailingAnchor),
+            activityMaskView.topAnchor.constraint(equalTo: customImageView.topAnchor),
+            activityMaskView.bottomAnchor.constraint(equalTo: customImageView.bottomAnchor)
+        ])
+    }
+
+    private var aspectRatioConstraint: NSLayoutConstraint? = nil
+
+    var targetAspectRatio: CGFloat {
+        set {
+            if let aspectRatioConstraint = aspectRatioConstraint {
+                customImageView.removeConstraint(aspectRatioConstraint)
+            }
+
+            aspectRatioConstraint = customImageView.heightAnchor.constraint(equalTo: customImageView.widthAnchor, multiplier: newValue, constant: 1.0)
+            aspectRatioConstraint?.isActive = true
+        }
+        get {
+            return aspectRatioConstraint?.multiplier ?? 0
+        }
+    }
+
+    // MARK: - Loading
+
+    var isLoading: Bool = false {
+        didSet {
+            if isLoading {
+                activityMaskView.alpha = 0.5
+                activityIndicator.startAnimating()
+            } else {
+                activityMaskView.alpha = 0
+                activityIndicator.stopAnimating()
+            }
+        }
+    }
+}
+
+struct MediaImageRow: ImmuTableRow {
+    static let cell = ImmuTableCell.class(ImageTableViewCell.self)
+
+    let media: Media
+    let action: ImmuTableAction?
+
+    func configureCell(_ cell: UITableViewCell) {
+        WPStyleGuide.configureTableViewCell(cell)
+
+        if let cell = cell as? ImageTableViewCell {
+            setAspectRatioFor(cell)
+            addPlaceholderImageFor(cell)
+            loadImageFor(cell)
+        }
+    }
+
+    func willDisplay(_ cell: UITableViewCell) {
+        if let cell = cell as? ImageTableViewCell {
+            cell.customImageView.backgroundColor = .black
+        }
+    }
+
+    private func setAspectRatioFor(_ cell: ImageTableViewCell) {
+        let width = CGFloat(media.width.floatValue)
+        let height = CGFloat(media.height.floatValue)
+        if (width > 0) {
+            cell.targetAspectRatio = height / width
+        }
+    }
+
+    private func addPlaceholderImageFor(_ cell: ImageTableViewCell) {
+        if let url = media.absoluteLocalURL,
+            let image = UIImage(contentsOfFile: url) {
+            cell.customImageView.image = image
+        } else if let url = media.absoluteThumbnailLocalURL,
+            let image = UIImage(contentsOfFile: url) {
+            cell.customImageView.image = image
+        }
+    }
+
+    private func loadImageFor(_ cell: ImageTableViewCell) {
+        cell.isLoading = true
+        media.image(with: .zero,
+                    completionHandler: { image, error in
+                        DispatchQueue.main.async {
+                            if let error = error, image == nil {
+                                self.show(error)
+                            } else if let image = image {
+                                self.animateImageChange(image: image, for: cell)
+                            }
+                        }
+        })
+    }
+
+    private func show(_ error: Error) {
+        let alertController = UIAlertController(title: nil, message: NSLocalizedString("There was a problem loading the media item.",
+                                                                                       comment: "Error message displayed when the Media Library is unable to load a full sized preview of an item."), preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: ""))
+        alertController.presentFromRootViewController()
+    }
+
+    private func animateImageChange(image: UIImage, for cell: ImageTableViewCell) {
+        UIView.transition(with: cell.customImageView, duration: 0.2, options: .transitionCrossDissolve, animations: {
+            cell.isLoading = false
+            cell.customImageView.image = image
+        }, completion: nil)
+    }
+}
+
+/// Provides some extra formatting for a Media asset's metadata, used
+/// to present it in the MediaItemViewController
+///
+private struct MediaMetadataPresenter {
+    let media: Media
+
+    /// A String containing the pixel size of the asset (width X height)
+    var dimensions: String {
+        let width = media.width ?? 0
+        let height = media.height ?? 0
+
+        return "\(width) ✕ \(height)"
+    }
+
+    /// A String containing the uppercased file extension of the asset (.JPG, .PNG, etc)
+    var fileType: String {
+        return (media.filename as NSString).pathExtension.uppercased()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -1,11 +1,16 @@
 import UIKit
+import WordPressShared
 import WPMediaPicker
 
+/// Displays the user's media library in a grid
+///
 class MediaLibraryViewController: UIViewController {
     let blog: Blog
 
     private let pickerViewController: WPMediaPickerViewController
     private let pickerDataSource: MediaLibraryPickerDataSource
+
+    // MARK: - Initializers
 
     init(blog: Blog) {
         self.blog = blog
@@ -30,11 +35,12 @@ class MediaLibraryViewController: UIViewController {
         pickerViewController.dataSource = pickerDataSource
     }
 
+    // MARK: - View Loading
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = NSLocalizedString("Media", comment: "")
-        navigationItem.backBarButtonItem?.title = ""
+        title = NSLocalizedString("Media", comment: "Title for Media Library section of the app.")
 
         addMediaPickerAsChildViewController()
     }
@@ -48,8 +54,30 @@ class MediaLibraryViewController: UIViewController {
     }
 }
 
+// MARK: - WPMediaPickerViewControllerDelegate
+
 extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
     func mediaPickerController(_ picker: WPMediaPickerViewController, didFinishPickingAssets assets: [Any]) {
 
+    }
+
+    func mediaPickerController(_ picker: WPMediaPickerViewController, previewViewControllerFor asset: WPMediaAsset) -> UIViewController? {
+        return mediaItemViewController(for: asset)
+    }
+
+    func mediaPickerController(_ picker: WPMediaPickerViewController, shouldSelect asset: WPMediaAsset) -> Bool {
+        if let viewController = mediaItemViewController(for: asset) {
+            navigationController?.pushViewController(viewController, animated: true)
+        }
+
+        return false
+    }
+
+    private func mediaItemViewController(for asset: WPMediaAsset) -> UIViewController? {
+        guard let asset = asset as? Media else {
+            return nil
+        }
+
+        return MediaItemViewController(media: asset)
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -1,0 +1,55 @@
+import UIKit
+import WPMediaPicker
+
+class MediaLibraryViewController: UIViewController {
+    let blog: Blog
+
+    private let pickerViewController: WPMediaPickerViewController
+    private let pickerDataSource: MediaLibraryPickerDataSource
+
+    init(blog: Blog) {
+        self.blog = blog
+        self.pickerViewController = WPMediaPickerViewController()
+        self.pickerDataSource = MediaLibraryPickerDataSource(blog: blog)
+
+        super.init(nibName: nil, bundle: nil)
+
+        configurePickerViewController()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configurePickerViewController() {
+        pickerViewController.mediaPickerDelegate = self
+        pickerViewController.allowCaptureOfMedia = false
+        pickerViewController.filter = .all
+        pickerViewController.allowMultipleSelection = false
+        pickerViewController.showMostRecentFirst = true
+        pickerViewController.dataSource = pickerDataSource
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = NSLocalizedString("Media", comment: "")
+        navigationItem.backBarButtonItem?.title = ""
+
+        addMediaPickerAsChildViewController()
+    }
+
+    private func addMediaPickerAsChildViewController() {
+        pickerViewController.willMove(toParentViewController: self)
+        pickerViewController.view.bounds = view.bounds
+        view.addSubview(pickerViewController.view)
+        addChildViewController(pickerViewController)
+        pickerViewController.didMove(toParentViewController: self)
+    }
+}
+
+extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
+    func mediaPickerController(_ picker: WPMediaPickerViewController, didFinishPickingAssets assets: [Any]) {
+
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
@@ -5,6 +5,9 @@
 
 @interface FeaturedImageViewController ()
 
+@property (nonatomic, strong) NSURL *url;
+@property (nonatomic, strong) UIImage *image;
+
 @property (nonatomic, strong) UIBarButtonItem *doneButton;
 @property (nonatomic, strong) UIBarButtonItem *removeButton;
 @property (nonatomic, strong) AbstractPost *post;

--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.h
@@ -1,13 +1,16 @@
 #import <UIKit/UIKit.h>
 
-@interface WPImageViewController : UIViewController
+@class Media;
 
-@property (nonatomic, strong) NSURL *url;
-@property (nonatomic, strong) UIImage *image;
+@interface WPImageViewController : UIViewController
 
 - (instancetype)initWithImage:(UIImage *)image;
 - (instancetype)initWithURL:(NSURL *)url;
+- (instancetype)initWithMedia:(Media *)media;
+
 - (instancetype)initWithImage:(UIImage *)image andURL:(NSURL *)url;
+- (instancetype)initWithImage:(UIImage *)image andMedia:(Media *)media;
+
 - (void)loadImage;
 - (void)hideBars:(BOOL)hide animated:(BOOL)animated;
 - (void)centerImage;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		1790A4531E28F0ED00AE54C2 /* UINavigationController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1790A4521E28F0ED00AE54C2 /* UINavigationController+Helpers.swift */; };
 		17AD36D51D36C1A60044B10D /* WPStyleGuide+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */; };
 		17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */; };
+		17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */; };
 		17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */; };
 		17EC9FC61DDC761D00D5BE8E /* UIWindow+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EC9FC51DDC761D00D5BE8E /* UIWindow+Helpers.swift */; };
 		1D3623260D0F684500981E51 /* WordPressAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* WordPressAppDelegate.m */; };
@@ -1171,6 +1172,7 @@
 		1790A4521E28F0ED00AE54C2 /* UINavigationController+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Helpers.swift"; sourceTree = "<group>"; };
 		17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Search.swift"; sourceTree = "<group>"; };
 		17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogSiteVisibilityHelperTest.m; sourceTree = "<group>"; };
+		17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewController.swift; sourceTree = "<group>"; };
 		17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanComparisonViewController.swift; sourceTree = "<group>"; };
 		17EC9FC51DDC761D00D5BE8E /* UIWindow+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWindow+Helpers.swift"; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -3211,6 +3213,7 @@
 				852CD8AC190E0BC4006C9AED /* WPMediaSizing.m */,
 				FFE3B2C51B2E651400E9F1E0 /* WPAndDeviceMediaLibraryDataSource.h */,
 				FFE3B2C61B2E651400E9F1E0 /* WPAndDeviceMediaLibraryDataSource.m */,
+				17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -6489,6 +6492,7 @@
 				B5B84CDB1D9985190058A8FF /* CGAffineTransform+Helpers.swift in Sources */,
 				FF8DDCDF1B5DB1C10098826F /* SettingTableViewCell.m in Sources */,
 				B52D29A51B66BEB70010BD3D /* RemoteNotificationSettings.swift in Sources */,
+				17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */,
 				5DF7F7741B22337C003A05C8 /* WordPress-30-31.xcmappingmodel in Sources */,
 				E19B17B21E5C8F36007517C6 /* AbstractPost.swift in Sources */,
 				5D577D361891360900B964C3 /* PostGeolocationView.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		176DEEE91D4615FE00331F30 /* WPSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */; };
 		177CBE501DA3A3AC009F951E /* CollectionType+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177CBE4F1DA3A3AC009F951E /* CollectionType+Helpers.swift */; };
 		177E7DAD1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */; };
+		1782BE841E70063100A91E7D /* MediaItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1782BE831E70063100A91E7D /* MediaItemViewController.swift */; };
 		178EDE701C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178EDE6F1C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift */; };
 		1790A4531E28F0ED00AE54C2 /* UINavigationController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1790A4521E28F0ED00AE54C2 /* UINavigationController+Helpers.swift */; };
 		17AD36D51D36C1A60044B10D /* WPStyleGuide+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */; };
@@ -1168,6 +1169,7 @@
 		176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPSplitViewController.swift; sourceTree = "<group>"; };
 		177CBE4F1DA3A3AC009F951E /* CollectionType+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionType+Helpers.swift"; sourceTree = "<group>"; };
 		177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+SplitViewFullscreen.swift"; sourceTree = "<group>"; };
+		1782BE831E70063100A91E7D /* MediaItemViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaItemViewController.swift; sourceTree = "<group>"; };
 		178EDE6F1C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PlanPostPurchaseViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		1790A4521E28F0ED00AE54C2 /* UINavigationController+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Helpers.swift"; sourceTree = "<group>"; };
 		17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Search.swift"; sourceTree = "<group>"; };
@@ -3214,6 +3216,7 @@
 				FFE3B2C51B2E651400E9F1E0 /* WPAndDeviceMediaLibraryDataSource.h */,
 				FFE3B2C61B2E651400E9F1E0 /* WPAndDeviceMediaLibraryDataSource.m */,
 				17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */,
+				1782BE831E70063100A91E7D /* MediaItemViewController.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -6197,6 +6200,7 @@
 				E6417B9E1CA07D240084050A /* SigninEmailViewController.swift in Sources */,
 				FF76A9D21D1C58EB0080EF1F /* WordPressOrgXMLRPCValidator.swift in Sources */,
 				E1D458691309589C00BF0235 /* Coordinate.m in Sources */,
+				1782BE841E70063100A91E7D /* MediaItemViewController.swift in Sources */,
 				E10A2E9B134E8AD3007643F9 /* PostAnnotation.m in Sources */,
 				FFB7B8201A0012E80032E723 /* ApiCredentials.m in Sources */,
 				B5DB8AF41C949DC20059196A /* WPImmuTableRows.swift in Sources */,


### PR DESCRIPTION
Related issues: #6817 and #4528

Here's our first PR towards adding Media Library functionality to WPiOS. The Media Library is currently feature flagged so it'll only show in debug mode.

**This PR adds:**

* A Media row to Blog Details.
* A grid view of media, using WPMediaPicker's collection view.
* A detail view of an individual piece of media, including some metadata. Metadata should match Calypso and Android.
* A zoomable preview of each image, accessible by tapping the image in the detail view.

![media-all](https://cloud.githubusercontent.com/assets/4780/23710144/91dd9ee2-0413-11e7-8b64-0b718ef1f156.png)

**What's not in here yet:**

* No results view if the user doesn't have any media items
* Video preview
* Editing metadata
* Deleting items
* Searching and filtering

Needs review: @kurzee 