### PR TITLE
Support wp.com site icons on the blog list

### DIFF
--- a/WordPress/Classes/Categories/UIImageView+Gravatar.m
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.m
@@ -26,7 +26,7 @@ NSString *const BlavatarDefault = @"blavatar-default";
 
 - (void)setImageWithSiteIcon:(NSString *)siteIcon placeholderImage:(UIImage *)placeholderImage
 {
-    if ([self isPhotonURL:siteIcon]) {
+    if ([self isPhotonURL:siteIcon] || [self isWordPressComFilesURL:siteIcon]) {
         [self setImageWithURL:[self siteIconURLForSiteIconUrl:siteIcon] placeholderImage:placeholderImage];
     } else if ([self isBlavatarURL:siteIcon]) {
         [self setImageWithURL:[self blavatarURLForBlavatarURL:siteIcon] placeholderImage:placeholderImage];
@@ -87,6 +87,11 @@ NSString *const BlavatarDefault = @"blavatar-default";
 - (BOOL)isPhotonURL:(NSString *)path
 {
     return [path rangeOfString:@".wp.com"].location != NSNotFound;
+}
+
+- (BOOL)isWordPressComFilesURL:(NSString *)path
+{
+    return [path containsString:@".files.wordpress.com"];
 }
 
 - (BOOL)isBlavatarURL:(NSString *)path


### PR DESCRIPTION
Fixes #6844 

This takes care of the issue for the new site icon storage, but it still won't work for private sites (request is unauthenticated) or self hosted (it will wrongly interpret the URL as a host for blavatar, but that's fine because we need a resized icon anyway). I considered fixing those as well, but I think it's better to wait for the upcoming network improvements and rethink or image loading in general.

To test:

- In a web browser, add a site icon to a WordPress.com site (in the general settings or in the customizer).
- Open the My Sites tab in the app and check that the right site icon is shown
- Visit the site details and check that the right icon is there as well.

Needs review: @elibud 