### PR TITLE
Share: extract selected text from Safari

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -281,13 +281,13 @@
 		5DFA7EC71AF814E40072023B /* PageListTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DFA7EC51AF814E40072023B /* PageListTableViewCell.m */; };
 		5DFA7EC81AF814E40072023B /* PageListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5DFA7EC61AF814E40072023B /* PageListTableViewCell.xib */; };
 		7059CD210F332B6500A0660B /* WPCategoryTree.m in Sources */ = {isa = PBXBuildFile; fileRef = 7059CD200F332B6500A0660B /* WPCategoryTree.m */; };
-		742C79981E5F511C00DB1608 /* DeleteSiteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C79971E5F511C00DB1608 /* DeleteSiteViewController.swift */; };
-		746A6F571E71C691003B67E3 /* DeleteSite.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 746A6F561E71C691003B67E3 /* DeleteSite.storyboard */; };
 		740BD8351A0D4C3600F04D18 /* WPUploadStatusButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 740BD8341A0D4C3600F04D18 /* WPUploadStatusButton.m */; };
 		740CAE7C1E816FC700D0E892 /* people-delete-follower-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 740CAE7A1E816FC700D0E892 /* people-delete-follower-failure.json */; };
 		740CAE7D1E816FC700D0E892 /* people-delete-follower-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 740CAE7B1E816FC700D0E892 /* people-delete-follower-success.json */; };
+		742C79981E5F511C00DB1608 /* DeleteSiteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C79971E5F511C00DB1608 /* DeleteSiteViewController.swift */; };
 		743BF32A1E82CE0700192E40 /* people-delete-viewer-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 743BF3291E82CE0700192E40 /* people-delete-viewer-failure.json */; };
 		743BF32C1E82CEB600192E40 /* people-delete-viewer-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 743BF32B1E82CEB600192E40 /* people-delete-viewer-success.json */; };
+		746A6F571E71C691003B67E3 /* DeleteSite.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 746A6F561E71C691003B67E3 /* DeleteSite.storyboard */; };
 		7470840F1E269669002CA726 /* JetpackLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7470840D1E269669002CA726 /* JetpackLoginViewController.swift */; };
 		747084101E269669002CA726 /* JetpackLoginViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7470840E1E269669002CA726 /* JetpackLoginViewController.xib */; };
 		74BB6F1A19AE7B9400FB7829 /* WPLegacyEditPageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 74BB6F1919AE7B9400FB7829 /* WPLegacyEditPageViewController.m */; };
@@ -1473,9 +1473,9 @@
 		740BD8341A0D4C3600F04D18 /* WPUploadStatusButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUploadStatusButton.m; sourceTree = "<group>"; };
 		740CAE7A1E816FC700D0E892 /* people-delete-follower-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "people-delete-follower-failure.json"; path = "WordPressTest/people-delete-follower-failure.json"; sourceTree = SOURCE_ROOT; };
 		740CAE7B1E816FC700D0E892 /* people-delete-follower-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "people-delete-follower-success.json"; path = "WordPressTest/people-delete-follower-success.json"; sourceTree = SOURCE_ROOT; };
+		742C79971E5F511C00DB1608 /* DeleteSiteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteSiteViewController.swift; sourceTree = "<group>"; };
 		743BF3291E82CE0700192E40 /* people-delete-viewer-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "people-delete-viewer-failure.json"; path = "WordPressTest/people-delete-viewer-failure.json"; sourceTree = SOURCE_ROOT; };
 		743BF32B1E82CEB600192E40 /* people-delete-viewer-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "people-delete-viewer-success.json"; path = "WordPressTest/people-delete-viewer-success.json"; sourceTree = SOURCE_ROOT; };
-		742C79971E5F511C00DB1608 /* DeleteSiteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteSiteViewController.swift; sourceTree = "<group>"; };
 		746A6F561E71C691003B67E3 /* DeleteSite.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = DeleteSite.storyboard; sourceTree = "<group>"; };
 		7470840D1E269669002CA726 /* JetpackLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackLoginViewController.swift; sourceTree = "<group>"; };
 		7470840E1E269669002CA726 /* JetpackLoginViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = JetpackLoginViewController.xib; sourceTree = "<group>"; };
@@ -6378,7 +6378,6 @@
 				85E105861731A597001071A3 /* WPWalkthroughOverlayView.m in Sources */,
 				85B125461B0294F6008A3D95 /* UIAlertControllerProxy.m in Sources */,
 				0857C27A1CE5375F0014AE99 /* MenuItemView.m in Sources */,
