### PR TITLE
Adds missing accessibility labels to reply to comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -208,6 +208,9 @@ class NotificationDetailsViewController: UIViewController {
 
         previousNavigationButton.isEnabled = shouldEnablePreviousButton
         nextNavigationButton.isEnabled = shouldEnableNextButton
+
+        previousNavigationButton.accessibilityLabel = NSLocalizedString("Previous notification", comment: "Accessibility label for the previous notification button")
+        nextNavigationButton.accessibilityLabel = NSLocalizedString("Next notification", comment: "Accessibility label for the next notification button")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -47,6 +47,7 @@ import WordPressShared.WPStyleGuide
     open var placeholder: String! {
         set {
             placeholderLabel.text = newValue ?? String()
+            textView.accessibilityLabel = placeholderLabel.text
         }
         get {
             return placeholderLabel.text
@@ -240,6 +241,7 @@ import WordPressShared.WPStyleGuide
         replyButton.titleLabel?.font = WPStyleGuide.Reply.buttonFont
         replyButton.setTitleColor(WPStyleGuide.Reply.disabledColor, for: .disabled)
         replyButton.setTitleColor(WPStyleGuide.Reply.enabledColor, for: UIControlState())
+        replyButton.accessibilityLabel = NSLocalizedString("Reply", comment: "Accessibility label for the reply button")
 
         // Background
         contentView.backgroundColor = WPStyleGuide.Reply.backgroundColor


### PR DESCRIPTION
**Fixes** #6894 

**To test:**

1. Turn on Voice Over or lunch the Accessibility Inspector
2. Navigate to a comment notification and check that all the elements on the screen have accessibility labels (back button, previous and next notification button, reply text field, reply button)

Needs review: @jleandroperez 
