### PR TITLE
Issue/7350 improve blog visibility handling

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -20,7 +20,7 @@ PODS:
     - CocoaLumberjack (~> 2.2.0)
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 0.4)
-  - BuddyBuildSDK (1.0.15)
+  - BuddyBuildSDK (1.0.16)
   - CocoaLumberjack (2.2.0):
     - CocoaLumberjack/Default (= 2.2.0)
     - CocoaLumberjack/Extensions (= 2.2.0)
@@ -206,7 +206,7 @@ SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   Alamofire: 7682d43245de14874acd142ec137b144aa1dd335
   Automattic-Tracks-iOS: 4903e125d88e564c68dedbb66c53a97740e89336
-  BuddyBuildSDK: b3038125612b1ad389c2aa89e4787dcb75cac89a
+  BuddyBuildSDK: 2c5469eee2981a3365386e46393e97068d75e4f4
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   Crashlytics: 79e236942ca1e7fc641df1feb9a275360a78ab6a
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe

--- a/WordPress/Classes/Networking/RemoteBlogOptionsHelper.m
+++ b/WordPress/Classes/Networking/RemoteBlogOptionsHelper.m
@@ -13,7 +13,6 @@
         options[@"jetpack_client_id"] = [response numberForKey:@"ID"];
     }
     if ( response[@"options"] ) {
-        options[@"blog_public"] = [response valueForKeyPath:@"options.blog_public"];
         options[@"post_thumbnail"] = [response valueForKeyPath:@"options.featured_images_enabled"];
         NSArray *optionsDirectMapKeys = @[
                                           @"active_modules",
@@ -25,7 +24,8 @@
                                           @"timezone",
                                           @"gmt_offset",
                                           @"allowed_file_types",
-                                          @"frame_nonce"
+                                          @"frame_nonce",
+                                          @"blog_public"
                                           ];
 
         for (NSString *key in optionsDirectMapKeys) {

--- a/WordPress/Classes/Networking/RemoteBlogOptionsHelper.m
+++ b/WordPress/Classes/Networking/RemoteBlogOptionsHelper.m
@@ -9,11 +9,11 @@
 {
     NSMutableDictionary *options = [NSMutableDictionary dictionary];
     options[@"home_url"] = response[@"URL"];
-    options[@"blog_public"] = [response valueForKeyPath:@"options.blog_public"];
     if ([[response numberForKey:@"jetpack"] boolValue]) {
         options[@"jetpack_client_id"] = [response numberForKey:@"ID"];
     }
     if ( response[@"options"] ) {
+        options[@"blog_public"] = [response valueForKeyPath:@"options.blog_public"];
         options[@"post_thumbnail"] = [response valueForKeyPath:@"options.featured_images_enabled"];
         NSArray *optionsDirectMapKeys = @[
                                           @"active_modules",

--- a/WordPress/Classes/Networking/RemoteBlogOptionsHelper.m
+++ b/WordPress/Classes/Networking/RemoteBlogOptionsHelper.m
@@ -9,8 +9,7 @@
 {
     NSMutableDictionary *options = [NSMutableDictionary dictionary];
     options[@"home_url"] = response[@"URL"];
-    // We'd be better off saving this as a BOOL property on Blog, but let's do what XML-RPC does for now
-    options[@"blog_public"] = [[response numberForKey:@"is_private"] boolValue] ? @"-1" : @"0";
+    options[@"blog_public"] = [response valueForKeyPath:@"options.blog_public"];
     if ([[response numberForKey:@"jetpack"] boolValue]) {
         options[@"jetpack_client_id"] = [response numberForKey:@"ID"];
     }

--- a/WordPress/WordPressTest/Test Data/me-sites-bad-json-failure.json
+++ b/WordPress/WordPressTest/Test Data/me-sites-bad-json-failure.json
@@ -62,11 +62,11 @@
               "url": "https:\/\/test1.files.wordpress.com\/2017\/02\/img_1111.jpg"
               },
               "visible": true,
-              "is_private": false,
               "single_user_site": false,
               "is_vip": false,
               "is_following": false,
               "options": {
+              "blog_public": 1,
               "timezone": "",
               "gmt_offset": 0,
               "videopress_enabled": false,

--- a/WordPress/WordPressTest/Test Data/me-sites-bad-json-failure.json
+++ b/WordPress/WordPressTest/Test Data/me-sites-bad-json-failure.json
@@ -62,6 +62,7 @@
               "url": "https:\/\/test1.files.wordpress.com\/2017\/02\/img_1111.jpg"
               },
               "visible": true,
+              "is_private": false,
               "single_user_site": false,
               "is_vip": false,
               "is_following": false,

--- a/WordPress/WordPressTest/Test Data/me-sites-success.json
+++ b/WordPress/WordPressTest/Test Data/me-sites-success.json
@@ -62,11 +62,11 @@
               "url": "https:\/\/test1.files.wordpress.com\/2017\/02\/img_1111.jpg"
               },
               "visible": true,
-              "is_private": false,
               "single_user_site": false,
               "is_vip": false,
               "is_following": false,
               "options": {
+              "blog_public": 1,
               "timezone": "",
               "gmt_offset": 0,
               "videopress_enabled": false,
@@ -196,11 +196,11 @@
               "url": ""
               },
               "visible": true,
-              "is_private": true,
               "single_user_site": true,
               "is_vip": false,
               "is_following": true,
               "options": {
+              "blog_public": -1,
               "timezone": "",
               "gmt_offset": 0,
               "videopress_enabled": true,
@@ -335,11 +335,11 @@
               "url": ""
               },
               "visible": true,
-              "is_private": false,
               "single_user_site": false,
               "is_vip": false,
               "is_following": false,
               "options": {
+              "blog_public": 1,
               "timezone": "",
               "gmt_offset": 0,
               "videopress_enabled": false,

--- a/WordPress/WordPressTest/Test Data/me-sites-success.json
+++ b/WordPress/WordPressTest/Test Data/me-sites-success.json
@@ -62,6 +62,7 @@
               "url": "https:\/\/test1.files.wordpress.com\/2017\/02\/img_1111.jpg"
               },
               "visible": true,
+              "is_private": false,
               "single_user_site": false,
               "is_vip": false,
               "is_following": false,
@@ -196,6 +197,7 @@
               "url": ""
               },
               "visible": true,
+              "is_private": true,
               "single_user_site": true,
               "is_vip": false,
               "is_following": true,
@@ -335,6 +337,7 @@
               "url": ""
               },
               "visible": true,
+              "is_private": false,
               "single_user_site": false,
               "is_vip": false,
               "is_following": false,

--- a/WordPress/WordPressTest/Test Data/me-sites-with-jetpack.json
+++ b/WordPress/WordPressTest/Test Data/me-sites-with-jetpack.json
@@ -15,6 +15,7 @@
             },
             "description": "",
             "is_following": false,
+            "is_private": false,
             "jetpack": false,
             "lang": "en",
             "logo": {
@@ -99,6 +100,7 @@
             },
             "description": "Just another Koke's Sites site",
             "is_following": false,
+            "is_private": false,
             "jetpack": true,
             "lang": "en",
             "logo": {

--- a/WordPress/WordPressTest/Test Data/me-sites-with-jetpack.json
+++ b/WordPress/WordPressTest/Test Data/me-sites-with-jetpack.json
@@ -15,7 +15,6 @@
             },
             "description": "",
             "is_following": false,
-            "is_private": false,
             "jetpack": false,
             "lang": "en",
             "logo": {
@@ -53,6 +52,7 @@
                     "key"
                 ],
                 "background_color": false,
+                "blog_public": 1,
                 "created_at": "2014-07-15T09:34:00+00:00",
                 "default_comment_status": true,
                 "default_likes_enabled": true,
@@ -99,7 +99,6 @@
             },
             "description": "Just another Koke's Sites site",
             "is_following": false,
-            "is_private": false,
             "jetpack": true,
             "lang": "en",
             "logo": {
@@ -137,6 +136,7 @@
                     "key"
                 ],
                 "background_color": false,
+                "blog_public": 1,
                 "created_at": "2014-08-20T15:57:01+00:00",
                 "default_comment_status": true,
                 "default_likes_enabled": true,


### PR DESCRIPTION
**Fixes** #7350 

**To test:**
An easy visual way of seeing the error we were making is following the steps on #7350 on develop, and then checkout this branch and do the same. The site visibility will remain unchanged.
What we are doing is moving away from the field `is_private` and instead use `options.blog_public`

Needs review: @aerych 