### PR TITLE
Fix #7387: Replace the _Post_ button to _Publish_ and update translation comment

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -578,7 +578,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 - (PostCardActionBarItem *)publishActionBarItemWithInsets:(UIEdgeInsets)imageInsets
 {
     __weak __typeof(self) weakSelf = self;
-    PostCardActionBarItem *item = [self actionBarItemWithTitle:NSLocalizedString(@"Publish", @"Label for the publish button. Tapping publishes a draft post.")
+    PostCardActionBarItem *item = [self actionBarItemWithTitle:NSLocalizedString(@"Publish", @"Label for the publish (verb) button. Tapping publishes a draft post.")
                                                          image:[UIImage imageNamed:@"icon-post-actionbar-publish"]
                                                    imageInsets:imageInsets
                                                    andCallback:^{

--- a/WordPress/Classes/ViewRelated/Post/PostEditorSaveAction.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorSaveAction.swift
@@ -34,7 +34,7 @@ extension WPPostViewController {
         case .schedule:
             return NSLocalizedString("Schedule", comment: "Schedule button, this is what the Publish button changes to in the Post Editor if the post has been scheduled for posting later.")
         case .post:
-            return NSLocalizedString("Post", comment: "Publish button label.")
+            return NSLocalizedString("Publish", comment: "Label for the publish (verb) button. Tapping publishes a draft post.")
         case .save:
             return NSLocalizedString("Save", comment: "Save button label (saving content, ex: Post, Page, Comment).")
         case .update:

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -15,7 +15,7 @@ public enum PostEditorAction {
     fileprivate var publishActionLabel: String {
         switch self {
         case .publish:
-            return NSLocalizedString("Publish", comment: "Publish button label.")
+            return NSLocalizedString("Publish", comment: "Label for the publish (verb) button. Tapping publishes a draft post.")
         case .save:
             return NSLocalizedString("Save", comment: "Save button label (saving content, ex: Post, Page, Comment).")
         case .schedule:

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -445,7 +445,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         return NSLocalizedString(@"Taxonomy", @"Label for the Taxonomy area (categories, keywords, ...) in post settings.");
 
     } else if (sec == PostSettingsSectionMeta) {
-        return NSLocalizedString(@"Publish", @"The grandiose Publish button in the Post Editor! Should use the same translation as core WP.");
+        return NSLocalizedString(@"Publish", @"Label for the publish (verb) button. Tapping publishes a draft post.");
 
     } else if (sec == PostSettingsSectionFormat) {
         return NSLocalizedString(@"Post Format", @"For setting the format of a post.");
@@ -626,7 +626,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 
             cell.detailTextLabel.text = [self.apost.dateCreated shortStringWithTime];
         } else {
-            cell.textLabel.text = NSLocalizedString(@"Publish", @"");
+            cell.textLabel.text = NSLocalizedString(@"Publish", @"Label for the publish (verb) button. Tapping publishes a draft post.");
             cell.detailTextLabel.text = NSLocalizedString(@"Immediately", @"");
         }
         cell.tag = PostSettingsRowPublishDate;

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -473,10 +473,8 @@ NSString *const WPAppAnalyticsEditorSourceValueLegacy = @"legacy";
     if (![self.post hasRemote] || ![self.post.status isEqualToString:self.post.original.status]) {
         if ([self.post isScheduled]) {
             buttonTitle = NSLocalizedString(@"Schedule", @"Schedule button, this is what the Publish button changes to in the Post Editor if the post has been scheduled for posting later.");
-
         } else if ([self.post.status isEqualToString:PostStatusPublish]) {
-            buttonTitle = NSLocalizedString(@"Post", @"Publish button label.");
-
+            buttonTitle = NSLocalizedString(@"Publish", @"Label for the publish (verb) button. Tapping publishes a draft post.");
         } else {
             buttonTitle = NSLocalizedString(@"Save", @"Save button label (saving content, ex: Post, Page, Comment).");
         }
@@ -731,7 +729,7 @@ NSString *const WPAppAnalyticsEditorSourceValueLegacy = @"legacy";
         properties[@"word_diff_count"] = @(wordCount - originalWordCount);
     }
 
-    if ([buttonTitle isEqualToString:NSLocalizedString(@"Post", nil)]) {
+    if ([buttonTitle isEqualToString:NSLocalizedString(@"Publish", nil)]) {
         properties[WPAnalyticsStatEditorPublishedPostPropertyCategory] = @([self.post hasCategories]);
         properties[WPAnalyticsStatEditorPublishedPostPropertyPhoto] = @([self.post hasPhoto]);
         properties[WPAnalyticsStatEditorPublishedPostPropertyTag] = @([self.post hasTags]);


### PR DESCRIPTION
Fix #7387: Replace the _Post_ button to _Publish_ and update translation comment