### PR TITLE
Make the app build in Xcode 9

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -63,7 +63,7 @@ abstract_target 'WordPress_Base' do
     pod 'NSURL+IDN', '0.3'
     pod 'WPMediaPicker', '0.17'
     pod 'WordPress-iOS-Editor', '1.9.1'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'be6802dfbfbd390086bc16b883bf1fc24be036ed'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :branch => 'try/xcode9'
     pod 'wpxmlrpc', '0.8.3'
 
     target 'WordPressTest' do

--- a/Podfile
+++ b/Podfile
@@ -63,7 +63,7 @@ abstract_target 'WordPress_Base' do
     pod 'NSURL+IDN', '0.3'
     pod 'WPMediaPicker', '0.17'
     pod 'WordPress-iOS-Editor', '1.9.1'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :branch => 'try/xcode9'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '28e8cd4eba56efc0080b3fdef7d1a5693e53b1e7'
     pod 'wpxmlrpc', '0.8.3'
 
     target 'WordPressTest' do

--- a/Podfile
+++ b/Podfile
@@ -72,7 +72,7 @@ abstract_target 'WordPress_Base' do
       shared_test_pods
       pod 'Specta', '1.0.5'
       pod 'Expecta', '1.0.5'
-      pod 'Nimble', '~> 5.0.0'
+      pod 'Nimble', '~> 7.0.0'
     end
   end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -97,7 +97,7 @@ PODS:
   - MRProgress/ProgressBaseClass (0.7.0)
   - MRProgress/Stopable (0.7.0):
     - MRProgress/Helper
-  - Nimble (5.0.0)
+  - Nimble (7.0.1)
   - NSObject-SafeExpectations (0.0.2)
   - NSURL+IDN (0.3)
   - OCMock (3.4)
@@ -148,7 +148,7 @@ DEPENDENCIES:
   - HockeySDK (~> 4.1.5)
   - MGSwipeTableCell (~> 1.5.6)
   - MRProgress (~> 0.7.0)
-  - Nimble (~> 5.0.0)
+  - Nimble (~> 7.0.0)
   - NSObject-SafeExpectations (= 0.0.2)
   - NSURL+IDN (= 0.3)
   - OCMock (~> 3.0)
@@ -217,7 +217,7 @@ SPEC CHECKSUMS:
   HockeySDK: 606b537bbfbe454ee440e92cc93bc634b3c77151
   MGSwipeTableCell: 616700eb0ffd1c611ba909066cb7fd739790a0a7
   MRProgress: 1cb0051b678be4a2ef4881414cd316768fc70028
-  Nimble: 56fc9f5020effa2206de22c3dd910f4fb011b92f
+  Nimble: 657d000e11df8aebe27cdaf9d244de7f30ed87f7
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   NSURL+IDN: 82355a0afd532fe1de08f6417c134b49b1a1c4b3
   OCMock: 35ae71d6a8fcc1b59434d561d1520b9dd4f15765
@@ -235,6 +235,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: a61e85ce289bb99113209091698ead23f7b44f6f
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: f266e7f4b28420ddfef4665b27caf591227584ec
+PODFILE CHECKSUM: 25a0fc1bca090180565444b2f46401351ac43ede
 
 COCOAPODS: 1.2.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -160,7 +160,7 @@ DEPENDENCIES:
   - SVProgressHUD (~> 2.1.2)
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, branch `try/xcode9`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `28e8cd4eba56efc0080b3fdef7d1a5693e53b1e7`)
   - WordPress-iOS-Editor (= 1.9.1)
   - WordPressCom-Analytics-iOS (= 0.1.29)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :branch: try/xcode9
+    :commit: 28e8cd4eba56efc0080b3fdef7d1a5693e53b1e7
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -195,7 +195,7 @@ CHECKOUT OPTIONS:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: 08dabea5a5150825a83e102d941ae35f4d6958f5
+    :commit: 28e8cd4eba56efc0080b3fdef7d1a5693e53b1e7
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -235,6 +235,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: a61e85ce289bb99113209091698ead23f7b44f6f
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 25a0fc1bca090180565444b2f46401351ac43ede
+PODFILE CHECKSUM: df8bc08fda8f0209251509114bab35b1483b5c91
 
 COCOAPODS: 1.2.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -160,7 +160,7 @@ DEPENDENCIES:
   - SVProgressHUD (~> 2.1.2)
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-AppbotX (from `https://github.com/wordpress-mobile/appbotx.git`, commit `479d05f7d6b963c9b44040e6ea9f190e8bd9a47a`)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `be6802dfbfbd390086bc16b883bf1fc24be036ed`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, branch `try/xcode9`)
   - WordPress-iOS-Editor (= 1.9.1)
   - WordPressCom-Analytics-iOS (= 0.1.29)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
@@ -178,7 +178,7 @@ EXTERNAL SOURCES:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: be6802dfbfbd390086bc16b883bf1fc24be036ed
+    :branch: try/xcode9
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -195,7 +195,7 @@ CHECKOUT OPTIONS:
     :commit: 479d05f7d6b963c9b44040e6ea9f190e8bd9a47a
     :git: https://github.com/wordpress-mobile/appbotx.git
   WordPress-Aztec-iOS:
-    :commit: be6802dfbfbd390086bc16b883bf1fc24be036ed
+    :commit: 08dabea5a5150825a83e102d941ae35f4d6958f5
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -235,6 +235,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: a61e85ce289bb99113209091698ead23f7b44f6f
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 4bcde0cd2247d6db5b7227d8b425b41f8f048077
+PODFILE CHECKSUM: f266e7f4b28420ddfef4665b27caf591227584ec
 
 COCOAPODS: 1.2.1

--- a/WordPress/Classes/Services/Store.swift
+++ b/WordPress/Classes/Services/Store.swift
@@ -146,9 +146,17 @@ class StoreCoordinator<S: Store> {
         var userInfo: [String: AnyObject] = [StoreKitCoordinator.NotificationProductIdentifierKey: productID as AnyObject]
 
         if let error = transaction.error as NSError? {
-            if error.code != SKError.paymentCancelled.rawValue {
+            // Disabled in the transition to Xcode 9
+            // SKError.Code was renamed SKErrorCode
+            // I can't make it work in both Xcode 8 and 9, and since this code
+            // isn't really being used, it's easier to comment it out
+             /*
+            if error.code != SKErrorCode.paymentCancelled.rawValue {
+             */
                 userInfo[NSUnderlyingErrorKey] = error as AnyObject?
+            /*
             }
+             */
 
             postTransactionFailedNotification(userInfo)
         } else {


### PR DESCRIPTION
The app now builds in Xcode 9, although tests crash due to a OCMock issue I'm still investigating.
It both builds and tests in Xcode 8, so I think it's enough for a first PR

I commented out conflicting code in Store, but we should probably remove all IAP code in another PR

See #7343 

To test:

(You might need to clean before build when switching Xcode versions)

- Build with Xcode 9
- Build and test with Xcode 8

Needs review: @frosty 
