### PR TITLE
Issues/7453 improve email verification

### DIFF
--- a/WordPress/Classes/Utility/EmailFormatValidator.swift
+++ b/WordPress/Classes/Utility/EmailFormatValidator.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Test a string to see if it resembles an email address.  The checks in this
+/// class are based on those in wp-includes/formatting.php `is_email`.
+///
+open class EmailFormatValidator {
+
+    /// Validate the specified string.
+    ///
+    public class func validate(str: NSString) -> Bool {
+        // Test for the minimum length the email can be
+        if !isMinEmailLength(str) {
+            return false
+        }
+
+        // Test for an @ character after the first position
+        if !hasAtSign(str) {
+            return false
+        }
+
+        // Split out the local and domain parts
+        let arr = str.components(separatedBy: "@")
+        if arr.count != 2 {
+            return false
+        }
+
+        let local = arr[0] as NSString
+        let domain = arr[1] as NSString
+
+        // Local part
+
+        // Test for invalid characters
+        if containsLocalPartForbiddenCharacters(local) {
+            return false
+        }
+
+        // Domain part
+
+        // Test for sequences of periods
+        if containsPeriodSequence(domain) {
+            return false
+        }
+
+        // Test for whitespace
+        if containsWhitespace(domain) {
+            return false
+        }
+
+        // Test for leading/trailing periods
+        if containsLeadingOrTrailingPeriod(domain) {
+            return false
+        }
+
+        // Check for unallowed characters
+        if containsDomainPartForbiddenCharacters(domain) {
+            return false
+        }
+
+        // Split the domain into parts. Assume a minimum of two parts.
+        if !resemblesHostname(domain) {
+            return false
+        }
+        
+        return true
+    }
+
+
+    /// Checks that the supplied string is at least the expected minimum email length.
+    ///
+    private class func isMinEmailLength(_ str: NSString) -> Bool {
+        return str.length >= 6
+    }
+
+
+    /// Checks if the supplied string contains an @ sign that is not the first character.
+    ///
+    private class func hasAtSign(_ str: NSString) -> Bool {
+        return str.range(of: "@").location > 0
+    }
+
+
+    /// Test that the string contains characters permitted in the local part of an email address.
+    ///
+    private class func containsLocalPartForbiddenCharacters(_ str: NSString) -> Bool {
+        // match for allowed characters
+        let regex = "^[a-zA-Z0-9!#$%&'*+\\/=?^_`{|}~\\.-]+$"
+        let match = NSPredicate(format: "SELF MATCHES %@", regex)
+        return !match.evaluate(with: str)
+    }
+
+
+    /// Check if the string contains more than one period in a row.
+    ///
+    private class func containsPeriodSequence(_ str: NSString) -> Bool {
+        return str.contains("..")
+    }
+
+
+    /// Check if the string contains any whitespace or newline characters.
+    ///
+    private class func containsWhitespace(_ str: NSString) -> Bool {
+        return str.rangeOfCharacter(from: .whitespacesAndNewlines).location != NSNotFound
+    }
+
+
+    /// Check if the string contains any leading or trailing periods.
+    ///
+    private class func containsLeadingOrTrailingPeriod(_ str: NSString) -> Bool {
+        return str.hasPrefix(".") || str.hasSuffix(".")
+    }
+
+
+    /// Check if the string contains characters forbidden in the domain part of an email address.
+    ///
+    private class func containsDomainPartForbiddenCharacters(_ str: NSString) -> Bool {
+        // Match for allowed characters
+        // If the match evaluates to true, then the string contains at least one forbidden character
+        let regex = "^[a-zA-Z0-9-.]+$"
+        let match = NSPredicate(format: "SELF MATCHES %@", regex)
+        return !match.evaluate(with: str)
+    }
+
+
+    /// Check if the supplied string resembles a host name.
+    ///
+    private class func resemblesHostname(_ str: NSString) -> Bool {
+        // A host name should have two or more parts
+        let parts = str.components(separatedBy: ".")
+        return parts.count > 1
+    }
+}

