### PR TITLE
ReplyTextView: Fixing Flicker

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -295,8 +295,8 @@ import WordPressShared.WPStyleGuide
 
 
     // MARK: - Constants
-    fileprivate let textViewMaxHeight = CGFloat(88)   // Fits 3 lines onscreen
-    fileprivate let textViewMinHeight = CGFloat(48)
+    fileprivate let textViewMaxHeight = CGFloat(86)   // Fits 3 lines onscreen
+    fileprivate let textViewMinHeight = CGFloat(50)
 
     // MARK: - Private Properties
     fileprivate var bundle: NSArray?


### PR DESCRIPTION
### To test:
Open any spot in which the ReplyTextView is wired, and verify that the inner textView does not flicker whenever you type a new character.

Since we changed the font over to **Noto**, few constants required adjustment!

Needs review: @aerych 
Thanks in advance!
