### PR TITLE
NoteTableViewCell: BackgroundColor Failsafe

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -76,10 +76,7 @@ class NoteTableViewCell: MGSwipeTableCell {
     }
     override var backgroundColor: UIColor? {
         didSet {
-            // Note: This is done to improve scrolling performance!
-            snippetLabel.backgroundColor = backgroundColor
-            subjectLabel.backgroundColor = backgroundColor
-            separatorsView.backgroundColor = backgroundColor
+            updateTextBackgroundColor(newBackgroundColor: backgroundColor)
         }
     }
     var onUndelete: (() -> Void)?
@@ -207,10 +204,16 @@ class NoteTableViewCell: MGSwipeTableCell {
 
         // Cell Background: Assign only if needed, for performance
         let newBackgroundColor = read ? Style.noteBackgroundReadColor : Style.noteBackgroundUnreadColor
-
-        if backgroundColor != newBackgroundColor {
-            backgroundColor = newBackgroundColor
+        guard newBackgroundColor != backgroundColor else {
+            return
         }
+
+        // Failsafe:
+        // Under unknown scenarios, `backgroundColor.didSet` is suspected of not being called. We'll make an explicit
+        // call, in order to set the Text Background Colors.
+        //
+        super.backgroundColor = newBackgroundColor
+        updateTextBackgroundColor(newBackgroundColor: newBackgroundColor)
     }
 
     fileprivate func refreshSelectionStyle() {
@@ -251,6 +254,14 @@ class NoteTableViewCell: MGSwipeTableCell {
         undoOverlayView.legendText = undeleteOverlayText
     }
 
+
+    // MARK: - Helpers
+
+    private func updateTextBackgroundColor(newBackgroundColor: UIColor?) {
+        snippetLabel.backgroundColor = backgroundColor
+        subjectLabel.backgroundColor = backgroundColor
+        separatorsView.backgroundColor = backgroundColor
+    }
 
 
     // MARK: - Action Handlers

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -202,16 +202,12 @@ class NoteTableViewCell: MGSwipeTableCell {
             noticonContainerView.backgroundColor = Style.noteBackgroundUnreadColor
         }
 
-        // Cell Background: Assign only if needed, for performance
-        let newBackgroundColor = read ? Style.noteBackgroundReadColor : Style.noteBackgroundUnreadColor
-        guard newBackgroundColor != backgroundColor else {
-            return
-        }
-
         // Failsafe:
         // Under unknown scenarios, `backgroundColor.didSet` is suspected of not being called. We'll make an explicit
         // call, in order to set the Text Background Colors.
         //
+        let newBackgroundColor = read ? Style.noteBackgroundReadColor : Style.noteBackgroundUnreadColor
+
         super.backgroundColor = newBackgroundColor
         updateTextBackgroundColor(newBackgroundColor: newBackgroundColor)
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -76,7 +76,10 @@ class NoteTableViewCell: MGSwipeTableCell {
     }
     override var backgroundColor: UIColor? {
         didSet {
-            updateTextBackgroundColor(newBackgroundColor: backgroundColor)
+            // Note: This is done to improve scrolling performance!
+            snippetLabel.backgroundColor = backgroundColor
+            subjectLabel.backgroundColor = backgroundColor
+            separatorsView.backgroundColor = backgroundColor
         }
     }
     var onUndelete: (() -> Void)?
@@ -202,14 +205,8 @@ class NoteTableViewCell: MGSwipeTableCell {
             noticonContainerView.backgroundColor = Style.noteBackgroundUnreadColor
         }
 
-        // Failsafe:
-        // Under unknown scenarios, `backgroundColor.didSet` is suspected of not being called. We'll make an explicit
-        // call, in order to set the Text Background Colors.
-        //
-        let newBackgroundColor = read ? Style.noteBackgroundReadColor : Style.noteBackgroundUnreadColor
-
-        super.backgroundColor = newBackgroundColor
-        updateTextBackgroundColor(newBackgroundColor: newBackgroundColor)
+        // Cell Background
+        backgroundColor = read ? Style.noteBackgroundReadColor : Style.noteBackgroundUnreadColor
     }
 
     fileprivate func refreshSelectionStyle() {
@@ -250,14 +247,6 @@ class NoteTableViewCell: MGSwipeTableCell {
         undoOverlayView.legendText = undeleteOverlayText
     }
 
-
-    // MARK: - Helpers
-
-    private func updateTextBackgroundColor(newBackgroundColor: UIColor?) {
-        snippetLabel.backgroundColor = backgroundColor
-        subjectLabel.backgroundColor = backgroundColor
-        separatorsView.backgroundColor = backgroundColor
-    }
 
 
     // MARK: - Action Handlers


### PR DESCRIPTION
### Details:
We got reports of the Title + Details labels being displayed with a backgroundColor that does not match with the rest of the cell.

(My suspicion is) that, under unknown conditions, `backgroundColor.didSet` is not being called. In this PR we're implementing a simple safety measure, which involves explicitly setting the Label's Background Colors.

### To test:
1. Launch WPiOS and log into a dotcom account
2. Switch over the Notifications Tab, and verify that the Cell Background (always) matches the Label's Background.

Needs review: @koke 
Thanks in advance sir!

