### PR TITLE
Remove Media Library feature flag

### DIFF
--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -2,7 +2,6 @@
 /// different builds.
 @objc
 enum FeatureFlag: Int {
-    case mediaLibrary
     case nativeEditor
     case exampleFeature
     case newLogin
@@ -12,8 +11,6 @@ enum FeatureFlag: Int {
         switch self {
         case .exampleFeature:
             return true
-        case .mediaLibrary:
-            return build(.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting)
         case .newLogin:
             return build(.localDeveloper, .a8cBranchTest)
         case .nativeEditor:

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -415,13 +415,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                      [weakSelf showPageList];
                                                  }]];
 
-    if ([Feature enabled:FeatureFlagMediaLibrary]) {
-        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Media", @"Noun. Title. Links to the blog's Media library.")
-                                                        image:[Gridicon iconOfType:GridiconTypeImage]
-                                                     callback:^{
-                                                         [weakSelf showMediaLibrary];
-                                                     }]];
-    }
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Media", @"Noun. Title. Links to the blog's Media library.")
+                                                    image:[Gridicon iconOfType:GridiconTypeImage]
+                                                 callback:^{
+                                                     [weakSelf showMediaLibrary];
+                                                 }]];
 
     BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Comments", @"Noun. Title. Links to the blog's Comments screen.")
                                                           image:[Gridicon iconOfType:GridiconTypeComment]


### PR DESCRIPTION
This PR removes the feature flag for the media library! The only thing it was used to control was whether the Media item showed in the Blog Detail list.

To test:

* Check the code looks okay and builds
* Perhaps try a release build and check the Media item shows?

Needs review: @elibud 