### PR TITLE
Issues/7272 login email vc tweaks

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -85,7 +85,13 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
     /// Hides the self-hosted login option.
     ///
     func configureForWPComOnlyIfNeeded() {
-        selfHostedSigninButton.isHidden = restrictToWPCom
+        if restrictToWPCom {
+            selfHostedSigninButton.isEnabled = false
+            selfHostedSigninButton.alpha = 0.0
+        } else {
+            selfHostedSigninButton.isEnabled = true
+            selfHostedSigninButton.alpha = 1.0
+        }
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -80,7 +80,7 @@ import WordPressShared
         }
         controller.restrictToWPCom = true
 
-        let navController = NUXNavigationController(rootViewController: controller)
+        let navController = LoginNavigationController(rootViewController: controller)
         presenter.present(navController, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
Refs #7272

This is a quick patch to fix some UI glitches when opening the new login flow from the Me tab.  The navbar style is corrected and the submit button retains its size and layout.

To test:
Be signed into the app with a self-hosted blog.
Switch to the Me tab and try to log in to wpcom.
Confirm that the UI looks correct.

Needs review: @nheagy 


![simulator screen shot jul 6 2017 5 43 58 pm](https://user-images.githubusercontent.com/1435271/27962370-565b83e6-62f7-11e7-880a-62216429b30f.png)
