### PR TITLE
Set date_created_gmt on publishing

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -794,10 +794,8 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
     func publishPost(_ apost: AbstractPost) {
         WPAnalytics.track(.postListPublishAction, withProperties: propertiesForAnalytics())
 
+        apost.date_created_gmt = Date()
         apost.status = .publish
-        if let date = apost.dateCreated, date == (Date() as NSDate).laterDate(date) {
-            apost.dateCreated = Date()
-        }
         uploadPost(apost)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -682,6 +682,7 @@ extension AztecPostViewController {
             if self.postEditorStateContext.secondaryPublishButtonAction == .save {
                 self.post.status = .draft
             } else if self.postEditorStateContext.secondaryPublishButtonAction == .publish {
+                self.post.date_created_gmt = Date()
                 self.post.status = .publish
             }
 


### PR DESCRIPTION
**Fixes** #3516 

This is a solution to the last stated problem on #3516:

> draft being published with the original creation date instead of the current date

As part of https://github.com/wordpress-mobile/WordPress-iOS/pull/7129 the places where the word "Publish" is used have been cleaned up. 
On this PR I am setting the date_created_gmt when "Publish Now" is tapped on the Editor or "Publish" is tapped on the post list. This is not a perfect solution, since a previously published post that was changed to a draft and then published will not retain its original publish date. However, that seems like a much more unusual case, and the publish date can be modified via the post options. 

Note: we still have to clean up/rethink our publishing logic, but this is a step closer to a consistent behavior across the current Editor, Aztec and the Post List. I avoided using `publishImmediately` and `dateCreated` since those do some weird logic with the post status and dates that we seem to be trying to avoid in `AztecPostViewController`

**To test:**

1. Create three drafts and make a note of the current time. 
2. Wait a few minutes.
3. Publish one draft on the current editor (Edit -> Publish Now)
4. Publish another one on Aztec (Edit -> Publish Now)
5. Publish the last one with the Publish button on the Post List.
6. Check that they all recorded the current time as the Published date.

Needs review: @aerych 