### PR TITLE
Media: fix issue with caption cell not selecting.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
@@ -323,11 +323,12 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
 
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-    if (cell.tag == ImageDetailsSectionFeatured) {
-        return NO;
+    if (indexPath.section == ImageDetailsSectionFeatured) {
+        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+        if (cell.tag == ImageDetailsRowFeatured) {
+            return NO;
+        }
     }
-
     return YES;
 }
 


### PR DESCRIPTION
Fixes #7137

There was an issue with how we were calculating `shouldHighlightRowAtIndexPath` and checking the wrong values.

Separately, it looks like featured images are broken altogether here and cannot be enabled/selected. Also, when hitting the detail for a featured image in the post options results in an all white scrollview of sorts. @frosty any ideas there?

To test:
1. Run, open the visual editor.
2. Insert media either from the library or device.
3. Tap to open the `EditImageDetailsViewController`.
4. Try and select the Caption cell, make sure you can.

Needs review: @frosty can you take a spin of this one?
