### PR TITLE
Newlines are no longer allowed in the title field.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1136,7 +1136,7 @@ extension AztecPostViewController : UITextViewDelegate {
         var sanitizedText = input
 
         while let range = sanitizedText.rangeOfCharacter(from: CharacterSet.newlines, options: [], range: nil) {
-            sanitizedText = sanitizedText.replacingCharacters(in: range, with: "")
+            sanitizedText = sanitizedText.replacingCharacters(in: range, with: " ")
         }
 
         return sanitizedText
@@ -1151,7 +1151,7 @@ extension AztecPostViewController : UITextViewDelegate {
     ///     - range: the range that would be modified.
     ///     - text: the new text for the specified range.
     ///
-    /// - Returns: `true` if the moficiation can take place, `false` otherwise.
+    /// - Returns: `true` if the modification can take place, `false` otherwise.
     ///
     private func shouldChangeTitleText(in range: NSRange, replacementText text: String) -> Bool {
 
@@ -1165,9 +1165,8 @@ extension AztecPostViewController : UITextViewDelegate {
             return true
         }
 
-        var sanitizedInput = sanitizeInputForTitle(text)
-
-        let newlinesWereRemoved = sanitizedInput.characters.count != text.characters.count
+        let sanitizedInput = sanitizeInputForTitle(text)
+        let newlinesWereRemoved = sanitizedInput != text
 
         guard !newlinesWereRemoved else {
             titleTextField.insertText(sanitizedInput)


### PR DESCRIPTION
### Description

Fixes #7106 

When enter is pressed while the caret is in the title view, the caret will be moved to the content view.

If text containing newlines is pasted into the title view, the newlines will be removed before pasting.

### Testing:

**Test 1:**

* Open the editor.
* Place the caret in the title view and press enter.
* The caret should be moved to the first position of the rich text view.

PS: Combine the above steps with having content in the title and rich text view.

**Test 2:**

* Copy text containing several newlines.
* Pase the text in the title view.
* Make sure all newlines are removed.
