### PR TITLE
Media Library: Hide upload buttons for users who don't have permission

### DIFF
--- a/WordPress/Classes/Models/Blog+Capabilities.swift
+++ b/WordPress/Classes/Models/Blog+Capabilities.swift
@@ -42,4 +42,10 @@ extension Blog {
     public func isPublishingPostsAllowed() -> Bool {
         return isUserCapableOf(.PublishPosts)
     }
+
+    /// Returns true if the current user is allowed to upload files to the Blog
+    ///
+    public func isUploadingFilesAllowed() -> Bool {
+        return isUserCapableOf(.UploadFiles)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -254,13 +254,20 @@ class MediaLibraryViewController: UIViewController {
         } else {
             navigationItem.setLeftBarButton(nil, animated: true)
 
-            let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addTapped))
+            var barButtonItems = [UIBarButtonItem]()
+
+            if blog.userCanUploadMedia {
+                let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addTapped))
+                barButtonItems.append(addButton)
+            }
 
             if blog.supports(.mediaDeletion) && assetCount > 0 {
                 let editButton = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(editTapped))
-                navigationItem.setRightBarButtonItems([addButton, editButton], animated: true)
+                barButtonItems.append(editButton)
+
+                navigationItem.setRightBarButtonItems(barButtonItems, animated: true)
             } else {
-                navigationItem.setRightBarButtonItems([addButton], animated: true)
+                navigationItem.setRightBarButtonItems(barButtonItems, animated: true)
             }
         }
     }
@@ -279,8 +286,11 @@ class MediaLibraryViewController: UIViewController {
             noResultsView?.buttonTitle = nil
         } else {
             noResultsView?.titleText = NSLocalizedString("You don't have any media.", comment: "Title displayed when the user doesn't have any media in their media library. Should match Calypso.")
-            noResultsView?.messageText = NSLocalizedString("Would you like to upload something?", comment: "Prompt displayed when the user has an empty media library. Should match Calypso.")
-            noResultsView?.buttonTitle = NSLocalizedString("Upload Media", comment: "Title for button displayed when the user has an empty media library")
+
+            if blog.userCanUploadMedia {
+                noResultsView?.messageText = NSLocalizedString("Would you like to upload something?", comment: "Prompt displayed when the user has an empty media library. Should match Calypso.")
+                noResultsView?.buttonTitle = NSLocalizedString("Upload Media", comment: "Title for button displayed when the user has an empty media library")
+            }
         }
 
         noResultsView?.sizeToFit()
@@ -645,5 +655,12 @@ extension MediaLibraryViewController: MediaProgressCoordinatorDelegate {
         }
 
         SVProgressHUD.showProgress(progress, status: NSLocalizedString("Uploading...\nTap to cancel", comment: "Text displayed in HUD while media items are being uploaded."))
+    }
+}
+
+fileprivate extension Blog {
+    var userCanUploadMedia: Bool {
+        // Self-hosted non-Jetpack blogs have no capabilities, so we'll just assume that users can post media
+        return capabilities != nil ? isUploadingFilesAllowed() : true
     }
 }


### PR DESCRIPTION
This PR removes the upload buttons in the Media Library for users who don't have permission to upload files to a site. Both the + button in the navigation bar and the upload text / button in the 'no results' view should be hidden.

![simulator screen shot 26 may 2017 17 50 35](https://cloud.githubusercontent.com/assets/4780/26504303/f64ea8ba-423b-11e7-86d6-6912a377a472.png)

To test:

* For a site where you have permission to upload files (Author role or higher) and an empty media library, visit the Media Library section in the app and ensure that you can see the + / Upload buttons indicated above.
* For a site where you don't have permission to upload files (Contributor role or lower) and an empty media library, visit the Media Library section in the app and ensure that the + / Upload buttons indicated above are *not* present.

Needs review: @elibud 