### PR TITLE
Don't show Publish Now on existing published posts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -117,6 +117,7 @@ public class PostEditorStateContext {
     }
 
     fileprivate var originalPostStatus: BasePost.Status?
+    fileprivate var currentPostStatus: BasePost.Status?
     fileprivate var userCanPublish: Bool
     private weak var delegate: PostEditorStateContextDelegate?
 
@@ -153,6 +154,7 @@ public class PostEditorStateContext {
     ///
     init(originalPostStatus: BasePost.Status? = nil, userCanPublish: Bool = true, delegate: PostEditorStateContextDelegate) {
         self.originalPostStatus = originalPostStatus
+        self.currentPostStatus = originalPostStatus
         self.userCanPublish = userCanPublish
         self.delegate = delegate
 
@@ -172,6 +174,7 @@ public class PostEditorStateContext {
     /// Call when the post status has changed due to a remote operation
     ///
     func updated(postStatus: BasePost.Status) {
+        currentPostStatus = postStatus
         let updatedState = editorState.updated(postStatus: postStatus, context: self)
         guard type(of: editorState) != type(of: updatedState) else {
             return
@@ -257,6 +260,11 @@ public class PostEditorStateContext {
     ///
     var isSecondaryPublishButtonShown: Bool {
         guard hasContent else {
+            return false
+        }
+
+        // Don't show Publish Now for an already published post with the update button as primary
+        guard !(currentPostStatus == .publish && editorState.action == .update) else {
             return false
         }
 

--- a/WordPress/WordPressTest/PostEditorStateTests.swift
+++ b/WordPress/WordPressTest/PostEditorStateTests.swift
@@ -189,6 +189,21 @@ extension PostEditorStateTests {
 
         XCTAssertFalse(context.isSecondaryPublishButtonShown, "should return false if post has no content")
     }
+
+    func testPublishSecondaryAlreadyPublishedPosts() {
+        context = PostEditorStateContext(originalPostStatus: .publish, userCanPublish: true, delegate: self)
+        context.updated(hasContent: true)
+
+        XCTAssertEqual(PostEditorAction.update, context.action)
+        XCTAssertFalse(context.isSecondaryPublishButtonShown, "should return false for already published posts")
+    }
+
+    func testPublishSecondaryAlreadyDraftedPosts() {
+        context = PostEditorStateContext(originalPostStatus: .draft, userCanPublish: true, delegate: self)
+        context.updated(hasContent: true)
+
+        XCTAssertTrue(context.isSecondaryPublishButtonShown, "should return true for existing drafts (publish now)")
+    }
 }
 
 extension PostEditorStateTests: PostEditorStateContextDelegate {


### PR DESCRIPTION
Fixes #6840 

Makes the context keep track of the current post status to prevent Publish Now from showing up when the button says "Update" but the post is published. 

To test:
1. Edit an existing published post. Verify action is Update.
2. Tap options. Verify Publish Now isn't present.
3. Edit an existing draft. Verify action is Update.
4. Tap options. Verify Publish Now is present.
5. Create a new post. Change post options to Draft.
6. Verify Publish Now is present.

Needs review: @jleandroperez 
