### PR TITLE
Issue/6815 publicize switch back to default message with empty custom message

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1165,6 +1165,8 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     vc.onValueChanged = ^(NSString *value) {
         if (value.length) {
             self.post.publicizeMessage = value;
+        } else {
+            self.post.publicizeMessage = nil;
         }
         [self.tableView reloadData];
     };

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -333,6 +333,9 @@ class PostTests: XCTestCase {
         revision.publicizeMessage = ""
         XCTAssertFalse(revision.hasLocalChanges())
 
+        revision.publicizeMessage = nil
+        XCTAssertFalse(revision.hasLocalChanges())
+
         revision.publicizeMessage = "Make it notorious"
         XCTAssertTrue(revision.hasLocalChanges())
 


### PR DESCRIPTION
Fixes #6815 

To test: 
Create a new post
Go to Options and update the Publicize Message
Go back to the Post
Change your mind, go to Options again and delete the previously entered message
The Publicize message will revert back to the Post title

Needs review: @astralbodies 
