### PR TITLE
Attempt to fix crash by explicitly unwrapping

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1095,11 +1095,11 @@ import WordPressComAnalytics
     /// Not intended for use as part of a user interaction. See syncIfAppropriate instead.
     ///
     func backgroundFetch(_ completionHandler: @escaping ((UIBackgroundFetchResult) -> Void)) {
-        let lastSeenPostID = (tableViewHandler.resultsController.fetchedObjects?.first as? ReaderPost)?.postID ?? -1
+        let lastSeenPostID = (tableViewHandler?.resultsController.fetchedObjects?.first as? ReaderPost)?.postID ?? -1
 
-        syncHelper.backgroundSync(success: { [weak self, weak lastSeenPostID] in
-            let newestFetchedPostID = (self?.tableViewHandler.resultsController.fetchedObjects?.first as? ReaderPost)?.postID ?? -1
-            self?.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+        syncHelper?.backgroundSync(success: { [weak self, weak lastSeenPostID] in
+            let newestFetchedPostID = (self?.tableViewHandler?.resultsController.fetchedObjects?.first as? ReaderPost)?.postID ?? -1
+            self?.tableView?.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
             if lastSeenPostID == newestFetchedPostID {
                 completionHandler(.noData)
             } else {


### PR DESCRIPTION
**Fixes** #7130 

**To test:**
We don't have steps to replicate, but you can trigger background refresh from XCode and see that it works fine.

Needs review: @koke 

Original PR for reference: https://github.com/wordpress-mobile/WordPress-iOS/pull/7049