### PR TITLE
Add entry points to new login flow

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -520,11 +520,7 @@ int ddLogLevel = DDLogLevelInfo;
 
 - (void)showWelcomeScreenAnimated:(BOOL)animated thenEditor:(BOOL)thenEditor
 {
-    if ([Feature enabled:FeatureFlagNewLogin]) {
-        [SigninHelpers showLoginFromPresenter:self.window.rootViewController animated:animated thenEditor:thenEditor];
-    } else {
-        [SigninHelpers showSigninFromPresenter:self.window.rootViewController animated:animated thenEditor:thenEditor];
-    }
+    [SigninHelpers showSigninFromPresenter:self.window.rootViewController animated:animated thenEditor:thenEditor];
 }
 
 - (BOOL)isWelcomeScreenVisible

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -28,7 +28,7 @@
         <!--Login Email View Controller-->
         <scene sceneID="w6Y-pB-a3f">
             <objects>
-                <viewController storyboardIdentifier="SigninEmailViewController" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="fwZ-QE-5et" customClass="LoginEmailViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="emailEntry" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="fwZ-QE-5et" customClass="LoginEmailViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="bn3-aC-RIM"/>
                         <viewControllerLayoutGuide type="bottom" id="tip-gy-Hwr"/>
@@ -430,7 +430,7 @@
         <!--Login Self Hosted View Controller-->
         <scene sceneID="b2O-iW-wfB">
             <objects>
-                <viewController storyboardIdentifier="SigninSelfHostedViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="SZS-o3-1P7" customClass="LoginSelfHostedViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="selfHosted" useStoryboardIdentifierAsRestorationIdentifier="YES" id="SZS-o3-1P7" customClass="LoginSelfHostedViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Yjk-Cc-Bxb"/>
                         <viewControllerLayoutGuide type="bottom" id="Ktl-It-Kmo"/>
@@ -1538,9 +1538,9 @@
         <image name="logo-wpcom-vertical" width="152" height="106"/>
     </resources>
     <inferredMetricsTieBreakers>
+        <segue reference="fA5-mb-vrv"/>
         <segue reference="07g-E6-aeG"/>
-        <segue reference="Jfl-Zm-PRR"/>
+        <segue reference="ySQ-EM-6JI"/>
         <segue reference="fWM-mD-lXg"/>
