### PR TITLE
Fix crash in attributedStringWithHTML

### DIFF
--- a/WordPress/Classes/Extensions/NSAttributedString+StyledHTML.swift
+++ b/WordPress/Classes/Extensions/NSAttributedString+StyledHTML.swift
@@ -45,7 +45,7 @@ extension NSAttributedString {
         attributedString.addAttribute(NSParagraphStyleAttributeName,
                                    value: paragraphStyle,
                                    range: NSMakeRange(0, attributedString.string.characters.count - 1))
-        
+
         return NSAttributedString(attributedString: attributedString)
     }
 

--- a/WordPress/Classes/Extensions/NSAttributedString+StyledHTML.swift
+++ b/WordPress/Classes/Extensions/NSAttributedString+StyledHTML.swift
@@ -19,8 +19,9 @@ extension NSAttributedString {
     class func attributedStringWithHTML(_ htmlString: String, attributes: StyledHTMLAttributes?) -> NSAttributedString {
         let styles = styleTagTextForAttributes(attributes)
         let styledString = styles + htmlString
-        guard let attributedString = try? NSMutableAttributedString(
-            data: styledString.data(using: String.Encoding.utf8)!,
+        guard let data = styledString.data(using: String.Encoding.utf8),
+            let attributedString = try? NSMutableAttributedString(
+            data: data,
             options: [ NSDocumentTypeDocumentAttribute: NSHTMLTextDocumentType, NSCharacterEncodingDocumentAttribute: NSNumber(value: String.Encoding.utf8.rawValue) ],
             documentAttributes: nil) else {
                 // if creating the html-ed string fails (and it has, thus this change) we return the string without any styling

--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -27,7 +27,6 @@ class Login2FAViewController: Signin2FAViewController, LoginViewController {
             NSParagraphStyleAttributeName: paragraphStyle ]]
 
         let attributedCode = NSAttributedString.attributedStringWithHTML(string, attributes: attributes)
-        let attributedCodeHighlighted = attributedCode.mutableCopy() as! NSMutableAttributedString
 
         if let titleLabel = sendCodeButton.titleLabel {
             titleLabel.lineBreakMode = .byWordWrapping
@@ -36,6 +35,6 @@ class Login2FAViewController: Signin2FAViewController, LoginViewController {
         }
 
         sendCodeButton.setAttributedTitle(attributedCode, for: UIControlState())
-        sendCodeButton.setAttributedTitle(attributedCodeHighlighted, for: .highlighted)
+        sendCodeButton.setAttributedTitle(attributedCode, for: .highlighted)
     }
 }


### PR DESCRIPTION
Fixes #7277

I was unable to reproduce this crash, despite many attempts, however this eliminates the `try!` that was causing the crash. Also removes two unnecessary lines in `Login2FAViewController.swift` that I found while working on this ;)

To test:
1. ensure that attributed text build with this method still appears correctly, such as:
   - the underlined text on the 2FA verification screen
   - text on the plans screens
   - text on the delete site screen

Needs review: @frosty 
_You touched this last, it seems, want to check out my hacking?_