### PR TITLE
Media Library: State restoration

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/MediaItemImageTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaItemImageTableViewCell.swift
@@ -1,0 +1,167 @@
+import UIKit
+import WordPressShared
+
+class MediaItemImageTableViewCell: WPTableViewCell {
+    let customImageView = UIImageView()
+    let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .white)
+    let activityMaskView = UIView()
+
+    // MARK: - Initializers
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    public required override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        commonInit()
+    }
+
+    public convenience init() {
+        self.init(style: .default, reuseIdentifier: nil)
+    }
+
+    func commonInit() {
+        setupImageView()
+        setupLoadingViews()
+    }
+
+    private func setupImageView() {
+        contentView.addSubview(customImageView)
+        customImageView.translatesAutoresizingMaskIntoConstraints = false
+        customImageView.contentMode = .scaleAspectFit
+
+        NSLayoutConstraint.activate([
+            customImageView.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor),
+            customImageView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
+            customImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            customImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            ])
+
+        customImageView.setContentHuggingPriority(UILayoutPriorityDefaultLow, for: .horizontal)
+    }
+
+    private func setupLoadingViews() {
+        contentView.addSubview(activityMaskView)
+        activityMaskView.translatesAutoresizingMaskIntoConstraints = false
+        activityMaskView.backgroundColor = .black
+        activityMaskView.alpha = 0.5
+
+        contentView.addSubview(activityIndicator)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        activityIndicator.hidesWhenStopped = true
+
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            activityMaskView.leadingAnchor.constraint(equalTo: customImageView.leadingAnchor),
+            activityMaskView.trailingAnchor.constraint(equalTo: customImageView.trailingAnchor),
+            activityMaskView.topAnchor.constraint(equalTo: customImageView.topAnchor),
+            activityMaskView.bottomAnchor.constraint(equalTo: customImageView.bottomAnchor)
+            ])
+    }
+
+    private var aspectRatioConstraint: NSLayoutConstraint? = nil
+
+    var targetAspectRatio: CGFloat {
+        set {
+            if let aspectRatioConstraint = aspectRatioConstraint {
+                customImageView.removeConstraint(aspectRatioConstraint)
+            }
+
+            aspectRatioConstraint = customImageView.heightAnchor.constraint(equalTo: customImageView.widthAnchor, multiplier: newValue, constant: 1.0)
+            aspectRatioConstraint?.priority = UILayoutPriorityDefaultHigh
+            aspectRatioConstraint?.isActive = true
+        }
+        get {
+            return aspectRatioConstraint?.multiplier ?? 0
+        }
+    }
+
+    // MARK: - Loading
+
+    var isLoading: Bool = false {
+        didSet {
+            if isLoading {
+                activityMaskView.alpha = 0.5
+                activityIndicator.startAnimating()
+            } else {
+                activityMaskView.alpha = 0
+                activityIndicator.stopAnimating()
+            }
+        }
+    }
+}
+
+struct MediaImageRow: ImmuTableRow {
+    static let cell = ImmuTableCell.class(MediaItemImageTableViewCell.self)
+
+    let media: Media
+    let action: ImmuTableAction?
+
+    func configureCell(_ cell: UITableViewCell) {
+        WPStyleGuide.configureTableViewCell(cell)
+
+        if let cell = cell as? MediaItemImageTableViewCell {
+            setAspectRatioFor(cell)
+            loadImageFor(cell)
+        }
+    }
+
+    func willDisplay(_ cell: UITableViewCell) {
+        if let cell = cell as? MediaItemImageTableViewCell {
+            cell.customImageView.backgroundColor = .black
+        }
+    }
+
+    private func setAspectRatioFor(_ cell: MediaItemImageTableViewCell) {
+        guard let width = media.width, let height = media.height, width.floatValue > 0 else {
+            return
+        }
+        cell.targetAspectRatio = CGFloat(height.floatValue) / CGFloat(width.floatValue)
+    }
+
+    private func addPlaceholderImageFor(_ cell: MediaItemImageTableViewCell) {
+        if let url = media.absoluteLocalURL,
+            let image = UIImage(contentsOfFile: url.path) {
+            cell.customImageView.image = image
+        } else if let url = media.absoluteThumbnailLocalURL,
+            let image = UIImage(contentsOfFile: url.path) {
+            cell.customImageView.image = image
+        }
+    }
+
+    private func loadImageFor(_ cell: MediaItemImageTableViewCell) {
+        if !cell.isLoading && cell.customImageView.image == nil {
+            addPlaceholderImageFor(cell)
+
+            cell.isLoading = true
+            media.image(with: .zero,
+                        completionHandler: { image, error in
+                            DispatchQueue.main.async {
+                                if let error = error, image == nil {
+                                    cell.isLoading = false
+                                    self.show(error)
+                                } else if let image = image {
+                                    self.animateImageChange(image: image, for: cell)
+                                }
+                            }
+            })
+        }
+    }
+
+    private func show(_ error: Error) {
+        let alertController = UIAlertController(title: nil, message: NSLocalizedString("There was a problem loading the media item.",
+                                                                                       comment: "Error message displayed when the Media Library is unable to load a full sized preview of an item."), preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: "Verb. User action to dismiss error alert when failing to load media ite,."))
+        alertController.presentFromRootViewController()
+    }
+
+    private func animateImageChange(image: UIImage, for cell: MediaItemImageTableViewCell) {
+        UIView.transition(with: cell.customImageView, duration: 0.2, options: .transitionCrossDissolve, animations: {
+            cell.isLoading = false
+            cell.customImageView.image = image
+        }, completion: nil)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -6,8 +6,9 @@ import WordPressShared
 /// Displays an image preview and metadata for a single Media asset.
 ///
 class MediaItemViewController: UITableViewController {
-    let media: Media
+    fileprivate static let restorationIdentifier = "MediaItemViewController"
 
+    let media: Media
 
     fileprivate var viewModel: ImmuTable!
     fileprivate var mediaMetadata: MediaMetadata {
@@ -22,6 +23,9 @@ class MediaItemViewController: UITableViewController {
         self.mediaMetadata = MediaMetadata(media: media)
 
         super.init(style: .grouped)
+
+        super.restorationIdentifier = MediaItemViewController.restorationIdentifier
+        restorationClass = MediaItemViewController.self
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -282,18 +286,37 @@ extension MediaItemViewController {
     }
 }
 
+// MARK: - State restoration
 
+extension MediaItemViewController: UIViewControllerRestoration {
+    enum EncodingKey {
+        static let mediaURL = "mediaURL"
     }
 
+    static func viewController(withRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
+        guard let identifier = identifierComponents.last as? String,
+            identifier == MediaItemViewController.restorationIdentifier else {
+                return nil
         }
 
+        guard let mediaURL = coder.decodeObject(forKey: EncodingKey.mediaURL) as? URL else {
+            return nil
         }
 
+        let context = ContextManager.sharedInstance().mainContext
+        guard let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: mediaURL),
+            let object = try? context.existingObject(with: objectID),
+            let media = object as? Media else {
+                return nil
         }
 
+        return MediaItemViewController(media: media)
     }
 
+    override func encodeRestorableState(with coder: NSCoder) {
+        super.encodeRestorableState(with: coder)
 
+        coder.encode(media.objectID.uriRepresentation(), forKey: EncodingKey.mediaURL)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -6,8 +6,6 @@ import WordPressShared
 /// Displays an image preview and metadata for a single Media asset.
 ///
 class MediaItemViewController: UITableViewController {
-    fileprivate static let restorationIdentifier = "MediaItemViewController"
-
     let media: Media
 
     fileprivate var viewModel: ImmuTable!
@@ -23,9 +21,6 @@ class MediaItemViewController: UITableViewController {
         self.mediaMetadata = MediaMetadata(media: media)
 
         super.init(style: .grouped)
-
-        super.restorationIdentifier = MediaItemViewController.restorationIdentifier
-        restorationClass = MediaItemViewController.self
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -309,40 +304,6 @@ extension MediaItemViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let row = viewModel.rowAtIndexPath(indexPath)
         row.action?(row)
-    }
-}
-
-// MARK: - State restoration
-
-extension MediaItemViewController: UIViewControllerRestoration {
-    enum EncodingKey {
-        static let mediaURL = "mediaURL"
-    }
-
-    static func viewController(withRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
-        guard let identifier = identifierComponents.last as? String,
-            identifier == MediaItemViewController.restorationIdentifier else {
-                return nil
-        }
-
-        guard let mediaURL = coder.decodeObject(forKey: EncodingKey.mediaURL) as? URL else {
-            return nil
-        }
-
-        let context = ContextManager.sharedInstance().mainContext
-        guard let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: mediaURL),
-            let object = try? context.existingObject(with: objectID),
-            let media = object as? Media else {
-                return nil
-        }
-
-        return MediaItemViewController(media: media)
-    }
-
-    override func encodeRestorableState(with coder: NSCoder) {
-        super.encodeRestorableState(with: coder)
-
-        coder.encode(media.objectID.uriRepresentation(), forKey: EncodingKey.mediaURL)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -282,168 +282,18 @@ extension MediaItemViewController {
     }
 }
 
-open class ImageTableViewCell: WPTableViewCell {
-    let customImageView = UIImageView()
-    let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .white)
-    let activityMaskView = UIView()
 
-    // MARK: - Initializers
-    public required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        commonInit()
     }
 
-    public required override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        commonInit()
-    }
-
-    public convenience init() {
-        self.init(style: .default, reuseIdentifier: nil)
-    }
-
-    func commonInit() {
-        setupImageView()
-        setupLoadingViews()
-    }
-
-    private func setupImageView() {
-        contentView.addSubview(customImageView)
-        customImageView.translatesAutoresizingMaskIntoConstraints = false
-        customImageView.contentMode = .scaleAspectFit
-
-        NSLayoutConstraint.activate([
-            customImageView.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor),
-            customImageView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
-            customImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            customImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
-            ])
-
-        customImageView.setContentHuggingPriority(UILayoutPriorityDefaultLow, for: .horizontal)
-    }
-
-    private func setupLoadingViews() {
-        contentView.addSubview(activityMaskView)
-        activityMaskView.translatesAutoresizingMaskIntoConstraints = false
-        activityMaskView.backgroundColor = .black
-        activityMaskView.alpha = 0.5
-
-        contentView.addSubview(activityIndicator)
-        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-        activityIndicator.hidesWhenStopped = true
-
-        NSLayoutConstraint.activate([
-            activityIndicator.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-            activityIndicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-
-            activityMaskView.leadingAnchor.constraint(equalTo: customImageView.leadingAnchor),
-            activityMaskView.trailingAnchor.constraint(equalTo: customImageView.trailingAnchor),
-            activityMaskView.topAnchor.constraint(equalTo: customImageView.topAnchor),
-            activityMaskView.bottomAnchor.constraint(equalTo: customImageView.bottomAnchor)
-        ])
-    }
-
-    private var aspectRatioConstraint: NSLayoutConstraint? = nil
-
-    var targetAspectRatio: CGFloat {
-        set {
-            if let aspectRatioConstraint = aspectRatioConstraint {
-                customImageView.removeConstraint(aspectRatioConstraint)
-            }
-
-            aspectRatioConstraint = customImageView.heightAnchor.constraint(equalTo: customImageView.widthAnchor, multiplier: newValue, constant: 1.0)
-            aspectRatioConstraint?.priority = UILayoutPriorityDefaultHigh
-            aspectRatioConstraint?.isActive = true
         }
-        get {
-            return aspectRatioConstraint?.multiplier ?? 0
+
         }
-    }
 
-    // MARK: - Loading
-
-    var isLoading: Bool = false {
-        didSet {
-            if isLoading {
-                activityMaskView.alpha = 0.5
-                activityIndicator.startAnimating()
-            } else {
-                activityMaskView.alpha = 0
-                activityIndicator.stopAnimating()
-            }
         }
-    }
-}
 
