### PR TITLE
Enable autocorrection in tags field

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -46,7 +46,7 @@ class PostTagPickerViewController: UIViewController {
         tableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: CGFloat.leastNonzeroMagnitude))
         reloadTableData()
 
-        textView.autocorrectionType = .no
+        textView.autocorrectionType = .yes
         textView.autocapitalizationType = .none
         textView.font = WPStyleGuide.tableviewTextFont()
         textView.textColor = WPStyleGuide.darkGrey()


### PR DESCRIPTION
In #7100 I disabled the autocorrection in the tags field, and I'm not sure it was a good idea.
From a support request, it seems users are expecting it:

> Is it possible to activate the keyboard word selector (the three words above the keyboard) in the tag interface for those of us who are spelling-challenged and fat finger typists?

Needs review: @elibud 