-				B587797B19B799D800E57C5A /* NSIndexPath+Swift.swift in Sources */,
 				FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */,
 				B5BE31C41CB825A100BDF770 /* NSURLCache+Helpers.swift in Sources */,
 				85AD6AEC173CCF9E002CB896 /* WPNUXPrimaryButton.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -729,6 +729,7 @@
 		E1AB5A091E0BF31E00574B4E /* ArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB5A081E0BF31E00574B4E /* ArrayTests.swift */; };
 		E1AB5A3A1E0C464700574B4E /* DelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB5A391E0C464700574B4E /* DelayTests.swift */; };
 		E1AC282D18282423004D394C /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		E1AFA8C31E8E34230004A323 /* WordPressShare.js in Resources */ = {isa = PBXBuildFile; fileRef = E1AFA8C21E8E34230004A323 /* WordPressShare.js */; };
 		E1B23B081BFB3B370006559B /* MyProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B23B071BFB3B370006559B /* MyProfileViewController.swift */; };
 		E1B289DB19F7AF7000DB0707 /* RemoteBlog.m in Sources */ = {isa = PBXBuildFile; fileRef = E1B289DA19F7AF7000DB0707 /* RemoteBlog.m */; };
 		E1B62A7B13AA61A100A6FCA4 /* WPWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E1B62A7A13AA61A100A6FCA4 /* WPWebViewController.m */; };
@@ -2122,6 +2123,7 @@
 		E1AB5A081E0BF31E00574B4E /* ArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayTests.swift; sourceTree = "<group>"; };
 		E1AB5A391E0C464700574B4E /* DelayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelayTests.swift; sourceTree = "<group>"; };
 		E1AC8CB91E54B891006FD056 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		E1AFA8C21E8E34230004A323 /* WordPressShare.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = WordPressShare.js; path = WordPressShareExtension/WordPressShare.js; sourceTree = SOURCE_ROOT; };
 		E1B23B071BFB3B370006559B /* MyProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyProfileViewController.swift; sourceTree = "<group>"; };
 		E1B289D919F7AF7000DB0707 /* RemoteBlog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RemoteBlog.h; path = "Remote Objects/RemoteBlog.h"; sourceTree = "<group>"; };
 		E1B289DA19F7AF7000DB0707 /* RemoteBlog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RemoteBlog.m; path = "Remote Objects/RemoteBlog.m"; sourceTree = "<group>"; };
@@ -3715,6 +3717,7 @@
 				B50248B11C96FF8400AFBDED /* ShareViewController.swift */,
 				B50248B21C96FF8400AFBDED /* SitePickerViewController.swift */,
 				E1CE41641E8D101A000CF5A4 /* ShareExtractor.swift */,
+				E1AFA8C21E8E34230004A323 /* WordPressShare.js */,
 			);
 			name = WordPressShareExtension;
 			path = WordPressShare;
@@ -5568,6 +5571,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B5623E901C7D060100CC29EA /* Images.xcassets in Resources */,
+				E1AFA8C31E8E34230004A323 /* WordPressShare.js in Resources */,
 				931430201E68B9C50014B6C6 /* Localizable.strings in Resources */,
 				B50248C71C96FFE800AFBDED /* MainInterface.storyboard in Resources */,
 				B51DAF041C7E4F0B007F474C /* AppImages.xcassets in Resources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -749,6 +749,7 @@
 		E1C545801C6C79BB001CEB0E /* MediaSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C5457F1C6C79BB001CEB0E /* MediaSettingsTests.swift */; };
 		E1C9AA511C10419200732665 /* Math.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA501C10419200732665 /* Math.swift */; };
 		E1C9AA561C10427100732665 /* MathTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C9AA551C10427100732665 /* MathTest.swift */; };
+		E1CE41661E8D1026000CF5A4 /* ShareExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CE41641E8D101A000CF5A4 /* ShareExtractor.swift */; };
 		E1CECE021E6EC7A8009C6695 /* FakePreviewBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CECE011E6EC7A8009C6695 /* FakePreviewBuilder.swift */; };
 		E1CECE051E6F01CE009C6695 /* PostPreviewGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CECE041E6F01CE009C6695 /* PostPreviewGenerator.swift */; };
 		E1CFC1571E0AC8FF001DF9E9 /* Pattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CFC1561E0AC8FF001DF9E9 /* Pattern.swift */; };
