### PR TITLE
Aztec: show page settings for pages

### DIFF
--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -62,6 +62,7 @@
 
 #import "PageListSectionHeaderView.h"
 #import "PageListTableViewCell.h"
+#import "PageSettingsViewController.h"
 #import "PhotonImageURLHelper.h"
 #import "PostContentProvider.h"
 #import "PostCardTableViewCell.h"

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -789,7 +789,12 @@ private extension AztecPostViewController {
     }
 
     func displayPostOptions() {
-        let settingsViewController = PostSettingsViewController(post: post)
+        let settingsViewController: PostSettingsViewController
+        if post is Page {
+            settingsViewController = PageSettingsViewController(post: post)
+        } else {
+            settingsViewController = PostSettingsViewController(post: post)
+        }
         settingsViewController.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(settingsViewController, animated: true)
     }


### PR DESCRIPTION
Fixes #6762 #6763 

To test:

- Edit a page using Aztec
- Go to Options

Only the Publish and Featured Image section should be there

![simulator screen shot 17 mar 2017 15 39 00](https://cloud.githubusercontent.com/assets/8739/24048052/ef638340-0b27-11e7-8152-962fa7281510.png)



Needs review: @SergioEstevao 
