### PR TITLE
Fix tag picker with Chinese keyboard.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -197,6 +197,10 @@ private extension PostTagPickerViewController {
 
 extension PostTagPickerViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
+        guard textView.markedTextRange == nil else {
+            // Don't try to normalize if we're still in multistage input
+            return
+        }
         normalizeText()
         updateSuggestions()
     }


### PR DESCRIPTION
Avoids premature normalization of text by checking markedTextRange. If that's
non-nil it means we're in "multistage input" and the text displayed is only
temporary.

To test:

- Switch to Chinese (Traditional) keyboard
- Enter tag picker
- Start typing and confirm it doesn't duplicate symbols.