### PR TITLE
Media Library: Add analytics events

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -50,7 +50,7 @@ abstract_target 'WordPress_Base' do
     pod 'NSURL+IDN', '0.3'
     pod 'WPMediaPicker', '0.13'
     pod 'WordPress-iOS-Editor', '1.9.0'
-    pod 'WordPressCom-Analytics-iOS', '0.1.24'
+    pod 'WordPressCom-Analytics-iOS', '0.1.25'
     pod 'WordPress-Aztec-iOS', '0.5a7.1'
     pod 'wpxmlrpc', '0.8.3'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -137,7 +137,7 @@ PODS:
     - WordPressCom-Analytics-iOS (~> 0.1.0)
   - WordPress-iOS-Shared (0.8.2):
     - CocoaLumberjack (~> 2.2.0)
-  - WordPressCom-Analytics-iOS (0.1.24)
+  - WordPressCom-Analytics-iOS (0.1.25)
   - WordPressCom-Stats-iOS (0.9.1):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
@@ -181,7 +181,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (= 0.5a7.1)
   - WordPress-iOS-Editor (= 1.9.0)
   - WordPress-iOS-Shared (= 0.8.2)
-  - WordPressCom-Analytics-iOS (= 0.1.24)
+  - WordPressCom-Analytics-iOS (= 0.1.25)
   - WordPressCom-Stats-iOS (= 0.9.1)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.13)
@@ -249,12 +249,12 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 90054eaca784b2e29819fc3130ac37edd4688732
   WordPress-iOS-Editor: 69c5d1e83aaa6e5ab6c80e067f1858de8dab4017
   WordPress-iOS-Shared: 999f5bfcf5744f94ebe9cb7459a138f5990fbf3a
-  WordPressCom-Analytics-iOS: 9787d0e0866f48ae759a1d56e21c5a8f3a08a67e
+  WordPressCom-Analytics-iOS: ec36976259d733430ba0fc2f8a51765947d2c7ba
   WordPressCom-Stats-iOS: 872a0c2ad9b691911257459bc353f96ac804374c
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 5f39880ac799dbbf41a99f73567a95ab5297dc93
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: c13ced88eb666f1f4bd129c6247b71d5dbf800c7
+PODFILE CHECKSUM: adae9a5815456f93b643cb6b0b3fdf2fe74024c1
 
 COCOAPODS: 1.1.1

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -415,6 +415,18 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatLowMemoryWarning:
             eventName = @"application_low_memory_warning";
             break;
+        case WPAnalyticsStatMediaLibraryDeletedItems:
+            eventName = @"media_library_deleted_items";
+            break;
+        case WPAnalyticsStatMediaLibraryEditedItemMetadata:
+            eventName = @"media_library_edited_item_metadata";
+            break;
+        case WPAnalyticsStatMediaLibraryPreviewedItem:
+            eventName = @"media_library_previewed_item";
+            break;
+        case WPAnalyticsStatMediaLibrarySharedItemLink:
+            eventName = @"media_library_shared_item_link";
+            break;
         case WPAnalyticsStatMenusAccessed:
             eventName = @"menus_accessed";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m
@@ -1113,6 +1113,18 @@ NSString *const SessionCount = @"session_count";
             instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"My Site - Accessed"];
             [instructions setSuperPropertyAndPeoplePropertyToIncrement:@"number_of_times_accessed_my_site"];
             break;
