### PR TITLE
Strip location from videos when option is selected.

### DIFF
--- a/WordPress/Classes/Extensions/NSURL+Exporters.swift
+++ b/WordPress/Classes/Extensions/NSURL+Exporters.swift
@@ -124,6 +124,9 @@ extension NSURL: ExportableAsset {
         exportSession.outputFileType = targetUTI
         exportSession.shouldOptimizeForNetworkUse = true
         exportSession.outputURL = url as URL
+        if stripGeoLocation {
+            exportSession.metadataItemFilter = AVMetadataItemFilter.forSharing()
+        }
         exportSession.exportAsynchronously(completionHandler: { () -> Void in
             guard exportSession.status == .completed else {
                 if let error = exportSession.error {

--- a/WordPress/Classes/Extensions/PHAsset+Exporters.swift
+++ b/WordPress/Classes/Extensions/PHAsset+Exporters.swift
@@ -248,6 +248,9 @@ extension PHAsset: ExportableAsset {
                     }
                     exportSession.outputFileType = targetUTI
                     exportSession.shouldOptimizeForNetworkUse = true
+                    if stripGeoLocation {
+                        exportSession.metadataItemFilter = AVMetadataItemFilter.forSharing()
+                    }
                     exportSession.outputURL = url
                     exportSession.exportAsynchronously(completionHandler: { () -> Void in
                         guard exportSession.status == .completed else {


### PR DESCRIPTION
Fixes #7257 

To test:
 - Record a video on the device with location info
 - Start the app
 - Make sure the option to Strip Geolocation is activated on : Me->App Settings-> Multimedia
 - Create a new post
 - Add to the post the video recorded on the first step
 - Publish the Post
 - Go to the web, download the video from the Media Library
 - Open the video in QuickTime Player
 - Press CMD+I
 - Check that no location information is present.

Needs review: @kurzee 