### PR TITLE
Only load fonts if they are not available yet.

### DIFF
--- a/WordPressShared/WordPressShared/Core/Utility/WPFontManager.m
+++ b/WordPressShared/WordPressShared/Core/Utility/WPFontManager.m
@@ -47,10 +47,13 @@ static NSString* const NotoRegularFileName = @"NotoSerif-Regular";
 
 + (void)loadNotoFontFamily
 {
-    [self loadIfNeededFontNamed:NotoRegularFontName resourceNamed:NotoRegularFileName withExtension:FontTypeTTF];
-    [self loadIfNeededFontNamed:NotoBoldFileName resourceNamed:NotoBoldFileName withExtension:FontTypeTTF];
-    [self loadIfNeededFontNamed:NotoBoldItalicFontName resourceNamed:NotoBoldItalicFileName withExtension:FontTypeTTF];
-    [self loadIfNeededFontNamed:NotoItalicFontName resourceNamed:NotoItalicFileName withExtension:FontTypeTTF];
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        [self loadFontNamed:NotoRegularFontName resourceNamed:NotoRegularFileName withExtension:FontTypeTTF];
+        [self loadFontNamed:NotoBoldFileName resourceNamed:NotoBoldFileName withExtension:FontTypeTTF];
+        [self loadFontNamed:NotoBoldItalicFontName resourceNamed:NotoBoldItalicFileName withExtension:FontTypeTTF];
+        [self loadFontNamed:NotoItalicFontName resourceNamed:NotoItalicFileName withExtension:FontTypeTTF];
+    });
 }
 
 + (UIFont *)notoBoldFontOfSize:(CGFloat)size
@@ -92,7 +95,7 @@ static NSString* const NotoRegularFileName = @"NotoSerif-Regular";
     return font;
 }
 
-+ (void)loadIfNeededFontNamed:(NSString *)fontName resourceNamed:(NSString *)resourceName withExtension:(NSString *)extension {
++ (void)loadFontNamed:(NSString *)fontName resourceNamed:(NSString *)resourceName withExtension:(NSString *)extension {
     UIFont *font = [UIFont fontWithName:fontName size:UIFont.systemFontSize];
     if (!font) {
         [self loadFontResourceNamed:resourceName withExtension:FontTypeTTF];

--- a/WordPressShared/WordPressShared/Core/Utility/WPFontManager.m
+++ b/WordPressShared/WordPressShared/Core/Utility/WPFontManager.m
@@ -47,10 +47,10 @@ static NSString* const NotoRegularFileName = @"NotoSerif-Regular";
 
 + (void)loadNotoFontFamily
 {
-    [self loadFontResourceNamed:NotoBoldFontName withExtension:FontTypeTTF];
-    [self loadFontResourceNamed:NotoBoldItalicFontName withExtension:FontTypeTTF];
-    [self loadFontResourceNamed:NotoItalicFontName withExtension:FontTypeTTF];
-    [self loadFontResourceNamed:NotoRegularFontName withExtension:FontTypeTTF];
+    [self loadIfNeededFontNamed:NotoRegularFontName resourceNamed:NotoRegularFileName withExtension:FontTypeTTF];
+    [self loadIfNeededFontNamed:NotoBoldFileName resourceNamed:NotoBoldFileName withExtension:FontTypeTTF];
+    [self loadIfNeededFontNamed:NotoBoldItalicFontName resourceNamed:NotoBoldItalicFileName withExtension:FontTypeTTF];
+    [self loadIfNeededFontNamed:NotoItalicFontName resourceNamed:NotoItalicFileName withExtension:FontTypeTTF];
 }
 
 + (UIFont *)notoBoldFontOfSize:(CGFloat)size
@@ -90,6 +90,13 @@ static NSString* const NotoRegularFileName = @"NotoSerif-Regular";
     }
 
     return font;
+}
+
++ (void)loadIfNeededFontNamed:(NSString *)fontName resourceNamed:(NSString *)resourceName withExtension:(NSString *)extension {
+    UIFont *font = [UIFont fontWithName:fontName size:UIFont.systemFontSize];
+    if (!font) {
+        [self loadFontResourceNamed:resourceName withExtension:FontTypeTTF];
+    }
 }
 
 + (void)loadFontResourceNamed:(NSString *)name withExtension:(NSString *)extension

--- a/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -3,11 +3,6 @@
 extension WPStyleGuide {
     static let defaultTableViewRowHeight: CGFloat = 44.0
 
-    static let notoLoaded = { () -> Bool in
-        WPFontManager.loadNotoFontFamily()
-        return true
-    }()
-
     /// Configures a table to automatically resize its rows according to their content.
     ///
     /// - Parameters:
@@ -175,7 +170,7 @@ extension WPStyleGuide {
     /// - Returns: The created font point size.
     ///
     private class func customNotoFontNamed(_ fontName: String, forTextStyle style: UIFontTextStyle) -> UIFont {
-        _ = notoLoaded
+        WPFontManager.loadNotoFontFamily()
         let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
         guard let font = UIFont(name: fontName, size: fontDescriptor.pointSize) else {
             // If we can't get the Noto font for some reason we will default to the system font


### PR DESCRIPTION
This PR make sure that before a font is loaded from file is not already loaded.

This avoid some logging errors being printed that can be confusing to HE and us.

To test:
 - Start the app
 - Make sure in the logs you don't see `"Failed to load font: XXXX"`

Needs review: @elibud 