### PR TITLE
Aztec: Adjust text container inset so scrollbar appears at edge of view

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -444,8 +444,8 @@ class AztecPostViewController: UIViewController {
             ])
 
         NSLayoutConstraint.activate([
-            richTextView.leftAnchor.constraint(equalTo: view.leftAnchor, constant: defaultMargin),
-            richTextView.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -defaultMargin),
+            richTextView.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 0),
+            richTextView.rightAnchor.constraint(equalTo: view.rightAnchor, constant: 0),
             richTextView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0),
             richTextView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -defaultMargin)
             ])
@@ -458,8 +458,8 @@ class AztecPostViewController: UIViewController {
             ])
 
         NSLayoutConstraint.activate([
-            placeholderLabel.leftAnchor.constraint(equalTo: richTextView.leftAnchor, constant: Constants.placeholderPadding.left),
-            placeholderLabel.rightAnchor.constraint(equalTo: richTextView.rightAnchor, constant: Constants.placeholderPadding.right),
+            placeholderLabel.leftAnchor.constraint(equalTo: richTextView.leftAnchor, constant: Constants.placeholderPadding.left + defaultMargin),
+            placeholderLabel.rightAnchor.constraint(equalTo: richTextView.rightAnchor, constant: Constants.placeholderPadding.right + defaultMargin),
             textPlaceholderTopConstraint,
             placeholderLabel.bottomAnchor.constraint(lessThanOrEqualTo: richTextView.bottomAnchor, constant: Constants.placeholderPadding.bottom)
             ])
@@ -478,6 +478,9 @@ class AztecPostViewController: UIViewController {
         textView.keyboardDismissMode = .interactive
         textView.textColor = UIColor.darkText
         textView.translatesAutoresizingMaskIntoConstraints = false
+
+        textView.textContainerInset.left = Constants.defaultMargin
+        textView.textContainerInset.right = Constants.defaultMargin
     }
 
     func configureNavigationBar() {


### PR DESCRIPTION
It was bugging me that in Aztec, the scrollbar was inset from the edge of the view. I adjusted the insets so that it now sits against the edge. 

I'm totally unfamiliar with Aztec, so please let me know if I did this wrong (or it was intentional) or I broke something :)

![aztec-insets](https://cloud.githubusercontent.com/assets/4780/26722517/38bcd48c-4788-11e7-81a4-8456276d9b52.png)

To test:

* Write a post in Aztec that's long enough to enable scrolling.
* Check the scroll indicators appear correctly.

Needs review: @jleandroperez 