### PR TITLE
CommentViewController: Nukes Duplicated Edit Action

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -137,16 +137,6 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     [self.view addSubview:self.replyTextView];
 }
 
-- (void)attachEditActionButton
-{
-    UIBarButtonItem *editBarButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Edit", @"Verb, start editing")
-                                                                      style:UIBarButtonItemStylePlain
-                                                                     target:self
-                                                                     action:@selector(editComment)];
-    
-    self.navigationItem.rightBarButtonItem = editBarButton;
-}
-
 - (void)setupAutolayoutConstraints
 {
     NSMutableDictionary *views = [@{@"tableView": self.tableView} mutableCopy];
@@ -209,7 +199,6 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 {
     [super viewDidLoad];
 
-    [self attachEditActionButton];
     [self fetchPostIfNecessary];
     [self reloadData];
 }


### PR DESCRIPTION
### Details:
In this PR we're removing the Comment Detail's Navbar Edit action, since it's duplicated. We can also trigger the Comment Edition screen by means of the `Edit` button, visible at the bottom of the comment.

### To test:
1. Lauch WPiOS
2. Open `My Sites` > `Site` > `Comment`
3. Pick up any Site's comments

Verify that the navbar's Top Right **Edit** action is gone. We still should have the **Edit** Action visible at the bottom of the comment

Needs review: @kurzee 
Sir, may i bug you with a small PR?

Thanks!!!

P.s.: @drw158 thanks for reporting this one!