### PR TITLE
Add check for specific error code on xml rpc when status changed on the server.

### DIFF
--- a/WordPress/Classes/Networking/CommentServiceRemote.h
+++ b/WordPress/Classes/Networking/CommentServiceRemote.h
@@ -48,17 +48,4 @@
              success:(void (^)())success
              failure:(void (^)(NSError *error))failure;
 
-
-/**
- Retrieves the comment information for the the specified commentID
-
- @param commentID the comment ID to fetch info from
- @param success the block to invoke if the call is successfull
- @param failure the block to invoke if the call failed
- */
-- (void)getCommentWithID:(NSNumber *)commentID
-                 success:(void (^)(RemoteComment *comment))success
-                 failure:(void (^)(NSError *error))failure;
-
-
 @end

--- a/WordPress/Classes/Networking/CommentServiceRemote.h
+++ b/WordPress/Classes/Networking/CommentServiceRemote.h
@@ -49,4 +49,16 @@
              failure:(void (^)(NSError *error))failure;
 
 
+/**
+ Retrieves the comment information for the the specified commentID
+
+ @param commentID the comment ID to fetch info from
+ @param success the block to invoke if the call is successfull
+ @param failure the block to invoke if the call failed
+ */
+- (void)getCommentWithID:(NSNumber *)commentID
+                 success:(void (^)(RemoteComment *comment))success
+                 failure:(void (^)(NSError *error))failure;
+
+
 @end

--- a/WordPress/Classes/Networking/CommentServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteREST.m
@@ -360,6 +360,31 @@
                            }];
 }
 
+- (void)getCommentWithID:(NSNumber *)commentID
+           success:(void (^)(RemoteComment *comment))success
+           failure:(void (^)(NSError *error))failure
+{
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", self.siteID, commentID];
+    NSString *requestUrl = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+
+    [self.wordPressComRestApi GET:requestUrl
+                        parameters:nil
+                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+                               if (success) {
+                                   NSDictionary *commentDict = (NSDictionary *)responseObject;
+                                   RemoteComment *comment = [self remoteCommentFromJSONDictionary:commentDict];
+                                   success(comment);
+                               }
+                           } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+                               if (failure) {
+                                   failure(error);
+                               }
+                           }];
+
+}
+
+
 
 #pragma mark - Private methods
 

--- a/WordPress/Classes/Networking/CommentServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteREST.m
@@ -360,32 +360,6 @@
                            }];
 }
 
-- (void)getCommentWithID:(NSNumber *)commentID
-           success:(void (^)(RemoteComment *comment))success
-           failure:(void (^)(NSError *error))failure
-{
-    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", self.siteID, commentID];
-    NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
-
-    [self.wordPressComRestApi GET:requestUrl
-                        parameters:nil
-                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-                               if (success) {
-                                   NSDictionary *commentDict = (NSDictionary *)responseObject;
-                                   RemoteComment *comment = [self remoteCommentFromJSONDictionary:commentDict];
-                                   success(comment);
-                               }
-                           } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
-                               if (failure) {
-                                   failure(error);
-                               }
-                           }];
-
-}
-
-
-
 #pragma mark - Private methods
 
 - (NSArray *)remoteCommentsFromJSONArray:(NSArray *)jsonComments

--- a/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
@@ -131,7 +131,9 @@
                      // If the error is a 500 this could be a signal that the error changed status on the server
                      if ([error.domain isEqualToString:WPXMLRPCFaultErrorDomain]
                          && error.code == 500) {
-                         [self getCommentWithID:comment.commentID success:success failure:failure];
+                         if (success) {
+                             success(comment);
+                         }
                          return;
                      }
                      if (failure) {

--- a/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/CommentServiceRemoteXMLRPC.m
@@ -1,6 +1,7 @@
 #import "CommentServiceRemoteXMLRPC.h"
 #import "RemoteComment.h"
 #import "WordPress-Swift.h"
+@import wpxmlrpc;
 
 @implementation CommentServiceRemoteXMLRPC
 
@@ -127,6 +128,12 @@
                                     success:success
                                     failure:failure];
                  } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+                     // If the error is a 500 this could be a signal that the error changed status on the server
+                     if ([error.domain isEqualToString:WPXMLRPCFaultErrorDomain]
+                         && error.code == 500) {
+                         [self getCommentWithID:comment.commentID success:success failure:failure];
+                         return;
+                     }
                      if (failure) {
                          failure(error);
                      }

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -13,7 +13,6 @@
 #import "AbstractPost.h"
 #import "NSDate+WordPressJSON.h"
 #import "WordPress-Swift.h"
-@import wpxmlrpc;
 
 NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
 NSInteger const  WPNumberOfCommentsToSync = 100;
@@ -675,47 +674,21 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
                         if (success) {
                             success();
                         }
-                    } failure:^(NSError *error) {
-                        // let's check if this error comes from self-hosted site and is an 500
-                        // This could be a signal that the error changed status on the server
-                        if ([error.domain isEqualToString:WPXMLRPCFaultErrorDomain]
-                            && error.code == 500) {
-                            [remote getCommentWithID:remoteComment.commentID success:^(RemoteComment *comment) {
-                                [self.managedObjectContext performBlock:^{
-                                    // Note: The comment might have been deleted at this point
-                                    Comment *commentInContext = (Comment *)[self.managedObjectContext existingObjectWithID:commentID error:nil];
-                                    if (commentInContext) {
-                                        commentInContext.status = remoteComment.status;
-                                        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-                                    }
+                    } failure:^(NSError *error) {                        
+                        [self.managedObjectContext performBlock:^{
+                            // Note: The comment might have been deleted at this point
+                            Comment *commentInContext = (Comment *)[self.managedObjectContext existingObjectWithID:commentID error:nil];
+                            if (commentInContext) {
+                                commentInContext.status = prevStatus;
+                                [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+                            }
 
-                                    if (success) {
-                                        dispatch_async(dispatch_get_main_queue(), ^{
-                                            success();
-                                        });
-                                    }
-                                }];
-                            } failure:^(NSError *error) {
+                            if (failure) {
                                 dispatch_async(dispatch_get_main_queue(), ^{
                                     failure(error);
                                 });
-                            }];
-                        } else {
-                            [self.managedObjectContext performBlock:^{
-                                // Note: The comment might have been deleted at this point
-                                Comment *commentInContext = (Comment *)[self.managedObjectContext existingObjectWithID:commentID error:nil];
-                                if (commentInContext) {
-                                    commentInContext.status = prevStatus;
-                                    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-                                }
-
-                                if (failure) {
-                                    dispatch_async(dispatch_get_main_queue(), ^{
-                                        failure(error);
-                                    });
-                                }
-                            }];
-                        }
+                            }
+                        }];
                     }];
 }
 


### PR DESCRIPTION
Fixes #4673 

To test:
 - On a self hosted site non jetpack
 - Add a comment to a post
 - Check that the comment shows in the app and is waiting moderation
 - Go back to the web as and admin and spam/delete the comment
 - Go back to the app and without a refresh, tap on the comment and tap spam/delete
 - See if the comment goes away.

Needs review: @koke 
