### PR TITLE
Issue/6757 ReaderPostCardCell crash fix

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -454,13 +454,11 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
             return
         }
 
-        let likeCount = provider.likeCount().intValue
-        let commentCount = provider.commentCount().intValue
+        let likeCount = provider.likeCount()?.intValue ?? 0
+        let commentCount = provider.commentCount()?.intValue ?? 0
 
         if superview?.frame.width < 480 {
             // remove title text
-            let likeTitle = likeCount > 0 ?  provider.likeCount().stringValue : ""
-            let commentTitle = commentCount > 0 ? provider.commentCount().stringValue : ""
             likeActionButton.setTitle(likeTitle, for: UIControlState())
             commentActionButton.setTitle(commentTitle, for: UIControlState())
             shareButton.setTitle("", for: UIControlState())

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -459,10 +459,12 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
 
         if superview?.frame.width < 480 {
             // remove title text
-            likeActionButton.setTitle(likeTitle, for: UIControlState())
-            commentActionButton.setTitle(commentTitle, for: UIControlState())
-            shareButton.setTitle("", for: UIControlState())
-            followButton.setTitle("", for: UIControlState())
+            let likeTitle = likeCount > 0 ?  String(likeCount) : ""
+            let commentTitle = commentCount > 0 ? String(commentCount) : ""
+            likeActionButton.setTitle(likeTitle, for: .normal)
+            commentActionButton.setTitle(commentTitle, for: .normal)
+            shareButton.setTitle("", for: .normal)
+            followButton.setTitle("", for: .normal)
             followButton.setTitle("", for: .selected)
             followButton.setTitle("", for: .highlighted)
 
@@ -476,11 +478,11 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
             let followTitle = WPStyleGuide.followStringForDisplay(false)
             let followingTitle = WPStyleGuide.followStringForDisplay(true)
 
-            likeActionButton.setTitle(likeTitle, for: UIControlState())
-            commentActionButton.setTitle(commentTitle, for: UIControlState())
-            shareButton.setTitle(shareTitle, for: UIControlState())
+            likeActionButton.setTitle(likeTitle, for: .normal)
+            commentActionButton.setTitle(commentTitle, for: .normal)
+            shareButton.setTitle(shareTitle, for: .normal)
 
-            followButton.setTitle(followTitle, for: UIControlState())
+            followButton.setTitle(followTitle, for: .normal)
             followButton.setTitle(followingTitle, for: .selected)
             followButton.setTitle(followingTitle, for: .highlighted)
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1321,6 +1321,11 @@ import WordPressComAnalytics
             return
         }
 
+        // To help avoid potential crash: https://github.com/wordpress-mobile/WordPress-iOS/issues/6757
+        guard !post.isDeleted else {
+            return
+        }
+
         let postCell = cell as! ReaderPostCardCell
 
         postCell.delegate = self


### PR DESCRIPTION
It looks like our old friend #6757 (ReaderPostCardCell crash) is still around in our latest releases. Whilst we don't seem to have got to the bottom of the root cause yet, I'm hoping this PR might at least prevent the app from crashing. However, I haven't been able to recreate the crash itself so it's all a bit of guesswork – I'm just ensuring that the post hasn't been deleted, and treating the like and comment counts as optionals in case for some reason they don't exist.

Needs review: @aerych

@astralbodies This is our current top crasher – is it okay for this fix to be targetted at 7.3?