### PR TITLE
Rename feature flag build configurations to be easier to understand

### DIFF
--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -13,12 +13,12 @@ enum FeatureFlag: Int {
         case .exampleFeature:
             return true
         case .mediaLibrary:
-            return build(.debug, .alpha, .internal)
+            return build(.debug, .buddy, .internal)
         case .newLogin:
             return build(.debug, .alpha)
         case .nativeEditor:
             // At the moment this is only visible by default in non-app store builds
-            if build(.alpha, .debug, .internal) {
+            if build(.buddy, .debug, .internal) {
                 return true
             }
             return false
@@ -40,8 +40,8 @@ class Feature: NSObject {
 enum Build: Int {
     /// Development build, usually what you get when you run from Xcode
     case debug
-    /// Daily buiilds released internally for Automattic employees
-    case alpha
+    /// Continuous builds created by BuddyBuild for Automattic employees
+    case buddy
     /// Beta released internally for Automattic employees
     case `internal`
     /// Production build released in the app store
@@ -56,7 +56,7 @@ enum Build: Int {
         #if DEBUG
             return .debug
         #elseif ALPHA_BUILD
-            return .alpha
+            return .buddy
         #elseif INTERNAL_BUILD
             return .`internal`
         #else

--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -13,12 +13,12 @@ enum FeatureFlag: Int {
         case .exampleFeature:
             return true
         case .mediaLibrary:
-            return build(.debug, .buddy, .internal)
+            return build(.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting)
         case .newLogin:
-            return build(.debug, .buddy)
+            return build(.localDeveloper, .a8cBranchTest)
         case .nativeEditor:
             // At the moment this is only visible by default in non-app store builds
-            if build(.buddy, .debug, .internal) {
+            if build(.a8cBranchTest, .localDeveloper, .a8cPrereleaseTesting) {
                 return true
             }
             return false
@@ -38,12 +38,12 @@ class Feature: NSObject {
 
 /// Represents a build configuration.
 enum Build: Int {
-    /// Development build, usually what you get when you run from Xcode
-    case debug
-    /// Continuous builds created by BuddyBuild for Automattic employees
-    case buddy
+    /// Development build, usually run from Xcode
+    case localDeveloper
+    /// Continuous integration builds for Automattic employees to test branches & PRs
+    case a8cBranchTest
     /// Beta released internally for Automattic employees
-    case `internal`
+    case a8cPrereleaseTesting
     /// Production build released in the app store
     case appStore
 
@@ -54,11 +54,11 @@ enum Build: Int {
         }
 
         #if DEBUG
-            return .debug
+            return .localDeveloper
         #elseif ALPHA_BUILD
-            return .buddy
+            return .a8cBranchTest
         #elseif INTERNAL_BUILD
-            return .`internal`
+            return .a8cPrereleaseTesting
         #else
             return .appStore
         #endif
@@ -72,7 +72,7 @@ enum Build: Int {
 ///
 /// Example:
 ///
-///     let enableExperimentalStuff = build(.Debug, .Internal)
+///     let enableExperimentalStuff = build(.localDeveloper, .a8cBranchTest)
 func build(_ any: Build...) -> Bool {
     return any.reduce(false, { previous, buildValue in
         previous || Build.current == buildValue

--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -15,7 +15,7 @@ enum FeatureFlag: Int {
         case .mediaLibrary:
             return build(.debug, .buddy, .internal)
         case .newLogin:
-            return build(.debug, .alpha)
+            return build(.debug, .buddy)
         case .nativeEditor:
             // At the moment this is only visible by default in non-app store builds
             if build(.buddy, .debug, .internal) {

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -45,7 +45,7 @@ final public class InteractiveNotificationsManager: NSObject {
     /// This method should be called once during the app initialization process.
     ///
     public func registerForUserNotifications() {
-        if sharedApplication.isRunningSimulator() || build(.alpha) {
+        if sharedApplication.isRunningSimulator() || build(.buddy) {
             return
         }
 
@@ -60,7 +60,7 @@ final public class InteractiveNotificationsManager: NSObject {
     /// Because of this, this should be called only when we know we will need to show notifications (for instance, after login).
     ///
     public func requestAuthorization() {
-        if sharedApplication.isRunningSimulator() || build(.alpha) {
+        if sharedApplication.isRunningSimulator() || build(.buddy) {
             return
         }
 

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -45,7 +45,7 @@ final public class InteractiveNotificationsManager: NSObject {
     /// This method should be called once during the app initialization process.
     ///
     public func registerForUserNotifications() {
-        if sharedApplication.isRunningSimulator() || build(.buddy) {
+        if sharedApplication.isRunningSimulator() || build(.a8cBranchTest) {
             return
         }
 
@@ -60,7 +60,7 @@ final public class InteractiveNotificationsManager: NSObject {
     /// Because of this, this should be called only when we know we will need to show notifications (for instance, after login).
     ///
     public func requestAuthorization() {
-        if sharedApplication.isRunningSimulator() || build(.buddy) {
+        if sharedApplication.isRunningSimulator() || build(.a8cBranchTest) {
             return
         }
 

--- a/WordPress/Classes/Utility/KeychainTools.swift
+++ b/WordPress/Classes/Utility/KeychainTools.swift
@@ -22,7 +22,7 @@ final class KeychainTools: NSObject {
     /// - Attention: This is only enabled in debug builds.
     ///
     static func processKeychainDebugArguments() {
-        guard build(.debug) else {
+        guard build(.localDeveloper) else {
             return
         }
 

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -77,7 +77,7 @@ final public class PushNotificationsManager: NSObject {
     /// Registers the device for Remote Notifications: Badge + Sounds + Alerts
     ///
     func registerForRemoteNotifications() {
-        if sharedApplication.isRunningSimulator() || build(.alpha) {
+        if sharedApplication.isRunningSimulator() || build(.buddy) {
             return
         }
 

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -77,7 +77,7 @@ final public class PushNotificationsManager: NSObject {
     /// Registers the device for Remote Notifications: Badge + Sounds + Alerts
     ///
     func registerForRemoteNotifications() {
-        if sharedApplication.isRunningSimulator() || build(.buddy) {
+        if sharedApplication.isRunningSimulator() || build(.a8cBranchTest) {
             return
         }
 

--- a/WordPress/WordPressTest/EditorSettingsTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsTests.swift
@@ -11,7 +11,7 @@ class EditorSettingsTests: XCTestCase {
     }
 
     func testNativeEditorAvailableIsAvailableBasedOnBuild() {
-        Build._overrideCurrent = .debug
+        Build._overrideCurrent = .localDeveloper
         let editorSettings = EditorSettings(database: EphemeralKeyValueDatabase())
 
         XCTAssertTrue(editorSettings.nativeEditorAvailable)
@@ -34,7 +34,7 @@ class EditorSettingsTests: XCTestCase {
     }
 
     func testNativeEditorEnabledAvailableButDisabledByDefault() {
-        Build._overrideCurrent = .debug
+        Build._overrideCurrent = .localDeveloper
         let editorSettings = EditorSettings(database: EphemeralKeyValueDatabase())
 
         XCTAssertTrue(editorSettings.nativeEditorAvailable)

--- a/WordPress/WordPressTest/FeatureFlagTest.swift
+++ b/WordPress/WordPressTest/FeatureFlagTest.swift
@@ -7,15 +7,15 @@ class FeatureFlagTest: XCTestCase {
     func testBuild() {
         Build.withCurrent(.debug) {
             expect(build(.debug)).to(beTrue())
-            expect(build(.debug, .alpha)).to(beTrue())
-            expect(build(.alpha)).to(beFalse())
+            expect(build(.debug, .buddy)).to(beTrue())
+            expect(build(.buddy)).to(beFalse())
             expect(build(.internal)).to(beFalse())
             expect(build(.appStore)).to(beFalse())
         }
 
         Build.withCurrent(.appStore) {
             expect(build(.debug)).to(beFalse())
-            expect(build(.alpha)).to(beFalse())
+            expect(build(.buddy)).to(beFalse())
             expect(build(.internal)).to(beFalse())
             expect(build(.appStore)).to(beTrue())
             expect(build(.internal,.appStore)).to(beTrue())

--- a/WordPress/WordPressTest/FeatureFlagTest.swift
+++ b/WordPress/WordPressTest/FeatureFlagTest.swift
@@ -5,20 +5,20 @@ import XCTest
 class FeatureFlagTest: XCTestCase {
 
     func testBuild() {
-        Build.withCurrent(.debug) {
-            expect(build(.debug)).to(beTrue())
-            expect(build(.debug, .buddy)).to(beTrue())
-            expect(build(.buddy)).to(beFalse())
-            expect(build(.internal)).to(beFalse())
+        Build.withCurrent(.localDeveloper) {
+            expect(build(.localDeveloper)).to(beTrue())
+            expect(build(.localDeveloper, .a8cBranchTest)).to(beTrue())
+            expect(build(.a8cBranchTest)).to(beFalse())
+            expect(build(.a8cPrereleaseTesting)).to(beFalse())
             expect(build(.appStore)).to(beFalse())
         }
 
         Build.withCurrent(.appStore) {
-            expect(build(.debug)).to(beFalse())
-            expect(build(.buddy)).to(beFalse())
-            expect(build(.internal)).to(beFalse())
+            expect(build(.localDeveloper)).to(beFalse())
+            expect(build(.a8cBranchTest)).to(beFalse())
+            expect(build(.a8cPrereleaseTesting)).to(beFalse())
             expect(build(.appStore)).to(beTrue())
-            expect(build(.internal,.appStore)).to(beTrue())
+            expect(build(.a8cPrereleaseTesting,.appStore)).to(beTrue())
         }
     }
 


### PR DESCRIPTION
To make it clearer where our feature build configurations apply.

### Discussion:
When setting up a feature flag, it's not entirely clear where a build configuration will apply, especially 'alpha' and 'internal'. By renaming them, hopefully setting up a new feature flag will be easier thus encouraging their use.

To test:
- make sure everything still builds
- make sure the BuddyBuild build still runs

Needs review: @astralbodies 
