### PR TITLE
Menus: persist CSS classes for MenuItems

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,6 +4,8 @@ This file documents changes in the data model. Please explain any changes to the
 data model as well as any custom migrations.
 
 ## WordPress 59
+- @kurzee 2017-05-04
+- `MenuItem` added `classes` property.
 - @elibud 2017-04-26
 - `BasePost` added `suggested_slug` property.
 

--- a/WordPress/Classes/Models/MenuItem.h
+++ b/WordPress/Classes/Models/MenuItem.h
@@ -55,6 +55,7 @@ extern NSString * const MenuItemLinkTargetBlank;
 @property (nullable, nonatomic, strong) NSString *typeFamily;
 @property (nullable, nonatomic, strong) NSString *typeLabel;
 @property (nullable, nonatomic, strong) NSString *urlStr;
+@property (nullable, nonatomic, strong) NSArray<NSString *> *classes;
 
 ///---------------------
 /// @name Relationships

--- a/WordPress/Classes/Models/MenuItem.m
+++ b/WordPress/Classes/Models/MenuItem.m
@@ -30,6 +30,7 @@ NSString * const MenuItemDefaultLinkTitle = @"New Item";
 @dynamic menu;
 @dynamic children;
 @dynamic parent;
+@dynamic classes;
 
 + (NSString *)entityName
 {

--- a/WordPress/Classes/Networking/MenusServiceRemote.m
+++ b/WordPress/Classes/Networking/MenusServiceRemote.m
@@ -23,6 +23,7 @@ NSString * const MenusRemoteKeyURL = @"url";
 NSString * const MenusRemoteKeyItems = @"items";
 NSString * const MenusRemoteKeyDeleted = @"deleted";
 NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
+NSString * const MenusRemoteKeyClasses = @"classes";
 
 @implementation MenusServiceRemote
 
@@ -282,6 +283,7 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
     item.typeFamily = [dictionary stringForKey:MenusRemoteKeyTypeFamily];
     item.typeLabel = [dictionary stringForKey:MenusRemoteKeyTypeLabel];
     item.urlStr = [dictionary stringForKey:MenusRemoteKeyURL];
+    item.classes = [dictionary arrayForKey:MenusRemoteKeyClasses];
     
     NSArray *itemDicts = [dictionary arrayForKey:MenusRemoteKeyItems];
     if (itemDicts.count) {
@@ -381,6 +383,10 @@ NSString * const MenusRemoteKeyLocationDefaultState = @"defaultState";
     
     if (item.urlStr.length) {
         dictionary[MenusRemoteKeyURL] = item.urlStr;
+    }
+
+    if (item.classes.count) {
+        dictionary[MenusRemoteKeyClasses] = item.classes;
     }
     
     if (item.children.count) {

--- a/WordPress/Classes/Networking/Remote Objects/RemoteMenuItem.h
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteMenuItem.h
@@ -12,6 +12,7 @@
 @property (nullable, nonatomic, copy) NSString *typeFamily;
 @property (nullable, nonatomic, copy) NSString *typeLabel;
 @property (nullable, nonatomic, copy) NSString *urlStr;
+@property (nullable, nonatomic, copy) NSArray<NSString *> *classes;
 
 @property (nullable, nonatomic, strong) NSArray<RemoteMenuItem *> *children;
 @property (nullable, nonatomic, weak) RemoteMenuItem *parentItem;

--- a/WordPress/Classes/Services/MenusService.m
+++ b/WordPress/Classes/Services/MenusService.m
@@ -321,7 +321,8 @@ NS_ASSUME_NONNULL_BEGIN
     item.typeLabel = remoteMenuItem.typeLabel;
     item.urlStr = remoteMenuItem.urlStr;
     item.menu = menu;
-    
+    item.classes = remoteMenuItem.classes;
+
     if (remoteMenuItem.children) {
         for (RemoteMenuItem *childRemoteItem in remoteMenuItem.children) {
             MenuItem *childItem = [self addMenuItemFromRemoteMenuItem:childRemoteItem forMenu:menu];
@@ -405,7 +406,8 @@ NS_ASSUME_NONNULL_BEGIN
     remoteItem.linkTitle = item.linkTitle;
     remoteItem.name = item.name;
     remoteItem.type = item.type;
-    
+    remoteItem.classes = item.classes;
+
     if (remoteItem.type) {
         // Override the type_family param based on the type.
         // This is a weird behavior of the API and is not documented.

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 59.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 59.xcdatamodel/contents
@@ -335,6 +335,7 @@
         <relationship name="locations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MenuLocation" inverseName="menu" inverseEntity="MenuLocation" syncable="YES"/>
     </entity>
     <entity name="MenuItem" representedClassName="MenuItem" syncable="YES">
+        <attribute name="classes" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="contentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="itemID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
@@ -630,7 +631,7 @@
         <element name="Domain" positionX="27" positionY="153" width="128" height="105"/>
         <element name="Media" positionX="0" positionY="0" width="128" height="360"/>
         <element name="Menu" positionX="63" positionY="198" width="128" height="135"/>
-        <element name="MenuItem" positionX="45" positionY="180" width="128" height="240"/>
+        <element name="MenuItem" positionX="45" positionY="180" width="128" height="255"/>
         <element name="MenuLocation" positionX="54" positionY="189" width="128" height="120"/>
         <element name="Notification" positionX="18" positionY="162" width="128" height="240"/>
         <element name="Page" positionX="0" positionY="0" width="128" height="60"/>

--- a/WordPress/WordPressTest/MenusServiceTests.m
+++ b/WordPress/WordPressTest/MenusServiceTests.m
@@ -187,6 +187,8 @@
     OCMStub([item typeFamily]).andReturn(MenuItemTypePage);
     OCMStub([item typeLabel]).andReturn(@"Page");
     OCMStub([item urlStr]).andReturn(@"http://wordpress.com/");
+    NSArray *classes = @[@"special_class", @"extra_special_class"];
+    OCMStub([item classes]).andReturn(classes);
     OCMStub([item children]).andReturn(nil);
     OCMStub([item parent]).andReturn(nil);
     NSOrderedSet *items = [NSOrderedSet orderedSetWithObject:item];


### PR DESCRIPTION
Fixes #7108 

This is a simple change that persists the `classes` field array for menu items coming in from the API, and upon subsequently saving a Menu.

To test:
1. Open up wp-admin on a .com or Jetpack site (self-hosted not supported for Menus)
2. Go to Appearance > Menus
3. In the top right, open up Screen Options, check the CSS Classes option if needed and reload the page.
4. Under Menus, check that you have a menu, or create one if needed.
5. Note which Menu is selected, it should be the "Primary Menu", select it if needed.
6. Open one of the menu items to view it's field options.
7. Type in a couple of custom classes under "CSS Classes (optional)".
   - Ex: `special_class, extra_special_class` which auto-formats to `special_class extra_special_class` upon save.
8. Open up the app from this branch.
9. For the same site, open up Menus in-app.
10. Check that you are viewing the same menu as edited in steps 1-7, or select it if needed.
11. Make a change, such as reordering an item by dragging the right drag indicator.
12. Save the menu.
13. On wp-admin, reload the page and check that the both the change is reflected and the previously entered custom classes are persisted on the corresponding menu item.
14. ☕️ 

Needs review: @elibud can I bug you with a review?
