### PR TITLE
Don’t clear the search when a theme is activated

### DIFF
--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -656,7 +656,6 @@ public protocol ThemePresenter: class {
             return
         }
 
-        searchController.isActive = false
         _ = themeService.activate(theme,
             for: blog,
             success: { [weak self] (theme: Theme?) in


### PR DESCRIPTION
**Fixes** #5906 

**To test:**

1. Go to Blog->Themes
2. Search for a theme
3. Activate it
4. Check that the search is not cleared

Needs review: @aerych 
