### PR TITLE
HUD messages are now dismissible by tapping anywhere on the screen

### DIFF
--- a/WordPress/Classes/Categories/SVProgressHUD+Dismiss.h
+++ b/WordPress/Classes/Categories/SVProgressHUD+Dismiss.h
@@ -2,7 +2,7 @@
 
 @interface SVProgressHUD (Dismiss)
 
-+ (void)showDismissableErrorWithStatus:(NSString*)status;
-+ (void)showDismissableSuccessWithStatus:(NSString*)status;
++ (void)showDismissibleErrorWithStatus:(NSString*)status;
++ (void)showDismissibleSuccessWithStatus:(NSString*)status;
 
 @end

--- a/WordPress/Classes/Categories/SVProgressHUD+Dismiss.h
+++ b/WordPress/Classes/Categories/SVProgressHUD+Dismiss.h
@@ -2,7 +2,7 @@
 
 @interface SVProgressHUD (Dismiss)
 
-+ (void)showDismissibleErrorWithStatus:(NSString*)status;
-+ (void)showDismissibleSuccessWithStatus:(NSString*)status;
++ (void)showDismissibleErrorWithStatus:(NSString *)status;
++ (void)showDismissibleSuccessWithStatus:(NSString *)status;
 
 @end

--- a/WordPress/Classes/Categories/SVProgressHUD+Dismiss.h
+++ b/WordPress/Classes/Categories/SVProgressHUD+Dismiss.h
@@ -1,0 +1,8 @@
+#import <SVProgressHUD/SVProgressHUD.h>
+
+@interface SVProgressHUD (Dismiss)
+
++ (void)showDismissableErrorWithStatus:(NSString*)status;
++ (void)showDismissableSuccessWithStatus:(NSString*)status;
+
+@end

--- a/WordPress/Classes/Categories/SVProgressHUD+Dismiss.m
+++ b/WordPress/Classes/Categories/SVProgressHUD+Dismiss.m
@@ -2,14 +2,14 @@
 
 @implementation SVProgressHUD (Dismiss)
 
-+ (void)showDismissibleErrorWithStatus:(NSString*)status
++ (void)showDismissibleErrorWithStatus:(NSString *)status
 {
     [SVProgressHUD registerForHUDNotifications];
     [SVProgressHUD setDefaultMaskType:SVProgressHUDMaskTypeClear];
     [SVProgressHUD showErrorWithStatus:status];
 }
 
-+ (void)showDismissibleSuccessWithStatus:(NSString*)status
++ (void)showDismissibleSuccessWithStatus:(NSString *)status
 {
     [SVProgressHUD registerForHUDNotifications];
     [SVProgressHUD setDefaultMaskType:SVProgressHUDMaskTypeClear];
@@ -18,12 +18,12 @@
 
 #pragma mark - NSNotificationCenter
 
-+ (void)handleHUDTappedNotification: (NSNotification *)notification
++ (void)handleHUDTappedNotification:(NSNotification *)notification
 {
     [SVProgressHUD dismiss];
 }
 
-+ (void)handleHUDDisappearedNotification: (NSNotification *)notification
++ (void)handleHUDDisappearedNotification:(NSNotification *)notification
 {
     [self unregisterFromHUDNotifications];
 }

--- a/WordPress/Classes/Categories/SVProgressHUD+Dismiss.m
+++ b/WordPress/Classes/Categories/SVProgressHUD+Dismiss.m
@@ -30,13 +30,18 @@
 
 + (void)registerForHUDNotifications
 {
+    // Remove the observer from NSNotificationCenter to prevent having duplicate entries
+    // when the HUD is re-displayed before being dismissed
+    [self unregisterFromHUDNotifications];
+
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleHUDTappedNotification:)
                                                  name:SVProgressHUDDidReceiveTouchEventNotification
                                                object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleHUDDisappearedNotification:)
-                                                 name:SVProgressHUDWillDisappearNotification object:nil];
+                                                 name:SVProgressHUDWillDisappearNotification
+                                               object:nil];
 }
 
 + (void)unregisterFromHUDNotifications

--- a/WordPress/Classes/Categories/SVProgressHUD+Dismiss.m
+++ b/WordPress/Classes/Categories/SVProgressHUD+Dismiss.m
@@ -1,0 +1,52 @@
+#import "SVProgressHUD+Dismiss.h"
+
+@implementation SVProgressHUD (Dismiss)
+
++ (void)showDismissableErrorWithStatus:(NSString*)status
+{
+    [SVProgressHUD registerForHUDNotifications];
+    [SVProgressHUD setDefaultMaskType:SVProgressHUDMaskTypeClear];
+    [SVProgressHUD showErrorWithStatus:status];
+}
+
++ (void)showDismissableSuccessWithStatus:(NSString*)status
+{
+    [SVProgressHUD registerForHUDNotifications];
+    [SVProgressHUD setDefaultMaskType:SVProgressHUDMaskTypeClear];
+    [SVProgressHUD showSuccessWithStatus:status];
+}
+
+#pragma mark - NSNotificationCenter
+
++ (void)handleHUDTappedNotification: (NSNotification *)notification
+{
+    [SVProgressHUD dismiss];
+}
+
++ (void)handleHUDDisappearedNotification: (NSNotification *)notification
+{
+    [self unregisterFromHUDNotifications];
+}
+
++ (void)registerForHUDNotifications
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleHUDTappedNotification:)
+                                                 name:SVProgressHUDDidReceiveTouchEventNotification
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleHUDDisappearedNotification:)
+                                                 name:SVProgressHUDWillDisappearNotification object:nil];
+}
+
++ (void)unregisterFromHUDNotifications
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:SVProgressHUDDidReceiveTouchEventNotification
+                                                  object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:SVProgressHUDWillDisappearNotification
+                                                  object:nil];
+}
+
+@end

