### PR TITLE
Notifications Cell: Keeping Label's background Clear Color

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -74,14 +74,6 @@ class NoteTableViewCell: MGSwipeTableCell {
             return noticonLabel.text
         }
     }
-    override var backgroundColor: UIColor? {
-        didSet {
-            // Note: This is done to improve scrolling performance!
-            snippetLabel.backgroundColor = backgroundColor
-            subjectLabel.backgroundColor = backgroundColor
-            separatorsView.backgroundColor = backgroundColor
-        }
-    }
     var onUndelete: (() -> Void)?
 
 


### PR DESCRIPTION
### Details:
We've been after an issue that's affecting Notifications List for a while: the Label's background color is getting out of sync with the BG Color, in an unknown scenario.

This can probably be tracked back to #6009 (in which we began matching the Label's Background Colors with the Cell's BG color as an optimization). Since i've been unable to pinpoint the exact scenario that breaks, let's revert that optimization.

Closes #7337
Closes #7040

### To test:
1. Launch WordPress iOS
2. Verify that Unread Notifications / Highlighted Notification cells look good

Needs review: @astralbodies 

Thanks in advance!!
