### PR TITLE
Adds back an errant analytics key. Will remove it in a future update.

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1019,6 +1019,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
 
             // to be implemented
+        case WPAnalyticsStatLoginEmailRetryViewed:
         case WPAnalyticsStatDefaultAccountChanged:
         case WPAnalyticsStatNoStat:
         case WPAnalyticsStatPerformedCoreDataMigrationFixFor45:


### PR DESCRIPTION
`WPAnalyticsStatLoginEmailRetryViewed` was slated to be removed by overlooked when updating the analytics pod.  This pr adds the key back for now to silence a compiler warning and fix a busted test. 

Needs review: @astralbodies 
