### PR TITLE
Respect animated when reader disappears

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -215,7 +215,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        setBarsHidden(false)
+        setBarsHidden(false, animated: animated)
 
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
     }
@@ -808,17 +808,17 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         WPAppAnalytics.track(.readerSitePreviewed, withProperties: properties)
     }
 
-    func setBarsHidden(_ hidden: Bool) {
+    func setBarsHidden(_ hidden: Bool, animated: Bool = true) {
         if (navigationController?.isNavigationBarHidden == hidden) {
             return
         }
 
         if (hidden) {
             // Hides the navbar and footer view
-            navigationController?.setNavigationBarHidden(true, animated: true)
+            navigationController?.setNavigationBarHidden(true, animated: animated)
             currentPreferredStatusBarStyle = .default
             footerViewHeightConstraint.constant = 0.0
-            UIView.animate(withDuration: 0.3,
+            UIView.animate(withDuration: animated ? 0.3 : 0,
                 delay: 0.0,
                 options: [.beginFromCurrentState, .allowUserInteraction],
                 animations: {
@@ -829,10 +829,10 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             // Shows the navbar and footer view
             let pinToBottom = isScrollViewAtBottom()
 
-            navigationController?.setNavigationBarHidden(false, animated: true)
+            navigationController?.setNavigationBarHidden(false, animated: animated)
             currentPreferredStatusBarStyle = .lightContent
             footerViewHeightConstraint.constant = footerViewHeightConstraintConstant
-            UIView.animate(withDuration: 0.3,
+            UIView.animate(withDuration: animated ? 0.3 : 0,
                 delay: 0.0,
                 options: [.beginFromCurrentState, .allowUserInteraction],
                 animations: {


### PR DESCRIPTION
Previously we were animating the navigation bar display even if the VC was
disappearing without animation. This somehow led to UIKit presenting a note
detail modally instead of pushing it when opening a push notification.

Refs: #6976

To test:

- Log in with your a8c account, find a notification that mentions you on a post (not a comment)
- The notification opens a reader view for the post.
- Scroll down a bit until the navigation bar disappears
- Put the app in the background
- Generate a new comment notification
- Tap on the new notification
- The comment notification should appear with the navigation bar

Needs review: @frosty 