### PR TITLE
Adds post ID & editor source to all editor-related events.

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-@class Blog;
+@class Blog, AbstractPost;
 
 typedef NSString*(^WPAppAnalyticsLastVisibleScreenCallback)();
 
@@ -10,6 +10,7 @@ extern NSString * const WPAppAnalyticsKeyPostID;
 extern NSString * const WPAppAnalyticsKeyFeedID;
 extern NSString * const WPAppAnalyticsKeyFeedItemID;
 extern NSString * const WPAppAnalyticsKeyIsJetpack;
+extern NSString * const WPAppAnalyticsKeyEditorSource;
 
 /**
  *  @class      WPAppAnalytics
@@ -69,6 +70,16 @@ extern NSString * const WPAppAnalyticsKeyIsJetpack;
  *  @brief      Tracks stats with the blog_id when available
  */
 + (void)track:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties withBlogID:(NSNumber*)blogID;
+
+/**
+ *  @brief      Tracks stats with the post details when available
+ */
++ (void)track:(WPAnalyticsStat)stat withPost:(AbstractPost *)postOrPage;
+
+/**
+ *  @brief      Tracks stats with the post details when available
+ */
++ (void)track:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties withPost:(AbstractPost *)postOrPage;
 
 /**
     @brief      Used only for bumping the TrainTracks interaction event. The stat's

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -8,6 +8,7 @@
 #import "ApiCredentials.h"
 #import "WordPressAppDelegate.h"
 #import "Blog.h"
+#import "AbstractPost.h"
 
 NSString * const WPAppAnalyticsDefaultsKeyUsageTracking = @"usage_tracking_enabled";
 NSString * const WPAppAnalyticsKeyBlogID = @"blog_id";
@@ -15,6 +16,7 @@ NSString * const WPAppAnalyticsKeyPostID = @"post_id";
 NSString * const WPAppAnalyticsKeyFeedID = @"feed_id";
 NSString * const WPAppAnalyticsKeyFeedItemID = @"feed_item_id";
 NSString * const WPAppAnalyticsKeyIsJetpack = @"is_jetpack";
+NSString * const WPAppAnalyticsKeyEditorSource = @"editor_source";
 static NSString * const WPAppAnalyticsKeyLastVisibleScreen = @"last_visible_screen";
 static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 
@@ -192,6 +194,26 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
         [WPAppAnalytics track:stat];
     }
 }
+
++ (void)track:(WPAnalyticsStat)stat withPost:(AbstractPost *)postOrPage {
+    [WPAppAnalytics track:stat withProperties:nil withPost:postOrPage];
+}
+
++ (void)track:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties withPost:(AbstractPost *)postOrPage {
+    NSMutableDictionary *mutableProperties;
+    if (properties) {
+        mutableProperties = [NSMutableDictionary dictionaryWithDictionary:properties];
+    } else {
+        mutableProperties = [NSMutableDictionary new];
+    }
+
+    if (postOrPage.postID.integerValue > 0) {
+        mutableProperties[WPAppAnalyticsKeyPostID] = postOrPage.postID;
+    }
+
+    [WPAppAnalytics track:stat withProperties:mutableProperties withBlog:postOrPage.blog];
+}
+
 
 + (void)trackTrainTracksInteraction:(WPAnalyticsStat)stat withProperties:(NSDictionary *)properties
 {

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -11,6 +11,7 @@ import WordPressComAnalytics
 // MARK: - Aztec's Native Editor!
 //
 class AztecPostViewController: UIViewController {
+    fileprivate let analyticsEditorSourceValue = "aztec"
 
     /// Closure to be executed when the editor gets closed
     ///
@@ -802,13 +803,13 @@ extension AztecPostViewController {
 
     private func trackPostSave(stat: WPAnalyticsStat) {
         guard stat != .editorSavedDraft && stat != .editorQuickSavedDraft else {
-            WPAppAnalytics.track(stat, with:post.blog)
+            WPAppAnalytics.track(stat, withProperties:[WPAppAnalyticsKeyEditorSource: analyticsEditorSourceValue], with:post.blog)
             return
         }
 
         let originalWordCount = post.original?.content?.wordCount() ?? 0
         let wordCount = post.content?.wordCount() ?? 0
-        var properties: [String: Any] = ["word_count": wordCount]
+        var properties: [String: Any] = ["word_count": wordCount, WPAppAnalyticsKeyEditorSource: analyticsEditorSourceValue]
         if post.hasRemote() {
             properties["word_diff_count"] = originalWordCount
         }
@@ -820,7 +821,7 @@ extension AztecPostViewController {
             properties[WPAnalyticsStatEditorPublishedPostPropertyVideo] = post.hasVideo()
         }
 
-        WPAppAnalytics.track(stat, withProperties: properties, with: post.blog)
+        WPAppAnalytics.track(stat, withProperties: properties, with: post)
     }
 }
 
@@ -1480,7 +1481,7 @@ fileprivate extension AztecPostViewController {
             return
         }
 
-        WPAppAnalytics.track(.editorDiscardedChanges, with: post.blog)
+        WPAppAnalytics.track(.editorDiscardedChanges, withProperties:[WPAppAnalyticsKeyEditorSource: analyticsEditorSourceValue], with: post)
 
         post = originalPost
         post.deleteRevision()
@@ -1502,7 +1503,7 @@ fileprivate extension AztecPostViewController {
     func dismissOrPopView(didSave: Bool) {
         stopEditing()
 
-        WPAppAnalytics.track(.editorClosed, with: post.blog)
+        WPAppAnalytics.track(.editorClosed, withProperties:[WPAppAnalyticsKeyEditorSource: analyticsEditorSourceValue], with: post)
 
         if let onClose = onClose {
             onClose(didSave)
@@ -1653,9 +1654,9 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
             let attachment = self.richTextView.insertImage(sourceURL:tempMediaURL, atPosition: self.richTextView.selectedRange.location, placeHolderImage: Assets.defaultMissingImage)
 
             if media.mediaType == .image {
-                WPAppAnalytics.track(.editorAddedPhotoViaWPMediaLibrary, withProperties: WPAppAnalytics.properties(for: media), with: post.blog)
+                WPAppAnalytics.track(.editorAddedPhotoViaWPMediaLibrary, withProperties: WPAppAnalytics.properties(for: media), with: post)
             } else if media.mediaType == .video {
-                WPAppAnalytics.track(.editorAddedVideoViaWPMediaLibrary, withProperties: WPAppAnalytics.properties(for: media), with: post.blog)
+                WPAppAnalytics.track(.editorAddedVideoViaWPMediaLibrary, withProperties: WPAppAnalytics.properties(for: media), with: post)
             }
 
             upload(media: media, mediaID: attachment.identifier)
@@ -1711,7 +1712,7 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
                     return
                 }
 
-                WPAppAnalytics.track(.editorUploadMediaFailed, with: strongSelf.post.blog)
+                WPAppAnalytics.track(.editorUploadMediaFailed, withProperties: [WPAppAnalyticsKeyEditorSource: strongSelf.analyticsEditorSourceValue], with: strongSelf.post.blog)
 
                 DispatchQueue.main.async {
                     strongSelf.handleError(error as NSError, onAttachment: attachment)
@@ -1790,7 +1791,7 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
                                                         self.richTextView.refreshLayoutFor(attachment: attachment)
                                                         self.mediaProgressCoordinator.track(numberOfItems: 1)
 
-                                                        WPAppAnalytics.track(.editorUploadMediaRetried, with: self.post.blog)
+                                                        WPAppAnalytics.track(.editorUploadMediaRetried, withProperties: [WPAppAnalyticsKeyEditorSource: self.analyticsEditorSourceValue], with: self.post.blog)
 
                                                         self.upload(media: media, mediaID: mediaID)
                                                     }
@@ -1821,7 +1822,7 @@ extension AztecPostViewController: MediaProgressCoordinatorDelegate {
         navController.modalPresentationStyle = .formSheet
         present(navController, animated: true, completion: nil)
 
-        WPAppAnalytics.track(.editorEditedImage, with: post.blog)
+        WPAppAnalytics.track(.editorEditedImage, withProperties: [WPAppAnalyticsKeyEditorSource: analyticsEditorSourceValue], with: post)
     }
 
     var mediaMessageAttributes: [String: Any] {

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -33,6 +33,7 @@
 
 NSString *const WPLegacyEditorNavigationRestorationID = @"WPLegacyEditorNavigationRestorationID";
 NSString *const WPLegacyAbstractPostRestorationKey = @"WPLegacyAbstractPostRestorationKey";
+NSString *const WPAppAnalyticsEditorSourceValueLegacy = @"legacy";
 static void *ProgressObserverContext = &ProgressObserverContext;
 
 
@@ -402,7 +403,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     }
 
     if (![self.post hasUnsavedChanges]) {
-        [WPAppAnalytics track:WPAnalyticsStatEditorClosed withBlog:self.post.blog];
+        [WPAppAnalytics track:WPAnalyticsStatEditorClosed withProperties:@{WPAppAnalyticsKeyEditorSource: WPAppAnalyticsEditorSourceValueLegacy} withPost:self.post];
 
         [self discardChanges];
         [self dismissEditView:NO];
@@ -420,7 +421,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
                                 handler:^(UIAlertAction * action) {
                                     [self discardChanges];
                                     [self dismissEditView:NO];
-                                    [WPAppAnalytics track:WPAnalyticsStatEditorDiscardedChanges withBlog:self.post.blog];
+                                    [WPAppAnalytics track:WPAnalyticsStatEditorDiscardedChanges withProperties:@{WPAppAnalyticsKeyEditorSource: WPAppAnalyticsEditorSourceValueLegacy} withPost:self.post];
                                 }];
     
     if ([self.post.original.status isEqualToString:PostStatusDraft]) {
@@ -740,29 +741,26 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     NSInteger originalWordCount = [self.post.original.content wordCount];
     NSInteger wordCount = [self.post.content wordCount];
 
-    NSMutableDictionary *properties = [[NSMutableDictionary alloc] initWithCapacity:2];
+    NSMutableDictionary *properties = [NSMutableDictionary new];
+    properties[WPAppAnalyticsKeyEditorSource] = WPAppAnalyticsEditorSourceValueLegacy;
     properties[@"word_count"] = @(wordCount);
+
     if ([self.post hasRemote]) {
         properties[@"word_diff_count"] = @(wordCount - originalWordCount);
     }
 
-    NSNumber *dotComID = [self.post blog].dotComID;
-    if (dotComID) {
-        properties[WPAppAnalyticsKeyBlogID] = dotComID;
-    }
-    
     if ([buttonTitle isEqualToString:NSLocalizedString(@"Post", nil)]) {
         properties[WPAnalyticsStatEditorPublishedPostPropertyCategory] = @([self.post hasCategories]);
         properties[WPAnalyticsStatEditorPublishedPostPropertyPhoto] = @([self.post hasPhoto]);
         properties[WPAnalyticsStatEditorPublishedPostPropertyTag] = @([self.post hasTags]);
         properties[WPAnalyticsStatEditorPublishedPostPropertyVideo] = @([self.post hasVideo]);
-        [WPAnalytics track:WPAnalyticsStatEditorPublishedPost withProperties:properties];
+        [WPAppAnalytics track:WPAnalyticsStatEditorPublishedPost withProperties:properties withPost:self.post];
     } else if ([buttonTitle isEqualToString:NSLocalizedString(@"Schedule", nil)]) {
-        [WPAnalytics track:WPAnalyticsStatEditorScheduledPost withProperties:properties];
+        [WPAppAnalytics track:WPAnalyticsStatEditorScheduledPost withProperties:properties withPost:self.post];
     } else if ([buttonTitle isEqualToString:NSLocalizedString(@"Save", nil)]) {
-        [WPAnalytics track:WPAnalyticsStatEditorSavedDraft];
+        [WPAppAnalytics track:WPAnalyticsStatEditorSavedDraft withProperties:properties withPost:self.post];
     } else {
-        [WPAnalytics track:WPAnalyticsStatEditorUpdatedPost withProperties:properties];
+        [WPAppAnalytics track:WPAnalyticsStatEditorUpdatedPost withProperties:properties withPost:self.post];
     }
 }
 
@@ -979,11 +977,11 @@ static void *ProgressObserverContext = &ProgressObserverContext;
             if (media.mediaType == WPMediaTypeImage) {
                 [WPAppAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary
                        withProperties:[WPAppAnalytics propertiesFor:media]
-                             withBlog:self.post.blog];
+                             withPost:self.post];
             } else if (media.mediaType == WPMediaTypeVideo) {
                 [WPAppAnalytics track:WPAnalyticsStatEditorAddedVideoViaLocalLibrary
                        withProperties:[WPAppAnalytics propertiesFor:media]
-                             withBlog:self.post.blog];
+                             withPost:self.post];
             }
             [self uploadMedia:media trackingId:imageUniqueId];
         }];
@@ -999,7 +997,7 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         [self insertMedia:media];
         [self stopTrackingProgressOfMediaWithId:mediaUniqueId];
     } failure:^(NSError *error) {
-        [WPAppAnalytics track:WPAnalyticsStatEditorUploadMediaFailed withBlog:self.post.blog];
+        [WPAppAnalytics track:WPAnalyticsStatEditorUploadMediaFailed withProperties:@{WPAppAnalyticsKeyEditorSource: WPAppAnalyticsEditorSourceValueLegacy} withPost:self.post];
         [self stopTrackingProgressOfMediaWithId:mediaUniqueId];
         if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) {
             DDLogWarn(@"Media uploader failed with cancelled upload: %@", error.localizedDescription);
@@ -1020,9 +1018,9 @@ static void *ProgressObserverContext = &ProgressObserverContext;
     NSString *mediaUniqueID = [self uniqueIdForMedia];
     if ([media.mediaID intValue] != 0) {
         if ([media mediaType] == MediaTypeImage) {
-            [WPAppAnalytics track:WPAnalyticsStatEditorAddedPhotoViaWPMediaLibrary withBlog:self.post.blog];
+            [WPAppAnalytics track:WPAnalyticsStatEditorAddedPhotoViaWPMediaLibrary withProperties:@{WPAppAnalyticsKeyEditorSource: WPAppAnalyticsEditorSourceValueLegacy} withPost:self.post];
         } else if ([media mediaType] == MediaTypeVideo) {
-            [WPAppAnalytics track:WPAnalyticsStatEditorAddedVideoViaWPMediaLibrary withBlog:self.post.blog];
+            [WPAppAnalytics track:WPAnalyticsStatEditorAddedVideoViaWPMediaLibrary withProperties:@{WPAppAnalyticsKeyEditorSource: WPAppAnalyticsEditorSourceValueLegacy} withPost:self.post];
         }
         [self trackMediaWithId:mediaUniqueID usingProgress:[NSProgress progressWithTotalUnitCount:1]];
         [self insertMedia:media];
@@ -1031,11 +1029,11 @@ static void *ProgressObserverContext = &ProgressObserverContext;
         if (media.mediaType == WPMediaTypeImage) {
             [WPAppAnalytics track:WPAnalyticsStatEditorAddedPhotoViaLocalLibrary
                    withProperties:[WPAppAnalytics propertiesFor:media]
-                         withBlog:self.post.blog];
+                         withPost:self.post];
         } else if (media.mediaType == WPMediaTypeVideo) {
             [WPAppAnalytics track:WPAnalyticsStatEditorAddedVideoViaLocalLibrary
                    withProperties:[WPAppAnalytics propertiesFor:media]
-                         withBlog:self.post.blog];
+                         withPost:self.post];
         }
         [self uploadMedia:media trackingId:mediaUniqueID];
     }


### PR DESCRIPTION
Fixes #7051 

This PR does a couple things.

First, it adds a convenience method to `WPAppAnalytics` to accept an `AbstractPost` parameter similar to the blog parameter method already available. I'm not a big fan of the naming but why rock the boat. This change will make it easy to include `post_id` in all of our analytics events when one is present. It then also subsequently adds `blog_id` because it makes good sense.

Second, it adds a new property `editor_source` to all editor-related events and indicates which editor is being used to send those events. This does feel ugly as well but then our analytics tracking code in general isn't the most pretty. When we remove the legacy and hybrid editors we can axe these properties.

To test:
1. Set a breakpoint or NSLog in `[TracksServiceRemote sendBatchOfEvents:withSharedProperties:completionHandler]` to dump out the pending events to the console. Example: `NSLog(@"Sending data:\n%@", dataToSend);`
2. Create a new post in any editor and verify post ID isn't being sent but blog ID is (post has to be remote to have a valid ID).
3. Edit an existing post and verify post ID is now present in the events.

Use a combination of Aztec, Legacy, and Hybrid editors. I did not add tracking to the created post analytics event as that code is a hot mess being in 3-4 different areas in the app. I think we're tracking enough with the source parameter to derive usage patterns.

Needs review: @jleandroperez, @nheagy 

cc: @0nko, @hypest 
