### PR TITLE
Only look for an image to feature on the post content

### DIFF
--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -671,8 +671,6 @@ static const NSUInteger ReaderPostTitleLength = 30;
  */
 - (NSString *)featuredImageFromPostDictionary:(NSDictionary *)dict
 {
-    NSDictionary *featured_media = [dict dictionaryForKey:PostRESTKeyFeaturedMedia];
-
     // Editorial trumps all
     NSString *featuredImage = [dict stringForKeyPath:@"editorial.image"];
 
@@ -681,25 +679,8 @@ static const NSUInteger ReaderPostTitleLength = 30;
         featuredImage = [dict stringForKey:PostRESTKeyFeaturedImage];
     }
 
-    // Get the post content.
+    // If there's no featured image look for a suitable one in the post content
     NSString *content = [dict stringForKey:PostRESTKeyContent];
-
-    // If no featured image specified, try featured media.
-    if (([featuredImage length] == 0) && ([[featured_media stringForKey:@"type"] isEqualToString:@"image"])) {
-        NSString *imageToDisplay = [self stringOrEmptyString:[featured_media stringForKey:@"uri"]];
-        if (imageToDisplay && [content containsString:imageToDisplay]) {
-            featuredImage = imageToDisplay;
-        }
-    }
-
-    // If still no image specified, try attachments.
-    if ([featuredImage length] == 0) {
-        NSDictionary *attachments = [dict dictionaryForKey:PostRESTKeyAttachments];
-        NSString *imageToDisplay = [DisplayableImageHelper searchPostAttachmentsForImageToDisplay:attachments existingInContent:content];
-        featuredImage = [self stringOrEmptyString:imageToDisplay];
-    }
-
-    // If stilll no match, parse content
     if ([featuredImage length] == 0) {
         NSString *imageToDisplay = [DisplayableImageHelper searchPostContentForImageToDisplay:content];
         featuredImage = [self stringOrEmptyString:imageToDisplay];

--- a/WordPress/Classes/Utility/DisplayableImageHelper.m
+++ b/WordPress/Classes/Utility/DisplayableImageHelper.m
@@ -81,7 +81,6 @@ static NSString * const AttachmentsDictionaryKeyMimeType = @"mime_type";
     // Find all the image tags in the content passed.
     NSArray *matches = [regex matchesInString:content options:0 range:NSMakeRange(0, [content length])];
 
-    NSInteger currentMaxWidth = FeaturedImageMinimumWidth;
     for (NSTextCheckingResult *match in matches) {
         NSString *tag = [content substringWithRange:match.range];
         NSString *src = [self extractSrcFromImgTag:tag];
@@ -100,9 +99,9 @@ static NSString * const AttachmentsDictionaryKeyMimeType = @"mime_type";
 
         // Check the tag for a good width
         NSInteger width = MAX([self widthFromElementAttribute:tag], [self widthFromQueryString:src]);
-        if (width > currentMaxWidth) {
+        if (width > FeaturedImageMinimumWidth) {
             imageSrc = src;
-            currentMaxWidth = width;
+            break;
         }
     }
 

--- a/WordPress/Classes/Utility/DisplayableImageHelper.m
+++ b/WordPress/Classes/Utility/DisplayableImageHelper.m
@@ -81,7 +81,6 @@ static NSString * const AttachmentsDictionaryKeyMimeType = @"mime_type";
     // Find all the image tags in the content passed.
     NSArray *matches = [regex matchesInString:content options:0 range:NSMakeRange(0, [content length])];
 
-    NSString *firstImageWithNoSize;
     NSInteger currentMaxWidth = FeaturedImageMinimumWidth;
     for (NSTextCheckingResult *match in matches) {
         NSString *tag = [content substringWithRange:match.range];
@@ -104,13 +103,7 @@ static NSString * const AttachmentsDictionaryKeyMimeType = @"mime_type";
         if (width > currentMaxWidth) {
             imageSrc = src;
             currentMaxWidth = width;
-        } else if (!firstImageWithNoSize && width == 0) {
-            firstImageWithNoSize = src;
         }
-    }
-
-    if ([imageSrc length] == 0 && firstImageWithNoSize) {
-        imageSrc = firstImageWithNoSize;
     }
 
     return imageSrc;

--- a/WordPress/WordPressTest/DisplayableImageHelperTest.m
+++ b/WordPress/WordPressTest/DisplayableImageHelperTest.m
@@ -92,10 +92,14 @@ static NSString * const PathForAttachmentD = @"http://www.example.com/exampleD.p
 
 - (void)testSearchPostContentForImageToDisplay
 {
-    NSString *imageSrc= [DisplayableImageHelper searchPostContentForImageToDisplay:@"Img200 <img width=\"100\" src=\"http://photo.com/200.jpg\" /> Img300<img width=\"300\" src=\"http://photo.com/300.jpg\" /> Img100<img width=\"100\" src=\"http://photo.com/100.jpg\" />"];
-
+    NSString *imageSrc= [DisplayableImageHelper searchPostContentForImageToDisplay:@"Img200 <img width=\"200\" src=\"http://photo.com/200.jpg\" /> Img300<img width=\"300\" src=\"http://photo.com/300.jpg\" /> Img100<img width=\"100\" src=\"http://photo.com/100.jpg\" />"];
     XCTAssertTrue([imageSrc isEqualToString:@"http://photo.com/300.jpg"], @"It should find the 300.jpg");
-}
 
+    imageSrc= [DisplayableImageHelper searchPostContentForImageToDisplay:@"Img200 <img width=\"200\" src=\"http://photo.com/200.jpg\" /> Img300<img src=\"http://photo.com/300.jpg\" /> Img100<img width=\"100\" src=\"http://photo.com/100.jpg\" />"];
+    XCTAssertTrue([imageSrc isEqualToString:@"http://photo.com/200.jpg"], @"It should find the 200.jpg");
+
+    imageSrc= [DisplayableImageHelper searchPostContentForImageToDisplay:@"Img200 <img src=\"http://photo.com/200.jpg\" /> Img300<img src=\"http://photo.com/300.jpg\" /> Img100<img src=\"http://photo.com/100.jpg\" />"];
+    XCTAssertTrue([imageSrc length] == 0, @"It shouldn't find an image since none have a width");
+}
 
 @end

--- a/WordPress/WordPressTest/DisplayableImageHelperTest.m
+++ b/WordPress/WordPressTest/DisplayableImageHelperTest.m
@@ -92,14 +92,17 @@ static NSString * const PathForAttachmentD = @"http://www.example.com/exampleD.p
 
 - (void)testSearchPostContentForImageToDisplay
 {
-    NSString *imageSrc= [DisplayableImageHelper searchPostContentForImageToDisplay:@"Img200 <img width=\"200\" src=\"http://photo.com/200.jpg\" /> Img300<img width=\"300\" src=\"http://photo.com/300.jpg\" /> Img100<img width=\"100\" src=\"http://photo.com/100.jpg\" />"];
-    XCTAssertTrue([imageSrc isEqualToString:@"http://photo.com/300.jpg"], @"It should find the 300.jpg");
-
-    imageSrc= [DisplayableImageHelper searchPostContentForImageToDisplay:@"Img200 <img width=\"200\" src=\"http://photo.com/200.jpg\" /> Img300<img src=\"http://photo.com/300.jpg\" /> Img100<img width=\"100\" src=\"http://photo.com/100.jpg\" />"];
+    NSString *imageSrc= [DisplayableImageHelper searchPostContentForImageToDisplay:@"Img100<img width=\"100\" src=\"http://photo.com/100.jpg\" /> Img200 <img width=\"200\" src=\"http://photo.com/200.jpg\" /> Img300<img width=\"300\" src=\"http://photo.com/300.jpg\" /> "];
     XCTAssertTrue([imageSrc isEqualToString:@"http://photo.com/200.jpg"], @"It should find the 200.jpg");
 
+    imageSrc= [DisplayableImageHelper searchPostContentForImageToDisplay:@"Img200 <img src=\"http://photo.com/200.jpg\" /> Img100<img width=\"100\" src=\"http://photo.com/100.jpg\" /> Img300<img width=\"300\" src=\"http://photo.com/300.jpg\" /> "];
+    XCTAssertTrue([imageSrc isEqualToString:@"http://photo.com/300.jpg"], @"It should find the 300.jpg");
+
     imageSrc= [DisplayableImageHelper searchPostContentForImageToDisplay:@"Img200 <img src=\"http://photo.com/200.jpg\" /> Img300<img src=\"http://photo.com/300.jpg\" /> Img100<img src=\"http://photo.com/100.jpg\" />"];
-    XCTAssertTrue([imageSrc length] == 0, @"It shouldn't find an image since none have a width");
+    XCTAssertTrue(imageSrc.length == 0, @"It shouldn't find an image since none have a width");
+
+    imageSrc= [DisplayableImageHelper searchPostContentForImageToDisplay:@"Img100 <img width=\"100\" src=\"http://photo.com/100.jpg\" />"];
+    XCTAssertTrue(imageSrc.length == 0, @"It shouldn't find an image since the width is too small");
 }
 
 @end

--- a/WordPress/WordPressTest/ReaderPostServiceRemoteTests.m
+++ b/WordPress/WordPressTest/ReaderPostServiceRemoteTests.m
@@ -205,7 +205,18 @@
              @"content": [NSString stringWithFormat:@"Sample text %@ sample text", uri]
              };
     imagePath = [remoteService featuredImageFromPostDictionary:dict];
