### PR TITLE
Issue/6852: Update Media Library filter to only show images and videos

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -29,7 +29,7 @@ class MediaLibraryViewController: UIViewController {
     private func configurePickerViewController() {
         pickerViewController.mediaPickerDelegate = self
         pickerViewController.allowCaptureOfMedia = false
-        pickerViewController.filter = .all
+        pickerViewController.filter = .videoOrImage
         pickerViewController.allowMultipleSelection = false
         pickerViewController.showMostRecentFirst = true
         pickerViewController.dataSource = pickerDataSource


### PR DESCRIPTION
Fixes #6852. It'll be nice to support other file types in the future, but for now let's limit things to images or video (I thought I'd done this already, but turns out I used the wrong filter type).

To test:

* Add a non-image or video file to your media library using Calypso
* Open the media library in the app, and check that you can't see the newly-added file.

Needs review: @kurzee 