### PR TITLE
Featured Images convenience tweaks

### DIFF
--- a/WordPress/Classes/Extensions/Media+Blog.swift
+++ b/WordPress/Classes/Extensions/Media+Blog.swift
@@ -35,4 +35,13 @@ extension Media {
         }
         return blogMedia.first(where: ({ $0.mediaID == mediaID }))
     }
+
+    /// Returns an existing Media object that matches the remoteURL if it exists, or nil.
+    ///
+    class func existingMediaWith(remoteURL: String, inBlog blog: Blog) -> Media? {
+        guard let blogMedia = blog.media as? Set<Media> else {
+            return nil
+        }
+        return blogMedia.first(where: ({ $0.remoteURL == remoteURL }))
+    }
 }

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.h
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.h
@@ -5,8 +5,8 @@
 @class AbstractPost;
 
 typedef NS_ENUM(NSUInteger, MediaPickerDataSourceType) {
-    MediaPickerDataSourceTypeMediaLibrary,
-    MediaPickerDataSourceTypeDevice
+    MediaPickerDataSourceTypeDevice,
+    MediaPickerDataSourceTypeMediaLibrary
 };
 
 @interface WPAndDeviceMediaLibraryDataSource : NSObject <WPMediaCollectionDataSource>
@@ -14,7 +14,11 @@ typedef NS_ENUM(NSUInteger, MediaPickerDataSourceType) {
 @property (nonatomic) MediaPickerDataSourceType dataSourceType;
 
 - (instancetype)initWithBlog:(Blog *)blog;
+- (instancetype)initWithBlog:(Blog *)blog
+              dataSourceType:(MediaPickerDataSourceType)sourceType;
 
 - (instancetype)initWithPost:(AbstractPost *)post;
+- (instancetype)initWithPost:(AbstractPost *)post
+              dataSourceType:(MediaPickerDataSourceType)sourceType;
 
 @end

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.h
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.h
@@ -15,10 +15,10 @@ typedef NS_ENUM(NSUInteger, MediaPickerDataSourceType) {
 
 - (instancetype)initWithBlog:(Blog *)blog;
 - (instancetype)initWithBlog:(Blog *)blog
-              dataSourceType:(MediaPickerDataSourceType)sourceType;
+       initialDataSourceType:(MediaPickerDataSourceType)sourceType;
 
 - (instancetype)initWithPost:(AbstractPost *)post;
 - (instancetype)initWithPost:(AbstractPost *)post
-              dataSourceType:(MediaPickerDataSourceType)sourceType;
+       initialDataSourceType:(MediaPickerDataSourceType)sourceType;
 
 @end

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.h
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.h
@@ -4,7 +4,14 @@
 @class Blog;
 @class AbstractPost;
 
+typedef NS_ENUM(NSUInteger, MediaPickerDataSourceType) {
+    MediaPickerDataSourceTypeMediaLibrary,
+    MediaPickerDataSourceTypeDevice
+};
+
 @interface WPAndDeviceMediaLibraryDataSource : NSObject <WPMediaCollectionDataSource>
+
+@property (nonatomic) MediaPickerDataSourceType dataSourceType;
 
 - (instancetype)initWithBlog:(Blog *)blog;
 

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -13,11 +13,12 @@
 
 - (instancetype)initWithBlog:(Blog *)blog
 {
-    return [self initWithBlog:blog dataSourceType:MediaPickerDataSourceTypeDevice];
+    return [self initWithBlog:blog
+        initialDataSourceType:MediaPickerDataSourceTypeDevice];
 }
 
 - (instancetype)initWithBlog:(Blog *)blog
-              dataSourceType:(MediaPickerDataSourceType)sourceType
+       initialDataSourceType:(MediaPickerDataSourceType)sourceType
 {
     self = [super init];
     if (self) {
@@ -30,11 +31,12 @@
 
 - (instancetype)initWithPost:(AbstractPost *)post
 {
-    return [self initWithPost:post dataSourceType:MediaPickerDataSourceTypeDevice];
+    return [self initWithPost:post
+        initialDataSourceType:MediaPickerDataSourceTypeDevice];
 }
 
 - (instancetype)initWithPost:(AbstractPost *)post
-              dataSourceType:(MediaPickerDataSourceType)sourceType
+       initialDataSourceType:(MediaPickerDataSourceType)sourceType
 {
     self = [super init];
     if (self) {
@@ -214,9 +216,5 @@
 {
     return [self.currentDataSource ascendingOrdering];
 }
-
-
-
-
 
 @end

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -13,28 +13,51 @@
 
 - (instancetype)initWithBlog:(Blog *)blog
 {
+    return [self initWithBlog:blog dataSourceType:MediaPickerDataSourceTypeDevice];
+}
+
+- (instancetype)initWithBlog:(Blog *)blog
+              dataSourceType:(MediaPickerDataSourceType)sourceType
+{
     self = [super init];
     if (self) {
         _mediaLibraryDataSource = [[MediaLibraryPickerDataSource alloc] initWithBlog:blog];
-        _deviceLibraryDataSource = [[WPPHAssetDataSource alloc] init];
 
-        _currentDataSource = _deviceLibraryDataSource;
-        _observers = [[NSMutableDictionary alloc] init];
+        [self commonInitWithSourceType:sourceType];
     }
     return self;
 }
 
 - (instancetype)initWithPost:(AbstractPost *)post
 {
+    return [self initWithPost:post dataSourceType:MediaPickerDataSourceTypeDevice];
+}
+
+- (instancetype)initWithPost:(AbstractPost *)post
+              dataSourceType:(MediaPickerDataSourceType)sourceType
+{
     self = [super init];
     if (self) {
         _mediaLibraryDataSource = [[MediaLibraryPickerDataSource alloc] initWithPost:post];
-        _deviceLibraryDataSource = [[WPPHAssetDataSource alloc] init];
 
-        _currentDataSource = _deviceLibraryDataSource;
-        _observers = [[NSMutableDictionary alloc] init];
+        [self commonInitWithSourceType:sourceType];
     }
     return self;
+}
+
+- (void)commonInitWithSourceType:(MediaPickerDataSourceType)sourceType
+{
+    _deviceLibraryDataSource = [[WPPHAssetDataSource alloc] init];
+
+    _observers = [[NSMutableDictionary alloc] init];
+
+    [self setDataSourceType:sourceType];
+
+    // If we're showing the media library first, ensure that we have
+    // the groups loaded for the device library so that the user can switch.
+    if (self.dataSourceType == MediaPickerDataSourceTypeMediaLibrary) {
+        [_deviceLibraryDataSource loadDataWithSuccess:nil failure:nil];
+    }
 }
 
 - (MediaPickerDataSourceType)dataSourceType

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -17,6 +17,7 @@
     if (self) {
         _mediaLibraryDataSource = [[MediaLibraryPickerDataSource alloc] initWithBlog:blog];
         _deviceLibraryDataSource = [[WPPHAssetDataSource alloc] init];
+
         _currentDataSource = _deviceLibraryDataSource;
         _observers = [[NSMutableDictionary alloc] init];
     }
@@ -29,10 +30,29 @@
     if (self) {
         _mediaLibraryDataSource = [[MediaLibraryPickerDataSource alloc] initWithPost:post];
         _deviceLibraryDataSource = [[WPPHAssetDataSource alloc] init];
+
         _currentDataSource = _deviceLibraryDataSource;
         _observers = [[NSMutableDictionary alloc] init];
     }
     return self;
+}
+
+- (MediaPickerDataSourceType)dataSourceType
+{
+    return (_currentDataSource == _deviceLibraryDataSource) ? MediaPickerDataSourceTypeDevice : MediaPickerDataSourceTypeMediaLibrary;
+}
+
+- (void)setDataSourceType:(MediaPickerDataSourceType)dataSourceType
+{
+    switch (dataSourceType) {
+        case MediaPickerDataSourceTypeDevice:
+            _currentDataSource = _deviceLibraryDataSource;
+            break;
+        case MediaPickerDataSourceTypeMediaLibrary:
+            _currentDataSource = _mediaLibraryDataSource;
+        default:
+            break;
+    }
 }
 
 - (NSInteger)numberOfGroups

--- a/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.h
@@ -2,6 +2,8 @@
 
 @class WPImageMeta;
 @class AbstractPost;
+@class Media;
+
 @protocol EditImageDetailsViewControllerDelegate;
 
 @interface EditImageDetailsViewController : UITableViewController
@@ -10,7 +12,9 @@
 @property (nonatomic) AbstractPost *post;
 @property (nonatomic, weak) id<EditImageDetailsViewControllerDelegate>delegate;
 
-+ (instancetype)controllerForDetails:(WPImageMeta *)details forPost:(AbstractPost *)post;
++ (instancetype)controllerForDetails:(WPImageMeta *)details
+                               media:(Media *)media
+                             forPost:(AbstractPost *)post;
 
 @end
 

--- a/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
@@ -216,10 +216,6 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
     [self.sections addObject:@(ImageDetailsSectionThumb)];
     [self.sections addObject:@(ImageDetailsSectionDetails)];
     [self.sections addObject:@(ImageDetailsSectionDisplay)];
-
-    if (self.media && self.media.assetType == WPMediaTypeImage) {
-        [self.sections addObject:@(ImageDetailsSectionFeatured)];
-    }
 }
 
 

--- a/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
@@ -260,9 +260,9 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    NSInteger sec = [[self.sections objectAtIndex:section] integerValue];
+    NSInteger imageDetailsSection = [[self.sections objectAtIndex:section] integerValue];
 
-    switch (sec) {
+    switch (imageDetailsSection) {
         case ImageDetailsSectionThumb:
             return 1;
         case ImageDetailsSectionFeatured:
@@ -277,16 +277,17 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
-    NSInteger sec = [[self.sections objectAtIndex:section] integerValue];
-    if (sec == ImageDetailsSectionDetails) {
-        return NSLocalizedString(@"Details", @"The title of the option group for editing an image's title, caption, etc. on the image details screen.");
+    NSInteger imageDetailsSection = [[self.sections objectAtIndex:section] integerValue];
 
-    } else if (sec == ImageDetailsSectionDisplay) {
-        return NSLocalizedString(@"Web Display Settings", @"The title of the option group for editing an image's size, alignment, etc. on the image details screen.");
-    } else if (sec == ImageDetailsSectionFeatured) {
-        return NSLocalizedString(@"Featured Image", @"The title of the option group for setting an image as a post's featured image on the image details screen.");
+    switch (imageDetailsSection) {
+        case ImageDetailsSectionDetails:
+            return NSLocalizedString(@"Details", @"The title of the option group for editing an image's title, caption, etc. on the image details screen.");
+        case ImageDetailsSectionDisplay:
+            return NSLocalizedString(@"Web Display Settings", @"The title of the option group for editing an image's size, alignment, etc. on the image details screen.");
+        case ImageDetailsSectionFeatured:
+            return NSLocalizedString(@"Featured Image", @"The title of the option group for setting an image as a post's featured image on the image details screen.");
+        default: return nil;
     }
-    return nil;
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
@@ -301,11 +302,11 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    NSInteger sec = [[self.sections objectAtIndex:indexPath.section] integerValue];
+    NSInteger imageDetailsSection = [[self.sections objectAtIndex:indexPath.section] integerValue];
 
     UITableViewCell *cell;
 
-    switch (sec) {
+    switch (imageDetailsSection) {
         case ImageDetailsSectionThumb:
             cell = [self thumbCellForIndexPath:indexPath];
             break;

--- a/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
@@ -217,7 +217,7 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
     [self.sections addObject:@(ImageDetailsSectionDetails)];
     [self.sections addObject:@(ImageDetailsSectionDisplay)];
 
-    if (self.media) {
+    if (self.media && self.media.assetType == WPMediaTypeImage) {
         [self.sections addObject:@(ImageDetailsSectionFeatured)];
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1226,7 +1226,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 {
     WPNavigationMediaPickerViewController *picker = [[WPNavigationMediaPickerViewController alloc] init];
     self.mediaDataSource = [[WPAndDeviceMediaLibraryDataSource alloc] initWithPost:self.apost
-                                                                    dataSourceType:MediaPickerDataSourceTypeMediaLibrary];
+                                                             initialDataSourceType:MediaPickerDataSourceTypeMediaLibrary];
     picker.dataSource = self.mediaDataSource;
     picker.filter = WPMediaTypeImage;
     picker.delegate = self;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1226,6 +1226,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 {
     WPNavigationMediaPickerViewController *picker = [[WPNavigationMediaPickerViewController alloc] init];
     self.mediaDataSource = [[WPAndDeviceMediaLibraryDataSource alloc] initWithPost:self.apost];
+    self.mediaDataSource.dataSourceType = MediaPickerDataSourceTypeMediaLibrary;
     picker.dataSource = self.mediaDataSource;
     picker.filter = WPMediaTypeImage;
     picker.delegate = self;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1225,8 +1225,8 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 - (void)showMediaPicker
 {
     WPNavigationMediaPickerViewController *picker = [[WPNavigationMediaPickerViewController alloc] init];
-    self.mediaDataSource = [[WPAndDeviceMediaLibraryDataSource alloc] initWithPost:self.apost];
-    self.mediaDataSource.dataSourceType = MediaPickerDataSourceTypeMediaLibrary;
+    self.mediaDataSource = [[WPAndDeviceMediaLibraryDataSource alloc] initWithPost:self.apost
+                                                                    dataSourceType:MediaPickerDataSourceTypeMediaLibrary];
     picker.dataSource = self.mediaDataSource;
     picker.filter = WPMediaTypeImage;
     picker.delegate = self;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -2073,7 +2073,7 @@ EditImageDetailsViewControllerDelegate
 {
     // Note: imageId is an editor specified data attribute, not the image's ID attribute.
     if (imageId.length == 0) {
-        [self displayImageDetailsForMeta:imageMeta];
+        [self displayImageDetailsForMeta:imageMeta url:url];
     } else {
         [self promptForActionForTappedMedia:imageId url:url];
     }
@@ -2110,9 +2110,16 @@ EditImageDetailsViewControllerDelegate
 }
 
 - (void)displayImageDetailsForMeta:(WPImageMeta *)imageMeta
+                               url:(NSURL *)url
 {
     [WPAppAnalytics track:WPAnalyticsStatEditorEditedImage withBlog:self.post.blog];
-    EditImageDetailsViewController *controller = [EditImageDetailsViewController controllerForDetails:imageMeta forPost:self.post];
+
+    Media *media = [Media existingMediaWithRemoteURL:[url absoluteString]
+                                              inBlog:self.post.blog];
+
+    EditImageDetailsViewController *controller = [EditImageDetailsViewController controllerForDetails:imageMeta
+                                                                                                media:media
+                                                                                              forPost:self.post];
     controller.delegate = self;
 
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:controller];


### PR DESCRIPTION
This PR makes a couple of tweaks to make it easier to set featured images. Note that these changes are currently only for the hybrid editor. If it's all okay we can do another small PR for Aztec.

There are two main changes:

### Post Settings: Default to Media Library

The Post Settings "Set Featured Image" button now shows the media picker defaulted to show the WP media library. This matches the behaviour on Android, and I know most of the time when I personally want to chose a featured image, I've already uploaded it. You can of course still switch back to the device library if necessary.

I had to add a new property to `WPAndDeviceMediaLibraryDataSource` to allow us to set the starting source. I also had to call `loadData` on the local photo library data source on `init` to ensure we have the groups available in the picker. I'm not 100% sure if this is the best approach, so let me know what you think.

### Edit Image: Set as Featured Image

When you Edit an image that you've inserted into a post, there's now a 'Set as Featured Image' toggle. This will show up a) as long as we could find a local Media object for the current blog with the same `remoteURL` as the image you're editing, and b) as long as the Media object is an image, not a video.

![simulator screen shot 12 apr 2017 19 30 37](https://cloud.githubusercontent.com/assets/4780/24976397/36fe06e6-1fc1-11e7-8d2e-df9f954c0882.png)

### To Test:

* Open a new post in the editor, and open Post Settings.
* Tap Set Featured Image and ensure that the media library loads, and that you can switch to the local library. Check that inserting an image works okay.
* Also check this on .com and self-hosted, and a clean install.
* Insert an image into the post, select it and tap Edit and check that if you enable the featured image toggle that it's also reflected in Post Settings.
* Check that if you remove the featured image from Post Settings that the toggle in the edit image VC is updated accordingly.
* Check that Cancel in the edit image VC doesn't save any changes you make to the toggle.

Needs review: @SergioEstevao 