### PR TITLE
Share from reader

### DIFF
--- a/WordPress/Classes/Models/SharePost+UIActivityItemSource.swift
+++ b/WordPress/Classes/Models/SharePost+UIActivityItemSource.swift
@@ -1,0 +1,37 @@
+import MobileCoreServices
+import UIKit
+
+extension SharePost: UIActivityItemSource {
+    func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        return url as Any
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivityType) -> Any? {
+        switch activityType {
+        case UIActivityType.mail:
+            return url
+        case SharePost.activityType:
+            return data
+        default:
+            return content
+        }
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivityType?) -> String {
+        return title ?? ""
+    }
+
+    func activityViewController(_ activityViewController: UIActivityViewController, dataTypeIdentifierForActivityType activityType: UIActivityType?) -> String {
+        guard let activityType = activityType else {
+            return kUTTypePlainText as String
+        }
+        switch activityType {
+        case UIActivityType.mail:
+            return kUTTypeURL as String
+        case SharePost.activityType:
+            return SharePost.typeIdentifier
+        default:
+            return kUTTypePlainText as String
+        }
+    }
+}

--- a/WordPress/Classes/Models/SharePost+UIActivityItemSource.swift
+++ b/WordPress/Classes/Models/SharePost+UIActivityItemSource.swift
@@ -8,12 +8,10 @@ extension SharePost: UIActivityItemSource {
 
     func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivityType) -> Any? {
         switch activityType {
-        case UIActivityType.mail:
-            return url
         case SharePost.activityType:
             return data
         default:
-            return content
+            return url
         }
     }
 