@@ -2185,6 +2186,7 @@
 		E1C807471696F72E00E545A6 /* WordPress 9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 9.xcdatamodel"; sourceTree = "<group>"; };
 		E1C9AA501C10419200732665 /* Math.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Math.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		E1C9AA551C10427100732665 /* MathTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MathTest.swift; sourceTree = "<group>"; };
+		E1CE41641E8D101A000CF5A4 /* ShareExtractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ShareExtractor.swift; path = WordPressShareExtension/ShareExtractor.swift; sourceTree = SOURCE_ROOT; };
 		E1CECE011E6EC7A8009C6695 /* FakePreviewBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakePreviewBuilder.swift; sourceTree = "<group>"; };
 		E1CECE041E6F01CE009C6695 /* PostPreviewGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostPreviewGenerator.swift; sourceTree = "<group>"; };
 		E1CFC1561E0AC8FF001DF9E9 /* Pattern.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pattern.swift; sourceTree = "<group>"; };
@@ -3712,6 +3714,7 @@
 				B50248B01C96FF8400AFBDED /* PostStatusPickerViewController.swift */,
 				B50248B11C96FF8400AFBDED /* ShareViewController.swift */,
 				B50248B21C96FF8400AFBDED /* SitePickerViewController.swift */,
+				E1CE41641E8D101A000CF5A4 /* ShareExtractor.swift */,
 			);
 			name = WordPressShareExtension;
 			path = WordPressShare;
