### PR TITLE
Reader: Tweaks the bar animation so the navbar always reappears.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -848,8 +848,8 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
                            options: [.beginFromCurrentState, .allowUserInteraction],
                            animations: {
                             self.view.layoutIfNeeded()
+                            self.navigationController?.setNavigationBarHidden(false, animated: animated)
                             if pinToBottom {
-                                self.navigationController?.setNavigationBarHidden(false, animated: animated)
                                 let y = self.textView.contentSize.height - self.textView.frame.height
                                 self.textView.setContentOffset(CGPoint(x: 0, y: y), animated: false)
                             }


### PR DESCRIPTION
In #7366 I fixed an issue with a glitchy bounce when scrolling to the bottom of the post detail.  The fix had a glitch that would keep the nav bar from reappearing if the user started scrolling back to the top before reaching the bottom of the post.  This PR fixes that glitch. 

To test:
- Scroll part of the way down a long post.  Confirm that bars properly hide.
- Scroll back up a bit.  Confirm that bars reappear.
- Test the original issue and confirm the fix is still in place. 

Needs review: @jleandroperez game for another peek at this one? 

cc @elibud 
