### PR TITLE
Update blog support method for CommentLikes

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -441,13 +441,13 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
         case BlogFeaturePeople:
             return [self supportsRestApi] && self.isListingUsersAllowed;
         case BlogFeatureWPComRESTAPI:
+        case BlogFeatureCommentLikes:
         case BlogFeatureStats:
             return [self supportsRestApi];
         case BlogFeatureSharing:
             return [self supportsSharing];
         case BlogFeatureOAuth2Login:
             return [self isHostedAtWPcom];
-        case BlogFeatureCommentLikes:
         case BlogFeatureReblog:
         case BlogFeatureMentions:
         case BlogFeaturePlans:


### PR DESCRIPTION
Fixes #7006 

This adds consistency, since currently comments for Jetpack sites can be liked from notifications. On this PR we add the functionality to like them from Site->Comments by updating how whether a blog supports or not Likes is determined.

To test:
 1. Select a self-hosted site without Jetpack, navigate to Comments, select a comment, check that Like is not available.
 2. Select a self-hosted site with Jetpack, navigate to Comments, select a comment, check that Like is available.

Needs review: @aerych 
