### PR TITLE
Pass the bool, not the string. Derp.

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -139,7 +139,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     id<AccountServiceRemote> remote = [self remoteForAnonymous];
     [remote isPasswordlessAccount:identifier success:^(BOOL passwordless) {
         if (success) {
-            success(identifier);
+            success(passwordless);
         }
     } failure:^(NSError * _Nonnull error) {
         if (failure) {


### PR DESCRIPTION
Silence a compiler warning about an incorrect type being passed. 

Needs review: @elibud 
