### PR TITLE
Login: Instantiate the correct login controller with the correct navcontroller

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -106,11 +106,11 @@ import WordPressShared
         }
 
         let storyboard = UIStoryboard(name: "Login", bundle: nil)
-        guard let controller = storyboard.instantiateViewController(withIdentifier: "selfHosted") as? NUXAbstractViewController else {
+        guard let controller = storyboard.instantiateViewController(withIdentifier: "siteAddress") as? NUXAbstractViewController else {
             return
         }
 
-        let navController = NUXNavigationController(rootViewController: controller)
+        let navController = LoginNavigationController(rootViewController: controller)
         presenter.present(navController, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
Refs #7272 
Shows the site address controller instead of the self-hosted username/password controller when adding a new self-hosted site. Shows the correct nav bar style.

To test: 
Be signed into the app.
From the My Sites controller, tap to add a new self-hosted site. 
Confirm the site address controller is presented (you should be prompted for your URL)
Confirm the navbar has the correct style. 
Confirm you can successfully add the self-hosted site.

Needs review: @elibud would you mind taking a peek at this one? 
