### PR TITLE
Media Library: Add support for video preview

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/PlayIconView.swift
+++ b/WordPress/Classes/ViewRelated/Views/PlayIconView.swift
@@ -5,7 +5,7 @@ import WordPressShared
 /// play button appearance in web views.
 ///
 class PlayIconView: UIView {
-    private static let defaultSize = CGSize(width: 110, height: 110)
+    private static let defaultSize = CGSize(width: 71, height: 71)
 
     private let playLayer = CAShapeLayer()
     private let visualEffectsView = UIVisualEffectView(effect: UIBlurEffect(style: .light))
@@ -49,6 +49,7 @@ class PlayIconView: UIView {
 
     private func addEffectsView() {
         visualEffectsView.frame = bounds
+
         addSubview(visualEffectsView)
     }
 
@@ -70,8 +71,8 @@ class PlayIconView: UIView {
         let halfBoundsWidth: CGFloat = bounds.width / 2
         let halfBoundsHeight: CGFloat = bounds.height / 2
 
-        let size = CGSize(width: halfBoundsWidth - lineWidth,
-                          height: halfBoundsHeight)
+        let size = CGSize(width: halfBoundsWidth - (lineWidth + halfLineWidth),
+                          height: halfBoundsHeight - halfLineWidth)
         let halfSizeWidth: CGFloat = size.width / 2
         let halfSizeHeight: CGFloat = size.height / 2
 
@@ -89,7 +90,7 @@ class PlayIconView: UIView {
         playLayer.lineCap = kCALineCapRound
         playLayer.lineJoin = kCALineJoinRound
 
-        let centerX = halfBoundsWidth - halfSizeWidth + lineWidth
+        let centerX = halfBoundsWidth - halfSizeWidth + halfLineWidth
         let centerY = halfBoundsHeight - halfSizeWidth - lineWidth
 
         playLayer.frame = CGRect(x: centerX, y: centerY, width: size.width, height: size.height)

--- a/WordPress/Classes/ViewRelated/Views/PlayIconView.swift
+++ b/WordPress/Classes/ViewRelated/Views/PlayIconView.swift
@@ -1,0 +1,97 @@
+import UIKit
+import WordPressShared
+
+/// A circular 'play' icon for use on videos that should match the system
+/// play button appearance in web views.
+///
+class PlayIconView: UIView {
+    private static let defaultSize = CGSize(width: 110, height: 110)
+
+    private let playLayer = CAShapeLayer()
+    private let visualEffectsView = UIVisualEffectView(effect: UIBlurEffect(style: .light))
+
+    var isHighlighted: Bool {
+        didSet {
+            let iconColor = isHighlighted ? .black : WPStyleGuide.darkGrey()
+            playLayer.strokeColor = iconColor.cgColor
+            playLayer.fillColor = iconColor.cgColor
+        }
+    }
+
+    convenience init() {
+        self.init(frame: CGRect(x: 0,
+                                y: 0,
+                                width: type(of: self).defaultSize.width,
+                                height: type(of: self).defaultSize.height))
+    }
+
+    override init(frame: CGRect) {
+        isHighlighted = false
+
+        super.init(frame: frame)
+
+        addEffectsView()
+        layer.addSublayer(playLayer)
+        refreshRadius()
+        updatePlayLayer()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("Not implemented")
+    }
+
+    override var frame: CGRect {
+        didSet {
+            refreshRadius()
+            updatePlayLayer()
+        }
+    }
+
+    private func addEffectsView() {
+        visualEffectsView.frame = bounds
+        addSubview(visualEffectsView)
+    }
+
+    fileprivate func refreshRadius() {
+        let radius: CGFloat = frame.width / 2
+
+        if visualEffectsView.layer.cornerRadius != radius {
+            visualEffectsView.layer.cornerRadius = radius
+        }
+
+        visualEffectsView.layer.masksToBounds = true
+        visualEffectsView.clipsToBounds = true
+    }
+
+    private func updatePlayLayer() {
+        let lineWidth: CGFloat = 5
+        let halfLineWidth: CGFloat = lineWidth / 2
+
+        let halfBoundsWidth: CGFloat = bounds.width / 2
+        let halfBoundsHeight: CGFloat = bounds.height / 2
+
+        let size = CGSize(width: halfBoundsWidth - lineWidth,
+                          height: halfBoundsHeight)
+        let halfSizeWidth: CGFloat = size.width / 2
+        let halfSizeHeight: CGFloat = size.height / 2
+
+        // Draw a triangle
+        let path = UIBezierPath()
+        path.move(to: CGPoint(x: size.width + halfLineWidth, y: halfSizeHeight + halfLineWidth))
+        path.addLine(to: CGPoint(x: halfLineWidth, y: size.height + halfLineWidth))
+        path.addLine(to: CGPoint(x: halfLineWidth, y: halfLineWidth))
+        path.addLine(to: CGPoint(x: size.width + halfLineWidth, y: halfSizeHeight + halfLineWidth))
+        path.close()
+
+        // Set a rounded line style
+        playLayer.path = path.cgPath
+        playLayer.lineWidth = lineWidth
+        playLayer.lineCap = kCALineCapRound
+        playLayer.lineJoin = kCALineJoinRound
+
+        let centerX = halfBoundsWidth - halfSizeWidth + lineWidth
+        let centerY = halfBoundsHeight - halfSizeWidth - lineWidth
+
+        playLayer.frame = CGRect(x: centerX, y: centerY, width: size.width, height: size.height)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		176579F71C63A40F0000978E /* PurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176579F61C63A40F0000978E /* PurchaseButton.swift */; };
 		1767494E1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */; };
 		176DEEE91D4615FE00331F30 /* WPSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */; };
+		177076211EA206C000705A4A /* PlayIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177076201EA206C000705A4A /* PlayIconView.swift */; };
 		177CBE501DA3A3AC009F951E /* CollectionType+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177CBE4F1DA3A3AC009F951E /* CollectionType+Helpers.swift */; };
 		177E7DAD1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */; };
 		1782BE841E70063100A91E7D /* MediaItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1782BE831E70063100A91E7D /* MediaItemViewController.swift */; };