-    XCTAssertTrue([uri isEqualToString:imagePath], @"Failed to retrieve the uri from attachments.");
+    XCTAssertTrue(imagePath.length == 0, @"No image should be retrieved from the attachments");
+
+    dict = @{
+             @"attachments": @{@"111": @{@"mime_type": @"image/jpg", @"width":@(2048), @"URL":uri}},
+             @"content": [NSString stringWithFormat:@"<p>Another one of those untitled posts</p>"
+                          "<p><img data-attachment-id=\"1\" data-permalink=\"%@\""
+                          "data-orig-file=\"%@\" data-orig-size=\"750,1334\""
+                          "src=\"%@\" width=\"750\" height=\"1334\"</p>",
+                          uri, uri, uri]
+             };
+    imagePath = [remoteService featuredImageFromPostDictionary:dict];
+    XCTAssertTrue([uri isEqualToString:imagePath], @"Failed to retrieve the image uri from the post content.");
 
     dict = [self editorialDictionaryWithKey:@"image" value:uri];
     imagePath = [remoteService featuredImageFromPostDictionary:dict];


### PR DESCRIPTION
**Fixes** #6714 

**To test:**
1. Before checking out this branch:
Find a post on the web reader with an image that does not match what you see on the reader in the app. A good example is: https://wordpress.com/read/feeds/3039616/posts/1219371263
2. Checkout this branch
3. Force refetch the feed (log out and back in or uninstall so even old posts are refetched?)
4. Check that the images match on the post

**Example:**

On the left you can see the reader on the browser, and on the right on the simulator.

Before this change:
![readerbefore](https://cloud.githubusercontent.com/assets/5558824/24169863/a4dde28c-0e5d-11e7-88a5-e0639db138b0.png)

After this change:
![readerafter](https://cloud.githubusercontent.com/assets/5558824/24169861/a38512d4-0e5d-11e7-9f22-44439cdffb4a.png)

That particular post has an image on the `featured_media` field and that's what caused the discrepancy.

Needs review: @aerych 