### PR TITLE
Issue/7068 dynamic type on reader and post list

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -33,14 +34,14 @@
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LUv-id-3Yc">
                                         <rect key="frame" x="42" y="0.0" width="234" height="17"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bbp-gj-1hE">
                                         <rect key="frame" x="42" y="18.5" width="234" height="14.5"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -33,14 +34,14 @@
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Glg-dS-0y2">
                                         <rect key="frame" x="42" y="0.0" width="234" height="17"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l4E-Qn-Vgl">
                                         <rect key="frame" x="42" y="18" width="234" height="15"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -94,7 +94,7 @@
 + (NSDictionary *)postCardAuthorSiteAttributes
 {
     UIFont *font = [self regularFont];
-    CGFloat lineHeight = font.pointSize * 1.5;
+    CGFloat lineHeight = font.pointSize * 1.4;
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -212,8 +212,8 @@
 + (void)applyRestorePageButtonStyle:(UIButton *)button
 {
     [WPStyleGuide configureLabel:button.titleLabel
-                    forTextStyle:UIFontTextStyleCallout
-                      withWeight:UIFontWeightSemibold];
+                       textStyle:UIFontTextStyleCallout
+                      fontWeight:UIFontWeightSemibold];
     [button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
     [button setTitleColor:[WPStyleGuide darkBlue] forState:UIControlStateHighlighted];
 }
@@ -233,15 +233,15 @@
 
 + (void)configureLabelForDeviceDependantStyle:(UILabel *)label {
     UIFontTextStyle textStyle = [UIDevice isPad] ? UIFontTextStyleSubheadline : UIFontTextStyleCaption1;
-    [WPStyleGuide configureLabel:label forTextStyle:textStyle];
+    [WPStyleGuide configureLabel:label textStyle:textStyle];
 }
 
 + (void)configureLabelForRegularFontStyle:(UILabel *)label {
-    [WPStyleGuide configureLabel:label forTextStyle:UIFontTextStyleSubheadline];
+    [WPStyleGuide configureLabel:label textStyle:UIFontTextStyleSubheadline];
 }
 
 + (void)configureLabelForSmallFontStyle:(UILabel *)label {
-    [WPStyleGuide configureLabel:label forTextStyle:UIFontTextStyleCaption1];
+    [WPStyleGuide configureLabel:label textStyle:UIFontTextStyleCaption1];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -9,8 +9,7 @@
 
 + (void)applyPostAuthorFilterStyle:(UISegmentedControl *)segmentControl
 {
-    CGFloat fontSize = [UIDevice isPad] ? 14.0 : 12.0;
-    NSDictionary *attributes = @{NSFontAttributeName: [WPFontManager systemRegularFontOfSize:fontSize]};
+    NSDictionary *attributes = @{NSFontAttributeName: [self deviceDependantFontForLabels]};
     [segmentControl setTitleTextAttributes:attributes forState:UIControlStateNormal];
     segmentControl.tintColor = [WPStyleGuide grey];
     segmentControl.backgroundColor = [UIColor whiteColor];
@@ -39,15 +38,13 @@
 
 + (void)applyPostAuthorSiteStyle:(UILabel *)label
 {
-    CGFloat fontSize = 14.0;
-    label.font = [WPFontManager systemRegularFontOfSize:fontSize];
+    [self configureLabelForRegularFontStyle:label];
     label.textColor = [self greyDarken20];
 }
 
 + (void)applyPostAuthorNameStyle:(UILabel *)label
 {
-    CGFloat fontSize = 12.0;
-    label.font = [WPFontManager systemRegularFontOfSize:fontSize];
+    [self configureLabelForSmallFontStyle:label];
     label.textColor = [self grey];
 }
 
@@ -63,35 +60,31 @@
 
 + (void)applyPostDateStyle:(UILabel *)label
 {
-    CGFloat fontSize = [UIDevice isPad] ? 14.0 : 12.0;
-    label.font = [WPFontManager systemRegularFontOfSize:fontSize];
+    [self configureLabelForDeviceDependantStyle:label];
     label.textColor = [self grey];
 }
 
 + (void)applyPostStatusStyle:(UILabel *)label
 {
-    CGFloat fontSize = [UIDevice isPad] ? 14.0 : 12.0;
-    label.font = [WPFontManager systemRegularFontOfSize:fontSize];
+    [self configureLabelForDeviceDependantStyle:label];
     label.textColor = [self grey];
 }
 
 + (void)applyPostMetaButtonStyle:(UIButton *)button
 {
-    CGFloat fontSize = [UIDevice isPad] ? 14.0 : 12.0;
+    [self configureLabelForDeviceDependantStyle:button.titleLabel];
     [button setTitleColor:[self grey] forState:UIControlStateNormal];
-    [button.titleLabel setFont:[WPFontManager systemRegularFontOfSize:fontSize]];
 }
 
 + (void)applyRestorePostLabelStyle:(UILabel *)label
 {
-    CGFloat fontSize = [UIDevice isPad] ? 14.0 : 12.0;
-    label.font = [WPFontManager systemRegularFontOfSize:fontSize];
+    [self configureLabelForDeviceDependantStyle:label];
     label.textColor = [self grey];
 }
 
 + (void)applyRestorePostButtonStyle:(UIButton *)button
 {
-    button.titleLabel.font = [WPStyleGuide subtitleFont];
+    [self configureLabelForSmallFontStyle:button.titleLabel];
     [button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
     [button setTitleColor:[WPStyleGuide darkBlue] forState:UIControlStateHighlighted];
 }
@@ -100,62 +93,63 @@
 
 + (NSDictionary *)postCardAuthorSiteAttributes
 {
-    CGFloat fontSize = 14.0;
-    CGFloat lineHeight = 20.0;
+    UIFont *font = [self regularFont];
+    CGFloat lineHeight = font.pointSize * 1.5;
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager systemRegularFontOfSize:fontSize]};
+    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : font};
 }
 
 + (NSDictionary *)postCardAuthorNameAttributes
 {
-    CGFloat fontSize = 12.0;
-    CGFloat lineHeight = 18.0;
+    UIFont *font = [self smallFont];
+    CGFloat lineHeight = font.pointSize * 1.5;
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager systemRegularFontOfSize:fontSize]};
+    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : font};
 }
 
 + (NSDictionary *)postCardTitleAttributes
 {
-    CGFloat fontSize = [UIDevice isPad] ? 24.0 : 18.0;
-    CGFloat lineHeight = [UIDevice isPad] ? 32.0 : 24.0;
+    UIFont *font = [WPStyleGuide notoBoldFontForTextStyle:UIFontTextStyleHeadline];
+    CGFloat lineHeight = font.pointSize * 1.5;
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager notoBoldFontOfSize:fontSize]};
+    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : font};
 }
 
 + (NSDictionary *)postCardSnippetAttributes
 {
-    CGFloat fontSize = [UIDevice isPad] ? 16.0 : 15.0;
-    CGFloat lineHeight = [UIDevice isPad] ? 26.0 : 22.0;
+    UIFontTextStyle textStyle = [UIDevice isPad] ? UIFontTextStyleCallout : UIFontTextStyleSubheadline;
+    UIFont *font = [WPStyleGuide notoFontForTextStyle:textStyle];
+    CGFloat lineHeight = font.pointSize * 1.5;
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager notoRegularFontOfSize:fontSize]};
+    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : font};
 }
 
 + (NSDictionary *)postCardDateAttributes
 {
-    CGFloat fontSize = [UIDevice isPad] ? 14.0 : 12.0;
-    CGFloat lineHeight = [UIDevice isPad] ? 22.0 : 18.0;
+    UIFont *font = [self deviceDependantFontForLabels];
+    CGFloat lineHeight = font.pointSize * 1.5;
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager systemRegularFontOfSize:fontSize]};
+    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : font};
 }
 
 + (NSDictionary *)postCardStatusAttributes
 {
-    CGFloat fontSize = [UIDevice isPad] ? 14.0 : 12.0;
-    CGFloat lineHeight = [UIDevice isPad] ? 22.0 : 18.0;
+    UIFont *font = [self deviceDependantFontForLabels];
+    CGFloat lineHeight = font.pointSize * 1.5;
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     paragraphStyle.minimumLineHeight = lineHeight;
     paragraphStyle.maximumLineHeight = lineHeight;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager systemRegularFontOfSize:fontSize]};
