### PR TITLE
Login: Smooths out the epilogue animation.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/EpilogueSegue.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueSegue.swift
@@ -22,7 +22,12 @@ extension EpilogueAnimation where Self: UIStoryboardSegue {
         containerView.addSubview(destinationVC.view)
         containerView.addSubview(sourceVC.view)
 
-        UIView.animate(withDuration: duration, delay: 0, options:UIViewAnimationOptions.curveEaseInOut, animations: {
+        // Force hide the navigation bar and perform a layout pass so frames
+        // are correct before starting the animation.
+        sourceVC.navigationController?.setNavigationBarHidden(true, animated: false)
+        sourceVC.navigationController?.view.layoutIfNeeded()
+
+        UIView.animate(withDuration: duration, delay: 0, options:.curveEaseInOut, animations: {
             sourceVC.view.center.y += sourceVC.view.frame.size.height
         }) { (finished) in
             completion()

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueSegue.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueSegue.swift
@@ -5,7 +5,7 @@ protocol EpilogueAnimation {
 
 /// Custom animation to allow presented views to appear to come from behind the presenter
 extension EpilogueAnimation where Self: UIStoryboardSegue {
-    func performEpilogue(completion: @escaping () -> ()) {
+    func performEpilogue(completion: @escaping () -> Void) {
         guard let containerView = source.view.superview else {
             return
         }
@@ -13,7 +13,11 @@ extension EpilogueAnimation where Self: UIStoryboardSegue {
         let destinationVC = destination
         let duration = 0.35
 
-        destinationVC.view.frame = sourceVC.view.frame
+        var frame = sourceVC.view.frame
+        // Adjust for the height of the status bar which seems to be ignored during the transition.
+        frame.origin.y += 20
+        frame.size.height -= 20
+        destinationVC.view.frame = frame
 
         containerView.addSubview(destinationVC.view)
         containerView.addSubview(sourceVC.view)
@@ -33,7 +37,8 @@ class EpilogueSegue: UIStoryboardSegue, EpilogueAnimation {
     override func perform() {
         performEpilogue() {
             self.destination.view.removeFromSuperview()
-            self.source.present(self.destination, animated: false) {}
+            let navController = self.source.navigationController
+            navController?.setViewControllers([self.destination], animated: false)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueSegue.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueSegue.swift
@@ -15,8 +15,9 @@ extension EpilogueAnimation where Self: UIStoryboardSegue {
 
         var frame = sourceVC.view.frame
         // Adjust for the height of the status bar which seems to be ignored during the transition.
-        frame.origin.y += 20
-        frame.size.height -= 20
+        let statusBarHeight = UIApplication.shared.statusBarFrame.height
+        frame.origin.y += statusBarHeight
+        frame.size.height -= statusBarHeight
         destinationVC.view.frame = frame
 
         containerView.addSubview(destinationVC.view)

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -74,7 +74,7 @@
         <scene sceneID="1BJ-CW-C88">
             <objects>
                 <navigationController id="Ck1-vY-O11" customClass="LoginNavigationController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="mKb-UO-KoA">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="mKb-UO-KoA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1051,7 +1051,7 @@
         <!--Login Epilogue View Controller-->
         <scene sceneID="mq7-wS-hIR">
             <objects>
-                <viewController storyboardIdentifier="epilogue" extendedLayoutIncludesOpaqueBars="YES" id="Mwz-tq-5A8" customClass="LoginEpilogueViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="epilogue" automaticallyAdjustsScrollViewInsets="NO" id="Mwz-tq-5A8" customClass="LoginEpilogueViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Vw0-RX-ERM"/>
                         <viewControllerLayoutGuide type="bottom" id="pCc-dg-bxb"/>
@@ -1083,7 +1083,7 @@
                                             <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                         </state>
                                         <connections>
-                                            <segue destination="SWX-Rp-5H1" kind="unwind" identifier="unwindOutOfLogin" customClass="EpilogueUnwindSegue" customModule="WordPress" customModuleProvider="target" unwindAction="unwindOutWithSegue:" id="oPV-La-BGA"/>
+                                            <action selector="dismissEpilogue" destination="Mwz-tq-5A8" eventType="touchUpInside" id="YjA-Wy-vFv"/>
                                         </connections>
                                     </button>
                                     <imageView hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="darkgrey-shadow" translatesAutoresizingMaskIntoConstraints="NO" id="cmz-zv-QBQ">
@@ -1116,6 +1116,7 @@
                             <constraint firstItem="Onf-X6-J5w" firstAttribute="top" secondItem="Vw0-RX-ERM" secondAttribute="bottom" id="zHX-lw-7Nx"/>
                         </constraints>
                     </view>
+                    <extendedEdge key="edgesForExtendedLayout"/>
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
                     <connections>
                         <outlet property="buttonPanel" destination="juu-ng-v2N" id="WUF-SL-5Nq"/>
@@ -1123,7 +1124,6 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="S0K-oR-yFr" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <exit id="SWX-Rp-5H1" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
             <point key="canvasLocation" x="4117.6000000000004" y="927.88605697151434"/>
         </scene>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -24,6 +24,11 @@ class LoginEpilogueViewController: UIViewController {
         }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.prepare(for: segue, sender: sender)
         if let vc = segue.destination as? LoginEpilogueTableView {
@@ -31,9 +36,8 @@ class LoginEpilogueViewController: UIViewController {
         }
     }
 
-    // @IBAction to allow to set the selector for target in the storyboard
-    @IBAction func unwindOut(segue: UIStoryboardSegue) {
-        dismissBlock?(false)
+    @IBAction func dismissEpilogue() {
+        navigationController?.dismiss(animated: true, completion: nil)
     }
 
     override func viewDidLayoutSubviews() {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -37,6 +37,7 @@ class LoginEpilogueViewController: UIViewController {
     }
 
     @IBAction func dismissEpilogue() {
+        dismissBlock?(false)
         navigationController?.dismiss(animated: true, completion: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -740,11 +740,4 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
 }
 
-// this method allows this VC to be a valid unwind destination for this selector
-- (IBAction)unwindOutWithSegue:(UIStoryboardSegue *)segue
-{
-    // unwind segues don't seem to always clean themselves up 😫
-    [self dismissViewControllerAnimated:NO completion:nil];
-}
-
 @end


### PR DESCRIPTION
This PR tweaks the way the login epilogue transitions into view and how it is dismissed from view. 

![epilogue-animation](https://cloud.githubusercontent.com/assets/1435271/26745984/ded3c8ba-47b2-11e7-95a5-fe2490356531.gif)

To test:
Log in via the new Login flow and observe the epilogue screen as it is presented and dismissed on both an iPhone and iPad.  Confirm the animation is smooth, there is no visual artifacts or jumps, and the previous login view controller is never visible when dismissing.

Needs review: @nheagy 