--- a/WordPress/Classes/Utility/EmailFormatValidator.swift
+++ b/WordPress/Classes/Utility/EmailFormatValidator.swift
@@ -7,7 +7,8 @@ open class EmailFormatValidator {
 
     /// Validate the specified string.
     ///
-    public class func validate(str: NSString) -> Bool {
+    public class func validate(string: String) -> Bool {
+        let str = string as NSString
         // Test for the minimum length the email can be
         if !isMinEmailLength(str) {
             return false

--- a/WordPress/Classes/Utility/EmailFormatValidator.swift
+++ b/WordPress/Classes/Utility/EmailFormatValidator.swift
@@ -61,7 +61,7 @@ open class EmailFormatValidator {
         if !resemblesHostname(domain) {
             return false
         }
-        
+
         return true
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -234,7 +234,7 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
     ///
     func validateForm() {
         displayError(message: "")
-        guard loginFields.username.isValidEmail() else {
+        guard EmailFormatValidator.validate(string: loginFields.username) else {
             assertionFailure("Form should not be submitted unless there is a valid looking email entered.")
             return
         }
@@ -270,7 +270,7 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
     /// Whether the form can be submitted.
     ///
     func canSubmit() -> Bool {
-        return loginFields.username.isValidEmail()
+        return EmailFormatValidator.validate(string: loginFields.username)
     }
 
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1004,6 +1004,8 @@
 		E6A3384C1BB08E3F00371587 /* ReaderGapMarker.m in Sources */ = {isa = PBXBuildFile; fileRef = E6A3384B1BB08E3F00371587 /* ReaderGapMarker.m */; };
 		E6A3384E1BB0A50900371587 /* ReaderGapMarkerCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E6A3384D1BB0A50900371587 /* ReaderGapMarkerCell.xib */; };
 		E6A338501BB0A70F00371587 /* ReaderGapMarkerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A3384F1BB0A70F00371587 /* ReaderGapMarkerCell.swift */; };
+		E6B046891F0FE85B0079F9FA /* EmailFormatValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B046881F0FE85B0079F9FA /* EmailFormatValidator.swift */; };
+		E6B0468B1F0FEC410079F9FA /* EmailFormatValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B0468A1F0FEC410079F9FA /* EmailFormatValidatorTests.swift */; };
 		E6B42CBF1D9DA6270043E228 /* Noticons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E6B42CBE1D9DA6270043E228 /* Noticons.ttf */; };
 		E6B84DD51F01BDAA00B1B686 /* SiteInfoHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B84DD41F01BDAA00B1B686 /* SiteInfoHeaderView.swift */; };
 		E6B896DC1CB7FB1F00E3FD8F /* SigninLinkAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B896DB1CB7FB1F00E3FD8F /* SigninLinkAuthViewController.swift */; };
@@ -2601,6 +2603,8 @@
 		E6A3384B1BB08E3F00371587 /* ReaderGapMarker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ReaderGapMarker.m; sourceTree = "<group>"; };
 		E6A3384D1BB0A50900371587 /* ReaderGapMarkerCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderGapMarkerCell.xib; sourceTree = "<group>"; };
 		E6A3384F1BB0A70F00371587 /* ReaderGapMarkerCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderGapMarkerCell.swift; sourceTree = "<group>"; };
+		E6B046881F0FE85B0079F9FA /* EmailFormatValidator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmailFormatValidator.swift; sourceTree = "<group>"; };
+		E6B0468A1F0FEC410079F9FA /* EmailFormatValidatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmailFormatValidatorTests.swift; sourceTree = "<group>"; };
 		E6B2101A1C444CB50063E271 /* WordPress 44.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 44.xcdatamodel"; sourceTree = "<group>"; };
 		E6B42CBE1D9DA6270043E228 /* Noticons.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Noticons.ttf; sourceTree = "<group>"; };
 		E6B84DD41F01BDAA00B1B686 /* SiteInfoHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteInfoHeaderView.swift; sourceTree = "<group>"; };
@@ -3813,6 +3817,7 @@
 				E19A10C91B010AA0006192B0 /* WPURLRequestTest.m */,
 				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
 				E1AB5A391E0C464700574B4E /* DelayTests.swift */,
+				E6B0468A1F0FEC410079F9FA /* EmailFormatValidatorTests.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -3870,6 +3875,7 @@
 				FD9A948B12FAEA2300438F94 /* DateUtils.m */,
 				E14BCABA1E0BC817002E0603 /* Delay.swift */,
 				E1C3C8521CE467A900D5DB36 /* EmailTypoChecker.swift */,
+				E6B046881F0FE85B0079F9FA /* EmailFormatValidator.swift */,
 				E1266D2C1BBE8B9A00FCB6B6 /* Gravatar.swift */,
 				E11000981CDB5F1E00E33887 /* KeychainTools.swift */,
 				5DB4683918A2E718004A89A9 /* LocationService.h */,
@@ -6497,6 +6503,7 @@
 				5D577D33189127BE00B964C3 /* PostGeolocationViewController.m in Sources */,
 				FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */,
 				1D3623260D0F684500981E51 /* WordPressAppDelegate.m in Sources */,