--- a/WordPress/Classes/Categories/SVProgressHUD+Dismiss.m
+++ b/WordPress/Classes/Categories/SVProgressHUD+Dismiss.m
@@ -2,14 +2,14 @@
 
 @implementation SVProgressHUD (Dismiss)
 
-+ (void)showDismissableErrorWithStatus:(NSString*)status
++ (void)showDismissibleErrorWithStatus:(NSString*)status
 {
     [SVProgressHUD registerForHUDNotifications];
     [SVProgressHUD setDefaultMaskType:SVProgressHUDMaskTypeClear];
     [SVProgressHUD showErrorWithStatus:status];
 }
 
-+ (void)showDismissableSuccessWithStatus:(NSString*)status
++ (void)showDismissibleSuccessWithStatus:(NSString*)status
 {
     [SVProgressHUD registerForHUDNotifications];
     [SVProgressHUD setDefaultMaskType:SVProgressHUDMaskTypeClear];

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -106,6 +106,7 @@
 #import "SuggestionService.h"
 #import "SuggestionsTableView.h"
 #import "SupportViewController.h"
+#import "SVProgressHUD+Dismiss.h"
 
 #import "Theme.h"
 #import "ThemeService.h"

--- a/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
@@ -4,10 +4,10 @@
 #import "BlogService.h"
 #import "ContextManager.h"
 #import "SettingTableViewCell.h"
+#import "SVProgressHud+Dismiss.h"
 #import "RelatedPostsPreviewTableViewCell.h"
 
 #import <WordPressShared/WPStyleGuide.h>
-#import <SVProgressHUD/SVProgressHUD.h>
 #import "WordPress-Swift.h"
 
 
@@ -255,7 +255,7 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
     [blogService updateSettingsForBlog:self.blog success:^{
         [self.tableView reloadData];
     } failure:^(NSError *error) {
-        [SVProgressHUD showErrorWithStatus:NSLocalizedString(@"Settings update failed", @"Message to show when setting save failed")];
+        [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Settings update failed", @"Message to show when setting save failed")];
         [self.tableView reloadData];
     }];
     [self.tableView reloadData];

--- a/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
@@ -255,7 +255,7 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
     [blogService updateSettingsForBlog:self.blog success:^{
         [self.tableView reloadData];
     } failure:^(NSError *error) {
-        [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Settings update failed", @"Message to show when setting save failed")];
+        [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Settings update failed", @"Message to show when setting save failed")];
         [self.tableView reloadData];
     }];
     [self.tableView reloadData];

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationHelper.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationHelper.m
@@ -2,7 +2,7 @@
 
 #import "Blog.h"
 #import "BlogService.h"
-#import "SVProgressHUD.h"
+#import "SVProgressHUD+Dismiss.h"
 #import "SharingAuthorizationWebViewController.h"
 #import "WordPress-Swift.h"
 
@@ -61,7 +61,7 @@
     [self dismissNavViewController];
     NSString *message = NSLocalizedString(@"%@ was reconnected.", @"Let's the user know that a third party sharing service was reconnected. The %@ is a placeholder for the service name.");
     message = [NSString stringWithFormat:message, self.publicizeService.label];
-    [SVProgressHUD showSuccessWithStatus:message];
+    [SVProgressHUD showDismissableSuccessWithStatus:message];
 }
 
 
@@ -139,7 +139,7 @@
         return;
     }
 
-    [SVProgressHUD showErrorWithStatus:NSLocalizedString(@"Connection failed", @"Message to show when Publicize authorization failed")];
+    [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Connection failed", @"Message to show when Publicize authorization failed")];
 }
 
 /**
@@ -156,7 +156,7 @@
         return;
     }
 
-    [SVProgressHUD showErrorWithStatus:NSLocalizedString(@"Connection cancelled", @"Message to show when Publicize authorization is cancelled")];
+    [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Connection cancelled", @"Message to show when Publicize authorization is cancelled")];
 }
 
 
@@ -196,7 +196,7 @@
                 return;
             }
             NSString *status = [NSString stringWithFormat:NSLocalizedString(@"No connections found for %@", @"Message to show when Keyring connection synchronization succeeded but no matching connections were found. %@ is a service name like Facebook or Twitter"), self.publicizeService.label];
-            [SVProgressHUD showErrorWithStatus:status];
+            [SVProgressHUD showDismissableErrorWithStatus:status];
             return;
         }
 
@@ -209,7 +209,7 @@
         }
 
         NSString *status = [NSString stringWithFormat:NSLocalizedString(@"We had trouble loading connections for %@", @"Message to show when Keyring connection synchronization failed. %@ is a service name like Facebook or Twitter"), self.publicizeService.label];
-        [SVProgressHUD showErrorWithStatus:status];
+        [SVProgressHUD showDismissableErrorWithStatus:status];
     }];
 }
 
@@ -383,7 +383,7 @@
         [self.delegate sharingAuthorizationHelper:self connectionFailedForService:self.publicizeService];
         return;
     }
-    [SVProgressHUD showErrorWithStatus:NSLocalizedString(@"Connection failed", @"Message to show when Publicize connect failed")];
+    [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Connection failed", @"Message to show when Publicize connect failed")];
 }
 
 
@@ -399,7 +399,7 @@
         [self.delegate sharingAuthorizationHelper:self connectionCancelledForService:self.publicizeService];
         return;
     }
-    [SVProgressHUD showErrorWithStatus:NSLocalizedString(@"Connection cancelled", @"Message to show when Publicize connection is cancelled by the user.")];
+    [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Connection cancelled", @"Message to show when Publicize connection is cancelled by the user.")];
 }
 
 - (void)sharingAccountViewController:(SharingAccountViewController *)controller

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationHelper.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationHelper.m
@@ -61,7 +61,7 @@
     [self dismissNavViewController];
     NSString *message = NSLocalizedString(@"%@ was reconnected.", @"Let's the user know that a third party sharing service was reconnected. The %@ is a placeholder for the service name.");
     message = [NSString stringWithFormat:message, self.publicizeService.label];
-    [SVProgressHUD showDismissableSuccessWithStatus:message];
+    [SVProgressHUD showDismissibleSuccessWithStatus:message];
 }
 
 
@@ -139,7 +139,7 @@
         return;
     }
 
-    [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Connection failed", @"Message to show when Publicize authorization failed")];
+    [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Connection failed", @"Message to show when Publicize authorization failed")];
 }
 
 /**
@@ -156,7 +156,7 @@
         return;
     }
 
-    [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Connection cancelled", @"Message to show when Publicize authorization is cancelled")];
+    [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Connection cancelled", @"Message to show when Publicize authorization is cancelled")];
 }
 
 
@@ -196,7 +196,7 @@
                 return;
             }
             NSString *status = [NSString stringWithFormat:NSLocalizedString(@"No connections found for %@", @"Message to show when Keyring connection synchronization succeeded but no matching connections were found. %@ is a service name like Facebook or Twitter"), self.publicizeService.label];
-            [SVProgressHUD showDismissableErrorWithStatus:status];
+            [SVProgressHUD showDismissibleErrorWithStatus:status];
             return;
         }
 
@@ -209,7 +209,7 @@
         }
 
         NSString *status = [NSString stringWithFormat:NSLocalizedString(@"We had trouble loading connections for %@", @"Message to show when Keyring connection synchronization failed. %@ is a service name like Facebook or Twitter"), self.publicizeService.label];
-        [SVProgressHUD showDismissableErrorWithStatus:status];
+        [SVProgressHUD showDismissibleErrorWithStatus:status];
     }];
 }
 
@@ -383,7 +383,7 @@
         [self.delegate sharingAuthorizationHelper:self connectionFailedForService:self.publicizeService];
         return;
     }
-    [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Connection failed", @"Message to show when Publicize connect failed")];
+    [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Connection failed", @"Message to show when Publicize connect failed")];
 }
 
 
@@ -399,7 +399,7 @@
         [self.delegate sharingAuthorizationHelper:self connectionCancelledForService:self.publicizeService];
         return;
     }
-    [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Connection cancelled", @"Message to show when Publicize connection is cancelled by the user.")];
+    [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Connection cancelled", @"Message to show when Publicize connection is cancelled by the user.")];
 }
 
 - (void)sharingAccountViewController:(SharingAccountViewController *)controller

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -156,7 +156,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
                                 success:nil
                                 failure:^(NSError *error) {
                                     DDLogError([error description]);
-                                    [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Change failed", @"Message to show when Publicize globally shared setting failed")];
+                                    [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Change failed", @"Message to show when Publicize globally shared setting failed")];
                                     [weakSelf.tableView reloadData];
                                 }];
 }
@@ -204,7 +204,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
     [sharingService deletePublicizeConnectionForBlog:self.blog pubConn:self.publicizeConnection success:nil failure:^(NSError *error) {
         DDLogError([error description]);
-        [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Disconnect failed", @"Message to show when Publicize disconnect failed")];
+        [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Disconnect failed", @"Message to show when Publicize disconnect failed")];
     }];
 
     // Since the service optimistically deletes the connection, go ahead and pop.
@@ -250,7 +250,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)sharingAuthorizationHelper:(SharingAuthorizationHelper *)helper didConnectToService:(PublicizeService *)service withPublicizeConnection:(PublicizeConnection *)keyringConnection
 {
-    [SVProgressHUD showDismissableSuccessWithStatus:NSLocalizedString(@"Reconnected", @"Message shwon to confirm a publicize connection has been successfully reconnected.")];
+    [SVProgressHUD showDismissibleSuccessWithStatus:NSLocalizedString(@"Reconnected", @"Message shwon to confirm a publicize connection has been successfully reconnected.")];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -1,7 +1,7 @@
 #import "SharingDetailViewController.h"
 #import "Blog.h"
 #import "BlogService.h"
-#import "SVProgressHUD.h"
+#import "SVProgressHUD+Dismiss.h"
 #import "SharingAuthorizationHelper.h"
 #import "UIImageView+AFNetworkingExtra.h"
 #import "WPTableViewCell.h"
@@ -156,7 +156,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
                                 success:nil
                                 failure:^(NSError *error) {
                                     DDLogError([error description]);
-                                    [SVProgressHUD showErrorWithStatus:NSLocalizedString(@"Change failed", @"Message to show when Publicize globally shared setting failed")];
+                                    [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Change failed", @"Message to show when Publicize globally shared setting failed")];
                                     [weakSelf.tableView reloadData];
                                 }];
 }
@@ -204,7 +204,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
     [sharingService deletePublicizeConnectionForBlog:self.blog pubConn:self.publicizeConnection success:nil failure:^(NSError *error) {
         DDLogError([error description]);
-        [SVProgressHUD showErrorWithStatus:NSLocalizedString(@"Disconnect failed", @"Message to show when Publicize disconnect failed")];
+        [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Disconnect failed", @"Message to show when Publicize disconnect failed")];
     }];
 
     // Since the service optimistically deletes the connection, go ahead and pop.
@@ -250,7 +250,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)sharingAuthorizationHelper:(SharingAuthorizationHelper *)helper didConnectToService:(PublicizeService *)service withPublicizeConnection:(PublicizeConnection *)keyringConnection
 {
-    [SVProgressHUD showErrorWithStatus:NSLocalizedString(@"Reconnected", @"Message shwon to confirm a publicize connection has been successfully reconnected.")];
+    [SVProgressHUD showDismissableSuccessWithStatus:NSLocalizedString(@"Reconnected", @"Message shwon to confirm a publicize connection has been successfully reconnected.")];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -2,7 +2,7 @@
 #import "Blog.h"
 #import "BlogService.h"
 #import "SharingConnectionsViewController.h"
-#import "SVProgressHUD.h"
+#import "SVProgressHUD+Dismiss.h"
 #import "WPTableViewCell.h"
 #import "WordPress-Swift.h"
 #import <AFNetworking/UIImageView+AFNetworking.h>
@@ -225,7 +225,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     [sharingService syncPublicizeServicesForBlog:self.blog success:^{
         [weakSelf syncConnections];
     } failure:^(NSError *error) {
-        [SVProgressHUD showErrorWithStatus:NSLocalizedString(@"Publicize service synchronization failed", @"Message to show when Publicize service synchronization failed")];
+        [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Publicize service synchronization failed", @"Message to show when Publicize service synchronization failed")];
         [weakSelf refreshPublicizers];
     }];
 }
@@ -237,7 +237,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     [sharingService syncPublicizeConnectionsForBlog:self.blog success:^{
         [weakSelf refreshPublicizers];
     } failure:^(NSError *error) {
-        [SVProgressHUD showErrorWithStatus:NSLocalizedString(@"Publicize connection synchronization failed", @"Message to show when Publicize connection synchronization failed")];
+        [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Publicize connection synchronization failed", @"Message to show when Publicize connection synchronization failed")];
         [weakSelf refreshPublicizers];
     }];
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -225,7 +225,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     [sharingService syncPublicizeServicesForBlog:self.blog success:^{
         [weakSelf syncConnections];
     } failure:^(NSError *error) {
-        [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Publicize service synchronization failed", @"Message to show when Publicize service synchronization failed")];
+        [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Publicize service synchronization failed", @"Message to show when Publicize service synchronization failed")];
         [weakSelf refreshPublicizers];
     }];
 }
@@ -237,7 +237,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     [sharingService syncPublicizeConnectionsForBlog:self.blog success:^{
         [weakSelf refreshPublicizers];
     } failure:^(NSError *error) {
-        [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Publicize connection synchronization failed", @"Message to show when Publicize connection synchronization failed")];
+        [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Publicize connection synchronization failed", @"Message to show when Publicize connection synchronization failed")];
         [weakSelf refreshPublicizers];
     }];
 }

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -226,7 +226,7 @@ open class DeleteSiteViewController: UITableViewController {
                                   success: { [weak self] in
                                     WPAppAnalytics.track(.siteSettingsDeleteSiteResponseOK, with: trackedBlog)
                                     let status = NSLocalizedString("Site deleted", comment: "Overlay message displayed when site successfully deleted")
-                                    SVProgressHUD.showDismissableSuccess(withStatus: status)
+                                    SVProgressHUD.showDismissibleSuccess(withStatus: status)
 
                                     self?.updateNavigationStackAfterSiteDeletion()
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -226,7 +226,7 @@ open class DeleteSiteViewController: UITableViewController {
                                   success: { [weak self] in
                                     WPAppAnalytics.track(.siteSettingsDeleteSiteResponseOK, with: trackedBlog)
                                     let status = NSLocalizedString("Site deleted", comment: "Overlay message displayed when site successfully deleted")
-                                    SVProgressHUD.showSuccess(withStatus: status)
+                                    SVProgressHUD.showDismissableSuccess(withStatus: status)
 
                                     self?.updateNavigationStackAfterSiteDeletion()
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteSettingsViewController+SiteManagement.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteSettingsViewController+SiteManagement.swift
@@ -52,7 +52,7 @@ public extension SiteSettingsViewController {
             success: {
                 WPAppAnalytics.track(.siteSettingsExportSiteResponseOK, with: trackedBlog)
                 let status = NSLocalizedString("Email sent!", comment: "Overlay message displayed when export content started")
-                SVProgressHUD.showDismissableSuccess(withStatus: status)
+                SVProgressHUD.showDismissibleSuccess(withStatus: status)
             },
             failure: { error in
                 DDLogSwift.logError("Error exporting content: \(error.localizedDescription)")

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteSettingsViewController+SiteManagement.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteSettingsViewController+SiteManagement.swift
@@ -52,7 +52,7 @@ public extension SiteSettingsViewController {
             success: {
                 WPAppAnalytics.track(.siteSettingsExportSiteResponseOK, with: trackedBlog)
                 let status = NSLocalizedString("Email sent!", comment: "Overlay message displayed when export content started")
-                SVProgressHUD.showSuccess(withStatus: status)
+                SVProgressHUD.showDismissableSuccess(withStatus: status)
             },
             failure: { error in
                 DDLogSwift.logError("Error exporting content: \(error.localizedDescription)")

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -952,7 +952,7 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:self.blog.managedObjectContext];
     [blogService updateSettingsForBlog:self.blog success:nil failure:^(NSError *error) {
-        [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Settings update failed", @"Message to show when setting save failed")];
+        [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Settings update failed", @"Message to show when setting save failed")];
         DDLogError(@"Error while trying to update BlogSettings: %@", error);
     }];
 }

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -13,11 +13,11 @@
 #import "SettingsMultiTextViewController.h"
 #import "SettingTableViewCell.h"
 #import "SettingsTextViewController.h"
+#import "SVProgressHUD+Dismiss.h"
 #import "WordPress-Swift.h"
 #import "WPWebViewController.h"
 #import "WordPress-Swift.h"
 #import "BlogServiceRemoteXMLRPC.h"
-#import <SVProgressHUD/SVProgressHUD.h>
 #import <wpxmlrpc/WPXMLRPC.h>
 
 
@@ -952,7 +952,7 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:self.blog.managedObjectContext];
     [blogService updateSettingsForBlog:self.blog success:nil failure:^(NSError *error) {
-        [SVProgressHUD showErrorWithStatus:NSLocalizedString(@"Settings update failed", @"Message to show when setting save failed")];
+        [SVProgressHUD showDismissableErrorWithStatus:NSLocalizedString(@"Settings update failed", @"Message to show when setting save failed")];
         DDLogError(@"Error while trying to update BlogSettings: %@", error);
     }];
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -5,7 +5,7 @@
 #import "WordPress-Swift.h"
 #import "Comment.h"
 #import "BasePost.h"
-#import "SVProgressHUD.h"
+#import "SVProgressHUD+Dismiss.h"
 #import "EditCommentViewController.h"
 #import "PostService.h"
 #import "BlogService.h"
@@ -629,7 +629,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     __typeof(self) __weak weakSelf = self;
     
     void (^successBlock)() = ^void() {
-        [SVProgressHUD showSuccessWithStatus:successMessage];
+        [SVProgressHUD showDismissableSuccessWithStatus:successMessage];
     };
     
     void (^failureBlock)(NSError *error) = ^void(NSError *error) {

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -629,7 +629,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     __typeof(self) __weak weakSelf = self;
     
     void (^successBlock)() = ^void() {
-        [SVProgressHUD showDismissableSuccessWithStatus:successMessage];
+        [SVProgressHUD showDismissibleSuccessWithStatus:successMessage];
     };
     
     void (^failureBlock)(NSError *error) = ^void(NSError *error) {

--- a/WordPress/Classes/ViewRelated/NUX/Signin2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Signin2FAViewController.swift
@@ -244,7 +244,7 @@ import WordPressShared
 
     @IBAction func handleSendVerificationButtonTapped(_ sender: UIButton) {
         let message = NSLocalizedString("SMS Sent", comment: "One Time Code has been sent via SMS")
-        SVProgressHUD.showDismissableSuccess(withStatus: message)
+        SVProgressHUD.showDismissibleSuccess(withStatus: message)
 
         loginFacade.requestOneTimeCode(with: loginFields)
     }

--- a/WordPress/Classes/ViewRelated/NUX/Signin2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Signin2FAViewController.swift
@@ -244,7 +244,7 @@ import WordPressShared
 
     @IBAction func handleSendVerificationButtonTapped(_ sender: UIButton) {
         let message = NSLocalizedString("SMS Sent", comment: "One Time Code has been sent via SMS")
-        SVProgressHUD.showSuccess(withStatus: message)
+        SVProgressHUD.showDismissableSuccess(withStatus: message)
 
         loginFacade.requestOneTimeCode(with: loginFields)
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1097,7 +1097,7 @@ private extension NotificationDetailsViewController {
             }
 
             let message = NSLocalizedString("Reply Sent!", comment: "The app successfully sent a comment")
-            SVProgressHUD.showSuccess(withStatus: message)
+            SVProgressHUD.showDismissableSuccess(withStatus: message)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1097,7 +1097,7 @@ private extension NotificationDetailsViewController {
             }
 
             let message = NSLocalizedString("Reply Sent!", comment: "The app successfully sent a comment")
-            SVProgressHUD.showDismissableSuccess(withStatus: message)
+            SVProgressHUD.showDismissibleSuccess(withStatus: message)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -239,7 +239,7 @@ extension InvitePersonViewController {
 
         service.sendInvitation(recipient, role: role, message: message, success: {
             let success = NSLocalizedString("Invitation Sent!", comment: "The app successfully sent an invitation")
-            SVProgressHUD.showSuccess(withStatus: success)
+            SVProgressHUD.showDismissableSuccess(withStatus: success)
 
         }, failure: { error in
             self.handleSendError() {

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -239,7 +239,7 @@ extension InvitePersonViewController {
 
         service.sendInvitation(recipient, role: role, message: message, success: {
             let success = NSLocalizedString("Invitation Sent!", comment: "The app successfully sent an invitation")
-            SVProgressHUD.showDismissableSuccess(withStatus: success)
+            SVProgressHUD.showDismissibleSuccess(withStatus: success)
 
         }, failure: { error in
             self.handleSendError() {

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1483,12 +1483,12 @@ EditImageDetailsViewControllerDelegate
                         switch (currentSaveAction) {
                             case PostEditorSaveActionSave: {
                                 NSString *hudText = NSLocalizedString(@"Saved!", @"Text displayed in HUD after a post was successfully saved as a draft.");
-                                [SVProgressHUD showDismissableSuccessWithStatus:hudText];
+                                [SVProgressHUD showDismissibleSuccessWithStatus:hudText];
                                 break;
                             }
                             case PostEditorSaveActionUpdate: {
                                 NSString *hudText = NSLocalizedString(@"Updated!", @"Text displayed in HUD after a post was successfully updated.");
-                                [SVProgressHUD showDismissableSuccessWithStatus:hudText];
+                                [SVProgressHUD showDismissibleSuccessWithStatus:hudText];
                                 break;
                             }
                             default:

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -9,7 +9,6 @@
 #import <WordPressShared/WPFontManager.h>
 #import <WordPressShared/WPStyleGuide.h>
 #import <WordPressComAnalytics/WPAnalytics.h>
-#import <SVProgressHUD/SVProgressHUD.h>
 #import <WPMediaPicker/WPMediaPicker.h>
 #import "BlogSelectorViewController.h"
 #import "BlogService.h"
@@ -24,6 +23,7 @@
 #import "PostService.h"
 #import "PostSettingsViewController.h"
 #import "PrivateSiteURLProtocol.h"
+#import "SVProgressHUD+Dismiss.h"
 #import "WordPressAppDelegate.h"
 #import "WPButtonForNavigationBar.h"
 #import "WPBlogSelectorButton.h"
@@ -1483,12 +1483,12 @@ EditImageDetailsViewControllerDelegate
                         switch (currentSaveAction) {
                             case PostEditorSaveActionSave: {
                                 NSString *hudText = NSLocalizedString(@"Saved!", @"Text displayed in HUD after a post was successfully saved as a draft.");
-                                [SVProgressHUD showSuccessWithStatus:hudText];
+                                [SVProgressHUD showDismissableSuccessWithStatus:hudText];
                                 break;
                             }
                             case PostEditorSaveActionUpdate: {
                                 NSString *hudText = NSLocalizedString(@"Updated!", @"Text displayed in HUD after a post was successfully updated.");
-                                [SVProgressHUD showSuccessWithStatus:hudText];
+                                [SVProgressHUD showDismissableSuccessWithStatus:hudText];
                                 break;
                             }
                             default:

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -207,7 +207,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         let service = ReaderSiteService(managedObjectContext: managedObjectContext())
         service.followSite(by: url, success: { [weak self] in
             let success = NSLocalizedString("Followed", comment: "User followed a site.")
-            SVProgressHUD.showDismissableSuccess(withStatus: success)
+            SVProgressHUD.showDismissibleSuccess(withStatus: success)
             generator.notificationOccurred(.success)
             self?.syncSites()
             self?.refreshPostsForFollowedTopic()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -207,7 +207,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         let service = ReaderSiteService(managedObjectContext: managedObjectContext())
         service.followSite(by: url, success: { [weak self] in
             let success = NSLocalizedString("Followed", comment: "User followed a site.")
-            SVProgressHUD.showSuccess(withStatus: success)
+            SVProgressHUD.showDismissableSuccess(withStatus: success)
             generator.notificationOccurred(.success)
             self?.syncSites()
             self?.refreshPostsForFollowedTopic()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -108,7 +108,7 @@ open class ReaderPostMenu {
 
         let postService = ReaderPostService(managedObjectContext: post.managedObjectContext!)
         postService.toggleFollowing(for: post, success: { () in
-            SVProgressHUD.showDismissableSuccess(withStatus: successMessage)
+            SVProgressHUD.showDismissibleSuccess(withStatus: successMessage)
             }, failure: { (error: Error?) in
                 SVProgressHUD.dismiss()
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -108,7 +108,7 @@ open class ReaderPostMenu {
 
         let postService = ReaderPostService(managedObjectContext: post.managedObjectContext!)
         postService.toggleFollowing(for: post, success: { () in
-            SVProgressHUD.showSuccess(withStatus: successMessage)
+            SVProgressHUD.showDismissableSuccess(withStatus: successMessage)
             }, failure: { (error: Error?) in
                 SVProgressHUD.dismiss()
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -777,7 +777,7 @@ import WordPressComAnalytics
         let postService = ReaderPostService(managedObjectContext: managedObjectContext())
         postService.toggleFollowing(for: post,
                                             success: {
-                                                SVProgressHUD.showSuccess(withStatus: successMessage)
+                                                SVProgressHUD.showDismissableSuccess(withStatus: successMessage)
                                             },
                                             failure: { (error: Error?) in
                                                 SVProgressHUD.dismiss()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -777,7 +777,7 @@ import WordPressComAnalytics
         let postService = ReaderPostService(managedObjectContext: managedObjectContext())
         postService.toggleFollowing(for: post,
                                             success: {
-                                                SVProgressHUD.showDismissableSuccess(withStatus: successMessage)
+                                                SVProgressHUD.showDismissibleSuccess(withStatus: successMessage)
                                             },
                                             failure: { (error: Error?) in
                                                 SVProgressHUD.dismiss()

--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
@@ -424,7 +424,7 @@ class JetpackLoginViewController: UIViewController {
         loginFields.username = usernameTextField.nonNilTrimmedText()
         loginFields.password = passwordTextField.nonNilTrimmedText()
         loginFacade.requestOneTimeCode(with: loginFields)
-        SVProgressHUD.showDismissableSuccess(withStatus: message)
+        SVProgressHUD.showDismissibleSuccess(withStatus: message)
     }
 
     fileprivate func completeLogin() {

--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
@@ -424,7 +424,7 @@ class JetpackLoginViewController: UIViewController {
         loginFields.username = usernameTextField.nonNilTrimmedText()
         loginFields.password = passwordTextField.nonNilTrimmedText()
         loginFacade.requestOneTimeCode(with: loginFields)
-        SVProgressHUD.showSuccess(withStatus: message)
+        SVProgressHUD.showDismissableSuccess(withStatus: message)
     }
 
     fileprivate func completeLogin() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		74D5FFD619ACDF6700389E8F /* WPLegacyEditPostViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 74D5FFD519ACDF6700389E8F /* WPLegacyEditPostViewController.m */; };
 		822876F11E929CFD00696BF7 /* ReachabilityUtils+OnlineActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822876F01E929CFD00696BF7 /* ReachabilityUtils+OnlineActions.swift */; };
 		82301B8F1E787420009C9C4E /* AppRatingUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82301B8E1E787420009C9C4E /* AppRatingUtilityTests.swift */; };
