### PR TITLE
3516 improve post create date handling

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -43,7 +43,7 @@ extern NSString * const PostStatusDeleted;
 @property (nonatomic, assign) BOOL metaIsLocal;
 @property (nonatomic, assign) BOOL metaPublishImmediately;
 @property (nonatomic) AbstractPostRemoteStatus remoteStatus;
-@property (nonatomic, assign) BOOL hasBeenPublished;
+@property (nonatomic, readonly) BOOL hasBeenPublished;
 
 /**
  Used to store the post's status before its sent to the trash.

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -75,7 +75,7 @@ extern NSString * const PostStatusDeleted;
 - (BOOL)hasRevision;
 
 #pragma mark - Conveniece Methods
-- (void)publishImmediately;
+- (void)publish;
 - (BOOL)shouldPublishImmediately;
 - (NSString *)authorNameForDisplay;
 - (NSString *)blavatarForDisplay;

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -43,6 +43,8 @@ extern NSString * const PostStatusDeleted;
 @property (nonatomic, assign) BOOL metaIsLocal;
 @property (nonatomic, assign) BOOL metaPublishImmediately;
 @property (nonatomic) AbstractPostRemoteStatus remoteStatus;
+@property (nonatomic, assign) BOOL hasBeenPublished;
+
 /**
  Used to store the post's status before its sent to the trash.
  */
@@ -76,6 +78,7 @@ extern NSString * const PostStatusDeleted;
 
 #pragma mark - Conveniece Methods
 - (void)publish;
