### PR TITLE
Fix Constraint Issue with Media Item View Controller

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -310,33 +310,33 @@ open class ImageTableViewCell: WPTableViewCell {
     }
 
     private func setupImageView() {
-        addSubview(customImageView)
+        contentView.addSubview(customImageView)
         customImageView.translatesAutoresizingMaskIntoConstraints = false
         customImageView.contentMode = .scaleAspectFit
 
         NSLayoutConstraint.activate([
-            customImageView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor),
-            customImageView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor),
-            customImageView.topAnchor.constraint(equalTo: topAnchor),
-            customImageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            customImageView.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor),
+            customImageView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
+            customImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            customImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
             ])
 
         customImageView.setContentHuggingPriority(UILayoutPriorityDefaultLow, for: .horizontal)
     }
 
     private func setupLoadingViews() {
-        addSubview(activityMaskView)
+        contentView.addSubview(activityMaskView)
         activityMaskView.translatesAutoresizingMaskIntoConstraints = false
         activityMaskView.backgroundColor = .black
         activityMaskView.alpha = 0.5
 
-        addSubview(activityIndicator)
+        contentView.addSubview(activityIndicator)
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         activityIndicator.hidesWhenStopped = true
 
         NSLayoutConstraint.activate([
-            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
-            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor),
+            activityIndicator.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
 
             activityMaskView.leadingAnchor.constraint(equalTo: customImageView.leadingAnchor),
             activityMaskView.trailingAnchor.constraint(equalTo: customImageView.trailingAnchor),

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -354,6 +354,7 @@ open class ImageTableViewCell: WPTableViewCell {
             }
 
             aspectRatioConstraint = customImageView.heightAnchor.constraint(equalTo: customImageView.widthAnchor, multiplier: newValue, constant: 1.0)
+            aspectRatioConstraint?.priority = UILayoutPriorityDefaultHigh
             aspectRatioConstraint?.isActive = true
         }
         get {


### PR DESCRIPTION
Fixes an unsatisfiable constraint issue that was occurring with `MediaItemViewController`, by setting a priority on the aspect ratio constraint. I've also moved all the custom views within `ImageTableViewCell` into the `contentView`.

To test:

* Check the cell still looks and works as expected, and there are no constraint issues in the console.

Needs review: @kurzee 