### PR TITLE
Xcode: remove leftover NSIndexPath extension reference

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -6371,7 +6371,6 @@
 				85E105861731A597001071A3 /* WPWalkthroughOverlayView.m in Sources */,
 				85B125461B0294F6008A3D95 /* UIAlertControllerProxy.m in Sources */,
 				0857C27A1CE5375F0014AE99 /* MenuItemView.m in Sources */,
-				B587797B19B799D800E57C5A /* NSIndexPath+Swift.swift in Sources */,
 				FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */,
 				B5BE31C41CB825A100BDF770 /* NSURLCache+Helpers.swift in Sources */,
 				85AD6AEC173CCF9E002CB896 /* WPNUXPrimaryButton.m in Sources */,


### PR DESCRIPTION
Looks like this was leftover from https://github.com/wordpress-mobile/WordPress-iOS/pull/6929, or snuck back in somewhere along the way. Running `pod install` produced this output:
```
[!] `<PBXSourcesBuildPhase UUID=`1D60588E0D05DD3D006BFB54`>` attempted to initialize an object with an unknown UUID. `B587797B19B799D800E57C5A` for attribute: `files`. This can be the result of a merge and  the unknown UUID is being discarded.
```

To test:
- Run `pod install`, but make sure there isn't any output complaining about that UUID
- Make sure the project builds

Needs review: @astralbodies 