### PR TITLE
Analytics: Include error description in passed props.

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -226,9 +226,9 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 
 + (void)track:(WPAnalyticsStat)stat error:(NSError * _Nonnull)error {
     NSDictionary *properties = @{
-                                 @"error_code" : [@(error.code) stringValue],
+                                 @"error_code": [@(error.code) stringValue],
                                  @"error_domain": error.domain,
-                                 @"error_description" : error.description
+                                 @"error_description": error.description
     };
     [self track:stat withProperties: properties];
 }

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -227,7 +227,8 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 + (void)track:(WPAnalyticsStat)stat error:(NSError * _Nonnull)error {
     NSDictionary *properties = @{
                                  @"error_code" : [@(error.code) stringValue],
-                                 @"error_domain": error.domain
+                                 @"error_domain": error.domain,
+                                 @"error_description" : error.description
     };
     [self track:stat withProperties: properties];
 }


### PR DESCRIPTION
Just a small tweak to add the error description to the list of properties tracked when tracking an error. 

To test: 
Add a breakpoint @ `[self track: withProperties:]`
Be signed out of the app.
Try to sign in to wpcom with invalid credentials.
Confirm that the properties dictionary contains the error description, and there are no errors.

Needs review: @elibud may I trouble you for a review? 
