### PR TITLE
Media Library: Add basic upload functionality

### DIFF
--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -40,6 +40,11 @@
            thumbnailCallback:(nullable void (^)(NSURL * _Nonnull thumbnailURL))thumbnailCallback
                   completion:(nullable void (^)(Media * _Nullable media, NSError * _Nullable error))completion;
 
+- (void)createMediaWithPHAsset:(nonnull PHAsset *)asset
+               forBlogObjectID:(nonnull NSManagedObjectID *)blogObjectID
+             thumbnailCallback:(nullable void (^)(NSURL * _Nonnull thumbnailURL))thumbnailCallback
+                    completion:(nullable void (^)(Media * _Nullable media, NSError * _Nullable error))completion;
+
 /**
  Get the Media object from the server using the blog and the mediaID as the identifier of the resource
  

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -308,7 +308,7 @@
                 }
                 return;
             }
-            
+
             [self updateMedia:mediaInContext withRemoteMedia:media];
             mediaInContext.remoteStatus = MediaRemoteStatusSync;
             [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -87,7 +87,7 @@ class MediaItemViewController: UITableViewController {
         let presenter = MediaMetadataPresenter(media: media)
 
         var rows = [ImmuTableRow]()
-        rows.append(TextRow(title: NSLocalizedString("File name", comment: "Label for the file name for a media asset (image / video)"), value: media.filename ?? ""))
+        rows.append(TextRow(title: NSLocalizedString("File name", comment: "Label for the file name for a media asset (image / video)"), value: media.filename() ?? ""))
         rows.append(TextRow(title: NSLocalizedString("File type", comment: "Label for the file type (.JPG, .PNG, etc) for a media asset (image / video)"), value: presenter.fileType ?? ""))
 
         switch media.mediaType {
@@ -426,7 +426,7 @@ private struct MediaMetadataPresenter {
 
     /// A String containing the uppercased file extension of the asset (.JPG, .PNG, etc)
     var fileType: String? {
-        return (media.filename! as NSString).pathExtension.uppercased()
+        return (media.filename()! as NSString).pathExtension.uppercased()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -87,7 +87,7 @@ class MediaItemViewController: UITableViewController {
         let presenter = MediaMetadataPresenter(media: media)
 
         var rows = [ImmuTableRow]()
-        rows.append(TextRow(title: NSLocalizedString("File name", comment: "Label for the file name for a media asset (image / video)"), value: media.filename() ?? ""))
+        rows.append(TextRow(title: NSLocalizedString("File name", comment: "Label for the file name for a media asset (image / video)"), value: media.filename ?? ""))
         rows.append(TextRow(title: NSLocalizedString("File type", comment: "Label for the file type (.JPG, .PNG, etc) for a media asset (image / video)"), value: presenter.fileType ?? ""))
 
         switch media.mediaType {
@@ -426,7 +426,7 @@ private struct MediaMetadataPresenter {
 
     /// A String containing the uppercased file extension of the asset (.JPG, .PNG, etc)
     var fileType: String? {
-        return (media.filename() as NSString).pathExtension.uppercased()
+        return (media.filename! as NSString).pathExtension.uppercased()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.h
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.h
@@ -35,4 +35,7 @@
 /// The total asset account, ignoring the current search query if there is one.
 @property (nonatomic, readonly) NSInteger totalAssetCount;
 
+/// While paused, the data source won't perform any updates if data changes.
+@property (nonatomic) BOOL isPaused;
+
 @end

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -291,6 +291,7 @@
 {
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K == %@", @"blog", blog];
     NSPredicate *mediaPredicate = [NSPredicate predicateWithValue:YES];
+    NSPredicate *statusPredicate = [NSPredicate predicateWithFormat:@"%K == %@", @"remoteStatusNumber", @(MediaRemoteStatusSync)];
     switch (filter) {
         case WPMediaTypeImage: {
             mediaPredicate = [NSPredicate predicateWithFormat:@"mediaTypeString == %@", [Media stringFromMediaType:MediaTypeImage]];
@@ -305,7 +306,7 @@
             break;
     };
     return [NSCompoundPredicate andPredicateWithSubpredicates:
-            @[predicate, mediaPredicate]];
+            @[predicate, mediaPredicate, statusPredicate]];
 }
 
 - (NSPredicate *)predicateForSearchQuery

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -66,6 +66,22 @@
     return [self initWithBlog:nil];
 }
 
+- (void)setIsPaused:(BOOL)isPaused
+{
+    if (_isPaused != isPaused) {
+        _isPaused = isPaused;
+
+        if (isPaused) {
+            _fetchController.delegate = nil;
+            _fetchController = nil;
+        } else {
+            [self.fetchController performFetch:nil];
+        }
+    }
+
+    return;
+}
+
 #pragma mark - WPMediaCollectionDataSource
 
 -(NSInteger)numberOfAssets

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -287,7 +287,7 @@ class MediaLibraryViewController: UIViewController {
 
     // MARK: - Actions
 
-    @objc private func addTapped() {
+    @objc fileprivate func addTapped() {
         let picker = WPNavigationMediaPickerViewController()
         picker.dataSource = WPPHAssetDataSource()
         picker.showMostRecentFirst = true
@@ -398,7 +398,7 @@ class MediaLibraryViewController: UIViewController {
 
 extension MediaLibraryViewController: WPNoResultsViewDelegate {
     func didTap(_ noResultsView: WPNoResultsView!) {
-        // TODO: Present upload UI
+        addTapped()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -228,7 +228,9 @@ class MediaLibraryViewController: UIViewController {
     private func updateNavigationItemButtons(for assetCount: Int) {
         if isEditing {
             navigationItem.setLeftBarButton(UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(editTapped)), animated: true)
-            navigationItem.setRightBarButton(UIBarButtonItem(image: Gridicon.iconOfType(.trash), style: .plain, target: self, action: #selector(trashTapped)), animated: true)
+
+            let trashButton = UIBarButtonItem(image: Gridicon.iconOfType(.trash), style: .plain, target: self, action: #selector(trashTapped))
+            navigationItem.setRightBarButtonItems([trashButton], animated: true)
             navigationItem.rightBarButtonItem?.isEnabled = false
         } else {
             navigationItem.setLeftBarButton(nil, animated: true)

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -463,6 +463,11 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
 
         dismiss(animated: true, completion: nil)
 
+        guard ReachabilityUtils.isInternetReachable() else {
+            ReachabilityUtils.showAlertNoInternetConnection()
+            return
+        }
+
         guard let assets = assets as? [PHAsset],
             assets.count > 0 else { return }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -468,6 +468,7 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
 
         SVProgressHUD.setDefaultMaskType(.clear)
         SVProgressHUD.setMinimumDismissTimeInterval(1.0)
+        SVProgressHUD.show(withStatus: NSLocalizedString("Preparing...\nTap to cancel", comment: "Text displayed in HUD while preparing to upload media items."))
 
         mediaProgressCoordinator.track(numberOfItems: assets.count)
         for asset in assets {


### PR DESCRIPTION
This PR adds upload functionality to the media library.

![simulator screen shot 23 may 2017 23 26 36](https://cloud.githubusercontent.com/assets/4780/26379159/a02022da-400f-11e7-8e61-e6742e62ee1d.png)

You can upload media either by tapping the new + button in the nav bar, or by tapping the Upload Media button in the no results view if you have no media.

During upload, we're currently showing blocking progress using the HUD. I think we can ditch this fairly soon, but I wanted to go for the simplest implementation first. You can tap on the HUD to cancel any pending uploads.

To test:

* Attempt to upload media!
* Try from an empty library and a library with existing content.
* Try cancelling uploads
* Try from dotcom and self hosted sites
* Try both photos and videos
* Note that progress reporting seems to be more granular on a device vs in the simulator

Needs review: @kurzee 

@SergioEstevao I also made a couple of tweaks to the media library data source and the media service – would you mind double checking those?