### PR TITLE
Display error when deleting a site admin

### DIFF
--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -130,16 +130,18 @@ struct PeopleService {
     ///
     /// - Parameters:
     ///     - user: The person that should be deleted
+    ///     - success: Closure to be executed in case of success.
     ///     - failure: Closure to be executed on error
     ///
-    func deleteUser(_ user: User, failure: ((Error) -> Void)? = nil) {
+    func deleteUser(_ user: User, success: (() -> Void)? = nil, failure: ((Error) -> Void)? = nil) {
         guard let managedPerson = managedPersonFromPerson(user) else {
             return
         }
 
         // Hit the Backend
-        remote.deleteUser(siteID, userID: user.ID, failure: { error in
-
+        remote.deleteUser(siteID, userID: user.ID, success: {
+            success?()
+        }, failure: { error in
             DDLogSwift.logError("### Error while deleting person \(user.ID) from blog \(self.siteID): \(error)")
 
             // Revert the deletion

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -222,10 +222,37 @@ private extension PersonViewController {
         }
 
         let service = PeopleService(blog: blog, context: context)
-        service?.deleteUser(user)
+        service?.deleteUser(user, failure: {[weak self] (error: Error?) -> () in
+            guard let strongSelf = self, let error = error as? NSError else {
+                return
+            }
+            guard let personWithError = strongSelf.person else {
+                return
+            }
+
+            strongSelf.handleRemoveUserError(error, userName: "@" + personWithError.username)
+        })
         _ = navigationController?.popViewController(animated: true)
 
         WPAnalytics.track(.personRemoved)
+    }
+
+    func handleRemoveUserError(_ error: NSError, userName: String) {
+        // The error code will be "forbidden" per:
+        // https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/users/%24user_ID/delete/
+        guard let errorCode = error.userInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String,
+            errorCode.localizedCaseInsensitiveContains("forbidden") else {
+            let errorWithSource = NSError(domain: error.domain, code: error.code, userInfo: error.userInfo)
+            WPError.showNetworkingAlertWithError(errorWithSource)
+            return
+        }
+
+        let errorTitleFormat = NSLocalizedString("Error removing %@", comment: "Title of error dialog when removing a site owner fails.")
+        let errorTitleText = String(format: errorTitleFormat, userName)
+        let errorMessage = NSLocalizedString("The user you are trying to remove is the owner of this site. " +
+                                             "Please contact support for assistance.",
+                                             comment: "Error message shown when user attempts to remove the site owner.")
+        WPError.showAlert(withTitle: errorTitleText, message: errorMessage, withSupportButton: true)
     }
 
     func updateUserRole(_ newRole: Role) {

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -222,7 +222,9 @@ private extension PersonViewController {
         }
 
         let service = PeopleService(blog: blog, context: context)
-        service?.deleteUser(user, failure: {[weak self] (error: Error?) -> () in
+        service?.deleteUser(user, success: {
+            WPAnalytics.track(.personRemoved)
+        }, failure: {[weak self] (error: Error?) -> () in
             guard let strongSelf = self, let error = error as? NSError else {
                 return
             }
@@ -233,8 +235,6 @@ private extension PersonViewController {
             strongSelf.handleRemoveUserError(error, userName: "@" + personWithError.username)
         })
         _ = navigationController?.popViewController(animated: true)
-
-        WPAnalytics.track(.personRemoved)
     }
 
     func handleRemoveUserError(_ error: NSError, userName: String) {


### PR DESCRIPTION
Fixes #5671 

This PR adds an alert after attempting to remove a site owner. In addition,  a `WPError.showNetworkingAlertWithError` will now display if there are any other issues when removing people.

![3](https://cloud.githubusercontent.com/assets/154014/24019375/b8df2c06-0a65-11e7-881c-cdbba74c212b.png)

![delete_user](https://cloud.githubusercontent.com/assets/154014/24019411/d4a27cf4-0a65-11e7-9182-b5239d310220.gif)

**To test:**
1. Set up a site with two users: the site owner and a second account you are using in the app
2. Open the app (logged in to the second account)
3. Go to My Site > People
4. Select the site owner in the list of users
5. Select "Remove User"
6. In the confirmation dialog, select "Remove" to confirm that you want to remove the user.

The app will take you back to the list of users on the site, display the alert, and that user should still be in the list.

Needs review: @kurzee would you be so kind?
