### PR TITLE
Allows sharing to WhatsApp and Telegraph from the reader

### DIFF
--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -355,6 +355,18 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
         return NO;
     }
     
+    // To handle WhatsApp and Telegraph shares
+    // Even though the documentation says that canOpenURL will only return YES for
+    // URLs configured on the plist under LSApplicationQueriesSchemes if we don't filter
+    // out http requests it also returns YES for those
+    if (![request.URL.scheme hasPrefix:@"http"]
+        && [[UIApplication sharedApplication] canOpenURL:request.URL]) {
+        [[UIApplication sharedApplication] openURL:request.URL
+                                           options:nil
+                                 completionHandler:nil];
+        return NO;
+    }
+
     //  Note:
     //  UIWebView callbacks will get hit for every frame that gets loaded. As a workaround, we'll consider
     //  we're in a "loading" state just for the Top Level request.

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -56,6 +56,8 @@
 	<array>
 		<string>org-appextension-feature-password-management</string>
 		<string>twitter</string>
+		<string>whatsapp</string>
+		<string>tg</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
**Fixes** #6820 

**To test:**
1. Choose an article from the reader that has sharing enabled.
2. Click on Visit for that article.
3. Scroll down to the share options.
4. Select WhatsApp and check that the application opens with the correct pre-populated message.
5. Select Telegraph and check that the application opens with the correct pre-populated message.


Needs review: @jleandroperez 