### PR TITLE
Improve scrolling performance for edit sites

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -516,15 +516,13 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
 - (BOOL)accountIsDefaultAccount
 {
     AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-    return [defaultAccount isEqual:self.account];
+    return [accountService isDefaultWordPressComAccount:self.account];
 }
 
 - (BOOL)jetpackAccountIsDefaultAccount
 {
     AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-    return [defaultAccount isEqual:self.jetpackAccount];
+    return [accountService isDefaultWordPressComAccount:self.jetpackAccount];
 }
 
 - (nullable NSNumber *)siteID

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -43,6 +43,11 @@ extern NSString *const WPAccountEmailAndDefaultBlogUpdatedNotification;
 - (void)removeDefaultWordPressComAccount;
 
 /**
+ Returns if the given account is the default WordPress.com account.
+ */
+- (BOOL)isDefaultWordPressComAccount:(WPAccount *)account;
+
+/**
  Query to check if an email address is paired to a wpcom account. Used in the 
  magic links signup flow.
 

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -127,6 +127,14 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:nil];
 }
 
+- (BOOL)isDefaultWordPressComAccount:(WPAccount *)account {
+    NSString *uuid = [[NSUserDefaults standardUserDefaults] stringForKey:DefaultDotcomAccountUUIDDefaultsKey];
+    if (uuid.length == 0) {
+        return false;
+    }
+    return [account.uuid isEqualToString:uuid];
+}
+
 - (void)isEmailAvailable:(NSString *)email success:(void (^)(BOOL available))success failure:(void (^)(NSError *error))failure
 {
     id<AccountServiceRemote> remote = [self remoteForAnonymous];

--- a/WordPress/Classes/ViewRelated/Blog/BlogListDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListDataSource.swift
@@ -105,6 +105,7 @@ class BlogListDataSource: NSObject {
     var account: WPAccount? = nil {
         didSet {
             if account != oldValue {
+                cachedSections = nil
                 dataChanged?()
             }
         }
@@ -168,10 +169,13 @@ class BlogListDataSource: NSObject {
     fileprivate var mode: Mode = .browsing {
         didSet {
             if mode != oldValue {
+                cachedSections = nil
                 dataChanged?()
             }
         }
     }
+
+    fileprivate var cachedSections: [[Blog]]?
 }
 
 // MARK: - Mode
@@ -234,7 +238,12 @@ private extension BlogListDataSource {
 
 private extension BlogListDataSource {
     var sections: [[Blog]] {
-        return mode.mapper.map(allBlogs)
+        if let sections = cachedSections {
+            return sections
+        }
+        let mappedSections = mode.mapper.map(allBlogs)
+        cachedSections = mappedSections
+        return mappedSections
     }
 
     var allBlogs: [Blog] {
@@ -252,6 +261,7 @@ private extension BlogListDataSource {
 
 extension BlogListDataSource: NSFetchedResultsControllerDelegate {
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        cachedSections = nil
         // TODO: only propagate if the filtered data changed
         dataChanged?()
     }


### PR DESCRIPTION
Instead of fetching the default account every time we check for visibility
support, we just need to check if the account's uuid matches the stored one.

We could optimize further, but I think the core data fetch was the big
bottleneck and I'm seeing a similar scrolling performance than the non-edit
list with this.

Fixes #6920 

Needs review: @jleandroperez 
