### PR TITLE
Aztec: Update preferences toggle

### DIFF
--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -308,6 +308,22 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
         }
         return tableView.rowHeight
     }
+
+    open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        if target.responds(to: #selector(UITableViewDelegate.tableView(_:heightForFooterInSection:))) {
+            return target.tableView(tableView, heightForFooterInSection: section)
+        }
+
+        return 0
+    }
+
+    open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        if target.responds(to: #selector(UITableViewDelegate.tableView(_:viewForFooterInSection:))) {
+            return target.tableView(tableView, viewForFooterInSection: section)
+        }
+
+        return nil
+    }
 }
 
 

--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -87,6 +87,22 @@ struct TextRow: ImmuTableRow {
     }
 }
 
+struct CheckmarkRow: ImmuTableRow {
+    static let cell = ImmuTableCell.class(WPTableViewCellDefault.self)
+
+    let title: String
+    let checked: Bool
+    let action: ImmuTableAction?
+
+    func configureCell(_ cell: UITableViewCell) {
+        cell.textLabel?.text = title
+        cell.selectionStyle = .none
+        cell.accessoryType = (checked) ? .checkmark : .none
+
+        WPStyleGuide.configureTableViewCell(cell)
+    }
+}
+
 struct LinkRow: ImmuTableRow {
     static let cell = ImmuTableCell.class(WPTableViewCellValue1.self)
 

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -244,18 +244,27 @@ class AppSettingsViewController: UITableViewController {
 
     func visualEditorChanged(editor: EditorSettings.Editor) -> ImmuTableAction {
         return { [weak self] row in
+            let currentEditorIsAztec = EditorSettings().nativeEditorEnabled
+
             switch editor {
             case .legacy:
                 EditorSettings().nativeEditorEnabled = false
                 EditorSettings().visualEditorEnabled = false
-                WPAnalytics.track(.editorToggledOff)
+                if currentEditorIsAztec {
+                    WPAnalytics.track(.editorToggledOff)
+                }
             case .hybrid:
                 EditorSettings().nativeEditorEnabled = false
                 EditorSettings().visualEditorEnabled = true
-                WPAnalytics.track(.editorToggledOn)
+                if currentEditorIsAztec {
+                    WPAnalytics.track(.editorToggledOff)
+                }
             case .aztec:
                 EditorSettings().visualEditorEnabled = true
                 EditorSettings().nativeEditorEnabled = true
+                if !currentEditorIsAztec {
+                    WPAnalytics.track(.editorToggledOn)
+                }
             }
 
             self?.reloadViewModel()


### PR DESCRIPTION
This PR updates the App Settings preferences toggle for Aztec.

![simulator screen shot 27 jun 2017 16 17 41](https://user-images.githubusercontent.com/4780/27595502-bdd4f1e2-5b54-11e7-8048-5fe7e9fc73c3.png)

Note: The button in the footer currently doesn't link anywhere.

To test:

* Launch the app, visit App Settings
* Check the correct current editor setting is reflected in the options
* Try changing between the different options and check the correct editor is presented
* Ensure the 'help' footer appears if you select the Beta option, and disappears if you toggle a different option.
* Check the changes to `ImmuTable` footer delegate methods didn't affect other VCs that use `ImmuTable`.

Needs review: @SergioEstevao 
cc @iamthomasbishop 