-        <segue reference="lIb-sw-yM7"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
@@ -11,6 +11,7 @@ class NUXAbstractViewController: UIViewController, LoginSegueHandler {
     var helpBadge: WPNUXHelpBadgeLabel!
     var helpButton: UIButton!
     var loginFields = LoginFields()
+    var restrictToWPCom = false
 
     let helpButtonMarginSpacerWidth = CGFloat(-8)
     let helpBadgeSize = CGSize(width: 12, height: 10)
@@ -71,6 +72,7 @@ class NUXAbstractViewController: UIViewController, LoginSegueHandler {
             destination.dismissBlock = source.dismissBlock
         } else if let destination = segue.destination as? NUXAbstractViewController {
             destination.loginFields = source.loginFields
+            destination.restrictToWPCom = source.restrictToWPCom
             destination.dismissBlock = source.dismissBlock
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEmailViewController.swift
@@ -23,7 +23,7 @@ import WordPressShared
 
     var didFindSafariSharedCredentials = false
     var didRequestSafariSharedCredentials = false
-    var restrictSigninToWPCom = false {
+    override var restrictToWPCom: Bool {
         didSet {
             if isViewLoaded {
                 configureForWPComOnlyIfNeeded()
@@ -100,7 +100,7 @@ import WordPressShared
     ///
     ///
     func configureForWPComOnlyIfNeeded() {
-        selfHostedSigninButton.isHidden = restrictSigninToWPCom
+        selfHostedSigninButton.isHidden = restrictToWPCom
     }
 
 
@@ -251,7 +251,7 @@ import WordPressShared
     func signinWithUsernamePassword(_ immediateSignin: Bool = false) {
         let controller = SigninWPComViewController.controller(loginFields, immediateSignin: immediateSignin)
         controller.dismissBlock = dismissBlock
-        controller.restrictSigninToWPCom = restrictSigninToWPCom
+        controller.restrictToWPCom = restrictToWPCom
         navigationController?.pushViewController(controller, animated: true)
     }
 
@@ -271,7 +271,7 @@ import WordPressShared
     func requestLink() {
         let controller = SigninLinkRequestViewController.controller(loginFields)
         controller.dismissBlock = dismissBlock
-        controller.restrictSigninToWPCom = restrictSigninToWPCom
+        controller.restrictToWPCom = restrictToWPCom
         navigationController?.pushViewController(controller, animated: true)
     }
 
@@ -322,7 +322,7 @@ import WordPressShared
             signinWithWPComDomain(username)
         } else if !SigninHelpers.isUsernameReserved(username) {
             signinWithUsernamePassword()
-        } else if restrictSigninToWPCom {
+        } else if restrictToWPCom {
             // When restricted, show a prompt then let the user enter a new username.
             SigninHelpers.promptForWPComReservedUsername(username, callback: {
                 self.loginFields.username = ""

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -28,6 +28,10 @@ import Mixpanel
 
     /// Used to present the signin flow from the app delegate
     class func showSigninFromPresenter(_ presenter: UIViewController, animated: Bool, thenEditor: Bool) {
+        if Feature.enabled(.newLogin) {
+            showLoginFromPresenter(presenter, animated: animated, thenEditor: thenEditor)
+            return
+        }
         let controller = createControllerForSigninFlow(showsEditor: thenEditor)
         let navController = NUXNavigationController(rootViewController: controller)
         presenter.present(navController, animated: animated, completion: nil)

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -26,7 +26,7 @@ import Mixpanel
         return controller
     }
 
-    // Helper used by the app delegate
+    /// Used to present the signin flow from the app delegate
     class func showSigninFromPresenter(_ presenter: UIViewController, animated: Bool, thenEditor: Bool) {
         let controller = createControllerForSigninFlow(showsEditor: thenEditor)
         let navController = NUXNavigationController(rootViewController: controller)
@@ -35,20 +35,28 @@ import Mixpanel
         trackOpenedLogin()
     }
 
-    class func showLoginFromPresenter(_ presenter: UIViewController, animated: Bool, thenEditor: Bool) {
+    /// Used to present the new login flow from the app delegate
+    fileprivate class func showLoginFromPresenter(_ presenter: UIViewController, animated: Bool, thenEditor: Bool) {
+        defer {
+            trackOpenedLogin()
+        }
+
         let storyboard = UIStoryboard(name: "Login", bundle: nil)
-        if let controller = storyboard.instantiateInitialViewController() {
-            // initial VC is NUXNavigationController
+        if let controller = storyboard.instantiateInitialViewController() as? NUXNavigationController {
             presenter.present(controller, animated: animated, completion: nil)
         }
-        trackOpenedLogin()
     }
 
 
-    // Helper used by the MeViewController
+    /// Used to present the wpcom-only signin flow from the app delegate
     class func showSigninForJustWPComFromPresenter(_ presenter: UIViewController) {
+        if Feature.enabled(.newLogin) {
+            showLoginForJustWPComFromPresenter(presenter)
+            return
+        }
+
         let controller = SigninEmailViewController.controller()
-        controller.restrictSigninToWPCom = true
+        controller.restrictToWPCom = true
 
         let navController = NUXNavigationController(rootViewController: controller)
         presenter.present(navController, animated: true, completion: nil)
@@ -56,14 +64,50 @@ import Mixpanel
         trackOpenedLogin()
     }
 
+    /// Used to present the new wpcom-only login flow from the app delegate
+    fileprivate class func showLoginForJustWPComFromPresenter(_ presenter: UIViewController) {
+        defer {
+            trackOpenedLogin()
+        }
 
-    // Helper used by the BlogListViewController
+        let storyboard = UIStoryboard(name: "Login", bundle: nil)
+        guard let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? NUXAbstractViewController else {
+            return
+        }
+        controller.restrictToWPCom = true
+
+        let navController = NUXNavigationController(rootViewController: controller)
+        presenter.present(navController, animated: true, completion: nil)
+    }
+
+
+    /// Used to present the self-hosted signin flow from BlogListViewController
     class func showSigninForSelfHostedSite(_ presenter: UIViewController) {
+        if Feature.enabled(.newLogin) {
+            showLoginForSelfHostedSite(presenter)
+            return
+        }
+
         let controller = SigninSelfHostedViewController.controller(LoginFields())
         let navController = NUXNavigationController(rootViewController: controller)
         presenter.present(navController, animated: true, completion: nil)
 
         trackOpenedLogin()
+    }
+
+    /// Used to present the new self-hosted login flow from BlogListViewController
+    fileprivate class func showLoginForSelfHostedSite(_ presenter: UIViewController) {
+        defer {
+            trackOpenedLogin()
+        }
+
+        let storyboard = UIStoryboard(name: "Login", bundle: nil)
+        guard let controller = storyboard.instantiateViewController(withIdentifier: "selfHosted") as? NUXAbstractViewController else {
+            return
+        }
+
+        let navController = NUXNavigationController(rootViewController: controller)
+        presenter.present(navController, animated: true, completion: nil)
     }
 
 
@@ -76,7 +120,7 @@ import Mixpanel
         }
 
         let controller = SigninWPComViewController.controller(loginFields)
-        controller.restrictSigninToWPCom = true
+        controller.restrictToWPCom = true
         controller.dismissBlock = onDismissed
         return NUXNavigationController(rootViewController: controller)
     }

--- a/WordPress/Classes/ViewRelated/NUX/SigninLinkMailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninLinkMailViewController.swift
@@ -8,7 +8,6 @@ class SigninLinkMailViewController: NUXAbstractViewController {
     @IBOutlet var label: UILabel!
     @IBOutlet var openMailButton: NUXSubmitButton!
     @IBOutlet var usePasswordButton: UIButton!
-    var restrictSigninToWPCom = false
 
     override var sourceTag: SupportSourceTag {
         get {
@@ -82,7 +81,7 @@ class SigninLinkMailViewController: NUXAbstractViewController {
         WPAppAnalytics.track(.loginMagicLinkExited)
         let controller = SigninWPComViewController.controller(loginFields)
         controller.dismissBlock = dismissBlock
-        controller.restrictSigninToWPCom = restrictSigninToWPCom
+        controller.restrictToWPCom = restrictToWPCom
         navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/SigninLinkRequestViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninLinkRequestViewController.swift
@@ -9,7 +9,6 @@ class SigninLinkRequestViewController: NUXAbstractViewController {
     @IBOutlet var label: UILabel!
     @IBOutlet var sendLinkButton: NUXSubmitButton!
     @IBOutlet var usePasswordButton: UIButton!
-    var restrictSigninToWPCom = false
 
     override var sourceTag: SupportSourceTag {
         get {
@@ -118,7 +117,7 @@ class SigninLinkRequestViewController: NUXAbstractViewController {
         SigninHelpers.saveEmailAddressForTokenAuth(loginFields.username)
         let controller = SigninLinkMailViewController.controller(loginFields)
         controller.dismissBlock = dismissBlock
-        controller.restrictSigninToWPCom = restrictSigninToWPCom
+        controller.restrictToWPCom = restrictToWPCom
         navigationController?.pushViewController(controller, animated: true)
     }
 
@@ -135,7 +134,7 @@ class SigninLinkRequestViewController: NUXAbstractViewController {
         WPAppAnalytics.track(.loginMagicLinkExited)
         let controller = SigninWPComViewController.controller(loginFields)
         controller.dismissBlock = dismissBlock
-        controller.restrictSigninToWPCom = restrictSigninToWPCom
+        controller.restrictToWPCom = restrictToWPCom
         navigationController?.pushViewController(controller, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninWPComViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninWPComViewController.swift
@@ -24,7 +24,7 @@ import WordPressShared
 
     var immediateSignin = false
 
-    var restrictSigninToWPCom = false {
+    override var restrictToWPCom: Bool {
         didSet {
             if isViewLoaded {
                 configureForWPComOnlyIfNeeded()
@@ -104,7 +104,7 @@ import WordPressShared
     ///
     ///
     func configureForWPComOnlyIfNeeded() {
-        selfHostedButton.isHidden = restrictSigninToWPCom
+        selfHostedButton.isHidden = restrictToWPCom
     }
 
 
@@ -234,7 +234,7 @@ import WordPressShared
     ///
     func handleReservedUsername(_ username: String) {
         // If we're restricted to wpcom, just prmopt that the name is reserved.
-        if restrictSigninToWPCom {
+        if restrictToWPCom {
             SigninHelpers.promptForWPComReservedUsername(username, callback: {
                 self.loginFields.username = ""
                 self.usernameField.text = ""


### PR DESCRIPTION
Add the wpcom-only and self-hosted-only entry points to the new login flow.

To test:
1. Test the self-hosted login entry point
  - login with a wpcom account
  - use the `+` to add a new self-hosted site
2. Test the wpcom login entry point
  - logout from wpcom with a self-hosted site already added
  - from the Me tab, tap `Log In`

Needs review: @kurzee  
Want to look at some login stuff, or want me to find a different victim?