### PR TITLE
Adds URL override for Aztec editor

### DIFF
--- a/WordPress/Classes/Services/EditorSettings.swift
+++ b/WordPress/Classes/Services/EditorSettings.swift
@@ -4,6 +4,7 @@ class EditorSettings: NSObject {
     // MARK: - Constants
     fileprivate let newEditorAvailableKey = "kUserDefaultsNewEditorAvailable"
     fileprivate let newEditorEnabledKey = "kUserDefaultsNewEditorEnabled"
+    fileprivate let nativeEditorAvailableKey = "kUserDefaultsNativeEditorAvailable"
     fileprivate let nativeEditorEnabledKey = "kUserDefaultsNativeEditorEnabled"
 
     // MARK: - Internal variables
@@ -35,11 +36,27 @@ class EditorSettings: NSObject {
         }
     }
 
+    var nativeEditorAvailable: Bool {
+        get {
+            // If the available flag exists in user settings, return it's value
+            if let nativeEditorAvailable = database.object(forKey: nativeEditorAvailableKey) as? Bool {
+                return nativeEditorAvailable
+            }
+
+            // If the flag doesn't exist in settings, look at FeatureFlag
+            return FeatureFlag.nativeEditor.enabled
+        }
+        set {
+            database.set(newValue, forKey: nativeEditorAvailableKey)
+        }
+    }
+
     var nativeEditorEnabled: Bool {
         get {
-            if !FeatureFlag.nativeEditor.enabled {
+            guard nativeEditorAvailable else {
                 return false
             }
+
             if let nativeEditorEnabled = database.object(forKey: nativeEditorEnabledKey) as? Bool {
                 return nativeEditorEnabled
             } else {

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -283,6 +283,7 @@ int ddLogLevel = DDLogLevelInfo;
                 return YES;
             }
         } else if ([[url host] isEqualToString:@"editor"]) {
+            // Example: wordpress://editor?available=1&enabled=0
             NSDictionary* params = [[url query] dictionaryFromQueryString];
 
             if (params.count > 0) {

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -282,6 +282,17 @@ int ddLogLevel = DDLogLevelInfo;
 
                 return YES;
             }
+        } else if ([[url host] isEqualToString:@"editor"]) {
+            NSDictionary* params = [[url query] dictionaryFromQueryString];
+
+            if (params.count > 0) {
+                BOOL available = [[params objectForKey:@"available"] boolValue];
+                BOOL enabled = [[params objectForKey:@"enabled"] boolValue];
+
+                EditorSettings *editorSettings = [EditorSettings new];
+                editorSettings.nativeEditorAvailable = available;
+                editorSettings.nativeEditorEnabled = enabled;
+            }
         }
     }
 

--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -14,7 +14,7 @@ enum FeatureFlag: Int {
         case .mediaLibrary:
             return build(.debug)
         case .nativeEditor:
-            // At the moment this is only active in debug mode
+            // At the moment this is only visible by default in non-app store builds
             if build(.alpha, .debug, .internal) {
                 return true
             }

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -91,7 +91,7 @@ class AppSettingsViewController: UITableViewController {
         )
         editorRows.append(visualEditor)
 
-        if FeatureFlag.nativeEditor.enabled && editorSettings.visualEditorEnabled {
+        if editorSettings.nativeEditorAvailable && editorSettings.visualEditorEnabled {
             let nativeEditor = SwitchRow(
                 title: NSLocalizedString("Native Editor", comment: "Option to enable the native visual editor"),
                 value: editorSettings.nativeEditorEnabled,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -348,6 +348,7 @@
 		931D270019EDAE8600114F17 /* CoreDataMigrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 931D26FF19EDAE8600114F17 /* CoreDataMigrationTests.m */; };
 		931DF4D618D09A2F00540BDD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 931DF4D818D09A2F00540BDD /* InfoPlist.strings */; };
 		932225B11C7CE50300443B02 /* WordPressShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 932225A71C7CE50300443B02 /* WordPressShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		932645A41E7C206600134988 /* EditorSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932645A31E7C206600134988 /* EditorSettingsTests.swift */; };
 		932AB00B1D526C1400BE486D /* gallery-reader-post-private.json in Resources */ = {isa = PBXBuildFile; fileRef = 932AB00A1D526C1400BE486D /* gallery-reader-post-private.json */; };
 		932C6CB31D521DFA006E4A62 /* gallery-reader-post-public.json in Resources */ = {isa = PBXBuildFile; fileRef = 932C6CB21D521DFA006E4A62 /* gallery-reader-post-public.json */; };
 		93414DE51E2D25AE003143A3 /* PostEditorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93414DE41E2D25AE003143A3 /* PostEditorState.swift */; };
@@ -1586,6 +1587,7 @@
 		931DF4DE18D09B2600540BDD /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		931DF4DF18D09B3900540BDD /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		932225A71C7CE50300443B02 /* WordPressShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WordPressShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		932645A31E7C206600134988 /* EditorSettingsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorSettingsTests.swift; sourceTree = "<group>"; };
 		93267A6019B896CD00997EB8 /* Info-Internal.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-Internal.plist"; sourceTree = "<group>"; };
 		932AB00A1D526C1400BE486D /* gallery-reader-post-private.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gallery-reader-post-private.json"; sourceTree = "<group>"; };
 		932C6CB21D521DFA006E4A62 /* gallery-reader-post-public.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "gallery-reader-post-public.json"; path = "../gallery-reader-post-public.json"; sourceTree = "<group>"; };
@@ -4241,6 +4243,7 @@
 				E1A7CA4A1CC9FD7800373E06 /* StoreCoordinatorTests.swift */,
 				59FBD5611B5684F300734466 /* ThemeServiceTests.m */,
 				1702BBE11CF319C600766A33 /* DomainsServiceTests.swift */,
+				932645A31E7C206600134988 /* EditorSettingsTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -6751,6 +6754,7 @@
 				FF34EEA91CF473F600F8B38D /* WordPressComServiceRemoteRestTests.swift in Sources */,
 				BE1071FF1BC75FFA00906AFF /* WPStyleGuide+BlogTests.swift in Sources */,
 				1702BBE21CF319C600766A33 /* DomainsServiceTests.swift in Sources */,
+				932645A41E7C206600134988 /* EditorSettingsTests.swift in Sources */,
 				B5BC25A01CFCB91800F7D8B9 /* PeopleRemoteTests.swift in Sources */,
 				85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */,
 				93D86B981C691E71003D8E3E /* LocalCoreDataServiceTests.m in Sources */,

--- a/WordPress/WordPressTest/EditorSettingsTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import WordPress
+
+class EditorSettingsTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+
+        let userDefaults = UserDefaults.standard
+        userDefaults.removeObject(forKey: "kUserDefaultsNativeEditorAvailable")
+        userDefaults.removeObject(forKey: "kUserDefaultsNativeEditorEnabled")
+        userDefaults.synchronize()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testNativeEditorAvailableIsAvailableBasedOnBuild() {
+        Build._overrideCurrent = .debug
+        let editorSettings = EditorSettings(database: EphemeralKeyValueDatabase())
+
+        XCTAssertTrue(editorSettings.nativeEditorAvailable)
+    }
+
+    func testNativeEditorAvailableIsNotAvailableBasedOnBuild() {
+        Build._overrideCurrent = .appStore
+        let editorSettings = EditorSettings(database: EphemeralKeyValueDatabase())
+
+        XCTAssertFalse(editorSettings.nativeEditorAvailable)
+    }
+
+    func testNativeEditorAvailableIsAvailableFromOverride() {
+        Build._overrideCurrent = .appStore
+        let editorSettings = EditorSettings(database: EphemeralKeyValueDatabase())
+        editorSettings.nativeEditorAvailable = true
+
+
+        XCTAssertTrue(editorSettings.nativeEditorAvailable)
+    }
+
+    func testNativeEditorEnabledAvailableButDisabledByDefault() {
+        Build._overrideCurrent = .debug
+        let editorSettings = EditorSettings(database: EphemeralKeyValueDatabase())
+
+        XCTAssertTrue(editorSettings.nativeEditorAvailable)
+        XCTAssertFalse(editorSettings.nativeEditorEnabled)
+    }
+
+    func testNativeEditorEnabledNotAvailable() {
+        Build._overrideCurrent = .appStore
+        let editorSettings = EditorSettings(database: EphemeralKeyValueDatabase())
+        editorSettings.nativeEditorEnabled = true // Force to enabled but build should still disable
+
+        XCTAssertFalse(editorSettings.nativeEditorEnabled)
+    }
+
+    func testNativeEditorEnabledIsAvailableAndEnabledFromOverride() {
+        Build._overrideCurrent = .appStore
+        let editorSettings = EditorSettings(database: EphemeralKeyValueDatabase())
+        editorSettings.nativeEditorAvailable = true
+        editorSettings.nativeEditorEnabled = true
+
+        XCTAssertTrue(editorSettings.nativeEditorEnabled)
+    }
+}