+- (void)publishImmediately;
 - (BOOL)shouldPublishImmediately;
 - (NSString *)authorNameForDisplay;
 - (NSString *)blavatarForDisplay;

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -452,8 +452,17 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 
 - (void)publishImmediately
 {
-    self.dateModified = [NSDate date];
-    [self setDateCreated:self.dateModified];
+    // If the post was modified later than it was created
+    // then this is a post that was published at some point
+    // we will not update the dateCreated
+    if (self.dateCreated &&
+        self.dateModified &&
+        [self.dateCreated compare:self.dateModified] == NSOrderedAscending) {
+        self.dateModified = [NSDate date];
+    } else {
+        self.dateModified = [NSDate date];
+        [self setDateCreated:self.dateModified];
+    }
 }
 
 - (BOOL)shouldPublishImmediately

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -462,10 +462,11 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 
 - (void)publish
 {
-    self.dateModified = [NSDate date];
-    // For once published posts we will not update the dateCreated
+    // For post that have been published before we will not update the dateCreated
     if (!self.hasBeenPublished) {
         [self publishImmediately];
+    } else {
+        self.dateModified = [NSDate date];
     }
 }
 

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -457,7 +457,7 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
     // we will not update the dateCreated
     if (self.dateCreated &&
         self.dateModified &&
-        [self.dateCreated compare:self.dateModified] == NSOrderedAscending) {
+        [self.dateCreated earlierDate:self.dateModified] == self.dateCreated) {
         self.dateModified = [NSDate date];
     } else {
         self.dateModified = [NSDate date];

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -459,7 +459,6 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 
 - (void)publish
 {
-
     // For once published posts we will not update the dateCreated
     if (self.dateCreated &&
         self.dateModified &&

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -454,18 +454,17 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 // then this is a post that was published at some point
 - (BOOL)hasBeenPublished
 {
-    return ![self.dateCreated isEqualToDate:self.dateModified] &&
+    return self.dateCreated &&
+           self.dateModified &&
+           ![self.dateCreated isEqualToDate:self.dateModified] &&
            [self.dateCreated earlierDate:self.dateModified] == self.dateCreated;
 }
 
 - (void)publish
 {
+    self.dateModified = [NSDate date];
     // For once published posts we will not update the dateCreated
-    if (self.dateCreated &&
-        self.dateModified &&
-        self.hasBeenPublished) {
-        self.dateModified = [NSDate date];
-    } else {
+    if (!self.hasBeenPublished) {
         [self publishImmediately];
     }
 }

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -450,19 +450,30 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
     return NO;
 }
 
+// If the post was modified later than it was created
+// then this is a post that was published at some point
+- (BOOL)hasBeenPublished
+{
+    return [self.dateCreated earlierDate:self.dateModified] == self.dateCreated;
+}
+
 - (void)publish
 {
-    // If the post was modified later than it was created
-    // then this is a post that was published at some point
-    // we will not update the dateCreated
+
+    // For once published posts we will not update the dateCreated
     if (self.dateCreated &&
         self.dateModified &&
-        [self.dateCreated earlierDate:self.dateModified] == self.dateCreated) {
+        self.hasBeenPublished) {
         self.dateModified = [NSDate date];
     } else {
-        self.dateModified = [NSDate date];
-        [self setDateCreated:self.dateModified];
+        [self publishImmediately];
     }
+}
+
+- (void)publishImmediately
+{
+    self.dateModified = [NSDate date];
+    [self setDateCreated:self.dateModified];
 }
 
 - (BOOL)shouldPublishImmediately

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -454,7 +454,8 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
 // then this is a post that was published at some point
 - (BOOL)hasBeenPublished
 {
-    return [self.dateCreated earlierDate:self.dateModified] == self.dateCreated;
+    return ![self.dateCreated isEqualToDate:self.dateModified] &&
+           [self.dateCreated earlierDate:self.dateModified] == self.dateCreated;
 }
 
 - (void)publish

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -450,7 +450,7 @@ NSString * const PostStatusDeleted = @"deleted"; // Returned by wpcom REST API w
     return NO;
 }
 
-- (void)publishImmediately
+- (void)publish
 {
     // If the post was modified later than it was created
     // then this is a post that was published at some point

--- a/WordPress/Classes/Networking/PostServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/PostServiceRemoteREST.m
@@ -376,6 +376,9 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
         // safety net. An existing post with no create date should publish immediately
         parameters[@"date"] = [[NSDate date] WordPressComJSONString];
     }
+    if (post.dateModified) {
+        parameters[@"modified"] = [post.dateModified WordPressComJSONString];
+    }
     if (post.excerpt) {
         parameters[@"excerpt"] = post.excerpt;
     }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -795,9 +795,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         WPAnalytics.track(.postListPublishAction, withProperties: propertiesForAnalytics())
 
         apost.status = .publish
-        if let date = apost.dateCreated, date == (Date() as NSDate).laterDate(date) {
-            apost.dateCreated = Date()
-        }
+        apost.publishImmediately()
 
         let postService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext)
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -795,7 +795,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         WPAnalytics.track(.postListPublishAction, withProperties: propertiesForAnalytics())
 
         apost.status = .publish
-        apost.publishImmediately()
+        apost.publish()
 
         let postService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext)
 

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -680,6 +680,7 @@ extension AztecPostViewController {
                 self.post.status = .draft
             } else if self.postEditorStateContext.secondaryPublishButtonAction == .publish {
                 self.post.status = .publish
+                self.post.publishImmediately()
             }
 
             if let stat = self.postEditorStateContext.secondaryPublishActionAnalyticsStat {

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -680,7 +680,7 @@ extension AztecPostViewController {
                 self.post.status = .draft
             } else if self.postEditorStateContext.secondaryPublishButtonAction == .publish {
                 self.post.status = .publish
-                self.post.publishImmediately()
+                self.post.publish()
             }
 
             if let stat = self.postEditorStateContext.secondaryPublishActionAnalyticsStat {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1460,6 +1460,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
             return;
         }
         self.apost.dateCreated = selectedDate;
+        self.apost.dateModified = [NSDate date];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -997,6 +997,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     }
 
     self.datePicker = [[PublishDatePickerView alloc] initWithDate:date];
