### PR TITLE
Fixed typo on recently released strings

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1503,16 +1503,16 @@ EditImageDetailsViewControllerDelegate
                         NSString *hudText;
                         switch (currentSaveAction) {
                             case PostEditorSaveActionSchedule:
-                                hudText = NSLocalizedString(@"Error occurred\nduring scheduling. Your changes where saved on the device.", @"Text displayed in HUD after attempting to schedule a post and an error occurred.");
+                                hudText = NSLocalizedString(@"Error occurred\nduring scheduling. Your changes were saved on the device.", @"Text displayed in HUD after attempting to schedule a post and an error occurred.");
                                 break;
                             case PostEditorSaveActionUpdate:
-                                hudText = NSLocalizedString(@"Error occurred\nduring updating. Your changes where saved on the device", @"Text displayed in HUD after attempting to update a post and an error occurred.");
+                                hudText = NSLocalizedString(@"Error occurred\nduring updating. Your changes were saved on the device", @"Text displayed in HUD after attempting to update a post and an error occurred.");
                                 break;
                             case PostEditorSaveActionPost:
-                                hudText = NSLocalizedString(@"Error occurred\nduring publishing. Your changes where saved on the device", @"Text displayed in HUD after attempting to publish a post and an error occurred.");
+                                hudText = NSLocalizedString(@"Error occurred\nduring publishing. Your changes were saved on the device", @"Text displayed in HUD after attempting to publish a post and an error occurred.");
                                 break;
                             default:
-                                hudText = NSLocalizedString(@"Error occurred\nduring saving. Your changes where saved on the device.", @"Text displayed in HUD after attempting to save a draft post and an error occurred.");
+                                hudText = NSLocalizedString(@"Error occurred\nduring saving. Your changes were saved on the device.", @"Text displayed in HUD after attempting to save a draft post and an error occurred.");
                                 break;
                         }
                         [SVProgressHUD showErrorWithStatus:hudText];


### PR DESCRIPTION
**Fixes** #7048
**IMPORTANT: All the string files will have to be regenerated.**

**To test:**
Post while offline, check that the error message is correct (were instead of where)


Needs review: @astralbodies 