### PR TITLE
Notifications: Arrows won't dance anymore

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -211,7 +211,9 @@ class NotificationDetailsViewController: UIViewController {
         buttons.spacing = buttonSpacing
         buttons.frame = CGRect(x: 0, y: 0, width: width, height: height)
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: buttons)
+        UIView.performWithoutAnimation {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(customView: buttons)
+        }
 
         previousNavigationButton.isEnabled = shouldEnablePreviousButton
         nextNavigationButton.isEnabled = shouldEnableNextButton

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/KeyboardDismissHelper.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/KeyboardDismissHelper.swift
@@ -102,12 +102,12 @@ import UIKit
     ///
     func startListeningToKeyboardNotifications() {
         let nc = NotificationCenter.default
-        nc.addObserver(self, selector: #selector(keyboardWillShow), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
-        nc.addObserver(self, selector: #selector(keyboardDidShow), name: NSNotification.Name.UIKeyboardDidShow, object: nil)
-        nc.addObserver(self, selector: #selector(keyboardWillHide), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
-        nc.addObserver(self, selector: #selector(keyboardDidHide), name: NSNotification.Name.UIKeyboardDidHide, object: nil)
-        nc.addObserver(self, selector: #selector(keyboardWillChangeFrame), name: NSNotification.Name.UIKeyboardWillChangeFrame, object: nil)
-        nc.addObserver(self, selector: #selector(keyboardDidChangeFrame), name: NSNotification.Name.UIKeyboardDidChangeFrame, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardWillShow), name: .UIKeyboardWillShow, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardDidShow), name: .UIKeyboardDidShow, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardWillHide), name: .UIKeyboardWillHide, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardDidHide), name: .UIKeyboardDidHide, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardWillChangeFrame), name: .UIKeyboardWillChangeFrame, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardDidChangeFrame), name: .UIKeyboardDidChangeFrame, object: nil)
 
     }
 


### PR DESCRIPTION
### Details:
This PR fixes an unintended animation, in which the Notification Details navigation arrows would move around the navigation bar.

Sample video here: [CrazyArrows.zip](https://github.com/wordpress-mobile/WordPress-iOS/files/962486/CrazyArrows.zip)

### To test:
1. Open a Comment-Y Notification
2. Press over the Reply Text View component
3. Swipe downwards

Verify that the `Previous` / `Next` notifications arrow don't dance around the navbar anymore.

Needs review: @koke 
Thanks in advance!
