### PR TITLE
Login: restore ability to use safari saved password

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -265,6 +265,7 @@
                         <segue destination="Kvo-Y2-yhG" kind="show" identifier="startMagicLinkFlow" id="db9-5R-Qq7"/>
                         <segue destination="lmD-c6-SLs" kind="show" identifier="showWPComLogin" id="ySQ-EM-6JI"/>
                         <segue destination="Mwz-tq-5A8" kind="custom" identifier="showEpilogue" customClass="EpilogueSegue" customModule="WordPress" customModuleProvider="target" id="gAE-di-Wyf"/>
+                        <segue destination="bAd-Df-IzS" kind="show" identifier="show2FA" id="kRR-qz-Hu2"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wWl-qb-1Yp" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -275,7 +275,7 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
     override func displayRemoteError(_ error: Error!) {
         configureViewLoading(false)
 
-        self.errorToPresent = error
+        errorToPresent = error
         performSegue(withIdentifier: .showWPComLogin, sender: self)
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -198,7 +198,7 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
         loginFields.safariStoredUsernameHash = username.hash
         loginFields.safariStoredPasswordHash = password.hash
 
-        loginWithUsernamePassword(immediately: false)
+        loginWithUsernamePassword(immediately: true)
 
         WPAppAnalytics.track(.loginAutoFillCredentialsFilled)
     }
@@ -270,6 +270,13 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
                                             strongSelf.displayError(error as NSError, sourceTag: strongSelf.sourceTag)
                                         }
         })
+    }
+
+    override func displayRemoteError(_ error: Error!) {
+        configureViewLoading(false)
+
+        self.errorToPresent = error
+        performSegue(withIdentifier: .showWPComLogin, sender: self)
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
@@ -3,6 +3,7 @@ import Foundation
 class LoginViewController: NUXAbstractViewController {
     @IBOutlet var errorLabel: UILabel?
     @IBOutlet var submitButton: NUXSubmitButton?
+    var errorToPresent: Error?
 
     lazy var loginFacade: LoginFacade = {
         let facade = LoginFacade()
@@ -14,6 +15,10 @@ class LoginViewController: NUXAbstractViewController {
         super.viewDidLoad()
         displayError(message: "")
         setupNavBarIcon()
+
+        if let error = errorToPresent {
+            displayRemoteError(error)
+        }
     }
 
     /// Places the WordPress logo in the navbar
@@ -65,6 +70,23 @@ class LoginViewController: NUXAbstractViewController {
         configureViewLoading(true)
 
         loginFacade.signIn(with: loginFields)
+    }
+
+    /// Manages data transfer when seguing to a new VC
+    ///
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard let source = segue.source as? LoginViewController else {
+            return
+        }
+
+        if let destination = segue.destination as? LoginEpilogueViewController {
+            destination.dismissBlock = source.dismissBlock
+        } else if let destination = segue.destination as? LoginViewController {
+            destination.loginFields = source.loginFields
+            destination.restrictToWPCom = source.restrictToWPCom
+            destination.dismissBlock = source.dismissBlock
+            destination.errorToPresent = source.errorToPresent
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXAbstractViewController.swift
@@ -62,20 +62,6 @@ class NUXAbstractViewController: UIViewController, LoginSegueHandler {
         return UIDevice.isPad() ? .all : .portrait
     }
 
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        guard let source = segue.source as? NUXAbstractViewController else {
-            return
-        }
-
-        if let destination = segue.destination as? LoginEpilogueViewController {
-            destination.dismissBlock = source.dismissBlock
-        } else if let destination = segue.destination as? NUXAbstractViewController {
-            destination.loginFields = source.loginFields
-            destination.restrictToWPCom = source.restrictToWPCom
-            destination.dismissBlock = source.dismissBlock
-        }
-    }
-
 
     // MARK: Setup and Configuration
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninEditingState.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEditingState.swift
@@ -1,6 +1,6 @@
 import Foundation
 
 class SigninEditingState {
-    static var signinEditingStateActive = true
+    static var signinEditingStateActive = false
     static var signinLastKeyboardHeightDelta: CGFloat = 0
 }

--- a/WordPress/Classes/ViewRelated/NUX/SigninEditingState.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninEditingState.swift
@@ -1,6 +1,6 @@
 import Foundation
 
 class SigninEditingState {
-    static var signinEditingStateActive = false
+    static var signinEditingStateActive = true
     static var signinLastKeyboardHeightDelta: CGFloat = 0
 }


### PR DESCRIPTION
Refs #7272

Safari saved passwords are functional again. Properly logs in, and handles errors with grace.

![safari-saved-demo](https://user-images.githubusercontent.com/517257/27976710-f29de212-6324-11e7-9eac-77b0671c11b7.gif)

To test:
- login via safari saved passwords
- the same, with an incorrect passwords
- with and without requiring 2fa

Needs review: @aerych 