### PR TITLE
Reconnect publicize from editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -80,8 +80,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 - (void)showDetailForConnection:(PublicizeConnection *)connection
 {
     SharingDetailViewController *controller = [[SharingDetailViewController alloc] initWithBlog:self.blog
-                                                                            publicizeConnection:connection
-                                                                               publicizeService:self.publicizeService];
+                                                                            publicizeConnection:connection];
     [self.navigationController pushViewController:controller animated:YES];
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.h
@@ -1,7 +1,6 @@
 #import <UIKit/UIKit.h>
 
 @class Blog;
-@class PublicizeService;
 @class PublicizeConnection;
 
 /**
@@ -14,12 +13,10 @@
  *
  *  @param  blog        the blog from where to read the information from
  *  @param  connection  the relevant publicize connection
- *  @param  service     the relevant publicize service
  *
  *  @return New instance of SharingDetailViewController
  */
 - (instancetype)initWithBlog:(Blog *)blog
-         publicizeConnection:(PublicizeConnection *)connection
-            publicizeService:(PublicizeService *)publicizeService;
+         publicizeConnection:(PublicizeConnection *)connection;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1151,18 +1151,8 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     if (indexPath.row < self.publicizeConnections.count) {
         PublicizeConnection *connection = self.publicizeConnections[indexPath.row];
         if (connection.isBroken) {
-            NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-            SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:context];
-            PublicizeService *publicizeService = [sharingService findPublicizeServiceNamed:connection.service];
-            if (!publicizeService) {
-                return;
-            }
             SharingDetailViewController *controller = [[SharingDetailViewController alloc] initWithBlog:self.post.blog
-                                                                                    publicizeConnection:connection
-                                                                                       publicizeService:publicizeService];
-            if (!controller) {
-                return;
-            }
+                                                                                    publicizeConnection:connection];
             [self.navigationController pushViewController:controller animated:YES];
         } else {
             UISwitch *cellSwitch = (UISwitch *)cell.accessoryView;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -11,6 +11,7 @@
 #import "PostGeolocationCell.h"
 #import "PostGeolocationViewController.h"
 #import "SettingsSelectionViewController.h"
+#import "SharingDetailViewController.h"
 #import "PublishDatePickerView.h"
 #import "WPTextFieldTableViewCell.h"
 #import "WordPressAppDelegate.h"
@@ -1149,7 +1150,21 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:indexPath];
     if (indexPath.row < self.publicizeConnections.count) {
         PublicizeConnection *connection = self.publicizeConnections[indexPath.row];
-        if (!connection.isBroken) {
+        if (connection.isBroken) {
+            NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+            SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:context];
+            PublicizeService *publicizeService = [sharingService findPublicizeServiceNamed:connection.service];
+            if (!publicizeService) {
+                return;
+            }
+            SharingDetailViewController *controller = [[SharingDetailViewController alloc] initWithBlog:self.post.blog
+                                                                                    publicizeConnection:connection
+                                                                                       publicizeService:publicizeService];
+            if (!controller) {
+                return;
+            }
+            [self.navigationController pushViewController:controller animated:YES];
+        } else {
             UISwitch *cellSwitch = (UISwitch *)cell.accessoryView;
             [cellSwitch setOn:!cellSwitch.on animated:YES];
             if (cellSwitch.on) {

--- a/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
+++ b/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
@@ -4,7 +4,7 @@
 #import "WPAccount.h"
 #import "Blog.h"
 
-@interface PrivateSiteURLProtocolSession: NSObject <NSURLSessionDelegate>
+@interface PrivateSiteURLProtocolSession: NSObject <NSURLSessionDelegate, NSURLSessionTaskDelegate>
 
 + (instancetype) sharedInstance;
 - (NSURLSessionTask *)createSessionTaskForRequest:(NSURLRequest *)request forProtocol:(NSURLProtocol *)protocol;
@@ -230,6 +230,19 @@ didReceiveResponse:(NSURLResponse *)response
 
     [client URLProtocol:protocol didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageAllowed];
     completionHandler(NSURLSessionResponseAllow);
+}
+
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+willPerformHTTPRedirection:(NSHTTPURLResponse *)response
+        newRequest:(NSURLRequest *)request
+ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler
+{
+    NSURLProtocol *protocol = self.taskToProtocolMapping[task];
+    id<NSURLProtocolClient> client = protocol.client;
+
+    [client URLProtocol:protocol wasRedirectedToRequest:request redirectResponse:response];
+    completionHandler(nil);
 }
 
 @end


### PR DESCRIPTION
We already show if a connection is broken from post options. This lets the user fix the issue right there. I had to refactor things a little bit as the sharing detail expected the publicize services to be synced, so I removed that requirement. It's still not bulletproof as the sync can fail and there's no retry, but I'd leave that for the new network infrastructure.

I also had to fix this crazy hard to debug thing where the same authorization web view would work from the Sharing section but not when presented from the editor, because the editor enables PrivateSiteURLProtocol. I updated it so it forwards redirects to the client, but perhaps we should limit it to wordpress.com sites (i.e. exclude public-api).

Fixes #6837 

To test:

- Do a fresh install to ensure publicize services aren't cached
- Break one of the publicize connections on the test account (e.g. remove WordPress from https://www.facebook.com/settings?tab=applications)
- Launch the app and log in
- Create a new post
- Go to post options
- Notice the exclamation icon next to the broken account and tap on it
- The sharing details view shows
- Tap on Reconnect
- A web browser pops up to reconnect the account

Needs review: @aerych 