### PR TITLE
Fix incorrect placement of notification badge icon

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -408,6 +408,10 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
                                self.meSplitViewController,
                                self.notificationsSplitViewController]];
 
+    // Bring the badge view to the front, while recreating the VCs the TabBarItems are
+    // recreated too, leaving it in the back
+    [self.tabBar bringSubviewToFront:self.notificationBadgeIconView];
+
     // Reset the selectedIndex to the default MySites tab.
     self.selectedIndex = WPTabMySites;
 }
@@ -693,6 +697,9 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         return;
     }
 
+    // When the user logs in the VCs are recreated and at the time viewDidLayoutSubviews is
+    // invoked the TabButton frames are not correct, so we need to recalculate the badge position
+    [self updateNotificationBadgeIconPosition];
     BOOL wasNotificationBadgeHidden = self.notificationBadgeIconView.hidden;
     self.notificationBadgeIconView.hidden = NO;
     tabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications Unread", @"Notifications tab bar item accessibility label, unread notifications state");


### PR DESCRIPTION
**Fixes** #6972 
I was able to reproduce the problem only by logging out and in with unread notifications. It's caused by two different issues:
1. The UITabBarItems recreation on top of the previously added Notification Badge
2. When `viewDidLayoutSubviews` is invoked after logging in the frames for the UITabBarButtons are not correct.

**To test:**
You can add this bit of code to `updateNotificationBadgeVisibility` so you always have a notification icon that comes and goes.
```
    count = arc4random() % 2;
    [self performSelector:@selector(updateNotificationBadgeVisibility)
               withObject:nil
               afterDelay:5];
```

I suggest doing this in develop, logging out and in and checking that the icon is misplaced. If you rotate the device it will go to the correct location, but behind the bell.
Then checkout this branch, repeat the procedure and confirm that everything looks good.

Needs review: @jleandroperez 