### PR TITLE
Issues/login limit epilogue blog list

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
@@ -5,11 +5,18 @@ import WordPressShared
 class LoginEpilogueTableView: UITableViewController {
     var blogDataSource: BlogListDataSource
     var blogCount: Int?
-    var epilogueUserInfo: LoginEpilogueUserInfo?
+    var epilogueUserInfo: LoginEpilogueUserInfo? {
+        didSet {
+            if let blog = epilogueUserInfo?.blog {
+                blogDataSource.blog = blog
+            } else {
+                blogDataSource.accountOwned = true
+            }
+        }
+    }
 
     required init?(coder aDecoder: NSCoder) {
         blogDataSource = BlogListDataSource()
-        blogDataSource.loggedIn = true
         super.init(coder: aDecoder)
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
@@ -7,11 +7,8 @@ class LoginEpilogueTableView: UITableViewController {
     var blogCount: Int?
     var epilogueUserInfo: LoginEpilogueUserInfo? {
         didSet {
-            if let blog = epilogueUserInfo?.blog {
-                blogDataSource.blog = blog
-            } else {
-                blogDataSource.accountOwned = true
-            }
+            blogDataSource.blog = epilogueUserInfo?.blog
+            blogDataSource.loggedIn = true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
@@ -7,6 +7,7 @@ struct LoginEpilogueUserInfo {
     var fullName = ""
     var email = ""
     var gravatarUrl: String?
+    var blog: Blog?
 
     init(account: WPAccount) {
         if let name = account.username {

--- a/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
@@ -3,6 +3,8 @@ import UIKit
 class LoginSelfHostedViewController: SigninSelfHostedViewController, LoginViewController {
     var gravatarProfile: GravatarProfile?
     var userProfile: UserProfile?
+    var blog: Blog?
+
     // let the storyboard's style stay
     override func setupStyles() {}
 
@@ -30,7 +32,7 @@ class LoginSelfHostedViewController: SigninSelfHostedViewController, LoginViewCo
             }
 
             RecentSitesService().touch(blog: blog)
-
+            self?.blog = blog
             self?.fetchUserProfileInfo(blog: blog, completion: {
                 self?.dismiss()
             })
@@ -66,6 +68,8 @@ class LoginSelfHostedViewController: SigninSelfHostedViewController, LoginViewCo
             info.fullName = profile.displayName
             info.email = profile.email
         }
+
+        info.blog = blog
 
         return info
     }


### PR DESCRIPTION
Refs #7272

This PR limits the blogs shown in the epilogue screen's blog list to just the account, or individual blog added during login. 

To test:
Scenario 1:
Log in with a self-hosted account. 
Confirm the epilogue screen shows only the blog added.

Scenario 2:
Log in to wpcom while there is a self-hosted blog already in the app.  The self-hosted blog should not be connected to jetpack via the same wpcom account being logged into.
Confirm that only the wpcom blogs are shown in the blog list.

Example:
![simulator screen shot jun 8 2017 4 16 05 pm](https://user-images.githubusercontent.com/1435271/26992031-6ae7d818-4d22-11e7-8be9-05359314e977.png)


Needs review: @nheagy 
