### PR TITLE
Fixes several static analyzer warnings in WordPressKit & Stats Framework

### DIFF
--- a/WordPressComStatsiOS/WordPressComStatsiOS/Services/WPStatsService.m
+++ b/WordPressComStatsiOS/WordPressComStatsiOS/Services/WPStatsService.m
@@ -355,7 +355,7 @@ NSString *const TodayCacheKey = @"Today";
 - (void)retrievePostDetailsStatsForPostID:(NSNumber *)postID
                     withCompletionHandler:(StatsPostDetailsCompletion)completion
 {
-    if (!postID || !completion) {
+    if (postID == nil || completion == nil) {
         return;
     }
     

--- a/WordPressComStatsiOS/WordPressComStatsiOS/UI/InsightsPostingActivityCollectionViewController.m
+++ b/WordPressComStatsiOS/WordPressComStatsiOS/UI/InsightsPostingActivityCollectionViewController.m
@@ -61,18 +61,18 @@ static NSString *const PostActivityCollectionFooterIdentifier = @"PostingActivit
            viewForSupplementaryElementOfKind:(NSString *)kind
                                  atIndexPath:(NSIndexPath *)indexPath
 {
-    UICollectionReusableView *reusableview = nil;
-    
+    NSParameterAssert(kind == UICollectionElementKindSectionHeader || kind == UICollectionElementKindSectionFooter);
+
     if (kind == UICollectionElementKindSectionHeader) {
-        reusableview = [collectionView dequeueReusableSupplementaryViewOfKind:kind
-                                                          withReuseIdentifier:PostActivityCollectionHeaderIdentifier
-                                                                 forIndexPath:indexPath];
-    } else if (kind == UICollectionElementKindSectionFooter) {
-        reusableview = [collectionView dequeueReusableSupplementaryViewOfKind:kind
-                                                          withReuseIdentifier:PostActivityCollectionFooterIdentifier
-                                                                 forIndexPath:indexPath];
+        return [collectionView dequeueReusableSupplementaryViewOfKind:UICollectionElementKindSectionHeader
+                                                  withReuseIdentifier:PostActivityCollectionHeaderIdentifier
+                                                         forIndexPath:indexPath];
+    } else {
+        // Implies footer
+        return [collectionView dequeueReusableSupplementaryViewOfKind:UICollectionElementKindSectionFooter
+                                                  withReuseIdentifier:PostActivityCollectionFooterIdentifier
+                                                         forIndexPath:indexPath];
     }
-    return reusableview;
 }
 
 @end

--- a/WordPressComStatsiOS/WordPressComStatsiOS/UI/InsightsTableViewController.m
+++ b/WordPressComStatsiOS/WordPressComStatsiOS/UI/InsightsTableViewController.m
@@ -1469,7 +1469,7 @@ static CGFloat const InsightsTableSectionFooterHeight = 10.0f;
 {
     NSNumber *subSectionValue = self.selectedSubsections[@(statsSection)];
     
-    if (!subSectionValue) {
+    if (subSectionValue == nil) {
         return StatsSubSectionNone;
     }
     

--- a/WordPressComStatsiOS/WordPressComStatsiOS/UI/WPStatsGraphViewController.m
+++ b/WordPressComStatsiOS/WordPressComStatsiOS/UI/WPStatsGraphViewController.m
@@ -138,16 +138,14 @@ static NSInteger const RecommendedYAxisTicks = 2;
 
 - (UICollectionReusableView *)collectionView:(UICollectionView *)collectionView viewForSupplementaryElementOfKind:(NSString *)kind atIndexPath:(NSIndexPath *)indexPath
 {
-    if ([kind isEqualToString:WPStatsCollectionElementKindGraphBackground]) {
-        WPStatsGraphBackgroundView *background = [collectionView dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:GraphBackgroundView forIndexPath:indexPath];
-        background.maximumYValue = (NSUInteger)self.maximumY;
-        background.numberOfXValues = self.numberOfXValues;
-        background.numberOfYValues = self.numberOfYValues;
-        
-        return background;
-    }
-    
-    return nil;
+    NSParameterAssert([kind isEqualToString:WPStatsCollectionElementKindGraphBackground]);
+
+    WPStatsGraphBackgroundView *background = [collectionView dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:GraphBackgroundView forIndexPath:indexPath];
+    background.maximumYValue = (NSUInteger)self.maximumY;
+    background.numberOfXValues = self.numberOfXValues;
+    background.numberOfYValues = self.numberOfYValues;
+
+    return background;
 }
 
 #pragma mark - UICollectionViewDelegateFlowLayout methods

--- a/WordPressKit/WordPressKit/WPStatsServiceRemote.m
+++ b/WordPressKit/WordPressKit/WPStatsServiceRemote.m
@@ -1682,8 +1682,12 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
 #pragma mark - Private convenience methods for data conversion
 
 
-- (NSDate * _Nullable)deviceLocalDateForString:(NSString * _Nonnull)dateString withPeriodUnit:(StatsPeriodUnit)unit
+- (NSDate * _Nullable)deviceLocalDateForString:(NSString * _Nullable)dateString withPeriodUnit:(StatsPeriodUnit)unit
 {
+    if (dateString == nil) {
+        return nil;
+    }
+
     switch (unit) {
         case StatsPeriodUnitDay:
         case StatsPeriodUnitMonth:
@@ -1762,8 +1766,8 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
 }
 
 
-- (NSString *)nicePointNameForDate:(NSDate *)date forStatsPeriodUnit:(StatsPeriodUnit)unit {
-    if (!date) {
+- (NSString * _Nonnull)nicePointNameForDate:(NSDate * _Nullable)date forStatsPeriodUnit:(StatsPeriodUnit)unit {
+    if (date == nil) {
         return @"";
     }
     
@@ -1796,9 +1800,9 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
     return [self localizedStringForNumber:number withNumberStyle:NSNumberFormatterDecimalStyle];
 }
 
-- (NSString *)localizedStringForNumber:(NSNumber *)number withNumberStyle:(NSNumberFormatterStyle)numberStyle
+- (NSString * _Nullable)localizedStringForNumber:(NSNumber * _Nullable)number withNumberStyle:(NSNumberFormatterStyle)numberStyle
 {
-    if (!number) {
+    if (number == nil) {
         return nil;
     }
     

--- a/WordPressKit/WordPressKit/WPStatsServiceRemote.m
+++ b/WordPressKit/WordPressKit/WPStatsServiceRemote.m
@@ -659,7 +659,8 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
         
         NSNumber *postID = [postDict numberForKey:@"ID"];
         NSString *postTitle = [self.stringUtilities displayablePostTitle:[postDict stringForKey:@"title"]];
-        NSDate *postDate = [self.rfc3339DateFormatter dateFromString:[postDict stringForKey:@"date"]];
+        NSString *postDateString = [postDict stringForKey:@"date"];
+        NSDate *postDate = postDateString != nil ? [self.rfc3339DateFormatter dateFromString:postDateString] : nil;
         NSString *postURL = [postDict stringForKey:@"URL"];
         NSNumber *likesValue = [postDict numberForKey:@"like_count"];
         NSString *likes = [self localizedStringForNumber:likesValue];
@@ -1508,14 +1509,18 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
         
         NSDictionary *longDict = [streakDict dictionaryForKey:@"long"];
         NSNumber *longLengthValue = [longDict numberForKey:@"length"];
-        NSDate *longStartDate = [self.deviceDateFormatter dateFromString:[longDict stringForKey:@"start"]];
-        NSDate *longEndDate = [self.deviceDateFormatter dateFromString:[longDict stringForKey:@"end"]];
+        NSString *longStartDateString = [longDict stringForKey:@"start"];
+        NSString *longEndDateString = [longDict stringForKey:@"end"];
+        NSDate *longStartDate = longStartDateString != nil ? [self.deviceDateFormatter dateFromString:longStartDateString] : nil;
+        NSDate *longEndDate = longEndDateString != nil ? [self.deviceDateFormatter dateFromString:longEndDateString] : nil;
         
         NSDictionary *currentDict = [streakDict dictionaryForKey:@"current"];
         NSNumber *currentLengthValue = [currentDict numberForKey:@"length"];
-        NSDate *currentStartDate = [self.deviceDateFormatter dateFromString:[currentDict stringForKey:@"start"]];
-        NSDate *currentEndDate = [self.deviceDateFormatter dateFromString:[currentDict stringForKey:@"end"]];
-        
+        NSString *currentStartDateString = [currentDict stringForKey:@"start"];
+        NSString *currentEndDateString = [currentDict stringForKey:@"end"];
+        NSDate *currentStartDate = currentStartDateString != nil ? [self.deviceDateFormatter dateFromString:currentStartDateString] : nil;
+        NSDate *currentEndDate = currentEndDateString != nil ? [self.deviceDateFormatter dateFromString:currentEndDateString] : nil;
+
         StatsStreak *statsStreak = [StatsStreak new];
         statsStreak.longestStreakLength = longLengthValue;
         statsStreak.longestStreakStartDate = longStartDate;
@@ -1677,7 +1682,7 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
 #pragma mark - Private convenience methods for data conversion
 
 
-- (NSDate *)deviceLocalDateForString:(NSString *)dateString withPeriodUnit:(StatsPeriodUnit)unit
+- (NSDate * _Nullable)deviceLocalDateForString:(NSString * _Nonnull)dateString withPeriodUnit:(StatsPeriodUnit)unit
 {
     switch (unit) {
         case StatsPeriodUnitDay:


### PR DESCRIPTION
Fixes #7417 

To test:
1. Run static analyzer.
2. Verify no warnings appear for WordPressKit or WordPressComStatsiOS
3. Run unit tests and verify they pass (technically Buddybuild will do this).

Needs review: @koke 
