### PR TITLE
Lets users unlock with aztec or editor parameter

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -282,7 +282,7 @@ int ddLogLevel = DDLogLevelInfo;
 
                 return YES;
             }
-        } else if ([[url host] isEqualToString:@"editor"]) {
+        } else if ([[url host] isEqualToString:@"editor"] || [[url host] isEqualToString:@"aztec"]) {
             // Example: wordpress://editor?available=1&enabled=0
             NSDictionary* params = [[url query] dictionaryFromQueryString];
 


### PR DESCRIPTION
Fixes #7052 

To test:
1. Follow the steps in #6890 but replace `editor` with `aztec`.

This doesn't need to be an exhaustive test given the relatively small code change.

Needs review: @diegoreymendez 

cc: @0nko 
