### PR TITLE
AccountSettings: Allow nil selected blog ID

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.h
@@ -13,7 +13,7 @@ typedef void (^BlogSelectorDismissHandler)();
                               successHandler:(BlogSelectorSuccessHandler)successHandler
                               dismissHandler:(nullable BlogSelectorDismissHandler)dismissHandler;
 
-- (instancetype)initWithSelectedBlogDotComID:(NSNumber *)dotComID
+- (instancetype)initWithSelectedBlogDotComID:(nullable NSNumber *)dotComID
                               successHandler:(BlogSelectorSuccessDotComHandler)successHandler
                               dismissHandler:(nullable BlogSelectorDismissHandler)dismissHandler;
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
@@ -45,7 +45,7 @@
     return self;
 }
 
-- (instancetype)initWithSelectedBlogDotComID:(NSNumber *)dotComID
+- (instancetype)initWithSelectedBlogDotComID:(nullable NSNumber *)dotComID
                               successHandler:(BlogSelectorSuccessDotComHandler)successHandler
                               dismissHandler:(BlogSelectorDismissHandler)dismissHandler
 {

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -141,12 +141,14 @@ private class AccountSettingsController: SettingsController {
         return {
             row in
 
-            let selectorViewController = BlogSelectorViewController(selectedBlogDotComID: settings?.primarySiteID as NSNumber!,
+            let selectorViewController = BlogSelectorViewController(selectedBlogDotComID: settings?.primarySiteID as NSNumber?,
                                                                     successHandler: { (dotComID: NSNumber?) in
-                    let change = AccountSettingsChange.primarySite((dotComID?.intValue)!)
-                    service.saveChange(change)
-                },
-                dismissHandler: nil)
+                                                                        if let dotComID = dotComID?.intValue {
+                                                                            let change = AccountSettingsChange.primarySite(dotComID)
+                                                                            service.saveChange(change)
+                                                                        }
+            },
+                                                                    dismissHandler: nil)
 
             selectorViewController.title = NSLocalizedString("Primary Site", comment: "Primary Site Picker's Title")
             selectorViewController.displaysOnlyDefaultAccountSites = true


### PR DESCRIPTION
Fixes #6956. We were getting a crash in Account Settings (see original issue) when editing the primary site. This PR just makes the optional handling around presenting and dismissing the blog selector a little more careful, by removing some force unwraps.

To test:

* Ensure you can still edit / change your primary blog correctly.
* Perhaps change the code to pass `nil` into the blog selector or to return `nil` from its success block and check that nothing breaks.

Needs review: @koke 