### PR TITLE
7.6: cherry-picks featured image/media caption fixes.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/EditImageDetailsViewController.m
@@ -323,11 +323,12 @@ typedef NS_ENUM(NSUInteger, ImageDetailsRow) {
 
 - (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-    if (cell.tag == ImageDetailsSectionFeatured) {
-        return NO;
+    if (indexPath.section == ImageDetailsSectionFeatured) {
+        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
+        if (cell.tag == ImageDetailsRowFeatured) {
+            return NO;
+        }
     }
-
     return YES;
 }
 

--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
@@ -17,6 +17,7 @@
 @implementation FeaturedImageViewController
 
 @dynamic url;
+@dynamic image;
 
 #pragma mark - Life Cycle Methods
 

--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
@@ -16,6 +16,8 @@
 
 @implementation FeaturedImageViewController
 
+@dynamic url;
+
 #pragma mark - Life Cycle Methods
 
 - (void)dealloc


### PR DESCRIPTION
This brings in the three commits from https://github.com/wordpress-mobile/WordPress-iOS/pull/7138 and https://github.com/wordpress-mobile/WordPress-iOS/pull/7140 in which a user could not select the "Caption" cell to add/edit a caption, as well as preview a featured image.

These bugs were introduced sometime in `7.4` or `7.5`, if we could go ahead and bring them into `7.6` it would be great!

Needs review: @astralbodies your call on this one for `7.6`! These are minimal, recent bugs. You can follow the testing steps from both PRs if you'd like. I'll be on a ✈️ so feel free to merge if ready.