-struct MediaImageRow: ImmuTableRow {
-    static let cell = ImmuTableCell.class(ImageTableViewCell.self)
-
-    let media: Media
-    let action: ImmuTableAction?
-
-    func configureCell(_ cell: UITableViewCell) {
-        WPStyleGuide.configureTableViewCell(cell)
-
-        if let cell = cell as? ImageTableViewCell {
-            setAspectRatioFor(cell)
-            loadImageFor(cell)
-        }
     }
 
-    func willDisplay(_ cell: UITableViewCell) {
-        if let cell = cell as? ImageTableViewCell {
-            cell.customImageView.backgroundColor = .black
-        }
-    }
 
-    private func setAspectRatioFor(_ cell: ImageTableViewCell) {
-        guard let width = media.width, let height = media.height, width.floatValue > 0 else {
-            return
-        }
-        cell.targetAspectRatio = CGFloat(height.floatValue) / CGFloat(width.floatValue)
-    }
-
-    private func addPlaceholderImageFor(_ cell: ImageTableViewCell) {
-        if let url = media.absoluteLocalURL,
-            let image = UIImage(contentsOfFile: url.path) {
-            cell.customImageView.image = image
-        } else if let url = media.absoluteThumbnailLocalURL,
-            let image = UIImage(contentsOfFile: url.path) {
-            cell.customImageView.image = image
-        }
-    }
-
-    private func loadImageFor(_ cell: ImageTableViewCell) {
-        if !cell.isLoading && cell.customImageView.image == nil {
-            addPlaceholderImageFor(cell)
-
-            cell.isLoading = true
-            media.image(with: .zero,
-                        completionHandler: { image, error in
-                            DispatchQueue.main.async {
-                                if let error = error, image == nil {
-                                    cell.isLoading = false
-                                    self.show(error)
-                                } else if let image = image {
-                                    self.animateImageChange(image: image, for: cell)
-                                }
-                            }
-            })
-        }
-    }
-
-    private func show(_ error: Error) {
-        let alertController = UIAlertController(title: nil, message: NSLocalizedString("There was a problem loading the media item.",
-                                                                                       comment: "Error message displayed when the Media Library is unable to load a full sized preview of an item."), preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: "Verb. User action to dismiss error alert when failing to load media ite,."))
-        alertController.presentFromRootViewController()
-    }
-
-    private func animateImageChange(image: UIImage, for cell: ImageTableViewCell) {
-        UIView.transition(with: cell.customImageView, duration: 0.2, options: .transitionCrossDissolve, animations: {
-            cell.isLoading = false
-            cell.customImageView.image = image
-        }, completion: nil)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -8,7 +8,6 @@ import WordPressShared
 class MediaItemViewController: UITableViewController {
     let media: Media
 
-    weak var dataSource: MediaLibraryPickerDataSource? = nil
 
     fileprivate var viewModel: ImmuTable!
     fileprivate var mediaMetadata: MediaMetadata {
@@ -17,9 +16,8 @@ class MediaItemViewController: UITableViewController {
         }
     }
 
-    init(media: Media, dataSource: MediaLibraryPickerDataSource) {
+    init(media: Media) {
         self.media = media
-        self.dataSource = dataSource
 
         self.mediaMetadata = MediaMetadata(media: media)
 

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -79,8 +79,24 @@ class MediaItemViewController: UITableViewController {
     }
 
     private func reloadViewModel() {
+        guard !isMediaDeleted else {
+            handleDeletedMedia()
+            return
+        }
+
         updateViewModel()
         tableView.reloadData()
+    }
+
+    private var isMediaDeleted: Bool {
+        return media.isDeleted || media.managedObjectContext == nil
+    }
+
+    private func handleDeletedMedia() {
+        SVProgressHUD.setDefaultMaskType(.clear)
+        SVProgressHUD.setMinimumDismissTimeInterval(1.0)
+        SVProgressHUD.showError(withStatus: NSLocalizedString("This media item has been deleted.", comment: "Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted."))
+        navigationController?.popViewController(animated: true)
     }
 
     private func updateNavigationItem() {
@@ -132,6 +148,11 @@ class MediaItemViewController: UITableViewController {
     }
 
     @objc private func trashTapped(_ sender: UIBarButtonItem) {
+        guard !isMediaDeleted else {
+            handleDeletedMedia()
+            return
+        }
+
         let alertController = UIAlertController(title: nil,
                                                 message: NSLocalizedString("Are you sure you want to permanently delete this item?", comment: "Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso."), preferredStyle: .alert)
         alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: ""))
@@ -143,6 +164,11 @@ class MediaItemViewController: UITableViewController {
     }
 
     private func deleteMediaItem() {
+        guard !isMediaDeleted else {
+            handleDeletedMedia()
+            return
+        }
+
         SVProgressHUD.setDefaultMaskType(.clear)
         SVProgressHUD.setMinimumDismissTimeInterval(1.0)
         SVProgressHUD.show(withStatus: NSLocalizedString("Deleting...", comment: "Text displayed in HUD while a media item is being deleted."))

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -458,7 +458,7 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
 
         selectedAsset = asset
 
-        return MediaItemViewController(media: asset, dataSource: pickerDataSource)
+        return MediaItemViewController(media: asset)
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		1724DDC81C60F1200099D273 /* PlanDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1724DDC71C60F1200099D273 /* PlanDetailViewController.swift */; };
 		1724DDCC1C6121D00099D273 /* Plans.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1724DDCB1C6121D00099D273 /* Plans.storyboard */; };
 		172797D91CE5D0CD00CB8057 /* PlansLoadingIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 172797D81CE5D0CD00CB8057 /* PlansLoadingIndicatorView.swift */; };
+		1730D4A31E97E3E400326B7C /* MediaItemImageTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1730D4A21E97E3E400326B7C /* MediaItemImageTableViewCell.swift */; };
 		1731BCD11DD9EFF1009FE3AE /* HelpshiftCustomConfig.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1731BCD01DD9EFF1009FE3AE /* HelpshiftCustomConfig.plist */; };
 		1731BCD31DDA01AF009FE3AE /* HelpshiftPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1731BCD21DDA01AF009FE3AE /* HelpshiftPresenter.swift */; };
 		173BCE731CEB368A00AE8817 /* DomainsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173BCE721CEB368A00AE8817 /* DomainsListViewController.swift */; };
