### PR TITLE
SettingsMultiTextViewController: Fixing recursive loop

### DIFF
--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -47,10 +47,12 @@ static CGFloat const SettingsMinHeight = 41.0f;
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 
-- (void)viewWillLayoutSubviews
+- (void)viewDidLayoutSubviews
 {
-    [super viewWillLayoutSubviews];
-    [self adjustCellSize];
+    [super viewDidLayoutSubviews];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self adjustCellSize];
+    });
 }
 
 - (UITableViewCell *)textViewCell
@@ -142,7 +144,6 @@ static CGFloat const SettingsMinHeight = 41.0f;
     if (fabs(self.tableView.rowHeight - height) > (self.textView.font.lineHeight * 0.5f))
     {
         [self.tableView beginUpdates];
-        self.textView.frame = CGRectMake(SettingsTextPadding.dx, SettingsTextPadding.dy, self.textView.frame.size.width, height);
         self.tableView.rowHeight = MAX(height, SettingsMinHeight) + SettingsTextPadding.dy;
         [self.tableView endUpdates];
     }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -38,8 +38,6 @@ static CGFloat const SettingsMinHeight = 41.0f;
 {
     [self.textView becomeFirstResponder];
     [super viewDidAppear:animated];
-
-    [self adjustCellSize];
 }
 
 - (void)viewDidLoad
@@ -47,6 +45,15 @@ static CGFloat const SettingsMinHeight = 41.0f;
     [super viewDidLoad];
     self.tableView.allowsSelection = NO;
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
+}
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self adjustCellSize];
+    });
 }
 
 - (UITableViewCell *)textViewCell

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -141,14 +141,17 @@ static CGFloat const SettingsMinHeight = 41.0f;
 {
     CGSize size = [self.textView sizeThatFits:CGSizeMake(self.textView.frame.size.width, CGFLOAT_MAX)];
     CGFloat height = size.height;
-    CGFloat halfCurrentFontLineHeight = self.textView.font.lineHeight * 0.5f;
+    CGFloat targetHeight = MAX(height, SettingsMinHeight) + SettingsTextPadding.dy;
+    targetHeight = roundf(targetHeight);
 
-    if (fabs(self.tableView.rowHeight - height) > MAX(halfCurrentFontLineHeight, SettingsMinHeight))
+    if (self.tableView.rowHeight == targetHeight)
     {
-        [self.tableView beginUpdates];
-        self.tableView.rowHeight = MAX(height, SettingsMinHeight) + SettingsTextPadding.dy;
-        [self.tableView endUpdates];
+        return;
     }
+
+    [self.tableView beginUpdates];
+    self.tableView.rowHeight = targetHeight;
+    [self.tableView endUpdates];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -38,6 +38,8 @@ static CGFloat const SettingsMinHeight = 41.0f;
 {
     [self.textView becomeFirstResponder];
     [super viewDidAppear:animated];
+
+    [self adjustCellSize];
 }
 
 - (void)viewDidLoad
@@ -45,14 +47,6 @@ static CGFloat const SettingsMinHeight = 41.0f;
     [super viewDidLoad];
     self.tableView.allowsSelection = NO;
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
-}
-
-- (void)viewDidLayoutSubviews
-{
-    [super viewDidLayoutSubviews];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self adjustCellSize];
-    });
 }
 
 - (UITableViewCell *)textViewCell
@@ -140,8 +134,9 @@ static CGFloat const SettingsMinHeight = 41.0f;
 {
     CGSize size = [self.textView sizeThatFits:CGSizeMake(self.textView.frame.size.width, CGFLOAT_MAX)];
     CGFloat height = size.height;
+    CGFloat halfCurrentFontLineHeight = self.textView.font.lineHeight * 0.5f;
 
-    if (fabs(self.tableView.rowHeight - height) > (self.textView.font.lineHeight * 0.5f))
+    if (fabs(self.tableView.rowHeight - height) > MAX(halfCurrentFontLineHeight, SettingsMinHeight))
     {
         [self.tableView beginUpdates];
         self.tableView.rowHeight = MAX(height, SettingsMinHeight) + SettingsTextPadding.dy;


### PR DESCRIPTION
### Details:
- Nuked tableView.frame update. Not needed, since we use autolayout, and the tableView is the top level component
- Updated the adjustCell call to be asynchronous. Since there's a guard condition, after the first resize, the loop effectively stops.

Fixes #6877

### To test:
1. Set Text Size to smallest in Settings > Display & Brightness > Text Size.
2. Launch the app.
3. Open the Me tab.
4. Tap My Profile > About Me.

Verify if the world is a happy place again. Or not.

Needs review: @astralbodies 
Thanks!

