### PR TITLE
Reader: Fix scroll bounce at end of post detail.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WordPressShared
 import WordPressComAnalytics
-
+import QuartzCore
 
 open class ReaderDetailViewController: UIViewController, UIViewControllerRestoration {
 
@@ -829,7 +829,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             navigationController?.setNavigationBarHidden(true, animated: animated)
             currentPreferredStatusBarStyle = .default
             footerViewHeightConstraint.constant = 0.0
-            UIView.animate(withDuration: animated ? 0.3 : 0,
+            UIView.animate(withDuration: animated ? 0.2 : 0,
                 delay: 0.0,
                 options: [.beginFromCurrentState, .allowUserInteraction],
                 animations: {
@@ -840,20 +840,20 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             // Shows the navbar and footer view
             let pinToBottom = isScrollViewAtBottom()
 
-            navigationController?.setNavigationBarHidden(false, animated: animated)
             currentPreferredStatusBarStyle = .lightContent
             footerViewHeightConstraint.constant = footerViewHeightConstraintConstant
-            UIView.animate(withDuration: animated ? 0.3 : 0,
-                delay: 0.0,
-                options: [.beginFromCurrentState, .allowUserInteraction],
-                animations: {
-                    self.view.layoutIfNeeded()
-                    if pinToBottom {
-                        let y = self.textView.contentSize.height - self.textView.frame.height
-                        self.textView.setContentOffset(CGPoint(x: 0, y: y), animated: false)
-                    }
+            UIView.animate(withDuration: animated ? 0.2 : 0,
+                           delay: 0.0,
+                           options: [.beginFromCurrentState, .allowUserInteraction],
+                           animations: {
+                            self.view.layoutIfNeeded()
+                            if pinToBottom {
+                                self.navigationController?.setNavigationBarHidden(false, animated: animated)
+                                let y = self.textView.contentSize.height - self.textView.frame.height
+                                self.textView.setContentOffset(CGPoint(x: 0, y: y), animated: false)
+                            }
 
-                }, completion: nil)
+            }, completion: nil)
         }
 
     }


### PR DESCRIPTION
Fixes #6867 (mostly)
This PR attempts to fix the jump in the reader post detail when scrolling to the end of a long post. The separate navbar animation was causing a conflict so its been moved inside the animation block. 
There remains a noticeable stutter if, while at the bottom of the post you scroll up slightly, then scroll back down in such a way that the bars are set to hide, then show before the hide animation completes. The fix for this eludes me but I'm fine to circle back on that later since this PR addresses the larger issue.

To test:
- Confirm the bug by scrolling to the bottom of a long article in the post detail. Observe the animation stutter. 
- Switch to this branch and repeat.  Note that upon reaching the bottom of the post the bars animate smoothly back into view and the text view remains scrolled to the bottom of the post.

Needs review: @koke would you kindly, since i know you're familiar with the issue having sent a lookback about it.

![reader-bounce](https://user-images.githubusercontent.com/1435271/27052400-2f018d4e-4f7f-11e7-9408-f61b86f903ad.gif)
