### PR TITLE
Quick hack to force Aztec on for every internal user upon initial launch

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -116,6 +116,23 @@ int ddLogLevel = DDLogLevelInfo;
 
     self.shouldRestoreApplicationState = !isFixingAuthTokenIssue;
 
+    // Temporary force of Aztec to "on" for all internal users
+#ifdef INTERNAL_BUILD
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *defaultsKey = @"AztecInternalForceOnVersion";
+    NSString *lastBuildAztecForcedOn = [defaults stringForKey:defaultsKey];
+    NSString *currentVersion = [[NSBundle mainBundle] bundleVersion];
+    if (![currentVersion isEqualToString:lastBuildAztecForcedOn]) {
+        [defaults setObject:currentVersion forKey:defaultsKey];
+        [defaults synchronize];
+
+        EditorSettings *settings = [EditorSettings new];
+        [settings setNativeEditorAvailable:TRUE];
+        [settings setVisualEditorEnabled:TRUE];
+        [settings setNativeEditorEnabled:TRUE];
+    }
+#endif
+
     return YES;
 }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -119,7 +119,7 @@ int ddLogLevel = DDLogLevelInfo;
     // Temporary force of Aztec to "on" for all internal users
 #ifdef INTERNAL_BUILD
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSString *defaultsKey = @"AztecInternalForceOnVersion";
+    NSString *defaultsKey = @"AztecInternalForcedOnVersion";
     NSString *lastBuildAztecForcedOn = [defaults stringForKey:defaultsKey];
     NSString *currentVersion = [[NSBundle mainBundle] bundleVersion];
     if (![currentVersion isEqualToString:lastBuildAztecForcedOn]) {


### PR DESCRIPTION
Closes #7291

Not my most proud code but it's the least amount of change in the rest of the app.

Note: We'll remove this code most likely before the end of the code freeze or after 7.9.

To test:
1. Comment out the ifdef & endif to test for debug builds.
2. Launch the app with Aztec disabled.
3. Verify Aztec gets enabled.
4. Turn off Aztec.
5. Relaunch and verify Aztec is not re-enabled.
6. Change the main target version & build number.
7. Relaunch and verify Aztec is re-enabled.

Needs review: @elibud 