+    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : font};
 }
 
 + (CGRect)navigationBarButtonRect
@@ -197,32 +191,57 @@
 
 + (NSDictionary *)pageCellTitleAttributes
 {
-    CGFloat fontSize = 15.0;
     NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
     paragraphStyle.lineSpacing = 4.0;
-    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPFontManager notoRegularFontOfSize:fontSize]};
+    return @{NSParagraphStyleAttributeName: paragraphStyle, NSFontAttributeName : [WPStyleGuide notoFontForTextStyle:UIFontTextStyleSubheadline]};
 }
 
 + (void)applySectionHeaderTitleStyle:(UILabel *)label
 {
+    [self configureLabelForSmallFontStyle:label];
     label.backgroundColor = [self lightGrey];
-    label.font = [WPFontManager systemRegularFontOfSize:12.0];
     label.textColor = [self grey];
 }
 
 + (void)applyRestorePageLabelStyle:(UILabel *)label
 {
-    CGFloat fontSize = 14.0;
-    label.font = [WPFontManager systemRegularFontOfSize:fontSize];
+    [self configureLabelForRegularFontStyle:label];
     label.textColor = [self grey];
 }
 
 + (void)applyRestorePageButtonStyle:(UIButton *)button
 {
-    CGFloat fontSize = 14.0;
-    button.titleLabel.font = [WPFontManager systemSemiBoldFontOfSize:fontSize];
+    [WPStyleGuide configureLabel:button.titleLabel
+                    forTextStyle:UIFontTextStyleCallout
+                      withWeight:UIFontWeightSemibold];
     [button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
     [button setTitleColor:[WPStyleGuide darkBlue] forState:UIControlStateHighlighted];
+}
+
++ (UIFont *)deviceDependantFontForLabels {
+    UIFontTextStyle textStyle = [UIDevice isPad] ? UIFontTextStyleSubheadline : UIFontTextStyleCaption1;
+    return [WPStyleGuide fontForTextStyle:textStyle];
+}
+
++ (UIFont *)regularFont {
+    return [WPStyleGuide fontForTextStyle:UIFontTextStyleSubheadline];
+}
+
++ (UIFont *)smallFont {
+    return [WPStyleGuide fontForTextStyle:UIFontTextStyleCaption1];
+}
+
++ (void)configureLabelForDeviceDependantStyle:(UILabel *)label {
+    UIFontTextStyle textStyle = [UIDevice isPad] ? UIFontTextStyleSubheadline : UIFontTextStyleCaption1;
+    [WPStyleGuide configureLabel:label forTextStyle:textStyle];
+}
+
++ (void)configureLabelForRegularFontStyle:(UILabel *)label {
+    [WPStyleGuide configureLabel:label forTextStyle:UIFontTextStyleSubheadline];
+}
+
++ (void)configureLabelForSmallFontStyle:(UILabel *)label {
+    [WPStyleGuide configureLabel:label forTextStyle:UIFontTextStyleCaption1];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
@@ -124,7 +124,7 @@ private enum ReaderCardDiscoverAttribution: Int {
         let str = String(format: pattern, blogName!)
 
         let range = (str as NSString).range(of: blogName!)
-        let font = WPStyleGuide.fontForTextStyle(WPStyleGuide.originalAttributionTextStyle(), withTraits: .traitItalic)
+        let font = WPStyleGuide.fontForTextStyle(WPStyleGuide.originalAttributionTextStyle(), symbolicTraits: .traitItalic)
         let attributes = originalAttributionParagraphAttributes as! [String: AnyObject]
         let attributedString = NSMutableAttributedString(string: str, attributes: attributes)
         attributedString.addAttribute(NSFontAttributeName, value: font, range: range)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
@@ -124,7 +124,7 @@ private enum ReaderCardDiscoverAttribution: Int {
         let str = String(format: pattern, blogName!)
 
         let range = (str as NSString).range(of: blogName!)
-        let font = WPFontManager.systemItalicFont(ofSize: WPStyleGuide.originalAttributionFontSize())
+        let font = WPStyleGuide.fontForTextStyle(WPStyleGuide.originalAttributionTextStyle(), withTraits: .traitItalic)
         let attributes = originalAttributionParagraphAttributes as! [String: AnyObject]
         let attributedString = NSMutableAttributedString(string: str, attributes: attributes)
         attributedString.addAttribute(NSFontAttributeName, value: font, range: range)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -166,7 +166,7 @@ import WordPressShared
         tableView.register(WPTableViewCell.self, forCellReuseIdentifier: actionCellIdentifier)
 
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
-        WPStyleGuide.configureAutomaticHeightRowsForTableView(tableView)
+        WPStyleGuide.configureAutomaticHeightRows(for: tableView)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -166,6 +166,7 @@ import WordPressShared
         tableView.register(WPTableViewCell.self, forCellReuseIdentifier: actionCellIdentifier)
 
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
+        WPStyleGuide.configureAutomaticHeightRowsForTableView(tableView)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -32,7 +32,8 @@
                                         <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
                                         <gestureRecognizers/>
                                         <constraints>
-                                            <constraint firstAttribute="width" secondItem="7Qj-iX-iqv" secondAttribute="height" multiplier="1:1" id="bcb-9y-7Gt"/>
+                                            <constraint firstAttribute="width" constant="32" id="3pD-gt-JrN"/>
+                                            <constraint firstAttribute="height" constant="32" id="PNX-pB-UCk"/>
                                         </constraints>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Pv6-I0-BNp">
@@ -77,9 +78,6 @@
                                         </connections>
                                     </button>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="32" id="cI8-6j-sje"/>
-                                </constraints>
                             </stackView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="D4Q-6L-ZIL">
                                 <rect key="frame" x="16" y="64" width="288" height="100"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -1,10 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,69 +16,74 @@
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8ws-PJ-KvB">
-                    <rect key="frame" x="-1" y="-1" width="322" height="66"/>
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="65"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="65" id="qoD-xb-867"/>
+                    </constraints>
                 </view>
-                <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="hoO-id-aes">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
+                <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="xPh-QH-rhp">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="136"/>
                     <subviews>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="dLW-aA-lHG">
-                            <rect key="frame" x="16" y="16" width="32" height="32"/>
-                            <constraints>
-                                <constraint firstAttribute="width" priority="999" constant="32" id="aZH-Ks-4Gm"/>
-                                <constraint firstAttribute="height" constant="32" id="fVc-DC-3t6"/>
-                            </constraints>
-                        </imageView>
-                        <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="lwo-YY-IFa">
-                            <rect key="frame" x="58" y="16" width="194" height="32"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Qis-1y-KvO">
+                            <rect key="frame" x="16" y="16" width="288" height="35.5"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Site name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uyl-RL-THb">
-                                    <rect key="frame" x="0.0" y="0.0" width="194" height="17"/>
+                                <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="sng-2e-9Fd">
+                                    <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
+                                    <gestureRecognizers/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="32" id="4fY-6f-21h"/>
+                                        <constraint firstAttribute="height" constant="32" id="DC5-LJ-Roc"/>
+                                    </constraints>
+                                </imageView>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ohA-OA-KJg">
+                                    <rect key="frame" x="42" y="0.0" width="194" height="31.5"/>
+                                    <subviews>
+                                        <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" horizontalCompressionResistancePriority="740" text="Author, Blog name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vHE-Md-jhn">
+                                            <rect key="frame" x="0.0" y="0.0" width="194" height="17"/>
+                                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <color key="textColor" red="0.0" green="0.66666666669999997" blue="0.86274509799999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="740" verticalCompressionResistancePriority="740" text="Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t34-RL-Noo">
+                                            <rect key="frame" x="0.0" y="17" width="194" height="14.5"/>
+                                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </stackView>
+                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="top" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QX0-Ya-vKs" customClass="PostMetaButton">
+                                    <rect key="frame" x="246" y="0.0" width="42" height="32"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="32" id="HI9-CL-cAd"/>
+                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="999" constant="32" id="iZj-HF-Xz8"/>
+                                    </constraints>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="site.com" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ynp-yJ-W5N">
-                                    <rect key="frame" x="0.0" y="17" width="194" height="15"/>
-                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
+                                    <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                    <inset key="imageEdgeInsets" minX="0.0" minY="2" maxX="0.0" maxY="0.0"/>
+                                    <state key="normal" title="Follow">
+                                        <color key="titleColor" red="0.0" green="0.66666666669999997" blue="0.86274509799999999" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
+                                    <state key="selected">
+                                        <color key="titleColor" red="0.2901960784" green="0.72156862749999995" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
+                                    <state key="highlighted">
+                                        <color key="titleColor" red="0.47058823529999999" green="0.86274509799999999" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
+                                    </state>
+                                </button>
                             </subviews>
                         </stackView>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="260" horizontalCompressionResistancePriority="760" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AlZ-YB-HNn" customClass="PostMetaButton">
-                            <rect key="frame" x="262" y="16" width="42" height="32"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="0.0" maxY="0.0"/>
-                            <state key="normal" title="Follow">
-                                <color key="titleColor" red="0.0" green="0.66666666669999997" blue="0.86274509799999999" alpha="1" colorSpace="calibratedRGB"/>
-                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="selected">
-                                <color key="titleColor" red="0.2901960784" green="0.72156862749999995" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
-                            </state>
-                            <state key="highlighted">
-                                <color key="titleColor" red="0.47058823529999999" green="0.86274509799999999" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
-                            </state>
-                            <connections>
-                                <action selector="didTapFollowButton:" destination="iN0-l3-epB" eventType="touchUpInside" id="Dvn-6I-u8E"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <edgeInsets key="layoutMargins" top="16" left="16" bottom="16" right="16"/>
-                </stackView>
-                <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="MFn-iZ-S65">
-                    <rect key="frame" x="0.0" y="64" width="320" height="70.5"/>
-                    <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Site description" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uvZ-h9-MUU">
-                            <rect key="frame" x="16" y="16" width="288" height="19.5"/>
+                            <rect key="frame" x="16" y="67.5" width="288" height="19.5"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="YIl-wa-h6D">
-                            <rect key="frame" x="16" y="45.5" width="288" height="17"/>
+                            <rect key="frame" x="16" y="103" width="288" height="17"/>
                             <subviews>
                                 <view contentMode="scaleToFill" horizontalHuggingPriority="240" translatesAutoresizingMaskIntoConstraints="NO" id="olT-MT-DPn">
                                     <rect key="frame" x="0.0" y="8" width="90.5" height="1"/>
@@ -107,37 +113,36 @@
                             </constraints>
                         </stackView>
                     </subviews>
-                    <edgeInsets key="layoutMargins" top="16" left="16" bottom="8" right="16"/>
+                    <edgeInsets key="layoutMargins" top="16" left="16" bottom="16" right="16"/>
                 </stackView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="8ws-PJ-KvB" firstAttribute="leading" secondItem="hoO-id-aes" secondAttribute="leading" constant="-1" id="3uF-Oc-pTk"/>
-                <constraint firstAttribute="trailing" secondItem="MFn-iZ-S65" secondAttribute="trailing" id="8fI-0x-qIT"/>
-                <constraint firstItem="hoO-id-aes" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="FwW-O1-w4K"/>
-                <constraint firstItem="hoO-id-aes" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="JVb-Hf-Vin"/>
-                <constraint firstItem="MFn-iZ-S65" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Jpu-09-xaX"/>
-                <constraint firstItem="hoO-id-aes" firstAttribute="trailing" secondItem="8ws-PJ-KvB" secondAttribute="trailing" constant="-1" id="b21-OL-HNX"/>
-                <constraint firstAttribute="bottom" secondItem="MFn-iZ-S65" secondAttribute="bottom" priority="999" id="cNG-2M-I5A"/>
-                <constraint firstItem="8ws-PJ-KvB" firstAttribute="top" secondItem="hoO-id-aes" secondAttribute="top" constant="-1" id="cOj-rj-a5o"/>
-                <constraint firstAttribute="trailing" secondItem="hoO-id-aes" secondAttribute="trailing" id="d5f-Lc-VWt"/>
-                <constraint firstItem="MFn-iZ-S65" firstAttribute="top" secondItem="hoO-id-aes" secondAttribute="bottom" id="gQE-hL-vW1"/>
-                <constraint firstItem="8ws-PJ-KvB" firstAttribute="bottom" secondItem="hoO-id-aes" secondAttribute="bottom" constant="1" id="j6W-Z5-MAx"/>
+                <constraint firstItem="xPh-QH-rhp" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="2Fo-ef-3ue"/>
+                <constraint firstAttribute="trailing" secondItem="xPh-QH-rhp" secondAttribute="trailing" id="Rfm-dj-BUB"/>
+                <constraint firstItem="xPh-QH-rhp" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="dbJ-R0-MaV"/>
+                <constraint firstAttribute="trailing" secondItem="8ws-PJ-KvB" secondAttribute="trailing" id="ffJ-W6-Hse"/>
+                <constraint firstAttribute="bottom" secondItem="xPh-QH-rhp" secondAttribute="bottom" id="pxN-sa-hXV"/>
+                <constraint firstItem="8ws-PJ-KvB" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="qgi-lH-S8T"/>
+                <constraint firstItem="8ws-PJ-KvB" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="xPc-44-QeI"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="avatarImageView" destination="dLW-aA-lHG" id="YfE-8M-Gf0"/>
+                <outlet property="avatarImageView" destination="sng-2e-9Fd" id="7of-On-Qql"/>
                 <outlet property="borderedView" destination="8ws-PJ-KvB" id="C9R-Zq-iEQ"/>
                 <outlet property="descriptionLabel" destination="uvZ-h9-MUU" id="xoH-cv-YZl"/>
-                <outlet property="detailLabel" destination="ynp-yJ-W5N" id="5Rl-fb-YbJ"/>
-                <outlet property="followButton" destination="AlZ-YB-HNn" id="IsY-t7-6GZ"/>
+                <outlet property="detailLabel" destination="t34-RL-Noo" id="DHm-Uq-SPU"/>
+                <outlet property="followButton" destination="QX0-Ya-vKs" id="Ok8-fk-N8h"/>
                 <outlet property="followCountLabel" destination="Y5o-aW-T7f" id="pQR-px-3FJ"/>
-                <outlet property="titleLabel" destination="uyl-RL-THb" id="hkl-Tg-zGh"/>
+                <outlet property="titleLabel" destination="vHE-Md-jhn" id="15m-Cd-g51"/>
             </connections>
             <point key="canvasLocation" x="624" y="389"/>
         </view>
     </objects>
+    <resources>
+        <image name="post-blavatar-placeholder" width="32" height="32"/>
+    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -21,8 +21,7 @@ extension WPStyleGuide {
     // MARK: - Original Post/Site Attribution Styles.
 
     public class func originalAttributionParagraphAttributes() -> [String: AnyObject] {
-        let fontSize = originalAttributionFontSize()
-        let font = WPFontManager.systemRegularFont(ofSize: fontSize)
+        let font = WPStyleGuide.fontForTextStyle(originalAttributionTextStyle())
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = Cards.defaultLineSpacing
@@ -32,8 +31,8 @@ extension WPStyleGuide {
         ]
     }
 
-    public class func originalAttributionFontSize() -> CGFloat {
-        return Cards.contentFontSize
+    public class func originalAttributionTextStyle() -> UIFontTextStyle {
+        return Cards.contentTextStyle
     }
 
 
@@ -60,8 +59,7 @@ extension WPStyleGuide {
     // MARK: - Card Attributed Text Attributes
 
     public class func readerCrossPostTitleAttributes() -> [String: AnyObject] {
-        let fontSize = Cards.crossPostTitleFontSize
-        let font = WPFontManager.notoBoldFont(ofSize: fontSize)
+        let font = WPStyleGuide.notoBoldFontForTextStyle(Cards.titleTextStyle)
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = Cards.crossPostLineSpacing
@@ -74,8 +72,7 @@ extension WPStyleGuide {
     }
 
     public class func readerCrossPostBoldSubtitleAttributes() -> [String: AnyObject] {
-        let fontSize = Cards.crossPostSubtitleFontSize
-        let font = WPFontManager.systemBoldFont(ofSize: fontSize)
+        let font = WPStyleGuide.notoBoldFontForTextStyle(Cards.titleTextStyle)
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = Cards.crossPostLineSpacing
@@ -88,8 +85,7 @@ extension WPStyleGuide {
     }
 
     public class func readerCrossPostSubtitleAttributes() -> [String: AnyObject] {
-        let fontSize = Cards.crossPostSubtitleFontSize
-        let font = WPFontManager.systemRegularFont(ofSize: fontSize)
+        let font = WPStyleGuide.notoBoldFontForTextStyle(Cards.crossPostSubtitleTextStyle)
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = Cards.crossPostLineSpacing
@@ -102,8 +98,7 @@ extension WPStyleGuide {
     }
 
     public class func readerCardTitleAttributes() -> [String: AnyObject] {
-        let fontSize = Cards.titleFontSize
-        let font = WPFontManager.notoBoldFont(ofSize: fontSize)
+        let font = WPStyleGuide.notoBoldFontForTextStyle(Cards.titleTextStyle)
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = Cards.titleLineSpacing
@@ -115,8 +110,7 @@ extension WPStyleGuide {
     }
 
     public class func readerCardSummaryAttributes() -> [String: AnyObject] {
-        let fontSize = Cards.contentFontSize
-        let font = WPFontManager.notoRegularFont(ofSize: fontSize)
+        let font = WPStyleGuide.notoFontForTextStyle(Cards.contentTextStyle)
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = Cards.contentLineSpacing
@@ -129,8 +123,7 @@ extension WPStyleGuide {
     }
 
     public class func readerCardReadingTimeAttributes() -> [String: AnyObject] {
-        let fontSize: CGFloat = Cards.subtextFontSize
-        let font = WPFontManager.systemRegularFont(ofSize: fontSize)
+        let font = WPStyleGuide.fontForTextStyle(Cards.subtextTextStyle)
 
         return [
             NSFontAttributeName: font,
@@ -140,10 +133,9 @@ extension WPStyleGuide {
     // MARK: - Detail styles
 
     public class func readerDetailTitleAttributes() -> [String: AnyObject] {
-        let fontSize = Detail.titleFontSize
-        let font = WPFontManager.notoBoldFont(ofSize: fontSize)
+        let font = WPStyleGuide.notoBoldFontForTextStyle(Detail.titleTextStyle)
 
-        let lineHeight = Detail.titleLineHeight
+        let lineHeight = font.pointSize + 10.0
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.minimumLineHeight = lineHeight
         paragraphStyle.maximumLineHeight = lineHeight
@@ -158,8 +150,7 @@ extension WPStyleGuide {
     // MARK: - Stream Header Attributed Text Attributes
 
     public class func readerStreamHeaderDescriptionAttributes() -> [String: AnyObject] {
-        let fontSize = Cards.contentFontSize
-        let font = WPFontManager.notoRegularFont(ofSize: fontSize)
+        let font = WPStyleGuide.notoFontForTextStyle(Cards.contentTextStyle)
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = Cards.defaultLineSpacing
@@ -175,23 +166,20 @@ extension WPStyleGuide {
     // MARK: - Apply Card Styles
 
     public class func applyReaderCardSiteButtonStyle(_ button: UIButton) {
-        let fontSize = Cards.buttonFontSize
-        button.titleLabel!.font = WPFontManager.systemRegularFont(ofSize: fontSize)
+        WPStyleGuide.configureLabel(button.titleLabel!, forTextStyle: Cards.buttonTextStyle)
         button.setTitleColor(mediumBlue(), for: UIControlState())
         button.setTitleColor(lightBlue(), for: .highlighted)
         button.setTitleColor(darkGrey(), for: .disabled)
     }
 
     public class func applyReaderCardBlogNameStyle(_ label: UILabel) {
-        let fontSize = Cards.buttonFontSize
-        label.font = WPFontManager.systemRegularFont(ofSize: fontSize)
+        WPStyleGuide.configureLabel(label, forTextStyle: Cards.buttonTextStyle)
         label.textColor = readerCardBlogNameLabelTextColor()
         label.highlightedTextColor = lightBlue()
     }
 
     public class func applyReaderCardBylineLabelStyle(_ label: UILabel) {
-        let fontSize: CGFloat = Cards.subtextFontSize
-        label.font = WPFontManager.systemRegularFont(ofSize: fontSize)
+        WPStyleGuide.configureLabel(label, forTextStyle: Cards.subtextTextStyle)
         label.textColor = greyLighten10()
     }
 
@@ -204,47 +192,41 @@ extension WPStyleGuide {
     }
 
     public class func applyReaderCardTagButtonStyle(_ button: UIButton) {
-        let fontSize = Cards.subtextFontSize
+        WPStyleGuide.configureLabel(button.titleLabel!, forTextStyle: Cards.subtextTextStyle)
         button.setTitleColor(mediumBlue(), for: UIControlState())
         button.setTitleColor(lightBlue(), for: .highlighted)
-        button.titleLabel?.font = WPFontManager.systemRegularFont(ofSize: fontSize)
         button.titleLabel?.allowsDefaultTighteningForTruncation = false
         button.titleLabel?.lineBreakMode = .byTruncatingTail
     }
 
     public class func applyReaderCardActionButtonStyle(_ button: UIButton) {
-        let fontSize = Cards.buttonFontSize
+        WPStyleGuide.configureLabel(button.titleLabel!, forTextStyle: Cards.buttonTextStyle)
         button.setTitleColor(greyLighten10(), for: UIControlState())
         button.setTitleColor(lightBlue(), for: .highlighted)
         button.setTitleColor(jazzyOrange(), for: .selected)
         button.setTitleColor(greyLighten10(), for: .disabled)
-        button.titleLabel?.font = WPFontManager.systemRegularFont(ofSize: fontSize)
     }
 
 
     // MARK: - Apply Stream Header Styles
 
     public class func applyReaderStreamHeaderTitleStyle(_ label: UILabel) {
-        let fontSize: CGFloat = 14.0
-        label.font = WPFontManager.systemRegularFont(ofSize: fontSize)
+        WPStyleGuide.configureLabel(label, forTextStyle: Cards.buttonTextStyle)
         label.textColor = darkGrey()
     }
 
     public class func applyReaderStreamHeaderDetailStyle(_ label: UILabel) {
-        let fontSize: CGFloat = Cards.subtextFontSize
-        label.font = WPFontManager.systemRegularFont(ofSize: fontSize)
+        WPStyleGuide.configureLabel(label, forTextStyle: Cards.subtextTextStyle)
         label.textColor = greyDarken10()
     }
 
     public class func applyReaderSiteStreamDescriptionStyle(_ label: UILabel) {
-        let fontSize = Cards.contentFontSize
-        label.font = WPFontManager.notoRegularFont(ofSize: fontSize)
+        WPStyleGuide.configureLabelForNotoFont(label, forTextStyle: .subheadline)
         label.textColor = darkGrey()
     }
 
     public class func applyReaderSiteStreamCountStyle(_ label: UILabel) {
-        let fontSize: CGFloat = 12.0
-        label.font = WPFontManager.systemRegularFont(ofSize: fontSize)
+        WPStyleGuide.configureLabel(label, forTextStyle: Cards.subtextTextStyle)
         label.textColor = grey()
     }
 
@@ -252,7 +234,7 @@ extension WPStyleGuide {
     // MARK: - Button Styles and Text
 
     public class func applyReaderFollowButtonStyle(_ button: UIButton) {
-        let side = button.titleLabel?.font.pointSize ?? Cards.buttonFontSize
+        let side = WPStyleGuide.fontSizeForTextStyle(Cards.buttonTextStyle)
         let size = CGSize(width: side, height: side)
         let followStr = followStringForDisplay(false)
         let followingStr = followStringForDisplay(true)
@@ -312,7 +294,7 @@ extension WPStyleGuide {
 
     public class func applyGapMarkerButtonStyle(_ button: UIButton) {
         button.backgroundColor = gapMarkerButtonBackgroundColor()
-        button.titleLabel?.font = WPFontManager.systemSemiBoldFont(ofSize: Cards.loadMoreButtonFontSize)
+        WPStyleGuide.configureLabel(button.titleLabel!, forTextStyle: Cards.loadMoreButtonTextStyle, withWeight: UIFontWeightSemibold)
         button.setTitleColor(UIColor.white, for: UIControlState())
     }
 
@@ -329,23 +311,20 @@ extension WPStyleGuide {
 
     public struct Cards {
         public static let defaultLineSpacing: CGFloat = WPDeviceIdentification.isiPad() ? 6.0 : 3.0
-        public static let titleFontSize: CGFloat = WPDeviceIdentification.isiPad() ? 24.0 : 18.0
+        public static let titleTextStyle: UIFontTextStyle = WPDeviceIdentification.isiPad() ? .title2 : .title3
         public static let titleLineSpacing: CGFloat = WPDeviceIdentification.isiPad() ? 0.0 : 0.0
-        public static let contentFontSize: CGFloat = 15.0
+        public static let contentTextStyle: UIFontTextStyle = .subheadline
         public static let contentLineSpacing: CGFloat = 4
-        public static let buttonFontSize: CGFloat = 14.0
-        public static let subtextFontSize: CGFloat = 12.0
-        public static let loadMoreButtonFontSize: CGFloat = 15.0
-        public static let crossPostTitleFontSize: CGFloat = 16.0
-        public static let crossPostSubtitleFontSize: CGFloat = 13.0
+        public static let buttonTextStyle: UIFontTextStyle = .subheadline
+        public static let subtextTextStyle: UIFontTextStyle = .caption1
+        public static let loadMoreButtonTextStyle: UIFontTextStyle = .subheadline
+        public static let crossPostSubtitleTextStyle: UIFontTextStyle = .footnote
         public static let crossPostLineSpacing: CGFloat = 2.0
     }
 
     public struct Detail {
-        public static let titleFontSize: CGFloat = WPDeviceIdentification.isiPad() ? 36.0 : 26.0
-        public static let titleLineHeight: CGFloat = WPDeviceIdentification.isiPad() ? 46.0 : 34.0
-        public static let contentFontSize: CGFloat = 16.0
-        public static let contentLineHeight: CGFloat = 27.0
+        public static let titleTextStyle: UIFontTextStyle = .title1
+        public static let contentTextStyle: UIFontTextStyle = .callout
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -166,20 +166,20 @@ extension WPStyleGuide {
     // MARK: - Apply Card Styles
 
     public class func applyReaderCardSiteButtonStyle(_ button: UIButton) {
-        WPStyleGuide.configureLabel(button.titleLabel!, forTextStyle: Cards.buttonTextStyle)
+        WPStyleGuide.configureLabel(button.titleLabel!, textStyle: Cards.buttonTextStyle)
         button.setTitleColor(mediumBlue(), for: UIControlState())
         button.setTitleColor(lightBlue(), for: .highlighted)
         button.setTitleColor(darkGrey(), for: .disabled)
     }
 
     public class func applyReaderCardBlogNameStyle(_ label: UILabel) {
-        WPStyleGuide.configureLabel(label, forTextStyle: Cards.buttonTextStyle)
+        WPStyleGuide.configureLabel(label, textStyle: Cards.buttonTextStyle)
         label.textColor = readerCardBlogNameLabelTextColor()
         label.highlightedTextColor = lightBlue()
     }
 
     public class func applyReaderCardBylineLabelStyle(_ label: UILabel) {
-        WPStyleGuide.configureLabel(label, forTextStyle: Cards.subtextTextStyle)
+        WPStyleGuide.configureLabel(label, textStyle: Cards.subtextTextStyle)
         label.textColor = greyLighten10()
     }
 
@@ -192,7 +192,7 @@ extension WPStyleGuide {
     }
 
     public class func applyReaderCardTagButtonStyle(_ button: UIButton) {
-        WPStyleGuide.configureLabel(button.titleLabel!, forTextStyle: Cards.subtextTextStyle)
+        WPStyleGuide.configureLabel(button.titleLabel!, textStyle: Cards.subtextTextStyle)
         button.setTitleColor(mediumBlue(), for: UIControlState())
         button.setTitleColor(lightBlue(), for: .highlighted)
         button.titleLabel?.allowsDefaultTighteningForTruncation = false
@@ -200,7 +200,7 @@ extension WPStyleGuide {
     }
 
     public class func applyReaderCardActionButtonStyle(_ button: UIButton) {
-        WPStyleGuide.configureLabel(button.titleLabel!, forTextStyle: Cards.buttonTextStyle)
+        WPStyleGuide.configureLabel(button.titleLabel!, textStyle: Cards.buttonTextStyle)
         button.setTitleColor(greyLighten10(), for: UIControlState())
         button.setTitleColor(lightBlue(), for: .highlighted)
         button.setTitleColor(jazzyOrange(), for: .selected)
@@ -211,22 +211,22 @@ extension WPStyleGuide {
     // MARK: - Apply Stream Header Styles
 
     public class func applyReaderStreamHeaderTitleStyle(_ label: UILabel) {
-        WPStyleGuide.configureLabel(label, forTextStyle: Cards.buttonTextStyle)
+        WPStyleGuide.configureLabel(label, textStyle: Cards.buttonTextStyle)
         label.textColor = darkGrey()
     }
 
     public class func applyReaderStreamHeaderDetailStyle(_ label: UILabel) {
-        WPStyleGuide.configureLabel(label, forTextStyle: Cards.subtextTextStyle)
+        WPStyleGuide.configureLabel(label, textStyle: Cards.subtextTextStyle)
         label.textColor = greyDarken10()
     }
 
     public class func applyReaderSiteStreamDescriptionStyle(_ label: UILabel) {
-        WPStyleGuide.configureLabelForNotoFont(label, forTextStyle: .subheadline)
+        WPStyleGuide.configureLabelForNotoFont(label, textStyle: .subheadline)
         label.textColor = darkGrey()
     }
 
     public class func applyReaderSiteStreamCountStyle(_ label: UILabel) {
-        WPStyleGuide.configureLabel(label, forTextStyle: Cards.subtextTextStyle)
+        WPStyleGuide.configureLabel(label, textStyle: Cards.subtextTextStyle)
         label.textColor = grey()
     }
 
@@ -294,7 +294,7 @@ extension WPStyleGuide {
 
     public class func applyGapMarkerButtonStyle(_ button: UIButton) {
         button.backgroundColor = gapMarkerButtonBackgroundColor()
-        WPStyleGuide.configureLabel(button.titleLabel!, forTextStyle: Cards.loadMoreButtonTextStyle, withWeight: UIFontWeightSemibold)
+        WPStyleGuide.configureLabel(button.titleLabel!, textStyle: Cards.loadMoreButtonTextStyle, fontWeight: UIFontWeightSemibold)
         button.setTitleColor(UIColor.white, for: UIControlState())
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -166,7 +166,10 @@ extension WPStyleGuide {
     // MARK: - Apply Card Styles
 
     public class func applyReaderCardSiteButtonStyle(_ button: UIButton) {
-        WPStyleGuide.configureLabel(button.titleLabel!, textStyle: Cards.buttonTextStyle)
+        guard let titleLabel = button.titleLabel else {
+            return
+        }
+        WPStyleGuide.configureLabel(titleLabel, textStyle: Cards.buttonTextStyle)
         button.setTitleColor(mediumBlue(), for: UIControlState())
         button.setTitleColor(lightBlue(), for: .highlighted)
         button.setTitleColor(darkGrey(), for: .disabled)
@@ -200,7 +203,10 @@ extension WPStyleGuide {
     }
 
     public class func applyReaderCardActionButtonStyle(_ button: UIButton) {
-        WPStyleGuide.configureLabel(button.titleLabel!, textStyle: Cards.buttonTextStyle)
+        guard let titleLabel = button.titleLabel else {
+            return
+        }
+        WPStyleGuide.configureLabel(titleLabel, textStyle: Cards.buttonTextStyle)
         button.setTitleColor(greyLighten10(), for: UIControlState())
         button.setTitleColor(lightBlue(), for: .highlighted)
         button.setTitleColor(jazzyOrange(), for: .selected)
@@ -294,7 +300,10 @@ extension WPStyleGuide {
 
     public class func applyGapMarkerButtonStyle(_ button: UIButton) {
         button.backgroundColor = gapMarkerButtonBackgroundColor()
-        WPStyleGuide.configureLabel(button.titleLabel!, textStyle: Cards.loadMoreButtonTextStyle, fontWeight: UIFontWeightSemibold)
+        guard let titleLabel = button.titleLabel else {
+            return
+        }
+        WPStyleGuide.configureLabel(titleLabel, textStyle: Cards.loadMoreButtonTextStyle, fontWeight: UIFontWeightSemibold)
         button.setTitleColor(UIColor.white, for: UIControlState())
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+ReaderComments.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+ReaderComments.swift
@@ -3,20 +3,6 @@ import WordPressShared
 
 extension WPStyleGuide {
 
-    public class func navbarButtonTintColor() -> UIColor {
-        return UIColor(white: 1.0, alpha: 0.5)
-    }
-
-    // Styles used by Comments in the Reader
-
-    public class func commentTitleFont() -> UIFont {
-        return WPFontManager.systemBoldFont(ofSize: 14)
-    }
-
-    public class func commentBodyFont() -> UIFont {
-        return WPFontManager.systemRegularFont(ofSize: 14)
-    }
-
     public class func defaultSearchBarTextAttributes(_ color: UIColor) -> [String: AnyObject] {
         return [
             NSForegroundColorAttributeName: color,

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -112,9 +112,9 @@ class WPRichContentView: UITextView {
         set {
             let str = newValue
             let style = "<style>" +
-                "body { font-family: Noto Serif; font-size:16.0; line-height:1.6875; color: #2e4453; } " +
+                "body { font:-apple-system-subheadline; font-family: 'Noto Serif'; font-weight: normal; line-height:1.6875; color: #2e4453; }" +
                 "blockquote { color:#4f748e; } " +
-                "em, i { font-size:16.0; font-style: italic; font-family: Noto Serif; } " +
+                "em, i { font:-apple-system-subheadline; font-family: 'Noto Serif'; font-weight: normal; font-style: italic; } " +
                 "a { color: #0087be; text-decoration: none; } " +
                 "a:active { color: #005082; } " +
                 "</style>"

--- a/WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj/project.pbxproj
+++ b/WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj/project.pbxproj
@@ -2309,6 +2309,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 78841A1AA400F7B97A609252 /* Pods-WordPressComStatsiOSTests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				INFOPLIST_FILE = WordPressComStatsiOSTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressComStatsiOSTests;
@@ -2320,6 +2321,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BC3EEE2226F82745E33EFFFE /* Pods-WordPressComStatsiOSTests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				INFOPLIST_FILE = WordPressComStatsiOSTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressComStatsiOSTests;
@@ -2396,6 +2398,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7D003069D6B08AE3C24EFC44 /* Pods-WordPressComStatsiOSTests.release-internal.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				INFOPLIST_FILE = WordPressComStatsiOSTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressComStatsiOSTests;
@@ -2472,6 +2475,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D4BE862BF6E98819D777D4E7 /* Pods-WordPressComStatsiOSTests.release-alpha.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				INFOPLIST_FILE = WordPressComStatsiOSTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressComStatsiOSTests;

--- a/WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj/project.pbxproj
+++ b/WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj/project.pbxproj
@@ -2271,6 +2271,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B9F362EF0B38B1C26652AD80 /* Pods-WordPressComStatsiOS.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2289,6 +2290,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 88530F3C0BA5BE3F66551E1F /* Pods-WordPressComStatsiOS.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2375,6 +2377,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 252C42D5CAE6BCB1F7EEEF54 /* Pods-WordPressComStatsiOS.release-internal.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -2450,6 +2453,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DA7997CE55C245EF5CB5AE64 /* Pods-WordPressComStatsiOS.release-alpha.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/WordPressShared/WordPressShared.xcodeproj/project.pbxproj
+++ b/WordPressShared/WordPressShared.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1126F23C2E306748AEF3599B /* Pods_WordPressSharedTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6872E440E02965E43A4960A /* Pods_WordPressSharedTests.framework */; };
 		194CC62575B20B55C8CDEFF6 /* Pods_WordPressShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77135294F00CA0119C1266FA /* Pods_WordPressShared.framework */; };
+		820ECCA11ECCE002004C7679 /* WPStyleGuide+DynamicType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820ECCA01ECCE002004C7679 /* WPStyleGuide+DynamicType.swift */; };
 		82706FF11ECA438500155CBF /* WPSharedLoggingPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 82706FED1ECA438500155CBF /* WPSharedLoggingPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		82706FF21ECA438500155CBF /* WPSharedLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 82706FEE1ECA438500155CBF /* WPSharedLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		82706FF31ECA438500155CBF /* WPSharedLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 82706FEF1ECA438500155CBF /* WPSharedLogging.m */; };
@@ -67,6 +68,7 @@
 		632D174EAC3A551E3E604567 /* Pods-WordPressShared.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShared.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShared/Pods-WordPressShared.debug.xcconfig"; sourceTree = "<group>"; };
 		71286271E2965F417DDAA7F9 /* Pods-WordPressSharedTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressSharedTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressSharedTests/Pods-WordPressSharedTests.debug.xcconfig"; sourceTree = "<group>"; };
 		77135294F00CA0119C1266FA /* Pods_WordPressShared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressShared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		820ECCA01ECCE002004C7679 /* WPStyleGuide+DynamicType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "WPStyleGuide+DynamicType.swift"; path = "WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift"; sourceTree = SOURCE_ROOT; };
 		82706FED1ECA438500155CBF /* WPSharedLoggingPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPSharedLoggingPrivate.h; path = WordPressShared/Core/Logging/WPSharedLoggingPrivate.h; sourceTree = SOURCE_ROOT; };
 		82706FEE1ECA438500155CBF /* WPSharedLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WPSharedLogging.h; path = WordPressShared/Core/Logging/WPSharedLogging.h; sourceTree = SOURCE_ROOT; };
 		82706FEF1ECA438500155CBF /* WPSharedLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WPSharedLogging.m; path = WordPressShared/Core/Logging/WPSharedLogging.m; sourceTree = SOURCE_ROOT; };
@@ -170,6 +172,7 @@
 				827070161ECA43C100155CBF /* WPNUXUtility.m */,
 				827070131ECA43C100155CBF /* WPStyleGuide.h */,
 				827070111ECA43C100155CBF /* WPStyleGuide.m */,
+				820ECCA01ECCE002004C7679 /* WPStyleGuide+DynamicType.swift */,
 				827070171ECA43C100155CBF /* WPTableViewCell.h */,
 				827070181ECA43C100155CBF /* WPTableViewCell.m */,
 				827070191ECA43C100155CBF /* WPTextFieldTableViewCell.h */,
@@ -369,6 +372,7 @@
 				TargetAttributes = {
 					829DD13D1EC9EED200AB8C12 = {
 						CreatedOnToolsVersion = 8.3;
+						LastSwiftMigration = 0830;
 						ProvisioningStyle = Automatic;
 					};
 					829DD1461EC9EED200AB8C12 = {
@@ -512,6 +516,7 @@
 				82706FF41ECA438500155CBF /* WPSharedLoggingPrivate.m in Sources */,
 				827070081ECA43AA00155CBF /* UIColor+Helpers.m in Sources */,
 				8270700E1ECA43AA00155CBF /* WPFontManager.m in Sources */,
+				820ECCA11ECCE002004C7679 /* WPStyleGuide+DynamicType.swift in Sources */,
 				827070241ECA43C100155CBF /* WPTextFieldTableViewCell.m in Sources */,
 				827070061ECA43AA00155CBF /* NSString+XMLExtensions.m in Sources */,
 				82706FF31ECA438500155CBF /* WPSharedLogging.m in Sources */,
@@ -590,6 +595,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 00D41E1E6DDF78853D018660 /* Pods-WordPressShared.release-internal.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -601,6 +607,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressShared;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = "Release-Internal";
 		};
@@ -608,6 +615,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1D8E4A4985C91A15B0FEB284 /* Pods-WordPressSharedTests.release-internal.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = WordPressSharedTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -669,6 +677,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A9D12BC8253E0DBA59BF461B /* Pods-WordPressShared.release-alpha.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -680,6 +689,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressShared;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = "Release-Alpha";
 		};
@@ -687,6 +697,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 34F3C2FE120EEE96E1657C16 /* Pods-WordPressSharedTests.release-alpha.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = WordPressSharedTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -800,6 +811,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 632D174EAC3A551E3E604567 /* Pods-WordPressShared.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -811,6 +823,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressShared;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -818,6 +832,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB10D1E96FC4A037F9A705FF /* Pods-WordPressShared.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -829,6 +844,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressShared;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -836,6 +852,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 71286271E2965F417DDAA7F9 /* Pods-WordPressSharedTests.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = WordPressSharedTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -851,6 +868,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 33A8051F740771B55E08E7A0 /* Pods-WordPressSharedTests.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = WordPressSharedTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/WordPressShared/WordPressShared.xcodeproj/project.pbxproj
+++ b/WordPressShared/WordPressShared.xcodeproj/project.pbxproj
@@ -615,7 +615,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1D8E4A4985C91A15B0FEB284 /* Pods-WordPressSharedTests.release-internal.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = WordPressSharedTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -697,7 +697,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 34F3C2FE120EEE96E1657C16 /* Pods-WordPressSharedTests.release-alpha.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = WordPressSharedTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -852,7 +852,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 71286271E2965F417DDAA7F9 /* Pods-WordPressSharedTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = WordPressSharedTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -868,7 +868,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 33A8051F740771B55E08E7A0 /* Pods-WordPressSharedTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = WordPressSharedTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/WordPressShared/WordPressShared.xcodeproj/project.pbxproj
+++ b/WordPressShared/WordPressShared.xcodeproj/project.pbxproj
@@ -595,7 +595,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 00D41E1E6DDF78853D018660 /* Pods-WordPressShared.release-internal.xcconfig */;
 			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -677,7 +677,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A9D12BC8253E0DBA59BF461B /* Pods-WordPressShared.release-alpha.xcconfig */;
 			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -811,7 +811,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 632D174EAC3A551E3E604567 /* Pods-WordPressShared.debug.xcconfig */;
 			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -832,7 +832,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DB10D1E96FC4A037F9A705FF /* Pods-WordPressShared.release.xcconfig */;
 			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -1,6 +1,7 @@
 /// Extension on WPStyleGuide to use Dynamic Type fonts.
 ///
 extension WPStyleGuide {
+    static let defaultTableViewRowHeight: CGFloat = 44.0
 
     static let notoLoaded = { () -> Bool in
         WPFontManager.loadNotoFontFamily()
@@ -14,7 +15,7 @@ extension WPStyleGuide {
     ///
     public class func configureAutomaticHeightRowsForTableView(_ tableView: UITableView) {
         tableView.rowHeight = UITableViewAutomaticDimension
-        tableView.estimatedRowHeight = 44//WPTableViewDefaultRowHeight
+        tableView.estimatedRowHeight = defaultTableViewRowHeight
     }
 
     /// Configures a label with the default system font with the specified style.

--- a/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -13,7 +13,7 @@ extension WPStyleGuide {
     /// - Parameters:
     ///     - tableView: The tableView to configure.
     ///
-    public class func configureAutomaticHeightRowsForTableView(_ tableView: UITableView) {
+    public class func configureAutomaticHeightRows(for tableView: UITableView) {
         tableView.rowHeight = UITableViewAutomaticDimension
         tableView.estimatedRowHeight = defaultTableViewRowHeight
     }
@@ -24,7 +24,7 @@ extension WPStyleGuide {
     ///     - label: The label to configure.
     ///     - style: The desired UIFontTextStyle.
     ///
-    public class func configureLabel(_ label: UILabel, forTextStyle style: UIFontTextStyle) {
+    public class func configureLabel(_ label: UILabel, textStyle style: UIFontTextStyle) {
         label.font = UIFont.preferredFont(forTextStyle: style)
         label.adjustsFontForContentSizeCategory = true
     }
@@ -36,8 +36,8 @@ extension WPStyleGuide {
     ///     - style: The desired UIFontTextStyle.
     ///     - traits: The desired UIFontDescriptorSymbolicTraits.
     ///
-    public class func configureLabel(_ label: UILabel, forTextStyle style: UIFontTextStyle, withTraits traits: UIFontDescriptorSymbolicTraits) {
-        label.font = self.fontForTextStyle(style, withTraits: traits)
+    public class func configureLabel(_ label: UILabel, textStyle style: UIFontTextStyle, symbolicTraits traits: UIFontDescriptorSymbolicTraits) {
+        label.font = self.fontForTextStyle(style, symbolicTraits: traits)
         label.adjustsFontForContentSizeCategory = true
     }
 
@@ -50,8 +50,8 @@ extension WPStyleGuide {
     ///       UIFontWeightRegular, UIFontWeightMedium, UIFontWeightSemibold, UIFontWeightBold,
     ///       UIFontWeightHeavy, UIFontWeightBlack).
     ///
-    public class func configureLabel(_ label: UILabel, forTextStyle style: UIFontTextStyle, withWeight weight: CGFloat) {
-        label.font = self.fontForTextStyle(style, withWeight: weight)
+    public class func configureLabel(_ label: UILabel, textStyle style: UIFontTextStyle, fontWeight weight: CGFloat) {
+        label.font = self.fontForTextStyle(style, fontWeight: weight)
         label.adjustsFontForContentSizeCategory = true
     }
 
@@ -61,7 +61,7 @@ extension WPStyleGuide {
     ///     - label: The label to configure.
     ///     - style: The desired UIFontTextStyle.
     ///
-    public class func configureLabelForNotoFont(_ label: UILabel, forTextStyle style: UIFontTextStyle) {
+    public class func configureLabelForNotoFont(_ label: UILabel, textStyle style: UIFontTextStyle) {
         label.font = self.notoFontForTextStyle(style)
         label.adjustsFontForContentSizeCategory = true
     }
@@ -86,7 +86,7 @@ extension WPStyleGuide {
     ///
     /// - Returns: The created font.
     ///
-    public class func fontForTextStyle(_ style: UIFontTextStyle, withTraits traits: UIFontDescriptorSymbolicTraits) -> UIFont {
+    public class func fontForTextStyle(_ style: UIFontTextStyle, symbolicTraits traits: UIFontDescriptorSymbolicTraits) -> UIFont {
         var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
         fontDescriptor = fontDescriptor.withSymbolicTraits(traits) ?? fontDescriptor
         return UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
@@ -102,7 +102,7 @@ extension WPStyleGuide {
     ///
     /// - Returns: The created font.
     ///
-    public class func fontForTextStyle(_ style: UIFontTextStyle, withWeight weight: CGFloat) -> UIFont {
+    public class func fontForTextStyle(_ style: UIFontTextStyle, fontWeight weight: CGFloat) -> UIFont {
         var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
         let traits = [UIFontWeightTrait: weight]
         fontDescriptor = fontDescriptor.addingAttributes([UIFontDescriptorTraitsAttribute: traits])

--- a/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -1,0 +1,181 @@
+/// Extension on WPStyleGuide to use Dynamic Type fonts.
+///
+extension WPStyleGuide {
+
+    static let notoLoaded = { () -> Bool in
+        WPFontManager.loadNotoFontFamily()
+        return true
+    }()
+
+    /// Configures a table to automatically resize its rows according to their content.
+    ///
+    /// - Parameters:
+    ///     - tableView: The tableView to configure.
+    ///
+    public class func configureAutomaticHeightRowsForTableView(_ tableView: UITableView) {
+        tableView.rowHeight = UITableViewAutomaticDimension
+        tableView.estimatedRowHeight = 44//WPTableViewDefaultRowHeight
+    }
+
+    /// Configures a label with the default system font with the specified style.
+    ///
+    /// - Parameters:
+    ///     - label: The label to configure.
+    ///     - style: The desired UIFontTextStyle.
+    ///
+    public class func configureLabel(_ label: UILabel, forTextStyle style: UIFontTextStyle) {
+        label.font = UIFont.preferredFont(forTextStyle: style)
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    /// Configures a label with the default system font with the specified style and traits.
+    ///
+    /// - Parameters:
+    ///     - label: The label to configure.
+    ///     - style: The desired UIFontTextStyle.
+    ///     - traits: The desired UIFontDescriptorSymbolicTraits.
+    ///
+    public class func configureLabel(_ label: UILabel, forTextStyle style: UIFontTextStyle, withTraits traits: UIFontDescriptorSymbolicTraits) {
+        label.font = self.fontForTextStyle(style, withTraits: traits)
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    /// Configures a label with the default system font with the specified style and weight.
+    ///
+    /// - Parameters:
+    ///     - label: The label to configure.
+    ///     - style: The desired UIFontTextStyle.
+    ///     - weight: The desired weight (UIFontWeightUltraLight, UIFontWeightThin, UIFontWeightLight,
+    ///       UIFontWeightRegular, UIFontWeightMedium, UIFontWeightSemibold, UIFontWeightBold,
+    ///       UIFontWeightHeavy, UIFontWeightBlack).
+    ///
+    public class func configureLabel(_ label: UILabel, forTextStyle style: UIFontTextStyle, withWeight weight: CGFloat) {
+        label.font = self.fontForTextStyle(style, withWeight: weight)
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    /// Configures a label with the regular Noto font with the specified style.
+    ///
+    /// - Parameters:
+    ///     - label: The label to configure.
+    ///     - style: The desired UIFontTextStyle.
+    ///
+    public class func configureLabelForNotoFont(_ label: UILabel, forTextStyle style: UIFontTextStyle) {
+        label.font = self.notoFontForTextStyle(style)
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    /// Creates a UIFont for the user current text size settings.
+    ///
+    /// - Parameters:
+    ///     - style: The desired UIFontTextStyle.
+    ///
+    /// - Returns: The created font.
+    ///
+    public class func fontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
+        let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
+        return UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
+    }
+
+    /// Creates a UIFont for the user current text size settings.
+    ///
+    /// - Parameters:
+    ///     - style: The desired UIFontTextStyle.
+    ///     - traits: The desired UIFontDescriptorSymbolicTraits.
+    ///
+    /// - Returns: The created font.
+    ///
+    public class func fontForTextStyle(_ style: UIFontTextStyle, withTraits traits: UIFontDescriptorSymbolicTraits) -> UIFont {
+        var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
+        fontDescriptor = fontDescriptor.withSymbolicTraits(traits) ?? fontDescriptor
+        return UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
+    }
+
+    /// Creates a UIFont for the user current text size settings.
+    ///
+    /// - Parameters:
+    ///     - style: The desired UIFontTextStyle.
+    ///     - weight: The desired weight (UIFontWeightUltraLight, UIFontWeightThin, UIFontWeightLight,
+    ///       UIFontWeightRegular, UIFontWeightMedium, UIFontWeightSemibold, UIFontWeightBold,
+    ///       UIFontWeightHeavy, UIFontWeightBlack).
+    ///
+    /// - Returns: The created font.
+    ///
+    public class func fontForTextStyle(_ style: UIFontTextStyle, withWeight weight: CGFloat) -> UIFont {
+        var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
+        let traits = [UIFontWeightTrait: weight]
+        fontDescriptor = fontDescriptor.addingAttributes([UIFontDescriptorTraitsAttribute: traits])
+        return UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
+    }
+
+    /// Creates a UIFont for the user current text size settings and calculates its size.
+    ///
+    /// - Parameters:
+    ///     - style: The desired UIFontTextStyle.
+    ///
+    /// - Returns: The created font point size.
+    ///
+    public class func fontSizeForTextStyle(_ style: UIFontTextStyle) -> CGFloat {
+        let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
+        let font = UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
+        return font.pointSize
+    }
+
+    /// Creates a NotoSerif UIFont for the user current text size settings.
+    ///
+    /// - Parameters:
+    ///     - style: The desired UIFontTextStyle.
+    ///
+    /// - Returns: The created font.
+    ///
+    public class func notoFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
+        return self.customNotoFontNamed("NotoSerif", forTextStyle: style)
+    }
+
+    /// Creates a NotoSerif Bold UIFont for the user current text size settings.
+    ///
+    /// - Parameters:
+    ///     - style: The desired UIFontTextStyle.
+    ///
+    /// - Returns: The created font.
+    ///
+    public class func notoBoldFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
+        return self.customNotoFontNamed("NotoSerif-Bold", forTextStyle: style)
+    }
+
+    /// Creates a NotoSerif Italic UIFont for the user current text size settings.
+    ///
+    /// - Parameters:
+    ///     - style: The desired UIFontTextStyle.
+    ///
+    /// - Returns: The created font.
+    ///
+    public class func notoItalicFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
+        return self.customNotoFontNamed("NotoSerif-Italic", forTextStyle: style)
+    }
+
+    /// Creates a NotoSerif BoldItalic UIFont for the user current text size settings.
+    ///
+    /// - Parameters:
+    ///     - style: The desired UIFontTextStyle.
+    ///
+    /// - Returns: The created font.
+    ///
+    public class func notoBoldItalicFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
+        return self.customNotoFontNamed("NotoSerif-BoldItalic", forTextStyle: style)
+    }
+
+    /// Creates a Noto UIFont for the user current text size settings.
+    ///
+    /// - Parameters:
+    ///     - fontName: the Noto font name (NotoSerif, NotoSerif-Bold, NotoSerif-Italic, NotoSerif-BoldItalic)
+    ///     - style: The desired UIFontTextStyle.
+    ///
+    /// - Returns: The created font point size.
+    ///
+    private class func customNotoFontNamed(_ fontName: String, forTextStyle style: UIFontTextStyle) -> UIFont {
+        _ = notoLoaded
+        let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
+        return UIFont(name: fontName, size: fontDescriptor.pointSize)!
+    }
+}

--- a/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -177,6 +177,10 @@ extension WPStyleGuide {
     private class func customNotoFontNamed(_ fontName: String, forTextStyle style: UIFontTextStyle) -> UIFont {
         _ = notoLoaded
         let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
-        return UIFont(name: fontName, size: fontDescriptor.pointSize)!
+        guard let font = UIFont(name: fontName, size: fontDescriptor.pointSize) else {
+            // If we can't get the Noto font for some reason we will default to the system font
+            return fontForTextStyle(style)
+        }
+        return font
     }
 }

--- a/WordPressShared/WordPressShared/Core/Views/WPStyleGuide.m
+++ b/WordPressShared/WordPressShared/Core/Views/WPStyleGuide.m
@@ -67,7 +67,7 @@
 
 + (UIFont *)regularTextFont
 {
-    return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleCallout];
 }
 
 + (UIFont *)regularTextFontSemiBold
@@ -85,12 +85,12 @@
 
 + (UIFont *)tableviewTextFont
 {
-    return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleCallout];
 }
 
 + (UIFont *)tableviewSubtitleFont
 {
-    return [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    return [UIFont preferredFontForTextStyle:UIFontTextStyleCallout];
 }
 
 + (UIFont *)tableviewSectionHeaderFont


### PR DESCRIPTION
**Fixes** #7068 

This PR provides support for Dynamic Type in the following places:
- Reader Post List
- Reader Detail
- Blog Post List

More PRs to come once this one is approved and merged to add support in other areas of the app.

**To test:**
Enable "Larger Text" on Settings->General->Accessibility->Larger Text
Check that the Reader Post List cells have bigger text and look good.
Check that the Reader Detail view has bigger text and looks good.
Check that the Blog Post List cells have bigger text and look good.

Since some font sizes changed slightly, I am adding before and after pictures for @mattmiklic to verify that everything looks good.

| Develop        | This branch           |
| ------------- |-------------|
|![postlist](https://cloud.githubusercontent.com/assets/5558824/26259039/9b215ed6-3c9d-11e7-866f-ca06e5431152.png)| ![postlistcurrent](https://cloud.githubusercontent.com/assets/5558824/26259041/9b587fc4-3c9d-11e7-8b24-04bf542ba6f6.png)|
![readerdetail](https://cloud.githubusercontent.com/assets/5558824/26259040/9b57c25a-3c9d-11e7-8755-c46b64ccdd48.png)|![readerdetailcurrent](https://cloud.githubusercontent.com/assets/5558824/26259043/9b5adfd0-3c9d-11e7-9c67-05286d1ec126.png)
![readerlist](https://cloud.githubusercontent.com/assets/5558824/26259042/9b58cfec-3c9d-11e7-97a5-169ac9d447b9.png) | ![readerlistcurrent](https://cloud.githubusercontent.com/assets/5558824/26259044/9b5b08d4-3c9d-11e7-96be-ecb17bb83f03.png)|


Needs review: @nheagy 