### PR TITLE
Update Aztec format bar colors

### DIFF
--- a/WordPress/Classes/Extensions/WPStyleGuide+Aztec.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+Aztec.swift
@@ -1,0 +1,20 @@
+import UIKit
+import WordPressShared
+
+extension WPStyleGuide {
+    static var aztecFormatBarInactiveColor: UIColor {
+        return UIColor(hexString: "7B9AB1")
+    }
+
+    static var aztecFormatBarActiveColor: UIColor {
+        return WPStyleGuide.darkGrey()
+    }
+
+    static var aztecFormatBarDisabledColor: UIColor {
+        return WPStyleGuide.greyLighten20()
+    }
+
+    static var aztecFormatBarBackgroundColor: UIColor {
+        return .white
+    }
+}

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1485,7 +1485,8 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
         }
 
         optionsViewController = OptionsTableViewController(options: options)
-        optionsViewController.cellDeselectedTintColor = .gray
+        optionsViewController.cellDeselectedTintColor = WPStyleGuide.aztecFormatBarInactiveColor
+        optionsViewController.view.tintColor = WPStyleGuide.aztecFormatBarActiveColor
         optionsViewController.onSelect = { [weak self] selected in
             if self?.presentedViewController != nil {
                 self?.dismiss(animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1597,11 +1597,11 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
         let toolbar = Aztec.FormatBar()
         toolbar.defaultItems = [[mediaItem], scrollableItems]
         toolbar.overflowItems = overflowItems
-        toolbar.tintColor = .gray
-        toolbar.highlightedTintColor = .blue
-        toolbar.selectedTintColor = view.tintColor
-        toolbar.disabledTintColor = .lightGray
-        toolbar.dividerTintColor = .gray
+        toolbar.tintColor = WPStyleGuide.aztecFormatBarInactiveColor
+        toolbar.highlightedTintColor = WPStyleGuide.aztecFormatBarActiveColor
+        toolbar.selectedTintColor = WPStyleGuide.aztecFormatBarActiveColor
+        toolbar.disabledTintColor = WPStyleGuide.aztecFormatBarDisabledColor
+        toolbar.dividerTintColor = WPStyleGuide.aztecFormatBarDisabledColor
         toolbar.overflowToggleIcon = Gridicon.iconOfType(.ellipsis)
         toolbar.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 44.0)
         toolbar.formatter = self

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */; };
 		17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */; };
 		17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */; };
+		17D975AF1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */; };
 		17EC9FC61DDC761D00D5BE8E /* UIWindow+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EC9FC51DDC761D00D5BE8E /* UIWindow+Helpers.swift */; };
 		1D3623260D0F684500981E51 /* WordPressAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* WordPressAppDelegate.m */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
@@ -1338,6 +1339,7 @@
 		17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogSiteVisibilityHelperTest.m; sourceTree = "<group>"; };
 		17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewController.swift; sourceTree = "<group>"; };
 		17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanComparisonViewController.swift; sourceTree = "<group>"; };
+		17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Aztec.swift"; sourceTree = "<group>"; };
 		17EC9FC51DDC761D00D5BE8E /* UIWindow+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWindow+Helpers.swift"; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D3623240D0F684500981E51 /* WordPressAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressAppDelegate.h; sourceTree = "<group>"; };
@@ -4533,6 +4535,7 @@
 				E177807F1C97FA9500FA7E14 /* StoreKit+Debug.swift */,
 				E678FC141C76241000F55F55 /* WPStyleGuide+ApplicationStyles.swift */,
 				17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */,
+				17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */,
 				E14B74101C7B16FD00C26E21 /* WPNoResultsView+Model.swift */,
 				1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */,
 				FF8A04DF1D9BFE7400523BC4 /* FLAnimatedImageView+Cache.swift */,
@@ -6692,6 +6695,7 @@
 				0859DCFB1CB8482200EB4069 /* MenusServiceRemote.m in Sources */,
 				E6374DC01C444D8B00F24720 /* PublicizeConnection.swift in Sources */,
 				0845B8C61E833C56001BA771 /* URL+Helpers.swift in Sources */,
+				17D975AF1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift in Sources */,
 				E647DD051CA71C2B002E54B5 /* UITextField+TextHelper.swift in Sources */,
 				5D17F0BE1A1D4C5F0087CCB8 /* PrivateSiteURLProtocol.m in Sources */,
 				E14B40FF1C58B93F005046F6 /* SettingsCommon.swift in Sources */,


### PR DESCRIPTION
Updates the format bar colors in Aztec to match the style guide.

<img width="376" alt="screen shot 2017-06-19 at 13 29 48" src="https://user-images.githubusercontent.com/4780/27285099-6250f95e-54f3-11e7-9b9c-c5980dbd3ad5.png">

<img width="376" alt="screen shot 2017-06-19 at 13 31 25" src="https://user-images.githubusercontent.com/4780/27285158-9cef0ec0-54f3-11e7-91f0-24485652fd4b.png">

To test:

* Launch the Aztec editor
* Check the colors look right:

<img width="356" alt="screen shot 2017-06-19 at 13 29 12" src="https://user-images.githubusercontent.com/4780/27285083-51f5a74e-54f3-11e7-8af3-1c1bcd46ffc9.png">

I know the tint color currently isn't correct in the header and list menus for selected items – this will require an Aztec library change.

Needs review: @jleandroperez  
cc @iamthomasbishop 