### PR TITLE
Forcing Notifications refresh

### DIFF
--- a/WordPress/Classes/Models/Notifications/NotificationBlock.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationBlock.swift
@@ -139,6 +139,12 @@ extension NotificationBlock {
         return metaTitles?[MetaKeys.Home] as? String
     }
 
+    /// Parent Notification ID
+    ///
+    var notificationID: String? {
+        return parent?.notificationId
+    }
+
     /// Returns the Meta ID's collection, if any.
     ///
     fileprivate var metaIds: [String: AnyObject]? {

--- a/WordPress/Classes/Services/NotificationActionsService.swift
+++ b/WordPress/Classes/Services/NotificationActionsService.swift
@@ -242,16 +242,41 @@ open class NotificationActionsService: LocalCoreDataService {
             completion?(false)
         })
     }
+}
 
 
 
-    // MARK: - Private Helpers
+// MARK: - Private Helpers
+//
+private extension NotificationActionsService {
 
-    fileprivate var commentService: CommentService {
+    /// Sync's a NotificationBlock container Notification. We need to manually do this to force Backend's Note
+    /// document regeneration. This is performed because retrieving `[NoteID, Hash]` might, in fact, return an 
+    /// outdated hash (ie. after a Like OP).
+    ///
+    /// - Parameter block: child NotificationBlock object of the Notification-to-be-refreshed.
+    ///
+    func forceSyncParentNotification(with block: NotificationBlock) {
+        guard let notificationID = block.notificationID, let mediator = NotificationSyncMediator() else {
+            return
+        }
+
+        DDLogSwift.logInfo("Res-ync'ing Notification \(notificationID)")
+        mediator.syncNote(with: notificationID)
+    }
+}
+
+
+
+// MARK: - Computed Properties
+//
+private extension NotificationActionsService {
+
+    var commentService: CommentService {
         return CommentService(managedObjectContext: managedObjectContext)
     }
 
-    fileprivate var siteService: ReaderSiteService {
+    var siteService: ReaderSiteService {
         return ReaderSiteService(managedObjectContext: managedObjectContext)
     }
 }

--- a/WordPress/Classes/Services/NotificationActionsService.swift
+++ b/WordPress/Classes/Services/NotificationActionsService.swift
@@ -18,7 +18,7 @@ open class NotificationActionsService: LocalCoreDataService {
 
         siteService.followSite(withID: siteID, success: {
             DDLogSwift.logInfo("Successfully followed site \(siteID)")
-            self.forceSyncParentNotification(with: block)
+            self.invalidateCacheForNotification(with: block)
             completion?(true)
 
         }, failure: { error in
@@ -44,7 +44,7 @@ open class NotificationActionsService: LocalCoreDataService {
 
         siteService.unfollowSite(withID: siteID, success: {
             DDLogSwift.logInfo("Successfully unfollowed site \(siteID)")
-            self.forceSyncParentNotification(with: block)
+            self.invalidateCacheForNotification(with: block)
             completion?(true)
 
         }, failure: { error in
@@ -71,7 +71,7 @@ open class NotificationActionsService: LocalCoreDataService {
 
         commentService.replyToComment(withID: commentID, siteID: siteID, content: content, success: {
             DDLogSwift.logInfo("Successfully replied to comment \(siteID).\(commentID)")
-            self.forceSyncParentNotification(with: block)
+            self.invalidateCacheForNotification(with: block)
             completion?(true)
 
         }, failure: { error in
@@ -99,7 +99,7 @@ open class NotificationActionsService: LocalCoreDataService {
         // Hit the backend
         commentService.updateComment(withID: commentID, siteID: siteID, content: content, success: {
             DDLogSwift.logInfo("Successfully updated to comment \(siteID).\(commentID)")
-            self.forceSyncParentNotification(with: block)
+            self.invalidateCacheForNotification(with: block)
             completion?(true)
 
         }, failure: { error in
@@ -128,7 +128,7 @@ open class NotificationActionsService: LocalCoreDataService {
         // Proceed toggling the Like field
         commentService.likeComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully liked comment \(siteID).\(commentID)")
-            self.forceSyncParentNotification(with: block)
+            self.invalidateCacheForNotification(with: block)
             completion?(true)
 
         }, failure: { error in
@@ -154,7 +154,7 @@ open class NotificationActionsService: LocalCoreDataService {
 
         commentService.unlikeComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully unliked comment \(siteID).\(commentID)")
-            self.forceSyncParentNotification(with: block)
+            self.invalidateCacheForNotification(with: block)
             completion?(true)
 
         }, failure: { error in
@@ -180,7 +180,7 @@ open class NotificationActionsService: LocalCoreDataService {
 
         commentService.approveComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully approved comment \(siteID).\(commentID)")
-            self.forceSyncParentNotification(with: block)
+            self.invalidateCacheForNotification(with: block)
             completion?(true)
 
         }, failure: { error in
@@ -206,7 +206,7 @@ open class NotificationActionsService: LocalCoreDataService {
 
         commentService.unapproveComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully unapproved comment \(siteID).\(commentID)")
-            self.forceSyncParentNotification(with: block)
+            self.invalidateCacheForNotification(with: block)
             completion?(true)
 
         }, failure: { error in
@@ -269,19 +269,20 @@ open class NotificationActionsService: LocalCoreDataService {
 //
 private extension NotificationActionsService {
 
-    /// Sync's a NotificationBlock container Notification. We need to manually do this to force Backend's Note
-    /// document regeneration. This is performed because retrieving `[NoteID, Hash]` might, in fact, return an 
-    /// outdated hash (ie. after a Like OP).
+    /// Invalidates the Local Cache for a given Notification. This will effectively cause the notification to
+    /// be re-downloaded from the remote endpoint.
+    ///
+    /// Required due to a beautiful backend bug. Details here: https://github.com/wordpress-mobile/WordPress-iOS/pull/6871
     ///
     /// - Parameter block: child NotificationBlock object of the Notification-to-be-refreshed.
     ///
-    func forceSyncParentNotification(with block: NotificationBlock) {
+    func invalidateCacheForNotification(with block: NotificationBlock) {
         guard let notificationID = block.notificationID, let mediator = NotificationSyncMediator() else {
             return
         }
 
-        DDLogSwift.logInfo("Res-ync'ing Notification \(notificationID)")
-        mediator.syncNote(with: notificationID)
+        DDLogSwift.logInfo("Invalidating cache for Notification with ID: \(notificationID)")
+        mediator.invalidateCacheForNotification(with: notificationID)
     }
 }
 

--- a/WordPress/Classes/Services/NotificationActionsService.swift
+++ b/WordPress/Classes/Services/NotificationActionsService.swift
@@ -4,6 +4,7 @@ import Foundation
 /// This service encapsulates all of the Actions that can be performed with a NotificationBlock
 ///
 open class NotificationActionsService: LocalCoreDataService {
+
     /// Follows a Site referenced by a given NotificationBlock.
     ///
     /// - Parameter block: The Notification's Site Block
@@ -17,7 +18,9 @@ open class NotificationActionsService: LocalCoreDataService {
 
         siteService.followSite(withID: siteID, success: {
             DDLogSwift.logInfo("Successfully followed site \(siteID)")
+            self.forceSyncParentNotification(with: block)
             completion?(true)
+
         }, failure: { error in
             DDLogSwift.logError("Error while trying to follow site: \(error)")
             block.removeOverrideValueForAction(.Follow)
@@ -41,7 +44,9 @@ open class NotificationActionsService: LocalCoreDataService {
 
         siteService.unfollowSite(withID: siteID, success: {
             DDLogSwift.logInfo("Successfully unfollowed site \(siteID)")
+            self.forceSyncParentNotification(with: block)
             completion?(true)
+
         }, failure: { error in
             DDLogSwift.logError("Error while trying to unfollow site: \(error)")
             block.removeOverrideValueForAction(.Follow)
@@ -66,7 +71,9 @@ open class NotificationActionsService: LocalCoreDataService {
 
         commentService.replyToComment(withID: commentID, siteID: siteID, content: content, success: {
             DDLogSwift.logInfo("Successfully replied to comment \(siteID).\(commentID)")
+            self.forceSyncParentNotification(with: block)
             completion?(true)
+
         }, failure: { error in
             DDLogSwift.logError("Error while trying to reply comment: \(error)")
             completion?(false)
@@ -92,7 +99,9 @@ open class NotificationActionsService: LocalCoreDataService {
         // Hit the backend
         commentService.updateComment(withID: commentID, siteID: siteID, content: content, success: {
             DDLogSwift.logInfo("Successfully updated to comment \(siteID).\(commentID)")
+            self.forceSyncParentNotification(with: block)
             completion?(true)
+
         }, failure: { error in
             DDLogSwift.logError("Error while trying to update comment: \(error)")
             completion?(false)
@@ -119,7 +128,9 @@ open class NotificationActionsService: LocalCoreDataService {
         // Proceed toggling the Like field
         commentService.likeComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully liked comment \(siteID).\(commentID)")
+            self.forceSyncParentNotification(with: block)
             completion?(true)
+
         }, failure: { error in
             DDLogSwift.logError("Error while trying to like comment: \(error)")
             block.removeOverrideValueForAction(.Like)
@@ -143,7 +154,9 @@ open class NotificationActionsService: LocalCoreDataService {
 
         commentService.unlikeComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully unliked comment \(siteID).\(commentID)")
+            self.forceSyncParentNotification(with: block)
             completion?(true)
+
         }, failure: { error in
             DDLogSwift.logError("Error while trying to unlike comment: \(error)")
             block.removeOverrideValueForAction(.Like)
@@ -167,7 +180,9 @@ open class NotificationActionsService: LocalCoreDataService {
 
         commentService.approveComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully approved comment \(siteID).\(commentID)")
+            self.forceSyncParentNotification(with: block)
             completion?(true)
+
         }, failure: { error in
             DDLogSwift.logError("Error while trying to moderate comment: \(error)")
             block.removeOverrideValueForAction(.Approve)
@@ -191,7 +206,9 @@ open class NotificationActionsService: LocalCoreDataService {
 
         commentService.unapproveComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully unapproved comment \(siteID).\(commentID)")
+            self.forceSyncParentNotification(with: block)
             completion?(true)
+
         }, failure: { error in
             DDLogSwift.logError("Error while trying to moderate comment: \(error)")
             block.removeOverrideValueForAction(.Approve)
@@ -216,6 +233,7 @@ open class NotificationActionsService: LocalCoreDataService {
         commentService.spamComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully spammed comment \(siteID).\(commentID)")
             completion?(true)
+
         }, failure: { error in
             DDLogSwift.logError("Error while trying to mark comment as spam: \(error)")
             completion?(false)
@@ -237,6 +255,7 @@ open class NotificationActionsService: LocalCoreDataService {
         commentService.deleteComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully deleted comment \(siteID).\(commentID)")
             completion?(true)
+
         }, failure: { error in
             DDLogSwift.logError("Error while trying to delete comment: \(error)")
             completion?(false)

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -130,12 +130,12 @@ class NotificationSyncMediator {
     ///     - noteId: Notification ID of the note to be downloaded.
     ///     - completion: Closure to be executed on completion.
     ///
-    func syncNote(with noteId: String, completion: @escaping ((Error?, Notification?) -> Void)) {
+    func syncNote(with noteId: String, completion: ((Error?, Notification?) -> Void)?) {
         assert(Thread.isMainThread)
 
         remote.loadNotes(noteIds: [noteId]) { error, remoteNotes in
             guard let remoteNotes = remoteNotes else {
-                completion(error, nil)
+                completion?(error, nil)
                 return
             }
 
@@ -144,7 +144,7 @@ class NotificationSyncMediator {
                 let predicate = NSPredicate(format: "(notificationId == %@)", noteId)
                 let note = helper.firstObject(matchingPredicate: predicate)
 
-                completion(nil, note)
+                completion?(nil, note)
             }
         }
     }

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -130,7 +130,7 @@ class NotificationSyncMediator {
     ///     - noteId: Notification ID of the note to be downloaded.
     ///     - completion: Closure to be executed on completion.
     ///
-    func syncNote(with noteId: String, completion: ((Error?, Notification?) -> Void)?) {
+    func syncNote(with noteId: String, completion: ((Error?, Notification?) -> Void)? = nil) {
         assert(Thread.isMainThread)
 
         remote.loadNotes(noteIds: [noteId]) { error, remoteNotes in

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -212,6 +212,24 @@ class NotificationSyncMediator {
             self.contextManager.saveDerivedContext(derivedContext)
         }
     }
+
+    /// Invalidates the local cache for the notification with the specified ID.
+    ///
+    func invalidateCacheForNotification(with noteID: String) {
+        let derivedContext = type(of: self).sharedDerivedContext(with: contextManager)
+        let helper = CoreDataHelper<Notification>(context: derivedContext)
+        let predicate = NSPredicate(format: "(notificationId == %@)", noteID)
+
+        derivedContext.perform {
+            guard let notification = helper.firstObject(matchingPredicate: predicate) else {
+                return
+            }
+
+            notification.notificationHash = nil
+
+            self.contextManager.saveDerivedContext(derivedContext)
+        }
+    }
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1085,9 +1085,10 @@ private extension NotificationDetailsViewController {
 
         actionsService.updateCommentWithBlock(block, content: content, completion: { success in
             guard success == false else {
-            generator.notificationOccurred(.error)
                 return
             }
+
+            generator.notificationOccurred(.error)
             self.displayCommentUpdateErrorWithBlock(block, content: content)
         })
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1013,6 +1013,8 @@ private extension NotificationDetailsViewController {
     }
 
     func approveCommentWithBlock(_ block: NotificationBlock) {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+
         actionsService.approveCommentWithBlock(block)
         WPAppAnalytics.track(.notificationsCommentApproved, withBlogID: block.metaSiteID)
     }


### PR DESCRIPTION
### Details:
Several Notification Actions are not forcing, backend side, a Notification Document Regeneration. As a result of this, retrieving the remote `[NoteID, Hash]` collection will not correctly indicate us if the notification has been updated.

Bottom line is: performing actions, such as Liking a Comment, **do work**, but upon relaunch, the Notification does not reflect it's actual remote state.

As a workaround, we'll force a Notification Refresh whenever the user perform an action such as `[Like, Unlike, Follow, Unfollow, Update Comment, Reply Comment, Approve Comment, Unapprove Comment]`

Fixes #6744

### To test:
1. Open a Comment-Y Notification
2. Try the following actions:
    `[Like, Unlike, Follow, Unfollow, Update Comment, Reply Comment, Approve Comment, Unapprove Comment]`
3. Kill the app
4. Relaunch
5. Verify that after the Notifications List gets reloaded, the updated notification looks as expected

Needs Review: @koke 
Thanks for reporting this @diegoreymendez!!
