### PR TITLE
Sharing: Broken publicize reconnection fixing can not be cancelled

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -14,6 +14,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 @property (nonatomic, strong, readonly) Blog *blog;
 @property (nonatomic, strong) PublicizeConnection *publicizeConnection;
+@property (nonatomic, strong) SharingAuthorizationHelper *helper;
 @end
 
 @implementation SharingDetailViewController
@@ -27,6 +28,14 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     if (self) {
         _blog = blog;
         _publicizeConnection = connection;
+        SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+        PublicizeService *publicizeService = [sharingService findPublicizeServiceNamed:connection.service];
+        if (publicizeService) {
+            self.helper = [[SharingAuthorizationHelper alloc] initWithViewController:self
+                                                                                blog:self.blog
+                                                                    publicizeService:publicizeService];
+            self.helper.delegate = self;
+        }
     }
     return self;
 }
@@ -171,8 +180,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
 
     __weak __typeof(self) weakSelf = self;
-    SharingAuthorizationHelper *helper = [self helper];
-    if (helper == nil) {
+    if (self.helper == nil) {
         [sharingService syncPublicizeServicesForBlog:self.blog
                                              success:^{
                                                  [[weakSelf helper] reconnectPublicizeConnection:weakSelf.publicizeConnection];
@@ -181,22 +189,8 @@ static NSString *const CellIdentifier = @"CellIdentifier";
                                                  [WPError showNetworkingAlertWithError:error];
                                              }];
     } else {
-        [helper reconnectPublicizeConnection:weakSelf.publicizeConnection];
+        [self.helper reconnectPublicizeConnection:weakSelf.publicizeConnection];
     }
-}
-
-- (SharingAuthorizationHelper *)helper
-{
-    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
-    PublicizeService *publicizeService = [sharingService findPublicizeServiceNamed:self.publicizeConnection.service];
-    if (!publicizeService) {
-        return nil;
-    }
-    SharingAuthorizationHelper *helper = [[SharingAuthorizationHelper alloc] initWithViewController:self
-                                                                                               blog:self.blog
-                                                                                   publicizeService:publicizeService];
-    helper.delegate = self;
-    return helper;
 }
 
 - (void)disconnectPublicizeConnection

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -19,6 +19,11 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 @implementation SharingDetailViewController
 
+- (void)dealloc
+{
+    self.helper.delegate = nil;
+}
+
 - (instancetype)initWithBlog:(Blog *)blog
          publicizeConnection:(PublicizeConnection *)connection
 {


### PR DESCRIPTION
**Fixes** #6959 

**To test:**

Start on the develop branch: 
1. Connect a sharing service to one of your sites.
2. Break the connection
3. Try to repair it, once the WebView is opened, try to close it form the cross on the top left.
4. Enjoy the app hanging.
5. Check-out this branch and repeat.
6. See that it works, pat yourself in the back for such great testing abilities.

Needs review: @koke 
