### PR TITLE
Improve tags replacement logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -210,6 +210,7 @@ extension PostTagPickerViewController: UITextViewDelegate {
             return false
         } else if
             range.length == 1 && text == "", // Deleting last character
+            range.location > 0, // Not at the beginning
             range.location + range.length == original.length, // At the end
             original.substring(with: NSRange(location: range.location - 1, length: 1)) == "," // Previous is a comma
         {

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -203,17 +203,19 @@ extension PostTagPickerViewController: UITextViewDelegate {
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         let original = textView.text as NSString
         if range.length == 0,
+            range.location == original.length,
             text == ",",
             partialTag.isEmpty {
             // Don't allow a second comma if the last tag is blank
             return false
         } else if
             range.length == 1 && text == "", // Deleting last character
-            range.location > 0, // Not at the beginning
+            range.location + range.length == original.length, // At the end
             original.substring(with: NSRange(location: range.location - 1, length: 1)) == "," // Previous is a comma
         {
             // Delete the comma as well
-            textView.text = original.substring(to: range.location - 1)
+            textView.text = original.substring(to: range.location - 1) + original.substring(from: range.location + range.length)
+            textView.selectedRange = NSRange(location: range.location - 1, length: 0)
             textViewDidChange(textView)
             return false
         } else if range.length == 0, // Inserting


### PR DESCRIPTION
This is a quick fix for #7254 in 7.7. I'd like to refactor this into something easier to follow, with unit tests, but I'll do that for develop later.

Only disallow typing a comma at the end of the string.
Only remove comma with space at the end of the string.

Fixes #7254 

To test:

- Type or add several tags.
- Move the cursor to one of the tags in the middle.
- Ensure you can delete tags, commas, and type new tags in the middle of the string.


Needs review: @elibud 
