### PR TITLE
Issue/4379 simplify removing a self hosted site from the app

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -612,15 +612,27 @@ static NSInteger HideSearchMinSites = 3;
         removeAction.backgroundColor = [WPStyleGuide errorRed];
         [actions addObject:removeAction];
     } else {
-        UITableViewRowAction *hideAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal
-                                                                              title:NSLocalizedString(@"Hide", @"Hides a site from the site picker list")
-                                                                            handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
-                                                                                [ReachabilityUtils onAvailableInternetConnectionDo:^{
-                                                                                    [weakSelf hideBlogAtIndexPath:indexPath];
+        if (blog.visible) {
+            UITableViewRowAction *hideAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal
+                                                                                  title:NSLocalizedString(@"Hide", @"Hides a site from the site picker list")
+                                                                                handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
+                                                                                    [ReachabilityUtils onAvailableInternetConnectionDo:^{
+                                                                                        [weakSelf hideBlogAtIndexPath:indexPath];
+                                                                                    }];
                                                                                 }];
-                                                                            }];
-        hideAction.backgroundColor = [WPStyleGuide grey];
-        [actions addObject:hideAction];
+            hideAction.backgroundColor = [WPStyleGuide grey];
+            [actions addObject:hideAction];
+        } else {
+            UITableViewRowAction *unhideAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal
+                                                                                    title:NSLocalizedString(@"Unhide", @"Unhides a site from the site picker list")
+                                                                                  handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
+                                                                                      [ReachabilityUtils onAvailableInternetConnectionDo:^{
+                                                                                          [weakSelf unhideBlogAtIndexPath:indexPath];
+                                                                                      }];
+                                                                                  }];
+            unhideAction.backgroundColor = [WPStyleGuide validGreen];
+            [actions addObject:unhideAction];
+        }
     }
 
     return actions;
@@ -660,8 +672,14 @@ static NSInteger HideSearchMinSites = 3;
 - (void)hideBlogAtIndexPath:(NSIndexPath *)indexPath
 {
     Blog *blog = [self.dataSource blogAtIndexPath:indexPath];
-    blog.visible = NO;
     [self setVisible:NO forBlog:blog];
+    [self.tableView setEditing:NO animated:YES];
+}
+
+- (void)unhideBlogAtIndexPath:(NSIndexPath *)indexPath
+{
+    Blog *blog = [self.dataSource blogAtIndexPath:indexPath];
+    [self setVisible:YES forBlog:blog];
     [self.tableView setEditing:NO animated:YES];
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -55,7 +55,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     SiteSettingsSectionAccount,
     SiteSettingsSectionWriting,
     SiteSettingsSectionDiscussion,
-    SiteSettingsSectionRemoveSite,
     SiteSettingsSectionAdvanced,
 };
 
@@ -79,8 +78,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 @property (nonatomic, strong) SettingTableViewCell *discussionSettingsCell;
 #pragma mark - Device Section
 @property (nonatomic, strong) SwitchTableViewCell *geotaggingCell;
-#pragma mark - Removal Section
-@property (nonatomic, strong) UITableViewCell *removeSiteCell;
 #pragma mark - Advanced Section
 @property (nonatomic, strong) SettingTableViewCell *startOverCell;
 @property (nonatomic, strong) WPTableViewCell *exportContentCell;
@@ -157,10 +154,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
         [sections addObject:@(SiteSettingsSectionDiscussion)];
     }
 
-    if ([self.blog supports:BlogFeatureRemovable]) {
-        [sections addObject:@(SiteSettingsSectionRemoveSite)];
-    }
-
     if ([self.blog supports:BlogFeatureSiteManagement]) {
         [sections addObject:@(SiteSettingsSectionAdvanced)];
     }
@@ -205,10 +198,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             return SiteSettingsWritingCount;
         }
         case SiteSettingsSectionDiscussion:
-        {
-            return 1;
-        }
-        case SiteSettingsSectionRemoveSite:
         {
             return 1;
         }
@@ -309,19 +298,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
                                                                  editable:YES
                                                           reuseIdentifier:nil];
     return _discussionSettingsCell;
-}
-
-- (UITableViewCell *)removeSiteCell
-{
-    if (_removeSiteCell) {
-        return _removeSiteCell;
-    }
-    _removeSiteCell = [[WPTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:nil];
-    [WPStyleGuide configureTableViewDestructiveActionCell:_removeSiteCell];
-    _removeSiteCell.textLabel.text = NSLocalizedString(@"Remove Site", @"Button to remove a site from the app");
-    _removeSiteCell.accessibilityIdentifier = @"removeSiteButton";
-
-    return _removeSiteCell;
 }
 
 - (void)configureDefaultCategoryCell
@@ -520,9 +496,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
 
         case SiteSettingsSectionDiscussion:
             return self.discussionSettingsCell;
-
-        case SiteSettingsSectionRemoveSite:
-            return self.removeSiteCell;
 
         case SiteSettingsSectionAdvanced:
             return [self tableView:tableView cellForAdvancedSettingsAtRow:indexPath.row];
@@ -831,11 +804,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
             [self showDiscussionSettingsForBlog:self.blog];
             break;
 
-        case SiteSettingsSectionRemoveSite:
-            [self showRemoveSiteForBlog:self.blog];
-            [tableView deselectSelectedRowWithAnimation:YES];
-            break;
-
         case SiteSettingsSectionAdvanced:
             [self tableView:tableView didSelectInAdvancedSectionRow:indexPath.row];
             break;
@@ -1000,42 +968,6 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     DiscussionSettingsViewController *settings = [[DiscussionSettingsViewController alloc] initWithBlog:blog];
     [self.navigationController pushViewController:settings animated:YES];
 }
