### PR TITLE
Media: Legacy support for MediaService implementation.

### DIFF
--- a/WordPress/Classes/Categories/Media+WPMediaAsset.m
+++ b/WordPress/Classes/Categories/Media+WPMediaAsset.m
@@ -10,7 +10,7 @@
 {
     NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
     MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:mainContext];
-    [mediaService imageForMedia:self size:size success:^(UIImage *image) {
+    [mediaService imageForMedia:self preferredSize:size success:^(UIImage *image) {
         if (completionHandler) {
             completionHandler(image, nil);
         }

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -167,7 +167,7 @@
     if (!self.localThumbnailURL.length) {
         return nil;
     }
-    return [self absoluteURLForLocalPath:self.localThumbnailURL];
+    return [self absoluteURLForLocalPath:self.localThumbnailURL cacheDirectory:YES];
 }
 
 - (void)setAbsoluteThumbnailLocalURL:(NSURL *)absoluteLocalURL
@@ -180,7 +180,7 @@
     if (!self.localURL.length) {
         return nil;
     }
-    return [self absoluteURLForLocalPath:self.localURL];
+    return [self absoluteURLForLocalPath:self.localURL cacheDirectory:NO];
 }
 
 - (void)setAbsoluteLocalURL:(NSURL *)absoluteLocalURL
@@ -188,10 +188,15 @@
     self.localURL = absoluteLocalURL.lastPathComponent;
 }
 
-- (NSURL *)absoluteURLForLocalPath:(NSString *)localPath
+- (NSURL *)absoluteURLForLocalPath:(NSString *)localPath cacheDirectory:(BOOL)cacheDirectory
 {
     NSError *error;
-    NSURL *mediaDirectory = [MediaFileManager uploadsDirectoryURLAndReturnError:&error];
+    NSURL *mediaDirectory = nil;
+    if (cacheDirectory) {
+        mediaDirectory = [[MediaFileManager cacheManager] directoryURLAndReturnError:&error];
+    } else {
+        mediaDirectory = [MediaFileManager uploadsDirectoryURLAndReturnError:&error];
+    }
     if (error) {
         DDLogInfo(@"Error resolving Media directory: %@", error);
         return nil;

--- a/WordPress/Classes/Services/MediaService+Legacy.h
+++ b/WordPress/Classes/Services/MediaService+Legacy.h
@@ -1,0 +1,37 @@
+#import "MediaService.h"
+#import "Media.h"
+#import "WordPress-Swift.h"
+
+/**
+ MediaService methods with the original implementation for exporting Media, while we feature-flag
+ and transition to the new exporting support. Once transitioned, this category implementation could be removed.
+ */
+@interface MediaService (Legacy)
+
+- (void)createMediaWith:(id<ExportableAsset>)asset
+            forObjectID:(NSManagedObjectID *)objectID
+              mediaName:(NSString *)mediaName
+      thumbnailCallback:(void (^)(NSURL *thumbnailURL))thumbnailCallback
+             completion:(void (^)(Media *media, NSError *error))completion;
+
+- (void) createMediaForObjectID:(NSManagedObjectID *)objectID
+                       mediaURL:(NSURL *)mediaURL
+              mediaThumbnailURL:(NSURL *)mediaThumbnailURL
+                      mediaType:(MediaType)mediaType
+                      mediaSize:(CGSize)mediaSize
+                          asset:(id <ExportableAsset>)asset
+                     completion:(void (^)(Media *media, NSError *error))completion;
+
+- (void)configureNewMedia:(Media *)media
+             withMediaURL:(NSURL *)mediaURL
+        mediaThumbnailURL:(NSURL *)mediaThumbnailURL
+                mediaType:(MediaType)mediaType
+                mediaSize:(CGSize)mediaSize
+                    asset:(id <ExportableAsset>)asset;
+
+- (void)imageForMedia:(Media *)mediaInRandomContext
+                 size:(CGSize)requestSize
+              success:(void (^)(UIImage *image))success
+              failure:(void (^)(NSError *error))failure;
+
+@end

--- a/WordPress/Classes/Services/MediaService+Legacy.m
+++ b/WordPress/Classes/Services/MediaService+Legacy.m
@@ -78,8 +78,8 @@
         return;
     }
     error = nil;
-    MediaFileManager *mediaFileManager = [MediaFileManager defaultManager];
-    NSURL *mediaThumbnailURL = [mediaFileManager makeLocalMediaURLWithFilename:[mediaFileManager mediaFilenameAppendingThumbnail:[mediaURL lastPathComponent]]
+    MediaFileManager *cacheFileManager = [MediaFileManager cacheManager];
+    NSURL *mediaThumbnailURL = [cacheFileManager makeLocalMediaURLWithFilename:[cacheFileManager mediaFilenameAppendingThumbnail:[mediaURL lastPathComponent]]
                                                                  fileExtension:[self extensionForUTI:[asset defaultThumbnailUTI]]
                                                                          error:&error];
     if (error) {
@@ -234,14 +234,14 @@
         CGSize availableSize = CGSizeZero;
         if (media.mediaType == MediaTypeImage) {
             fileURL = media.absoluteThumbnailLocalURL;
-            availableSize = [[MediaFileManager defaultManager] imageSizeForMediaAtFileURL:fileURL];
+            availableSize = [[MediaFileManager cacheManager] imageSizeForMediaAtFileURL:fileURL];
             if (size.height > availableSize.height && size.width > availableSize.width) {
                 fileURL = media.absoluteLocalURL;
-                availableSize = [[MediaFileManager defaultManager] imageSizeForMediaAtFileURL:fileURL];
+                availableSize = [[MediaFileManager cacheManager] imageSizeForMediaAtFileURL:fileURL];
             }
         } else if (media.mediaType == MediaTypeVideo) {
             fileURL = media.absoluteThumbnailLocalURL;
-            availableSize = [[MediaFileManager defaultManager] imageSizeForMediaAtFileURL:fileURL];
+            availableSize = [[MediaFileManager cacheManager] imageSizeForMediaAtFileURL:fileURL];
         }
 
         // check if the available local image is equal or larger than the requested size
@@ -291,7 +291,7 @@
 
             [self.managedObjectContext performBlock:^{
                 NSError *error = nil;
-                MediaFileManager *mediaFileManager = [MediaFileManager defaultManager];
+                MediaFileManager *mediaFileManager = [MediaFileManager cacheManager];
                 NSURL *fileURL = [mediaFileManager makeLocalMediaURLWithFilename:[mediaFileManager mediaFilenameAppendingThumbnail:media.filename]
                                                                    fileExtension:[self extensionForUTI:(__bridge NSString*)kUTTypeJPEG]
                                                                            error:&error];

--- a/WordPress/Classes/Services/MediaService+Legacy.m
+++ b/WordPress/Classes/Services/MediaService+Legacy.m
@@ -1,0 +1,350 @@
+#import "MediaService+Legacy.h"
+#import "AccountService.h"
+#import "Blog.h"
+#import "UIImage+Resize.h"
+#import <MobileCoreServices/MobileCoreServices.h>
+#import "PhotonImageURLHelper.h"
+#import <WordPressShared/WPImageSource.h>
+
+@implementation MediaService (Legacy)
+
+- (void)createMediaWith:(id<ExportableAsset>)asset
+            forObjectID:(NSManagedObjectID *)objectID
+              mediaName:(NSString *)mediaName
+      thumbnailCallback:(void (^)(NSURL *thumbnailURL))thumbnailCallback
+             completion:(void (^)(Media *media, NSError *error))completion
+{
+    AbstractPost *post = nil;
+    Blog *blog = nil;
+    NSError *error = nil;
+    NSManagedObject *existingObject = [self.managedObjectContext existingObjectWithID:objectID error:&error];
+
+    if ([existingObject isKindOfClass:[AbstractPost class]]) {
+        post = (AbstractPost *)existingObject;
+        blog = post.blog;
+    } else if ([existingObject isKindOfClass:[Blog class]]) {
+        blog = (Blog *)existingObject;
+    }
+
+    if (!post && !blog) {
+        if (completion) {
+            completion(nil, error);
+        }
+        return;
+    }
+
+    MediaType mediaType = [asset assetMediaType];
+    NSString *assetUTI = [asset originalUTI];
+    NSString *extension = [self extensionForUTI:assetUTI];
+    if (mediaType == MediaTypeImage) {
+        NSSet *allowedFileTypes = blog.allowedFileTypes;
+        if (![allowedFileTypes containsObject:extension]) {
+            assetUTI = (__bridge NSString *)kUTTypeJPEG;
+            extension = [self extensionForUTI:assetUTI];
+        }
+    } else if (mediaType == MediaTypeVideo) {
+        if (![blog isHostedAtWPcom]) {
+            assetUTI = (__bridge NSString *)kUTTypeMPEG4;
+            extension = [self extensionForUTI:assetUTI];
+        }
+    }
+
+    MediaSettings *mediaSettings = [MediaSettings new];
+    BOOL stripGeoLocation = mediaSettings.removeLocationSetting;
+
+    NSInteger maxImageSize = [mediaSettings imageSizeForUpload];
+    CGSize maximumResolution = CGSizeMake(maxImageSize, maxImageSize);
+
+    void(^trackResizedPhotoError)() = nil;
+    if (mediaType == MediaTypeImage && maxImageSize > 0) {
+        // Only tracking resized photo if the user selected a max size that's not the -1 value for "Original"
+        NSDictionary *properties = @{@"resize_width": @(maxImageSize)};
+        [WPAppAnalytics track:WPAnalyticsStatEditorResizedPhoto withProperties:properties withBlog:blog];
+        trackResizedPhotoError = ^() {
+            [self.managedObjectContext performBlock:^{
+                [WPAppAnalytics track:WPAnalyticsStatEditorResizedPhotoError withProperties:properties withBlog:blog];
+            }];
+        };
+    }
+
+    error = nil;
+    NSURL *mediaURL = [[MediaFileManager defaultManager] makeLocalMediaURLWithFilename:mediaName
+                                                                         fileExtension:extension
+                                                                                 error:&error];
+    if (error) {
+        if (completion) {
+            completion(nil, error);
+        }
+        return;
+    }
+    error = nil;
+    MediaFileManager *mediaFileManager = [MediaFileManager defaultManager];
+    NSURL *mediaThumbnailURL = [mediaFileManager makeLocalMediaURLWithFilename:[mediaFileManager mediaFilenameAppendingThumbnail:[mediaURL lastPathComponent]]
+                                                                 fileExtension:[self extensionForUTI:[asset defaultThumbnailUTI]]
+                                                                         error:&error];
+    if (error) {
+        if (completion) {
+            completion(nil, error);
+        }
+        return;
+    }
+
+    CGFloat imageMaxDimension = MAX([UIScreen mainScreen].nativeBounds.size.width, [UIScreen mainScreen].nativeBounds.size.height);
+    CGSize thumbnailSize = CGSizeMake(imageMaxDimension, imageMaxDimension);
+
+    [[self.class queueForResizeMediaOperations] addOperationWithBlock:^{
+        [asset exportThumbnailToURL:mediaThumbnailURL
+                         targetSize:thumbnailSize
+                        synchronous:YES
+                     successHandler:^(CGSize thumbnailSize) {
+                         if (thumbnailCallback) {
+                             thumbnailCallback(mediaThumbnailURL);
+                         }
+                         if ([assetUTI isEqual:(__bridge NSString *)kUTTypeGIF]) {
+                             // export original gif
+                             [asset exportOriginalImage:mediaURL successHandler:^(CGSize resultingSize) {
+                                 [self createMediaForObjectID:objectID
+                                                     mediaURL:mediaURL
+                                            mediaThumbnailURL:mediaThumbnailURL
+                                                    mediaType:mediaType
+                                                    mediaSize:resultingSize
+                                                        asset:asset
+                                                   completion:completion];
+                             } errorHandler:^(NSError * _Nonnull error) {
+                                 if (completion){
+                                     completion(nil, error);
+                                 }
+                             }];
+                         } else {
+                             [asset exportToURL:mediaURL
+                                      targetUTI:assetUTI
+                              maximumResolution:maximumResolution
+                               stripGeoLocation:stripGeoLocation
+                                    synchronous:true
+                                 successHandler:^(CGSize resultingSize) {
+                                     [self createMediaForObjectID:objectID
+                                                         mediaURL:mediaURL
+                                                mediaThumbnailURL:mediaThumbnailURL
+                                                        mediaType:mediaType
+                                                        mediaSize:resultingSize
+                                                            asset:asset
+                                                       completion:completion];
+                                 } errorHandler:^(NSError *error) {
+                                     if (completion){
+                                         completion(nil, error);
+                                     }
+                                     if (trackResizedPhotoError) {
+                                         trackResizedPhotoError();
+                                     }
+                                 }];
+                         }
+                     }
+                       errorHandler:^(NSError *error) {
+                           if (completion){
+                               completion(nil, error);
+                           }
+                           if (trackResizedPhotoError) {
+                               trackResizedPhotoError();
+                           }
+                       }];
+    }];
+}
+
+- (void) createMediaForObjectID:(NSManagedObjectID *)objectID
+                       mediaURL:(NSURL *)mediaURL
+              mediaThumbnailURL:(NSURL *)mediaThumbnailURL
+                      mediaType:(MediaType)mediaType
+                      mediaSize:(CGSize)mediaSize
+                          asset:(id <ExportableAsset>)asset
+                     completion:(void (^)(Media *media, NSError *error))completion
+{
+    [self.managedObjectContext performBlock:^{
+        Media *media = nil;
+        NSManagedObject *object = [self.managedObjectContext objectWithID:objectID];
+
+        if ([object isKindOfClass:[AbstractPost class]]) {
+            AbstractPost *post = (AbstractPost *)object;
+            media = [Media makeMediaWithPost:post];
+            media.postID = post.postID;
+        } else if ([object isKindOfClass:[Blog class]]) {
+            Blog *blog = (Blog *)object;
+            media = [Media makeMediaWithBlog:blog];
+            media.remoteStatusNumber = @(MediaRemoteStatusLocal);
+        }
+
+        if (media) {
+            [self configureNewMedia:media
+                       withMediaURL:mediaURL
+                  mediaThumbnailURL:mediaThumbnailURL
+                          mediaType:mediaType
+                          mediaSize:mediaSize
+                              asset:asset];
+        }
+
+        [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
+            if (completion) {
+                completion(media, nil);
+            }
+        }];
+    }];
+}
+
+- (void)configureNewMedia:(Media *)media
+             withMediaURL:(NSURL *)mediaURL
+        mediaThumbnailURL:(NSURL *)mediaThumbnailURL
+                mediaType:(MediaType)mediaType
+                mediaSize:(CGSize)mediaSize
+                    asset:(id <ExportableAsset>)asset
+{
+    media.filename = [mediaURL lastPathComponent];
+    media.absoluteLocalURL = mediaURL;
+    media.absoluteThumbnailLocalURL = mediaThumbnailURL;
+    NSNumber * fileSize;
+    if ([mediaURL getResourceValue:&fileSize forKey:NSURLFileSizeKey error:nil]) {
+        media.filesize = @([fileSize longLongValue] / 1024);
+    } else {
+        media.filesize = 0;
+    }
+    media.width = @(mediaSize.width);
+    media.height = @(mediaSize.height);
+    media.mediaType = mediaType;
+    if (mediaType == WPMediaTypeVideo && [asset isKindOfClass:[PHAsset class]]) {
+        PHAsset *originalAsset = (PHAsset *)asset;
+        media.length = @(originalAsset.duration);
+    }
+}
+
+- (void)imageForMedia:(Media *)mediaInRandomContext
+                 size:(CGSize)requestSize
+              success:(void (^)(UIImage *image))success
+              failure:(void (^)(NSError *error))failure
+{
+    NSManagedObjectID *mediaID = [mediaInRandomContext objectID];
+    [self.managedObjectContext performBlock:^{
+        Media *media = (Media *)[self.managedObjectContext objectWithID: mediaID];
+        BOOL isPrivate = media.blog.isPrivate;
+
+        // search if there is a local copy of the file already
+        NSURL *fileURL;
+        CGSize mediaOriginalSize = CGSizeMake([media.width floatValue], [media.height floatValue]);
+        CGSize size = requestSize;
+        if (CGSizeEqualToSize(requestSize, CGSizeZero)) {
+            size = mediaOriginalSize;
+        }
+        CGSize availableSize = CGSizeZero;
+        if (media.mediaType == MediaTypeImage) {
+            fileURL = media.absoluteThumbnailLocalURL;
+            availableSize = [[MediaFileManager defaultManager] imageSizeForMediaAtFileURL:fileURL];
+            if (size.height > availableSize.height && size.width > availableSize.width) {
+                fileURL = media.absoluteLocalURL;
+                availableSize = [[MediaFileManager defaultManager] imageSizeForMediaAtFileURL:fileURL];
+            }
+        } else if (media.mediaType == MediaTypeVideo) {
+            fileURL = media.absoluteThumbnailLocalURL;
+            availableSize = [[MediaFileManager defaultManager] imageSizeForMediaAtFileURL:fileURL];
+        }
+
+        // check if the available local image is equal or larger than the requested size
+        if (availableSize.height >= size.height && availableSize.width >= size.width) {
+            [[[self class] queueForResizeMediaOperations] addOperationWithBlock:^{
+                UIImage *image = [UIImage imageWithContentsOfFile:fileURL.path];
+                if (success) {
+                    if (!CGSizeEqualToSize(image.size, size)){
+                        image = [image resizedImage:size interpolationQuality:kCGInterpolationMedium];
+                    }
+                    success(image);
+                }
+            }];
+            return;
+        }
+
+        // No Image available so let's download it
+        NSURL *remoteURL = nil;
+        BOOL mediaIsVideo = media.mediaType == MediaTypeVideo;
+        if (mediaIsVideo) {
+            remoteURL = [NSURL URLWithString:media.remoteThumbnailURL];
+        } else if (media.mediaType == MediaTypeImage) {
+            NSString *remote = media.remoteURL;
+            remoteURL = [NSURL URLWithString:remote];
+            if (!media.blog.isPrivate) {
+                remoteURL = [PhotonImageURLHelper photonURLWithSize:size forImageURL:remoteURL];
+            } else {
+                remoteURL = [WPImageURLHelper imageURLWithSize:size forImageURL:remoteURL];
+            }
+
+        }
+        if (!remoteURL) {
+            if (failure) {
+                failure(nil);
+            }
+            return;
+        }
+        WPImageSource *imageSource = [WPImageSource sharedSource];
+        void (^successBlock)(UIImage *) = ^(UIImage *image) {
+            // Check the media hasn't been deleted whilst we were loading.
+            if (!media || media.isDeleted) {
+                if (success) {
+                    success([UIImage new]);
+                }
+                return;
+            }
+
+            [self.managedObjectContext performBlock:^{
+                NSError *error = nil;
+                MediaFileManager *mediaFileManager = [MediaFileManager defaultManager];
+                NSURL *fileURL = [mediaFileManager makeLocalMediaURLWithFilename:[mediaFileManager mediaFilenameAppendingThumbnail:media.filename]
+                                                                   fileExtension:[self extensionForUTI:(__bridge NSString*)kUTTypeJPEG]
+                                                                           error:&error];
+                if (error) {
+                    if (failure) {
+                        failure(error);
+                    }
+                    return;
+                }
+                if (CGSizeEqualToSize(size, mediaOriginalSize) && !mediaIsVideo) {
+                    media.absoluteLocalURL = fileURL;
+                } else {
+                    media.absoluteThumbnailLocalURL = fileURL;
+                }
+                [self.managedObjectContext save:nil];
+                [[[self class] queueForResizeMediaOperations] addOperationWithBlock:^{
+                    [image writeToURL:fileURL type:(__bridge NSString*)kUTTypeJPEG compressionQuality:0.9 metadata:nil error:nil];
+                    if (success) {
+                        success(image);
+                    }
+                }];
+            }];
+        };
+
+        if (isPrivate) {
+            AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:self.managedObjectContext];
+            NSString *authToken = [[accountService defaultWordPressComAccount] authToken];
+            [imageSource downloadImageForURL:remoteURL
+                                   authToken:authToken
+                                 withSuccess:successBlock
+                                     failure:failure];
+        } else {
+            [imageSource downloadImageForURL:remoteURL
+                                 withSuccess:successBlock
+                                     failure:failure];
+        }
+    }];
+}
+
+- (NSString *)extensionForUTI:(NSString *)UTI {
+    return (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassFilenameExtension);
+}
+
++ (NSOperationQueue *)queueForResizeMediaOperations {
+    static NSOperationQueue * _queueForResizeMediaOperations = nil;
+    static dispatch_once_t _onceToken;
+    dispatch_once(&_onceToken, ^{
+        _queueForResizeMediaOperations = [[NSOperationQueue alloc] init];
+        _queueForResizeMediaOperations.name = @"MediaService-ResizeMediaOperation";
+        _queueForResizeMediaOperations.maxConcurrentOperationCount = 1;
+    });
+
+    return _queueForResizeMediaOperations;
+}
+
+@end

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -155,12 +155,12 @@
  @discussion If the media asset is a video a frame of the video is returned.
 
  @param mediaInRandomContext the object from where to get the thumbnail
- @param requestSize the request size for the image, if CGSizeZero the image returned has the image original pixel dimensions.
+ @param preferredSize the preferred size for the image, if CGSizeZero the image returned has the image original pixel dimensions.
  @param success a block that will be invoked when the media is retrieved
  @param failure a block that will be invoked if an error happens, provinding an error object with details.
  */
 - (void)imageForMedia:(nonnull Media *)mediaInRandomContext
-                 size:(CGSize)requestSize
+        preferredSize:(CGSize)preferredSize
               success:(nullable void (^)(UIImage * _Nonnull image))success
               failure:(nullable void (^)(NSError * _Nonnull error))failure;
 

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -13,6 +13,7 @@
 #import "WPXMLRPCDecoder.h"
 #import "PhotonImageURLHelper.h"
 #import <WordPressShared/WPImageSource.h>
+#import "MediaService+Legacy.h"
 
 @import WordPressComAnalytics;
 
@@ -63,148 +64,6 @@
      ];
 }
 
-- (void)createMediaWith:(id<ExportableAsset>)asset
-            forObjectID:(NSManagedObjectID *)objectID
-              mediaName:(NSString *)mediaName
-      thumbnailCallback:(void (^)(NSURL *thumbnailURL))thumbnailCallback
-             completion:(void (^)(Media *media, NSError *error))completion
-{
-    AbstractPost *post = nil;
-    Blog *blog = nil;
-    NSError *error = nil;
-    NSManagedObject *existingObject = [self.managedObjectContext existingObjectWithID:objectID error:&error];
-
-    if ([existingObject isKindOfClass:[AbstractPost class]]) {
-        post = (AbstractPost *)existingObject;
-        blog = post.blog;
-    } else if ([existingObject isKindOfClass:[Blog class]]) {
-        blog = (Blog *)existingObject;
-    }
-
-    if (!post && !blog) {
-        if (completion) {
-            completion(nil, error);
-        }
-        return;
-    }
-
-    MediaType mediaType = [asset assetMediaType];
-    NSString *assetUTI = [asset originalUTI];
-    NSString *extension = [self extensionForUTI:assetUTI];
-    if (mediaType == MediaTypeImage) {
-        NSSet *allowedFileTypes = blog.allowedFileTypes;
-        if (![allowedFileTypes containsObject:extension]) {
-            assetUTI = (__bridge NSString *)kUTTypeJPEG;
-            extension = [self extensionForUTI:assetUTI];
-        }
-    } else if (mediaType == MediaTypeVideo) {
-        if (![blog isHostedAtWPcom]) {
-            assetUTI = (__bridge NSString *)kUTTypeMPEG4;
-            extension = [self extensionForUTI:assetUTI];
-        }
-    }
-    
-    MediaSettings *mediaSettings = [MediaSettings new];
-    BOOL stripGeoLocation = mediaSettings.removeLocationSetting;
-
-    NSInteger maxImageSize = [mediaSettings imageSizeForUpload];
-    CGSize maximumResolution = CGSizeMake(maxImageSize, maxImageSize);
-
-    void(^trackResizedPhotoError)() = nil;
-    if (mediaType == MediaTypeImage && maxImageSize > 0) {
-        // Only tracking resized photo if the user selected a max size that's not the -1 value for "Original"
-        NSDictionary *properties = @{@"resize_width": @(maxImageSize)};
-        [WPAppAnalytics track:WPAnalyticsStatEditorResizedPhoto withProperties:properties withBlog:blog];
-        trackResizedPhotoError = ^() {
-            [self.managedObjectContext performBlock:^{
-                [WPAppAnalytics track:WPAnalyticsStatEditorResizedPhotoError withProperties:properties withBlog:blog];
-            }];
-        };
-    }
-
-    error = nil;
-    NSURL *mediaURL = [[MediaFileManager defaultManager] makeLocalMediaURLWithFilename:mediaName
-                                                                         fileExtension:extension
-                                                                                 error:&error];
-    if (error) {
-        if (completion) {
-            completion(nil, error);
-        }
-        return;
-    }
-    error = nil;
-    MediaFileManager *mediaFileManager = [MediaFileManager defaultManager];
-    NSURL *mediaThumbnailURL = [mediaFileManager makeLocalMediaURLWithFilename:[mediaFileManager mediaFilenameAppendingThumbnail:[mediaURL lastPathComponent]]
-                                                                 fileExtension:[self extensionForUTI:[asset defaultThumbnailUTI]]
-                                                                         error:&error];
-    if (error) {
-        if (completion) {
-            completion(nil, error);
-        }
-        return;
-    }
-
-    CGFloat imageMaxDimension = MAX([UIScreen mainScreen].nativeBounds.size.width, [UIScreen mainScreen].nativeBounds.size.height);
-    CGSize thumbnailSize = CGSizeMake(imageMaxDimension, imageMaxDimension);
-
-    [[self.class queueForResizeMediaOperations] addOperationWithBlock:^{
-        [asset exportThumbnailToURL:mediaThumbnailURL
-                         targetSize:thumbnailSize
-                        synchronous:YES
-                     successHandler:^(CGSize thumbnailSize) {
-                         if (thumbnailCallback) {
-                             thumbnailCallback(mediaThumbnailURL);
-                         }
-                         if ([assetUTI isEqual:(__bridge NSString *)kUTTypeGIF]) {
-                             // export original gif
-                             [asset exportOriginalImage:mediaURL successHandler:^(CGSize resultingSize) {
-                                 [self createMediaForObjectID:objectID
-                                                     mediaURL:mediaURL
-                                            mediaThumbnailURL:mediaThumbnailURL
-                                                    mediaType:mediaType
-                                                    mediaSize:resultingSize
-                                                        asset:asset
-                                                   completion:completion];
-                             } errorHandler:^(NSError * _Nonnull error) {
-                                 if (completion){
-                                     completion(nil, error);
-                                 }
-                             }];
-                         } else {
-                             [asset exportToURL:mediaURL
-                                      targetUTI:assetUTI
-                              maximumResolution:maximumResolution
-                               stripGeoLocation:stripGeoLocation
-                                    synchronous:true
-                                 successHandler:^(CGSize resultingSize) {
-                                     [self createMediaForObjectID:objectID
-                                                         mediaURL:mediaURL
-                                                mediaThumbnailURL:mediaThumbnailURL
-                                                        mediaType:mediaType
-                                                        mediaSize:resultingSize
-                                                            asset:asset
-                                                       completion:completion];
-                                 } errorHandler:^(NSError *error) {
-                                     if (completion){
-                                         completion(nil, error);
-                                     }
-                                     if (trackResizedPhotoError) {
-                                         trackResizedPhotoError();
-                                     }
-                                   }];
-                         }
-                     }
-                       errorHandler:^(NSError *error) {
-                           if (completion){
-                               completion(nil, error);
-                           }
-                           if (trackResizedPhotoError) {
-                               trackResizedPhotoError();
-                           }
-                       }];
-    }];
-}
-
 - (void)createMediaWithPHAsset:(PHAsset *)asset
                forBlogObjectID:(NSManagedObjectID *)blogObjectID
              thumbnailCallback:(void (^)(NSURL *thumbnailURL))thumbnailCallback
@@ -230,70 +89,6 @@
                 mediaName:[[NSUUID UUID] UUIDString]
         thumbnailCallback:thumbnailCallback
                completion:completion];
-}
-
-- (void) createMediaForObjectID:(NSManagedObjectID *)objectID
-                       mediaURL:(NSURL *)mediaURL
-              mediaThumbnailURL:(NSURL *)mediaThumbnailURL
-                      mediaType:(MediaType)mediaType
-                      mediaSize:(CGSize)mediaSize
-                          asset:(id <ExportableAsset>)asset
-                     completion:(void (^)(Media *media, NSError *error))completion
-{
-    [self.managedObjectContext performBlock:^{
-        Media *media = nil;
-        NSManagedObject *object = [self.managedObjectContext objectWithID:objectID];
-
-        if ([object isKindOfClass:[AbstractPost class]]) {
-            AbstractPost *post = (AbstractPost *)object;
-            media = [Media makeMediaWithPost:post];
-            media.postID = post.postID;
-        } else if ([object isKindOfClass:[Blog class]]) {
-            Blog *blog = (Blog *)object;
-            media = [Media makeMediaWithBlog:blog];
-            media.remoteStatusNumber = @(MediaRemoteStatusLocal);
-        }
-
-        if (media) {
-            [self configureNewMedia:media
-                       withMediaURL:mediaURL
-                  mediaThumbnailURL:mediaThumbnailURL
-                          mediaType:mediaType
-                          mediaSize:mediaSize
-                              asset:asset];
-        }
-
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
-            if (completion) {
-                completion(media, nil);
-            }
-        }];
-    }];
-}
-
-- (void)configureNewMedia:(Media *)media
-             withMediaURL:(NSURL *)mediaURL
-        mediaThumbnailURL:(NSURL *)mediaThumbnailURL
-                mediaType:(MediaType)mediaType
-                mediaSize:(CGSize)mediaSize
-                    asset:(id <ExportableAsset>)asset
-{
-    media.filename = [mediaURL lastPathComponent];
-    media.absoluteLocalURL = mediaURL;
-    media.absoluteThumbnailLocalURL = mediaThumbnailURL;
-    NSNumber * fileSize;
-    if ([mediaURL getResourceValue:&fileSize forKey:NSURLFileSizeKey error:nil]) {
-        media.filesize = @([fileSize longLongValue] / 1024);
-    } else {
-        media.filesize = 0;
-    }
-    media.width = @(mediaSize.width);
-    media.height = @(mediaSize.height);
-    media.mediaType = mediaType;
-    if (mediaType == WPMediaTypeVideo && [asset isKindOfClass:[PHAsset class]]) {
-        PHAsset *originalAsset = (PHAsset *)asset;
-        media.length = @(originalAsset.duration);
-    }
 }
 
 - (void)uploadMedia:(Media *)media