+				E6B046891F0FE85B0079F9FA /* EmailFormatValidator.swift in Sources */,
 				E102B7901E714F24007928E8 /* RecentSitesService.swift in Sources */,
 				E1D7FF381C74EB0E00E7E5E5 /* PlanService.swift in Sources */,
 				5D7DEA2919D488DD0032EE77 /* WPStyleGuide+ReaderComments.swift in Sources */,
@@ -7246,6 +7253,7 @@
 				5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */,
 				85D239C01AE5A7020074768D /* LoginFacadeTests.m in Sources */,
 				FF8032661EE9E22200861F28 /* MediaProgressCoordinatorTests.swift in Sources */,
+				E6B0468B1F0FEC410079F9FA /* EmailFormatValidatorTests.swift in Sources */,
 				E63C897C1CB9A0D700649C8F /* UITextFieldTextHelperTests.swift in Sources */,
 				E63C897A1CB9A0BB00649C8F /* StringHelperTests.swift in Sources */,
 				5DA988061AEEA594002AFB12 /* DisplayableImageHelperTest.m in Sources */,

--- a/WordPress/WordPressTest/EmailFormatValidatorTests.swift
+++ b/WordPress/WordPressTest/EmailFormatValidatorTests.swift
@@ -4,28 +4,28 @@ import XCTest
 class EmailFormatValidatorTests: XCTestCase {
 
     func testValidEmailAddresses() {
-        XCTAssertTrue(EmailFormatValidator.validate(str: "e@example.com"))
-        XCTAssertTrue(EmailFormatValidator.validate(str: "example@example.com"))
-        XCTAssertTrue(EmailFormatValidator.validate(str: "example@example-example.com"))
-        XCTAssertTrue(EmailFormatValidator.validate(str: "example@example.example.example.com"))
-        XCTAssertTrue(EmailFormatValidator.validate(str: "example.example+example@example.com"))
+        XCTAssertTrue(EmailFormatValidator.validate(string: "e@example.com"))
+        XCTAssertTrue(EmailFormatValidator.validate(string: "example@example.com"))
+        XCTAssertTrue(EmailFormatValidator.validate(string: "example@example-example.com"))
+        XCTAssertTrue(EmailFormatValidator.validate(string: "example@example.example.example.com"))
+        XCTAssertTrue(EmailFormatValidator.validate(string: "example.example+example@example.com"))
     }
 
     func testInvalidEmailAddresses() {
-        XCTAssertFalse(EmailFormatValidator.validate(str: ""))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "example"))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "example@@example.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "example@example@.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "@example.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "example@example"))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "example@.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "example@example..com"))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "example@.example.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "example@example.com."))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "example@examp?.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "example@exam_ple.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "examp***le@exam_ple.com"))
-        XCTAssertFalse(EmailFormatValidator.validate(str: "example@exam ple.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: ""))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "example"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "example@@example.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "example@example@.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "@example.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "example@example"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "example@.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "example@example..com"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "example@.example.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "example@example.com."))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "example@examp?.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "example@exam_ple.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "examp***le@exam_ple.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(string: "example@exam ple.com"))
     }
 
 }

--- a/WordPress/WordPressTest/EmailFormatValidatorTests.swift
+++ b/WordPress/WordPressTest/EmailFormatValidatorTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import WordPress
+
+class EmailFormatValidatorTests: XCTestCase {
+
+    func testValidEmailAddresses() {
+        XCTAssertTrue(EmailFormatValidator.validate(str: "e@example.com"))
+        XCTAssertTrue(EmailFormatValidator.validate(str: "example@example.com"))
+        XCTAssertTrue(EmailFormatValidator.validate(str: "example@example-example.com"))
+        XCTAssertTrue(EmailFormatValidator.validate(str: "example@example.example.example.com"))
+        XCTAssertTrue(EmailFormatValidator.validate(str: "example.example+example@example.com"))
+    }
+
+    func testInvalidEmailAddresses() {
+        XCTAssertFalse(EmailFormatValidator.validate(str: ""))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "example"))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "example@@example.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "example@example@.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "@example.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "example@example"))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "example@.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "example@example..com"))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "example@.example.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "example@example.com."))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "example@examp?.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "example@exam_ple.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "examp***le@exam_ple.com"))
+        XCTAssertFalse(EmailFormatValidator.validate(str: "example@exam ple.com"))
+    }
+
+}


### PR DESCRIPTION
Fixes #7453
Refs #7272 

This PR adds a new email validator based on the WP core email validation method `is_email` in `wp-includes/formatting.php`. 

To test:
Confirm that the new tests pass. 
Confirm that for a valid email address, the new login screen's submit button is not enabled until the first letter of the host's tld is typed.
Confirm that an invalid email address never enables the submit button.

Needs review: @koke 
cc @kwonye 
