### PR TITLE
Login: Add check for prologue vc.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -513,7 +513,8 @@ int ddLogLevel = DDLogLevelInfo;
         return YES;
     }
 
-    return [presentedViewController.visibleViewController isKindOfClass:[NUXAbstractViewController class]];
+    UIViewController *controller = presentedViewController.visibleViewController;
+    return [controller isKindOfClass:[NUXAbstractViewController class]] || [controller isKindOfClass:[LoginPrologueViewController class]];
 }
 
 - (BOOL)noWordPressDotComAccount


### PR DESCRIPTION
Fixes #3120 
The flicker at launch is due to login being launched twice, once by the app delegate (as expected) and once by the `BlogListViewController` when its `viewWillAppear` method is invoked. From what I can tell `viewWillAppear` is invoked due to how we've composed the split view and tabbarcontroller but I might be missing/misunderstanding something here.  In any event, this PR resolve the issue by adding a check for the new prologue view controller when determining if the login flow is visible. 

To test:
Sign out of the app completely.
Launch the app. 
Watch carefully and confirm there is no flicker.

Needs review: @nheagy 
