### PR TITLE
Fix blog OAuth capability detection

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -438,10 +438,11 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
             return [self supportsRestApi];
         case BlogFeatureSharing:
             return [self supportsSharing];
+        case BlogFeatureOAuth2Login:
+            return [self isHostedAtWPcom];
         case BlogFeatureCommentLikes:
         case BlogFeatureReblog:
         case BlogFeatureMentions:
-        case BlogFeatureOAuth2Login:
         case BlogFeaturePlans:
             return [self isHostedAtWPcom] && [self isAdmin];
         case BlogFeaturePushNotifications:


### PR DESCRIPTION
Fixes #7009 
OAuth support of a blog was detected only when the blog was hosted at WP.com and the current user was an admin of the blog, this PR removes the requisite that the current user is an admin.

To test:
On branch develop, as a non-admin user, preview a Post. You will get a local preview.
Checkout this branch and repeat the process, you should correctly see a remote on-site preview.

Needs review: @aerych 
