### PR TITLE
Don’t allow video shortcodes to point to local files.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Processors/VideoProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/VideoProcessor.swift
@@ -77,7 +77,7 @@ public struct VideoProcessor {
             if let src = shortcode.attributes.named["src"] {
                 html += "src=\"\(src)\" "
             }
-            if let poster = shortcode.attributes.named["poster"] {
+            if let poster = shortcode.attributes.named["poster"], let posterURL = URL(string: poster), !posterURL.isFileURL {
                 html += "poster=\"\(poster)\" "
             }
             html += "]"


### PR DESCRIPTION
This PR fixes the following problem:

The poster parameter in the video shortcode always referred to a local file on my device, like this:

```
[video src="https://videos.files.wordpress.com/4wBIvbhH/img_9678-2.mov" poster="file:///var/mobile/Containers/Data/Application/1E4DD69E-2A51-4B4A-A6F1-8F35DFB3740A/Documents/Media/img_9678-2-thumbnail.jpeg"
```


To test:
 - Start the app
 - Make sure Aztec is active.
 - On a self-hosted site create a new post
 - Add a video to the post
 - After the upload is done
 - Switch to HTML mode
 - Check that no poster image attribute is set on the image
 - Switch back to visual and see if the preview image shows up.



Needs review: @jleandroperez 