### PR TITLE
Aztec: Helpshift and App Settings footer

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ target 'WordPress' do
   # WordPress components
   # --------------------
   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.0'
-  pod 'Gridicons', '0.9'
+  pod 'Gridicons', '0.10'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.18'
   pod 'WordPress-iOS-Editor', '1.9.3'

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ def shared_with_all_pods
   pod 'CocoaLumberjack', '~> 3.2.0'
   pod 'FormatterKit/TimeIntervalFormatter', '~> 1.8.1'
   pod 'NSObject-SafeExpectations', '0.0.2'
-  pod 'WordPressCom-Analytics-iOS', '0.1.30'
+  pod 'WordPressCom-Analytics-iOS', '0.1.31'
 end
 
 def shared_with_networking_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -35,7 +35,7 @@ PODS:
   - FormatterKit/Resources (1.8.2)
   - FormatterKit/TimeIntervalFormatter (1.8.2):
     - FormatterKit/Resources
-  - Gridicons (0.9)
+  - Gridicons (0.10)
   - HockeySDK (4.1.5):
     - HockeySDK/DefaultLib (= 4.1.5)
   - HockeySDK/DefaultLib (4.1.5)
@@ -113,7 +113,7 @@ DEPENDENCIES:
   - Expecta (= 1.0.5)
   - FLAnimatedImage (~> 1.0)
   - FormatterKit/TimeIntervalFormatter (~> 1.8.1)
-  - Gridicons (= 0.9)
+  - Gridicons (= 0.10)
   - HockeySDK (~> 4.1.5)
   - lottie-ios (~> 1.5.1)
   - MGSwipeTableCell (~> 1.5.6)
@@ -170,7 +170,7 @@ SPEC CHECKSUMS:
   Fabric: 5911403591946b8228ab1c51d98f1d7137e863c6
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
-  Gridicons: f3aa1f3977c966354d1aae087b1b43260726cefa
+  Gridicons: e661b35e7d4f0ca79e8b2a2072c0081b91b5d1e0
   HockeySDK: 606b537bbfbe454ee440e92cc93bc634b3c77151
   lottie-ios: f680a7c4cb7a567ecf258fde0f967913aff111b8
   MGSwipeTableCell: 616700eb0ffd1c611ba909066cb7fd739790a0a7
@@ -192,6 +192,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 71152f51bcce902b70d03caf47ef03f4757c0019
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: b4945f1107e7211398bf42c93e1aa8d2fccebaee
+PODFILE CHECKSUM: 7286be426d520cac7c9b52d1921d70dec0f8cc04
 
 COCOAPODS: 1.2.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -97,7 +97,7 @@ PODS:
   - WordPress-iOS-Editor (1.9.3):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
-  - WordPressCom-Analytics-iOS (0.1.30)
+  - WordPressCom-Analytics-iOS (0.1.31)
   - WordPressComKit (0.0.6):
     - Alamofire (= 4.0.1)
   - WPMediaPicker (0.18)
@@ -131,7 +131,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.1)
   - WordPress-Aztec-iOS (= 1.0.0-beta.6)
   - WordPress-iOS-Editor (= 1.9.3)
-  - WordPressCom-Analytics-iOS (= 0.1.30)
+  - WordPressCom-Analytics-iOS (= 0.1.31)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.18)
   - wpxmlrpc (= 0.8.3)
@@ -187,11 +187,11 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: 5e9592aaeb2592eea3b11d9236696dc95cea9fcb
   WordPress-iOS-Editor: ed02135d783ecb9aa4ee5e2462935432d464d461
-  WordPressCom-Analytics-iOS: b7ecda7af610231c0bc2130849f7c0fdc58c1678
+  WordPressCom-Analytics-iOS: a64e051690f9408fd71343625bf68f55389cd42d
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 71152f51bcce902b70d03caf47ef03f4757c0019
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 28d1862732f4c19493f613f935b6e562b7f74efc
+PODFILE CHECKSUM: b4945f1107e7211398bf42c93e1aa8d2fccebaee
 
 COCOAPODS: 1.2.1

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -286,6 +286,18 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             eventName = @"editor_video_added";
             eventProperties = @{ @"via" : @"media_library" };
             break;
