### PR TITLE
Fix comment edit button

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -427,6 +427,10 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     cell.onSpamClick = ^(UIButton *sender){
         [weakSelf spamComment];
     };
+
+    cell.onEditClick = ^(UIButton *sender) {
+        [weakSelf editComment];
+    };
 }
 
 


### PR DESCRIPTION
Fixes #6470 

To test:

1. Navigate to My Sites > Site > Comments > Comment
2. Tap the edit button next to Spam
3. The comment editor should appear

Needs review: @jleandroperez 
