### PR TITLE
Signup: Fixing 1Password Integration

### DIFF
--- a/WordPress/Classes/Services/OnePasswordFacade.m
+++ b/WordPress/Classes/Services/OnePasswordFacade.m
@@ -51,7 +51,7 @@ NSInteger WPOnePasswordErrorCodeCancelledByUser = AppExtensionErrorCodeCancelled
                                              };
 
     NSDictionary *passwordGenerationOptions = @{
-                                                AppExtensionGeneratedPasswordMaxLengthKey: @(WPOnePasswordGeneratedMinLength),
+                                                AppExtensionGeneratedPasswordMinLengthKey: @(WPOnePasswordGeneratedMinLength),
                                                 AppExtensionGeneratedPasswordMaxLengthKey: @(WPOnePasswordGeneratedMaxLength),
                                                 };
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -424,7 +424,7 @@ import WordPressShared
                                                         }
                                                         if let password = password {
                                                             self.loginFields.password = password
-                                                            self.usernameField.text = password
+                                                            self.passwordField.text = password
                                                         }
 
                                                         WPAnalytics.track(.onePasswordSignup)


### PR DESCRIPTION
### Details:
In this PR we're addressing two 1P Signup bugs:

- Autogenerated password was being displayed in the Username field
- Autogenerated password max-length constant was invalid

Closes #6319

### To test:
1. Make sure you've got 1Password installed
2. Fresh install WPiOS
3. Hit the signup button
4. Attempt to generate a password. Verify that the min/max length ranges from 7-50
5. Verify that the username / password are correctly displayed, in the right fields

Needs review: @nheagy May i bug you with this one?
Thanks in advance!!