+        case WPAnalyticsStatEditorAztecBetaLink:
+            eventName = @"editor_aztec_beta_link";
+            break;
+        case WPAnalyticsStatEditorAztecPromoLink:
+            eventName = @"editor_aztec_promo_link";
+            break;
+        case WPAnalyticsStatEditorAztecPromoPositive:
+            eventName = @"editor_aztec_promo_positive";
+            break;
+        case WPAnalyticsStatEditorAztecPromoNegative:
+            eventName = @"editor_aztec_promo_negative";
+            break;
         case WPAnalyticsStatEditorClosed:
             eventName = @"editor_closed";
             break;

--- a/WordPress/Classes/Utility/WPWebViewController.h
+++ b/WordPress/Classes/Utility/WPWebViewController.h
@@ -59,4 +59,16 @@
  */
 + (instancetype)webViewControllerWithURL:(NSURL *)url;
 
+/**
+ *	@brief      Helper method to initialize a WebViewController Instance with a 
+ *              custom options button
+ *
+ *	@param		url         The URL that needs to be rendered
+ *  @param      button      A custom options button to display instead of the
+ *                          default share button.
+ *  @returns                A WPWebViewController instance ready to be pushed.
+ */
++ (instancetype)webViewControllerWithURL:(NSURL *)url
+                           optionsButton:(UIBarButtonItem *)button;
+
 @end

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -88,10 +88,14 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     self.navigationItem.titleView           = self.titleView;
     
     // Buttons
-    self.optionsButton = [[UIBarButtonItem alloc] initWithImage:[Gridicon iconOfType:GridiconTypeShareIOS] style:UIBarButtonItemStylePlain target:self action:@selector(showLinkOptions)];
+    if (!self.optionsButton) {
+        self.optionsButton = [[UIBarButtonItem alloc] initWithImage:[Gridicon iconOfType:GridiconTypeShareIOS] style:UIBarButtonItemStylePlain target:self action:@selector(showLinkOptions)];
+
+        self.optionsButton.accessibilityLabel   = NSLocalizedString(@"Share",   @"Spoken accessibility label");
+    }
+
     self.dismissButton = [[UIBarButtonItem alloc] initWithImage:[Gridicon iconOfType:GridiconTypeCross] style:UIBarButtonItemStylePlain target:self action:@selector(dismiss)];
 
-    self.optionsButton.accessibilityLabel   = NSLocalizedString(@"Share",   @"Spoken accessibility label");
     self.dismissButton.accessibilityLabel   = NSLocalizedString(@"Dismiss", @"Dismiss a view. Verb");
     self.backButton.accessibilityLabel      = NSLocalizedString(@"Back",    @"Previous web page");
     self.forwardButton.accessibilityLabel   = NSLocalizedString(@"Forward", @"Next web page");
@@ -518,6 +522,17 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     
     WPWebViewController *webViewController = [WPWebViewController new];
     webViewController.url = url;