--- a/WordPress/WordPressTest/EditorSettingsTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsTests.swift
@@ -4,11 +4,6 @@ import XCTest
 class EditorSettingsTests: XCTestCase {
     override func setUp() {
         super.setUp()
-
-        let userDefaults = UserDefaults.standard
-        userDefaults.removeObject(forKey: "kUserDefaultsNativeEditorAvailable")
-        userDefaults.removeObject(forKey: "kUserDefaultsNativeEditorEnabled")
-        userDefaults.synchronize()
     }
 
     override func tearDown() {


### PR DESCRIPTION
Closes #6647 

Provides a way to enable the Aztec editor in builds where it's not available by default (like the App Store/TestFlight builds). URL scheme is defined in the referenced issue.

## To test:

1. Launch the app and verify Native Editor is visible in Me > App Settings.
2. Open `FeatureFlag.swift` and temporarily remove `.debug` from the `case .nativeEditor` if statement. This simulates the configuration for the App Store build.
3. Launch the app and verify Native Editor is not visible in Me > App Settings.
4. Open Safari and visit the URL `wpdebug://editor?available=1&enabled=1`. Allow Safari to launch WordPress.
5. Go back to App Settings and verify Native Editor is both visible and enabled.
6. Open Safari and visit the URL `wpdebug://editor?available=1&enabled=0`. Allow Safari to launch WordPress.
7. Go back to App Settings and verify Native Editor is visible but disabled.
8. Open Safari and visit the URL `wpdebug://editor?available=0`. Allow Safari to launch WordPress.
9. Go back to App Settings and verify Native Editor not visible. 

Needs review: @diegoreymendez, @SergioEstevao 
