### PR TITLE
Post Options: fix issue with subclassed featured image VC.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
@@ -17,6 +17,7 @@
 @implementation FeaturedImageViewController
 
 @dynamic url;
+@dynamic image;
 
 #pragma mark - Life Cycle Methods
 

--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
@@ -16,6 +16,8 @@
 
 @implementation FeaturedImageViewController
 
+@dynamic url;
+
 #pragma mark - Life Cycle Methods
 
 - (void)dealloc


### PR DESCRIPTION
Fixes a separate issue seen in #7138

Declaring `url` property as `dynamic` since we're actually using the property from the super class, `WPImageViewController`. Nice fix as suggested by @frosty 🎩 

To test:
1. Open editor, options.
2. Add a featured image, select it to view the detail.
3. Ensure the image loads as expected within the scrollview.

Needs review: @frosty at your leisure!