### PR TITLE
Signin: Fixes value of dotcom_user property.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninWPComSyncHandler.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninWPComSyncHandler.swift
@@ -64,8 +64,8 @@ extension SigninWPComSyncHandler {
         dismiss()
 
         let properties = [
-            "multifactor": requiredMultifactor ? "1" : "0",
-            "dotcom_user": "1"
+            "multifactor": requiredMultifactor ? true.description : false.description,
+            "dotcom_user": true.description
         ]
 
         WPAppAnalytics.track(WPAnalyticsStat.signedIn, withProperties: properties)


### PR DESCRIPTION
This PR fixes an issue where the `dotcom_user` property was being set a string value of `1` rather than `true` on a successful login.  The same change is made to the `multifactor` property.

To test:
Add a breakpoint after the change.
Sign into wpcom.
Inspect the value of the properties dictionary and confirm that `dotcom_user` is set to `true`, and that multifactor is set to either `true` or `false` and not `1` or `0`. 
Bonus points for checking in our analytics dashboards.

Needs review: @astralbodies 
