### PR TITLE
Removes UI tests from the main test target until we stub remote calls

### DIFF
--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -38,21 +38,6 @@
                ReferencedContainer = "container:WordPress.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FF27168E1CAAC87A0006E2D4"
-               BuildableName = "WordPressUITests.xctest"
-               BlueprintName = "WordPressUITests"
-               ReferencedContainer = "container:WordPress.xcodeproj">
-            </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "MainNavigationTests">
-               </Test>
-            </SkippedTests>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
Right now there is a UI tests that is creating a WordPress.com account every time it runs. Luckily most of us do not have the test credentials locally (including Buddybuild) so we've only created 65 accounts so far. For now I'm removing the UI tests from the main target scheme so they're not executed every time we run unit tests. We should work on a solution that stubs out the networking calls or at least provides some indicator for a scheduled job to clean up those accounts on a regular basis.

To test:
1. Build & test WordPress target.
2. Ensure UI tests are not executed.

Needs review: @SergioEstevao 

cc: @hoverduck 
