### PR TITLE
ShareExtension: Fixing Sharing from Google Photos

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -51,10 +51,10 @@ struct ShareExtractor {
 private extension ShareExtractor {
     var supportedExtractors: [ExtensionContentExtractor] {
         return [
+            ImageExtractor(),
             SharePostExtractor(),
             PropertyListExtractor(),
-            URLExtractor(),
-            ImageExtractor()
+            URLExtractor()
         ]
     }
 

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -51,9 +51,9 @@ struct ShareExtractor {
 private extension ShareExtractor {
     var supportedExtractors: [ExtensionContentExtractor] {
         return [
-            ImageExtractor(),
             SharePostExtractor(),
             PropertyListExtractor(),
+            ImageExtractor(),
             URLExtractor()
         ]
     }


### PR DESCRIPTION
### Details:
This PR updates the `ShareExtractor` order, so that whenever the ImageExtractor can handle a request, it'll be returned **before** the Text Extractor.

Fixes #5690

### To test:
1. Open the Google Photos app
2. Select a photo and tap the sharing icon
3. Select WordPress as the sharing target

Verify that the actual picture gets shared (instead of the local URL)

Needs review: @koke 
Thanks in advance!
