### PR TITLE
Categories: request max by default for REST

### DIFF
--- a/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/TaxonomyServiceRemoteREST.m
@@ -20,6 +20,8 @@ static NSString * const TaxonomyRESTNumberParameter = @"number";
 static NSString * const TaxonomyRESTOffsetParameter = @"offset";
 static NSString * const TaxonomyRESTPageParameter = @"page";
 
+static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
+
 @implementation TaxonomyServiceRemoteREST
 
 #pragma mark - categories
@@ -50,7 +52,7 @@ static NSString * const TaxonomyRESTPageParameter = @"page";
                          failure:(nullable void (^)(NSError *))failure
 {
     [self getTaxonomyWithType:TaxonomyRESTCategoryIdentifier
-                   parameters:nil
+                   parameters:@{TaxonomyRESTNumberParameter: @(TaxonomyRESTNumberMaxValue)}
                       success:^(NSDictionary *responseObject) {
                           success([self remoteCategoriesWithJSONArray:[responseObject arrayForKey:TaxonomyRESTCategoryIdentifier]]);
                       } failure:failure];

--- a/WordPress/WordPressTest/TaxonomyServiceRemoteRESTTests.m
+++ b/WordPress/WordPressTest/TaxonomyServiceRemoteRESTTests.m
@@ -71,12 +71,16 @@
 - (void)testThatGetCategoriesWorks
 {
     NSString *url = [self GETtaxonomyURLWithType:@"categories"];
-    
+
+    BOOL (^parametersCheckBlock)(id obj) = ^BOOL(NSDictionary *parameters) {
+        return ([parameters isKindOfClass:[NSDictionary class]] && [[parameters objectForKey:@"number"] integerValue] == 1000);
+    };
+
     WordPressComRestApi *api = self.service.wordPressComRestApi;
     OCMStub([api GET:[OCMArg isEqual:url]
-           parameters:[OCMArg isNil]
-              success:[OCMArg isNotNil]
-              failure:[OCMArg isNotNil]]);
+          parameters:[OCMArg checkWithBlock:parametersCheckBlock]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
     
     [self.service getCategoriesWithSuccess:^(NSArray<RemotePostCategory *> * _Nonnull categories) {}
                                    failure:^(NSError * _Nonnull error) {}];


### PR DESCRIPTION
Fixes #6861 

I'm not proud of this fix, but with a current user only being able to pull in half of their total categories at the moment, we probably ought to lean towards a quicker patch.

Since we currently only pull in the default `100` categories we can remedy this issue quickly, but with potential performance impact by requesting up to the full `1000`. However, we already receive the full set of categories on XML-RPC, so technically we're not doing anything too different for REST. Furthermore I suppose there's not too many cases of sites with more than 100 categories.

Also, looks like Android currently has the same problem glancing at: https://github.com/wordpress-mobile/WordPress-Android/blob/develop/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java#L90

@maxme ^

Moving forward, perhaps the broken windows team can take a crack at properly paging and loading batches of all categories with a more performant implementation.

To test:
1. Delete the app, fresh install.
2. Load it up on a .COM site.
3. Ensure all categories are loaded.
4. Bonus if you find a site with over 100 categories to load.

Needs review: @astralbodies, and if you're not 100% comfortable with this as a quick patch, we can hold off for a future refactor. (However an existing user in the support queue can't pull in there ~200 categories right now)
