### PR TITLE
NotificationsViewController: didSelectRow Failsafe

### DIFF
--- a/WordPress/Classes/Extensions/NSFetchedResultsController+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSFetchedResultsController+Helpers.swift
@@ -16,14 +16,10 @@ extension NSFetchedResultsController {
         return indexPath.row == sections[indexPath.section].numberOfObjects - 1
     }
 
-/*
-     Nuked for Swift 3 migration, see: https://swift.org/migration-guide/
-     Ref: "Objective-C lightweight generic classes are now imported as generic types"
-     - Brent Nov 28/16
-
-    /// Returns an object of the specified type. Nil if the indexPath is out of bounds.
+    /// Returns the NSManagedObject at the specified indexPath, if the Row + Section are still valid.
+    /// Otherwise, null will be returned.
     ///
-    func objectOfType<T : NSManagedObject>(_ type: T.Type, atIndexPath indexPath: IndexPath) -> T? {
+    func managedObject(atUnsafe indexPath: IndexPath) -> NSManagedObject? {
         guard let sections = sections else {
             return nil
         }
@@ -36,7 +32,6 @@ extension NSFetchedResultsController {
             return nil
         }
 
-        return object(at: indexPath) as? T
+        return object(at: indexPath) as? NSManagedObject
     }
-*/
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -278,7 +278,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         // Failsafe: Make sure that the Notification (still) exists
-        guard let note = tableViewHandler.resultsController.object(at: indexPath) as? Notification else {
+        guard let note = tableViewHandler.resultsController.managedObject(atUnsafe: indexPath) as? Notification else {
             tableView.deselectSelectedRowWithAnimation(true)
             return
         }


### PR DESCRIPTION
Closes #6771

### To test:
I've been unable to directly repro this bug. I'm reimplementing an old failsafe we had in that spot, that got removed after the Swift 3.0 migration.

Please, log into a dotcom account, and verify that pressing over any Notification would display it's details.

Needs review: @kurzee 
Thanks in advance Brent!!
