### PR TITLE
SharingServiceRemote: Crash Failsafe

### DIFF
--- a/WordPress/Classes/Networking/SharingServiceRemote.swift
+++ b/WordPress/Classes/Networking/SharingServiceRemote.swift
@@ -363,18 +363,12 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     /// - Returns: A `RemotePublicizeConnection` object.
     ///
     fileprivate func remotePublicizeConnectionFromDictionary(_ dict: NSDictionary) -> RemotePublicizeConnection? {
-        let conn = RemotePublicizeConnection()
-
-        guard let connectionID = dict.number(forKey: ConnectionDictionaryKeys.ID),
-            let expirationDateAsString = dict.string(forKey: ConnectionDictionaryKeys.expires),
-            let issueDateAsString = dict.string(forKey: ConnectionDictionaryKeys.issued)
-        else {
+        guard let connectionID = dict.number(forKey: ConnectionDictionaryKeys.ID) else {
             return nil
         }
 
+        let conn = RemotePublicizeConnection()
         conn.connectionID = connectionID
-        conn.dateExpires = DateUtils.date(fromISOString: expirationDateAsString)
-        conn.dateIssued = DateUtils.date(fromISOString: issueDateAsString)
         conn.externalDisplay = dict.string(forKey: ConnectionDictionaryKeys.externalDisplay) ?? conn.externalDisplay
         conn.externalID = dict.string(forKey: ConnectionDictionaryKeys.externalID) ?? conn.externalID
         conn.externalName = dict.string(forKey: ConnectionDictionaryKeys.externalName) ?? conn.externalName
@@ -387,12 +381,22 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         conn.status = dict.string(forKey: ConnectionDictionaryKeys.status) ?? conn.status
         conn.service = dict.string(forKey: ConnectionDictionaryKeys.service) ?? conn.service
 
+        if let expirationDateAsString = dict.string(forKey: ConnectionDictionaryKeys.expires) {
+            conn.dateExpires = DateUtils.date(fromISOString: expirationDateAsString)
+        }
+
+        if let issueDateAsString = dict.string(forKey: ConnectionDictionaryKeys.issued) {
+            conn.dateIssued = DateUtils.date(fromISOString: issueDateAsString)
+        }
+
         if let sharedDictNumber = dict.number(forKey: ConnectionDictionaryKeys.shared) {
             conn.shared = sharedDictNumber.boolValue
         }
+
         if let siteIDDictNumber = dict.number(forKey: ConnectionDictionaryKeys.siteID) {
             conn.siteID = siteIDDictNumber
         }
+
         if let userIDDictNumber = dict.number(forKey: ConnectionDictionaryKeys.userID) {
             conn.userID = userIDDictNumber
         }

--- a/WordPress/Classes/Networking/SharingServiceRemote.swift
+++ b/WordPress/Classes/Networking/SharingServiceRemote.swift
@@ -365,13 +365,16 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     fileprivate func remotePublicizeConnectionFromDictionary(_ dict: NSDictionary) -> RemotePublicizeConnection? {
         let conn = RemotePublicizeConnection()
 
-        if dict.number(forKey: ConnectionDictionaryKeys.ID) == nil {
+        guard let connectionID = dict.number(forKey: ConnectionDictionaryKeys.ID),
+            let expirationDateAsString = dict.string(forKey: ConnectionDictionaryKeys.expires),
+            let issueDateAsString = dict.string(forKey: ConnectionDictionaryKeys.issued)
+        else {
             return nil
         }
 
-        conn.connectionID = dict.number(forKey: ConnectionDictionaryKeys.ID) ?? conn.connectionID
-        conn.dateExpires = DateUtils.date(fromISOString: dict.string(forKey: ConnectionDictionaryKeys.expires))
-        conn.dateIssued = DateUtils.date(fromISOString: dict.string(forKey: ConnectionDictionaryKeys.issued))
+        conn.connectionID = connectionID
+        conn.dateExpires = DateUtils.date(fromISOString: expirationDateAsString)
+        conn.dateIssued = DateUtils.date(fromISOString: issueDateAsString)
         conn.externalDisplay = dict.string(forKey: ConnectionDictionaryKeys.externalDisplay) ?? conn.externalDisplay
         conn.externalID = dict.string(forKey: ConnectionDictionaryKeys.externalID) ?? conn.externalID
         conn.externalName = dict.string(forKey: ConnectionDictionaryKeys.externalName) ?? conn.externalName


### PR DESCRIPTION
### Details:
Although i've been unable to reproduce this crash, i'm adding a couple `guard let` in the spot that, according to the crashlog, the app was crashing.

Closes #7102

### Testing:
Please, run a smoke test over Publicize, and make sure nothing breaks.

Needs review: @aerych 
Eric, may i bug you with this one?
