### PR TITLE
Issue/501 post slug editing

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -604,6 +604,12 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
         return YES;
     }
 
+    if (!([self.wp_slug length] == 0 && [original.wp_slug length] == 0)
+        && (![self.wp_slug isEqual:original.wp_slug]))
+    {
+        return YES;
+    }
+
     return NO;
 }
 

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -538,6 +538,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     }
     post.authorAvatarURL = remotePost.authorAvatarURL;
     post.mt_excerpt = remotePost.excerpt;
+    post.wp_slug = remotePost.slug;
 
     if (remotePost.postID != previousPostID) {
         [self updateCommentsForPost:post];
@@ -617,6 +618,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     remotePost.type = @"post";
     remotePost.authorAvatarURL = post.authorAvatarURL;
     remotePost.excerpt = post.mt_excerpt;
+    remotePost.slug = post.wp_slug;
 
     if ([post isKindOfClass:[Page class]]) {
         Page *pagePost = (Page *)post;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSInteger, PostSettingsRow) {
     PostSettingsRowShareConnection,
     PostSettingsRowShareMessage,
     PostSettingsRowGeolocation,
+    PostSettingsRowSlug,
     PostSettingsRowExcerpt
 };
 
@@ -448,7 +449,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         return 1;
 
     } else if (sec == PostSettingsSectionMoreOptions) {
-        return 1;
+        return 2;
 
     }
 
@@ -556,7 +557,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     } else if (sec == PostSettingsSectionGeolocation) {
         cell = [self configureGeolocationCellForIndexPath:indexPath];
     } else if (sec == PostSettingsSectionMoreOptions) {
-        cell = [self configureExcerptCellForIndexPath:indexPath];
+        cell = [self configureMoreOptionsCellForIndexPath:indexPath];
     }
 
     return cell;
@@ -588,6 +589,8 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         [self showEditShareMessageController];
     } else if (cell.tag == PostSettingsRowGeolocation) {
         [self showPostGeolocationSelector];
+    } else if (cell.tag == PostSettingsRowSlug) {
+        [self showEditSlugController];
     } else if (cell.tag == PostSettingsRowExcerpt) {
         [self showEditExcerptController];
     }
@@ -865,6 +868,25 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     } else {
         return self.postGeoLocationCell;
     }
+    return cell;
+}
+
+- (UITableViewCell *)configureMoreOptionsCellForIndexPath:(NSIndexPath *)indexPath
+{
+    if (indexPath.row == 0) {
+        return [self configureSlugCellForIndexPath:indexPath];
+    } else {
+        return [self configureExcerptCellForIndexPath:indexPath];
+    }
+}
+
+- (UITableViewCell *)configureSlugCellForIndexPath:(NSIndexPath *)indexPath
+{
+    WPTableViewCell *cell = [self getWPTableViewDisclosureCell];
+    cell.textLabel.text = NSLocalizedString(@"Slug", @"Label for the slug field. Should be the same as WP core.");
+    cell.detailTextLabel.text = self.apost.wp_slug;
+    cell.tag = PostSettingsRowSlug;
+    cell.accessibilityIdentifier = @"Slug";
     return cell;
 }
 
@@ -1206,6 +1228,21 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
             [self showMediaPicker];
         }
     }
+}
+
+- (void)showEditSlugController
+{
+    SettingsMultiTextViewController *vc = [[SettingsMultiTextViewController alloc] initWithText:self.apost.wp_slug
+                                                                                    placeholder:nil
+                                                                                           hint:NSLocalizedString(@"The slug is the URL-friendly version of the post title.", @"Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso.")
+                                                                                     isPassword:NO];
+    vc.title = NSLocalizedString(@"Slug", @"Label for the slug field. Should be the same as WP core.");
+    vc.autocapitalizationType = UITextAutocapitalizationTypeNone;
+    vc.onValueChanged = ^(NSString *value) {
+        self.apost.wp_slug = value;
+        [self.tableView reloadData];
+    };
+    [self.navigationController pushViewController:vc animated:YES];
 }
 
 - (void)showEditExcerptController

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.h
@@ -25,6 +25,9 @@ typedef void (^SettingsMultiTextChanged)(NSString * _Nonnull);
 ///
 @property (nonatomic, assign) BOOL isPassword;
 
+/// Autocapitalization type used in the textfield, defaults to UITextAutocapitalizationTypeSentences
+@property (nonatomic, assign) UITextAutocapitalizationType autocapitalizationType;
+
 /// Block to be executed on dismiss, if the value was effectively updated.
 ///
 @property (nullable, nonatomic, copy) SettingsMultiTextChanged onValueChanged;

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -25,6 +25,7 @@ static CGFloat const SettingsMinHeight = 41.0f;
         _placeholder = placeholder;
         _hint = hint;
         _isPassword = isPassword;
+        _autocapitalizationType = UITextAutocapitalizationTypeSentences;
     }
     return self;
 }
@@ -73,6 +74,7 @@ static CGFloat const SettingsMinHeight = 41.0f;
     textView.textColor = [WPStyleGuide darkGrey];
     textView.delegate = self;
     textView.scrollEnabled = NO;
+    textView.autocapitalizationType = self.autocapitalizationType;
 
     UIEdgeInsets textInset = textView.textContainerInset;
     textInset.left = 0.0;

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -365,6 +365,12 @@ class PostTests: XCTestCase {
 
         revision.mt_excerpt = original.mt_excerpt
         XCTAssertFalse(revision.hasLocalChanges())
+
+        revision.wp_slug = "New pretty slug"
+        XCTAssertTrue(revision.hasLocalChanges())
+
+        revision.wp_slug = original.wp_slug
+        XCTAssertFalse(revision.hasLocalChanges())
     }
 
     func testThatEnablingDisablingPublicizeConnectionsWorks() {


### PR DESCRIPTION
**Fixes** #501 

**To test:**
1. Select a Post
2. Go to Post Settings
3. Scroll down, edit the slug
4. Save the Post and check that your slug is save (either on the app or on the browser)

Notes: 
Spaces will be replaced by '-' by the backend
There is a bug on the API (I will take care of reporting it) that doesn't allow you to set the slug to the empty string once it's been given a value. This affects Calypso too, but the UI fakes that is updated, I'm guessing because of the local storage on the browser. 

Needs review: @kurzee 
