### PR TITLE
Fix site icon for Jetpack sites

### DIFF
--- a/WordPress/Classes/Categories/UIImageView+Gravatar.h
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.h
@@ -10,9 +10,4 @@
 - (void)setImageWithSiteIcon:(NSString *)siteIcon;
 - (void)setImageWithSiteIcon:(NSString *)siteIcon placeholderImage:(UIImage *)placeholderImage;
 
-#pragma mark - Blavatar Helpers
-
-- (NSURL *)blavatarURLForHost:(NSString *)host;
-- (NSURL *)blavatarURLForHost:(NSString *)host withSize:(NSInteger)size;
-
 @end

--- a/WordPress/Classes/Categories/UIImageView+Gravatar.m
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.m
@@ -36,7 +36,7 @@ NSString *const BlavatarDefault = @"blavatar-default";
     } else if ([self isBlavatarURL:siteIcon]) {
         return [self blavatarURLForBlavatarURL:siteIcon];
     } else {
-        return [self resizedURLForUrl:siteIcon];
+        return [self URLForResizedImageURL:siteIcon];
     }
 }
 
@@ -52,7 +52,7 @@ NSString *const BlavatarDefault = @"blavatar-default";
 
 #pragma mark - Photon Helpers
 
-- (nullable NSURL *)resizedURLForUrl:(NSString *)urlString
+- (nullable NSURL *)URLForResizedImageURL:(NSString *)urlString
 {
     CGSize size = CGSizeMake(BlavatarDefaultSize, BlavatarDefaultSize);
     NSURL *url = [NSURL URLWithString:urlString];


### PR DESCRIPTION
This stops relying on blavatar for self hosted sites and will use the blog.icon
passed through photon.

To avoid some problems with resizing, the site icon size is fixed at 40x40 for
download. We previously tried to calculate it based on the imageView size, but
for some reason it's 74x73.5 by the time the cell is being configured

Fixes #6802 

To test:

- Ensure site icons are visible for both wp.com and Jetpack sites


Needs review: @elibud 
