### PR TITLE
Menus: prevent crash and bad UI state when editing items.

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemsViewController.m
@@ -790,6 +790,9 @@ static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
 
 - (void)itemViewSelected:(MenuItemView *)itemView
 {
+    if (self.isEditingForItemViewInsertion) {
+        [self removeItemInsertionViews:YES];
+    }
     [self.delegate itemsViewController:self selectedItemForEditing:itemView.item];
 }
 


### PR DESCRIPTION
Fixes #7269 

This prevents the UI issue seen in #7269 as well as the crash that can occur from navigating within that UI state. Simply fixed by closing out the "insertion" views that show up when a menu item is toggled for adding items around it, before presenting the detail view.

To test:
1. Repeat the steps in the original issue.
2. Now, the items should close once you select the item.
3. When returning from the selected item's detail view, there shouldn't be any more of the "insertion" views.
4. Tap on any remaining items, make sure they don't crash when selected.

Needs review: @elibud can you take a quick peak at this one? 🔍🐞🔎 

Note: there are some constraint issues going on Menus, for another day's efforts.
