### PR TITLE
Remov references to MainWindow.xib for Alpha and Internal

### DIFF
--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -80,10 +80,6 @@
 	<string>WordPress would like to add your location to posts on sites where you have enabled geotagging.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>WordPress would like to add your location to posts on sites where you have enabled geotagging.</string>
-	<key>NSMainNibFile</key>
-	<string>MainWindow</string>
-	<key>NSMainNibFile~ipad</key>
-	<string>MainWindow-iPad</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>For your videos to have sound on them.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/WordPress/Wordpress-Alpha-Info.plist
+++ b/WordPress/Wordpress-Alpha-Info.plist
@@ -81,10 +81,6 @@
 	<string>WordPress would like to add your location to posts on sites where you have enabled geotagging.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>WordPress would like to add your location to posts on sites where you have enabled geotagging.</string>
-	<key>NSMainNibFile</key>
-	<string>MainWindow</string>
-	<key>NSMainNibFile~ipad</key>
-	<string>MainWindow-iPad</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>For your videos to have sound on them.</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
**Fixes** #7060 

On https://github.com/wordpress-mobile/WordPress-iOS/pull/7047 the references to MainWindow.xib were removed from Info.plist 
On this PR they are removed from WordPress-Internal.plist and WordPress-Alpha.plist

**To test:**

Run the app for both schemes and see that it works.

Needs review: @jleandroperez @aerych 