### PR TITLE
Notification Details: Fix potential crash on viewWillDisappear

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -62,7 +62,7 @@ class NotificationDetailsViewController: UIViewController {
 
     /// Keyboard Manager: Aids in the Interactive Dismiss Gesture
     ///
-    fileprivate var keyboardManager: KeyboardDismissHelper? = nil
+    fileprivate var keyboardManager: KeyboardDismissHelper?
 
     /// Cached values used for returning the estimated row heights of autosizing cells.
     ///

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -62,7 +62,7 @@ class NotificationDetailsViewController: UIViewController {
 
     /// Keyboard Manager: Aids in the Interactive Dismiss Gesture
     ///
-    fileprivate var keyboardManager: KeyboardDismissHelper!
+    fileprivate var keyboardManager: KeyboardDismissHelper? = nil
 
     /// Cached values used for returning the estimated row heights of autosizing cells.
     ///
@@ -143,7 +143,7 @@ class NotificationDetailsViewController: UIViewController {
         super.viewWillAppear(animated)
 
         tableView.deselectSelectedRowWithAnimation(true)
-        keyboardManager.startListeningToKeyboardNotifications()
+        keyboardManager?.startListeningToKeyboardNotifications()
 
         refreshInterface()
     }
@@ -156,8 +156,10 @@ class NotificationDetailsViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+
         isViewVisible = false
-        keyboardManager.stopListeningToKeyboardNotifications()
+
+        keyboardManager?.stopListeningToKeyboardNotifications()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -1222,15 +1224,15 @@ extension NotificationDetailsViewController: ReplyTextViewDelegate {
 //
 extension NotificationDetailsViewController: UIScrollViewDelegate {
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-        keyboardManager.scrollViewWillBeginDragging(scrollView)
+        keyboardManager?.scrollViewWillBeginDragging(scrollView)
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        keyboardManager.scrollViewDidScroll(scrollView)
+        keyboardManager?.scrollViewDidScroll(scrollView)
     }
 
     func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-        keyboardManager.scrollViewWillEndDragging(scrollView, withVelocity: velocity)
+        keyboardManager?.scrollViewWillEndDragging(scrollView, withVelocity: velocity)
     }
 }
 


### PR DESCRIPTION
Fixes #6948. 

One of our current top crashes for 7.2 is happening on `keyboardManager.stopListeningToKeyboardNotifications()` in `viewWillDisappear` of `NotificationDetailsViewController`. `keyboardManager` was an implicitly-unwrapped optional, so there is a possibility it could be nil (which I'm presuming is the cause of the crash).

I've switched `keyboardManager` to a real optional, and we'll fail silently if it doesn't exist at that point. There _might_ be a deeper issue going on here, but at least this should stop us crashing.

To test:

* Ensure the keyboard handling still works as expected.
* You could try nilling out the `keyboardManager` and ensure we don't crash.

Needs review: @jleandroperez 