@@ -1193,6 +1194,7 @@
 		1724DDCB1C6121D00099D273 /* Plans.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Plans.storyboard; sourceTree = "<group>"; };
 		172797D81CE5D0CD00CB8057 /* PlansLoadingIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlansLoadingIndicatorView.swift; sourceTree = "<group>"; };
 		172BEDF325F12BAED87A400B /* Pods-WordPressTest.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		1730D4A21E97E3E400326B7C /* MediaItemImageTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaItemImageTableViewCell.swift; sourceTree = "<group>"; };
 		1731BCD01DD9EFF1009FE3AE /* HelpshiftCustomConfig.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = HelpshiftCustomConfig.plist; sourceTree = "<group>"; };
 		1731BCD21DDA01AF009FE3AE /* HelpshiftPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HelpshiftPresenter.swift; sourceTree = "<group>"; };
 		173BCE721CEB368A00AE8817 /* DomainsListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsListViewController.swift; sourceTree = "<group>"; };
@@ -3403,6 +3405,7 @@
 				5D6C4AF51B603CA3005E3C43 /* WPTableViewActivityCell.xib */,
 				8370D10811FA499A009D650F /* WPTableViewActivityCell.h */,
 				8370D10911FA499A009D650F /* WPTableViewActivityCell.m */,
