### PR TITLE
Aztec: Revert the latest 'read more' icon change in the format bar

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Extensions/FormattingIdentifier+WordPress.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Extensions/FormattingIdentifier+WordPress.swift
@@ -35,7 +35,7 @@ extension FormattingIdentifier {
         case .sourcecode:
             return Gridicon.iconOfType(.code)
         case .more:
-            return Gridicon.iconOfType(.nextPage)
+            return Gridicon.iconOfType(.readMore)
         case .header1:
             return Gridicon.iconOfType(.headingH1)
         case .header2:


### PR DESCRIPTION
This PR reverts the 'read more' icon change in the Aztec toolbar. I updated it to the wrong icon, and I'll need to update Gridicons to pull in the new one.

Needs review: @SergioEstevao 