@@ -1212,6 +1213,7 @@
 		176579F61C63A40F0000978E /* PurchaseButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseButton.swift; sourceTree = "<group>"; };
 		1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSearchHeaderView.swift; sourceTree = "<group>"; };
 		176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPSplitViewController.swift; sourceTree = "<group>"; };
+		177076201EA206C000705A4A /* PlayIconView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayIconView.swift; sourceTree = "<group>"; };
 		177CBE4F1DA3A3AC009F951E /* CollectionType+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionType+Helpers.swift"; sourceTree = "<group>"; };
 		177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+SplitViewFullscreen.swift"; sourceTree = "<group>"; };
 		1782BE831E70063100A91E7D /* MediaItemViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaItemViewController.swift; sourceTree = "<group>"; };
@@ -2650,6 +2652,7 @@
 				591A428A1A6DC1B0003807A6 /* WPBackgroundDimmerView.h */,
 				591A428B1A6DC1B0003807A6 /* WPBackgroundDimmerView.m */,
 				1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */,
+				177076201EA206C000705A4A /* PlayIconView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -6463,6 +6466,7 @@
 				85B6F74F1742DA1E00CE7F3A /* WPNUXMainButton.m in Sources */,
 				E64ECA4D1CE62041000188A0 /* ReaderSearchViewController.swift in Sources */,
 				E14977181C0DC0770057CD60 /* MediaSizeSliderCell.swift in Sources */,
+				177076211EA206C000705A4A /* PlayIconView.swift in Sources */,
 				E1468DE71E794A4D0044D80F /* LanguageSelectorViewController.swift in Sources */,
 				85D239BB1AE5A6620074768D /* LoginFields.m in Sources */,
 				E1C3C8531CE467A900D5DB36 /* EmailTypoChecker.swift in Sources */,


### PR DESCRIPTION
This PR adds playback of video assets to the media library. When you view details for a video, you'll see a play icon over the video thumbnail:

![img_6675](https://cloud.githubusercontent.com/assets/4780/25062097/234db85a-21bd-11e7-87c4-45f598cc8e2c.PNG)

This is a custom view, which I've tried to match as close as I could to the system icon that's shown over videos in Safari. When you tap the video, we play it back through `AVPlayerViewController`.

To test:

* Try playing back video assets on different types of site (self-hosted, .com etc)
* Check that the video icon only shows on videos, not images
* Check that the icon is centered correctly and looks right

Needs review: @kurzee 
cc @SergioEstevao 