+    self.datePicker.displayPublishImmediately = !self.apost.hasBeenPublished;
     self.datePicker.delegate = self;
     CGRect frame = self.datePicker.frame;
     if (IS_IPAD) {
@@ -1449,7 +1450,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 {
     if (value == nil) {
         // Publish Immediately
-        [self.apost publish];
+        [self.apost publishImmediately];
     } else {
         // Compare via timeIntervalSinceDate to let us ignore subsecond variation.
         NSDate *startingDate = (NSDate *)self.datePicker.startingValue;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1449,7 +1449,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 {
     if (value == nil) {
         // Publish Immediately
-        [self.apost publishImmediately];
+        [self.apost publish];
     } else {
         // Compare via timeIntervalSinceDate to let us ignore subsecond variation.
         NSDate *startingDate = (NSDate *)self.datePicker.startingValue;

--- a/WordPress/Classes/ViewRelated/Post/PublishDatePickerView.h
+++ b/WordPress/Classes/ViewRelated/Post/PublishDatePickerView.h
@@ -2,4 +2,6 @@
 
 @interface PublishDatePickerView : WPPickerView
 
+@property (nonatomic, assign) BOOL displayPublishImmediately;
+
 @end

--- a/WordPress/Classes/ViewRelated/Post/PublishDatePickerView.m
+++ b/WordPress/Classes/ViewRelated/Post/PublishDatePickerView.m
@@ -6,10 +6,16 @@
 {
     NSMutableArray *arr = [[super buttonsForToolbar] mutableCopy];
 
-    NSString *title = NSLocalizedString(@"Publish Immediately", @"Post publishing status in the Post Editor/Settings area (compare with WP core translations).");
-    UIBarButtonItem *publishButton = [[UIBarButtonItem alloc] initWithTitle:title style:UIBarButtonItemStylePlain target:self action:@selector(publishImmediately)];
-    [arr replaceObjectAtIndex:0 withObject:publishButton];
-
+    if (self.displayPublishImmediately) {
+        NSString *title = NSLocalizedString(@"Publish Immediately", @"Post publishing status in the Post Editor/Settings area (compare with WP core translations).");
+        UIBarButtonItem *publishButton = [[UIBarButtonItem alloc] initWithTitle:title
+                                                                          style:UIBarButtonItemStylePlain
+                                                                         target:self
+                                                                         action:@selector(publishImmediately)];
+        [arr replaceObjectAtIndex:0 withObject:publishButton];
+    } else {
+        [arr removeObjectAtIndex:0];
+    }
     return arr;
 }
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1260,14 +1260,14 @@ EditImageDetailsViewControllerDelegate
             return [UIAlertAction actionWithTitle:NSLocalizedString(@"Publish Now", @"Title of button allowing the user to immediately publish the post they are editing.")
                                             style:UIAlertActionStyleDestructive
                                           handler:^(UIAlertAction * _Nonnull action) {
-                                              [self.post publishImmediately];
+                                              [self.post publish];
                                               [self saveAction:action];
                                           }];
         } else {
             return [UIAlertAction actionWithTitle:NSLocalizedString(@"Submit for Review", @"Title of button allowing a contributor to a site to submit the post they are editing for review.")
                                             style:UIAlertActionStyleDestructive
                                           handler:^(UIAlertAction * _Nonnull action) {
-                                              [self.post publishImmediately];
+                                              [self.post publish];
                                               [self saveAction:action];
                                           }];
         }

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1260,6 +1260,7 @@ EditImageDetailsViewControllerDelegate
             return [UIAlertAction actionWithTitle:NSLocalizedString(@"Publish Now", @"Title of button allowing the user to immediately publish the post they are editing.")
                                             style:UIAlertActionStyleDestructive
                                           handler:^(UIAlertAction * _Nonnull action) {
+                                              self.post.status = PostStatusPublish;
                                               [self.post publish];
                                               [self saveAction:action];
                                           }];
@@ -1267,6 +1268,7 @@ EditImageDetailsViewControllerDelegate
             return [UIAlertAction actionWithTitle:NSLocalizedString(@"Submit for Review", @"Title of button allowing a contributor to a site to submit the post they are editing for review.")
                                             style:UIAlertActionStyleDestructive
                                           handler:^(UIAlertAction * _Nonnull action) {
+                                              self.post.status = PostStatusPublish;
                                               [self.post publish];
                                               [self saveAction:action];
                                           }];


### PR DESCRIPTION
**Fixes** #3516 

**To test:**

Cases have to be tested for for Aztec, current/old Editor and quick Post Actions.

Case 1: 
1. Create a new Draft and Save it.
2. Wait a few minutes and Publish it.
3. Check that the Publish date is when the Post was published and not when it was created.

Case 2:
1. Chose a published post and make a note if its Published Date.
2. Change the status of the post from Published to Draft.
3. Check that you can't change the Publish date to Publish Immediately.
4. Republish the Post.
5. Check that the Publish Date remains being the one recorded at 1.

== This two are not working, the `dateModified` field is not recorded on a post first save, this is an issue with the current app version too ==

Case 3:
1. Create a new Post.
2. Change its Publish Date to something in the past.
3. Publish the Post.
4. Check that the Published Date is correct.

Case 4: 
1. Create a new Post
2. Change its publish date to something in the past.
3. Save the post as a Draft.
4. Publish the Post.
6. Check that the Published Date is correct.

Needs review: @aerych 