### PR TITLE
Mark notifications read only when they're displayed

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -88,6 +88,7 @@ class NotificationDetailsViewController: UIViewController {
                 return
             }
 
+            markReadIfNeeded()
             refreshInterface()
         }
     }
@@ -104,7 +105,7 @@ class NotificationDetailsViewController: UIViewController {
     ///
     var onSelectedNoteChange: ((Notification) -> Void)?
 
-
+    private var isViewVisible = false
 
     deinit {
         NotificationCenter.default.removeObserver(self)
@@ -147,8 +148,15 @@ class NotificationDetailsViewController: UIViewController {
         refreshInterface()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        isViewVisible = true
+        markReadIfNeeded()
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        isViewVisible = false
         keyboardManager.stopListeningToKeyboardNotifications()
     }
 
@@ -179,6 +187,14 @@ class NotificationDetailsViewController: UIViewController {
         attachSuggestionsViewIfNeeded()
         adjustLayoutConstraintsIfNeeded()
         refreshNavigationBar()
+    }
+
+    fileprivate func markReadIfNeeded() {
+        guard isViewVisible, !note.read else {
+            return
+        }
+        let mediator = NotificationSyncMediator()
+        mediator?.markAsRead(note)
     }
 
     fileprivate func refreshNavigationBar() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -313,9 +313,6 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         }
         detailsViewController.onSelectedNoteChange = { note in
             self.selectRowForNotification(note)
-            if !note.read {
-                NotificationSyncMediator()?.markAsRead(note)
-            }
         }
     }
 }
@@ -528,12 +525,6 @@ extension NotificationsViewController {
         // Failsafe: Don't push nested!
         if navigationController?.visibleViewController != self {
             _ = navigationController?.popViewController(animated: false)
-        }
-
-        // Mark as Read
-        if note.read == false {
-            let mediator = NotificationSyncMediator()
-            mediator?.markAsRead(note)
         }
     }
 


### PR DESCRIPTION
This switches the responsibility for marking a note as read to the detail view
controller, since it'll be able to tell if it's visible or not.

Previously it was marked as read when the view was loaded, regardless of
visibility: split view would preload the first notification even on iPhone or
if the user was in different tab.

Fixes #6919 

To test:

- Make sure you have a new unread notification
- Launch the app
- The new notification should stay unread
- When you visit the notification it should be marked as read


Needs review: @jleandroperez 
