### PR TITLE
Login: Remove method definition in header.

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -48,6 +48,4 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)showNotificationsTabForNoteWithID:(NSString *)notificationID;
 - (void)updateNotificationBadgeVisibility;
 
-- (IBAction)unwindOutWithSegue:(UIStoryboardSegue *)segue;
-
 @end


### PR DESCRIPTION
Fixes warning due to method declaration left in header. (doh!)

To test:  Build the project and confirm the warning is removed.

Needs review: @astralbodies 
