### PR TITLE
Aztec: Update format bar colors

### DIFF
--- a/WordPress/Classes/Extensions/WPStyleGuide+Aztec.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+Aztec.swift
@@ -2,20 +2,24 @@ import UIKit
 import WordPressShared
 
 extension WPStyleGuide {
-    static var aztecFormatBarInactiveColor: UIColor {
-        return UIColor(hexString: "7B9AB1")
+    static let aztecFormatBarInactiveColor = UIColor(hexString: "7B9AB1")
+
+    static let aztecFormatBarActiveColor = WPStyleGuide.wordPressBlue()
+
+    static let aztecFormatBarDisabledColor = WPStyleGuide.greyLighten20()
+
+    static let aztecFormatBarBackgroundColor = UIColor.white
+
+    static var aztecFormatPickerSelectedCellBackgroundColor: UIColor {
+        get {
+            return (UIDevice.isPad()) ? WPStyleGuide.lightGrey() : WPStyleGuide.greyLighten30()
+        }
     }
 
-    static var aztecFormatBarActiveColor: UIColor {
-        return WPStyleGuide.darkGrey()
-    }
-
-    static var aztecFormatBarDisabledColor: UIColor {
-        return WPStyleGuide.greyLighten20()
-    }
-
-    static var aztecFormatBarBackgroundColor: UIColor {
-        return .white
+    static var aztecFormatPickerBackgroundColor: UIColor {
+        get {
+            return (UIDevice.isPad()) ? .white : WPStyleGuide.lightGrey()
+        }
     }
 
     static func configureBetaButton(_ button: UIButton) {

--- a/WordPress/Classes/ViewRelated/Aztec/Extensions/Header+WordPress.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Extensions/Header+WordPress.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Aztec
-
+import Gridicons
+import WordPressShared
 
 // MARK: - Header and List presentation extensions
 //
@@ -30,6 +31,9 @@ extension Header.HeaderType {
     }
 
     var iconImage: UIImage? {
-        return formattingIdentifier.iconImage
+        switch self {
+        case .none: return UIImage(color: .clear, havingSize: Gridicon.defaultSize)
+        default: return formattingIdentifier.iconImage
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Options/OptionsTableView.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Options/OptionsTableView.swift
@@ -122,6 +122,13 @@ class OptionsTableViewCell: UITableViewCell {
         fatalError("Not implemented")
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        // Our Gridicons look slightly better if shifted down one px
+        imageView?.frame.origin.y += 1
+    }
+
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
 

--- a/WordPress/Classes/ViewRelated/Aztec/Options/OptionsTableView.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Options/OptionsTableView.swift
@@ -22,6 +22,9 @@ class OptionsTableViewController: UITableViewController {
 
     var onSelect: OnSelectHandler?
 
+    var cellBackgroundColor: UIColor = .white
+    var cellSelectedBackgroundColor: UIColor = .lightGray
+
     var cellDeselectedTintColor: UIColor? {
         didSet {
             tableView?.reloadData()
@@ -70,6 +73,14 @@ extension OptionsTableViewController {
         cell.accessoryType = .checkmark
         onSelect?(indexPath.row)
     }
+
+    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        cell.backgroundColor = cellBackgroundColor
+
+        let selectedView = UIView()
+        selectedView.backgroundColor = cellSelectedBackgroundColor
+        cell.selectedBackgroundView = selectedView
+    }
 }
 
 extension OptionsTableViewController {
@@ -114,7 +125,8 @@ class OptionsTableViewCell: UITableViewCell {
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
 
-        imageView?.tintColor = selected ? tintColor : deselectedTintColor
+        // Icons should always appear deselected
+        imageView?.tintColor = deselectedTintColor
         accessoryType = selected ? .checkmark : .none
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Options/OptionsTableView.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Options/OptionsTableView.swift
@@ -22,7 +22,13 @@ class OptionsTableViewController: UITableViewController {
 
     var onSelect: OnSelectHandler?
 
-    var cellBackgroundColor: UIColor = .white
+    var cellBackgroundColor: UIColor = .white {
+        didSet {
+            tableView.backgroundColor = cellBackgroundColor
+            tableView?.reloadData()
+        }
+    }
+
     var cellSelectedBackgroundColor: UIColor = .lightGray
 
     var cellDeselectedTintColor: UIColor? {
@@ -38,6 +44,8 @@ class OptionsTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        tableView.backgroundColor = cellBackgroundColor
 
         view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         tableView.register(OptionsTableViewCell.self, forCellReuseIdentifier: OptionsTableViewCell.reuseIdentifier)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1594,7 +1594,8 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
         let headerOptions = Constants.headers.map { (headerType) -> OptionsTableViewOption in
             return OptionsTableViewOption(image: headerType.iconImage,
                                           title: NSAttributedString(string: headerType.description,
-                                                                    attributes:[NSFontAttributeName: UIFont.systemFont(ofSize: headerType.fontSize)]))
+                                                                    attributes:[NSFontAttributeName: UIFont.systemFont(ofSize: headerType.fontSize),
+                                                                                NSForegroundColorAttributeName: WPStyleGuide.darkGrey()]))
         }
 
         let selectedIndex = Constants.headers.index(of: self.headerLevelForSelectedText())
@@ -1627,6 +1628,8 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
 
         optionsViewController = OptionsTableViewController(options: options)
         optionsViewController.cellDeselectedTintColor = WPStyleGuide.aztecFormatBarInactiveColor
+        optionsViewController.cellBackgroundColor = WPStyleGuide.aztecFormatPickerBackgroundColor
+        optionsViewController.cellSelectedBackgroundColor = WPStyleGuide.aztecFormatPickerSelectedCellBackgroundColor
         optionsViewController.view.tintColor = WPStyleGuide.aztecFormatBarActiveColor
         optionsViewController.onSelect = { [weak self] selected in
             if self?.presentedViewController != nil {
@@ -1662,7 +1665,7 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
         let frame = barItem.superview?.convert(barItem.frame, to: UIScreen.main.coordinateSpace)
 
         optionsViewController.popoverPresentationController?.sourceRect = view.convert(frame!, from: UIScreen.main.coordinateSpace)
-        optionsViewController.popoverPresentationController?.backgroundColor = .white
+        optionsViewController.popoverPresentationController?.backgroundColor = WPStyleGuide.aztecFormatPickerBackgroundColor
         optionsViewController.popoverPresentationController?.delegate = self
 
         present(optionsViewController, animated: true, completion: completion)


### PR DESCRIPTION
A few more tweaks to button and table colors for the format bar.

![simulator screen shot 28 jun 2017 21 26 24](https://user-images.githubusercontent.com/4780/27658621-939ddeda-5c48-11e7-8026-e770b84318f6.png)

<img width="443" alt="screen shot 2017-06-28 at 21 12 43" src="https://user-images.githubusercontent.com/4780/27658635-a06366d0-5c48-11e7-86bf-346f4021610f.png">

To test:

* Build and run Aztec, check the colors look correct:
  * Any highlighted items in the format bar should now be WordPress blue
  * The table view for headings and lists should now have a background colour of `lightGrey` on iPhone and white on iPad.
  * The background of selected cells on the tables should now be `greyLighten30` on iPhone and `lightGrey` on iPad.
* The "Default" paragraph / heading style should now have no icon in the list.

Needs review: @SergioEstevao 
cc @iamthomasbishop 