### PR TITLE
Improve upload progress report

### DIFF
--- a/WordPress/Classes/Networking/MediaServiceRemoteREST.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteREST.m
@@ -149,8 +149,6 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
         }
         
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
-        localProgress.totalUnitCount = 0;
-        localProgress.completedUnitCount = 0;
         DDLogDebug(@"Error uploading file: %@", [error localizedDescription]);
         if (failure) {
             failure(error);

--- a/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
+++ b/WordPress/Classes/Networking/MediaServiceRemoteXMLRPC.m
@@ -128,8 +128,6 @@
                                                    success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
           NSDictionary *response = (NSDictionary *)responseObject;
           if (![response isKindOfClass:[NSDictionary class]]) {
-              localProgress.completedUnitCount=0;
-              localProgress.totalUnitCount=0;
               NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorBadServerResponse userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"The server returned an empty response. This usually means you need to increase the memory limit for your site.", @"")}];
               if (failure) {
                   failure(error);
@@ -141,9 +139,7 @@
                   success(remoteMedia);
               }
           }
-      } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
-          localProgress.completedUnitCount=0;
-          localProgress.totalUnitCount=0;          
+      } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {          
           if (failure) {
               failure(error);
           }

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -2404,9 +2404,7 @@ class MediaProgressCoordinator: NSObject {
     func refreshMediaProgress() {
         var value = Float(0)
         if let progress = mediaUploadingProgress {
-            // Sergio Estevao: make sure the progress value reflects the number of upload that actually finished 100%
-            let fractionOfUploadsCompleted = Float(Float((progress.completedUnitCount + 1))/Float(progress.totalUnitCount))
-            value = min(fractionOfUploadsCompleted, Float(progress.fractionCompleted))
+            value = Float(progress.fractionCompleted)
         }
 
         delegate?.mediaProgressCoordinator(self, progressDidChange: value)

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -2404,7 +2404,7 @@ class MediaProgressCoordinator: NSObject {
     func refreshMediaProgress() {
         var value = Float(0)
         if let progress = mediaUploadingProgress {
-            // make sure the progress value reflects the number of upload finished 100%
+            // Sergio Estevao: make sure the progress value reflects the number of upload that actually finished 100%
             let fractionOfUploadsCompleted = Float(Float((progress.completedUnitCount + 1))/Float(progress.totalUnitCount))
             value = min(fractionOfUploadsCompleted, Float(progress.fractionCompleted))
         }

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1609,7 +1609,7 @@ EditImageDetailsViewControllerDelegate
     float fractionOfUploadsCompleted = (float)(self.mediaGlobalProgress.completedUnitCount+1)/(float)self.mediaGlobalProgress.totalUnitCount;
     self.mediaProgressView.progress = MIN(fractionOfUploadsCompleted ,self.mediaGlobalProgress.fractionCompleted);
     for(NSProgress * progress in [self.mediaInProgress allValues]){
-        if (progress.totalUnitCount != 0 && !progress.cancelled){
+        if (progress.userInfo[WPProgressMediaError] == nil && !progress.cancelled){
             [self.editorView setProgress:progress.fractionCompleted onImage:progress.userInfo[WPProgressMediaID]];
             [self.editorView setProgress:progress.fractionCompleted onVideo:progress.userInfo[WPProgressMediaID]];
         }
@@ -1619,7 +1619,7 @@ EditImageDetailsViewControllerDelegate
 - (BOOL)hasFailedMedia
 {
     for(NSProgress * progress in self.mediaInProgress.allValues) {
-        if (progress.totalUnitCount == 0){
+        if (progress.userInfo[WPProgressMediaError] != nil){
             return YES;
         }
     }
@@ -1629,7 +1629,7 @@ EditImageDetailsViewControllerDelegate
 - (BOOL)isMediaUploading
 {
     for(NSProgress *progress in self.mediaInProgress.allValues) {
-        if (!progress.isCancelled && progress.totalUnitCount != 0){
+        if (!progress.isCancelled && progress.fractionCompleted != 1){
             return YES;
         }
     }
@@ -1663,7 +1663,7 @@ EditImageDetailsViewControllerDelegate
 {
     NSMutableArray * keys = [NSMutableArray array];
     [self.mediaInProgress enumerateKeysAndObjectsUsingBlock:^(NSString * key, NSProgress * progress, BOOL *stop) {
-        if (progress.totalUnitCount == 0){
+        if (progress.userInfo[WPProgressMediaError]){
             [self.editorView removeImage:key];
             [self.editorView removeVideo:key];
             [keys addObject:key];

--- a/WordPress/WordPressApi/WordPressComRestApi.swift
+++ b/WordPress/WordPressApi/WordPressComRestApi.swift
@@ -234,11 +234,13 @@ open class WordPressComRestApi: NSObject {
         }
         let progress = Progress(totalUnitCount: 1)
         let progressUpdater = {(taskProgress: Progress) in
-            progress.totalUnitCount = taskProgress.totalUnitCount+1
+            // Sergio Estevao: Add an extra 1 unit to the progress to take in account the upload response and not only the uploading of data
+            progress.totalUnitCount = taskProgress.totalUnitCount + 1
             progress.completedUnitCount = taskProgress.completedUnitCount
         }
         let uploadSessionManager = self.uploadSessionManager
         let task = uploadSessionManager.uploadTask(withStreamedRequest: request as URLRequest, progress: progressUpdater) { (response, result, error) in
+            progress.completedUnitCount = progress.totalUnitCount
             // if this manager was created just for uploading let's invalidated it after.
             if uploadSessionManager != self.sessionManager {
                 uploadSessionManager.invalidateSessionCancelingTasks(false)
@@ -246,7 +248,6 @@ open class WordPressComRestApi: NSObject {
             if let error = error {
                 failure(error as NSError, response as? HTTPURLResponse)
             } else {
-                progress.completedUnitCount = progress.totalUnitCount
                 guard let responseObject = result else {
                     failure(WordPressComRestApiError.unknown as NSError , response as? HTTPURLResponse)
                     return

--- a/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
+++ b/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
@@ -102,7 +102,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
                 return
             }
         })
-        progress = createProgresForTask(task)
+        progress = createProgressForTask(task)
         task.resume()
         return progress
     }
@@ -154,7 +154,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
         })
         task.resume()
 
-        progress = createProgresForTask(task)
+        progress = createProgressForTask(task)
         return progress
     }
 
@@ -193,7 +193,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
     // MARK: - Progress reporting
 
-    fileprivate func createProgresForTask(_ task: URLSessionTask) -> Progress {
+    fileprivate func createProgressForTask(_ task: URLSessionTask) -> Progress {
         // Progress report
         let progress = Progress(parent: Progress.current(), userInfo: nil)
         progress.totalUnitCount = 1


### PR DESCRIPTION
This PR changes the way progress report is done in two ways:

 - Now failed uploads report their progress has completed and don't go back to zero total Units and completed Units
 - XML-RPC calls have an extra 1 unit in progress to account for processing time in server, so the call only report 100% progress when an answer is given from the server and not when the upload is done.

To test:
 - Start the app
 - Using the post editor, insert media and see if all progress report is done correctly
 - Try scenarios where media fails to upload (go offline, exceed limits of files)
 - Test on all site scenarios ( WP.com, self-hosted, self-hosted Jetpack)
 - Test also on the media library of the site.

Needs review: @frosty 
