### PR TITLE
Update version check on login

### DIFF
--- a/WordPress/Classes/Services/LoginFacade.m
+++ b/WordPress/Classes/Services/LoginFacade.m
@@ -80,7 +80,7 @@
             } else {
                 NSString *versionString = options[@"software_version"][@"value"];
                 CGFloat version = [versionString floatValue];
-                if (version < [WordPressMinimumVersion floatValue]) {
+                if (version > 0 && version < [WordPressMinimumVersion floatValue]) {
                     NSString *errorMessage = [NSString stringWithFormat:NSLocalizedString(@"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@", nil), [xmlRPCURL host], versionString, WordPressMinimumVersion];
                     NSError *versionError = [NSError errorWithDomain:WordPressAppErrorDomain
                                         code:WordPressAppErrorCodeInvalidVersion


### PR DESCRIPTION
If we can't get the blog's version then pretend it's good so users aren't stuck
without being able to log in.

To test:

You need a self hosted site that doesn't include the version in the `wp.getOptions` response. You can do that with the following code:

```php
add_filter('xmlrpc_blog_options','no_version_in_xmlrpc');
function no_version_in_xmlrpc($options) {
        unset($options['software_version']);
        return $options;
}
```

Then try to log in to that site and verify that you can log in and it doesn't show an error about the version being too low

Needs review: @SergioEstevao 