### PR TITLE
ImmuTable: Restores auto sizing footers

### DIFF
--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -314,7 +314,7 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
             return target.tableView(tableView, heightForFooterInSection: section)
         }
 
-        return 0
+        return UITableViewAutomaticDimension
     }
 
     open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -176,7 +176,7 @@ class AppSettingsViewController: UITableViewController {
             return AppSettingsEditorFooterView.height
         }
 
-        return 0
+        return UITableViewAutomaticDimension
     }
 
     private func shouldShowEditorFooterForSection(_ section: Int) -> Bool {


### PR DESCRIPTION
Fixes a bug where I accidentally broke ImmuTable footers.

![footers](https://user-images.githubusercontent.com/4780/27755203-1c5ed6d6-5de6-11e7-8a22-430b4f74c938.png)

To test:

* Build and run, check footers now look correct and wrap over multiple lines. Two examples:
  * Me > App Settings (seen in screenshot above)
  * Blog > Plans

Needs review: @astralbodies 