### PR TITLE
Aztec: Adds all editor analytics tracking events to Aztec VC

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -733,10 +733,10 @@ extension AztecPostViewController {
         }
 
         if stat == .editorPublishedPost {
-            properties[WPAnalyticsStatEditorPublishedPostPropertyCategory] = post.hasCategories
-            properties[WPAnalyticsStatEditorPublishedPostPropertyPhoto] = post.hasPhoto
-            properties[WPAnalyticsStatEditorPublishedPostPropertyTag] = post.hasTags
-            properties[WPAnalyticsStatEditorPublishedPostPropertyVideo] = post.hasVideo
+            properties[WPAnalyticsStatEditorPublishedPostPropertyCategory] = post.hasCategories()
+            properties[WPAnalyticsStatEditorPublishedPostPropertyPhoto] = post.hasPhoto()
+            properties[WPAnalyticsStatEditorPublishedPostPropertyTag] = post.hasTags()
+            properties[WPAnalyticsStatEditorPublishedPostPropertyVideo] = post.hasVideo()
         }
 
         WPAppAnalytics.track(stat, withProperties: properties, with: post.blog)

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -683,6 +683,8 @@ extension AztecPostViewController {
                 self.post = uploadedPost
 
                 generator.notificationOccurred(.success)
+
+                // TODO: Analytics for saving WPAnalyticsStatEditorSavedDraft, WPAnalyticsStatEditorQuickSavedDraft, etc
             }
 
             if dismissWhenDone {
@@ -1345,6 +1347,8 @@ fileprivate extension AztecPostViewController {
             return
         }
 
+        // TODO: Track WPAnalyticsStatEditorDiscardedChanges
+
         post = originalPost
         post.deleteRevision()
 
@@ -1364,6 +1368,8 @@ fileprivate extension AztecPostViewController {
 
     func dismissOrPopView(didSave: Bool) {
         stopEditing()
+
+        // TODO: Track WPAnalyticsStatEditorClosed
 
         if let onClose = onClose {
             onClose(didSave)
@@ -1488,6 +1494,8 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
                 }
                 return
             }
+
+            // TODO: Analytics WPAnalyticsStatEditorAddedPhotoViaLocalLibrary, WPAnalyticsStatEditorAddedVideoViaLocalLibrary
             strongSelf.upload(media: media, mediaID: attachment.identifier)
         })
     }
@@ -1497,6 +1505,7 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
             guard let remoteURLStr = media.remoteURL, let remoteURL = URL(string: remoteURLStr) else {
                 return
             }
+            // TODO: Track analytics WPAnalyticsStatEditorAddedPhotoViaWPMediaLibrary WPAnalyticsStatEditorAddedVideoViaWPMediaLibrary
             let _ = richTextView.insertImage(sourceURL: remoteURL, atPosition: self.richTextView.selectedRange.location, placeHolderImage: Assets.defaultMissingImage)
             self.mediaProgressCoordinator.finishOneItem()
         } else {
@@ -1507,6 +1516,7 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
             }
             let attachment = self.richTextView.insertImage(sourceURL:tempMediaURL, atPosition: self.richTextView.selectedRange.location, placeHolderImage: Assets.defaultMissingImage)
 
+            // TODO: Track analytics WPAnalyticsStatEditorAddedPhotoViaLocalLibrary WPAnalyticsStatEditorAddedVideoViaLocalLibrary
             upload(media: media, mediaID: attachment.identifier)
         }
     }
@@ -1531,6 +1541,8 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
                 }
                 return
             }
+
+            // TODO Analytics track WPAnalyticsStatEditorAddedPhotoViaLocalLibrary
             strongSelf.upload(media: media, mediaID: attachment.identifier)
         })
     }
@@ -1552,6 +1564,8 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
                 guard let strongSelf = self else {
                     return
                 }
+
+                // TODO: Track analytics WPAnalyticsStatEditorUploadMediaFailed
                 DispatchQueue.main.async {
                     strongSelf.handleError(error as NSError, onAttachment: attachment)
                 }
@@ -1624,6 +1638,7 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
                                                     //retry upload
                                                     if let media = self.mediaProgressCoordinator.object(forMediaID: mediaID) as? Media,
                                                         let attachment = self.richTextView.attachment(withId: mediaID) {
+                                                        // TODO Track Analytics WPAnalyticsStatEditorUploadMediaRetried
                                                         attachment.clearAllOverlays()
                                                         attachment.progress = 0
                                                         self.richTextView.refreshLayoutFor(attachment: attachment)
@@ -1650,7 +1665,7 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
     }
 
     func displayDetails(forAttachment attachment: TextAttachment) {
-
+        // TODO Analytics track WPAnalyticsStatEditorEditedImage
         let controller = AztecAttachmentViewController()
         controller.delegate = self
         controller.attachment = attachment

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressComAnalytics
 
 /// The various states of the editor interface and all associated UI values
 ///
@@ -83,6 +84,32 @@ public enum PostEditorAction {
         }
     }
 
+    fileprivate var publishActionAnalyticsStat: WPAnalyticsStat {
+        switch self {
+        case .save:
+            return .editorSavedDraft
+        case .schedule:
+            return .editorScheduledPost
+        case .publish:
+            return .editorPublishedPost
+        case .update:
+            return .editorUpdatedPost
+        case .submitForReview:
+            // TODO: When support is added for submit for review, add a new stat to support it
+            return .editorPublishedPost
+        }
+    }
+
+    fileprivate var secondaryPublishActionAnalyticsStat: WPAnalyticsStat? {
+        switch self {
+        case .save:
+            return .editorQuickSavedDraft
+        case .publish:
+            return .editorQuickPublishedPost
+        default:
+            return nil
+        }
+    }
 }
 
 /// Protocol used by all concrete states for the UI - never exposed outside of `PostEditorStateContext`
@@ -250,6 +277,11 @@ public class PostEditorStateContext {
         return editorState.action.publishingErrorLabel
     }
 
+    /// Returns the WPAnalyticsStat enum to be tracked when this post is published
+    var publishActionAnalyticsStat: WPAnalyticsStat {
+        return editorState.action.publishActionAnalyticsStat
+    }
+
     /// Should post-post be shown for the current editor when publishing has happened
     ///
     var isPostPostShown: Bool {
@@ -290,6 +322,16 @@ public class PostEditorStateContext {
 
         return editorState.action.secondaryPublishAction?.secondaryPublishActionLabel
     }
+
+    /// Returns the WPAnalyticsStat enum to be tracked when this post is published with the secondary action
+    var secondaryPublishActionAnalyticsStat: WPAnalyticsStat? {
+        guard isSecondaryPublishButtonShown else {
+            return nil
+        }
+
+        return editorState.action.secondaryPublishAction?.secondaryPublishActionAnalyticsStat
+    }
+
 
     /// Indicates whether the Publish Action should be allowed, or not
     ///


### PR DESCRIPTION
Fixes #6549 

Testing this PR could be a bit of a challenge. I ended up going through the existing editor VC and finding all of the methods that had events and added them into similar places in Aztec. You could perform checks on each event making its way into Tracks & Mixpanel.

Needs review: @bummytime, @nheagy 