+        case WPAnalyticsStatMediaLibraryDeletedItems:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Media Library - Deleted items"];
+            break;
+        case WPAnalyticsStatMediaLibraryEditedItemMetadata:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Media Library - Edited item metadata"];
+            break;
+        case WPAnalyticsStatMediaLibraryPreviewedItem:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Media Library - Previewed item"];
+            break;
+        case WPAnalyticsStatMediaLibrarySharedItemLink:
+            instructions = [WPAnalyticsTrackerMixpanelInstructionsForStat mixpanelInstructionsForEventName:@"Media Library - Shared item link"];
+            break;
 
         // To be implemented
         case WPAnalyticsStatAppUpgraded:

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -121,6 +121,11 @@ class MediaItemViewController: UITableViewController {
             let activityController = UIActivityViewController(activityItems: [ url ], applicationActivities: nil)
                 activityController.modalPresentationStyle = .popover
                 activityController.popoverPresentationController?.barButtonItem = sender
+                activityController.completionWithItemsHandler = { [weak self] _, completed, _, _ in
+                    if completed {
+                        WPAppAnalytics.track(.mediaLibrarySharedItemLink, with: self?.media.blog)
+                    }
+                }
                 present(activityController, animated: true, completion: nil)
         } else {
             let alertController = UIAlertController(title: nil, message: NSLocalizedString("Unable to get URL for media item.", comment: "Error message displayed when we were unable to copy the URL for an item in the user's media library."), preferredStyle: .alert)
@@ -146,7 +151,8 @@ class MediaItemViewController: UITableViewController {
         SVProgressHUD.show(withStatus: NSLocalizedString("Deleting...", comment: "Text displayed in HUD while a media item is being deleted."))
 
         let service = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        service.delete(media, success: {
+        service.delete(media, success: { [weak self] in
+            WPAppAnalytics.track(.mediaLibraryDeletedItems, withProperties: ["number_photos_deleted": 1], with: self?.media.blog)
             SVProgressHUD.showSuccess(withStatus: NSLocalizedString("Deleted!", comment: "Text displayed in HUD after successfully deleting a media item"))
         }, failure: { error in
             SVProgressHUD.showError(withStatus: NSLocalizedString("Unable to delete media item.", comment: "Text displayed in HUD if there was an error attempting to delete a media item."))
@@ -167,9 +173,10 @@ class MediaItemViewController: UITableViewController {
         mediaMetadata.update(media)
 
         let service = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        service.update(media, success: {
+        service.update(media, success: { [weak self] in
+            WPAppAnalytics.track(.mediaLibraryEditedItemMetadata, with: self?.media.blog)
             SVProgressHUD.showSuccess(withStatus: NSLocalizedString("Saved!", comment: "Text displayed in HUD when a media item's metadata (title, etc) is saved successfully."))
-            self.updateNavigationItem()
+            self?.updateNavigationItem()
         }, failure: { error in
             SVProgressHUD.showError(withStatus: NSLocalizedString("Unable to save media item.", comment: "Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved."))
             self.updateNavigationItem()

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -152,7 +152,7 @@ class MediaItemViewController: UITableViewController {
 
         let service = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
         service.delete(media, success: { [weak self] in
-            WPAppAnalytics.track(.mediaLibraryDeletedItems, withProperties: ["number_photos_deleted": 1], with: self?.media.blog)
+            WPAppAnalytics.track(.mediaLibraryDeletedItems, withProperties: ["number_of_items_deleted": 1], with: self?.media.blog)
             SVProgressHUD.showSuccess(withStatus: NSLocalizedString("Deleted!", comment: "Text displayed in HUD after successfully deleting a media item"))
         }, failure: { error in
             SVProgressHUD.showError(withStatus: NSLocalizedString("Unable to delete media item.", comment: "Text displayed in HUD if there was an error attempting to delete a media item."))

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -299,6 +299,8 @@ class MediaLibraryViewController: UIViewController {
         guard pickerViewController.selectedAssets.count > 0 else { return }
         guard let assets = pickerViewController.selectedAssets.copy() as? [Media] else { return }
 
+        let deletedItemsCount = assets.count
+
         let updateProgress = { (progress: Progress?) in
             let fractionCompleted = progress?.fractionCompleted ?? 0
             SVProgressHUD.showProgress(Float(fractionCompleted), status: NSLocalizedString("Deleting...", comment: "Text displayed in HUD while a media item is being deleted."))
@@ -314,6 +316,7 @@ class MediaLibraryViewController: UIViewController {
         service.deleteMedia(assets,
                             progress: updateProgress,
                             success: { [weak self] in
+                                WPAppAnalytics.track(.mediaLibraryDeletedItems, withProperties: ["number_photos_deleted": deletedItemsCount], with: self?.blog)
                                 SVProgressHUD.showSuccess(withStatus: NSLocalizedString("Deleted!", comment: "Text displayed in HUD after successfully deleting a media item"))
                                 self?.isEditing = false
         }, failure: { error in
@@ -411,6 +414,7 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, previewViewControllerFor asset: WPMediaAsset) -> UIViewController? {
+        WPAppAnalytics.track(.mediaLibraryPreviewedItem, with: blog)
         return mediaItemViewController(for: asset)
     }
 
@@ -418,6 +422,7 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
         if isEditing { return true }
 
         if let viewController = mediaItemViewController(for: asset) {
+            WPAppAnalytics.track(.mediaLibraryPreviewedItem, with: blog)
             navigationController?.pushViewController(viewController, animated: true)
         }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -316,7 +316,7 @@ class MediaLibraryViewController: UIViewController {
         service.deleteMedia(assets,
                             progress: updateProgress,
                             success: { [weak self] in
-                                WPAppAnalytics.track(.mediaLibraryDeletedItems, withProperties: ["number_photos_deleted": deletedItemsCount], with: self?.blog)
+                                WPAppAnalytics.track(.mediaLibraryDeletedItems, withProperties: ["number_of_items_deleted": deletedItemsCount], with: self?.blog)
                                 SVProgressHUD.showSuccess(withStatus: NSLocalizedString("Deleted!", comment: "Text displayed in HUD after successfully deleting a media item"))
                                 self?.isEditing = false
         }, failure: { error in


### PR DESCRIPTION
I've added a handful of new analytics events for the new media library functionality (added to the analytics pod here: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS/pull/89). 

WPAnalyticsStatMediaLibraryDeletedItems
WPAnalyticsStatMediaLibraryEditedItemMetadata
WPAnalyticsStatMediaLibraryPreviewedItem
WPAnalyticsStatMediaLibrarySharedItemLink

To test:

* Ensure the tracks events are being logged as expected.
* Deleted items should be triggered if you delete a single media item, or if you delete multiple items from the grid view. It should include a property containing the number of items deleted.
* Previewed item should be triggered whether you just tap into an item or if you preview it with force touch.
* Edited item should be triggered if you edit and save an item's metadata (but not if you cancel out of it).
* Share link should be triggered if you successfully choose somewhere to share the item's URL (but not if you cancel out of the share sheet).

Needs review: @elibud would you mind?