### PR TITLE
Blog List Search Bar pinned to top

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -148,10 +148,10 @@ static NSInteger HideSearchMinSites = 3;
     [self configureStackView];
 
     [self configureSearchBar];
-    [self.stackView insertArrangedSubview:self.searchBar atIndex:0];
+    [self.stackView addArrangedSubview:self.searchBar];
 
     [self configureTableView];
-    [self.stackView insertArrangedSubview:self.tableView atIndex:1];
+    [self.stackView addArrangedSubview:self.tableView];
 
     self.editButtonItem.accessibilityIdentifier = NSLocalizedString(@"Edit", @"");
 
@@ -409,13 +409,7 @@ static NSInteger HideSearchMinSites = 3;
     stackView.axis = UILayoutConstraintAxisVertical;
     stackView.spacing = 0;
     [self.view addSubview:stackView];
-
-    [NSLayoutConstraint activateConstraints:@[
-                                              [stackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
-                                              [stackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
-                                              [stackView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
-                                              [stackView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
-                                              ]];
+    [self.view pinSubviewToAllEdges:stackView];
     _stackView = stackView;
 }
 
@@ -738,13 +732,19 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText
 {
-    self.dataSource.searching = YES;
     self.dataSource.searchQuery = searchText;
 }
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar
 {
+    self.dataSource.searching = YES;
     [searchBar setShowsCancelButton:YES animated:YES];
+}
+
+- (void)searchBarTextDidEndEditing:(UISearchBar *)searchBar
+{
+    self.dataSource.searching = NO;
+    [searchBar setShowsCancelButton:NO animated:YES];
 }
 
 - (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -27,16 +27,16 @@ static NSInteger HideSearchMinSites = 3;
 @interface BlogListViewController () <UIViewControllerRestoration,
                                         UIDataSourceModelAssociation,
                                         UITableViewDelegate,
-                                        UISearchResultsUpdating,
-                                        UISearchControllerDelegate,
+                                        UISearchBarDelegate,
                                         WPNoResultsViewDelegate,
                                         WPSplitViewControllerDetailProvider>
 
+@property (nonatomic, strong) UIStackView *stackView;
 @property (nonatomic, strong) UITableView *tableView;
 @property (nonatomic, strong) UIView *headerView;
 @property (nonatomic, strong) UILabel *headerLabel;
 @property (nonatomic, strong) WPNoResultsView *noResultsView;
-@property (nonatomic, strong) UISearchController *searchController;
+@property (nonatomic, strong) UISearchBar *searchBar;
 @property (nonatomic,   weak) UIAlertController *addSiteAlertController;
 @property (nonatomic, strong) UIBarButtonItem *addSiteButton;
 
@@ -145,16 +145,16 @@ static NSInteger HideSearchMinSites = 3;
 {
     [super viewDidLoad];
 
-    self.tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
-    self.tableView.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.view addSubview:self.tableView];
-    [self.view pinSubviewToAllEdges:self.tableView];
+    [self configureStackView];
 
-    [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
-    self.editButtonItem.accessibilityIdentifier = NSLocalizedString(@"Edit", @"");
+    [self configureSearchBar];
+    [self.stackView insertArrangedSubview:self.searchBar atIndex:0];
 
     [self configureTableView];
-    [self configureSearchController];
+    [self.stackView insertArrangedSubview:self.tableView atIndex:1];
+
+    self.editButtonItem.accessibilityIdentifier = NSLocalizedString(@"Edit", @"");
+
     [self configureNoResultsView];
 
     [self registerForAccountChangeNotification];
@@ -180,9 +180,11 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)viewWillDisappear:(BOOL)animated
 {
-    self.searchController.active = NO;
     [super viewWillDisappear:animated];
     [self unregisterForKeyboardNotifications];
+    if (self.searchBar.isFirstResponder) {
+        [self.searchBar resignFirstResponder];
+    }
     self.visible = NO;
 }
 
@@ -219,9 +221,9 @@ static NSInteger HideSearchMinSites = 3;
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     if ([blogService blogCountForAllAccounts] <= HideSearchMinSites) {
         // Hide the search bar if there's only a few blogs
-        self.tableView.tableHeaderView = nil;
-    } else {
-        [self addSearchBarTableHeaderView];
+        [self.searchBar removeFromSuperview];
+    } else if (self.searchBar.superview != self.stackView) {
+        [self.stackView insertArrangedSubview:self.searchBar atIndex:0];
     }
 }
 
@@ -400,49 +402,43 @@ static NSInteger HideSearchMinSites = 3;
     return UIStatusBarStyleLightContent;
 }
 
+- (void)configureStackView
+{
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    stackView.axis = UILayoutConstraintAxisVertical;
+    stackView.spacing = 0;
+    [self.view addSubview:stackView];
+
+    [NSLayoutConstraint activateConstraints:@[
+                                              [stackView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+                                              [stackView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+                                              [stackView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+                                              [stackView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+                                              ]];
+    _stackView = stackView;
+}
+
 - (void)configureTableView
 {
+    self.tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStylePlain];
     self.tableView.delegate = self;
     self.tableView.dataSource = self.dataSource;
     [self.tableView registerClass:[WPBlogTableViewCell class] forCellReuseIdentifier:[WPBlogTableViewCell reuseIdentifier]];
     self.tableView.allowsSelectionDuringEditing = YES;
     self.tableView.accessibilityIdentifier = NSLocalizedString(@"Blogs", @"");
+    self.tableView.translatesAutoresizingMaskIntoConstraints = NO;
 
     self.tableView.tableFooterView = [UIView new];
+    [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }
 
-- (void)configureSearchController
+- (void)configureSearchBar
 {
-    // Required for insets to work out correctly when the search bar becomes active
-    self.extendedLayoutIncludesOpaqueBars = YES;
-    self.definesPresentationContext = YES;
+    self.searchBar = [[UISearchBar alloc] initWithFrame:CGRectZero];
+    self.searchBar.delegate = self;
 
-    self.searchController = [[UISearchController alloc] initWithSearchResultsController:nil];
-    self.searchController.dimsBackgroundDuringPresentation = NO;
-
-    [self addSearchBarTableHeaderView];
-
-    self.searchController.delegate = self;
-    self.searchController.searchResultsUpdater = self;
-
-    [WPStyleGuide configureSearchBar:self.searchController.searchBar];
-}
-
-- (void)addSearchBarTableHeaderView
-{
-    if (!self.tableView.tableHeaderView) {
-        // Required to work around a bug where the search bar was extending a
-        // grey background above the top of the tableview, which was visible when
-        // pulling down further than offset zero
-        SearchWrapperView *wrapperView = [SearchWrapperView new];
-        [wrapperView addSubview:self.searchController.searchBar];
-        wrapperView.frame = CGRectMake(0, 0, self.view.bounds.size.width, self.searchController.searchBar.bounds.size.height);
-        self.tableView.tableHeaderView = wrapperView;
-    }
-}
-
-- (CGFloat)searchBarHeight {
-    return CGRectGetHeight(self.searchController.searchBar.bounds) + self.topLayoutGuide.length;
+    [WPStyleGuide configureSearchBar:self.searchBar];
 }
 
 - (void)configureNoResultsView
@@ -506,25 +502,14 @@ static NSInteger HideSearchMinSites = 3;
 
     UIEdgeInsets insets = self.tableView.contentInset;
 
-    self.tableView.scrollIndicatorInsets = UIEdgeInsetsMake([self searchBarHeight], insets.left, keyboardHeight, insets.right);
+    self.tableView.scrollIndicatorInsets = UIEdgeInsetsMake(0, insets.left, keyboardHeight, insets.right);
     self.tableView.contentInset = UIEdgeInsetsMake(self.topLayoutGuide.length, insets.left, keyboardHeight, insets.right);
 }
 
 - (void)keyboardWillHide:(NSNotification*)notification
 {
-    CGFloat tabBarHeight = self.tabBarController.tabBar.bounds.size.height;
-
-    UIEdgeInsets insets = self.tableView.contentInset;
-    insets.top = self.topLayoutGuide.length;
-    insets.bottom = tabBarHeight;
-
-    self.tableView.contentInset = insets;
-
-    if (self.searchController.active) {
-        insets.top = [self searchBarHeight];
-    }
-
-    self.tableView.scrollIndicatorInsets = insets;
+    self.tableView.scrollIndicatorInsets = UIEdgeInsetsZero;
+    self.tableView.contentInset = UIEdgeInsetsZero;
 }
 
 -(CGRect)localKeyboardFrameFromNotification:(NSNotification *)notification
@@ -749,29 +734,32 @@ static NSInteger HideSearchMinSites = 3;
     return [WPBlogTableViewCell cellHeight];
 }
 
-# pragma mark - UISearchController delegate methods
+# pragma mark - UISearchBar delegate methods
 
-- (void)willPresentSearchController:(UISearchController *)searchController
+- (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText
 {
     self.dataSource.searching = YES;
+    self.dataSource.searchQuery = searchText;
 }
 
-- (void)willDismissSearchController:(UISearchController *)searchController
+- (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar
 {
+    [searchBar setShowsCancelButton:YES animated:YES];
+}
+
+- (void)searchBarCancelButtonClicked:(UISearchBar *)searchBar
+{
+    [searchBar setShowsCancelButton:NO animated:YES];
+    [searchBar resignFirstResponder];
+    self.searchBar.text = nil;
     self.dataSource.searching = NO;
-    self.searchController.searchBar.text = nil;
+    self.dataSource.searchQuery = nil;
 }
 
-- (void)didDismissSearchController:(UISearchController *)searchController
+- (void)searchBarSearchButtonClicked:(UISearchBar *)searchBar
 {
-    UIEdgeInsets insets = self.tableView.scrollIndicatorInsets;
-    insets.top = self.topLayoutGuide.length;
-    self.tableView.scrollIndicatorInsets = insets;
-}
-
-- (void)updateSearchResultsForSearchController:(UISearchController *)searchController
-{
-    self.dataSource.searchQuery = searchController.searchBar.text;
+    [searchBar setShowsCancelButton:NO animated:YES];
+    [searchBar resignFirstResponder];
 }
 
 # pragma mark - Navigation Bar
@@ -789,6 +777,7 @@ static NSInteger HideSearchMinSites = 3;
     [self toggleRightBarButtonItems:!editing];
 
     if (editing) {
+        [self.searchBar removeFromSuperview];
         [self.addSiteAlertController dismissViewControllerAnimated:YES completion:nil];
         [self updateHeaderSize];
         self.tableView.tableHeaderView = self.headerView;
@@ -798,8 +787,9 @@ static NSInteger HideSearchMinSites = 3;
         self.noResultsView.hidden = YES;
     }
     else {
-        self.tableView.tableHeaderView = self.searchController.searchBar;
+        self.tableView.tableHeaderView = nil;
         [self updateViewsForCurrentSiteCount];
+        [self updateSearchVisibility];
     }
 }
 


### PR DESCRIPTION
**Fixes** #6468 
This PR replaces the UISearchController by a UISearchBar on the Blog List screen. 
This allows us to pin the search bar on top of the screen as it was requested, but it also plays nicely with the SplitVC.
Moreover using a search bar is consistent with how search is implemented both on Reader and on Media Library.

**To test:**
Go to My Sites and Search. 
Edit the list of available blogs.
Search again.
Play around.

Please test on IPad and landscape 7plus.


Needs review: @frosty 