+		8261B4CC1EA8E13700668298 /* SVProgressHUD+Dismiss.m in Sources */ = {isa = PBXBuildFile; fileRef = 8261B4CA1EA8E13700668298 /* SVProgressHUD+Dismiss.m */; };
 		83043E55126FA31400EC9953 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83043E54126FA31400EC9953 /* MessageUI.framework */; };
 		83418AAA11C9FA6E00ACF00C /* Comment.m in Sources */ = {isa = PBXBuildFile; fileRef = 83418AA911C9FA6E00ACF00C /* Comment.m */; };
 		834CAE7C122D528A003DDF49 /* UIImage+Resize.m in Sources */ = {isa = PBXBuildFile; fileRef = 834CAE7B122D528A003DDF49 /* UIImage+Resize.m */; };
@@ -1522,6 +1523,8 @@
 		82270C8E1E3FBF72005F697D /* WordPress 56.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 56.xcdatamodel"; sourceTree = "<group>"; };
 		822876F01E929CFD00696BF7 /* ReachabilityUtils+OnlineActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ReachabilityUtils+OnlineActions.swift"; sourceTree = "<group>"; };
 		82301B8E1E787420009C9C4E /* AppRatingUtilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppRatingUtilityTests.swift; sourceTree = "<group>"; };
+		8261B4CA1EA8E13700668298 /* SVProgressHUD+Dismiss.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SVProgressHUD+Dismiss.m"; sourceTree = "<group>"; };
+		8261B4CB1EA8E13700668298 /* SVProgressHUD+Dismiss.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SVProgressHUD+Dismiss.h"; sourceTree = "<group>"; };
 		827482C81E966E32001A2B62 /* WordPress 58.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 58.xcdatamodel"; sourceTree = "<group>"; };
 		83043E54126FA31400EC9953 /* MessageUI.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		833AF259114575A50016DE8F /* PostAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostAnnotation.h; sourceTree = "<group>"; };
@@ -4700,14 +4703,26 @@
 		C59D3D480E6410BC00AA591D /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				080AAA671E7C63C3004DCD11 /* Media+HTML.h */,
