### PR TITLE
When adding a category, the done button now dismisses the keyboard.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Categories/WPAddPostCategoryViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Categories/WPAddPostCategoryViewController.m
@@ -13,7 +13,7 @@
 
 static const CGFloat HorizontalMargin = 15.0f;
 
-@interface WPAddPostCategoryViewController ()<PostCategoriesViewControllerDelegate>
+@interface WPAddPostCategoryViewController ()<PostCategoriesViewControllerDelegate, UITextFieldDelegate>
 
 @property (nonatomic, strong) PostCategory *parentCategory;
 @property (nonatomic, strong) Blog *blog;
@@ -194,6 +194,7 @@ static const CGFloat HorizontalMargin = 15.0f;
     self.categoryTextField.keyboardType = UIKeyboardTypeDefault;
     self.categoryTextField.secureTextEntry = NO;
     self.categoryTextField.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    self.categoryTextField.delegate = self;
 
     [_createCategoryCell.contentView addSubview:self.categoryTextField];
     


### PR DESCRIPTION
<h3>Description:</h3>

When adding a category to a post, tapping on the "DONE" button in the keyboard, now properly dismisses it.

Fixes #5904 .

<h3>Testing:</h3>

**Test 1:**

1. Go to the list of posts for a blog.
2. Select any post.
3. Tap in the top-right "..." button.
4. Select "Options".
5. Tap on "Category", and tap "+" in the top right corner to add a new category.
6. Start typing the category name, and press "DONE" in the virtual keyboard.

Make sure the keyboard is properly dismissed.

Needs review: @aerych 