@@ -23,15 +21,13 @@ extension SharePost: UIActivityItemSource {
 
     func activityViewController(_ activityViewController: UIActivityViewController, dataTypeIdentifierForActivityType activityType: UIActivityType?) -> String {
         guard let activityType = activityType else {
-            return kUTTypePlainText as String
+            return kUTTypeURL as String
         }
         switch activityType {
-        case UIActivityType.mail:
-            return kUTTypeURL as String
         case SharePost.activityType:
             return SharePost.typeIdentifier
         default:
-            return kUTTypePlainText as String
+            return kUTTypeURL as String
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -5,19 +5,9 @@ import SVProgressHUD
 
     func shareController(_ title: String?, summary: String?, link: String?) -> UIActivityViewController {
         var activityItems = [AnyObject]()
-        let postDictionary = NSMutableDictionary()
-
-        if let str = title {
-            postDictionary["title"] = str
-        }
-        if let str = summary {
-            postDictionary["summary"] = str
-        }
-
-        activityItems.append(postDictionary)
-        if let urlPath = link, let url = URL(string: urlPath) {
-            activityItems.append(url as AnyObject)
-        }
+        let url = link.flatMap(URL.init(string:))
+        let post = SharePost(title: title, summary: summary, url: url?.absoluteString)
+        activityItems.append(post)
 
         let activities = WPActivityDefaults.defaultActivities() as! [UIActivity]
         let controller = UIActivityViewController(activityItems: activityItems, applicationActivities: activities)

--- a/WordPress/Shared/SharePost.swift
+++ b/WordPress/Shared/SharePost.swift
@@ -1,0 +1,99 @@
+import Foundation
+import MobileCoreServices
+
+/// A simple shared model to represent a post
+///
+/// This is a simplified version of a post used as a base for sharing amongst
+/// the app, the Share extension, and other share options.
+///
+/// It supports NSCoding and can be imported/exported as NSData. It also defines
+/// its own UTI data type.
+///
+@objc class SharePost: NSObject, NSSecureCoding {
+    static let typeIdentifier = "org.wordpress.share-post"
+    static let activityType = UIActivityType(rawValue: "org.wordpress.WordPressShare")
+
+    let title: String?
+    let summary: String?
+    let url: URL?
+
+    init(title: String?, summary: String?, url: String?) {
+        self.title = title
+        self.summary = summary
+        self.url = url.flatMap(URL.init(string:))
+        super.init()
+    }
+
+    required convenience init?(coder aDecoder: NSCoder) {
+        let title = aDecoder.decodeString(forKey: .title)
+        let summary = aDecoder.decodeString(forKey: .summary)
+        let url = aDecoder.decodeString(forKey: .url)
+        self.init(title: title, summary: summary, url: url)
+    }
+
+    convenience init?(data: Data) {
+        let decoder = NSKeyedUnarchiver(forReadingWith: data)
+        self.init(coder: decoder)
+    }
+
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(title, forKey: .title)
+        aCoder.encode(summary, forKey: .summary)
+        aCoder.encode(url?.absoluteString, forKey: .url)
+    }
+
+    static var supportsSecureCoding: Bool {
+        return true
+    }
+
+    var content: String {
+        var content = ""
+        if let title = title {
+            content.append("\(title)\n\n")
+        }
+        if let url = url {
+            content.append(url.absoluteString)
+        }
+        return content
+    }
+
+    var data: Data {
+        let data = NSMutableData()
+        let encoder = NSKeyedArchiver(forWritingWith: data)
+        encode(with: encoder)
+        encoder.finishEncoding()
+        return data as Data
+    }
+}
+
+extension SharePost {
+    private func decode(coder: NSCoder, key: Key) -> String? {
+        return coder.decodeObject(forKey: key.rawValue) as? String
+    }
+
+    private func encode(coder: NSCoder, string: String?, forKey key: Key) {
+        guard let string = string else {
+            return
+        }
+        coder.encode(string, forKey: key.rawValue)
+    }
+
+    enum Key: String {
+        case title
+        case summary
+        case url
+    }
+}
+
+private extension NSCoder {
+    func encode(_ string: String?, forKey key: SharePost.Key) {
+        guard let string = string else {
+            return
+        }
+        encode(string, forKey: key.rawValue)
+    }
+
+    func decodeString(forKey key: SharePost.Key) -> String? {
+        return decodeObject(forKey: key.rawValue) as? String
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -631,6 +631,9 @@
 		E124CE721C86D27100F7BA99 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E124CE711C86D27100F7BA99 /* StoreTests.swift */; };
 		E125443C12BF5A7200D87A0A /* WordPress.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = E125443B12BF5A7200D87A0A /* WordPress.xcdatamodeld */; };
 		E125445612BF5B3900D87A0A /* PostCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = E125445512BF5B3900D87A0A /* PostCategory.m */; };
+		E125F1E41E8E595E00320B67 /* SharePost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E125F1E31E8E595E00320B67 /* SharePost.swift */; };
+		E125F1E51E8E596200320B67 /* SharePost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E125F1E31E8E595E00320B67 /* SharePost.swift */; };
+		E125F1E71E8E59C800320B67 /* SharePost+UIActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = E125F1E61E8E59C800320B67 /* SharePost+UIActivityItemSource.swift */; };
 		E1266D2D1BBE8B9A00FCB6B6 /* Gravatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1266D2C1BBE8B9A00FCB6B6 /* Gravatar.swift */; };
 		E1266D2F1BBEC37B00FCB6B6 /* GravatarTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1266D2E1BBEC37B00FCB6B6 /* GravatarTest.swift */; };
 		E12BE5EE1C5235DB000FD5CA /* get-me-settings-v1.1.json in Resources */ = {isa = PBXBuildFile; fileRef = E12BE5ED1C5235DB000FD5CA /* get-me-settings-v1.1.json */; };
@@ -1975,6 +1978,8 @@
 		E125443D12BF5A7200D87A0A /* WordPress 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 2.xcdatamodel"; sourceTree = "<group>"; };
 		E125445412BF5B3900D87A0A /* PostCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostCategory.h; sourceTree = "<group>"; };
 		E125445512BF5B3900D87A0A /* PostCategory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostCategory.m; sourceTree = "<group>"; };
+		E125F1E31E8E595E00320B67 /* SharePost.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharePost.swift; sourceTree = "<group>"; };
+		E125F1E61E8E59C800320B67 /* SharePost+UIActivityItemSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SharePost+UIActivityItemSource.swift"; sourceTree = "<group>"; };
 		E1266D2C1BBE8B9A00FCB6B6 /* Gravatar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Gravatar.swift; sourceTree = "<group>"; };
 		E1266D2E1BBEC37B00FCB6B6 /* GravatarTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarTest.swift; sourceTree = "<group>"; };
 		E12963A8174654B2002E7744 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -2823,6 +2828,7 @@
 				29B97315FDCFA39411CA2CEA /* Other Sources */,
 				29B97317FDCFA39411CA2CEA /* Resources */,
 				45C73C23113C36F50024D0D2 /* Resources-iPad */,
+				E125F1E21E8E594C00320B67 /* Shared */,
 				932225A81C7CE50300443B02 /* WordPressShareExtension */,
 				93E5283D19A7741A003A1A9C /* WordPressTodayWidget */,
 				E16AB92F14D978240047A2E5 /* WordPressTest */,
