### PR TITLE
Login: Segue identifiers become an enum

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -2,6 +2,6 @@ import UIKit
 
 class Login2FAViewController: Signin2FAViewController {
     override func dismiss() {
-        self.performSegue(withIdentifier: "showEpilogue", sender: self)
+        self.performSegue(withIdentifier: .showEpilogue, sender: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -2,14 +2,14 @@ import UIKit
 
 class LoginEmailViewController: SigninEmailViewController {
     override func requestLink() {
-        performSegue(withIdentifier: "startMagicLinkFlow", sender: self)
+        performSegue(withIdentifier: .startMagicLinkFlow, sender: self)
     }
 
     override func signinWithUsernamePassword(_ immediateSignin: Bool = false) {
-        performSegue(withIdentifier: "showWPComLogin", sender: self)
+        performSegue(withIdentifier: .showWPComLogin, sender: self)
     }
 
     override func signinToSelfHostedSite() {
-        performSegue(withIdentifier: "showSelfHostedLogin", sender: self)
+        performSegue(withIdentifier: .showSelfHostedLogin, sender: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginLinkAuthViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginLinkAuthViewController.swift
@@ -2,6 +2,6 @@ import UIKit
 
 class LoginLinkAuthViewController: SigninLinkAuthViewController {
     override func dismiss() {
-        self.performSegue(withIdentifier: "showEpilogue", sender: self)
+        self.performSegue(withIdentifier: .showEpilogue, sender: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginLinkRequestViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginLinkRequestViewController.swift
@@ -8,6 +8,6 @@ class LoginLinkRequestViewController: SigninLinkRequestViewController {
     override func didRequestAuthenticationLink() {
         WPAppAnalytics.track(.loginMagicLinkRequested)
         SigninHelpers.saveEmailAddressForTokenAuth(loginFields.username)
-        performSegue(withIdentifier: "showLinkMailView", sender: self)
+        performSegue(withIdentifier: .showLinkMailView, sender: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginSegueHandler.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSegueHandler.swift
@@ -1,8 +1,11 @@
+// Based on this article by @NatashaTheRobot:
+// https://www.natashatherobot.com/protocol-oriented-segue-identifiers-swift/
+
 protocol LoginSegueHandler {
     associatedtype SegueIdentifier: RawRepresentable
 }
 
-extension LoginSegueHandler where Self: UIViewController, SegueIdentifier.RawValue == String {
+extension LoginSegueHandler where Self: NUXAbstractViewController, SegueIdentifier.RawValue == String {
     func performSegue(withIdentifier identifier: SegueIdentifier, sender: AnyObject?) {
         performSegue(withIdentifier: identifier.rawValue, sender: sender)
     }

--- a/WordPress/Classes/ViewRelated/NUX/LoginSegueHandler.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSegueHandler.swift
@@ -1,0 +1,9 @@
+protocol LoginSegueHandler {
+    associatedtype SegueIdentifier: RawRepresentable
+}
+
+extension LoginSegueHandler where Self: UIViewController, SegueIdentifier.RawValue == String {
+    func performSegue(withIdentifier identifier: SegueIdentifier, sender: AnyObject?) {
+        performSegue(withIdentifier: identifier.rawValue, sender: sender)
+    }
+}

--- a/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
@@ -2,10 +2,10 @@ import UIKit
 
 class LoginSelfHostedViewController: SigninSelfHostedViewController {
     override func needsMultifactorCode() {
-        self.performSegue(withIdentifier: "show2FA", sender: self)
+        self.performSegue(withIdentifier: .show2FA, sender: self)
     }
-    
+
     override func dismiss() {
-        self.performSegue(withIdentifier: "showEpilogue", sender: self)
+        self.performSegue(withIdentifier: .showEpilogue, sender: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginWPComViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginWPComViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class LoginWPComViewController: SigninWPComViewController {
     override func dismiss() {
-        self.performSegue(withIdentifier: "showEpilogue", sender: self)
+        self.performSegue(withIdentifier: .showEpilogue, sender: self)
     }
 
     override func needsMultifactorCode() {
@@ -10,6 +10,6 @@ class LoginWPComViewController: SigninWPComViewController {
         configureViewLoading(false)
 
         WPAppAnalytics.track(.twoFactorCodeRequested)
-        self.performSegue(withIdentifier: "show2FA", sender: self)
+        self.performSegue(withIdentifier: .show2FA, sender: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
@@ -7,7 +7,7 @@ import WordPressShared
 /// button and badge.
 /// It is assumed that NUX controllers will always be presented modally.
 ///
-class NUXAbstractViewController: UIViewController {
+class NUXAbstractViewController: UIViewController, LoginSegueHandler {
     var helpBadge: WPNUXHelpBadgeLabel!
     var helpButton: UIButton!
     var loginFields = LoginFields()
@@ -17,6 +17,16 @@ class NUXAbstractViewController: UIViewController {
     let helpButtonContainerFrame = CGRect(x: 0, y: 0, width: 44, height: 44)
 
     var dismissBlock: ((_ cancelled: Bool) -> Void)?
+
+    enum SegueIdentifier: String {
+        case showSelfHostedLogin
+        case showWPComLogin
+        case startMagicLinkFlow
+        case showMagicLink
+        case showLinkMailView
+        case show2FA
+        case showEpilogue
+    }
 
     // MARK: - Lifecycle Methods
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		438A809E1EA5DC31005D4651 /* LoginWPComViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 438A809D1EA5DC31005D4651 /* LoginWPComViewController.swift */; };
 		43A85B311E9E815B00FA990B /* Login.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 43A85B301E9E815B00FA990B /* Login.storyboard */; };
 		43AB7C5E1D3E70510066CB6A /* PostListFilterSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */; };
+		43D2436D1EAFCE3C00D0C77B /* LoginSegueHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D2436C1EAFCE3C00D0C77B /* LoginSegueHandler.swift */; };
 		43D54D131DCAA070007F575F /* PostPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D54D121DCAA070007F575F /* PostPostViewController.swift */; };
 		462F4E0A18369F0B0028D2F8 /* BlogDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 462F4E0718369F0B0028D2F8 /* BlogDetailsViewController.m */; };
 		4645AFC51961E1FB005F7509 /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4645AFC41961E1FB005F7509 /* AppImages.xcassets */; };
@@ -1330,6 +1331,7 @@
 		438A809D1EA5DC31005D4651 /* LoginWPComViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginWPComViewController.swift; sourceTree = "<group>"; };
 		43A85B301E9E815B00FA990B /* Login.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Login.storyboard; sourceTree = "<group>"; };
 		43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostListFilterSettings.swift; sourceTree = "<group>"; };
+		43D2436C1EAFCE3C00D0C77B /* LoginSegueHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginSegueHandler.swift; sourceTree = "<group>"; };
 		43D54D121DCAA070007F575F /* PostPostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostPostViewController.swift; sourceTree = "<group>"; };
 		462F4E0618369F0B0028D2F8 /* BlogDetailsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogDetailsViewController.h; sourceTree = "<group>"; };
 		462F4E0718369F0B0028D2F8 /* BlogDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BlogDetailsViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -5263,6 +5265,7 @@
 			isa = PBXGroup;
 			children = (
 				433432531E9EE0B100915988 /* EpilogueSegue.swift */,
+				43D2436C1EAFCE3C00D0C77B /* LoginSegueHandler.swift */,
 				434D96051EA92A4A00B90B89 /* Login2FAViewController.swift */,
 				438A80971EA5666B005D4651 /* LoginEmailViewController.swift */,
 				433432511E9ED18900915988 /* LoginEpilogueViewController.swift */,
@@ -6695,6 +6698,7 @@
 				85D239B21AE5A5FC0074768D /* WordPressComOAuthClientFacade.m in Sources */,
 				85D239B31AE5A5FC0074768D /* WordPressXMLRPCAPIFacade.m in Sources */,
 				E183BD7417621D87000B0822 /* WPCookie.m in Sources */,
+				43D2436D1EAFCE3C00D0C77B /* LoginSegueHandler.swift in Sources */,
 				08216FD41CDBF96000304BA7 /* MenuItemTypeSelectionView.m in Sources */,
 				176DEEE91D4615FE00331F30 /* WPSplitViewController.swift in Sources */,
 				FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */,


### PR DESCRIPTION
Small improvement to #7066

Based on: https://www.natashatherobot.com/protocol-oriented-segue-identifiers-swift/

To test, ensure the new login process is still working:
1. use a debug build to:
2. Login via both wp.com and self-hosted
3. Ensure all necessary screens appear, and that the epilogue screen appears at end

Needs review: @frosty
Got time for this one?