### PR TITLE
Media Library: Fixes a retain cycle

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -177,35 +177,35 @@ class MediaItemViewController: UITableViewController {
     }
 
     private func editTitle() -> ((ImmuTableRow) -> ()) {
-        return { row in
+        return { [weak self] row in
             let editableRow = row as! EditableTextRow
-            self.pushSettingsController(for: editableRow, hint: NSLocalizedString("Image title", comment: "Hint for image title on image settings."),
+            self?.pushSettingsController(for: editableRow, hint: NSLocalizedString("Image title", comment: "Hint for image title on image settings."),
                                         onValueChanged: { value in
-                self.title = value
-                self.mediaMetadata.title = value
-                self.reloadViewModel()
+                self?.title = value
+                self?.mediaMetadata.title = value
+                self?.reloadViewModel()
             })
         }
     }
 
     private func editCaption() -> ((ImmuTableRow) -> ()) {
-        return { row in
+        return { [weak self] row in
             let editableRow = row as! EditableTextRow
-            self.pushSettingsController(for: editableRow, hint: NSLocalizedString("Image Caption", comment: "Hint for image caption on image settings."),
+            self?.pushSettingsController(for: editableRow, hint: NSLocalizedString("Image Caption", comment: "Hint for image caption on image settings."),
                                         onValueChanged: { value in
-                self.mediaMetadata.caption = value
-                self.reloadViewModel()
+                self?.mediaMetadata.caption = value
+                self?.reloadViewModel()
             })
         }
     }
 
     private func editDescription() -> ((ImmuTableRow) -> ()) {
-        return { row in
+        return { [weak self] row in
             let editableRow = row as! EditableTextRow
-            self.pushSettingsController(for: editableRow, hint: NSLocalizedString("Image Description", comment: "Hint for image description on image settings."),
+            self?.pushSettingsController(for: editableRow, hint: NSLocalizedString("Image Description", comment: "Hint for image description on image settings."),
                                         onValueChanged: { value in
-                self.mediaMetadata.desc  = value
-                self.reloadViewModel()
+                self?.mediaMetadata.desc  = value
+                self?.reloadViewModel()
             })
         }
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -36,8 +36,9 @@
     self = [super init];
     if (self) {
         _mediaGroup = [[MediaLibraryGroup alloc] initWithBlog:blog];
+        __weak __typeof__(self) weakSelf = self;
         _groupObserverHandler = [_mediaGroup registerChangeObserverBlock:^(BOOL incrementalChanges, NSIndexSet *removed, NSIndexSet *inserted, NSIndexSet *changed, NSArray<id<WPMediaMove>> *moved) {
-            [self notifyObserversWithIncrementalChanges:incrementalChanges removed:removed inserted:inserted changed:changed moved:moved];
+            [weakSelf notifyObserversWithIncrementalChanges:incrementalChanges removed:removed inserted:inserted changed:changed moved:moved];
         }];
         _blog = blog;
         NSManagedObjectContext *backgroundContext = [[ContextManager sharedInstance] newDerivedContext];


### PR DESCRIPTION
I noticed a retain cycle in the media library earlier, so this PR fixes that up. It's just a case of making a few blocks use a weak `self`.

![pasted image at 2017_04_07 05_43 pm](https://cloud.githubusercontent.com/assets/4780/24814009/0a03835c-1bc8-11e7-8a68-ab73df1c2014.png)

To test:

* Open the app, navigate into the media library (from Blog Details VC), tap into a single media item, and then navigate back to Blog Details. Repeat this a couple of times. Finally, tap into another item in Blog Details, like Posts.
* In Xcode, view the Memory Graph:

<img width="39" alt="screen shot 2017-04-07 at 19 24 14" src="https://cloud.githubusercontent.com/assets/4780/24813938/d830a8aa-1bc7-11e7-8e00-97541a26a765.png">

* On `develop`, you should see `MediaLibraryPickerDataSource`, `MediaService` `MediaLibraryGroup`, and some `MediaItemViewController`s hanging around:

<img width="232" alt="screen shot 2017-04-07 at 20 13 32" src="https://cloud.githubusercontent.com/assets/4780/24815883/bd2f2cdc-1bce-11e7-9056-8b048a32d8e8.png">

* On this branch, they should be all gone.

Needs review: @SergioEstevao 
