### PR TITLE
Media Library #5: Search

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -148,7 +148,6 @@ class MediaItemViewController: UITableViewController {
         let service = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
         service.delete(media, success: {
             SVProgressHUD.showSuccess(withStatus: NSLocalizedString("Deleted!", comment: "Text displayed in HUD after successfully deleting a media item"))
-            _ = self.navigationController?.popViewController(animated: true)
         }, failure: { error in
             SVProgressHUD.showError(withStatus: NSLocalizedString("Unable to delete media item.", comment: "Text displayed in HUD if there was an error attempting to delete a media item."))
         })

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.h
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.h
@@ -27,4 +27,9 @@
 
 - (instancetype)initWithPost:(AbstractPost *)post;
 
+/// If a search query is set, the media assets fetched by the data source
+/// will be filtered to only those whose name, caption, or description
+/// contain the search query.
+@property (nonatomic, copy) NSString *searchQuery;
+
 @end

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -319,10 +319,12 @@
 
 - (void)setSearchQuery:(NSString *)searchQuery
 {
-    _searchQuery = [searchQuery copy];
+    if (!_searchQuery || ![_searchQuery isEqualToString:searchQuery]) {
+        _searchQuery = [searchQuery copy];
 
-    _fetchController = nil;
-    [self.fetchController performFetch:nil];
+        _fetchController = nil;
+        [self.fetchController performFetch:nil];
+    }
 }
 
 - (NSFetchedResultsController *)fetchController

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -319,7 +319,7 @@
 
 - (void)setSearchQuery:(NSString *)searchQuery
 {
-    if (!_searchQuery || ![_searchQuery isEqualToString:searchQuery]) {
+    if (![_searchQuery isEqualToString:searchQuery]) {
         _searchQuery = [searchQuery copy];
 
         _fetchController = nil;

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -259,8 +259,10 @@ class MediaLibraryViewController: UIViewController {
 
 extension MediaLibraryViewController: UISearchResultsUpdating, UISearchControllerDelegate, UISearchBarDelegate {
     func updateSearchResults(for searchController: UISearchController) {
-        pickerDataSource.searchQuery = searchController.searchBar.text
-        pickerViewController.collectionView?.reloadData()
+        if searchController.isActive {
+            pickerDataSource.searchQuery = searchController.searchBar.text
+            pickerViewController.collectionView?.reloadData()
+        }
     }
 
     func didDismissSearchController(_ searchController: UISearchController) {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -14,6 +14,25 @@ class MediaLibraryViewController: UIViewController {
 
     fileprivate var selectedAsset: Media? = nil
 
+    lazy fileprivate var searchBarContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    lazy fileprivate var searchController: UISearchController = {
+        let controller = UISearchController(searchResultsController: nil)
+        controller.searchResultsUpdater = self
+        controller.hidesNavigationBarDuringPresentation = true
+        controller.dimsBackgroundDuringPresentation = false
+
+        WPStyleGuide.configureSearchBar(controller.searchBar)
+        controller.searchBar.delegate = self
+        controller.searchBar.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+        return controller
+    }()
+
     // MARK: - Initializers
 
     init(blog: Blog) {
@@ -50,9 +69,14 @@ class MediaLibraryViewController: UIViewController {
 
         title = NSLocalizedString("Media", comment: "Title for Media Library section of the app.")
 
+        definesPresentationContext = true
+        automaticallyAdjustsScrollViewInsets = false
+
         updateNavigationItemButtonsForEditingState()
 
         addMediaPickerAsChildViewController()
+        addSearchBarContainer()
+        addSearchBar()
 
         registerChangeObserver()
     }
@@ -61,6 +85,14 @@ class MediaLibraryViewController: UIViewController {
         super.viewDidAppear(animated)
 
         selectedAsset = nil
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        if searchController.isActive {
+            searchController.isActive = false
+        }
     }
 
     private func updateNavigationItemButtonsForEditingState() {
@@ -80,11 +112,48 @@ class MediaLibraryViewController: UIViewController {
 
     private func addMediaPickerAsChildViewController() {
         pickerViewController.willMove(toParentViewController: self)
-        pickerViewController.view.bounds = view.bounds
         view.addSubview(pickerViewController.view)
+        pickerViewController.view.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            pickerViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            pickerViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            pickerViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
         addChildViewController(pickerViewController)
         pickerViewController.didMove(toParentViewController: self)
     }
+
+    private func addSearchBarContainer() {
+        view.addSubview(searchBarContainer)
+
+        NSLayoutConstraint.activate([
+            searchBarContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            searchBarContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            searchBarContainer.topAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor),
+            searchBarContainer.bottomAnchor.constraint(equalTo: pickerViewController.view.topAnchor)
+        ])
+
+        let searchBarHeight = searchController.searchBar.bounds.height
+
+        let heightConstraint = searchBarContainer.heightAnchor.constraint(equalToConstant: searchBarHeight)
+        heightConstraint.priority = UILayoutPriorityDefaultLow
+        heightConstraint.isActive = true
+
+        let expandedHeightConstraint = searchBarContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: searchBarHeight)
+        expandedHeightConstraint.priority = UILayoutPriorityRequired
+        expandedHeightConstraint.isActive = true
+    }
+
+    private func addSearchBar() {
+        searchBarContainer.layoutIfNeeded()
+
+        searchBarContainer.addSubview(searchController.searchBar)
+        searchController.searchBar.sizeToFit()
+    }
+
+    // MARK: - Actions
 
     @objc private func editTapped() {
         isEditing = !isEditing
@@ -171,6 +240,13 @@ class MediaLibraryViewController: UIViewController {
         if let mediaLibraryChangeObserverKey = mediaLibraryChangeObserverKey {
             pickerDataSource.unregisterChangeObserver(mediaLibraryChangeObserverKey)
         }
+    }
+}
+
+extension MediaLibraryViewController: UISearchResultsUpdating, UISearchControllerDelegate, UISearchBarDelegate {
+    func updateSearchResults(for searchController: UISearchController) {
+        pickerDataSource.searchQuery = searchController.searchBar.text
+        pickerViewController.collectionView?.reloadData()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -33,6 +33,8 @@ class MediaLibraryViewController: UIViewController {
         return controller
     }()
 
+    var searchQuery: String? = nil
+
     // MARK: - Initializers
 
     init(blog: Blog) {
@@ -81,6 +83,15 @@ class MediaLibraryViewController: UIViewController {
         registerChangeObserver()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if let searchQuery = searchQuery,
+            !searchQuery.isEmpty {
+            searchController.searchBar.text = searchQuery
+        }
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -91,6 +102,7 @@ class MediaLibraryViewController: UIViewController {
         super.viewWillDisappear(animated)
 
         if searchController.isActive {
+            searchQuery = searchController.searchBar.text
             searchController.isActive = false
         }
     }
@@ -243,9 +255,25 @@ class MediaLibraryViewController: UIViewController {
     }
 }
 
+// MARK: - UISearchResultsUpdating
+
 extension MediaLibraryViewController: UISearchResultsUpdating, UISearchControllerDelegate, UISearchBarDelegate {
     func updateSearchResults(for searchController: UISearchController) {
         pickerDataSource.searchQuery = searchController.searchBar.text
+        pickerViewController.collectionView?.reloadData()
+    }
+
+    func didDismissSearchController(_ searchController: UISearchController) {
+        clearSearch()
+    }
+
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        clearSearch()
+    }
+
+    func clearSearch() {
+        searchQuery = nil
+        pickerDataSource.searchQuery = nil
         pickerViewController.collectionView?.reloadData()
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -88,7 +88,13 @@ class MediaLibraryViewController: UIViewController {
 
         if let searchQuery = searchQuery,
             !searchQuery.isEmpty {
-            searchController.searchBar.text = searchQuery
+
+            // If we deleted the last asset, then clear the search
+            if pickerDataSource.numberOfAssets() == 0 {
+                clearSearch()
+            } else {
+                searchController.searchBar.text = searchQuery
+            }
         }
     }
 
@@ -98,8 +104,8 @@ class MediaLibraryViewController: UIViewController {
         selectedAsset = nil
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
 
         if searchController.isActive {
             searchQuery = searchController.searchBar.text


### PR DESCRIPTION
This PR adds search to the media library. The search will search the title, caption, and description fields of media items.

**Note:**

* There's a noticeable flickering when the collection view is refreshed as you type your search query. This is due to the way the media picker loads its images asynchronously, and will be fixed separately in the media picker.
* Search currently doesn't have a 'no results' state. I'll be adding no results separately for when a user has no items in their media library, so I'll address search at the same time.

**To test:**

* Try searching a media library!
* Try editing metadata for an item and check you can search for the new values
* Check the scroll insets play correctly with the keyboard

Needs review: @kurzee 