+				080AAA681E7C63C3004DCD11 /* Media+HTML.m */,
 				B55853F519630D5400FAF6C3 /* NSAttributedString+Util.h */,
 				B55853F619630D5400FAF6C3 /* NSAttributedString+Util.m */,
+				85CE4C1E1A703CF200780DFE /* NSBundle+VersionNumberHelper.h */,
+				85CE4C1F1A703CF200780DFE /* NSBundle+VersionNumberHelper.m */,
 				E13F23C114FE84600081D9CC /* NSMutableDictionary+Helpers.h */,
 				E13F23C214FE84600081D9CC /* NSMutableDictionary+Helpers.m */,
+				B57B99DC19A2DBF200506504 /* NSObject+Helpers.h */,
+				B57B99DD19A2DBF200506504 /* NSObject+Helpers.m */,
 				B55853F11962337500FAF6C3 /* NSScanner+Helpers.h */,
 				B55853F21962337500FAF6C3 /* NSScanner+Helpers.m */,
 				296526FC105810E100597FA3 /* NSString+Helpers.h */,
 				296526FD105810E100597FA3 /* NSString+Helpers.m */,
+				851734411798C64700A30E27 /* NSURL+Util.h */,
+				851734421798C64700A30E27 /* NSURL+Util.m */,
+				8261B4CB1EA8E13700668298 /* SVProgressHUD+Dismiss.h */,
+				8261B4CA1EA8E13700668298 /* SVProgressHUD+Dismiss.m */,
+				B5416CFF1C17693B00006DD8 /* UIApplication+Helpers.h */,
+				B5416D001C17693B00006DD8 /* UIApplication+Helpers.m */,
 				E1A0FAE5162F11CE0063B098 /* UIDevice+Helpers.h */,
 				E1A0FAE6162F11CE0063B098 /* UIDevice+Helpers.m */,
 				834CAE9B122D56B1003DDF49 /* UIImage+Alpha.h */,
