### PR TITLE
Fix an issue where notifications sometimes present with no navigation

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -514,7 +514,9 @@ extension NotificationsViewController {
             return
         }
 
-        performSegue(withIdentifier: NotificationDetailsViewController.classNameWithoutNamespaces(), sender: note)
+        DispatchQueue.main.async {
+            self.performSegue(withIdentifier: NotificationDetailsViewController.classNameWithoutNamespaces(), sender: note)
+        }
     }
 
     fileprivate func prepareToShowDetailsForNotification(_ note: Notification) {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -514,6 +514,10 @@ extension NotificationsViewController {
             return
         }
 
+        // This dispatch avoids a bug that was occurring occasionally where navigation (nav bar and tab bar)
+        // would be missing entirely when launching the app from the background and presenting a notification.
+        // The issue seems tied to performing a `pop` in `prepareToShowDetailsForNotification` and presenting
+        // the new detail view controller at the same time. More info: https://github.com/wordpress-mobile/WordPress-iOS/issues/6976
         DispatchQueue.main.async {
             self.performSegue(withIdentifier: NotificationDetailsViewController.classNameWithoutNamespaces(), sender: note)
         }


### PR DESCRIPTION
Fixes #6976 

Whilst I don't like a magical dispatch main fix, this _seems_ to fix our missing navigation issue.

To test:

- Log in with your a8c account, find a notification that mentions you on a post (not a comment)
- The notification opens a reader view for the post.
- Scroll down a bit until the navigation bar disappears
- Put the app in the background
- Generate a new comment notification
- Tap on the new notification
- The comment notification should appear with the navigation bar

Needs review: @koke 