### PR TITLE
Editor: Updates Discard Action Placement

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -610,11 +610,6 @@ extension AztecPostViewController {
         // Button: Keep editing
         alertController.addCancelActionWithTitle(NSLocalizedString("Keep Editing", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post."))
 
-        // Button: Discard
-        alertController.addDestructiveActionWithTitle(NSLocalizedString("Discard", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")) { _ in
-            self.discardChangesAndUpdateGUI()
-        }
-
         // Button: Save Draft/Update Draft
         if post.hasLocalChanges() {
             if !post.hasRemote() {
@@ -629,6 +624,11 @@ extension AztecPostViewController {
                     self.publishTapped(dismissWhenDone: true)
                 }
             }
+        }
+
+        // Button: Discard
+        alertController.addDestructiveActionWithTitle(NSLocalizedString("Discard", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")) { _ in
+            self.discardChangesAndUpdateGUI()
         }
 
         alertController.popoverPresentationController?.barButtonItem = closeBarButtonItem

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -840,11 +840,6 @@ EditImageDetailsViewControllerDelegate
                                 handler:^(UIAlertAction * action) {
         [self actionSheetKeepEditingButtonPressed];
     }];
-    [alertController addActionWithTitle:NSLocalizedString(@"Discard", @"Button shown if there are unsaved changes and the author is trying to move away from the post.")
-                                  style:UIAlertActionStyleDestructive
-                                handler:^(UIAlertAction * action) {
-        [self actionSheetDiscardButtonPressed];
-    }];
     
     if ([self.post hasLocalChanges]) {
         if (![self.post hasRemote]) {
@@ -864,6 +859,12 @@ EditImageDetailsViewControllerDelegate
         }
     }
     
+    [alertController addActionWithTitle:NSLocalizedString(@"Discard", @"Button shown if there are unsaved changes and the author is trying to move away from the post.")
+                                  style:UIAlertActionStyleDestructive
+                                handler:^(UIAlertAction * action) {
+                                    [self actionSheetDiscardButtonPressed];
+                                }];
+
     alertController.popoverPresentationController.barButtonItem = self.currentCancelButton;
     [self presentViewController:alertController animated:YES completion:nil];
 }


### PR DESCRIPTION
Fixes #6565

### To test:
1. Launch Aztec
2. Enter some random Text
3. Verify that the **Discard** action shows **below** the **Save Draft** action

Please, retry with the Hybrid editor as well. I've updated them both, for consistency's sake.

Needs review: @astralbodies 
Thanks in advance!
