### PR TITLE
Include string representation of data with error userInfo.

### DIFF
--- a/WordPressKit/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -242,11 +242,13 @@ open class WordPressOrgXMLRPCApi: NSObject {
     }
 
     open static let WordPressOrgXMLRPCApiErrorKeyData = "WordPressOrgXMLRPCApiErrorKeyData"
+    open static let WordPressOrgXMLRPCApiErrorKeyDataString = "WordPressOrgXMLRPCApiErrorKeyDataString"
 
     fileprivate func convertError(_ error: NSError, data: Data?) -> NSError {
         if let data = data {
             var userInfo: [AnyHashable: Any] = error.userInfo
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data
+            userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyDataString] = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
             return NSError(domain: error.domain, code: error.code, userInfo: userInfo)
         }
         return error


### PR DESCRIPTION
Fixes #7398 

To test:
A practical test would be to modify an xmlrpc.php to return an HTML document and 403 error code (mimicing the situation that prompted this issue and PR), but confirming that the data to string conversion is properly performed would be sufficient I think. 

Needs review: @elibud, would you mind taking a peek at this one?