+    return webViewController;
+}
+
++ (instancetype)webViewControllerWithURL:(NSURL *)url
+                           optionsButton:(UIBarButtonItem *)button
+{
+    NSParameterAssert(url);
+
+    WPWebViewController *webViewController = [WPWebViewController new];
+    webViewController.url = url;
+    webViewController.optionsButton = button;
     return webViewController;
 }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -953,11 +953,7 @@ extension AztecPostViewController {
     @IBAction func betaButtonTapped() {
         WPAppAnalytics.track(.editorAztecBetaLink)
 
-        guard let webViewController = WPWebViewController(url: AztecAnnouncementWhatsNewURL) else { return }
-
-        let navigationController = UINavigationController(rootViewController: webViewController)
-
-        present(navigationController, animated: true, completion: nil)
+        WPWebViewController.presentWhatsNewWebView(from: self)
     }
 
     private func trackPostSave(stat: WPAnalyticsStat) {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -951,6 +951,8 @@ extension AztecPostViewController {
     }
 
     @IBAction func betaButtonTapped() {
+        WPAppAnalytics.track(.editorAztecBetaLink)
+
         guard let webViewController = WPWebViewController(url: AztecAnnouncementWhatsNewURL) else { return }
 
         let navigationController = UINavigationController(rootViewController: webViewController)

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -164,7 +164,14 @@ class AppSettingsViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         if shouldShowEditorFooterForSection(section) {
-            let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: AppSettingsEditorFooterView.reuseIdentifier)
+            let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: AppSettingsEditorFooterView.reuseIdentifier) as! AppSettingsEditorFooterView
+
+            view.tapBlock = { [weak self] in
+                WPAppAnalytics.track(.editorAztecBetaLink)
+
+                WPWebViewController.presentWhatsNewWebView(from: self)
+            }
+
             return view
         }
 
@@ -347,6 +354,7 @@ fileprivate struct MediaSizingRow: ImmuTableRow {
 fileprivate class AppSettingsEditorFooterView: UITableViewHeaderFooterView {
     static let height: CGFloat = 38.0
     static let reuseIdentifier = "AppSettingsEditorFooterView"
+    var tapBlock: (() -> Void)? = nil
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
@@ -366,6 +374,7 @@ fileprivate class AppSettingsEditorFooterView: UITableViewHeaderFooterView {
         let button = UIButton(type: .custom)
         button.setImage(Gridicon.iconOfType(.infoOutline), for: .normal)
         button.tintColor = WPStyleGuide.greyDarken10()
+        button.addTarget(self, action: #selector(footerButtonTapped), for: .touchUpInside)
 
         contentView.addSubview(stackView)
         stackView.addArrangedSubview(button)
@@ -380,5 +389,9 @@ fileprivate class AppSettingsEditorFooterView: UITableViewHeaderFooterView {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    @IBAction private func footerButtonTapped() {
+        tapBlock?()
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -169,7 +169,9 @@ class AppSettingsViewController: UITableViewController {
             view.tapBlock = { [weak self] in
                 WPAppAnalytics.track(.editorAztecBetaLink)
 
-                WPWebViewController.presentWhatsNewWebView(from: self)
+                if let controller = self {
+                    WPWebViewController.presentWhatsNewWebView(from: controller)
+                }
             }
 
             return view

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Gridicons
 import WordPressComAnalytics
 
 let AztecAnnouncementWhatsNewURL = URL(string: "https://make.wordpress.org/mobile/whats-new-in-beta-ios-editor/")
@@ -18,14 +19,6 @@ extension FancyAlertViewController {
         static let successAnimationDampingRaio: CGFloat = 0.6
         static let confettiViewInset: CGFloat = -40.0
         static let confettiDuration: TimeInterval = 2.0
-    }
-
-    private func presentWhatsNewWebView() {
-        guard let webViewController = WPWebViewController(url: AztecAnnouncementWhatsNewURL) else { return }
-
-        let navigationController = UINavigationController(rootViewController: webViewController)
-
-        present(navigationController, animated: true, completion: nil)
     }
 
     static func aztecAnnouncementController() -> FancyAlertViewController {
@@ -101,12 +94,12 @@ extension FancyAlertViewController {
 
         let moreInfoButton = Button(Strings.whatsNew, { controller in
             WPAppAnalytics.track(.editorAztecPromoLink)
-            controller.presentWhatsNewWebView()
+            WPWebViewController.presentWhatsNewWebView(from: controller)
         })
 
         let titleAccessoryButton = Button(Strings.beta, { controller in
             WPAppAnalytics.track(.editorAztecBetaLink)
-            controller.presentWhatsNewWebView()
+            WPWebViewController.presentWhatsNewWebView(from: controller)
         })
 
         let image = UIImage(named: "wp-illustration-hand-write")
@@ -136,12 +129,12 @@ extension FancyAlertViewController {
 
         let moreInfoButton = Button(Strings.whatsNew, { controller in
             WPAppAnalytics.track(.editorAztecPromoLink)
-            controller.presentWhatsNewWebView()
+            WPWebViewController.presentWhatsNewWebView(from: controller)
         })
 
         let titleAccessoryButton = Button(Strings.beta, { controller in
             WPAppAnalytics.track(.editorAztecBetaLink)
-            controller.presentWhatsNewWebView()
+            WPWebViewController.presentWhatsNewWebView(from: controller)
         })
 
         let image = UIImage(named: "wp-illustration-hand-write")
@@ -174,7 +167,7 @@ extension FancyAlertViewController {
 
         let titleAccessoryButton = Button(Strings.beta, { controller in
             WPAppAnalytics.track(.editorAztecBetaLink)
-            controller.presentWhatsNewWebView()
+            WPWebViewController.presentWhatsNewWebView(from: controller)
         })
 
         let image = UIImage(named: "wp-illustration-thank-you")
@@ -219,3 +212,41 @@ extension UserDefaults {
         }
     }
 }
+
+// MARK: - What's New Web View
+
+extension WPWebViewController {
+    static func presentWhatsNewWebView(from viewController: UIViewController) {
+        // Replace the web view's options button with our own bug reporting button
+        let bugButton = UIBarButtonItem(image: Gridicon.iconOfType(.bug), style: .plain, target: self, action: #selector(bugButtonTapped))
+
+        guard let webViewController = WPWebViewController(url: AztecAnnouncementWhatsNewURL, optionsButton: bugButton) else { return }
+
+        let navigationController = UINavigationController(rootViewController: webViewController)
+
+        viewController.present(navigationController, animated: true, completion: nil)
+    }
+
+    @objc static private func bugButtonTapped() {
+        // Find the topmost view controller that we can present from
+        guard let delegate = UIApplication.shared.delegate,
+            let window = delegate.window,
+            let viewController = window?.topmostPresentedViewController else { return }
+
+        if HelpshiftUtils.isHelpshiftEnabled() {
+            // Present a Helpshift window if available
+            let presenter = HelpshiftPresenter()
+            presenter.sourceTag = SupportSourceTag.inAppFeedback
+            presenter.presentHelpshiftConversationWindowFromViewController(viewController,
+                                                                           refreshUserDetails: true,
+                                                                           completion:nil)
+        } else {
+            // Otherwise email
+            if let contact = URL(string: contactURL) {
+                UIApplication.shared.open(contact)
+            }
+        }
+    }
+}
+
+private let contactURL = "https://support.wordpress.com/contact/"

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -69,6 +69,8 @@ extension FancyAlertViewController {
         }
 
         let defaultButton = Button(Strings.tryIt, { controller in
+            WPAppAnalytics.track(.editorAztecPromoPositive)
+
             enableEditor()
 
             controller.setViewConfiguration(aztecAnnouncementSuccessConfig,
@@ -93,14 +95,17 @@ extension FancyAlertViewController {
         })
 
         let cancelButton = Button(Strings.notNow, { controller in
+            WPAppAnalytics.track(.editorAztecPromoNegative)
             controller.dismiss(animated: true, completion: nil)
         })
 
         let moreInfoButton = Button(Strings.whatsNew, { controller in
+            WPAppAnalytics.track(.editorAztecPromoLink)
             controller.presentWhatsNewWebView()
         })
 
         let titleAccessoryButton = Button(Strings.beta, { controller in
+            WPAppAnalytics.track(.editorAztecBetaLink)
             controller.presentWhatsNewWebView()
         })
 
@@ -109,7 +114,11 @@ extension FancyAlertViewController {
         let config = FancyAlertViewController.Config(titleText: Strings.titleText,
                                                      bodyText: Strings.bodyText,
                                                      headerImage: image,
-                                                     defaultButton: defaultButton, cancelButton: cancelButton, moreInfoButton: moreInfoButton, titleAccessoryButton: titleAccessoryButton, dismissAction: nil)
+                                                     defaultButton: defaultButton,
+                                                     cancelButton: cancelButton,
+                                                     moreInfoButton: moreInfoButton,
+                                                     titleAccessoryButton: titleAccessoryButton,
+                                                     dismissAction: nil)
 
         return FancyAlertViewController.controllerWithConfiguration(configuration: config)
     }
@@ -125,8 +134,15 @@ extension FancyAlertViewController {
 
         typealias Button = FancyAlertViewController.Config.ButtonConfig
 
-        let moreInfoButton = Button(Strings.whatsNew, { _ in })
-        let titleAccessoryButton = Button(Strings.beta, { _ in })
+        let moreInfoButton = Button(Strings.whatsNew, { controller in
+            WPAppAnalytics.track(.editorAztecPromoLink)
+            controller.presentWhatsNewWebView()
+        })
+
+        let titleAccessoryButton = Button(Strings.beta, { controller in
+            WPAppAnalytics.track(.editorAztecBetaLink)
+            controller.presentWhatsNewWebView()
+        })
 
         let image = UIImage(named: "wp-illustration-hand-write")
 
@@ -157,6 +173,7 @@ extension FancyAlertViewController {
         })
 
         let titleAccessoryButton = Button(Strings.beta, { controller in
+            WPAppAnalytics.track(.editorAztecBetaLink)
             controller.presentWhatsNewWebView()
         })
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -219,8 +219,15 @@ extension WPWebViewController {
     static func presentWhatsNewWebView(from viewController: UIViewController) {
         // Replace the web view's options button with our own bug reporting button
         let bugButton = UIBarButtonItem(image: Gridicon.iconOfType(.bug), style: .plain, target: self, action: #selector(bugButtonTapped))
+        bugButton.accessibilityLabel = NSLocalizedString("Report a bug", comment: "Button allowing the user to report a bug with the beta Aztec editor")
 
-        guard let webViewController = WPWebViewController(url: AztecAnnouncementWhatsNewURL, optionsButton: bugButton) else { return }
+        var webViewController: WPWebViewController
+
+        if HelpshiftUtils.isHelpshiftEnabled() {
+            webViewController = WPWebViewController(url: AztecAnnouncementWhatsNewURL, optionsButton: bugButton)
+        } else {
+            webViewController = WPWebViewController(url: AztecAnnouncementWhatsNewURL)
+        }
 
         let navigationController = UINavigationController(rootViewController: webViewController)
 
@@ -233,19 +240,13 @@ extension WPWebViewController {
             let window = delegate.window,
             let viewController = window?.topmostPresentedViewController else { return }
 
-        if HelpshiftUtils.isHelpshiftEnabled() {
-            // Present a Helpshift window if available
-            let presenter = HelpshiftPresenter()
-            presenter.sourceTag = SupportSourceTag.inAppFeedback
-            presenter.presentHelpshiftConversationWindowFromViewController(viewController,
-                                                                           refreshUserDetails: true,
-                                                                           completion:nil)
-        } else {
-            // Otherwise email
-            if let contact = URL(string: contactURL) {
-                UIApplication.shared.open(contact)
-            }
-        }
+        guard HelpshiftUtils.isHelpshiftEnabled() else { return }
+
+        let presenter = HelpshiftPresenter()
+        presenter.sourceTag = SupportSourceTag.inAppFeedback
+        presenter.presentHelpshiftConversationWindowFromViewController(viewController,
+                                                                       refreshUserDetails: true,
+                                                                       completion:nil)
     }
 }
 


### PR DESCRIPTION
This PR hooks up the button in the Aztec footer in App Settings:

<img width="321" alt="screen shot 2017-07-04 at 19 06 37" src="https://user-images.githubusercontent.com/4780/27839787-fbbe83fa-60eb-11e7-9b04-563da6bafa00.png">

It'll display the same web view as the other beta / what's new links for Aztec. I've centralised the code that displays that web view so we're not repeating it everywhere.

I've also updated that code so that the web view displays a "bug" link in the top right of the webview, which will launch Helpshift if available.

To test:

* Check the footer link in App Settings loads the web view
* Check the bug link in the web view works correctly
* Ensure I haven't broken the other web view links

Needs review: @elibud 