@@ -6590,6 +6593,7 @@
 			files = (
 				B50248B41C96FF8400AFBDED /* PostStatusPickerViewController.swift in Sources */,
 				B50248AF1C96FF6200AFBDED /* WPStyleGuide+Share.swift in Sources */,
+				E1CE41661E8D1026000CF5A4 /* ShareExtractor.swift in Sources */,
 				930F09191C7E1C1E00995926 /* ShareExtensionService.swift in Sources */,
 				B5FA868C1D10A4C400AB5F7E /* UIImage+Extensions.swift in Sources */,
 				B50248B71C96FF8400AFBDED /* UIImageView+Extensions.swift in Sources */,

--- a/WordPress/WordPressShareExtension/Info-Alpha.plist
+++ b/WordPress/WordPressShareExtension/Info-Alpha.plist
@@ -30,6 +30,8 @@
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
+			<key>NSExtensionJavaScriptPreprocessingFile</key>
+			<string>WordPressShare</string>
 			<key>NSExtensionActivationRule</key>
 			<dict>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>

--- a/WordPress/WordPressShareExtension/Info-Internal.plist
+++ b/WordPress/WordPressShareExtension/Info-Internal.plist
@@ -30,6 +30,8 @@
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
+			<key>NSExtensionJavaScriptPreprocessingFile</key>
+			<string>WordPressShare</string>
 			<key>NSExtensionActivationRule</key>
 			<dict>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>

--- a/WordPress/WordPressShareExtension/Info.plist
+++ b/WordPress/WordPressShareExtension/Info.plist
@@ -30,6 +30,8 @@
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
+			<key>NSExtensionJavaScriptPreprocessingFile</key>
+			<string>WordPressShare</string>
 			<key>NSExtensionActivationRule</key>
 			<dict>
 				<key>NSExtensionActivationDictionaryVersion</key>

--- a/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
+++ b/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
@@ -3,81 +3,16 @@ import Foundation
 /// Encapsulates NSExtensionContext Helper Methods.
 ///
 extension NSExtensionContext {
-
-    // MARK: - Public
-
-    /// Attempts to load the Website URL, and returns, asynchronously, the result.
+    /// Returns all the NSItemProvider attachments on the first NSItemProvider 
+    /// that conform to a specific type identifier
     ///
-    func loadWebsiteUrl(_ completion: @escaping ((URL?) -> Void)) {
-        loadItemOfType(URL.self, identifier: Identifier.PublicURL, completion: completion)
-    }
-
-    /// Attempts to load the Image Attachment, and returns, asynchronously, the result.
-    ///
-    func loadMediaImage(_ completion: @escaping ((UIImage?) -> Void)) {
-        loadItemOfType(AnyObject.self, identifier: Identifier.PublicImage) { payload in
-            var loadedImage: UIImage?
-
-            switch payload {
-            case let url as URL:
-                loadedImage = UIImage(contentsOfURL: url)
-            case let data as Data:
-                loadedImage = UIImage(data: data)
-            case let image as UIImage:
-                loadedImage = image
-            default:
-                break
-            }
-
-            completion(loadedImage)
-        }
-    }
-
-    /// Verifies if the Context contains an Image Attachment, or not
-    ///
-    func containsMediaAttachment() -> Bool {
-        return firstItemProviderConformingToTypeIdentifier(Identifier.PublicImage) != nil
-    }
-
-
-
-    // MARK: - Private
-
-    /// Extension Item Identifiers
-    ///
-    fileprivate enum Identifier: String {
-        case PublicURL      = "public.url"
-        case PublicImage    = "public.image"
-    }
-
-    /// Loads the First Item with the specified identifier, and returns its value asynchronously on the main thread.
-    ///
-    fileprivate func loadItemOfType<T>(_ type: T.Type, identifier: Identifier, completion: @escaping ((T?) -> Void)) {
-        guard let itemProvider = firstItemProviderConformingToTypeIdentifier(identifier) else {
-            completion(nil)
-            return
-        }
-
-        itemProvider.loadItem(forTypeIdentifier: identifier.rawValue, options: nil) { (item, error) in
-            DispatchQueue.main.async {
-                let targetItem = item as? T
-                completion(targetItem)
-            }
-        }
-    }
-
-    /// Returns the first NSItemProvider available, that matches with a given identifier.
-    ///
-    fileprivate func firstItemProviderConformingToTypeIdentifier(_ identifier: Identifier) -> NSItemProvider? {
+    func itemProviders(ofType type: String) -> [NSItemProvider] {
         guard let item = inputItems.first as? NSExtensionItem,
-            let itemProviders = item.attachments as? [NSItemProvider] else {
-            return nil
+            let providers = item.attachments as? [NSItemProvider] else {
+            return []
         }
-
-        let filteredItemProviders = itemProviders.filter { itemProvider in
-            return itemProvider.hasItemConformingToTypeIdentifier(identifier.rawValue)
+        return providers.filter { provider in
+            return provider.hasItemConformingToTypeIdentifier(type)
         }
-
-        return filteredItemProviders.first
     }
 }

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -1,0 +1,125 @@
+import Foundation
+import MobileCoreServices
+import UIKit
+
+/// A type that represents the information we can extract from an extension context
+///
+enum ExtractedShare {
+    /// Some text
+    case text(String)
+    /// An image
+    case image(UIImage)
+}
+
+/// Extracts valid information from an extension context.
+///
+struct ShareExtractor {
+    let extensionContext: NSExtensionContext
+
+    init(extensionContext: NSExtensionContext) {
+        self.extensionContext = extensionContext
+    }
+
+    /// Loads the content asynchronously.
+    ///
+    /// - Important: This method will only call completion if it can successfully extract content.
+    /// - Parameters:
+    ///   - completion: the block to be called when the extractor has obtained content.
+    ///
+    func loadShare(completion: @escaping (ExtractedShare) -> Void) {
+        guard let extractor = extractor else {
+            return
+        }
+        extractor.extract(context: extensionContext, completion: completion)
+    }
+
+    /// Determines if the extractor will be able to obtain valid content from
+    /// the extension context.
+    ///
+    /// This doesn't ensure success though. It will only check that the context
+    /// includes known types, but there might still be errors loading the content.
+    ///
+    var validContent: Bool {
+        return extractor != nil
+    }
+
+}
+
+
+// MARK: - Private
+
+private extension ShareExtractor {
+    var supportedExtractors: [ExtensionContentExtractor] {
+        return [
+            URLExtractor(),
+            ImageExtractor()
+        ]
+    }
+
+    var extractor: ExtensionContentExtractor? {
+        return supportedExtractors.first(where: { extractor in
+            extractor.canHandle(context: extensionContext)
+        })
+    }
+}
+
+private protocol ExtensionContentExtractor {
+    func canHandle(context: NSExtensionContext) -> Bool
+    func extract(context: NSExtensionContext, completion: @escaping (ExtractedShare) -> Void)
+}
+
+private protocol TypeBasedExtensionContentExtractor: ExtensionContentExtractor {
+    associatedtype Payload
+    var acceptedType: String { get }
+    func convert(payload: Payload) -> ExtractedShare?
+}
+
+private extension TypeBasedExtensionContentExtractor {
+    func canHandle(context: NSExtensionContext) -> Bool {
+        return !context.itemProviders(ofType: acceptedType).isEmpty
+    }
+
+    func extract(context: NSExtensionContext, completion: @escaping (ExtractedShare) -> Void) {
+        guard let provider = context.itemProviders(ofType: acceptedType).first else {
+            return
+        }
+        provider.loadItem(forTypeIdentifier: acceptedType, options: nil) { (payload, error) in
+            guard let payload = payload as? Payload,
+                let result = self.convert(payload: payload) else {
+                return
+            }
+            DispatchQueue.main.async {
+                completion(result)
+            }
+        }
+    }
+}
+
+private struct URLExtractor: TypeBasedExtensionContentExtractor {
+    typealias Payload = URL
+    let acceptedType = kUTTypeURL as String
+
+    func convert(payload: URL) -> ExtractedShare? {
+        return .text(payload.absoluteString)
+    }
+}
+
+private struct ImageExtractor: TypeBasedExtensionContentExtractor {
+    typealias Payload = AnyObject
+    let acceptedType = kUTTypeImage as String
+    func convert(payload: AnyObject) -> ExtractedShare? {
+        let loadedImage: UIImage?
+        switch payload {
+        case let url as URL:
+            loadedImage = UIImage(contentsOfURL: url)
+        case let data as Data:
+            loadedImage = UIImage(data: data)
+        case let image as UIImage:
+            loadedImage = image
+        default:
+            loadedImage = nil
+        }
+
+        return loadedImage.map(ExtractedShare.image)
+    }
+}

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -79,9 +79,6 @@ class ShareViewController: SLComposeServiceViewController {
 
         // Initialization
         setupBearerToken()
-
-        // Load TextView + PreviewImage
-        loadContent()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -91,6 +88,11 @@ class ShareViewController: SLComposeServiceViewController {
         dismissIfNeeded()
     }
 
+
+    override func beginRequest(with context: NSExtensionContext) {
+        super.beginRequest(with: context)
+        loadContent(extensionContext: context)
+    }
 
 
     // MARK: - SLComposeService Overriden Methods
@@ -214,10 +216,7 @@ private extension ShareViewController {
         RequestRouter.bearerToken = bearerToken
     }
 
-    func loadContent() {
-        guard let extensionContext = extensionContext else {
-            return
-        }
+    func loadContent(extensionContext: NSExtensionContext) {
         ShareExtractor(extensionContext: extensionContext)
             .loadShare { [weak self] share in
                 switch share {

--- a/WordPress/WordPressShareExtension/WordPressShare.js
+++ b/WordPress/WordPressShareExtension/WordPressShare.js
@@ -1,0 +1,34 @@
+var WordPressShare = function() {};
+
+WordPressShare.prototype = {
+    title: function() {
+        return document.title;
+    },
+
+    description: function() {
+        var description = document.getElementsByName("description")[0];
+        if (description == null) {
+            return "";
+        }
+        return description.content;
+    },
+
+    selection: function() {
+        return window.getSelection().toString();
+    },
+
+    result: function() {
+        return {
+            "title": this.title(),
+            "description": this.description(),
+            "selection": this.selection(),
+            "url": document.baseURI
+        }
+    },
+
+    run: function(arguments) {
+        arguments.completionFunction(this.result());
+    }
+};
+
+var ExtensionPreprocessingJS = new WordPressShare;


### PR DESCRIPTION
Fixes #5224, also #5198 was partly a duplicate.

I've refactored the content extraction from `NSExtensionContext` so it's easier to add new supported types: I have another PR ready with a custom data type for posts shared from the reader that was [super simple](https://github.com/wordpress-mobile/WordPress-iOS/commit/54018768bb58605b7bc6d98f6bc263d5eb0c6faa#diff-5abc91b1e16e8a80744054d07c84b507) to add.

Having models of the extracted data will also help when we get to implement a custom UI and can differentiate, for instance, between a title and a quote.

During the refactor, I also learned that `UIViewController` has a `beginRequest` method, which is where you are supposed to start looking into the extensionContext content instead of `viewDidLoad`

To test:

- Run the app
- Switch to Safari and load a web page
- Share to WordPress, it should include the title and link
- Cancel and go back to the page
- Select some text
- Share to WordPress, it should include the selected text and the link

![safari-selected-to-wp](https://cloud.githubusercontent.com/assets/8739/24554192/fdb26de8-162c-11e7-937e-b0faeba9cb73.png)


Needs review: @jleandroperez 