### PR TITLE
Preselect the last used site on Share Extension

### DIFF
--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -40,6 +40,8 @@ extern NSString *const WPShareExtensionKeychainTokenKey;
 extern NSString *const WPShareExtensionKeychainServiceName;
 extern NSString *const WPShareExtensionUserDefaultsPrimarySiteName;
 extern NSString *const WPShareExtensionUserDefaultsPrimarySiteID;
+extern NSString *const WPShareExtensionUserDefaultsLastUsedSiteName;
+extern NSString *const WPShareExtensionUserDefaultsLastUsedSiteID;
 extern NSString *const WPShareExtensionMaximumMediaDimensionKey;
 
 /// Today Widget Constants

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -52,6 +52,8 @@ NSString *const WPShareExtensionKeychainTokenKey                    = @"OAuth2To
 NSString *const WPShareExtensionKeychainServiceName                 = @"ShareExtension";
 NSString *const WPShareExtensionUserDefaultsPrimarySiteName         = @"WPShareUserDefaultsPrimarySiteName";
 NSString *const WPShareExtensionUserDefaultsPrimarySiteID           = @"WPShareUserDefaultsPrimarySiteID";
+NSString *const WPShareExtensionUserDefaultsLastUsedSiteName        = @"WPShareUserDefaultsLastUsedSiteName";
+NSString *const WPShareExtensionUserDefaultsLastUsedSiteID          = @"WPShareUserDefaultsLastUsedSiteID";
 NSString *const WPShareExtensionMaximumMediaDimensionKey            = @"WPShareExtensionMaximumMediaDimensionKey";
 
 /// Today Widget Constants

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -22,13 +22,13 @@ class ShareViewController: SLComposeServiceViewController {
     /// Selected Site's ID
     ///
     fileprivate lazy var selectedSiteID: Int? = {
-        ShareExtensionService.retrieveShareExtensionPrimarySite()?.siteID
+        ShareExtensionService.retrieveShareExtensionDefaultSite()?.siteID
     }()
 
     /// Selected Site's Name
     ///
     fileprivate lazy var selectedSiteName: String? = {
-        ShareExtensionService.retrieveShareExtensionPrimarySite()?.siteName
+        ShareExtensionService.retrieveShareExtensionDefaultSite()?.siteName
     }()
 
     /// Maximum Image Size
@@ -124,6 +124,10 @@ class ShareViewController: SLComposeServiceViewController {
             fatalError("The view should have been dismissed on viewDidAppear!")
         }
 
+        // Save the last used site
+        if let siteName = selectedSiteName {
+            ShareExtensionService.configureShareExtensionLastUsedSiteID(siteID, lastUsedSiteName: siteName)
+        }
 
         // Proceed uploading the actual post
         let (subject, body) = contentText.stringWithAnchoredLinks().splitContentTextIntoSubjectAndBody()


### PR DESCRIPTION
**Fixes** #7027 

**To test:**

_Test the new functionality:_
Do a share and select one site that is not your primary site.
Do another share and verify that the last used site is pre-selected.

_Test that nothing else broke:_
Uninstall the app.
Install it and log in.
Do a share and check that your primary site is selected.

Needs review: @koke  
