### PR TITLE
Media Library: Add upload analytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,7 @@ end
 def shared_with_stats_pods
   pod 'AFNetworking', '3.1.0'  
   pod 'NSObject-SafeExpectations', '0.0.2'
-  pod 'WordPressCom-Analytics-iOS', '0.1.27'
+  pod 'WordPressCom-Analytics-iOS', :git => 'https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS', :branch => 'media-library-upload-events'
 end
 
 def shared_test_pods

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,7 @@ end
 def shared_with_stats_pods
   pod 'AFNetworking', '3.1.0'  
   pod 'NSObject-SafeExpectations', '0.0.2'
-  pod 'WordPressCom-Analytics-iOS', :git => 'https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS', :branch => 'media-library-upload-events'
+  pod 'WordPressCom-Analytics-iOS', '0.1.28'
 end
 
 def shared_test_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -128,7 +128,7 @@ PODS:
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
-  - WordPressCom-Analytics-iOS (0.1.27)
+  - WordPressCom-Analytics-iOS (0.1.28)
   - WordPressComKit (0.0.6):
     - Alamofire (= 4.0.1)
   - WPMediaPicker (0.16)
@@ -162,7 +162,7 @@ DEPENDENCIES:
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
   - WordPress-Aztec-iOS (= 1.0.0-beta.1)
   - WordPress-iOS-Editor (= 1.9.1)
-  - WordPressCom-Analytics-iOS (from `https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS`, branch `media-library-upload-events`)
+  - WordPressCom-Analytics-iOS (= 0.1.28)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.16)
   - wpxmlrpc (= 0.8.3)
@@ -177,9 +177,6 @@ EXTERNAL SOURCES:
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPressCom-Analytics-iOS:
-    :branch: media-library-upload-events
-    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -194,9 +191,6 @@ CHECKOUT OPTIONS:
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
-  WordPressCom-Analytics-iOS:
-    :commit: 223e53a3a0dcdfebeb323819a556230a278170ad
-    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -230,11 +224,11 @@ SPEC CHECKSUMS:
   WordPress-AppbotX: b5abc0ba45e3da5827f84e9f346c963180f1b545
   WordPress-Aztec-iOS: b6ab82e2570fe20954a824f8622767cf9f58b156
   WordPress-iOS-Editor: 995f47fbf745f34fb392103ec97c0edb7f062f21
-  WordPressCom-Analytics-iOS: 43aedcbc4363896c5d40a4fe7f71bdeac8d6a98e
+  WordPressCom-Analytics-iOS: 65ec7ad809b791bdfb10a1872f6da2e32a84cb47
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 126e4dc5aca121cf63f0a4096cc3854572d42c19
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 0a3e26935e6c886def9a1e904663fddf6498c5e2
+PODFILE CHECKSUM: 2c1b85d4f59e0375f300168bac8ac487722ba22e
 
 COCOAPODS: 1.2.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -162,7 +162,7 @@ DEPENDENCIES:
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
   - WordPress-Aztec-iOS (= 1.0.0-beta.1)
   - WordPress-iOS-Editor (= 1.9.1)
-  - WordPressCom-Analytics-iOS (= 0.1.27)
+  - WordPressCom-Analytics-iOS (from `https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS`, branch `media-library-upload-events`)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.16)
   - wpxmlrpc (= 0.8.3)
@@ -177,6 +177,9 @@ EXTERNAL SOURCES:
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
+  WordPressCom-Analytics-iOS:
+    :branch: media-library-upload-events
+    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -191,6 +194,9 @@ CHECKOUT OPTIONS:
   WordPress-AppbotX:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
+  WordPressCom-Analytics-iOS:
+    :commit: 223e53a3a0dcdfebeb323819a556230a278170ad
+    :git: https://github.com/wordpress-mobile/WordPressCom-Analytics-iOS
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -229,6 +235,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 126e4dc5aca121cf63f0a4096cc3854572d42c19
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 6e094f4ce71695be2aadcf7402d141b4706f5e44
+PODFILE CHECKSUM: 0a3e26935e6c886def9a1e904663fddf6498c5e2
 
 COCOAPODS: 1.2.1

--- a/WordPress/Classes/Networking/MediaServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteREST.m
@@ -156,6 +156,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
             failure(error);
         }
     }];
+
     *progress = localProgress;
 }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -427,6 +427,24 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatMediaLibrarySharedItemLink:
             eventName = @"media_library_shared_item_link";
             break;
+        case WPAnalyticsStatMediaLibraryAddedPhoto:
+            eventName = @"media_library_photo_added";
+            break;
+        case WPAnalyticsStatMediaLibraryAddedVideo:
+            eventName = @"media_library_video_added";
+            break;
+        case WPAnalyticsStatMediaServiceUploadStarted:
+            eventName = @"media_service_upload_started";
+            break;
+        case WPAnalyticsStatMediaServiceUploadFailed:
+            eventName = @"media_service_upload_failed";
+            break;
+        case WPAnalyticsStatMediaServiceUploadSuccessful:
+            eventName = @"media_service_upload_successful";
+            break;
+        case WPAnalyticsStatMediaServiceUploadCanceled:
+            eventName = @"media_service_upload_canceled";
+            break;
         case WPAnalyticsStatMenusAccessed:
             eventName = @"menus_accessed";
             break;

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -561,6 +561,7 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
                                 var uploadProgress: Progress? = nil
                                 service.uploadMedia(media, progress: &uploadProgress, success: { [weak self] in
                                     self?.unpauseDataSource()
+                                    self?.trackUploadFor(media)
                                 }, failure: { error in
                                     if let mediaID = media.mediaID?.stringValue {
                                         self?.mediaProgressCoordinator.attach(error: error as NSError, toMediaID: mediaID)
@@ -575,6 +576,22 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
                                     self?.mediaProgressCoordinator.track(progress: progress, ofObject: media, withMediaID: mediaID)
                                 }
         })
+    }
+
+    fileprivate func trackUploadFor(_ media: Media) {
+        let properties = WPAppAnalytics.properties(for: media)
+
+        switch media.mediaType {
+        case .image:
+            WPAppAnalytics.track(.mediaLibraryAddedPhoto,
+                                 withProperties: properties,
+                                 with: blog)
+        case .video:
+            WPAppAnalytics.track(.mediaLibraryAddedVideo,
+                                 withProperties: properties,
+                                 with: blog)
+        default: break
+        }
     }
 
     fileprivate func unpauseDataSource() {


### PR DESCRIPTION
This PR adds analytics to the media library and media service to track uploads, in line with Android's events. Added events:

```
WPAnalyticsStatMediaLibraryAddedPhoto
WPAnalyticsStatMediaLibraryAddedVideo
WPAnalyticsStatMediaServiceUploadStarted
WPAnalyticsStatMediaServiceUploadFailed
WPAnalyticsStatMediaServiceUploadSuccessful
WPAnalyticsStatMediaServiceUploadCanceled
```

I've currently set this to "do not merge", until the analytics branch I'm targeting is merged and released. I'll update the Podfile for this PR branch when that happens.

To test:

* Perform uploads to check each event – photo and video uploads (successful), cancel uploads in progress, and make uploads fail, ensure that events are being sent / arriving as expected.

Needs review: @SergioEstevao 