### PR TITLE
Aztec announcement: Add analytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ def shared_with_all_pods
   pod 'CocoaLumberjack', '~> 3.2.0'
   pod 'FormatterKit/TimeIntervalFormatter', '~> 1.8.1'
   pod 'NSObject-SafeExpectations', '0.0.2'
-  pod 'WordPressCom-Analytics-iOS', '0.1.30'
+  pod 'WordPressCom-Analytics-iOS', '0.1.31'
 end
 
 def shared_with_networking_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -97,7 +97,7 @@ PODS:
   - WordPress-iOS-Editor (1.9.3):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
-  - WordPressCom-Analytics-iOS (0.1.30)
+  - WordPressCom-Analytics-iOS (0.1.31)
   - WordPressComKit (0.0.6):
     - Alamofire (= 4.0.1)
   - WPMediaPicker (0.18)
@@ -131,7 +131,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-Aztec-iOS (= 1.0.0-beta.6)
   - WordPress-iOS-Editor (= 1.9.3)
-  - WordPressCom-Analytics-iOS (= 0.1.30)
+  - WordPressCom-Analytics-iOS (= 0.1.31)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.18)
   - wpxmlrpc (= 0.8.3)
@@ -187,11 +187,11 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: 5e9592aaeb2592eea3b11d9236696dc95cea9fcb
   WordPress-iOS-Editor: ed02135d783ecb9aa4ee5e2462935432d464d461
-  WordPressCom-Analytics-iOS: b7ecda7af610231c0bc2130849f7c0fdc58c1678
+  WordPressCom-Analytics-iOS: a64e051690f9408fd71343625bf68f55389cd42d
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 71152f51bcce902b70d03caf47ef03f4757c0019
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 28d1862732f4c19493f613f935b6e562b7f74efc
+PODFILE CHECKSUM: b4945f1107e7211398bf42c93e1aa8d2fccebaee
 
 COCOAPODS: 1.2.1

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -286,6 +286,18 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             eventName = @"editor_video_added";
             eventProperties = @{ @"via" : @"media_library" };
             break;
+        case WPAnalyticsStatEditorAztecBetaLink:
+            eventName = @"editor_aztec_beta_link";
+            break;
+        case WPAnalyticsStatEditorAztecPromoLink:
+            eventName = @"editor_aztec_promo_link";
+            break;
+        case WPAnalyticsStatEditorAztecPromoPositive:
+            eventName = @"editor_aztec_promo_positive";
+            break;
+        case WPAnalyticsStatEditorAztecPromoNegative:
+            eventName = @"editor_aztec_promo_negative";
+            break;
         case WPAnalyticsStatEditorClosed:
             eventName = @"editor_closed";
             break;

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -951,6 +951,8 @@ extension AztecPostViewController {
     }
 
     @IBAction func betaButtonTapped() {
+        WPAppAnalytics.track(.editorAztecBetaLink)
+
         guard let webViewController = WPWebViewController(url: AztecAnnouncementWhatsNewURL) else { return }
 
         let navigationController = UINavigationController(rootViewController: webViewController)

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -69,6 +69,8 @@ extension FancyAlertViewController {
         }
 
         let defaultButton = Button(Strings.tryIt, { controller in
+            WPAppAnalytics.track(.editorAztecPromoPositive)
+
             enableEditor()
 
             controller.setViewConfiguration(aztecAnnouncementSuccessConfig,
@@ -93,14 +95,17 @@ extension FancyAlertViewController {
         })
 
         let cancelButton = Button(Strings.notNow, { controller in
+            WPAppAnalytics.track(.editorAztecPromoNegative)
             controller.dismiss(animated: true, completion: nil)
         })
 
         let moreInfoButton = Button(Strings.whatsNew, { controller in
+            WPAppAnalytics.track(.editorAztecPromoLink)
             controller.presentWhatsNewWebView()
         })
 
         let titleAccessoryButton = Button(Strings.beta, { controller in
+            WPAppAnalytics.track(.editorAztecBetaLink)
             controller.presentWhatsNewWebView()
         })
 
@@ -109,7 +114,11 @@ extension FancyAlertViewController {
         let config = FancyAlertViewController.Config(titleText: Strings.titleText,
                                                      bodyText: Strings.bodyText,
                                                      headerImage: image,
-                                                     defaultButton: defaultButton, cancelButton: cancelButton, moreInfoButton: moreInfoButton, titleAccessoryButton: titleAccessoryButton, dismissAction: nil)
+                                                     defaultButton: defaultButton,
+                                                     cancelButton: cancelButton,
+                                                     moreInfoButton: moreInfoButton,
+                                                     titleAccessoryButton: titleAccessoryButton,
+                                                     dismissAction: nil)
 
         return FancyAlertViewController.controllerWithConfiguration(configuration: config)
     }
@@ -125,8 +134,15 @@ extension FancyAlertViewController {
 
         typealias Button = FancyAlertViewController.Config.ButtonConfig
 
-        let moreInfoButton = Button(Strings.whatsNew, { _ in })
-        let titleAccessoryButton = Button(Strings.beta, { _ in })
+        let moreInfoButton = Button(Strings.whatsNew, { controller in
+            WPAppAnalytics.track(.editorAztecPromoLink)
+            controller.presentWhatsNewWebView()
+        })
+
+        let titleAccessoryButton = Button(Strings.beta, { controller in
+            WPAppAnalytics.track(.editorAztecBetaLink)
+            controller.presentWhatsNewWebView()
+        })
 
         let image = UIImage(named: "wp-illustration-hand-write")
 
@@ -157,6 +173,7 @@ extension FancyAlertViewController {
         })
 
         let titleAccessoryButton = Button(Strings.beta, { controller in
+            WPAppAnalytics.track(.editorAztecBetaLink)
             controller.presentWhatsNewWebView()
         })
 


### PR DESCRIPTION
This PR adds the new analytics events to the buttons in the new Aztec announcement alert. It also hooks up an analytics call to the 'beta' button in the top of the Aztec editor view controller.

To test:

* Check the analytics calls look right.
* If you like, open `TracksServiceRemote.m` (in WP analytics) and edit `sendBatchOfEvents:` to dump events out with `NSLog`. Check they appear in your log after you tap each button (there may be a few seconds delay before each batch of events are logged).

Needs review: @elibud 