### PR TITLE
Improve handling of return in tag picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -224,6 +224,16 @@ extension PostTagPickerViewController: UITextViewDelegate {
             textView.text = original.replacingCharacters(in: range, with: ", ")
             textViewDidChange(textView)
             return false
+        } else if text == "\n", // return
+            range.location == original.length, // at the end
+            !partialTag.isEmpty // with some (partial) tag typed
+        {
+            textView.text = original.replacingCharacters(in: range, with: ", ")
+            textViewDidChange(textView)
+            return false
+        } else if text == "\n" // return anywhere else
+            {
+                return false
         }
         return true
     }


### PR DESCRIPTION
If there's a partial tag, finish it and add a comma, otherwise ignore the return.

See #7100 

To test:

- Create a new post, go to options, tags
- Pressing return on the keyboard should be ignored
- Type some text
- Pressing return should add a comma and start a new tag
- Any extra return should not add any other commas

Needs review: @elibud 
