### PR TITLE
Add keyboard shortcuts to Aztec editor.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -688,6 +688,26 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     // MARK: - Keyboard Handling
 
+    override var keyCommands: [UIKeyCommand] {
+        if richTextView.isFirstResponder {
+            return [ UIKeyCommand(input:"B", modifierFlags: .command, action:#selector(toggleBold), discoverabilityTitle:NSLocalizedString("Bold", comment: "Discoverability title for bold formatting keyboard shortcut.")),
+                     UIKeyCommand(input:"I", modifierFlags: .command, action:#selector(toggleItalic), discoverabilityTitle:NSLocalizedString("Italic", comment: "Discoverability title for italic formatting keyboard shortcut.")),
+                     UIKeyCommand(input:"S", modifierFlags: [.command], action:#selector(toggleStrikethrough), discoverabilityTitle: NSLocalizedString("Strikethrough", comment:"Discoverability title for strikethrough formatting keyboard shortcut.")),
+                     UIKeyCommand(input:"U", modifierFlags: .command, action:#selector(toggleUnderline(_:)), discoverabilityTitle: NSLocalizedString("Underline", comment:"Discoverability title for underline formatting keyboard shortcut.")),
+                     UIKeyCommand(input:"Q", modifierFlags:[.command,.alternate], action: #selector(toggleBlockquote), discoverabilityTitle: NSLocalizedString("Block Quote", comment: "Discoverability title for block quote keyboard shortcut.")),
+                     UIKeyCommand(input:"K", modifierFlags:.command, action:#selector(toggleLink), discoverabilityTitle: NSLocalizedString("Insert Link", comment: "Discoverability title for insert link keyboard shortcut.")),
+                     UIKeyCommand(input:"M", modifierFlags:[.command,.alternate], action:#selector(presentMediaPicker(animated:)), discoverabilityTitle: NSLocalizedString("Insert Media", comment: "Discoverability title for insert media keyboard shortcut.")),
+                     UIKeyCommand(input:"U", modifierFlags:[.command, .alternate], action:#selector(toggleUnorderedList), discoverabilityTitle:NSLocalizedString("Bullet List", comment: "Discoverability title for bullet list keyboard shortcut.")),
+                     UIKeyCommand(input:"O", modifierFlags:[.command, .alternate], action:#selector(toggleOrderedList), discoverabilityTitle:NSLocalizedString("Numbered List", comment:"Discoverability title for numbered list keyboard shortcut.")),
+                     UIKeyCommand(input:"H", modifierFlags:[.command, .shift], action:#selector(toggleEditingMode), discoverabilityTitle:NSLocalizedString("Toggle HTML Source ", comment: "Discoverability title for HTML keyboard shortcut."))
+            ]
+        } else if htmlTextView.isFirstResponder {
+            return [UIKeyCommand(input:"H", modifierFlags:[.command, .shift], action:#selector(toggleEditingMode), discoverabilityTitle:NSLocalizedString("Toggle HTML Source ", comment: "Discoverability title for HTML keyboard shortcut."))
+            ]
+        }
+        return []
+    }
+
     func keyboardWillShow(_ notification: Foundation.Notification) {
         guard
             let userInfo = notification.userInfo as? [String: AnyObject],
@@ -1349,6 +1369,15 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
         richTextView.toggleStrikethrough(range: richTextView.selectedRange)
     }
 
+    func toggleOrderedList() {
+        trackFormatBarAnalytics(stat: .editorTappedOrderedList)
+        richTextView.toggleOrderedList(range: richTextView.selectedRange)
+    }
+
+    func toggleUnorderedList() {
+        trackFormatBarAnalytics(stat: .editorTappedUnorderedList)
+        richTextView.toggleUnorderedList(range: richTextView.selectedRange)
+    }
 
     func toggleList(fromItem item: FormatBarItem) {
         let listOptions = Constants.lists.map { (listType) -> OptionsTableViewOption in
@@ -1364,16 +1393,13 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
                                                   fromBarItem: item,
                                                   selectedRowIndex: index,
                                                   onSelect: { [weak self] selected in
-                                                    guard let range = self?.richTextView.selectedRange else { return }
 
                                                     let listType = Constants.lists[selected]
                                                     switch listType {
                                                     case .unordered:
-                                                        self?.trackFormatBarAnalytics(stat: .editorTappedUnorderedList)
-                                                        self?.richTextView.toggleUnorderedList(range: range)
+                                                        self?.toggleUnorderedList()
                                                     case .ordered:
-                                                        self?.trackFormatBarAnalytics(stat: .editorTappedOrderedList)
-                                                        self?.richTextView.toggleOrderedList(range: range)
+                                                        self?.toggleOrderedList()
                                                     }
 
                                                     self?.optionsViewController = nil
@@ -1550,6 +1576,7 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
         }
 
         trackFormatBarAnalytics(stat: .editorTappedHTML)
+        formatBar.overflowToolbar(expand: true)
         mode.toggle()
     }
 


### PR DESCRIPTION
This add the keyboard shortcuts to the Aztec editor in the main app.

The PR is basically a copy over of this [PR in Aztec](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/566).

To test:
 - Start the app on a iPad device
 - Make sure you have the Aztec editor active
 - Test the shortcuts

Needs review: @frosty 