### PR TITLE
NotificationActionsService: Wiring force sync for Spam and Delete OP's

### DIFF
--- a/WordPress/Classes/Services/NotificationActionsService.swift
+++ b/WordPress/Classes/Services/NotificationActionsService.swift
@@ -232,6 +232,7 @@ open class NotificationActionsService: LocalCoreDataService {
 
         commentService.spamComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully spammed comment \(siteID).\(commentID)")
+            self.invalidateCacheAndForceSyncNotification(with: block)
             completion?(true)
 
         }, failure: { error in
@@ -254,6 +255,7 @@ open class NotificationActionsService: LocalCoreDataService {
 
         commentService.deleteComment(withID: commentID, siteID: siteID, success: {
             DDLogSwift.logInfo("Successfully deleted comment \(siteID).\(commentID)")
+            self.invalidateCacheAndForceSyncNotification(with: block)
             completion?(true)
 
         }, failure: { error in


### PR DESCRIPTION
### To test:
1. Receive a Comment Notification
2. Try Spam / Delete OP's
3. Relaunch WPiOS
4. Verify the Nuked Comment Notification doesn't turn zombie!

Needs review: @koke 
Thanks in advance!
