### PR TITLE
Recent Sites data layer

### DIFF
--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -18,11 +18,6 @@ extern NSString *const WordPressMinimumVersion;
 - (nullable Blog *)blogByBlogId:(NSNumber *)blogID;
 
 /**
- Stores the blog's URL in NSUserDefaults, for later retrieval
- */
-- (void)flagBlogAsLastUsed:(Blog *)blog;
-
-/**
  Returns the blog currently flagged as the one last used, or the primary blog,
  or the first blog in an alphanumerically sorted list, whichever is found first.
  */

--- a/WordPress/Classes/Services/KeyValueDatabase.swift
+++ b/WordPress/Classes/Services/KeyValueDatabase.swift
@@ -5,7 +5,7 @@ import Foundation
 /// `NSString`, `NSNumber`, `NSDate`, `NSArray`, or `NSDictionary`.
 /// For `NSArray` and `NSDictionary` objects, their contents must be property
 /// list objects.
-public protocol KeyValueDatabase {
+protocol KeyValueDatabase {
     func object(forKey defaultName: String) -> Any?
     func set(_ value: Any?, forKey defaultName: String)
     func removeObject(forKey defaultName: String)
@@ -17,11 +17,8 @@ extension UserDefaults: KeyValueDatabase {}
 
 /// `EphemeralKeyValueDatabase` stores values in a dictionary in memory, and is
 /// never persisted between app launches.
-public class EphemeralKeyValueDatabase: KeyValueDatabase {
+class EphemeralKeyValueDatabase: KeyValueDatabase {
     fileprivate var memory = [String: Any]()
-
-    public init() {
-    }
 
     open func set(_ value: Any?, forKey defaultName: String) {
         memory[defaultName] = value

--- a/WordPress/Classes/Services/KeyValueDatabase.swift
+++ b/WordPress/Classes/Services/KeyValueDatabase.swift
@@ -5,7 +5,7 @@ import Foundation
 /// `NSString`, `NSNumber`, `NSDate`, `NSArray`, or `NSDictionary`.
 /// For `NSArray` and `NSDictionary` objects, their contents must be property
 /// list objects.
-protocol KeyValueDatabase {
+public protocol KeyValueDatabase {
     func object(forKey defaultName: String) -> Any?
     func set(_ value: Any?, forKey defaultName: String)
     func removeObject(forKey defaultName: String)
@@ -17,8 +17,11 @@ extension UserDefaults: KeyValueDatabase {}
 
 /// `EphemeralKeyValueDatabase` stores values in a dictionary in memory, and is
 /// never persisted between app launches.
-class EphemeralKeyValueDatabase: KeyValueDatabase {
+public class EphemeralKeyValueDatabase: KeyValueDatabase {
     fileprivate var memory = [String: Any]()
+
+    public init() {
+    }
 
     open func set(_ value: Any?, forKey defaultName: String) {
         memory[defaultName] = value

--- a/WordPress/Classes/Services/RecentSitesService.swift
+++ b/WordPress/Classes/Services/RecentSitesService.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public class RecentSitesService: NSObject {
+    // MARK: - Internal variables
+    private let database: KeyValueDatabase
+    private let databaseKey = "RecentSites"
+    public let maxSiteCount = 3
+
+    // MARK: - Initialization
+    public init(database: KeyValueDatabase) {
+        self.database = database
+        super.init()
+    }
+
+    convenience override init() {
+        self.init(database: UserDefaults() as KeyValueDatabase)
+    }
+
+    // MARK: - Public accessors
+
+    public var recentSites: [Int] {
+        return database.object(forKey: databaseKey) as? [Int] ?? []
+    }
+
+    public func touch(site: Int) {
+        var recent = [site]
+        for recentSite in recentSites
+            where recentSite != site
+                && recent.count < maxSiteCount {
+                    recent.append(recentSite)
+        }
+        database.set(recent, forKey: databaseKey)
+    }
+}

--- a/WordPress/Classes/Services/RecentSitesService.swift
+++ b/WordPress/Classes/Services/RecentSitesService.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 public class RecentSitesService: NSObject {
+    // We use the site's URL to identify a site
+    public typealias SiteIdentifierType = String
+
     // MARK: - Internal variables
     private let database: KeyValueDatabase
     private let databaseKey = "RecentSites"
@@ -18,11 +21,11 @@ public class RecentSitesService: NSObject {
 
     // MARK: - Public accessors
 
-    public var recentSites: [Int] {
-        return database.object(forKey: databaseKey) as? [Int] ?? []
+    public var recentSites: [SiteIdentifierType] {
+        return database.object(forKey: databaseKey) as? [SiteIdentifierType] ?? []
     }
 
-    public func touch(site: Int) {
+    public func touch(site: SiteIdentifierType) {
         var recent = [site]
         for recentSite in recentSites
             where recentSite != site

--- a/WordPress/Classes/Services/RecentSitesService.swift
+++ b/WordPress/Classes/Services/RecentSitesService.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Keep track of recently used sites
 ///
-public class RecentSitesService: NSObject {
+class RecentSitesService: NSObject {
     // We use the site's URL to identify a site
-    public typealias SiteIdentifierType = String
+    typealias SiteIdentifierType = String
 
     // MARK: - Internal variables
     private let database: KeyValueDatabase
@@ -13,7 +13,7 @@ public class RecentSitesService: NSObject {
 
     /// The maximum number of recent sites (read only)
     ///
-    public let maxSiteCount = 3
+    let maxSiteCount = 3
 
     // MARK: - Initialization
 
@@ -21,7 +21,7 @@ public class RecentSitesService: NSObject {
     ///
     /// This initializer was meant for testing. You probably want to use the convenience `init()` that uses the standard UserDefaults as the database.
     ///
-    public init(database: KeyValueDatabase) {
+    init(database: KeyValueDatabase) {
         self.database = database
         super.init()
     }
@@ -36,7 +36,7 @@ public class RecentSitesService: NSObject {
 
     /// Returns a list of recently used sites
     ///
-    public var recentSites: [SiteIdentifierType] {
+    var recentSites: [SiteIdentifierType] {
         if let sites = database.object(forKey: databaseKey) as? [SiteIdentifierType] {
             return sites
         }
@@ -55,7 +55,7 @@ public class RecentSitesService: NSObject {
     /// Marks a site identifier as recently used. We currently use URL as the identifier.
     ///
     @objc(touchBlogWithIdentifier:)
-    public func touch(site: SiteIdentifierType) {
+    func touch(site: SiteIdentifierType) {
         var recent = [site]
         for recentSite in recentSites
             where recentSite != site
@@ -68,7 +68,7 @@ public class RecentSitesService: NSObject {
     /// Marks a Blog as recently used.
     ///
     @objc(touchBlog:)
-    public func touch(blog: Blog) {
+    func touch(blog: Blog) {
         guard let url = blog.url else {
             assertionFailure("Tried to mark as used a Blog without URL")
             return

--- a/WordPress/Classes/Services/RecentSitesService.swift
+++ b/WordPress/Classes/Services/RecentSitesService.swift
@@ -38,6 +38,7 @@ public class RecentSitesService: NSObject {
         return initializedSites
     }
 
+    @objc(touchBlogWithIdentifier:)
     public func touch(site: SiteIdentifierType) {
         var recent = [site]
         for recentSite in recentSites
@@ -46,5 +47,14 @@ public class RecentSitesService: NSObject {
                     recent.append(recentSite)
         }
         database.set(recent, forKey: databaseKey)
+    }
+
+    @objc(touchBlog:)
+    public func touch(blog: Blog) {
+        guard let url = blog.url else {
+            assertionFailure("Tried to mark as used a Blog without URL")
+            return
+        }
+        touch(site: url)
     }
 }

--- a/WordPress/Classes/Services/RecentSitesService.swift
+++ b/WordPress/Classes/Services/RecentSitesService.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Keep track of recently used sites
+///
 public class RecentSitesService: NSObject {
     // We use the site's URL to identify a site
     public typealias SiteIdentifierType = String
@@ -8,20 +10,32 @@ public class RecentSitesService: NSObject {
     private let database: KeyValueDatabase
     private let databaseKey = "RecentSites"
     private let legacyLastUsedBlogKey = "LastUsedBlogURLDefaultsKey"
+
+    /// The maximum number of recent sites (read only)
+    ///
     public let maxSiteCount = 3
 
     // MARK: - Initialization
+
+    /// Initialize the service with the given database
+    ///
+    /// This initializer was meant for testing. You probably want to use the convenience `init()` that uses the standard UserDefaults as the database.
+    ///
     public init(database: KeyValueDatabase) {
         self.database = database
         super.init()
     }
 
+    /// Initialize the service using the standard UserDefaults as the database.
+    ///
     convenience override init() {
         self.init(database: UserDefaults() as KeyValueDatabase)
     }
 
     // MARK: - Public accessors
 
+    /// Returns a list of recently used sites
+    ///
     public var recentSites: [SiteIdentifierType] {
         if let sites = database.object(forKey: databaseKey) as? [SiteIdentifierType] {
             return sites
@@ -38,6 +52,8 @@ public class RecentSitesService: NSObject {
         return initializedSites
     }
 
+    /// Marks a site identifier as recently used. We currently use URL as the identifier.
+    ///
     @objc(touchBlogWithIdentifier:)
     public func touch(site: SiteIdentifierType) {
         var recent = [site]
@@ -49,6 +65,8 @@ public class RecentSitesService: NSObject {
         database.set(recent, forKey: databaseKey)
     }
 
+    /// Marks a Blog as recently used.
+    ///
     @objc(touchBlog:)
     public func touch(blog: Blog) {
         guard let url = blog.url else {

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -699,11 +699,11 @@ static NSInteger HideSearchMinSites = 3;
         }
         return;
     } else {
-        NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
         Blog *blog = [self.resultsController objectAtIndexPath:indexPath];
         blog.visible = YES;
-        [blogService flagBlogAsLastUsed:blog];
+
+        RecentSitesService *recentSites = [RecentSitesService new];
+        [recentSites touchBlog:blog];
 
         self.selectedBlog = blog;
     }

--- a/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninSelfHostedViewController.swift
@@ -296,7 +296,7 @@ extension SigninSelfHostedViewController: LoginFacadeDelegate {
             let context = ContextManager.sharedInstance().mainContext
             let service = BlogService(managedObjectContext: context)
             if let blog = service.findBlog(withXmlrpc: xmlrpc, andUsername: username) {
-                service.flagBlog(asLastUsed: blog)
+                RecentSitesService().touch(blog: blog)
             }
 
             NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: SigninHelpers.WPSigninDidFinishNotification), object: nil)

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -1260,8 +1260,7 @@ fileprivate extension AztecPostViewController {
     }
 
     func markBlogAsLastUsed(_ blog: Blog) {
-        let blogService = BlogService(managedObjectContext: mainContext)
-        blogService.flagBlog(asLastUsed: blog)
+        RecentSitesService().touch(blog: blog)
     }
 
     func cancelEditing() {

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -291,9 +291,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         Blog *blog = (Blog *)[context objectWithID:selectedObjectID];
 
         if (blog) {
-            BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+            RecentSitesService *recentSites = [RecentSitesService new];
+            [recentSites touchBlog:blog];
 
-            [blogService flagBlogAsLastUsed:blog];
             AbstractPost *newPost = [self createNewDraftForBlog:blog];
             AbstractPost *oldPost = self.post;
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -611,9 +611,9 @@ EditImageDetailsViewControllerDelegate
         Blog *blog = (Blog *)[context objectWithID:selectedObjectID];
         
         if (blog) {
-            BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+            RecentSitesService *recentSites = [RecentSitesService new];
+            [recentSites touchBlog:blog];
 
-            [blogService flagBlogAsLastUsed:blog];
             AbstractPost *newPost = [self createNewDraftForBlog:blog];
             AbstractPost *oldPost = self.post;
             

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -592,6 +592,7 @@
 		C58349C51806F95100B64089 /* IOS7CorrectedTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = C58349C41806F95100B64089 /* IOS7CorrectedTextView.m */; };
 		CEBD3EAB0FF1BA3B00C1396E /* Blog.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBD3EAA0FF1BA3B00C1396E /* Blog.m */; };
 		E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */; };
+		E102B7901E714F24007928E8 /* RecentSitesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E102B78F1E714F24007928E8 /* RecentSitesService.swift */; };
 		E10A2E9B134E8AD3007643F9 /* PostAnnotation.m in Sources */ = {isa = PBXBuildFile; fileRef = 833AF25A114575A50016DE8F /* PostAnnotation.m */; };
 		E10B3652158F2D3F00419A93 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E10B3651158F2D3F00419A93 /* QuartzCore.framework */; };
 		E10B3654158F2D4500419A93 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E10B3653158F2D4500419A93 /* UIKit.framework */; };
@@ -622,6 +623,7 @@
 		E131CB5616CACF1E004B0314 /* get-user-blogs_has-blog.json in Resources */ = {isa = PBXBuildFile; fileRef = E131CB5516CACF1E004B0314 /* get-user-blogs_has-blog.json */; };
 		E131CB5816CACFB4004B0314 /* get-user-blogs_doesnt-have-blog.json in Resources */ = {isa = PBXBuildFile; fileRef = E131CB5716CACFB4004B0314 /* get-user-blogs_doesnt-have-blog.json */; };
 		E131F5351C2930FC00D2D975 /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E131F5341C2930FC00D2D975 /* String+Helpers.swift */; };
+		E135965D1E7152D1006C6606 /* RecentSitesServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E135965C1E7152D1006C6606 /* RecentSitesServiceTests.swift */; };
 		E1389ADB1C59F7C200FB2466 /* PlanListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1389ADA1C59F7C200FB2466 /* PlanListViewController.swift */; };
 		E13A8C9B1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13A8C9A1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift */; };
 		E13F23C314FE84600081D9CC /* NSMutableDictionary+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = E13F23C214FE84600081D9CC /* NSMutableDictionary+Helpers.m */; };
@@ -1901,6 +1903,7 @@
 		D7590F70D7755777DD739589 /* Pods-WordPress_Base-WordPressTodayWidget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPressTodayWidget.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPressTodayWidget/Pods-WordPress_Base-WordPressTodayWidget.debug.xcconfig"; sourceTree = "<group>"; };
 		DA67DF58196D8F6A005B5BC8 /* WordPress 20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 20.xcdatamodel"; sourceTree = "<group>"; };
 		E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-11-12.xcmappingmodel"; sourceTree = "<group>"; };
+		E102B78F1E714F24007928E8 /* RecentSitesService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentSitesService.swift; sourceTree = "<group>"; };
 		E105E9CD1726955600C0D9E7 /* WPAccount.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPAccount.h; sourceTree = "<group>"; };
 		E105E9CE1726955600C0D9E7 /* WPAccount.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAccount.m; sourceTree = "<group>"; };
 		E10675C9183FA78E00E5CE5C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -1947,6 +1950,7 @@
 		E131CB5716CACFB4004B0314 /* get-user-blogs_doesnt-have-blog.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "get-user-blogs_doesnt-have-blog.json"; sourceTree = "<group>"; };
 		E131F5341C2930FC00D2D975 /* String+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		E133DB40137AE180003C0AF9 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Localizable.strings; sourceTree = "<group>"; };
+		E135965C1E7152D1006C6606 /* RecentSitesServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentSitesServiceTests.swift; sourceTree = "<group>"; };
 		E135CD6E1E54BC0A0021E79F /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E135CD6F1E54BC0C0021E79F /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E135CD711E54BCA70021E79F /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -3766,6 +3770,7 @@
 				5DBCD9D318F35D7500B32229 /* ReaderTopicService.h */,
 				5DBCD9D418F35D7500B32229 /* ReaderTopicService.m */,
 				E62079E01CF7A61200F5CD46 /* ReaderSearchSuggestionService.swift */,
+				E102B78F1E714F24007928E8 /* RecentSitesService.swift */,
 				930F09161C7D110E00995926 /* ShareExtensionService.swift */,
 				E616E4B21C480896002C024E /* SharingService.swift */,
 				E69B125D1CE23A8E00594C73 /* SignupService.swift */,
@@ -4209,6 +4214,7 @@
 				59A9AB391B4C3ECD00A433DC /* LocalCoreDataServiceTests.m */,
 				E1C5457F1C6C79BB001CEB0E /* MediaSettingsTests.swift */,
 				08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */,
+				E135965C1E7152D1006C6606 /* RecentSitesServiceTests.swift */,
 				B5EFB1C81B333C5A007608A3 /* NotificationSettingsServiceTests.swift */,
 				B532ACCE1DC3AB8E00FFFA57 /* NotificationSyncMediatorTests.swift */,
 				08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */,
@@ -5986,6 +5992,7 @@
 				5D577D33189127BE00B964C3 /* PostGeolocationViewController.m in Sources */,
 				FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */,
 				1D3623260D0F684500981E51 /* WordPressAppDelegate.m in Sources */,
+				E102B7901E714F24007928E8 /* RecentSitesService.swift in Sources */,
 				E1D7FF381C74EB0E00E7E5E5 /* PlanService.swift in Sources */,
 				173BCE771CEB3D8200AE8817 /* DomainsServiceRemote.swift in Sources */,
 				5D7DEA2919D488DD0032EE77 /* WPStyleGuide+ReaderComments.swift in Sources */,
@@ -6653,6 +6660,7 @@
 				93B853231B4416A30064FE72 /* WPAnalyticsTrackerAutomatticTracksTests.m in Sources */,
 				E66969CA1B9E0C4F00EC9C00 /* ReaderTopicServiceRemoteTests.m in Sources */,
 				E1926C091C779868009F3C2C /* PlanListViewControllerTest.swift in Sources */,
+				E135965D1E7152D1006C6606 /* RecentSitesServiceTests.swift in Sources */,
 				59ECF87B1CB7061D00E68F25 /* PostSharingControllerTests.swift in Sources */,
 				E157D5E01C690A6C00F04FB9 /* ImmuTableTestUtils.swift in Sources */,
 				FFB8E5C71E48B85700556B50 /* MediaProgressCoordinatorTest.swift in Sources */,

--- a/WordPress/WordPressTest/RecentSitesServiceTests.swift
+++ b/WordPress/WordPressTest/RecentSitesServiceTests.swift
@@ -24,6 +24,13 @@ class RecentSitesServiceTests: XCTestCase {
         XCTAssertEqual(service.recentSites, ["site1", "site2"])
     }
 
+    func testMigratesLastBlogUsed() {
+        let database = EphemeralKeyValueDatabase()
+        database.set("site1", forKey: "LastUsedBlogURLDefaultsKey")
+        let service = RecentSitesService(database: database)
+        XCTAssertEqual(service.recentSites, ["site1"])
+    }
+
     private func newService() -> RecentSitesService {
         return RecentSitesService(database: EphemeralKeyValueDatabase())
     }

--- a/WordPress/WordPressTest/RecentSitesServiceTests.swift
+++ b/WordPress/WordPressTest/RecentSitesServiceTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import WordPress
+
+class RecentSitesServiceTests: XCTestCase {
+    func testEmptyByDefault() {
+        let service = newService()
+        XCTAssertEqual(service.recentSites.count, 0)
+    }
+
+    func testRecentSitesLimited() {
+        let service = newService()
+        service.touch(site: 123)
+        service.touch(site: 234)
+        service.touch(site: 345)
+        service.touch(site: 456)
+        XCTAssertEqual(service.recentSites, [456, 345, 234])
+    }
+
+    func testDoesNotDuplicate() {
+        let service = newService()
+        service.touch(site: 123)
+        service.touch(site: 234)
+        service.touch(site: 123)
+        XCTAssertEqual(service.recentSites, [123, 234])
+    }
+
+    private func newService() -> RecentSitesService {
+        return RecentSitesService(database: EphemeralKeyValueDatabase())
+    }
+}

--- a/WordPress/WordPressTest/RecentSitesServiceTests.swift
+++ b/WordPress/WordPressTest/RecentSitesServiceTests.swift
@@ -9,19 +9,19 @@ class RecentSitesServiceTests: XCTestCase {
 
     func testRecentSitesLimited() {
         let service = newService()
-        service.touch(site: 123)
-        service.touch(site: 234)
-        service.touch(site: 345)
-        service.touch(site: 456)
-        XCTAssertEqual(service.recentSites, [456, 345, 234])
+        service.touch(site: "site1")
+        service.touch(site: "site2")
+        service.touch(site: "site3")
+        service.touch(site: "site4")
+        XCTAssertEqual(service.recentSites, ["site4", "site3", "site2"])
     }
 
     func testDoesNotDuplicate() {
         let service = newService()
-        service.touch(site: 123)
-        service.touch(site: 234)
-        service.touch(site: 123)
-        XCTAssertEqual(service.recentSites, [123, 234])
+        service.touch(site: "site1")
+        service.touch(site: "site2")
+        service.touch(site: "site1")
+        XCTAssertEqual(service.recentSites, ["site1", "site2"])
     }
 
     private func newService() -> RecentSitesService {

--- a/WordPress/WordPressTest/RecentSitesServiceTests.swift
+++ b/WordPress/WordPressTest/RecentSitesServiceTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import WordPress
+@testable import WordPress
 
 class RecentSitesServiceTests: XCTestCase {
     func testEmptyByDefault() {


### PR DESCRIPTION
First part of #6217. To keep PRs small, I've implemented the data layer and use it to power the existing "last used blog" feature.

To test:

- Log in to an account with multiple sites
- Go to the sites list, visit a site and go back
- The new post button should create a post for that site
- Visit another site and go back
- The new post button should create a post for that site
- Use the blog selector to switch to another site
- The new post button should create a post for that site
- The behavior shouldn't differ from `develop`, just using a new backend to store the data.

Needs review: @frosty 
