### PR TITLE
Allow wp.com domains as username

### DIFF
--- a/WordPress/Classes/Networking/AccountServiceRemote.h
+++ b/WordPress/Classes/Networking/AccountServiceRemote.h
@@ -49,6 +49,17 @@
                  failure:(void (^)(NSError *error))failure;
 
 /**
+ *  @brief      Query to see if a username is available. Used in the auth link signup flow.
+ *
+ *  @param username
+ *  @param success
+ *  @param failure
+ */
+- (void)isUsernameAvailable:(NSString *)username
+                 success:(void (^)(BOOL available))success
+                 failure:(void (^)(NSError *error))failure;
+
+/**
 *  @brief      Request an authentication link be sent to the email address provided.
 *
 *  @param email

--- a/WordPress/Classes/Networking/AccountServiceRemote.h
+++ b/WordPress/Classes/Networking/AccountServiceRemote.h
@@ -50,14 +50,15 @@
 
 /**
  *  @brief      Query to see if a username is available. Used in the auth link signup flow.
+ *  @note       This is an unversioned endpoint. Success will mean, generally, that the username already exists.
  *
  *  @param username
- *  @param success
- *  @param failure
+ *  @param taken
+ *  @param available
  */
-- (void)isUsernameAvailable:(NSString *)username
-                 success:(void (^)(BOOL available))success
-                 failure:(void (^)(NSError *error))failure;
+- (void)checkUsernameAvailability:(NSString *)username
+                 taken:(void (^)())taken
+                 available:(void (^)())available;
 
 /**
 *  @brief      Request an authentication link be sent to the email address provided.

--- a/WordPress/Classes/Networking/AccountServiceRemote.h
+++ b/WordPress/Classes/Networking/AccountServiceRemote.h
@@ -53,12 +53,12 @@
  *  @note       This is an unversioned endpoint. Success will mean, generally, that the username already exists.
  *
  *  @param username
- *  @param taken
- *  @param available
+ *  @param success
+ *  @param failure
  */
