### PR TITLE
Magic Links: Pass scheme when requesting link.

### DIFF
--- a/WordPress/Classes/Networking/AccountServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/AccountServiceRemoteREST.m
@@ -192,12 +192,17 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
     NSString *path = [self pathForEndpoint:@"auth/send-login-email"
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
+    NSMutableDictionary *params = [NSMutableDictionary dictionaryWithDictionary:@{
+                                                                                  @"email": email,
+                                                                                  @"client_id": [ApiCredentials client],
+                                                                                  @"client_secret": [ApiCredentials secret],
+                                                                                  }];
+    if (![@"wordpress" isEqualToString:WPComScheme]) {
+        [params setObject:WPComScheme forKey:@"scheme"];
+    }
+
     [self.wordPressComRestApi POST:path
-        parameters:@{
-                     @"email": email,
-                     @"client_id": [ApiCredentials client],
-                     @"client_secret": [ApiCredentials secret],
-                     }
+        parameters:[NSDictionary dictionaryWithDictionary:params]
            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                if (success) {
                    success();


### PR DESCRIPTION
This PR passes the current WPComScheme of the app when requesting a magic link.  The link that is sent will be constructed with the specified scheme.  The link may then be used to open debug, internal, or alpha builds rather than just production builds.

To test: 
- Request a link via a debug build.
- Background the app.
- Copy the link in the email you receive.
- Paste it into the simulator.  Open Safari tap into the URL field and choose Paste & Go.
- Open the link with WordPress. 
- Confirm that you are logged in. 

Needs review: @nheagy 