@@ -642,135 +437,6 @@
                            }];
 }
 
-+ (NSOperationQueue *)queueForResizeMediaOperations {
-    static NSOperationQueue * _queueForResizeMediaOperations = nil;
-    static dispatch_once_t _onceToken;
-    dispatch_once(&_onceToken, ^{
-        _queueForResizeMediaOperations = [[NSOperationQueue alloc] init];
-        _queueForResizeMediaOperations.name = @"MediaService-ResizeMediaOperation";
-        _queueForResizeMediaOperations.maxConcurrentOperationCount = 1;
-    });
-    
-    return _queueForResizeMediaOperations;
-}
-
-- (void)imageForMedia:(Media *)mediaInRandomContext
-                 size:(CGSize)requestSize
-              success:(void (^)(UIImage *image))success
-              failure:(void (^)(NSError *error))failure
-{
-    NSManagedObjectID *mediaID = [mediaInRandomContext objectID];
-    [self.managedObjectContext performBlock:^{
-        Media *media = (Media *)[self.managedObjectContext objectWithID: mediaID];
-        BOOL isPrivate = media.blog.isPrivate;
-
-        // search if there is a local copy of the file already
-        NSURL *fileURL;
-        CGSize mediaOriginalSize = CGSizeMake([media.width floatValue], [media.height floatValue]);
-        CGSize size = requestSize;
-        if (CGSizeEqualToSize(requestSize, CGSizeZero)) {
-            size = mediaOriginalSize;
-        }
-        CGSize availableSize = CGSizeZero;
-        if (media.mediaType == MediaTypeImage) {
-            fileURL = media.absoluteThumbnailLocalURL;
-            availableSize = [[MediaFileManager defaultManager] imageSizeForMediaAtFileURL:fileURL];
-            if (size.height > availableSize.height && size.width > availableSize.width) {
-                fileURL = media.absoluteLocalURL;
-                availableSize = [[MediaFileManager defaultManager] imageSizeForMediaAtFileURL:fileURL];
-            }
-        } else if (media.mediaType == MediaTypeVideo) {
-            fileURL = media.absoluteThumbnailLocalURL;
-            availableSize = [[MediaFileManager defaultManager] imageSizeForMediaAtFileURL:fileURL];
-        }
-
-        // check if the available local image is equal or larger than the requested size
-        if (availableSize.height >= size.height && availableSize.width >= size.width) {
-            [[[self class] queueForResizeMediaOperations] addOperationWithBlock:^{
-                UIImage *image = [UIImage imageWithContentsOfFile:fileURL.path];
-                if (success) {
-                    if (!CGSizeEqualToSize(image.size, size)){
-                        image = [image resizedImage:size interpolationQuality:kCGInterpolationMedium];
-                    }
-                    success(image);
-                }
-            }];
-            return;
-        }
-
-        // No Image available so let's download it
-        NSURL *remoteURL = nil;
-        BOOL mediaIsVideo = media.mediaType == MediaTypeVideo;
-        if (mediaIsVideo) {
-            remoteURL = [NSURL URLWithString:media.remoteThumbnailURL];
-        } else if (media.mediaType == MediaTypeImage) {
-            NSString *remote = media.remoteURL;
-            remoteURL = [NSURL URLWithString:remote];
-            if (!media.blog.isPrivate) {
-                remoteURL = [PhotonImageURLHelper photonURLWithSize:size forImageURL:remoteURL];
-            } else {
-                remoteURL = [WPImageURLHelper imageURLWithSize:size forImageURL:remoteURL];
-            }
-
-        }
-        if (!remoteURL) {
-            if (failure) {
-                failure(nil);
-            }
-            return;
-        }
-        WPImageSource *imageSource = [WPImageSource sharedSource];
-        void (^successBlock)(UIImage *) = ^(UIImage *image) {
-            // Check the media hasn't been deleted whilst we were loading.
-            if (!media || media.isDeleted) {
-                if (success) {
-                    success([UIImage new]);
-                }
-                return;
-            }
-
-            [self.managedObjectContext performBlock:^{
-                NSError *error = nil;
-                MediaFileManager *mediaFileManager = [MediaFileManager defaultManager];
-                NSURL *fileURL = [mediaFileManager makeLocalMediaURLWithFilename:[mediaFileManager mediaFilenameAppendingThumbnail:media.filename]
-                                                                   fileExtension:[self extensionForUTI:(__bridge NSString*)kUTTypeJPEG]
-                                                                           error:&error];
-                if (error) {
-                    if (failure) {
-                        failure(error);
-                    }
-                    return;
-                }
-                if (CGSizeEqualToSize(size, mediaOriginalSize) && !mediaIsVideo) {
-                    media.absoluteLocalURL = fileURL;
-                } else {
-                    media.absoluteThumbnailLocalURL = fileURL;
-                }
-                [self.managedObjectContext save:nil];
-                [[[self class] queueForResizeMediaOperations] addOperationWithBlock:^{                    
-                    [image writeToURL:fileURL type:(__bridge NSString*)kUTTypeJPEG compressionQuality:0.9 metadata:nil error:nil];
-                    if (success) {
-                        success(image);
-                    }
-                }];
-            }];
-        };
-        
-        if (isPrivate) {
-            AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:self.managedObjectContext];
-            NSString *authToken = [[accountService defaultWordPressComAccount] authToken];
-            [imageSource downloadImageForURL:remoteURL
-                                   authToken:authToken
-                                 withSuccess:successBlock
-                                     failure:failure];
-        } else {
-            [imageSource downloadImageForURL:remoteURL
-                                 withSuccess:successBlock
-                                     failure:failure];
-        }
-    }];
-}
-
 - (NSInteger)getMediaLibraryCountForBlog:(Blog *)blog
                            forMediaTypes:(NSSet *)mediaTypes
 {
@@ -819,6 +485,16 @@
     }];
 }
 
