### PR TITLE
Feature/login self hosted profile part 1

### DIFF
--- a/WordPress/Classes/Models/GravatarProfile.swift
+++ b/WordPress/Classes/Models/GravatarProfile.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+open class GravatarProfile {
+
+    var profileID = ""
+    var hash = ""
+    var requestHash = ""
+    var profileUrl = ""
+    var preferredUsername = ""
+    var thumbnailUrl = ""
+    var name = ""
+    var displayName = ""
+
+}

--- a/WordPress/Classes/Networking/GravatarServiceRemote.swift
+++ b/WordPress/Classes/Networking/GravatarServiceRemote.swift
@@ -4,7 +4,7 @@ import AFNetworking
 /// This ServiceRemote encapsulates all of the interaction with the Gravatar endpoint.
 ///
 open class GravatarServiceRemote {
-    let baseGravatarURL = "https://wwww.gravatar.com/"
+    let baseGravatarURL = "https://www.gravatar.com/"
 
     /// This method fetches the Gravatar profile for the specified email address.
     ///

--- a/WordPress/Classes/Networking/GravatarServiceRemote.swift
+++ b/WordPress/Classes/Networking/GravatarServiceRemote.swift
@@ -6,7 +6,7 @@ import AFNetworking
 open class GravatarServiceRemote {
     let baseGravatarURL = "https://wwww.gravatar.com/"
 
-    /// This method fetches the Gravatar profile for the specified email addres.
+    /// This method fetches the Gravatar profile for the specified email address.
     ///
     /// - Parameters:
     ///     - email: The email address of the gravatar profile to fetch.

--- a/WordPress/Classes/Networking/GravatarServiceRemote.swift
+++ b/WordPress/Classes/Networking/GravatarServiceRemote.swift
@@ -4,17 +4,6 @@ import Foundation
 /// This ServiceRemote encapsulates all of the interaction with the Gravatar endpoint.
 ///
 open class GravatarServiceRemote {
-    /// Designated Initializer
-    ///
-    /// - Parameters:
-    ///     - accountToken: A valid WordPress.com User Token
-    ///     - accountEmail: Account Email
-    ///
-    public init(accountToken: String, accountEmail: String) {
-        self.accountToken   = accountToken
-        self.accountEmail   = accountEmail
-    }
-
 
     /// This method hits the Gravatar Endpoint, and uploads a new image, to be used as profile.
     ///
@@ -22,7 +11,7 @@ open class GravatarServiceRemote {
     ///     - image: The new Gravatar Image, to be uploaded
     ///     - completion: An optional closure to be executed on completion.
     ///
-    open func uploadImage(_ image: UIImage, completion: ((_ error: NSError?) -> ())?) {
+    open func uploadImage(_ image: UIImage, accountEmail: String, accountToken: String, completion: ((_ error: NSError?) -> ())?) {
         guard let targetURL = URL(string: UploadParameters.endpointURL) else {
             assertionFailure()
             return
@@ -49,7 +38,6 @@ open class GravatarServiceRemote {
 
         task.resume()
     }
-
 
 
     // MARK: - Private Helpers
@@ -92,11 +80,6 @@ open class GravatarServiceRemote {
         return body as Data
     }
 
-
-
-    // MARK: - Private Properties
-    fileprivate let accountEmail: String
-    fileprivate let accountToken: String
 
     // MARK: - Private Structs
     fileprivate struct UploadParameters {

--- a/WordPress/Classes/Networking/GravatarServiceRemote.swift
+++ b/WordPress/Classes/Networking/GravatarServiceRemote.swift
@@ -28,8 +28,11 @@ open class GravatarServiceRemote {
         let session = URLSession.shared
         let task = session.dataTask(with: targetURL) { (data: Data?, response: URLResponse?, error: Error?) in
             let errPointer: NSErrorPointer = nil
-            if let response = AFJSONResponseSerializer().responseObject(for: response, data: data, error: errPointer) as? [String: String] {
-                let profile = RemoteGravatarProfile(dict: response)
+            if  let response = AFJSONResponseSerializer().responseObject(for: response, data: data, error: errPointer) as? [String: Array<Any>],
+                let entry = response["entry"],
+                let profileData = entry.first as? [String: Any] {
+
+                let profile = RemoteGravatarProfile(dict: profileData)
                 success(profile)
                 return
             }

--- a/WordPress/Classes/Networking/Remote Objects/RemoteGravatarProfile.swift
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteGravatarProfile.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+open class RemoteGravatarProfile {
+    var profileID = ""
+    var hash = ""
+    var requestHash = ""
+    var profileUrl = ""
+    var preferredUsername = ""
+    var thumbnailUrl = ""
+    var name = ""
+    var displayName = ""
+
+    convenience init(dict: [String: String]) {
+        self.init()
+
+        profileID = dict["id"] ?? ""
+        hash = dict["hash"] ?? ""
+        requestHash = dict["requestHash"] ?? ""
+        profileUrl = dict["profileUrl"] ?? ""
+        preferredUsername = dict["preferredUsername"] ?? ""
+        thumbnailUrl = dict["thumbnailUrl"] ?? ""
+        name = dict["name"] ?? ""
+        displayName = dict["displayName"] ?? ""
+    }
+}

--- a/WordPress/Classes/Networking/Remote Objects/RemoteGravatarProfile.swift
+++ b/WordPress/Classes/Networking/Remote Objects/RemoteGravatarProfile.swift
@@ -10,16 +10,16 @@ open class RemoteGravatarProfile {
     var name = ""
     var displayName = ""
 
-    convenience init(dict: [String: String]) {
+    convenience init(dict: [String: Any]) {
         self.init()
 
-        profileID = dict["id"] ?? ""
-        hash = dict["hash"] ?? ""
-        requestHash = dict["requestHash"] ?? ""
-        profileUrl = dict["profileUrl"] ?? ""
-        preferredUsername = dict["preferredUsername"] ?? ""
-        thumbnailUrl = dict["thumbnailUrl"] ?? ""
-        name = dict["name"] ?? ""
-        displayName = dict["displayName"] ?? ""
+        profileID = dict.valueAsString(forKey: "id") ?? ""
+        hash = dict.valueAsString(forKey: "hash") ?? ""
+        requestHash = dict.valueAsString(forKey: "requestHash") ?? ""
+        profileUrl = dict.valueAsString(forKey: "profileUrl") ?? ""
+        preferredUsername = dict.valueAsString(forKey: "preferredUsername") ?? ""
+        thumbnailUrl = dict.valueAsString(forKey: "thumbnailUrl") ?? ""
+        name = dict.valueAsString(forKey: "name") ?? ""
+        displayName = dict.valueAsString(forKey: "displayName") ?? ""
     }
 }

--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -31,7 +31,7 @@ open class GravatarService {
     ///
     open func uploadImage(_ image: UIImage, completion: ((_ error: NSError?) -> ())? = nil) {
         let remote = gravatarServiceRemoteForAccountToken(accountToken: accountToken, andAccountEmail: accountEmail)
-        remote.uploadImage(image) { (error) in
+        remote.uploadImage(image, accountEmail: accountEmail, accountToken: accountToken) { (error) in
             if let theError = error {
                 DDLogSwift.logError("GravatarService.uploadImage Error: \(theError)")
             } else {
@@ -43,7 +43,7 @@ open class GravatarService {
     }
 
     func gravatarServiceRemoteForAccountToken(accountToken: String, andAccountEmail accountEmail: String) -> GravatarServiceRemote {
-        return GravatarServiceRemote(accountToken: accountToken, accountEmail: accountEmail)
+        return GravatarServiceRemote()
     }
 
     // MARK: - Private Properties

--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -16,14 +16,23 @@ open class GravatarService {
     ///     - success: A success block.
     ///     - failure: A failure block.
     ///
-    open func fetchProfile(_ email: String, success:(() -> Void), failure:((_ error: NSError?) -> Void)) {
+    open func fetchProfile(_ email: String, success:@escaping ((_ profile: GravatarProfile) -> Void), failure:@escaping ((_ error: NSError?) -> Void)) {
         let remote = gravatarServiceRemote()
         remote.fetchProfile(email, success: { (remoteProfile) in
+            let profile = GravatarProfile()
+            profile.profileID = remoteProfile.profileID
+            profile.hash = remoteProfile.hash
+            profile.requestHash = remoteProfile.requestHash
+            profile.profileUrl = remoteProfile.profileUrl
+            profile.preferredUsername = remoteProfile.preferredUsername
+            profile.thumbnailUrl = remoteProfile.thumbnailUrl
+            profile.name = remoteProfile.name
+            profile.displayName = remoteProfile.displayName
+            success(profile)
 
-            // TODO:
-
-        }, failure:{ (error) in
+        }, failure: { (error) in
             DDLogSwift.logError(error.debugDescription)
+            failure(error as NSError?)
         })
     }
 

--- a/WordPress/Classes/Services/GravatarService.swift
+++ b/WordPress/Classes/Services/GravatarService.swift
@@ -9,6 +9,25 @@ import Foundation
 ///
 open class GravatarService {
 
+    /// This method fetches the Gravatar profile for the specified email address.
+    ///
+    /// - Parameters:
+    ///     - email: The email address of the gravatar profile to fetch.
+    ///     - success: A success block.
+    ///     - failure: A failure block.
+    ///
+    open func fetchProfile(_ email: String, success:(() -> Void), failure:((_ error: NSError?) -> Void)) {
+        let remote = gravatarServiceRemote()
+        remote.fetchProfile(email, success: { (remoteProfile) in
+
+            // TODO:
+
+        }, failure:{ (error) in
+            DDLogSwift.logError(error.debugDescription)
+        })
+    }
+
+
     /// This method hits the Gravatar Endpoint, and uploads a new image, to be used as profile.
     ///
     /// - Parameters:

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -332,13 +332,17 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
     // MARK: - Gravatar Helpers
 
     fileprivate func uploadGravatarImage(_ newGravatar: UIImage) {
+        guard let account = defaultAccount() else {
+            return
+        }
+
         WPAppAnalytics.track(.gravatarUploaded)
 
         gravatarUploadInProgress = true
         headerView.overrideGravatarImage(newGravatar)
 
-        let service = GravatarService(context: ContextManager.sharedInstance().mainContext)
-        service?.uploadImage(newGravatar) { [weak self] error in
+        let service = GravatarService()
+        service.uploadImage(newGravatar, forAccount: account) { [weak self] error in
             DispatchQueue.main.async(execute: {
                 self?.gravatarUploadInProgress = false
                 self?.reloadViewModel()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -909,6 +909,7 @@
 		E60646801CB3133000A3073F /* SigninEditingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E606467F1CB3133000A3073F /* SigninEditingState.swift */; };
 		E60C2ED51DE5048200488630 /* ReaderCommentCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E60C2ED41DE5048200488630 /* ReaderCommentCell.xib */; };
 		E60C2ED71DE5075100488630 /* ReaderCommentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60C2ED61DE5075100488630 /* ReaderCommentCell.swift */; };
+		E60EA5701EC64F4A003E3592 /* RemoteGravatarProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60EA56F1EC64F4A003E3592 /* RemoteGravatarProfile.swift */; };
 		E61084BE1B9B47BA008050C5 /* ReaderAbstractTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61084B91B9B47BA008050C5 /* ReaderAbstractTopic.swift */; };
 		E61084BF1B9B47BA008050C5 /* ReaderDefaultTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61084BA1B9B47BA008050C5 /* ReaderDefaultTopic.swift */; };
 		E61084C01B9B47BA008050C5 /* ReaderListTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61084BB1B9B47BA008050C5 /* ReaderListTopic.swift */; };
@@ -1291,8 +1292,6 @@
 		08DF9C431E8475530058678C /* test-image-portrait.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "test-image-portrait.jpg"; sourceTree = "<group>"; };
 		08E5CAD31E7B3A4500FAC71B /* WordPress 57.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 57.xcdatamodel"; sourceTree = "<group>"; };
 		08F37EC61C7554EF0095BE8B /* PostServiceRemoteOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostServiceRemoteOptions.h; sourceTree = "<group>"; };
-		15C84DEA0B01A0CF82962DC4 /* Pods-WordPress_Base-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPress/Pods-WordPress_Base-WordPress.release.xcconfig"; sourceTree = "<group>"; };
-		16E856FF9B881D72F0F118A2 /* Pods-WordPressTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.debug.xcconfig"; sourceTree = "<group>"; };
 		08F8CD291EBD22EF0049D0C0 /* MediaExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaExporter.swift; sourceTree = "<group>"; };
 		08F8CD2C1EBD245F0049D0C0 /* MediaExporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaExporterTests.swift; sourceTree = "<group>"; };
 		08F8CD2E1EBD29440049D0C0 /* MediaImageExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaImageExporter.swift; sourceTree = "<group>"; };
@@ -1301,6 +1300,8 @@
 		08F8CD341EBD2AA80049D0C0 /* test-image-device-photo-gps.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "test-image-device-photo-gps.jpg"; sourceTree = "<group>"; };
 		08F8CD381EBD2C970049D0C0 /* MediaURLExporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaURLExporter.swift; sourceTree = "<group>"; };
 		08F8CD3A1EBD2D020049D0C0 /* MediaURLExporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaURLExporterTests.swift; sourceTree = "<group>"; };
+		15C84DEA0B01A0CF82962DC4 /* Pods-WordPress_Base-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPress/Pods-WordPress_Base-WordPress.release.xcconfig"; sourceTree = "<group>"; };
+		16E856FF9B881D72F0F118A2 /* Pods-WordPressTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.debug.xcconfig"; sourceTree = "<group>"; };
 		1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
 		1702BBDF1CF3034E00766A33 /* DomainsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsService.swift; sourceTree = "<group>"; };
 		1702BBE11CF319C600766A33 /* DomainsServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsServiceTests.swift; sourceTree = "<group>"; };
@@ -2492,6 +2493,7 @@
 		E606467F1CB3133000A3073F /* SigninEditingState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SigninEditingState.swift; sourceTree = "<group>"; };
 		E60C2ED41DE5048200488630 /* ReaderCommentCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderCommentCell.xib; sourceTree = "<group>"; };
 		E60C2ED61DE5075100488630 /* ReaderCommentCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderCommentCell.swift; sourceTree = "<group>"; };
+		E60EA56F1EC64F4A003E3592 /* RemoteGravatarProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RemoteGravatarProfile.swift; path = "Remote Objects/RemoteGravatarProfile.swift"; sourceTree = "<group>"; };
 		E61084B91B9B47BA008050C5 /* ReaderAbstractTopic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderAbstractTopic.swift; sourceTree = "<group>"; };
 		E61084BA1B9B47BA008050C5 /* ReaderDefaultTopic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderDefaultTopic.swift; sourceTree = "<group>"; };
 		E61084BB1B9B47BA008050C5 /* ReaderListTopic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderListTopic.swift; sourceTree = "<group>"; };
@@ -5090,6 +5092,7 @@
 				5DED0E131B42E3E400431FCD /* RemoteSourcePostAttribution.m */,
 				598F86A51B67B7A000550C9C /* RemoteTheme.h */,
 				598F86A61B67B7A000550C9C /* RemoteTheme.m */,
+				E60EA56F1EC64F4A003E3592 /* RemoteGravatarProfile.swift */,
 			);
 			name = "Remote Objects";
 			sourceTree = "<group>";
@@ -6718,6 +6721,7 @@
 				438A809C1EA5DB88005D4651 /* LoginLinkRequestViewController.swift in Sources */,
 				E14BCABB1E0BC817002E0603 /* Delay.swift in Sources */,
 				598DD1711B97985700146967 /* ThemeBrowserCell.swift in Sources */,
+				E60EA5701EC64F4A003E3592 /* RemoteGravatarProfile.swift in Sources */,
 				B5A05AD91CA48601002EC787 /* ImageCropViewController.swift in Sources */,
 				E1F80825146420B000726BC7 /* UIImageView+Gravatar.m in Sources */,
 				B576B4881C6A22FB0027C754 /* Languages.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1018,6 +1018,7 @@
 		E6ED090B1D46AFAF003283C4 /* ReaderFollowedSitesStreamHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = E6ED090A1D46AFAF003283C4 /* ReaderFollowedSitesStreamHeader.xib */; };
 		E6F058021C1A122B008000F9 /* ReaderPostMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F058011C1A122B008000F9 /* ReaderPostMenu.swift */; };
 		E6F66D421E00966000F875A5 /* UIImage+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F66D411E00966000F875A5 /* UIImage+Rotation.swift */; };
+		E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */; };
 		F128C31C1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */; };
 		F1564E5B18946087009F8F97 /* NSStringHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */; };
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
@@ -2618,6 +2619,7 @@
 		E6ED090A1D46AFAF003283C4 /* ReaderFollowedSitesStreamHeader.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderFollowedSitesStreamHeader.xib; sourceTree = "<group>"; };
 		E6F058011C1A122B008000F9 /* ReaderPostMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostMenu.swift; sourceTree = "<group>"; };
 		E6F66D411E00966000F875A5 /* UIImage+Rotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Rotation.swift"; sourceTree = "<group>"; };
+		E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarProfile.swift; sourceTree = "<group>"; };
 		E7E2F7FF374281D90CDB91E2 /* Pods-WordPress_Base-WordPressShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPressShareExtension.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPressShareExtension/Pods-WordPress_Base-WordPressShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		F128C31A1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPNavigationMediaPickerViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
 		F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WPNavigationMediaPickerViewController+StatusBarStyle.m"; sourceTree = "<group>"; };
@@ -3264,6 +3266,7 @@
 				5D35F7581A042255004E7B0D /* WPCommentContentViewProvider.h */,
 				173BCE781CEB780800AE8817 /* Domain.swift */,
 				E125F1E61E8E59C800320B67 /* SharePost+UIActivityItemSource.swift */,
+				E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -7093,6 +7096,7 @@
 				E1EBC36F1C118EA500F638E0 /* ImmuTable.swift in Sources */,
 				B59B18751CC7FB8D0055EB7C /* PersonViewController.swift in Sources */,
 				E1D086E2194214C600F0CC19 /* NSDate+WordPressJSON.m in Sources */,
+				E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */,
 				5D839AAB187F0D8000811F4A /* PostGeolocationCell.m in Sources */,
 				FF0CAC321E4A8A0D00C7D4F1 /* AztecAttachmentViewController.swift in Sources */,
 				5D732F971AE84E3C00CD89E7 /* PostListFooterView.m in Sources */,

--- a/WordPress/WordPressTest/GravatarServiceTests.swift
+++ b/WordPress/WordPressTest/GravatarServiceTests.swift
@@ -10,17 +10,21 @@ class GravatarServiceTests: XCTestCase {
         let capturedAccountToken: String
         let capturedAccountEmail: String
 
-        override init(accountToken: String, accountEmail: String) {
+        init(accountToken: String, accountEmail: String) {
             capturedAccountToken = accountToken
             capturedAccountEmail = accountEmail
 
-            super.init(accountToken: accountToken, accountEmail: accountEmail)
+            super.init()
         }
 
-        override func uploadImage(_ image: UIImage, completion: ((_ error: NSError?) -> ())?) {
+        override func uploadImage(_ image: UIImage, accountEmail: String, accountToken: String, completion: ((NSError?) -> ())?) {
             if let completion = completion {
                 completion(nil)
             }
+        }
+
+        func uploadImage(_ image: UIImage, completion: ((_ error: NSError?) -> ())?) {
+            uploadImage(image, accountEmail: capturedAccountEmail, accountToken: capturedAccountToken, completion: completion)
         }
     }
 

--- a/WordPress/WordPressTest/GravatarServiceTests.swift
+++ b/WordPress/WordPressTest/GravatarServiceTests.swift
@@ -7,32 +7,25 @@ import XCTest
 ///
 class GravatarServiceTests: XCTestCase {
     class GravatarServiceRemoteMock: GravatarServiceRemote {
-        let capturedAccountToken: String
-        let capturedAccountEmail: String
-
-        init(accountToken: String, accountEmail: String) {
-            capturedAccountToken = accountToken
-            capturedAccountEmail = accountEmail
-
-            super.init()
-        }
+        var capturedAccountToken: String = ""
+        var capturedAccountEmail: String = ""
 
         override func uploadImage(_ image: UIImage, accountEmail: String, accountToken: String, completion: ((NSError?) -> ())?) {
+            capturedAccountEmail = accountEmail
+            capturedAccountToken = accountToken
+
             if let completion = completion {
                 completion(nil)
             }
         }
 
-        func uploadImage(_ image: UIImage, completion: ((_ error: NSError?) -> ())?) {
-            uploadImage(image, accountEmail: capturedAccountEmail, accountToken: capturedAccountToken, completion: completion)
-        }
     }
 
     class GravatarServiceTester: GravatarService {
         var gravatarServiceRemoteMock: GravatarServiceRemoteMock?
 
-        override func gravatarServiceRemoteForAccountToken(accountToken: String, andAccountEmail accountEmail: String) -> GravatarServiceRemote {
-            gravatarServiceRemoteMock = GravatarServiceRemoteMock(accountToken: accountToken, accountEmail: accountEmail)
+        override func gravatarServiceRemote() -> GravatarServiceRemote {
+            gravatarServiceRemoteMock = GravatarServiceRemoteMock()
             return gravatarServiceRemoteMock!
         }
     }
@@ -49,45 +42,25 @@ class GravatarServiceTests: XCTestCase {
         ContextManager.overrideSharedInstance(nil)
     }
 
-    func testServiceInitializerFailsWhenMissingDefaultAccount() {
-        let mainContext = contextManager.mainContext
+    func testServiceSanitizesEmailAddressCapitals() {
+        let account = createTestAccount(username: "some", token: "1234", emailAddress: "emAil@wordpress.com")
 
-        let accountService = AccountService(managedObjectContext: mainContext)
-        accountService.removeDefaultWordPressComAccount()
+        let gravatarService = GravatarServiceTester()
+        gravatarService.uploadImage(UIImage(), forAccount: account)
 
-        let gravatarService = GravatarService(context: mainContext)
-        XCTAssertNil(gravatarService)
+        XCTAssertEqual("email@wordpress.com", gravatarService.gravatarServiceRemoteMock!.capturedAccountEmail)
     }
 
-    func testServiceInitializerSucceedsWhenTokenAndMailAreBothValid() {
-        createTestAccount(username: "some", token: "1234", emailAddress: "email@wordpress.com")
+    func testServiceSanitizesEmailAddressTrimsSpaces() {
+        let account = createTestAccount(username: "some", token: "1234", emailAddress: " email@wordpress.com ")
 
-        let mainContext = contextManager.mainContext
-        let gravatarService = GravatarService(context: mainContext)
-        XCTAssertNotNil(gravatarService)
+        let gravatarService = GravatarServiceTester()
+        gravatarService.uploadImage(UIImage(), forAccount: account)
+
+        XCTAssertEqual("email@wordpress.com", gravatarService.gravatarServiceRemoteMock!.capturedAccountEmail)
     }
 
-    func testServiceInitializerSanitizesEmailAddressCapitals() {
-        createTestAccount(username: "some", token: "1234", emailAddress: "emAil@wordpress.com")
-
-        let mainContext = contextManager.mainContext
-        let gravatarService = GravatarServiceTester(context: mainContext)
-        gravatarService?.uploadImage(UIImage())
-
-        XCTAssertEqual("email@wordpress.com", gravatarService!.gravatarServiceRemoteMock!.capturedAccountEmail)
-    }
-
-    func testServiceInitializerSanitizesEmailAddressTrimsSpaces() {
-        createTestAccount(username: "some", token: "1234", emailAddress: " email@wordpress.com ")
-
-        let mainContext = contextManager.mainContext
-        let gravatarService = GravatarServiceTester(context: mainContext)
-        gravatarService?.uploadImage(UIImage())
-
-        XCTAssertEqual("email@wordpress.com", gravatarService!.gravatarServiceRemoteMock!.capturedAccountEmail)
-    }
-
-    private func createTestAccount(username: String, token: String, emailAddress: String) {
+    private func createTestAccount(username: String, token: String, emailAddress: String) -> WPAccount {
         let mainContext = contextManager.mainContext
 
         let accountService = AccountService(managedObjectContext: mainContext)
@@ -97,5 +70,7 @@ class GravatarServiceTests: XCTestCase {
 
         accountService.setDefaultWordPressComAccount(defaultAccount)
         XCTAssertNotNil(accountService.defaultWordPressComAccount())
+
+        return defaultAccount
     }
 }


### PR DESCRIPTION
This PR introduces a new call to fetch a portion of the Gravatar profile for a specific email address. 
I've opted to add the new methods to the existing Gravatar service and remote, along with a refactor so they can be used without requiring an account or token/email.  Tests were updated accordingly.

This is the first of probably three PRs that combined will fetched profile information for self-hosted users for display at the conclusion of the login flow. Part 2 will fetch from `wp.getProfile`.  Part 3 will use the combined info to populate the login epilogue.   I'm thinking for now we can avoid adding new core data models for the data being synced.  We can revisit later if there is a need.

To test:
Run tests and confirm they still pass. 
Perform a practical test by instantiating the service and calling the new method from a view controller of your choosing.  Ensure the call succeeds.

Needs review: @bummytime, given your recent networking focus would you mind taking a peek at this one? 

cc @nheagy 