-- (void)checkUsernameAvailability:(NSString *)username
-                 taken:(void (^)())taken
-                 available:(void (^)())available;
+- (void)isUsernameAvailable:(NSString *)username
+                    success:(void (^)(BOOL available))success
+                    failure:(void (^)(NSError *error))failure;
 
 /**
 *  @brief      Request an authentication link be sent to the email address provided.

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -175,8 +175,7 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                               // If the username is not available (has already been used)
                               // the endpoint will reply with a 200 status code but describe
                               // an error. This causes a JSON error, which we can test for here.
-                              if (httpResponse.statusCode == 200 && [error.description containsString:@"JSON"])
-                              {
+                              if (httpResponse.statusCode == 200 && [error.description containsString:@"JSON"]) {
                                   if (success) {
                                       success(true);
                                   }

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -151,32 +151,23 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
           }];
 }
 
-- (void)isUsernameAvailable:(NSString *)username success:(void (^)(BOOL available))success failure:(void (^)(NSError *error))failure
+- (void)checkUsernameAvailability:(NSString *)username
+                            taken:(void (^)())taken
+                        available:(void (^)())available;
 {
     NSString *path = @"https://public-api.wordpress.com/is-available/username";
     [self.wordPressComRestApi GET:path
                        parameters:@{ @"q": username, @"format": @"json"}
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-                              if (!success) {
-                                  return;
+                              if (taken) {
+                                  taken();
                               }
-
+                          } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
                               // If the username is not available (has already been used)
                               // the endpoint will reply with a 200 status code and an JSON
                               // object describing an error.
-                              // The error is that the queried username is not available,
-                              // which is our failure case. Test the error response for the
-                              // "taken" reason to confirm the email address exists.
-                              BOOL available = NO;
-                              if ([responseObject isKindOfClass:[NSDictionary class]]) {
-                                  NSDictionary *dict = (NSDictionary *)responseObject;
-                                  available = [[dict numberForKey:@"available"] boolValue];
-                              }
-                              success(available);
-
-                          } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
-                              if (failure) {
-                                  failure(error);
+                              if (available) {
+                                  available();
                               }
                           }];
 }

--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -151,23 +151,37 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
           }];
 }
 
-- (void)checkUsernameAvailability:(NSString *)username
-                            taken:(void (^)())taken
-                        available:(void (^)())available;
+- (void)isUsernameAvailable:(NSString *)username
+                    success:(void (^)(BOOL available))success
+                    failure:(void (^)(NSError *error))failure
 {
     NSString *path = @"https://public-api.wordpress.com/is-available/username";
     [self.wordPressComRestApi GET:path
                        parameters:@{ @"q": username, @"format": @"json"}
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-                              if (taken) {
-                                  taken();
+                              if (!success) {
+                                  return;
                               }
+
+                              // currently the endpoint will not respond with available=false
+                              // but it could one day, and this should still work in that case
+                              BOOL available = NO;
+                              if ([responseObject isKindOfClass:[NSDictionary class]]) {
+                                  NSDictionary *dict = (NSDictionary *)responseObject;
+                                  available = [[dict numberForKey:@"available"] boolValue];
+                              }
+                              success(available);
                           } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
                               // If the username is not available (has already been used)
-                              // the endpoint will reply with a 200 status code and an JSON
-                              // object describing an error.
-                              if (available) {
-                                  available();
+                              // the endpoint will reply with a 200 status code but describe
+                              // an error. This causes a JSON error, which we can test for here.
+                              if (httpResponse.statusCode == 200 && [error.description containsString:@"JSON"])
+                              {
+                                  if (success) {
+                                      success(true);
+                                  }
+                              } else if (failure) {
+                                  failure(error);
                               }
                           }];
 }

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -53,6 +53,16 @@ extern NSString *const WPAccountEmailAndDefaultBlogUpdatedNotification;
 - (void)isEmailAvailable:(NSString *)email success:(void (^)(BOOL available))success failure:(void (^)(NSError *error))failure;
 
 /**
+ Query to check if a username is available. Used in the signup flow.
+ 
+ @param email
+ @param success
+ @param failure
+ */
+- (void)isUsernameAvailable:(NSString *)username success:(void (^)(BOOL available))success failure:(void (^)(NSError *error))failure;
+
+
+/**
  Requets a one-time authentication link sent to an existing account associated with the
  specified email address.
 

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -59,7 +59,7 @@ extern NSString *const WPAccountEmailAndDefaultBlogUpdatedNotification;
  @param success
  @param failure
  */
-- (void)isUsernameAvailable:(NSString *)username success:(void (^)(BOOL available))success failure:(void (^)(NSError *error))failure;
+- (void)checkUsernameAvailability:(NSString *)username taken:(void (^)())taken available:(void (^)())available;
 
 
 /**

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -59,7 +59,9 @@ extern NSString *const WPAccountEmailAndDefaultBlogUpdatedNotification;
  @param success
  @param failure
  */