-
-
-#pragma mark - Remove Site
-
-- (void)showRemoveSiteForBlog:(Blog *)blog
-{
-    NSParameterAssert(blog);
-    
-    NSString *model = [[UIDevice currentDevice] localizedModel];
-    NSString *message = [NSString stringWithFormat:NSLocalizedString(@"Are you sure you want to continue?\n All site data will be removed from your %@.", @"Title for the remove site confirmation alert, %@ will be replaced with iPhone/iPad/iPod Touch"), model];
-    NSString *cancelTitle = NSLocalizedString(@"Cancel", nil);
-    NSString *destructiveTitle = NSLocalizedString(@"Remove Site", @"Button to remove a site from the app");
-    
-    UIAlertControllerStyle alertStyle = [UIDevice isPad] ? UIAlertControllerStyleAlert : UIAlertControllerStyleActionSheet;
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil
-                                                                             message:message
-                                                                      preferredStyle:alertStyle];
-    
-    [alertController addCancelActionWithTitle:cancelTitle handler:nil];
-    [alertController addDestructiveActionWithTitle:destructiveTitle handler:^(UIAlertAction *action) {
-        [self confirmRemoveSite:blog];
-    }];
-    
-    [self presentViewController:alertController animated:YES completion:nil];
-}
-
-- (void)confirmRemoveSite:(Blog *)blog
-{
-    NSParameterAssert(blog);
-    
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-    [blogService removeBlog:blog];
-    [self.navigationController popToRootViewControllerAnimated:YES];
-}
-
 
 #pragma mark - PostCategoriesViewControllerDelegate
 

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -159,13 +159,13 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
             action: pushHelp())
 
         let logIn = ButtonRow(
-            title: NSLocalizedString("Connect to WordPress.com", comment: "Label for connecting to WordPress.com account"),
+            title: NSLocalizedString("Log In", comment: "Label for logging in to WordPress.com account"),
             action: presentLogin())
 
         let logOut = DestructiveButtonRow(
-            title: NSLocalizedString("Disconnect from WordPress.com", comment: "Label for disconnecting from WordPress.com account"),
+            title: NSLocalizedString("Log Out", comment: "Label for logging out from WordPress.com account"),
             action: confirmLogout(),
-            accessibilityIdentifier: "disconnectFromWPcomButton")
+            accessibilityIdentifier: "logOutFromWPcomButton")
 
         let wordPressComAccount = NSLocalizedString("WordPress.com Account", comment: "WordPress.com sign-in/sign-out section header title")
 

--- a/WordPress/WordPressUITests/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/XCTest+Extensions.swift
@@ -34,7 +34,7 @@ public struct elementStringIDs {
     static var removeSiteButton = "removeSiteButton"
 
     // Me tab
-    static var disconnectFromWPcomButton = "disconnectFromWPcomButton"
+    static var logOutFromWPcomButton = "logOutFromWPcomButton"
 }
 
 extension XCUIElement {
@@ -86,7 +86,7 @@ extension XCTestCase {
         if !app.textFields[ elementStringIDs.loginUsernameField ].exists && !app.textFields[ elementStringIDs.nuxUsernameField ].exists {
             app.tabBars[ elementStringIDs.mainNavigationBar ].buttons[ elementStringIDs.mainNavigationMeButton ].tap()
             app.tables.element(boundBy: 0).swipeUp()
-            app.tables.cells[ elementStringIDs.disconnectFromWPcomButton ].tap()
+            app.tables.cells[ elementStringIDs.logOutFromWPcomButton ].tap()
             app.alerts.buttons.element(boundBy: 1).tap()
             //Give some time to everything get proper saved.
             sleep(2)


### PR DESCRIPTION
**Fixes** #4379 

There is three different changes to fix this issue:
1. Update the copy on the Me tab to Log In/Log Out

![loginpng](https://cloud.githubusercontent.com/assets/5558824/24721798/d0811bfa-1a17-11e7-93b2-8bf31bbf4a33.png) |  ![logout](https://cloud.githubusercontent.com/assets/5558824/24721814/d9c4588a-1a17-11e7-8a7d-7ec711b4dc76.png)

2. For self-hosted sites remove move the Remove Site option from Site Settings to Site Details

![removesite](https://cloud.githubusercontent.com/assets/5558824/24721423/b7ba8706-1a16-11e7-9e91-51c0e88ef69d.png)

3. On the Sites list, add swipe to Hide/Remove

![hideandremovesites](https://cloud.githubusercontent.com/assets/5558824/24722737/419ae03e-1a1b-11e7-8ed8-a606a0aedd96.gif)

**To test:**

First of all add a self hosted site, then to test each scenario:

Part 1
Go to the Me tab and Log Out (check copy)
Go to the Me tab and Log In (check copy)

Part 2
Select  your self hosted site, go to Site Settings and check that there's no Remove Site option
Go to Site Details, scroll down and select Remove Site.
Check that the site is removed.

Part 3
Go to the Site List
Hide some sites
Remove your self hosted site
Check that everything works as expected

Needs review: @jleandroperez 