### PR TITLE
Fix Login's unwind segue breaking transitions

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/EpilogueSegue.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueSegue.swift
@@ -43,8 +43,6 @@ class EpilogueUnwindSegue: UIStoryboardSegue, EpilogueAnimation {
     let duration = 0.35
 
     override func perform() {
-        performEpilogue() {
-            self.destination.dismiss(animated: false) {}
-        }
+        performEpilogue() {}
     }
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -888,7 +888,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
                                  completion:nil];
 }
 
-// this class allows this VC to be a valid unwind destination for this selector
+// this method allows this VC to be a valid unwind destination for this selector
 - (IBAction)unwindOutWithSegue:(UIStoryboardSegue *)segue
 {
     // unwind segues don't seem to always clean themselves up 😫

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -888,9 +888,11 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
                                  completion:nil];
 }
 
+// this class allows this VC to be a valid unwind destination for this selector
 - (IBAction)unwindOutWithSegue:(UIStoryboardSegue *)segue
 {
-    // here so that this VC is a valid unwind destination for this selector
+    // unwind segues don't seem to always clean themselves up 😫
+    [self dismissViewControllerAnimated:NO completion:nil];
 }
 
 @end


### PR DESCRIPTION
Fixes #7088

To test:
- Use the new login process to login (on for debug builds)
- Ensure that the blog list navigation controller's transitions still work
- Also ensure that the tab bar can still show UIAlerts—such as when tapping "Log Out" from the Me tab

Needs review: @frosty 
_You found it you have to review it_ 😝