-- (void)checkUsernameAvailability:(NSString *)username taken:(void (^)())taken available:(void (^)())available;
+- (void)isUsernameAvailable:(NSString *)username
+                    success:(void (^)(BOOL available))success
+                    failure:(void (^)(NSError *error))failure;
 
 
 /**

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -141,16 +141,18 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     }];
 }
 
-- (void)checkUsernameAvailability:(NSString *)username taken:(void (^)())taken available:(void (^)())available;
+- (void)isUsernameAvailable:(NSString *)username
+                    success:(void (^)(BOOL available))success
+                    failure:(void (^)(NSError *error))failure
 {
     id<AccountServiceRemote> remote = [self remoteForAnonymous];
-    [remote checkUsernameAvailability:username taken:^{
-        if (taken) {
-            taken();
+    [remote isUsernameAvailable:username success:^(BOOL available) {
+        if (success) {
+            success(available);
         }
-    } available:^() {
-        if (available) {
-            available();
+    } failure:^(NSError *error) {
+        if (failure) {
+            failure(error);
         }
     }];
 }

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -141,6 +141,20 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     }];
 }
 
+- (void)isUsernameAvailable:(NSString *)username success:(void (^)(BOOL available))success failure:(void (^)(NSError *error))failure
+{
+    id<AccountServiceRemote> remote = [self remoteForAnonymous];
+    [remote isUsernameAvailable:username success:^(BOOL available) {
+        if (success) {
+            success(available);
+        }
+    } failure:^(NSError *error) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+}
+
 
 - (void)requestAuthenticationLink:(NSString *)email success:(void (^)())success failure:(void (^)(NSError *error))failure
 {

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -141,16 +141,16 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     }];
 }
 
-- (void)isUsernameAvailable:(NSString *)username success:(void (^)(BOOL available))success failure:(void (^)(NSError *error))failure
+- (void)checkUsernameAvailability:(NSString *)username taken:(void (^)())taken available:(void (^)())available;
 {
     id<AccountServiceRemote> remote = [self remoteForAnonymous];
-    [remote isUsernameAvailable:username success:^(BOOL available) {
-        if (success) {
-            success(available);
+    [remote checkUsernameAvailability:username taken:^{
+        if (taken) {
+            taken();
         }
-    } failure:^(NSError *error) {
-        if (failure) {
-            failure(error);
+    } available:^() {
+        if (available) {
+            available();
         }
     }];
 }

--- a/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
@@ -153,6 +153,18 @@ class NUXAbstractViewController: UIViewController {
         controller.displayError(error, loginFields: loginFields, delegate: self, sourceTag: sourceTag)
     }
 
+    /// Displays an error message in an overlay
+    ///
+    /// - Parameters:
+    ///     - message: The message to display
+    ///
+    func displayErrorMessage(_ message: String) {
+        let presentingController = navigationController ?? self
+        let controller = SigninErrorViewController.controller()
+        controller.delegate = self
+        controller.presentFromController(presentingController)
+        controller.displayGenericErrorMessage(message, sourceTag: sourceTag)
+    }
 
     /// It is assumed that NUX view controllers are always presented modally.
     ///

--- a/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
@@ -306,7 +306,7 @@ import WordPressShared
                                     } else {
                                         self?.requestLink()
                                     }
-            },
+                                 },
                                  failure: { [weak self] (error: Error) in
                                     DDLogSwift.logError(error.localizedDescription)
                                     guard let strongSelf = self else {
@@ -336,9 +336,8 @@ import WordPressShared
     }
 
     private func signinWithWPComDomain(_ domain: String) {
-        func showFailureError() {
-            weak var weakSelf = self
-            guard let strongSelf = weakSelf else {
+        let showFailureError = { [weak self] in
+            guard let strongSelf = self else {
                 return
             }
             strongSelf.displayErrorMessage(NSLocalizedString("Please enter a valid username or email address", comment: "A short prompt asking the user to properly fill out all login fields."))

--- a/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
@@ -292,7 +292,7 @@ import WordPressShared
             // A username was entered, not an email address.
             // Proceed to the next form:
             if SigninHelpers.isWPComDomain(emailOrUsername) {
-                let username = emailOrUsername.removingSuffix(".wordpress.com")
+                let username = SigninHelpers.extractUsername(from: emailOrUsername)
                 configureViewLoading(true)
 
                 service.checkUsernameAvailability(username, taken: { [weak self] in

--- a/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
@@ -292,13 +292,22 @@ import WordPressShared
             // A username was entered, not an email address.
             // Proceed to the next form:
             if SigninHelpers.isWPComDomain(emailOrUsername) {
-                let username = emailOrUsername.removingSuffix("wordpress.com")
-                service.isUsernameAvailable(username, success: { (available: Bool) in
-                    // if the name is available, that means it can't be used to login
-                    // show error
-                }, failure: { (error: Error) in
-                    self.loginFields.username = username
-                    self.signinWithUsernamePassword()
+                let username = emailOrUsername.removingSuffix(".wordpress.com")
+                configureViewLoading(true)
+
+                service.checkUsernameAvailability(username, taken: { [weak self] in
+                    guard let strongSelf = self else {
+                        return
+                    }
+                    strongSelf.configureViewLoading(false)
+                    strongSelf.loginFields.username = username
+                    strongSelf.signinWithUsernamePassword()
+                }, available: { [weak self] in
+                    guard let strongSelf = self else {
+                        return
+                    }
+                    strongSelf.configureViewLoading(false)
+                    strongSelf.displayErrorMessage(NSLocalizedString("Please enter a valid username or email address", comment: "A short prompt asking the user to properly fill out all login fields."))
                 })
             } else if !SigninHelpers.isUsernameReserved(emailOrUsername) {
                 signinWithUsernamePassword()

--- a/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
@@ -275,7 +275,6 @@ import WordPressShared
         navigationController?.pushViewController(controller, animated: true)
     }
 
-
     /// Validates what is entered in the various form fields and, if valid,
     /// proceeds with the submit action.
     ///
@@ -286,81 +285,89 @@ import WordPressShared
             return
         }
 
-        let service = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-
-        guard emailOrUsername.isValidEmail() else {
-            // A username was entered, not an email address.
-            // Proceed to the next form:
-            if SigninHelpers.isWPComDomain(emailOrUsername) {
-
-                func showFailureError() {
-                    weak var weakSelf = self
-                    guard let strongSelf = weakSelf else {
-                        return
-                    }
-                    strongSelf.displayErrorMessage(NSLocalizedString("Please enter a valid username or email address", comment: "A short prompt asking the user to properly fill out all login fields."))
-                }
-
-                let username = SigninHelpers.extractUsername(from: emailOrUsername)
-                configureViewLoading(true)
-
-                service.isUsernameAvailable(username, success: { [weak self] (available: Bool) in
-                        guard let strongSelf = self else {
-                            return
-                        }
-                        strongSelf.configureViewLoading(false)
-                        if (available) {
-                            // can't login with a username that doesn't exist
-                            showFailureError()
-                        } else {
-                            strongSelf.loginFields.username = username
-                            strongSelf.signinWithUsernamePassword()
-                        }
-                    }, failure: { [weak self] (error: Error) in
-                        showFailureError()
-                        if let strongSelf = self {
-                            strongSelf.configureViewLoading(false)
-                        }
-                })
-            } else if !SigninHelpers.isUsernameReserved(emailOrUsername) {
-                signinWithUsernamePassword()
-
-            } else if restrictSigninToWPCom {
-                // When restricted, show a prompt then let the user enter a new username.
-                SigninHelpers.promptForWPComReservedUsername(emailOrUsername, callback: {
-                    self.loginFields.username = ""
-                    self.emailTextField.text = ""
-                    self.emailTextField.becomeFirstResponder()
-                })
-
-            } else {
-                // Switch to the signin flow when not restricted.
-                signinToSelfHostedSite()
-            }
-            return
+        if emailOrUsername.isValidEmail() {
+            validate(email: emailOrUsername)
+        } else {
+            validate(username: emailOrUsername)
         }
+    }
 
+    private func validate(email: String) {
+        let service = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
         configureViewLoading(true)
 
-        service.isEmailAvailable(emailOrUsername,
-            success: { [weak self] (available: Bool) in
-                self?.configureViewLoading(false)
-                if (available) {
-                    // No matching email address found so treat this as a
-                    // self-hosted sign in.
-                    self?.signinToSelfHostedSite()
-                } else {
-                    self?.requestLink()
-                }
+        service.isEmailAvailable(email,
+                                 success: { [weak self] (available: Bool) in
+                                    self?.configureViewLoading(false)
+                                    if (available) {
+                                        // No matching email address found so treat this as a
+                                        // self-hosted sign in.
+                                        self?.signinToSelfHostedSite()
+                                    } else {
+                                        self?.requestLink()
+                                    }
             },
-            failure: { [weak self] (error: Error) in
-                DDLogSwift.logError(error.localizedDescription)
-                guard let strongSelf = self else {
-                    return
-                }
-                strongSelf.configureViewLoading(false)
-                strongSelf.displayError(error as NSError, sourceTag: strongSelf.sourceTag)
+                                 failure: { [weak self] (error: Error) in
+                                    DDLogSwift.logError(error.localizedDescription)
+                                    guard let strongSelf = self else {
+                                        return
+                                    }
+                                    strongSelf.configureViewLoading(false)
+                                    strongSelf.displayError(error as NSError, sourceTag: strongSelf.sourceTag)
+        })
+    }
+
+    private func validate(username: String) {
+        if SigninHelpers.isWPComDomain(username) {
+            signinWithWPComDomain(username)
+        } else if !SigninHelpers.isUsernameReserved(username) {
+            signinWithUsernamePassword()
+        } else if restrictSigninToWPCom {
+            // When restricted, show a prompt then let the user enter a new username.
+            SigninHelpers.promptForWPComReservedUsername(username, callback: {
+                self.loginFields.username = ""
+                self.emailTextField.text = ""
+                self.emailTextField.becomeFirstResponder()
             })
+        } else {
+            // Switch to the signin flow when not restricted.
+            signinToSelfHostedSite()
+        }
+    }
+
+    private func signinWithWPComDomain(_ domain: String) {
+        func showFailureError() {
+            weak var weakSelf = self
+            guard let strongSelf = weakSelf else {
+                return
+            }
+            strongSelf.displayErrorMessage(NSLocalizedString("Please enter a valid username or email address", comment: "A short prompt asking the user to properly fill out all login fields."))
+        }
+
+        let username = SigninHelpers.extractUsername(from: domain)
+        configureViewLoading(true)
+
+        let service = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        service.isUsernameAvailable(username,
+                                    success: { [weak self] (available: Bool) in
+                                        guard let strongSelf = self else {
+                                            return
+                                        }
+                                        strongSelf.configureViewLoading(false)
+                                        if (available) {
+                                            // can't login with a username that doesn't exist
+                                            showFailureError()
+                                        } else {
+                                            strongSelf.loginFields.username = username
+                                            strongSelf.signinWithUsernamePassword()
+                                        }
+            },
+                                    failure: { [weak self] (error: Error) in
+                                        showFailureError()
+                                        if let strongSelf = self {
+                                            strongSelf.configureViewLoading(false)
+                                        }
+        })
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -219,6 +219,13 @@ import Mixpanel
         return ["admin", "administrator", "invite", "main", "root", "web", "www"].contains(name) || name.contains("wordpress")
     }
 
+    /// Checks if the provided username is a wordpress.com domain
+    ///
+    /// - Parameter username: the username to test
+    /// - Returns: true if the username is a wordpress.com domain
+    class func isWPComDomain(_ username: String) -> Bool {
+        return username.hasSuffix("wordpress.com")
+    }
 
     /// Checks whether credentials have been populated.
     /// Note: that loginFields.emailAddress is not checked. Use loginFields.username instead.

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -225,12 +225,16 @@ import Mixpanel
     /// - Parameter username: the username to test
     /// - Returns: true if the username is a wordpress.com domain
     class func isWPComDomain(_ username: String) -> Bool {
-        return username.hasSuffix(WPComSuffix)
+        return username.contains(WPComSuffix)
     }
 
     /// Extracts the username from a wordpress.com domain
     class func extractUsername(from hostname: String) -> String {
-        return hostname.removingSuffix(WPComSuffix)
+        var host = hostname
+        if let hostParsed = URL(string: hostname)?.host {
+            host = hostParsed
+        }
+        return host.components(separatedBy: WPComSuffix).first ?? host
     }
 
     /// Checks whether credentials have been populated.

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -7,6 +7,7 @@ import Mixpanel
 ///
 @objc class SigninHelpers: NSObject {
     fileprivate static let AuthenticationEmailKey = "AuthenticationEmailKey"
+    fileprivate static let WPComSuffix = ".wordpress.com"
     @objc static let WPSigninDidFinishNotification = "WPSigninDidFinishNotification"
 
 
@@ -224,7 +225,12 @@ import Mixpanel
     /// - Parameter username: the username to test
     /// - Returns: true if the username is a wordpress.com domain
     class func isWPComDomain(_ username: String) -> Bool {
-        return username.hasSuffix("wordpress.com")
+        return username.hasSuffix(WPComSuffix)
+    }
+
+    /// Extracts the username from a wordpress.com domain
+    class func extractUsername(from hostname: String) -> String {
+        return hostname.removingSuffix(WPComSuffix)
     }
 
     /// Checks whether credentials have been populated.

--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -261,21 +261,6 @@ import WordPressShared
         return username
     }
 
-
-    /// Displays an error message in an overlay
-    ///
-    /// - Parameters:
-    ///     - message: The message to display
-    ///
-    func displayErrorMessage(_ message: String) {
-        let presentingController = navigationController ?? self
-        let controller = SigninErrorViewController.controller()
-        controller.delegate = self
-        controller.presentFromController(presentingController)
-        controller.displayGenericErrorMessage(message, sourceTag: sourceTag)
-    }
-
-
     /// Validates what is entered in the various form fields and, if valid,
     /// proceeds with the submit action.
     ///

--- a/WordPress/WordPressTest/SigninHelperTests.swift
+++ b/WordPress/WordPressTest/SigninHelperTests.swift
@@ -76,6 +76,15 @@ class SigninHelperTests: XCTestCase {
 
         let wpComSite = "testuser.wordpress.com"
         XCTAssertEqual("testuser", SigninHelpers.extractUsername(from:wpComSite))
+
+        let wpComSiteSlash = "testuser.wordpress.com/"
+        XCTAssertEqual("testuser", SigninHelpers.extractUsername(from:wpComSiteSlash))
+
+        let wpComSiteHttp = "http://testuser.wordpress.com/"
+        XCTAssertEqual("testuser", SigninHelpers.extractUsername(from:wpComSiteHttp))
+
+        let nonWPComSiteFtp = "ftp://asite.mycompany.co/"
+        XCTAssertEqual("asite.mycompany.co", SigninHelpers.extractUsername(from: nonWPComSiteFtp))
     }
 
     func testIsWPComDomain() {

--- a/WordPress/WordPressTest/SigninHelperTests.swift
+++ b/WordPress/WordPressTest/SigninHelperTests.swift
@@ -67,6 +67,28 @@ class SigninHelperTests: XCTestCase {
         XCTAssert(SigninHelpers.validateFieldsPopulatedForSignin(loginFields), "should validate self-hosted with username, password, and site.")
     }
 
+    func testExtractUsernameFrom() {
+        let plainUsername = "auser"
+        XCTAssertEqual(plainUsername, SigninHelpers.extractUsername(from: plainUsername))
+
+        let nonWPComSite = "asite.mycompany.com"
+        XCTAssertEqual(nonWPComSite, SigninHelpers.extractUsername(from: nonWPComSite))
+
+        let wpComSite = "testuser.wordpress.com"
+        XCTAssertEqual("testuser", SigninHelpers.extractUsername(from:wpComSite))
+    }
+
+    func testIsWPComDomain() {
+        let plainUsername = "auser"
+        XCTAssertFalse(SigninHelpers.isWPComDomain(plainUsername))
+
+        let nonWPComSite = "asite.mycompany.com"
+        XCTAssertFalse(SigninHelpers.isWPComDomain(nonWPComSite))
+
+        let wpComSite = "testuser.wordpress.com"
+        XCTAssert(SigninHelpers.isWPComDomain(wpComSite))
+    }
+
 
     func testValidateSiteForSignin() {
         let loginFields = LoginFields()


### PR DESCRIPTION
Fixes #6600 

WordPress.com domains containing valid usernames will now work for logging in.

![wpcom-domain-login-pr](https://cloud.githubusercontent.com/assets/517257/23753562/9656dd4e-049f-11e7-975a-19d17d0220ab.gif)

To test:
1. At the first username/email screen, enter a wp.com domain whose subdomain is a username
2. Hitting next should cause the wp.com login screen to appear with the username prefilled

And a possible failure case:
1. At the same screen, enter a wp.com domain whose subdomain isn't a username
2. Hitting next should cause an error screen to appear

Needs review: @aerych 
You handled the Android side, figured that makes you the expert +wink
