### PR TITLE
Notifications: Mark as Read

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -88,7 +88,6 @@ class NotificationDetailsViewController: UIViewController {
                 return
             }
 
-            markReadIfNeeded()
             refreshInterface()
         }
     }
@@ -105,7 +104,6 @@ class NotificationDetailsViewController: UIViewController {
     ///
     var onSelectedNoteChange: ((Notification) -> Void)?
 
-    private var isViewVisible = false
 
     deinit {
         NotificationCenter.default.removeObserver(self)
@@ -148,17 +146,8 @@ class NotificationDetailsViewController: UIViewController {
         refreshInterface()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        isViewVisible = true
-        markReadIfNeeded()
-    }
-
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-
-        isViewVisible = false
-
         keyboardManager?.stopListeningToKeyboardNotifications()
     }
 
@@ -189,14 +178,6 @@ class NotificationDetailsViewController: UIViewController {
         attachSuggestionsViewIfNeeded()
         adjustLayoutConstraintsIfNeeded()
         refreshNavigationBar()
-    }
-
-    fileprivate func markReadIfNeeded() {
-        guard isViewVisible, !note.read else {
-            return
-        }
-        let mediator = NotificationSyncMediator()
-        mediator?.markAsRead(note)
     }
 
     fileprivate func refreshNavigationBar() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -164,6 +164,14 @@ class NotificationDetailsViewController: UIViewController {
         refreshNavigationBar()
     }
 
+    fileprivate func markAsReadIfNeeded() {
+        guard !note.read else {
+            return
+        }
+
+        NotificationSyncMediator()?.markAsRead(note)
+    }
+
     fileprivate func refreshInterfaceIfNeeded() {
         guard isViewLoaded else {
             return
@@ -404,7 +412,7 @@ extension NotificationDetailsViewController {
         let nc = NotificationCenter.default
         nc.addObserver(self,
                        selector: #selector(notificationWasUpdated),
-                       name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
+                       name: .NSManagedObjectContextObjectsDidChange,
                        object: note.managedObjectContext)
     }
 }
@@ -753,9 +761,10 @@ extension NotificationDetailsViewController {
         let refreshed = notification.userInfo?[NSRefreshedObjectsKey] as? Set<NSManagedObject> ?? Set()
         let deleted   = notification.userInfo?[NSDeletedObjectsKey]   as? Set<NSManagedObject> ?? Set()
 
-        // Reload the table, if *our* notification got updated
+        // Reload the table, if *our* notification got updated + Mark as Read since it's already onscreen!
         if updated.contains(note) || refreshed.contains(note) {
             refreshInterface()
+            markAsReadIfNeeded()
         } else {
             // Otherwise, refresh the navigation bar as the notes list might have changed
             refreshNavigationBar()

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -145,6 +145,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         super.viewDidAppear(animated)
         showRatingViewIfApplicable()
         syncNewNotifications()
+        markSelectedNotificationAsRead()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -592,6 +593,21 @@ private extension NotificationsViewController {
 
 
 
+// MARK: - Marking as Read
+//
+private extension NotificationsViewController {
+
+    func markSelectedNotificationAsRead() {
+        guard let note = selectedNotification else {
+            return
+        }
+
+        markAsRead(note: note)
+    }
+}
+
+
+
 // MARK: - Unread notifications caching
 //
 private extension NotificationsViewController {
@@ -888,8 +904,6 @@ extension NotificationsViewController: WPTableViewHandlerDelegate {
 
 // MARK: - Actions
 //
-
-
 private extension NotificationsViewController {
     func leadingButtons(note: Notification) -> [MGSwipeButton] {
         guard !note.read else {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -290,7 +290,6 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         }
 
         selectedNotification = note
-
         showDetailsForNotification(note)
     }
 
@@ -508,6 +507,8 @@ extension NotificationsViewController {
 
         prepareToShowDetailsForNotification(note)
 
+        markAsRead(note: note)
+
         // Display Details
         if let postID = note.metaPostID, let siteID = note.metaSiteID, note.kind == .Matcher {
             let readerViewController = ReaderDetailViewController.controllerWithPostID(postID, siteID: siteID)
@@ -603,6 +604,14 @@ private extension NotificationsViewController {
         }
 
         markAsRead(note: note)
+    }
+
+    func markAsRead(note: Notification) {
+        guard !note.read else {
+            return
+        }
+
+        NotificationSyncMediator()?.markAsRead(note)
     }
 }
 
@@ -911,11 +920,11 @@ private extension NotificationsViewController {
         }
 
         return [
-            MGSwipeButton(title: NSLocalizedString("Mark Read", comment: "Marks a notification as read"), backgroundColor: WPStyleGuide.greyDarken20(), callback: { _ in
-                ReachabilityUtils.onAvailableInternetConnectionDo {
-                    NotificationSyncMediator()?.markAsRead(note)
-                }
-                return true
+            MGSwipeButton(title: NSLocalizedString("Mark Read", comment: "Marks a notification as read"),
+                          backgroundColor: WPStyleGuide.greyDarken20(),
+                          callback: { _ in
+                            self.markAsRead(note: note)
+                            return true
             })
         ]
     }


### PR DESCRIPTION
### Description:
This PR updates the Mark Notification as Read mechanism.

Fixes #7074

### Details:
We'll mark Notifications as Read in two scenarios:
- The user explicitly selects a notification row
- We're on SplitView, the user opens Notifications, and the preselected row _was_ unread

### Scenario: Post Mention
1. On a iPhone device!
2. Log into a dotcom account with unread notifications
3. Try opening a Post Mention Notification
4. Verify that the Reader is onscreen
5. Hit back and verify the note is marked as read
6. Repeat 4 and 5 for a **Comment Mention**. The Note Details should be rendered instead

### Scenario: Comment Mention
1. On a iPhone device!
2. Log into a dotcom account with unread notifications
3. Try opening a Comment Mention Notification
4. Verify that the Notification Details are Onscreen
5. Hit back and verify the note is marked as read

### Scenario: Split!
1. On an iPad Device
2. Make sure you've got an unread item in your account!
3. Open the Notifications section
4. Verify that the top notification (the unread one!) gets marked as read, only after opening the Notes tab.

### Scenario: Update while Onscreen
1. On an iPhone device
2. Open a Like(s) Notification
3. Receive a new Like
4. Verify that the Notification remains marked as read


### Scenario: Update while in BG
1. On an iPhone device
2. Open a Like(s) Notification
3. Send the app to BG
4. Receive a new Like
5. Open the app via the Notification event
6. Verify that the Notification gets properly opened, and that it remains marked as read

Needs review: @frosty  @koke 
Thaaaanks in advance!!
