### PR TITLE
Turn off the OS_ACTIVITY_MODE disabling so we see important stuff

### DIFF
--- a/WordPress/Classes/Utility/Logging/WPLogger.m
+++ b/WordPress/Classes/Utility/Logging/WPLogger.m
@@ -43,7 +43,7 @@
     
     // Sets up the CocoaLumberjack logging; debug output to console and file
 #ifdef DEBUG
-    [DDLog addLogger:[DDASLLogger sharedInstance]];
+    [DDLog addLogger:[DDTTYLogger sharedInstance]];
 #endif
     
 #ifndef DEBUG

--- a/WordPress/Classes/Utility/Logging/WPLogger.m
+++ b/WordPress/Classes/Utility/Logging/WPLogger.m
@@ -44,7 +44,6 @@
     // Sets up the CocoaLumberjack logging; debug output to console and file
 #ifdef DEBUG
     [DDLog addLogger:[DDASLLogger sharedInstance]];
-    [DDLog addLogger:[DDTTYLogger sharedInstance]];
 #endif
     
 #ifndef DEBUG

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -99,7 +99,7 @@
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"
             value = "disable"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>


### PR DESCRIPTION
Removes the CocoaLumberjack TTY logger to prevent duplicate log events from being seen and turns on OS activity. We've been missing out on important logging like autolayout constraints being broken.

To test:
1. Compile & run.
2. Ensure duplicate logging isn't showing up.

Needs review: @koke, @frosty 
