### PR TITLE
Fix crash on Aztec when pressing header icon twice.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1443,7 +1443,6 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
         if let optionsViewController = optionsViewController,
             presentedViewController == optionsViewController {
             dismiss(animated: true, completion: nil)
-
             self.optionsViewController = nil
         }
     }
@@ -1474,8 +1473,8 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
                                                    selectedRowIndex index: Int?,
                                                    onSelect: OptionsTableViewController.OnSelectHandler?) {
         // Hide the input view if we're already showing these options
-        if let optionsViewController = optionsViewController, optionsViewController.options == options {
-            if presentedViewController != nil {
+        if let optionsViewController = optionsViewController ?? (presentedViewController as? OptionsTableViewController), optionsViewController.options == options {
+            if self.optionsViewController != nil && presentedViewController != nil {
                 dismiss(animated: true, completion: nil)
             }
 
@@ -1524,13 +1523,7 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
         optionsViewController.popoverPresentationController?.backgroundColor = .white
         optionsViewController.popoverPresentationController?.delegate = self
 
-        if presentedViewController != nil {
-            dismiss(animated: true, completion: {
-                self.present(self.optionsViewController, animated: true, completion: completion)
-            })
-        } else {
-            present(optionsViewController, animated: true, completion: completion)
-        }
+        present(optionsViewController, animated: true, completion: completion)
     }
 
     private func presentOptionsViewControllerAsInputView(_ optionsViewController: OptionsTableViewController) {


### PR DESCRIPTION
This PR fixes a crash on the Aztec editor, when tapping twice on the Headers Icon or Bullets icon make the app crash. This only happen on the iPad

To test:
 - Start the app on the iPad
 - Start the Aztec editor
 - Tap on the Headers option in the toolbar
 - Tap on the Headers options again
 - Check the app doesn't crash
 - Try the same but now press another icon on the toolbar
 - Check that everything works.

Needs review: @frosty 
