### PR TITLE
Issue/4871 occasional crash when deleting a post

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -873,9 +873,11 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
             if let index = strongSelf.recentlyTrashedPostObjectIDs.index(of: postObjectID) {
                 strongSelf.recentlyTrashedPostObjectIDs.remove(at: index)
-
-                if let indexPath = indexPath {
-                    strongSelf.tableView.reloadRows(at: [indexPath], with: .automatic)
+                // We don't really know what happened here, why did the request fail?
+                // Maybe we could not delete the post or maybe the post was already deleted
+                // It is safer to re fetch the results than to reload that specific row
+                DispatchQueue.main.async {
+                    strongSelf.updateAndPerformFetchRequestRefreshingResults()
                 }
             }
         }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -476,38 +476,48 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func cell(_ cell: UITableViewCell, handleStatsFor post: AbstractPost) {
-        viewStatsForPost(post)
+        ReachabilityUtils.onAvailableInternetConnectionDo {
+            viewStatsForPost(post)
+        }
     }
 
     func cell(_ cell: UITableViewCell, handlePublishPost post: AbstractPost) {
-        publishPost(post)
+        ReachabilityUtils.onAvailableInternetConnectionDo {
+            publishPost(post)
+        }
     }
 
     func cell(_ cell: UITableViewCell, handleSchedulePost post: AbstractPost) {
-        schedulePost(post)
+        ReachabilityUtils.onAvailableInternetConnectionDo {
+            schedulePost(post)
+        }
     }
 
     func cell(_ cell: UITableViewCell, handleTrashPost post: AbstractPost) {
-        if (post.status == .trash) {
+        ReachabilityUtils.onAvailableInternetConnectionDo {
+            if (post.status == .trash) {
 
-            let cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
-            let deleteText = NSLocalizedString("Delete", comment: "Deletes post permanently")
-            let messageText = NSLocalizedString("Delete this post permanently?", comment: "Deletes post permanently")
-            let alertController = UIAlertController(title: nil, message: messageText, preferredStyle: .alert)
+                let cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
+                let deleteText = NSLocalizedString("Delete", comment: "Deletes post permanently")
+                let messageText = NSLocalizedString("Delete this post permanently?", comment: "Deletes post permanently")
+                let alertController = UIAlertController(title: nil, message: messageText, preferredStyle: .alert)
 
-            alertController.addCancelActionWithTitle(cancelText)
-            alertController.addDestructiveActionWithTitle(deleteText) { [weak self] action in
-                self?.deletePost(post)
+                alertController.addCancelActionWithTitle(cancelText)
+                alertController.addDestructiveActionWithTitle(deleteText) { [weak self] action in
+                    self?.deletePost(post)
+                }
+                alertController.presentFromRootViewController()
+
+            } else {
+                deletePost(post)
             }
-            alertController.presentFromRootViewController()
-
-        } else {
-            deletePost(post)
         }
     }
 
     func cell(_ cell: UITableViewCell, handleRestore post: AbstractPost) {
-        restorePost(post)
+        ReachabilityUtils.onAvailableInternetConnectionDo {
+            restorePost(post)
+        }
     }
 
     // MARK: - Refreshing noResultsView


### PR DESCRIPTION
**Fixes** #4871 

**To test:**
First make sure you can replicate the two crashes on develop. Note that they only happen for the *last* item in the Trashed post list.

Scenario 1 - Navigate to the Trashed filter, disable the network connection, then tap Delete -> Crash
Scenario 2 - Navigate to the Trashed filter, delete the post via the web, then tap Delete -> Crash

None of those should crash anymore on this branch. 

Needs review: @bummytime 