### PR TITLE
Aztec: Fix incorrect divider color in format bar

### DIFF
--- a/WordPress/Classes/Extensions/WPStyleGuide+Aztec.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+Aztec.swift
@@ -8,6 +8,8 @@ extension WPStyleGuide {
 
     static let aztecFormatBarDisabledColor = WPStyleGuide.greyLighten20()
 
+    static let aztecFormatBarDividerColor = WPStyleGuide.greyLighten30()
+
     static let aztecFormatBarBackgroundColor = UIColor.white
 
     static var aztecFormatPickerSelectedCellBackgroundColor: UIColor {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1757,7 +1757,7 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
         toolbar.highlightedTintColor = WPStyleGuide.aztecFormatBarActiveColor
         toolbar.selectedTintColor = WPStyleGuide.aztecFormatBarActiveColor
         toolbar.disabledTintColor = WPStyleGuide.aztecFormatBarDisabledColor
-        toolbar.dividerTintColor = WPStyleGuide.aztecFormatBarDisabledColor
+        toolbar.dividerTintColor = WPStyleGuide.aztecFormatBarDividerColor
         toolbar.overflowToggleIcon = Gridicon.iconOfType(.ellipsis)
         toolbar.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: 44.0)
         toolbar.formatter = self


### PR DESCRIPTION
The divider color (top and bottom lines, and between the add media button item and the other items) in the format bar in Aztec wasn't quite right. This PR updates it to `greyLighten30`.

<img width="375" alt="screen shot 2017-06-30 at 17 01 08" src="https://user-images.githubusercontent.com/4780/27743983-c969373a-5db5-11e7-9671-046b481ae76e.png">

To test:

* Build and run, check the color is correct in Aztec.

Needs review: @SergioEstevao 