@@ -4716,32 +4731,22 @@
 				834CAE7B122D528A003DDF49 /* UIImage+Resize.m */,
 				834CAE9C122D56B1003DDF49 /* UIImage+RoundedCorner.h */,
 				834CAE9E122D56B1003DDF49 /* UIImage+RoundedCorner.m */,
-				E1F80823146420B000726BC7 /* UIImageView+Gravatar.h */,
-				E1F80824146420B000726BC7 /* UIImageView+Gravatar.m */,
-				5D97C2F115CAF8D8009B44DD /* UINavigationController+KeyboardFix.h */,
-				5D97C2F215CAF8D8009B44DD /* UINavigationController+KeyboardFix.m */,
 				5D119DA1176FBE040073D83A /* UIImageView+AFNetworkingExtra.h */,
 				5D119DA2176FBE040073D83A /* UIImageView+AFNetworkingExtra.m */,
+				E1F80823146420B000726BC7 /* UIImageView+Gravatar.h */,
+				E1F80824146420B000726BC7 /* UIImageView+Gravatar.m */,
 				5DF59C091770AE3A00171208 /* UILabel+SuggestSize.h */,
 				5DF59C0A1770AE3A00171208 /* UILabel+SuggestSize.m */,
-				851734411798C64700A30E27 /* NSURL+Util.h */,
-				851734421798C64700A30E27 /* NSURL+Util.m */,
+				5D97C2F115CAF8D8009B44DD /* UINavigationController+KeyboardFix.h */,
+				5D97C2F215CAF8D8009B44DD /* UINavigationController+KeyboardFix.m */,
 				E2AA87A318523E5300886693 /* UIView+Subviews.h */,
 				E2AA87A418523E5300886693 /* UIView+Subviews.m */,
