### PR TITLE
Aztec: Add Beta tag to editor

### DIFF
--- a/WordPress/Classes/Extensions/WPStyleGuide+Aztec.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+Aztec.swift
@@ -17,4 +17,21 @@ extension WPStyleGuide {
     static var aztecFormatBarBackgroundColor: UIColor {
         return .white
     }
+
+    static func configureBetaButton(_ button: UIButton) {
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 11.0)
+        button.layer.borderWidth = 1.0
+        button.layer.cornerRadius = 3.0
+
+        button.tintColor = WPStyleGuide.darkGrey()
+        button.setTitleColor(WPStyleGuide.darkGrey(), for: .disabled)
+        button.layer.borderColor = WPStyleGuide.greyLighten20().cgColor
+
+        let verticalInset = CGFloat(6.0)
+        let horizontalInset = CGFloat(8.0)
+        button.contentEdgeInsets = UIEdgeInsets(top: verticalInset,
+                                                left: horizontalInset,
+                                                bottom: verticalInset,
+                                                right: horizontalInset)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -487,7 +487,7 @@ class AztecPostViewController: UIViewController, PostEditor {
             ])
 
         NSLayoutConstraint.activate([
-            betaButton.centerYAnchor.constraint(equalTo: titleTextField.centerYAnchor),
+            betaButton.centerYAnchor.constraint(equalTo: titlePlaceholderLabel.centerYAnchor),
             betaButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -defaultMargin),
             titleTextField.trailingAnchor.constraint(equalTo: betaButton.leadingAnchor, constant: -defaultMargin)
             ])

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -454,7 +454,14 @@ class AztecPostViewController: UIViewController, PostEditor {
     func updateTitleHeight() {
         let referenceView: UITextView = mode == .richText ? richTextView : htmlTextView
 
-        let sizeThatShouldFitTheContent = titleTextField.sizeThatFits(CGSize(width:view.frame.width - ( 2 * Constants.defaultMargin), height: CGFloat.greatestFiniteMagnitude))
+        var titleWidth = titleTextField.bounds.width
+        if titleWidth <= 0 {
+            // Use the title text field's width if available, otherwise calculate it.
+            // View's frame minus left and right margins as well as margin between title and beta button
+            titleWidth = view.frame.width - (3 * Constants.defaultMargin) - betaButton.frame.width
+        }
+
+        let sizeThatShouldFitTheContent = titleTextField.sizeThatFits(CGSize(width:titleWidth, height: CGFloat.greatestFiniteMagnitude))
         let insets = titleTextField.textContainerInset
         titleHeightConstraint.constant = max(sizeThatShouldFitTheContent.height, titleTextField.font!.lineHeight + insets.top + insets.bottom)
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -217,6 +217,21 @@ class AztecPostViewController: UIViewController, PostEditor {
     }()
 
 
+    /// Beta Tag Button
+    ///
+    fileprivate lazy var betaButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        WPStyleGuide.configureBetaButton(button)
+
+        button.setTitle(NSLocalizedString("Beta", comment: "Title for Beta tag button for the new Aztec editor"), for: .normal)
+        button.setContentHuggingPriority(UILayoutPriorityRequired, for: .horizontal)
+        button.isEnabled = false
+
+        return button
+    }()
+
+
     /// Active Editor's Mode
     ///
     fileprivate(set) var mode = EditionMode.richText {
@@ -466,10 +481,15 @@ class AztecPostViewController: UIViewController, PostEditor {
         updateTitleHeight()
 
         NSLayoutConstraint.activate([
-            titleTextField.leftAnchor.constraint(equalTo: view.leftAnchor, constant: defaultMargin),
-            titleTextField.rightAnchor.constraint(equalTo: view.rightAnchor, constant: -defaultMargin),
+            titleTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: defaultMargin),
             titleTopConstraint,
             titleHeightConstraint
+            ])
+
+        NSLayoutConstraint.activate([
+            betaButton.centerYAnchor.constraint(equalTo: titleTextField.centerYAnchor),
+            betaButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -defaultMargin),
+            titleTextField.trailingAnchor.constraint(equalTo: betaButton.leadingAnchor, constant: -defaultMargin)
             ])
 
         let insets = titleTextField.textContainerInset
@@ -550,6 +570,8 @@ class AztecPostViewController: UIViewController, PostEditor {
         view.addSubview(titlePlaceholderLabel)
         view.addSubview(separatorView)
         view.addSubview(placeholderLabel)
+        view.addSubview(betaButton)
+
         mediaProgressView.isHidden = true
         view.addSubview(mediaProgressView)
     }


### PR DESCRIPTION
This PR adds a 'beta' tag to the top right of the Aztec editor. When we launch the beta, this button will be hooked up to show more info or release notes in a web view.

<img width="375" alt="screen shot 2017-06-21 at 21 47 29" src="https://user-images.githubusercontent.com/4780/27405918-3fb23b90-56cb-11e7-9720-01cb13e36365.png">

Needs review: @jleandroperez 
cc @iamthomasbishop 