+				1730D4A21E97E3E400326B7C /* MediaItemImageTableViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -6108,6 +6111,7 @@
 				E11E775A1E72932F0072AD40 /* BlogListDataSource.swift in Sources */,
 				E1A2A3F41CB504D400EAF51E /* PlansFeaturesRemote.swift in Sources */,
 				E149D65119349E69006A843D /* MediaServiceRemoteXMLRPC.m in Sources */,
+				1730D4A31E97E3E400326B7C /* MediaItemImageTableViewCell.swift in Sources */,
 				E6ED09091D46AD29003283C4 /* ReaderFollowedSitesStreamHeader.swift in Sources */,
 				E66969E41B9E68B200EC9C00 /* ReaderPostToReaderPost37to38.swift in Sources */,
 				08216FD01CDBF96000304BA7 /* MenuItemSourceFooterView.m in Sources */,


### PR DESCRIPTION
This PR adds state restoration to the media library. Both the main media library and the individual item view controller should be restored. We encode the blog for the media library, and the viewed media item for the item VC.

The PR looks a little bigger than you might expect just because I pulled the media image table view row and immutable row out into their own file to clean things up a little – but none of the content has changed in there.

To test:

* You know the dance. Open one of the media screens in the app, background the app, stop it in Xcode. Reopen and check the correct screen is restored.

Needs review: @kurzee 