### PR TITLE
Reader: Escape html entities in the author's name.

### DIFF
--- a/WordPress/Classes/Networking/ReaderPostServiceRemote.m
+++ b/WordPress/Classes/Networking/ReaderPostServiceRemote.m
@@ -293,7 +293,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
     
     post.author = [self stringOrEmptyString:[authorDict stringForKey:PostRESTKeyNiceName]]; // typically the author's screen name
     post.authorAvatarURL = [self stringOrEmptyString:[authorDict stringForKey:PostRESTKeyAvatarURL]];
-    post.authorDisplayName = [self stringOrEmptyString:[authorDict stringForKey:PostRESTKeyName]]; // Typically the author's given name
+    post.authorDisplayName = [[self stringOrEmptyString:[authorDict stringForKey:PostRESTKeyName]] stringByDecodingXMLCharacters]; // Typically the author's given name
     post.authorEmail = [self authorEmailFromAuthorDictionary:authorDict];
     post.authorURL = [self stringOrEmptyString:[authorDict stringForKey:PostRESTKeyURL]];
     post.siteIconURL = [self stringOrEmptyString:[dict stringForKeyPath:@"meta.data.site.icon.img"]];


### PR DESCRIPTION
Fixes an issue where html entities were not being escaped in the author's name.

To test:
Follow a blog like `https://taliwutblog.wordpress.com/` where the author's name has an ampersand.  Confirm the ampersand is shown and not its html entity. 

Needs review: @kurzee One more review for the road, sir? 