+- (void)imageForMedia:(nonnull Media *)mediaInRandomContext
+        preferredSize:(CGSize)preferredSize
+              success:(nullable void (^)(UIImage * _Nonnull image))success
+              failure:(nullable void (^)(NSError * _Nonnull error))failure
+{
+    [self imageForMedia:mediaInRandomContext
+                   size:preferredSize
+                success:success
+                failure:failure];
+}
 
 - (NSString *)mimeTypeForMediaType:(NSNumber *)mediaType
 {
@@ -850,10 +526,6 @@
 #pragma mark - Private
 
 #pragma mark - Media helpers
-
-- (NSString *)extensionForUTI:(NSString *)UTI {
-    return (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassFilenameExtension);
-}
 
 - (id<MediaServiceRemote>)remoteForBlog:(Blog *)blog
 {

--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -46,6 +46,13 @@ class MediaFileManager: NSObject {
         return MediaFileManager()
     }()
 
+    /// Helper method for getting a MediaFileManager for the .cache directory.
+    ///
+    @objc (cacheManager)
+    class var cache: MediaFileManager {
+        return MediaFileManager(directory: .cache)
+    }
+
     // MARK: - Init
 
     /// Init with default directory of .uploads.
@@ -151,13 +158,14 @@ class MediaFileManager: NSObject {
         }
     }
 
-    /// Clear the local Media directory of any files that are no longer in use by any managed Media objects.
+    /// Clear the local Media directory of any files that are no longer in use or can be fetched again,
+    /// such as Media without a blog or with a remote URL.
     ///
     /// - Note: These files can show up because of the app being killed while a media object
     ///   was being created or when a CoreData migration fails and the database is recreated.
     ///
     func clearUnusedFilesFromDirectory(onCompletion: (() -> Void)?, onError: ((Error) -> Void)?) {
-        purgeMediaFiles(exceptMedia: NSPredicate(format: "blog != NULL"),
+        purgeMediaFiles(exceptMedia: NSPredicate(format: "blog != NULL || remoteURL == NULL"),
                         onCompletion: onCompletion,
                         onError: onError)
     }

--- a/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
@@ -143,7 +143,7 @@ extension SiteIconPickerPresenter: WPMediaPickerViewControllerDelegate {
             showLoadingMessage()
             originalMedia = media
             let mediaService = MediaService(managedObjectContext:ContextManager.sharedInstance().mainContext)
-            mediaService.image(for: media, size: CGSize.zero, success: { [weak self] image in
+            mediaService.image(for: media, preferredSize: CGSize.zero, success: { [weak self] image in
                 self?.showImageCropViewController(image)
             }, failure: { [weak self] _ in
                 self?.showErrorLoadingImageMessage()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		086C4D101E81F9240011D960 /* Media+Blog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086C4D0F1E81F9240011D960 /* Media+Blog.swift */; };
 		086E1FE01BBB35D2002D86CA /* MenusViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 086E1FDF1BBB35D2002D86CA /* MenusViewController.m */; };
 		0879FC161E9301DD00E1EFC8 /* MediaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0879FC151E9301DD00E1EFC8 /* MediaTests.swift */; };
+		087CD9C91F044F8E0021B385 /* MediaService+Legacy.m in Sources */ = {isa = PBXBuildFile; fileRef = 087CD9C81F044F8E0021B385 /* MediaService+Legacy.m */; };
 		087EBFA81F02313E001F7ACE /* MediaThumbnailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */; };
 		0885A3671E837AFE00619B4D /* URLIncrementalFilenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885A3661E837AFE00619B4D /* URLIncrementalFilenameTests.swift */; };
 		088B89891DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088B89881DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift */; };
@@ -1251,6 +1252,8 @@
 		086E1FDE1BBB35D2002D86CA /* MenusViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusViewController.h; sourceTree = "<group>"; };
 		086E1FDF1BBB35D2002D86CA /* MenusViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusViewController.m; sourceTree = "<group>"; };
 		0879FC151E9301DD00E1EFC8 /* MediaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaTests.swift; sourceTree = "<group>"; };
+		087CD9C71F044F8E0021B385 /* MediaService+Legacy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MediaService+Legacy.h"; sourceTree = "<group>"; };
+		087CD9C81F044F8E0021B385 /* MediaService+Legacy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "MediaService+Legacy.m"; sourceTree = "<group>"; };
 		087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaThumbnailService.swift; sourceTree = "<group>"; };
 		0885A3661E837AFE00619B4D /* URLIncrementalFilenameTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLIncrementalFilenameTests.swift; sourceTree = "<group>"; };
 		088B89881DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostCardContentLabel.swift; sourceTree = "<group>"; };
@@ -4119,6 +4122,8 @@
 				087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */,
 				5DA3EE141925090A00294E0B /* MediaService.h */,
 				5DA3EE151925090A00294E0B /* MediaService.m */,
+				087CD9C71F044F8E0021B385 /* MediaService+Legacy.h */,
+				087CD9C81F044F8E0021B385 /* MediaService+Legacy.m */,
 				E1C5457D1C6B962D001CEB0E /* MediaSettings.swift */,
 				FF54D4631D6F3FA900A0DC4D /* EditorSettings.swift */,
 				08AAD69D1CBEA47D002B2418 /* MenusService.h */,
@@ -6632,6 +6637,7 @@
 				B532D4EB199D4357006E4DF6 /* NoteBlockTableViewCell.swift in Sources */,
 				E11000991CDB5F1E00E33887 /* KeychainTools.swift in Sources */,
 				E6D2E1671B8AAD8C0000ED14 /* ReaderTagStreamHeader.swift in Sources */,
+				087CD9C91F044F8E0021B385 /* MediaService+Legacy.m in Sources */,
 				85D239B61AE5A6170074768D /* ReachabilityFacade.m in Sources */,
 				E6D3B1431D1C702600008D4B /* ReaderFollowedSitesViewController.swift in Sources */,
 				B5899ADE1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift in Sources */,

--- a/WordPress/WordPressTest/MediaTests.swift
+++ b/WordPress/WordPressTest/MediaTests.swift
@@ -49,7 +49,7 @@ class MediaTests: XCTestCase {
         do {
             let media = newTestMedia()
             let filePath = "sample-thumbnail.jpeg"
-            var expectedAbsoluteURL = try MediaFileManager.uploadsDirectoryURL()
+            var expectedAbsoluteURL = try MediaFileManager.cache.directoryURL()
             expectedAbsoluteURL.appendPathComponent(filePath)
             media.absoluteThumbnailLocalURL = expectedAbsoluteURL
             guard


### PR DESCRIPTION
This PR adds legacy support for the original `MediaService` implementation. This also adds support for existing `Media` objects that were not exported with the new file and URL specifications.

Why legacy support? Moving forward, I don't want to just merge in use of the new exporting code (and walk away). Instead, we'll support the original implementation now seen in this category and revert to it via a feature flag. While we bring in use of the new exporting code, we'll elevate it's use through the feature flag support, e.g. internal, testflight, release.

Eventually we can remove this category altogether, only using the new exporting code itself.

Changes:

- Excise the relevant code from `MediaService` and support it via `MediaService+Legacy`.
- Update methods just a bit.
- Support existing Media objects and their URLs by using the relevant `MediaFileManager`.
- Write new Media objects, with the old code, to the expected `MediaFileManager` cache URLs.

To test:
1. Build and run.
2. Check that the Media Library in-app loads as expected.
3. Check that adding Media to a post in the editor and publishing works as expected.
4. Run all tests.

Needs review: @frosty, @SergioEstevao, nearing the end here folks! 😅 
