### PR TITLE
Jetpack Login: Don't force unwrap username and password

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
@@ -441,8 +441,8 @@ class JetpackLoginViewController: UIViewController {
         WPAppAnalytics.track(.selectedInstallJetpack)
         let targetURL = blog.adminUrl(withPath: jetpackInstallRelativePath)
         displayWebView(url: targetURL,
-                            username: blog.usernameForSite!,
-                            password: blog.password!,
+                            username: blog.usernameForSite,
+                            password: blog.password,
                             wpLoginURL: URL(string: blog.loginUrl()))
     }
 


### PR DESCRIPTION
Fixes #6950 

This should fix a crash on the Jetpack login screen, which appears to be due to force unwrapping a blog's username and password. I've simply removed the force unwraps, as `displayWebView` can take optional usernames and passwords anyway.

To test:

* Slightly tricky testing this one, but you could try modifying the `password` getter in `Blog` to return nil, and check nothing crashes with this fix in place.

Needs review: @bummytime 