### PR TITLE
Feature/login self hosted profile part 3

### DIFF
--- a/WordPress/Classes/Networking/GravatarServiceRemote.swift
+++ b/WordPress/Classes/Networking/GravatarServiceRemote.swift
@@ -27,18 +27,20 @@ open class GravatarServiceRemote {
 
         let session = URLSession.shared
         let task = session.dataTask(with: targetURL) { (data: Data?, response: URLResponse?, error: Error?) in
-            let errPointer: NSErrorPointer = nil
-            if  let response = AFJSONResponseSerializer().responseObject(for: response, data: data, error: errPointer) as? [String: Array<Any>],
-                let entry = response["entry"],
-                let profileData = entry.first as? NSDictionary {
+            DispatchQueue.main.async {
+                let errPointer: NSErrorPointer = nil
+                if  let response = AFJSONResponseSerializer().responseObject(for: response, data: data, error: errPointer) as? [String: Array<Any>],
+                    let entry = response["entry"],
+                    let profileData = entry.first as? NSDictionary {
 
-                let profile = RemoteGravatarProfile(dictionary: profileData)
-                success(profile)
-                return
+                    let profile = RemoteGravatarProfile(dictionary: profileData)
+                    success(profile)
+                    return
+                }
+
+                let err = errPointer?.pointee ?? error
+                failure(err)
             }
-
-            let err = errPointer?.pointee ?? error
-            failure(err)
         }
 
         task.resume()

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
@@ -5,6 +5,7 @@ import WordPressShared
 class LoginEpilogueTableView: UITableViewController {
     var blogDataSource: BlogListDataSource
     var blogCount: Int?
+    var epilogueUserInfo: LoginEpilogueUserInfo?
 
     required init?(coder aDecoder: NSCoder) {
         blogDataSource = BlogListDataSource()
@@ -45,16 +46,11 @@ class LoginEpilogueTableView: UITableViewController {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "userInfo") as? LoginEpilogueUserInfoCell else {
                 fatalError("Failed to get a user info cell")
             }
-            guard let account = defaultAccount() else {
-                return cell
+
+            if let info = epilogueUserInfo {
+                cell.configure(userInfo: info)
             }
-            if let username = account.username {
-                cell.usernameLabel?.text = "@\(username)"
-            } else {
-                cell.usernameLabel?.text = ""
-            }
-            cell.gravatarView?.downloadGravatarWithEmail(account.email, rating: .x)
-            cell.fullNameLabel?.text = account.displayName
+
             return cell
         } else {
             let wrappedPath = IndexPath(row: indexPath.row, section: indexPath.section-1)

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
@@ -19,14 +19,6 @@ class LoginEpilogueTableView: UITableViewController {
         tableView.register(headerNib, forHeaderFooterViewReuseIdentifier: "SectionHeader")
     }
 
-    /// - Note: Copied from MeViewController which I bet @koke is happy about :P
-    fileprivate func defaultAccount() -> WPAccount? {
-        let context = ContextManager.sharedInstance().mainContext
-        let service = AccountService(managedObjectContext: context)
-        let account = service.defaultWordPressComAccount()
-        return account
-    }
-
     override func numberOfSections(in tableView: UITableView) -> Int {
         return blogDataSource.numberOfSections(in:tableView) + 1
     }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
@@ -4,16 +4,16 @@ import Foundation
 ///
 struct LoginEpilogueUserInfo {
     var username = ""
-    var fullname = ""
+    var fullName = ""
     var email = ""
     var gravatarUrl: String?
 
     init(account: WPAccount) {
         if let name = account.username {
-            username = "@\(name)"
+            username = name
         }
         email = account.email
-        fullname = account.displayName
+        fullName = account.displayName
     }
 
     init() {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// A simple container for the user info shown on the login epilogue screen.
+///
+struct LoginEpilogueUserInfo {
+    var username = ""
+    var fullname = ""
+    var email = ""
+    var gravatarUrl: String?
+}

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
@@ -7,4 +7,16 @@ struct LoginEpilogueUserInfo {
     var fullname = ""
     var email = ""
     var gravatarUrl: String?
+
+    init(account: WPAccount) {
+        if let name = account.username {
+            username = "@\(name)"
+        }
+        email = account.email
+        fullname = account.displayName
+    }
+
+    init() {
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfoCell.swift
@@ -8,7 +8,7 @@ class LoginEpilogueUserInfoCell: UITableViewCell {
 
     func configure(userInfo: LoginEpilogueUserInfo) {
         usernameLabel?.text = "@\(userInfo.username)"
-        fullNameLabel?.text = userInfo.fullname
+        fullNameLabel?.text = userInfo.fullName
 
         if let gravatarUrl = userInfo.gravatarUrl,
             let url = URL(string: gravatarUrl) {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfoCell.swift
@@ -1,4 +1,3 @@
-
 import UIKit
 
 class LoginEpilogueUserInfoCell: UITableViewCell {
@@ -7,4 +6,15 @@ class LoginEpilogueUserInfoCell: UITableViewCell {
     @IBOutlet var fullNameLabel: UILabel?
     @IBOutlet var usernameLabel: UILabel?
 
+    func configure(userInfo: LoginEpilogueUserInfo) {
+        usernameLabel?.text = "@\(userInfo.username)"
+        fullNameLabel?.text = userInfo.fullname
+
+        if let gravatarUrl = userInfo.gravatarUrl,
+            let url = URL(string: gravatarUrl) {
+            gravatarView?.downloadImage(url, placeholderImage: nil)
+        } else {
+            gravatarView?.downloadGravatarWithEmail(userInfo.email, rating: .x)
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -6,6 +6,30 @@ class LoginEpilogueViewController: UIViewController {
     var dismissBlock: ((_ cancelled: Bool) -> Void)?
     @IBOutlet var buttonPanel: UIView?
     @IBOutlet var shadowView: UIView?
+    var tableViewController: LoginEpilogueTableView?
+    var epilogueUserInfo: LoginEpilogueUserInfo?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if let info = epilogueUserInfo {
+            tableViewController?.epilogueUserInfo = info
+        } else {
+            // The self-hosted flow sets user info,  If no user info is set, assume
+            // a wpcom flow and try the default wp account.
+            let service = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+            if let account = service.defaultWordPressComAccount() {
+                tableViewController?.epilogueUserInfo = LoginEpilogueUserInfo(account: account)
+            }
+        }
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        super.prepare(for: segue, sender: sender)
+        if let vc = segue.destination as? LoginEpilogueTableView {
+            tableViewController = vc
+        }
+    }
 
     // @IBAction to allow to set the selector for target in the storyboard
     @IBAction func unwindOut(segue: UIStoryboardSegue) {

--- a/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
@@ -1,7 +1,96 @@
 import UIKit
 
 class LoginSelfHostedViewController: SigninSelfHostedViewController {
+    var gravatarProfile: GravatarProfile?
+    var userProfile: UserProfile?
+
     override func needsMultifactorCode() {
-        self.performSegue(withIdentifier: .show2FA, sender: self)
+        performSegue(withIdentifier: .show2FA, sender: self)
+    }
+
+
+    override func dismiss() {
+        configureViewLoading(false)
+        performSegue(withIdentifier: .showEpilogue, sender: self)
+    }
+
+
+    override func finishedLogin(withUsername username: String!, password: String!, xmlrpc: String!, options: [AnyHashable: Any]!) {
+        displayLoginMessage(NSLocalizedString("", comment: ""))
+
+        BlogSyncFacade().syncBlog(withUsername: username, password: password, xmlrpc: xmlrpc, options: options) { [weak self] in
+            NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: SigninHelpers.WPSigninDidFinishNotification), object: nil)
+
+            let context = ContextManager.sharedInstance().mainContext
+            let service = BlogService(managedObjectContext: context)
+            guard let blog = service.findBlog(withXmlrpc: xmlrpc, andUsername: username) else {
+                assertionFailure("A blog was just added but was not found in core data.")
+                self?.dismiss()
+                return
+            }
+
+            RecentSitesService().touch(blog: blog)
+
+            self?.fetchUserProfileInfo(blog: blog, completion: {
+                self?.dismiss()
+            })
+        }
+    }
+
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        super.prepare(for: segue, sender: sender)
+        // Ensure that the user info is set on the epilogue vc.
+        if let vc = segue.destination as? LoginEpilogueViewController {
+            vc.epilogueUserInfo = epilogueUserInfo()
+        }
+    }
+
+
+    /// Returns an instance of LoginEpilogueUserInfo composed from
+    /// a user's gravatar profile, and/or self-hosted blog profile.
+    ///
+    func epilogueUserInfo() -> LoginEpilogueUserInfo {
+        var info = LoginEpilogueUserInfo()
+        if let profile = gravatarProfile {
+            info.gravatarUrl = profile.thumbnailUrl
+            info.fullname = profile.displayName
+        }
+
+        // Whatever is in user profile trumps whatever is in the gravatar profile.
+        if let profile = userProfile {
+            info.username = profile.username
+            info.fullname = profile.displayName
+            info.email = profile.email
+        }
+
+        return info
+    }
+
+
+    /// Fetches the user's profile data from their blog. If success, it next queries
+    /// the user's gravatar profile data passing the completion block.
+    ///
+    func fetchUserProfileInfo(blog: Blog, completion: @escaping (() -> Void )) {
+        let service = UsersService()
+        service.fetchProfile(blog: blog, success: { [weak self] (profile) in
+            self?.userProfile = profile
+            self?.fetchGravatarProfileInfo(email: profile.email, completion: completion)
+        }, failure: { [weak self] (_) in
+            self?.dismiss()
+        })
+    }
+
+
+    /// Queries the user's gravatar profile data. On success calls completion.
+    ///
+    func fetchGravatarProfileInfo(email: String, completion: @escaping (() -> Void )) {
+        let service = GravatarService()
+        service.fetchProfile(email, success: { [weak self] (profile) in
+            self?.gravatarProfile = profile
+            completion()
+        }, failure: { [weak self] (_) in
+            self?.dismiss()
+        })
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
@@ -54,13 +54,13 @@ class LoginSelfHostedViewController: SigninSelfHostedViewController {
         var info = LoginEpilogueUserInfo()
         if let profile = gravatarProfile {
             info.gravatarUrl = profile.thumbnailUrl
-            info.fullname = profile.displayName
+            info.fullName = profile.displayName
         }
 
         // Whatever is in user profile trumps whatever is in the gravatar profile.
         if let profile = userProfile {
             info.username = profile.username
-            info.fullname = profile.displayName
+            info.fullName = profile.displayName
             info.email = profile.email
         }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -918,6 +918,7 @@
 		E61084C11B9B47BA008050C5 /* ReaderSiteTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61084BC1B9B47BA008050C5 /* ReaderSiteTopic.swift */; };
 		E61084C21B9B47BA008050C5 /* ReaderTagTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61084BD1B9B47BA008050C5 /* ReaderTagTopic.swift */; };
 		E61084C41B9DC09C008050C5 /* ReaderPostServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E61084C31B9DC09C008050C5 /* ReaderPostServiceRemoteTests.m */; };
+		E6158ACA1ECDF518005FA441 /* LoginEpilogueUserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6158AC91ECDF518005FA441 /* LoginEpilogueUserInfo.swift */; };
 		E616E4B31C480896002C024E /* SharingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E616E4B21C480896002C024E /* SharingService.swift */; };
 		E62079DF1CF79FC200F5CD46 /* ReaderSearchSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62079DE1CF79FC200F5CD46 /* ReaderSearchSuggestion.swift */; };
 		E62079E11CF7A61200F5CD46 /* ReaderSearchSuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62079E01CF7A61200F5CD46 /* ReaderSearchSuggestionService.swift */; };
@@ -1309,8 +1310,6 @@
 		08F8CD3A1EBD2D020049D0C0 /* MediaURLExporterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaURLExporterTests.swift; sourceTree = "<group>"; };
 		0B881E0AD67384380C096CF9 /* Pods-WordPressTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.debug.xcconfig"; sourceTree = "<group>"; };
 		0D3D1A7B9F4A23E2349E35A4 /* Pods-WordPress_Base-WordPress.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPress.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPress/Pods-WordPress_Base-WordPress.debug.xcconfig"; sourceTree = "<group>"; };
-		15C84DEA0B01A0CF82962DC4 /* Pods-WordPress_Base-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPress/Pods-WordPress_Base-WordPress.release.xcconfig"; sourceTree = "<group>"; };
-		16E856FF9B881D72F0F118A2 /* Pods-WordPressTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.debug.xcconfig"; sourceTree = "<group>"; };
 		1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
 		1702BBDF1CF3034E00766A33 /* DomainsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsService.swift; sourceTree = "<group>"; };
 		1702BBE11CF319C600766A33 /* DomainsServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsServiceTests.swift; sourceTree = "<group>"; };
@@ -1411,11 +1410,11 @@
 		43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostListFilterSettings.swift; sourceTree = "<group>"; };
 		43D2436C1EAFCE3C00D0C77B /* LoginSegueHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginSegueHandler.swift; sourceTree = "<group>"; };
 		43D54D121DCAA070007F575F /* PostPostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostPostViewController.swift; sourceTree = "<group>"; };
-		44474AFFDCB91F63FD730FF8 /* Pods-WordPress_Base-WordPressTodayWidget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPressTodayWidget.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPressTodayWidget/Pods-WordPress_Base-WordPressTodayWidget.release.xcconfig"; sourceTree = "<group>"; };
 		43FB3F401EBD215C00FC8A62 /* LoginEpilogueBlogCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueBlogCell.swift; sourceTree = "<group>"; };
 		43FB3F421EC0DDAD00FC8A62 /* LoginEpilogueSectionHeader.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LoginEpilogueSectionHeader.xib; sourceTree = "<group>"; };
 		43FB3F441EC1020600FC8A62 /* LoginEpilogueSectionHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueSectionHeader.swift; sourceTree = "<group>"; };
 		43FB3F461EC10F1E00FC8A62 /* LoginEpilogueTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueTableView.swift; sourceTree = "<group>"; };
+		44474AFFDCB91F63FD730FF8 /* Pods-WordPress_Base-WordPressTodayWidget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPressTodayWidget.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPressTodayWidget/Pods-WordPress_Base-WordPressTodayWidget.release.xcconfig"; sourceTree = "<group>"; };
 		462F4E0618369F0B0028D2F8 /* BlogDetailsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogDetailsViewController.h; sourceTree = "<group>"; };
 		462F4E0718369F0B0028D2F8 /* BlogDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BlogDetailsViewController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		4645AFC41961E1FB005F7509 /* AppImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = AppImages.xcassets; path = Resources/AppImages.xcassets; sourceTree = "<group>"; };
@@ -2510,6 +2509,7 @@
 		E61084BC1B9B47BA008050C5 /* ReaderSiteTopic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSiteTopic.swift; sourceTree = "<group>"; };
 		E61084BD1B9B47BA008050C5 /* ReaderTagTopic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderTagTopic.swift; sourceTree = "<group>"; };
 		E61084C31B9DC09C008050C5 /* ReaderPostServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReaderPostServiceRemoteTests.m; sourceTree = "<group>"; };
+		E6158AC91ECDF518005FA441 /* LoginEpilogueUserInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueUserInfo.swift; sourceTree = "<group>"; };
 		E616E4B21C480896002C024E /* SharingService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingService.swift; sourceTree = "<group>"; };
 		E62079DE1CF79FC200F5CD46 /* ReaderSearchSuggestion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSearchSuggestion.swift; sourceTree = "<group>"; };
 		E62079E01CF7A61200F5CD46 /* ReaderSearchSuggestionService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSearchSuggestionService.swift; sourceTree = "<group>"; };
@@ -2633,9 +2633,8 @@
 		E6ED090A1D46AFAF003283C4 /* ReaderFollowedSitesStreamHeader.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderFollowedSitesStreamHeader.xib; sourceTree = "<group>"; };
 		E6F058011C1A122B008000F9 /* ReaderPostMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostMenu.swift; sourceTree = "<group>"; };
 		E6F66D411E00966000F875A5 /* UIImage+Rotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Rotation.swift"; sourceTree = "<group>"; };
-		F0F1A1CF5954D56FE6F57BC1 /* Pods-WordPress_Base-WordPressTodayWidget.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPressTodayWidget.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPressTodayWidget/Pods-WordPress_Base-WordPressTodayWidget.release-internal.xcconfig"; sourceTree = "<group>"; };
 		E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarProfile.swift; sourceTree = "<group>"; };
-		E7E2F7FF374281D90CDB91E2 /* Pods-WordPress_Base-WordPressShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPressShareExtension.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPressShareExtension/Pods-WordPress_Base-WordPressShareExtension.release.xcconfig"; sourceTree = "<group>"; };
+		F0F1A1CF5954D56FE6F57BC1 /* Pods-WordPress_Base-WordPressTodayWidget.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress_Base-WordPressTodayWidget.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress_Base-WordPressTodayWidget/Pods-WordPress_Base-WordPressTodayWidget.release-internal.xcconfig"; sourceTree = "<group>"; };
 		F128C31A1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPNavigationMediaPickerViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
 		F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WPNavigationMediaPickerViewController+StatusBarStyle.m"; sourceTree = "<group>"; };
 		F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringHelpersTests.m; sourceTree = "<group>"; };
@@ -5522,6 +5521,7 @@
 		E6417B9A1CA07C0A0084050A /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				E6158AC91ECDF518005FA441 /* LoginEpilogueUserInfo.swift */,
 				85D239B71AE5A6620074768D /* LoginFields.h */,
 				85D239B81AE5A6620074768D /* LoginFields.m */,
 				E6417BAB1CA07F7F0084050A /* SigninHelpers.swift */,
@@ -6808,6 +6808,7 @@
 				5903AE1B19B60A98009D5354 /* WPButtonForNavigationBar.m in Sources */,
 				08B6D6F91C8F7EF20052C52B /* RemotePostType.m in Sources */,
 				5D5D0027187DA9D30027CEF6 /* PostCategoriesViewController.m in Sources */,
+				E6158ACA1ECDF518005FA441 /* LoginEpilogueUserInfo.swift in Sources */,
 				E6417B9C1CA07C3C0084050A /* NUXAbstractViewController.swift in Sources */,
 				E1E4CE0B1773C59B00430844 /* WPAvatarSource.m in Sources */,
 				85D239AE1AE5A5FC0074768D /* BlogSyncFacade.m in Sources */,

--- a/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
+++ b/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
@@ -86,12 +86,14 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
         // Create task
         let task = session.dataTask(with: request, completionHandler: { (data, urlResponse, error) in
-            do {
-                let responseObject = try self.handleResponseWithData(data, urlResponse: urlResponse, error: error as NSError?)
-                success(responseObject, urlResponse as? HTTPURLResponse)
-            } catch let error as NSError {
-                failure(error, urlResponse as? HTTPURLResponse)
-                return
+            DispatchQueue.main.async {
+                do {
+                    let responseObject = try self.handleResponseWithData(data, urlResponse: urlResponse, error: error as NSError?)
+                    success(responseObject, urlResponse as? HTTPURLResponse)
+                } catch let error as NSError {
+                    failure(error, urlResponse as? HTTPURLResponse)
+                    return
+                }
             }
         })
         task.resume()


### PR DESCRIPTION
This is the third and final PR adding support for showing self-hosted user info in the new login epilogue vc.  

In this PR the new end points are queried from the self-hosted login vc, the relevant data is retained in a new LoginEpilogueUserInfo instance and passed along via segue.   The self-hosted vc composes the user info itself since its querying multiple sources, but i've opted to have a convenience initializer accepting a WPAccount for the wpcom flows.

Both Gravatar and self-hosted profile endpoints are queried. The self-hosted profile is preferred for username and full name with the gravatar profile acting as a fallback. The gravatar profile is preferred for the actual image shown, with the self-hosted blog's email address as a fallback. 

A minor edit was made to the new remote services to ensure callbacks were performed on the main thread.

To test: Sign in with self-hosted and with wpcom accounts. Confirm you see the proper user info on the epilogue screen for both flows when the user does and does not have a gravatar assigned.

Needs review: @nheagy 
