### PR TITLE
Use character replacement instead of string encoding.

### DIFF
--- a/WordPress/Classes/Networking/JetpackServiceRemote.m
+++ b/WordPress/Classes/Networking/JetpackServiceRemote.m
@@ -69,7 +69,7 @@ static NSString * const GetUsersBlogsApiPath = @"https://public-api.wordpress.co
                     failure:(void (^)(NSError *error))failure
 {
     NSString *siteStr = [[NSString stringWithFormat:@"%@%@", siteURL.host, siteURL.path]
-                         stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLHostAllowedCharacterSet];
+                         stringByReplacingOccurrencesOfString:@"/" withString:@"::"];
     NSString *scheme = siteURL.scheme ?: @"http";
 
     NSString *endpoint = [NSString stringWithFormat:@"connect/site-info/%@/%@", scheme, siteStr];

--- a/WordPress/Classes/Networking/JetpackServiceRemote.m
+++ b/WordPress/Classes/Networking/JetpackServiceRemote.m
@@ -68,8 +68,9 @@ static NSString * const GetUsersBlogsApiPath = @"https://public-api.wordpress.co
                     success:(void (^)(BOOL isJetpack))success
                     failure:(void (^)(NSError *error))failure
 {
-    NSString *siteStr = [[NSString stringWithFormat:@"%@%@", siteURL.host, siteURL.path]
-                         stringByReplacingOccurrencesOfString:@"/" withString:@"::"];
+    NSString *siteStr = [NSString stringWithFormat:@"%@%@", siteURL.host, siteURL.path];
+    siteStr = [siteStr stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
+    siteStr = [siteStr stringByReplacingOccurrencesOfString:@"/" withString:@"::"];
     NSString *scheme = siteURL.scheme ?: @"http";
 
     NSString *endpoint = [NSString stringWithFormat:@"connect/site-info/%@/%@", scheme, siteStr];


### PR DESCRIPTION
Follow up to #7071. It turns out that the endpoint expects slashes in the path to be replaced with a double colon instead of simply escaping the character. Props to @maxme who noticed the incorrect response when testing the REST endpoint with his own blog. 

Needs review: @koke would you take a peek since you're already familiar with this? 
