### PR TITLE
Support for setting icon for private sites

### DIFF
--- a/WordPress/Classes/Categories/UIImageView+Gravatar.h
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.h
@@ -1,7 +1,6 @@
 #import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
-
-
+#import "Blog.h"
 
 @interface UIImageView (Gravatar)
 
@@ -9,6 +8,8 @@
 
 - (void)setImageWithSiteIcon:(NSString *)siteIcon;
 - (void)setImageWithSiteIcon:(NSString *)siteIcon placeholderImage:(UIImage *)placeholderImage;
+- (void)setImageWithSiteIconForBlog:(Blog *)blog;
+- (void)setImageWithSiteIconForBlog:(Blog *)blog placeholderImage:(UIImage *)placeholderImage;
 - (void)setDefaultSiteIconImage;
 
 @end

--- a/WordPress/Classes/Categories/UIImageView+Gravatar.m
+++ b/WordPress/Classes/Categories/UIImageView+Gravatar.m
@@ -3,6 +3,7 @@
 #import "NSString+Helpers.h"
 #import "Constants.h"
 #import "PhotonImageURLHelper.h"
+#import "PrivateSiteURLProtocol.h"
 
 
 #pragma mark - Constants
@@ -30,13 +31,19 @@ NSString *const BlavatarDefault = @"blavatar-default";
     [self setImageWithURL:[self URLWithSiteIcon:siteIcon] placeholderImage:placeholderImage];
 }
 
-- (NSURL *)URLWithSiteIcon:(NSString *)siteIcon {
-    if ([self isPhotonURL:siteIcon] || [self isWordPressComFilesURL:siteIcon]) {
-        return [self siteIconURLForSiteIconUrl:siteIcon];
-    } else if ([self isBlavatarURL:siteIcon]) {
-        return [self blavatarURLForBlavatarURL:siteIcon];
+- (void)setImageWithSiteIconForBlog:(Blog *)blog
+{
+    UIImage *blavatarDefaultImage = [UIImage imageNamed:BlavatarDefault];
+
+    [self setImageWithSiteIconForBlog:blog placeholderImage:blavatarDefaultImage];
+}
+
+- (void)setImageWithSiteIconForBlog:(Blog *)blog placeholderImage:(UIImage *)placeholderImage
+{
+    if (blog.isHostedAtWPcom && blog.isPrivate) {
+        [self setImageWithPrivateSiteIcon:blog.icon placeholderImage:placeholderImage];
     } else {
-        return [self URLForResizedImageURL:siteIcon];
+        [self setImageWithSiteIcon:blog.icon placeholderImage:placeholderImage];
     }
 }
 
@@ -47,12 +54,32 @@ NSString *const BlavatarDefault = @"blavatar-default";
 
 #pragma mark - Site Icon Private Methods
 
+- (NSURL *)URLWithSiteIcon:(NSString *)siteIcon
+{
+    if ([self isPhotonURL:siteIcon] || [self isWordPressComFilesURL:siteIcon]) {
+        return [self siteIconURLForSiteIconUrl:siteIcon];
+    } else if ([self isBlavatarURL:siteIcon]) {
+        return [self blavatarURLForBlavatarURL:siteIcon];
+    } else {
+        return [self URLForResizedImageURL:siteIcon];
+    }
+}
+
 - (NSURL *)siteIconURLForSiteIconUrl:(NSString *)path
 {
     NSInteger size = [self sizeForBlavatarDownload];
     NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithString:path];
     urlComponents.query = [NSString stringWithFormat:@"w=%d&h=%d", size, size];
     return urlComponents.URL;
+}
+
+- (void)setImageWithPrivateSiteIcon:(NSString *)siteIcon placeholderImage:(UIImage *)placeholderImage
+{
+    NSURLRequest *imageRequest = [PrivateSiteURLProtocol requestForPrivateSiteFromURL:[self URLWithSiteIcon:siteIcon]];
+    [self setImageWithURLRequest:imageRequest
+                placeholderImage:placeholderImage
+                         success:nil
+                         failure:nil];
 }
 
 #pragma mark - Photon Helpers

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -52,7 +52,7 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 - (void)refreshIconImage
 {
     if (self.blog.hasIcon) {
-        [self.blavatarImageView setImageWithSiteIcon:self.blog.icon placeholderImage:nil];
+        [self.blavatarImageView setImageWithSiteIconForBlog:self.blog placeholderImage:nil];
     } else {
         [self.blavatarImageView setDefaultSiteIconImage];
     }

--- a/WordPress/Classes/ViewRelated/Blog/BlogListDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListDataSource.swift
@@ -319,7 +319,7 @@ extension BlogListDataSource: UITableViewDataSource {
         }
 
         cell.selectionStyle = tableView.isEditing ? .none : .blue
-        cell.imageView?.setImageWithSiteIcon(blog.icon)
+        cell.imageView?.setImageWithSiteIconFor(blog)
         cell.visibilitySwitch?.accessibilityIdentifier = String(format: "Switch-Visibility-%@", blog.settings?.name ?? "")
         cell.visibilitySwitch?.isOn = blog.visible
         cell.visibilitySwitchToggled = { [visibilityChanged] cell in

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -230,8 +230,8 @@ open class NotificationSettingsViewController: UIViewController {
             cell.detailTextLabel?.text      = settings.blog?.displayURL as String? ?? String()
             cell.accessoryType              = .disclosureIndicator
 
-            if let siteIconURL = settings.blog?.icon {
-                cell.imageView?.setImageWithSiteIcon(siteIconURL)
+            if let blog = settings.blog {
+                cell.imageView?.setImageWithSiteIconFor(blog)
             } else {
                 cell.imageView?.image = WPStyleGuide.Notifications.blavatarPlaceholderImage
             }

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -238,7 +238,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     self.authorNameLabel.text = [self.post authorNameForDisplay];
     UIImage *placeholder = [UIImage imageNamed:@"post-blavatar-placeholder"];
 
-    [self.avatarImageView setImageWithSiteIcon:[self.post blavatarForDisplay] placeholderImage:placeholder];
+    [self.avatarImageView setImageWithSiteIconForBlog:self.post.blog placeholderImage:placeholder];
 }
 
 - (void)configureCardImage

--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -140,9 +140,7 @@ class PostPostViewController: UIViewController {
         }
         siteNameLabel.text = blogSettings.name
         siteUrlLabel.text = post.blog.displayURL as String?
-        if let icon = post.blog.icon {
-            siteIconView.setImageWithSiteIcon(icon, placeholderImage: nil)
-        }
+        siteIconView.setImageWithSiteIconFor(post.blog, placeholderImage: nil)
         if siteIconView.image == .none {
             siteIconView.superview?.isHidden = true
         }


### PR DESCRIPTION
**Fixes** #7345 and improves on https://github.com/wordpress-mobile/WordPress-iOS/pull/7268
 
**To test:**
1. Change the icon of a private site.
2. Check that the icon looks good in: BlogList, BlogDetail, PostList, PostPost, Notification settings.
3. Remove the icon for the site, and do number 2 again.
4. Check that all that still works for Public sites. 

Needs review: @frosty 