### PR TITLE
Fix preview of video assets on WP library

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -624,7 +624,8 @@
 
         // No Image available so let's download it
         NSURL *remoteURL = nil;
-        if (media.mediaType == MediaTypeVideo) {
+        BOOL mediaIsVideo = media.mediaType == MediaTypeVideo;
+        if (mediaIsVideo) {
             remoteURL = [NSURL URLWithString:media.remoteThumbnailURL];
         } else if (media.mediaType == MediaTypeImage) {
             NSString *remote = media.remoteURL;
@@ -663,7 +664,7 @@
                     }
                     return;
                 }
-                if (CGSizeEqualToSize(size, mediaOriginalSize)) {
+                if (CGSizeEqualToSize(size, mediaOriginalSize) && !mediaIsVideo) {
                     media.absoluteLocalURL = fileURL;
                 } else {
                     media.absoluteThumbnailLocalURL = fileURL;

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -587,7 +587,7 @@
 
     NSURL *url = nil;
 
-    if ([self.absoluteLocalURL checkResourceIsReachableAndReturnError:nil]) {
+    if ([self.absoluteLocalURL checkResourceIsReachableAndReturnError:nil] && [self.absoluteLocalURL isVideo]) {
         url = self.absoluteLocalURL;
     }
     // Do we have a local url, or remote url to use for the video

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -585,7 +585,11 @@
         return 0;
     }
 
-    NSURL *url = self.absoluteLocalURL;
+    NSURL *url = nil;
+
+    if ([self.absoluteLocalURL checkResourceIsReachableAndReturnError:nil]) {
+        url = self.absoluteLocalURL;
+    }
     // Do we have a local url, or remote url to use for the video
     if (!url && self.remoteURL) {
         url = [NSURL URLWithString:self.remoteURL];


### PR DESCRIPTION
This PR fixes an issue find by @frosty where videos on the WordPress media library where being returned as images.

This was cause by a bug while fetching thumbnails for videos where the thumbnail was save to the location of the local video.

To test:
 - Open the app
 - Go to Setting -> App Settings  and clear the Media Cache
 - Go to a blog where you have videos save on your media library
 - Create a new post
 - Tap on add media
 - Select the video and force touch/long press to preview it
 - See if the video shows correctly.

Needs review: @frosty cc @kurzee 