### PR TITLE
Notifications: Smoot Interactive Keyboard Dismissal

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Tools/KeyboardDismissHelper.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/KeyboardDismissHelper.swift
@@ -146,8 +146,13 @@ import UIKit
             return
         }
 
+        let previousContentOffset = scrollView.contentOffset
+
         bottomLayoutConstraint.constant = newConstant
         parentView.layoutIfNeeded()
+
+        // Make sure the Scroll View's offset does not get reset!
+        scrollView.contentOffset = previousContentOffset
     }
 
     func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint) {


### PR DESCRIPTION
### Description:
Whenever the user interactively dismisses the ReplyTextView component, in some conditions, the Content Offset was getting reset.

As a result of this, you would see the ScrollView getting back to `offset.y = 0`, as soon as the dragging OP began moving the Reply component.

In this PR we're fixing this. Yay!

### To test:
1. Open a Comment-Y Notification
2. Press over the ReplyTextView component
3. Drag downwards to dismiss the keyboard

Verify that the TableView's cells follow your finger. There should not be any "Reset to Zero" flicker anymore.

Needs review: @elibud 
Elisa, may i bug you with a fun one?

Thanks in advance!!

🔥 
