### PR TITLE
Issue/fix force touch shortcuts

### DIFF
--- a/WordPress/Classes/Services/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/BlogSyncFacade.m
@@ -16,7 +16,13 @@
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-    [blogService syncBlogsForAccount:account success:success failure:failure];
+    [blogService syncBlogsForAccount:account success:^{
+        WP3DTouchShortcutCreator *shortcutCreator = [WP3DTouchShortcutCreator new];
+        [shortcutCreator createShortcutsIf3DTouchAvailable:YES];
+        if (success) {
+            success();
+        }
+    }  failure:failure];
 }
 
 - (void)syncBlogWithUsername:(NSString *)username

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -436,6 +436,8 @@ int ddLogLevel = DDLogLevelInfo;
     
     // Configure Extensions
     [self setupWordPressExtensions];
+
+    [self create3DTouchShortcutItems];
     
     self.window.rootViewController = [WPTabBarController sharedInstance];
 }

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -16,6 +16,7 @@ class AztecPostViewController: UIViewController {
     ///
     var onClose: ((_ changesSaved: Bool) -> ())?
 
+    var isOpenedDirectlyForPhotoPost: Bool = false
 
     /// Aztec's Awesomeness
     ///
@@ -316,6 +317,10 @@ class AztecPostViewController: UIViewController {
         view.setNeedsUpdateConstraints()
 
         configureMediaAppearance()
+
+        if isOpenedDirectlyForPhotoPost {
+            showImagePicker(animated: false)
+        }
     }
 
 
@@ -1145,7 +1150,7 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
         insertAction.isEnabled = !urlFieldText.isEmpty
     }
 
-    func showImagePicker() {
+    func showImagePicker(animated: Bool = true) {
 
         let picker = WPNavigationMediaPickerViewController()
         picker.dataSource = mediaLibraryDataSource
@@ -1154,7 +1159,7 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
         picker.delegate = self
         picker.modalPresentationStyle = .currentContext
 
-        present(picker, animated: true, completion: nil)
+        present(picker, animated: animated, completion: nil)
     }
 
     func toggleEditingMode() {

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -129,6 +129,7 @@ class EditPostViewController: UIViewController {
 
     fileprivate func editPostInNativeVisualEditor() -> UIViewController {
         let postViewController = AztecPostViewController(post: postToEdit())
+        postViewController.isOpenedDirectlyForPhotoPost = openWithMediaPicker
         postViewController.onClose = { [weak self] (changesSaved) in
             guard let strongSelf = self else {
                 postViewController.dismiss(animated: true) {}


### PR DESCRIPTION
Fixes #6759 

To test:
 - Build the app and run
 - Switch out of the app
 - Check if force touching on the icon show the appropriate shortcuts
 - Go inside the app
 - Activate Aztec
 - Check if the new media post work shortcut works 
 - Log out  and check actions are remove
 - Log in again and see if actions are added again.


Needs review: @frosty 