### PR TITLE
Aztec: Enable webview links for announcements UI

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -226,7 +226,8 @@ class AztecPostViewController: UIViewController, PostEditor {
 
         button.setTitle(NSLocalizedString("Beta", comment: "Title for Beta tag button for the new Aztec editor"), for: .normal)
         button.setContentHuggingPriority(UILayoutPriorityRequired, for: .horizontal)
-        button.isEnabled = false
+        button.isEnabled = true
+        button.addTarget(self, action: #selector(betaButtonTapped), for: .touchUpInside)
 
         return button
     }()
@@ -919,6 +920,14 @@ extension AztecPostViewController {
 
     @IBAction func moreWasPressed() {
         displayMoreSheet()
+    }
+
+    @IBAction func betaButtonTapped() {
+        guard let webViewController = WPWebViewController(url: AztecAnnouncementWhatsNewURL) else { return }
+
+        let navigationController = UINavigationController(rootViewController: webViewController)
+
+        present(navigationController, animated: true, completion: nil)
     }
 
     private func trackPostSave(stat: WPAnalyticsStat) {

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -124,6 +124,16 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         return headerView
     }
 
+    private var appSettingsRow: NavigationItemRow {
+        let accessoryType: UITableViewCellAccessoryType = (splitViewControllerIsHorizontallyCompact) ? .disclosureIndicator : .none
+
+        return NavigationItemRow(
+            title: NSLocalizedString("App Settings", comment: "Link to App Settings section"),
+            icon: Gridicon.iconOfType(.phone),
+            accessoryType: accessoryType,
+            action: pushAppSettings())
+    }
+
     fileprivate func tableViewModel(_ loggedIn: Bool, helpshiftBadgeCount: Int) -> ImmuTable {
         let accessoryType: UITableViewCellAccessoryType = (splitViewControllerIsHorizontallyCompact) ? .disclosureIndicator : .none
 
@@ -138,12 +148,6 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
             icon: Gridicon.iconOfType(.cog),
             accessoryType: accessoryType,
             action: pushAccountSettings())
-
-        let appSettings = NavigationItemRow(
-            title: NSLocalizedString("App Settings", comment: "Link to App Settings section"),
-            icon: Gridicon.iconOfType(.phone),
-            accessoryType: accessoryType,
-            action: pushAppSettings())
 
         let notificationSettings = NavigationItemRow(
             title: NSLocalizedString("Notification Settings", comment: "Link to Notification Settings section"),
@@ -175,7 +179,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
                     ImmuTableSection(rows: [
                         myProfile,
                         accountSettings,
-                        appSettings,
+                        appSettingsRow,
                         notificationSettings
                         ]),
                     ImmuTableSection(rows: [
@@ -191,7 +195,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
             return ImmuTable(
                 sections: [
                     ImmuTableSection(rows: [
-                        appSettings,
+                        appSettingsRow,
                         ]),
                     ImmuTableSection(rows: [
                         helpAndSupport
@@ -321,6 +325,29 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         }
     }
 
+    /// Selects the App Settings row and pushes the App Settings view controller
+    ///
+    public func navigateToAppSettings() {
+        let matchRow: ((ImmuTableRow) -> Bool) = { [weak self] row in
+            if let row = row as? NavigationItemRow {
+                return row.title == self?.appSettingsRow.title
+            }
+
+            return false
+        }
+
+        let sections = handler.viewModel.sections
+
+        if let section = sections.index(where: { $0.rows.contains(where: matchRow) }),
+            let row = sections[section].rows.index(where: matchRow) {
+            let indexPath = IndexPath(row: row, section: section)
+
+            tableView.selectRow(at: indexPath, animated: true, scrollPosition: .middle)
+            handler.tableView(self.tableView, didSelectRowAt: indexPath)
+        }
+    }
+    
+    
 
     // MARK: - Notification observers
 

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -346,8 +346,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
             handler.tableView(self.tableView, didSelectRowAt: indexPath)
         }
     }
-    
-    
+
 
     // MARK: - Notification observers
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -89,7 +89,11 @@ extension FancyAlertViewController {
 
         typealias Button = FancyAlertViewController.Config.ButtonConfig
 
-        let moreInfoButton = Button(Strings.appSettings, { _ in })
+        let moreInfoButton = Button(Strings.appSettings, { controller in
+            controller.presentingViewController?.dismiss(animated: true, completion: {
+                WPTabBarController.sharedInstance().switchMeTabToAppSettings()
+            })
+        })
 
         let titleAccessoryButton = Button(Strings.beta, { controller in
             controller.presentWhatsNewWebView()

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -1,5 +1,8 @@
 import UIKit
 
+let AztecAnnouncementWhatsNewURL = URL(string: "https://make.wordpress.org/mobile/whats-new-in-beta-ios-editor/")
+
+
 extension FancyAlertViewController {
     private enum Constants {
         static let successAnimationTransform: CGAffineTransform = {
@@ -12,6 +15,14 @@ extension FancyAlertViewController {
         }()
         static let successAnimationDuration: TimeInterval = 0.8
         static let successAnimationDampingRaio: CGFloat = 0.6
+    }
+
+    private func presentWhatsNewWebView() {
+        guard let webViewController = WPWebViewController(url: AztecAnnouncementWhatsNewURL) else { return }
+
+        let navigationController = UINavigationController(rootViewController: webViewController)
+
+        present(navigationController, animated: true, completion: nil)
     }
 
     static func aztecAnnouncementController() -> FancyAlertViewController {
@@ -50,8 +61,13 @@ extension FancyAlertViewController {
             controller.dismiss(animated: true, completion: nil)
         })
 
-        let moreInfoButton = Button(Strings.whatsNew, { _ in })
-        let titleAccessoryButton = Button(Strings.beta, { _ in })
+        let moreInfoButton = Button(Strings.whatsNew, { controller in
+            controller.presentWhatsNewWebView()
+        })
+
+        let titleAccessoryButton = Button(Strings.beta, { controller in
+            controller.presentWhatsNewWebView()
+        })
 
         let image = UIImage(named: "wp-illustration-hand-write")
 
@@ -75,7 +91,9 @@ extension FancyAlertViewController {
 
         let moreInfoButton = Button(Strings.appSettings, { _ in })
 
-        let titleAccessoryButton = Button(Strings.beta, { _ in })
+        let titleAccessoryButton = Button(Strings.beta, { controller in
+            controller.presentWhatsNewWebView()
+        })
 
         let image = UIImage(named: "wp-illustration-thank-you")
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts.storyboard
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts.storyboard
@@ -83,7 +83,7 @@
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH2-Nt-ZNa">
+                                                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH2-Nt-ZNa">
                                                                                 <rect key="frame" x="51.5" y="0.0" width="46" height="20.5"/>
                                                                                 <state key="normal" title="Button"/>
                                                                                 <connections>

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)switchMySitesTabToCustomizeViewForBlog:(Blog *)blog;
 - (void)switchMySitesTabToThemesViewForBlog:(Blog *)blog;
 - (void)switchTabToPostsListForPost:(AbstractPost *)post;
+- (void)switchMeTabToAppSettings;
 
 - (void)showNotificationsTabForNoteWithID:(NSString *)notificationID;
 - (void)updateNotificationBadgeVisibility;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -539,6 +539,19 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [blogListVC setSelectedBlog:blog animated:NO];
 }
 
+- (void)switchMeTabToAppSettings
+{
+    [self showMeTab];
+
+    [self.meNavigationController popToRootViewControllerAnimated:NO];
+
+    // If we don't dispatch_async here, the top inset of the app
+    // settings VC isn't correct when pushed...
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.meViewController navigateToAppSettings];
+    });
+}
+
 - (NSString *)currentlySelectedScreen
 {
     // Check which tab is currently selected


### PR DESCRIPTION
This PR enables the various links in the Aztec beta announcements UI.

**To test:**

Build and run, and check the following links work as expected:

* In the Aztec editor, the 'beta' tag should link to our placeholder blog post
* In the announcement UI, the 'beta' tag and what's new text should link to the placeholder blog post
* On the second announcement screen (after you tap Try It), the 'Me > App Settings' link should take you to the app settings screen.

![aztec-links](https://user-images.githubusercontent.com/4780/27793205-016e0f48-5ff5-11e7-90a7-47cd2a5db191.png)

![aztec-links-2](https://user-images.githubusercontent.com/4780/27793285-535a371e-5ff5-11e7-9f4d-0655573090e3.png)

Needs review: @astralbodies 
