### PR TITLE
Avoid creating new media item when unnecessary

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -941,6 +941,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     settings.tagline = remoteSettings.tagline;
     settings.privacy = remoteSettings.privacy ?: settings.privacy;
     settings.languageID = remoteSettings.languageID ?: settings.languageID;
+    settings.iconMediaID = remoteSettings.iconMediaID;
     
     // Writing
     settings.defaultCategoryID = remoteSettings.defaultCategoryID ?: settings.defaultCategoryID;

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -644,13 +644,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     self.siteIconPickerPresenter = [[SiteIconPickerPresenter alloc]initWithBlog:self.blog];
     __weak __typeof(self) weakSelf = self;
     self.siteIconPickerPresenter.onCompletion = ^(Media *media, NSError *error) {
-        if (media == nil && error == nil) {
+        if (error) {
+            [weakSelf showErrorForSiteIconUpdate];
+        } else if (media) {
+            [weakSelf updateBlogIconWithMedia:media];
+        } else {
             // If no media and no error the picker was cancelled
             [weakSelf dismissViewControllerAnimated:YES completion:nil];
-        } else if (media && error == nil) {
-            [weakSelf updateBlogIconWithMedia:media];
-        } else if (error != nil) {
-            [weakSelf showErrorForSiteIconUpdate];
         }
         weakSelf.siteIconPickerPresenter = nil;
     };

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -643,9 +643,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     self.siteIconPickerPresenter = [[SiteIconPickerPresenter alloc]initWithBlog:self.blog];
     __weak __typeof(self) weakSelf = self;
-    self.siteIconPickerPresenter.onCompletion = ^(UIImage * image) {
+    self.siteIconPickerPresenter.onCompletion = ^(UIImage *image, Media *media) {
         if (image) {
             [weakSelf siteIconImageSelected:image];
+        } else if (media) {
+            [weakSelf updateBlogIconWithMedia:media];
         }
         [weakSelf dismissViewControllerAnimated:YES completion:nil];
         weakSelf.siteIconPickerPresenter = nil;
@@ -676,12 +678,17 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
          [mediaService uploadMedia:media
                           progress:&progress
                            success:^{
-              self.blog.settings.iconMediaID = media.mediaID;
-              [self updateBlogSettingsAndRefreshIcon];
+              [self updateBlogIconWithMedia:media];
           } failure:^(NSError * _Nonnull error) {
               [self showErrorForSiteIconUpdate];
           }];
      }];
+}
+
+- (void)updateBlogIconWithMedia:(Media *)media
+{
+    self.blog.settings.iconMediaID = media.mediaID;
+    [self updateBlogSettingsAndRefreshIcon];
 }
 
 - (void)updateBlogSettingsAndRefreshIcon

--- a/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
@@ -11,8 +11,7 @@ class SiteIconPickerPresenter: NSObject {
     /// MARK: - Public Properties
 
     var blog: Blog
-    /// Will be invoked with a newly created image OR an existing media item to set
-    /// as the site icon
+    /// Will be invoked with a Media item from the user library or an error
     var onCompletion: ((Media?, Error?) -> Void)?
     var onIconSelection: (() -> Void)?
     var originalMedia: Media?

--- a/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
@@ -97,7 +97,7 @@ class GravatarPickerViewController: UIViewController, WPMediaPickerViewControlle
     //
     fileprivate func newImageCropViewController(_ rawGravatar: UIImage) -> ImageCropViewController {
         let imageCropViewController = ImageCropViewController(image: rawGravatar)
-        imageCropViewController.onCompletion = { [weak self] image in
+        imageCropViewController.onCompletion = { [weak self] image, _ in
             self?.onCompletion?(image)
             self?.dismiss(animated: true, completion: nil)
         }

--- a/WordPress/Classes/ViewRelated/Media/ImageCropViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/ImageCropViewController.swift
@@ -7,7 +7,9 @@ import UIKit
 ///
 class ImageCropViewController: UIViewController, UIScrollViewDelegate {
     // MARK: - Public Properties
-    var onCompletion: ((UIImage) -> Void)?
+    /// Will be invoked with the cropped and scaled image and a boolean indicating
+    /// whether or not the original image was modified
+    var onCompletion: ((UIImage, Bool) -> Void)?
     var maskShape: ImageCropOverlayMaskShape = .circle
 
     // MARK: - Public Initializers
@@ -73,6 +75,14 @@ class ImageCropViewController: UIViewController, UIScrollViewDelegate {
                                      width: scrollView.frame.width * screenScale,
                                      height: scrollView.frame.height * screenScale)
 
+        if scrollView.contentOffset.x == 0 &&
+            scrollView.contentOffset.y == 0 &&
+            oldSize.width == clippingRect.width &&
+            oldSize.height == clippingRect.height {
+            onCompletion?(rawImage, false)
+            return
+        }
+
         // Resize
         UIGraphicsBeginImageContextWithOptions(resizeRect.size, false, screenScale)
         rawImage?.draw(in: resizeRect)
@@ -85,7 +95,7 @@ class ImageCropViewController: UIViewController, UIScrollViewDelegate {
         }
 
         let clippedImage = UIImage(cgImage: clippedImageRef, scale: screenScale, orientation: .up)
-        onCompletion?(clippedImage)
+        onCompletion?(clippedImage, true)
     }
 
 


### PR DESCRIPTION
**Fixes** #7344 

**To test:**
1. Select one site
2. Tap on its icon
3. Select Change Icon
4. Select the Media Library
5. Chose a square item and do not resize it nor crop it
6. Once the item is set as the site icon, check on the Media Library that there is not a duplicate instance of it.
7. Do the same steps but modifying the media item, check that a new media item is created.
8. Do the same steps but choosing an image from your camera roll, check that a new media item is created.

Needs review: @frosty 