### PR TITLE
Move View Site and Dashboard to External section

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -32,6 +32,7 @@ NSString * const WPBlogDetailsSelectedIndexPathKey = @"WPBlogDetailsSelectedInde
 NSInteger const BlogDetailHeaderViewVerticalMargin = 18;
 CGFloat const BLogDetailGridiconAccessorySize = 17.0;
 NSTimeInterval const PreloadingCacheTimeout = 60.0 * 5; // 5 minutes
+NSString * const HideWPAdminDate = @"2015-09-07T00:00:00Z";
 
 // NOTE: Currently "stats" acts as the calypso dashboard with a redirect to
 // stats/insights. Per @mtias, if the dashboard should change at some point the
@@ -348,15 +349,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     return (cellIsNotFullyVisible) ? UITableViewScrollPositionMiddle : UITableViewScrollPositionNone;
 }
 
-- (NSString *)adminRowTitle
-{
-    if (self.blog.isHostedAtWPcom) {
-        return NSLocalizedString(@"Dashboard", @"Action title. Noun. Opens the user's WordPress.com dashboard in an external browser.");
-    } else {
-        return NSLocalizedString(@"WP Admin", @"Action title. Noun. Opens the user's WordPress Admin in an external browser.");
-    }
-}
-
 - (void)configureTableViewData
 {
     NSMutableArray *marr = [NSMutableArray array];
@@ -366,6 +358,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [marr addObject:[self personalizeSectionViewModel]];
     }
     [marr addObject:[self configurationSectionViewModel]];
+    [marr addObject:[self externalSectionViewModel]];
 
     // Assign non mutable copy.
     self.tableSections = [NSArray arrayWithArray:marr];
@@ -380,27 +373,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                  callback:^{
                                                      [weakSelf showStats];
                                                  }]];
-
-    BlogDetailsRow *viewSiteRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"View Site", @"Action title. Opens the user's site in an in-app browser")
-                                                                  image:[Gridicon iconOfType:GridiconTypeHouse]
-                                                               callback:^{
-                                                                   [weakSelf showViewSite];
-                                                               }];
-    viewSiteRow.showsSelectionState = NO;
-    [rows addObject:viewSiteRow];
-
-    BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:[self adminRowTitle]
-                                                          image:[Gridicon iconOfType:GridiconTypeMySites]
-                                                       callback:^{
-                                                           [weakSelf showViewAdmin];
-                                                           [weakSelf.tableView deselectSelectedRowWithAnimation:YES];
-                                                       }];
-    UIImage *image = [[Gridicon iconOfType:GridiconTypeExternal withSize:CGSizeMake(BLogDetailGridiconAccessorySize, BLogDetailGridiconAccessorySize)] imageFlippedForRightToLeftLayoutDirection];
-    UIImageView *accessoryView = [[UIImageView alloc] initWithImage:image];
-    accessoryView.tintColor = [WPStyleGuide cellGridiconAccessoryColor]; // Match disclosure icon color.
-    row.accessoryView = accessoryView;
-    row.showsSelectionState = NO;
-    [rows addObject:row];
 
     if ([self.blog supports:BlogFeaturePlans]) {
         BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Plans", @"Action title. Noun. Links to a blog's Plans screen.")
@@ -513,6 +485,60 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     return [[BlogDetailsSection alloc] initWithTitle:title andRows:rows];
 }
 
