### PR TITLE
Integrates Beta 7 of Aztec.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -57,7 +57,7 @@ target 'WordPress' do
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.18'
   pod 'WordPress-iOS-Editor', '1.9.3'
-  pod 'WordPress-Aztec-iOS', '1.0.0-beta.6'
+  pod 'WordPress-Aztec-iOS', '1.0.0-beta.7'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -93,7 +93,7 @@ PODS:
   - Starscream (2.0.2)
   - SVProgressHUD (2.1.2)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.6)
+  - WordPress-Aztec-iOS (1.0.0-beta.7)
   - WordPress-iOS-Editor (1.9.3):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
@@ -129,7 +129,7 @@ DEPENDENCIES:
   - Starscream (from `https://github.com/wordpress-mobile/Starscream`, branch `wordpress-ios`)
   - SVProgressHUD (~> 2.1.2)
   - UIDeviceIdentifier (~> 0.1)
-  - WordPress-Aztec-iOS (= 1.0.0-beta.6)
+  - WordPress-Aztec-iOS (= 1.0.0-beta.7)
   - WordPress-iOS-Editor (= 1.9.3)
   - WordPressCom-Analytics-iOS (= 0.1.30)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
@@ -185,13 +185,13 @@ SPEC CHECKSUMS:
   Starscream: 4ee1be18da5170faafce1698225b61f9765634d5
   SVProgressHUD: c404a55d78acbeb7ebb78b76d3faf986475a6994
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 5e9592aaeb2592eea3b11d9236696dc95cea9fcb
+  WordPress-Aztec-iOS: 88c7dd91f7db8f4967606cbf21fd3df67694e297
   WordPress-iOS-Editor: ed02135d783ecb9aa4ee5e2462935432d464d461
   WordPressCom-Analytics-iOS: b7ecda7af610231c0bc2130849f7c0fdc58c1678
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 71152f51bcce902b70d03caf47ef03f4757c0019
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 28d1862732f4c19493f613f935b6e562b7f74efc
+PODFILE CHECKSUM: ed7f10eb5c989b6c9a3d4d197997afc755738be4
 
 COCOAPODS: 1.2.1


### PR DESCRIPTION
Integrates Aztec Beta 7.

The only change is that it's now possible to indent lists using a hardware keyboard with Tab, and SHIFT + TAB.