### PR TITLE
Issue/6069 like should not be an option for comments on jetpack sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -681,8 +681,13 @@ private extension NotificationDetailsViewController {
         // Setup: Properties
         // Note: Approve Action is actually a synonym for 'Edit' (Based on Calypso's basecode)
         //
+        // Jetpack sites don't support liking comments (same as what is done on CommentVC)
+        if let blog = blogWithBlogID(note.metaSiteID), blog.supports(.commentLikes) {
+            cell.isLikeEnabled = commentBlock.isActionEnabled(.Like)
+        } else {
+            cell.isLikeEnabled = false
+        }
         cell.isReplyEnabled     = UIDevice.isPad() && commentBlock.isActionOn(.Reply)
-        cell.isLikeEnabled      = commentBlock.isActionEnabled(.Like)
         cell.isApproveEnabled   = commentBlock.isActionEnabled(.Approve)
         cell.isTrashEnabled     = commentBlock.isActionEnabled(.Trash)
         cell.isSpamEnabled      = commentBlock.isActionEnabled(.Spam)


### PR DESCRIPTION
**Fixes** #6069

**To test:**
Create a comment on a Jetpack site.
Go to Notifications, navigate to that Comment, check that the Like button is not visible. 
Then tap on the Comment to trigger the thread view, check that the Like button is not visible there either.
Do the same steps for a Comment on a .com site and check that the Like button is visible.

**WordPress.com site**
![wp1](https://cloud.githubusercontent.com/assets/5558824/24865820/c3cb950a-1dde-11e7-9a7e-8c37ad94a540.png) ![wp2](https://cloud.githubusercontent.com/assets/5558824/24865819/c3999b40-1dde-11e7-9a82-a6baf5325f29.png)

**Jetpack site**
![jetpack1](https://cloud.githubusercontent.com/assets/5558824/24865721/7b9c50a8-1dde-11e7-9b84-06067465d468.png) ![jatpack2](https://cloud.githubusercontent.com/assets/5558824/24865723/7b9fef06-1dde-11e7-8781-6f9033eb7ece.png)



Needs review: @jleandroperez 