-				B57B99DC19A2DBF200506504 /* NSObject+Helpers.h */,
-				B57B99DD19A2DBF200506504 /* NSObject+Helpers.m */,
+				F128C31A1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.h */,
+				F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */,
 				E69BA1961BB5D7D300078740 /* WPStyleGuide+ReadableMargins.h */,
 				E69BA1971BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m */,
 				31EC15061A5B6675009FC8B3 /* WPStyleGuide+Suggestions.h */,
 				31EC15071A5B6675009FC8B3 /* WPStyleGuide+Suggestions.m */,
-				85CE4C1E1A703CF200780DFE /* NSBundle+VersionNumberHelper.h */,
-				85CE4C1F1A703CF200780DFE /* NSBundle+VersionNumberHelper.m */,
-				F128C31A1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.h */,
-				F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */,
-				B5416CFF1C17693B00006DD8 /* UIApplication+Helpers.h */,
-				B5416D001C17693B00006DD8 /* UIApplication+Helpers.m */,
-				080AAA671E7C63C3004DCD11 /* Media+HTML.h */,
-				080AAA681E7C63C3004DCD11 /* Media+HTML.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -6570,6 +6575,7 @@
 				B5DB8AF21C949DA90059196A /* WPReusableTableViewCells.swift in Sources */,
 				B5B68BD41C19AAED00EB59E0 /* InteractiveNotificationsManager.swift in Sources */,
 				B54E1DF01A0A7BAA00807537 /* ReplyBezierView.swift in Sources */,
+				8261B4CC1EA8E13700668298 /* SVProgressHUD+Dismiss.m in Sources */,
 				596C035E1B84F21D00899EEB /* ThemeBrowserViewController.swift in Sources */,
 				E2E7EB46185FB140004F5E72 /* WPBlogSelectorButton.m in Sources */,
 				85D239B21AE5A5FC0074768D /* WordPressComOAuthClientFacade.m in Sources */,


### PR DESCRIPTION
**Fixes** #7058 

Adds a Category to `SVProgressHUD` to make them dismissible by tapping anywhere on the screen.
Note: we need `[SVProgressHUD setDefaultMaskType:SVProgressHUDMaskTypeClear]` to allow user interactions with the control.

**To test:**

Do an action that displays a HUD, for example replying to a comment (for a success one) or posting while offline (for a failure one). 
Once the message is displayed you can tap anywhere on the screen to dismiss it.

Needs review: @koke 