+- (BlogDetailsSection *)externalSectionViewModel
+{
+    __weak __typeof(self) weakSelf = self;
+    NSMutableArray *rows = [NSMutableArray array];
+    BlogDetailsRow *viewSiteRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"View Site", @"Action title. Opens the user's site in an in-app browser")
+                                                                  image:[Gridicon iconOfType:GridiconTypeHouse]
+                                                               callback:^{
+                                                                   [weakSelf showViewSite];
+                                                               }];
+    viewSiteRow.showsSelectionState = NO;
+    [rows addObject:viewSiteRow];
+
+    if ([self shouldDisplayLinkToWPAdmin]) {
+        BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:[self adminRowTitle]
+                                                              image:[Gridicon iconOfType:GridiconTypeMySites]
+                                                           callback:^{
+                                                               [weakSelf showViewAdmin];
+                                                               [weakSelf.tableView deselectSelectedRowWithAnimation:YES];
+                                                           }];
+        UIImage *image = [[Gridicon iconOfType:GridiconTypeExternal withSize:CGSizeMake(BLogDetailGridiconAccessorySize, BLogDetailGridiconAccessorySize)] imageFlippedForRightToLeftLayoutDirection];
+        UIImageView *accessoryView = [[UIImageView alloc] initWithImage:image];
+        accessoryView.tintColor = [WPStyleGuide cellGridiconAccessoryColor]; // Match disclosure icon color.
+        row.accessoryView = accessoryView;
+        row.showsSelectionState = NO;
+        [rows addObject:row];
+    }
+
+    NSString *title = NSLocalizedString(@"External", @"Section title for the external table section in the blog details screen");
+    return [[BlogDetailsSection alloc] initWithTitle:title andRows:rows];
+}
+
+- (NSString *)adminRowTitle
+{
+    if (self.blog.isHostedAtWPcom) {
+        return NSLocalizedString(@"Dashboard", @"Action title. Noun. Opens the user's WordPress.com dashboard in an external browser.");
+    } else {
+        return NSLocalizedString(@"WP Admin", @"Action title. Noun. Opens the user's WordPress Admin in an external browser.");
+    }
+}
+
+// Non .com users and .com user whose accounts were created
+// before LastWPAdminAccessDate should have access to WPAdmin
+- (BOOL)shouldDisplayLinkToWPAdmin
+{
+    if (!self.blog.isHostedAtWPcom) {
+        return YES;
+    } else {
+        NSDate *hideWPAdminDate = [NSDate dateWithISO8601String:HideWPAdminDate];
+        NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+        AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+        WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
+        return [defaultAccount.dateCreated compare:hideWPAdminDate] == NSOrderedAscending;
+    }
+}
 
 #pragma mark - Configuration
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -531,13 +531,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     if (!self.blog.isHostedAtWPcom) {
         return YES;
-    } else {
-        NSDate *hideWPAdminDate = [NSDate dateWithISO8601String:HideWPAdminDate];
-        NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
-        WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-        return [defaultAccount.dateCreated compare:hideWPAdminDate] == NSOrderedAscending;
     }
+    NSDate *hideWPAdminDate = [NSDate dateWithISO8601String:HideWPAdminDate];
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
+    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
+    return [defaultAccount.dateCreated compare:hideWPAdminDate] == NSOrderedAscending;
 }
 
 #pragma mark - Configuration


### PR DESCRIPTION
On Site settings the _View Site_ and _Dashboard_ options are moved to a new section called _External_ at the bottom of the settings. 
_Dashboard_ access is hidden for WPCom users that created their account after September 7th, 2015

**Fixes** #6832 

 Before        | Dashboard Disabled           | Dashboard Enabled
------------ | -------------|------------ |
 ![before](https://cloud.githubusercontent.com/assets/5558824/24114167/00f33184-0d7e-11e7-8eff-2e75f476d0ed.png)    | ![disabled](https://cloud.githubusercontent.com/assets/5558824/24114169/0123909a-0d7e-11e7-8ff1-5bf1276f40cb.png) | ![enabled](https://cloud.githubusercontent.com/assets/5558824/24114170/012b32c8-0d7e-11e7-9e1f-10f7cc95af80.png) |

**To test:**

With a WPCom account created before September 7th, 2015 check that View Site and Dashboard are at the bottom of the settings.
With a WPCom account created after September 7th, 2015 check that ONLY View Site is at the bottom of the settings.
With a non WPCom account check that View Site and Dashboard are at the bottom of the settings.



Needs review: @koke 