@@ -3016,6 +3022,7 @@
 				46F84612185A8B7E009D0DA5 /* PostContentProvider.h */,
 				5D35F7581A042255004E7B0D /* WPCommentContentViewProvider.h */,
 				173BCE781CEB780800AE8817 /* Domain.swift */,
+				E125F1E61E8E59C800320B67 /* SharePost+UIActivityItemSource.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -4785,6 +4792,14 @@
 			name = "Remote Objects";
 			sourceTree = "<group>";
 		};
+		E125F1E21E8E594C00320B67 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				E125F1E31E8E595E00320B67 /* SharePost.swift */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
 		E12F55F714A1F2640060A510 /* Vendor */ = {
 			isa = PBXGroup;
 			children = (
@@ -6239,6 +6254,7 @@
 				FFB7B8201A0012E80032E723 /* ApiCredentials.m in Sources */,
 				B5DB8AF41C949DC20059196A /* WPImmuTableRows.swift in Sources */,
 				BEC62E2C1BF2F58D007685B2 /* CreateNewBlogViewController.m in Sources */,
+				E125F1E71E8E59C800320B67 /* SharePost+UIActivityItemSource.swift in Sources */,
 				E1B62A7B13AA61A100A6FCA4 /* WPWebViewController.m in Sources */,
 				B587798119B799D800E57C5A /* UITableViewCell+Helpers.swift in Sources */,
 				E63BBC931C5161B800598BE8 /* KeyringConnectionExternalUser.swift in Sources */,
@@ -6525,6 +6541,7 @@
 				E64E17661CA8518800BE7744 /* NUXSubmitButton.swift in Sources */,
 				B5EEDB971C91F10400676B2B /* Blog+Interface.swift in Sources */,
 				5D839AA8187F0D6B00811F4A /* PostFeaturedImageCell.m in Sources */,
+				E125F1E41E8E595E00320B67 /* SharePost.swift in Sources */,
 				B587798219B799D800E57C5A /* UIView+Helpers.swift in Sources */,
 				B56FEB791CD8E13C00E621F9 /* RoleViewController.swift in Sources */,
 				E166FA221BB1359E00374B5B /* PeopleRemote.swift in Sources */,
@@ -6648,6 +6665,7 @@
 				B52937E01C94A2B100940C1C /* WPReusableTableViewCells.swift in Sources */,
 				B5BEA5621C7CE71D00C8035B /* WPDDLogWrapper.m in Sources */,
 				B50248B61C96FF8400AFBDED /* SitePickerViewController.swift in Sources */,
+				E125F1E51E8E596200320B67 /* SharePost.swift in Sources */,
 				B5D7A0EC1CCFD1FC003C375D /* UIImage+RoundedCorner.m in Sources */,
 				B5D7A0EB1CCFD1F6003C375D /* UIImage+Alpha.m in Sources */,
 				B5BEA55F1C7CE6D100C8035B /* Constants.m in Sources */,

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -51,6 +51,7 @@ struct ShareExtractor {
 private extension ShareExtractor {
     var supportedExtractors: [ExtensionContentExtractor] {
         return [
+            SharePostExtractor(),
             PropertyListExtractor(),
             URLExtractor(),
             ImageExtractor()
@@ -153,5 +154,16 @@ private struct PropertyListExtractor: TypeBasedExtensionContentExtractor {
             return nil
         }
         return value
+    }
+}
+
+private struct SharePostExtractor: TypeBasedExtensionContentExtractor {
+    typealias Payload = Data
+    let acceptedType = SharePost.typeIdentifier
+    func convert(payload: Data) -> ExtractedShare? {
+        guard let post = SharePost(data: payload) else {
+            return nil
+        }
+        return .text(post.content)
     }
 }


### PR DESCRIPTION
Improves sharing from reader by passing extra data about the post when sharing to WordPress.

For now, we're only using title/link since the share UI is very simple, but this opens the door to more advanced sharing.

For sharing to other apps, we still pass just the URL, but the new custom `UIActivityItemSource` will allow us to make tweaks for specific apps

Fixes #5198 

To test:

- Launch the app and find a Reader post
- Share to WordPress, it should have the post title and link
- Share to other apps, it should have the link. Apps like Facebook, Twitter, or Notes should show a link preview and not just plain text.


Needs review: @jleandroperez 
