### PR TITLE
Posts: Defaults the post filter's hasMore prop to false.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -28,7 +28,7 @@ import Foundation
     }
 
     init(title: String, filterType: Status, predicate: NSPredicate, statuses: [BasePost.Status]) {
-        hasMore = true
+        hasMore = false
 
         self.filterType = filterType
         predicateForFetchRequest = predicate


### PR DESCRIPTION
Refs #6819 
See the issue for more details.  This is a hail-mary pass at fixing the issue, but I think its a likely fix.

To test:
Primarily we want to confirm that the post list continues to refresh properly after the change. 
Confirm a first time load, a subsequent refresh, and load more all function correctly.

Needs review: @kurzee, you're probably the most recently acquainted with the post filters. Would you care to review? 
