### PR TITLE
Notifications: cell bottom padding constraint @ 999.

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="ipad12_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -24,8 +25,8 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6Fx-cw-9OG" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="5.5" width="37" height="37"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="37" id="DMw-1c-pNS"/>
-                                    <constraint firstAttribute="height" constant="32" id="KBo-qG-huZ"/>
+                                    <constraint firstAttribute="height" priority="999" constant="37" id="DMw-1c-pNS"/>
+                                    <constraint firstAttribute="height" priority="999" constant="32" id="KBo-qG-huZ"/>
                                     <constraint firstAttribute="width" constant="37" id="bQA-lh-KOQ"/>
                                     <constraint firstAttribute="width" constant="32" id="yaH-Wc-jzV"/>
                                 </constraints>

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -93,7 +94,7 @@
                     <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="WuB-h0-mSd" secondAttribute="bottom" id="W83-eQ-gaV"/>
                     <constraint firstItem="WuB-h0-mSd" firstAttribute="leading" secondItem="JUi-EY-Obv" secondAttribute="trailing" constant="13" id="Wef-tC-bRq"/>
                     <constraint firstAttribute="topMargin" secondItem="JUi-EY-Obv" secondAttribute="top" id="Zav-nr-UzA"/>
-                    <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="JUi-EY-Obv" secondAttribute="bottom" constant="3" id="bb5-uM-agq"/>
+                    <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="JUi-EY-Obv" secondAttribute="bottom" priority="999" constant="3" id="bb5-uM-agq"/>
                     <constraint firstItem="Z3U-oU-FSh" firstAttribute="centerY" secondItem="JUi-EY-Obv" secondAttribute="centerY" constant="19" id="h5p-yY-IvK"/>
                     <constraint firstAttribute="trailingMargin" secondItem="WuB-h0-mSd" secondAttribute="trailing" id="tuw-OS-5Gn"/>
                 </constraints>


### PR DESCRIPTION
Resolves constraint conflict warnings when loading the Notifications cells; auto layout not
liking the height constraint versus the bottom constraint, together. Simply setting the bottom constraint to priority to `999` fixes the constraint conflict, and is ideal.

To test:

1. Launch the app, check that no warnings appear.
2. Give the Notifications tab a few good scrolls, rotations, push/pop, make sure all of the cells layout as expected.
3. Reader seems to have it's own warnings going on, might need to pop to root on the Reader tab before testing to avoid those warnings.
4. Test again on iPad.

Needs review: @elibud can you give it a whirl?

cc @astralbodies 
