### PR TITLE
Fix duplicates in Media Library

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -13,7 +13,6 @@
 @property (nonatomic, assign) WPMediaType filter;
 @property (nonatomic, assign) BOOL ascendingOrdering;
 @property (nonatomic, strong) NSMutableDictionary *observers;
-@property (nonatomic, strong) MediaService *mediaService;
 @property (nonatomic, strong) NSFetchedResultsController *fetchController;
 @property (nonatomic, strong) id groupObserverHandler;
 #pragma mark - change trackers
@@ -41,8 +40,6 @@
             [weakSelf notifyObserversWithIncrementalChanges:incrementalChanges removed:removed inserted:inserted changed:changed moved:moved];
         }];
         _blog = blog;
-        NSManagedObjectContext *backgroundContext = [[ContextManager sharedInstance] newDerivedContext];
-        _mediaService = [[MediaService alloc] initWithManagedObjectContext:backgroundContext];
         _observers = [NSMutableDictionary dictionary];
 
         _mediaRemoved = [[NSMutableIndexSet alloc] init];
@@ -121,7 +118,9 @@
         }
     }
     // try to sync from the server
-    [self.mediaService syncMediaLibraryForBlog:self.blog success:^{
+    NSManagedObjectContext *backgroundContext = [[ContextManager sharedInstance] newDerivedContext];
+    MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:backgroundContext];
+    [mediaService syncMediaLibraryForBlog:self.blog success:^{
         if (!localResultsAvailable && successBlock) {
             successBlock();
         }


### PR DESCRIPTION
I found a bug in the media picker data source, where it could end up with stale data and show duplicate media items.

* The data source was creating a media service on `init`, with a new background context. It would hang onto this and use it for every request to sync the library.
* If the user uploaded media through the app whilst a picker data source was alive (for example, in the Media Library section, behind the editor), the new media would be added on the main context and the background picker's context would _not_ be updated.
* When the background picker next performed a sync and attempt to merge changes from the server, it wouldn't see the new local media items, and recreate them.
* This would result in duplicate media items once the picker saved up to the main context.

To fix it, I've just taken the approach we use most other places with services, and just created one with a new context right before we use it.

To test:

* Open the Media Library section of the app for a site, and check that it's refreshed correctly.
* Tap Create Post, and insert an image into a post for the same site. Post the post to dismiss the editor.
* When the editor dismisses, you should already see the new image in the media library. Pull to refresh the media library, and no new items should be added. If you perform this step on `develop`, you should see a duplicate of the new item added.

Needs review: @SergioEstevao 