### PR TITLE
Media Library: Upload progress tweaks

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -685,14 +685,17 @@ extension MediaLibraryViewController: MediaProgressCoordinatorDelegate {
     func mediaProgressCoordinatorDidFinishUpload(_ mediaProgressCoordinator: MediaProgressCoordinator) {
         guard !mediaProgressCoordinator.hasFailedMedia else {
             SVProgressHUD.showError(withStatus: NSLocalizedString("Upload failed", comment: "Text displayed in a HUD when media items have failed to upload."))
+            mediaProgressCoordinator.stopTrackingOfAllUploads()
             return
         }
 
         guard let progress = mediaProgressCoordinator.mediaUploadingProgress,
             !progress.isCancelled else {
+            mediaProgressCoordinator.stopTrackingOfAllUploads()
             return
         }
 
+        mediaProgressCoordinator.stopTrackingOfAllUploads()
         SVProgressHUD.showSuccess(withStatus: NSLocalizedString("Uploaded!", comment: "Text displayed in a HUD when media items have been uploaded successfully."))
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -2338,6 +2338,7 @@ class MediaProgressCoordinator: NSObject {
         if let mediaUploadingProgress = self.mediaUploadingProgress, !isRunning {
             mediaUploadingProgress.removeObserver(self, forKeyPath: #keyPath(Progress.fractionCompleted))
             self.mediaUploadingProgress = nil
+            self.mediaUploading = [String: Progress]()
         }
 
         if self.mediaUploadingProgress == nil {

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -2338,7 +2338,6 @@ class MediaProgressCoordinator: NSObject {
         if let mediaUploadingProgress = self.mediaUploadingProgress, !isRunning {
             mediaUploadingProgress.removeObserver(self, forKeyPath: #keyPath(Progress.fractionCompleted))
             self.mediaUploadingProgress = nil
-            self.mediaUploading.removeAll()
         }
 
         if self.mediaUploadingProgress == nil {
@@ -2464,6 +2463,14 @@ class MediaProgressCoordinator: NSObject {
         }
 
         mediaUploadingProgress?.cancel()
+    }
+
+    func stopTrackingOfAllUploads() {
+        if let mediaUploadingProgress = self.mediaUploadingProgress, !isRunning {
+            mediaUploadingProgress.removeObserver(self, forKeyPath: #keyPath(Progress.fractionCompleted))
+            self.mediaUploadingProgress = nil
+        }
+        mediaUploading.removeAll()
     }
 
     var failedMediaIDs: [String] {

--- a/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AztecPostViewController.swift
@@ -2338,7 +2338,7 @@ class MediaProgressCoordinator: NSObject {
         if let mediaUploadingProgress = self.mediaUploadingProgress, !isRunning {
             mediaUploadingProgress.removeObserver(self, forKeyPath: #keyPath(Progress.fractionCompleted))
             self.mediaUploadingProgress = nil
-            self.mediaUploading = [String: Progress]()
+            self.mediaUploading.removeAll()
         }
 
         if self.mediaUploadingProgress == nil {

--- a/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
+++ b/WordPress/WordPressApi/WordPressOrgXMLRPCApi.swift
@@ -138,9 +138,6 @@ open class WordPressOrgXMLRPCApi: NSObject {
         let session = uploadSession
         var progress: Progress?
         let task = session.uploadTask(with: request, fromFile: fileURL, completionHandler: { (data, urlResponse, error) in
-            if let uploadProgress = progress {
-                uploadProgress.completedUnitCount = uploadProgress.totalUnitCount
-            }
             if session != self.session {
                 session.finishTasksAndInvalidate()
             }
@@ -150,6 +147,9 @@ open class WordPressOrgXMLRPCApi: NSObject {
                 success(responseObject, urlResponse as? HTTPURLResponse)
             } catch let error as NSError {
                 failure(error, urlResponse as? HTTPURLResponse)
+            }
+            if let uploadProgress = progress {
+                uploadProgress.completedUnitCount = uploadProgress.totalUnitCount
             }
         })
         task.resume()


### PR DESCRIPTION
A couple of tweaks to fix some issues with upload progress reporting in the media library. Mainly switching to use asset identifiers instead of media IDs (which were all 0, as they were new media).

To test:

* Upload items in the media library, ensure that progress reporting works as expected. 
* In particularly, check cases when items fail.
* Check on self-hosted as well as wpcom.

Needs review: @SergioEstevao 