### PR TITLE
Improve handling of local drafts

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -7,12 +7,12 @@ NS_ASSUME_NONNULL_BEGIN
 @class Media;
 @class Comment;
 
-typedef enum {
+typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
     AbstractPostRemoteStatusPushing,    // Uploading post
     AbstractPostRemoteStatusFailed,      // Upload failed
     AbstractPostRemoteStatusLocal,       // Only local version
     AbstractPostRemoteStatusSync,       // Post uploaded
-} AbstractPostRemoteStatus;
+};
 
 extern NSString * const PostStatusDraft;
 extern NSString * const PostStatusPending;

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -424,6 +424,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
 
 - (void)initializeDraft:(AbstractPost *)post {
     post.remoteStatus = AbstractPostRemoteStatusLocal;
+    post.dateModified = [NSDate date];
 }
 
 - (void)mergePosts:(NSArray <RemotePost *> *)remotePosts

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -373,7 +373,9 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
         navController.modalPresentationStyle = .fullScreen
 
-        present(navController, animated: true, completion: nil)
+        present(navController, animated: true, completion: { [weak self] in
+            self?.updateFilterWithPostStatus(.draft)
+        })
 
         WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "posts_view"], with: blog)
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -259,7 +259,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
         let page = pageAtIndexPath(indexPath)
 
-        if page.remoteStatus != AbstractPostRemoteStatusPushing && page.status != .trash {
+        if page.remoteStatus != .pushing && page.status != .trash {
             editPage(page)
         }
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -320,6 +320,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     override func createPost() {
         let navController: UINavigationController
 
+        let filterIndex = filterSettings.currentFilterIndex()
         let editorSettings = EditorSettings()
         if editorSettings.visualEditorEnabled {
 
@@ -337,6 +338,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
                         if let postStatus = postViewController.post.status {
                             self?.updateFilterWithPostStatus(postStatus)
                         }
+                    } else {
+                        self?.updateFilter(index: filterIndex)
                     }
                     navController.dismiss(animated: true, completion: nil)
                 }
@@ -351,6 +354,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
                         if let postStatus = postViewController?.post.status {
                             self?.updateFilterWithPostStatus(postStatus)
                         }
+                    } else {
+                        self?.updateFilter(index: filterIndex)
                     }
                     navController.dismiss(animated: true, completion: nil)
                 }
@@ -366,6 +371,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
                     if let postStatus = editPostViewController?.post.status {
                         self?.updateFilterWithPostStatus(postStatus)
                     }
+                } else {
+                    self?.updateFilter(index: filterIndex)
                 }
                 navController.dismiss(animated: true, completion: nil)
             }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -972,6 +972,11 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         WPAnalytics.track(.postListStatusFilterChanged, withProperties: propertiesForAnalytics())
     }
 
+    func updateFilter(index: Int) {
+        filterSettings.setCurrentFilterIndex(index)
+        refreshAndReload()
+    }
+
     func updateFilterTitle() {
         filterButton.setAttributedTitleForTitle(filterSettings.currentPostListFilter().title)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -66,7 +66,7 @@ import Foundation
     class func publishedFilter() -> PostListFilter {
         let filterType: Status = .published
         let statuses: [BasePost.Status] = [.publish, .publishPrivate]
-        let predicate = NSPredicate(format: "status IN %@", statuses.strings)
+        let predicate = NSPredicate(format: "status IN %@ AND remoteStatusNumber <> %d", statuses.strings, AbstractPostRemoteStatus.local.rawValue)
         let title = NSLocalizedString("Published", comment: "Title of the published filter. This filter shows a list of posts that the user has published.")
 
         return PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
@@ -76,7 +76,7 @@ import Foundation
         let filterType: Status = .draft
         let statuses: [BasePost.Status] = [.draft, .pending]
         let statusesExcluded: [BasePost.Status] = [.publish, .publishPrivate, .scheduled, .trash]
-        let predicate = NSPredicate(format: "NOT status IN %@", statusesExcluded.strings)
+        let predicate = NSPredicate(format: "NOT status IN %@ OR remoteStatusNumber = %d", statusesExcluded.strings, AbstractPostRemoteStatus.local.rawValue)
         let title = NSLocalizedString("Draft", comment: "Title of the draft filter.  This filter shows a list of draft posts.")
 
         return PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -322,7 +322,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         let post = postAtIndexPath(indexPath)
 
-        if post.remoteStatus == AbstractPostRemoteStatusPushing {
+        if post.remoteStatus == .pushing {
             // Don't allow editing while pushing changes
             return
         }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -383,12 +383,15 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     // MARK: - Post Actions
 
     override func createPost() {
+        let filterIndex = filterSettings.currentFilterIndex()
         let editor = EditPostViewController(blog: blog)
         editor.onClose = { [weak self] changesSaved in
             if changesSaved {
                 if let postStatus = editor.post?.status {
                     self?.updateFilterWithPostStatus(postStatus)
                 }
+            } else {
+                self?.updateFilter(index: filterIndex)
             }
         }
         editor.modalPresentationStyle = .fullScreen

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -392,7 +392,9 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             }
         }
         editor.modalPresentationStyle = .fullScreen
-        present(editor, animated: false, completion: nil)
+        present(editor, animated: false, completion: { [weak self] in
+            self?.updateFilterWithPostStatus(.draft)
+        })
         WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "posts_view"], with: blog)
     }
 


### PR DESCRIPTION
We have some reports of "lost posts" that aren't actually lost. What happens is when the app crashes/closes when editing a new (unsaved) post, it will appear to be gone on relaunch, but it'd actually be at the bottom of the published posts list. This is because the post had no date, so it's sorted that way. We can't set a date on drafts because then all kind of wrong things happen.

While this is not ideal, it's the best solution I could imagine without a major refactor of how we store and save posts in the app.

What this PR does:

- Put any post with `remoteStatus == .local` in the Drafts filter
- Populate `dateModified` as soon as a draft is created
- Switch to the Drafts filter when a new one is created. This way the list will show the right post list if the app closes/crashes.
- Switch back to the current filter if you cancel editing. If you are looking at Published, create a new post and immediately cancel, you should not be in drafts.

Fixes #7205 

To test:

- Create a new post
- Write a title and some content
- Force quit the app
- Verify that the post is apparent on relaunch

Needs review: @elibud 
