### PR TITLE
Aztec announcement tweaks

### DIFF
--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressComAnalytics
 
 extension FancyAlertViewController {
     private enum Constants {
@@ -26,9 +27,16 @@ extension FancyAlertViewController {
 
         typealias Button = FancyAlertViewController.Config.ButtonConfig
 
-        let defaultButton = Button(Strings.tryIt, { controller in
+        let enableEditor = {
             let settings = EditorSettings(database: UserDefaults.standard)
+            settings.visualEditorEnabled = true
             settings.nativeEditorEnabled = true
+
+            WPAnalytics.track(.editorToggledOn)
+        }
+
+        let defaultButton = Button(Strings.tryIt, { controller in
+            enableEditor()
 
             controller.setViewConfiguration(aztecAnnouncementSuccessConfig,
                                             animated: true,

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -16,6 +16,15 @@ extension FancyAlertViewController {
     }
 
     static func aztecAnnouncementController() -> FancyAlertViewController {
+        if EditorSettings().nativeEditorEnabled {
+            return existingTesterAztecAnnouncementController()
+        } else {
+            return newTesterAztecAnnouncementController()
+        }
+    }
+
+    // Shown to users of the app who don't have Aztec enabled
+    private static func newTesterAztecAnnouncementController() -> FancyAlertViewController {
         struct Strings {
             static let titleText = NSLocalizedString("Try the New Editor", comment: "Title of alert prompting users to try the new Aztec editor")
             static let bodyText = NSLocalizedString("The WordPress app now includes a beautiful new editor. Try it out by creating a new post!", comment: "Body text of alert prompting users to try the new Aztec editor")
@@ -69,6 +78,33 @@ extension FancyAlertViewController {
                                                      defaultButton: defaultButton, cancelButton: cancelButton, moreInfoButton: moreInfoButton, titleAccessoryButton: titleAccessoryButton, dismissAction: nil)
 
         return FancyAlertViewController.controllerWithConfiguration(configuration: config)
+    }
+
+    // Shown to users of the app who already have Aztec enabled
+    static func existingTesterAztecAnnouncementController() -> FancyAlertViewController {
+        struct Strings {
+            static let titleText = NSLocalizedString("New Editor in Public Beta!", comment: "Title of alert prompting users to try the new Aztec editor")
+            static let bodyText = NSLocalizedString("The WordPress app's beautiful new editor is now in public beta. It looks like you already have it enabled, so you're all set!", comment: "Body text of alert informing existing testers that the new Aztec editor is now in public beta")
+            static let whatsNew = NSLocalizedString("What's new?", comment: "Title of more info button on alert prompting users to try the new Aztec editor")
+            static let beta = NSLocalizedString("Beta", comment: "Used to indicate a feature of the app currently in beta testing.")
+        }
+
+        typealias Button = FancyAlertViewController.Config.ButtonConfig
+
+        let moreInfoButton = Button(Strings.whatsNew, { _ in })
+        let titleAccessoryButton = Button(Strings.beta, { _ in })
+
+        let image = UIImage(named: "wp-illustration-hand-write")
+
+        let config = FancyAlertViewController.Config(titleText: Strings.titleText,
+                                                     bodyText: Strings.bodyText,
+                                                     headerImage: image,
+                                                     defaultButton: nil,
+                                                     cancelButton: nil,
+                                                     moreInfoButton: moreInfoButton, titleAccessoryButton: titleAccessoryButton, dismissAction: nil)
+
+        return FancyAlertViewController.controllerWithConfiguration(configuration: config)
+        
     }
 
     private static let aztecAnnouncementSuccessConfig: FancyAlertViewController.Config = {

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -104,7 +104,6 @@ extension FancyAlertViewController {
                                                      moreInfoButton: moreInfoButton, titleAccessoryButton: titleAccessoryButton, dismissAction: nil)
 
         return FancyAlertViewController.controllerWithConfiguration(configuration: config)
-        
     }
 
     private static let aztecAnnouncementSuccessConfig: FancyAlertViewController.Config = {


### PR DESCRIPTION
This PR introduces two small tweaks to the Aztec announcement UI.

1. We now track an analytics event for 'editor toggled on' if the user taps the 'Try It' button
2. We show an alternative message if the user already had Aztec enabled.

<img width="358" alt="screen shot 2017-06-30 at 14 31 35" src="https://user-images.githubusercontent.com/4780/27737647-d9e03506-5da0-11e7-937c-bb6f330110b5.png">

To test:

* Check out `develop`, run the app and enable Aztec in App Settings.
* Build and run this version over the top.
* You should see the announcement UI shown above.
* Delete the app from the simulator and build and run again.
* After logging in, you should see the original two step announcement UI asking you to enable Aztec.

Needs review: @nheagy 