### PR TITLE
Issues/7272 login ui tweaks

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -1160,20 +1160,20 @@
                         <viewControllerLayoutGuide type="bottom" id="pCc-dg-bxb"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="gJB-TV-Tpp">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="64" width="383" height="612"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Onf-X6-J5w">
-                                <rect key="frame" x="0.0" y="20" width="375" height="563"/>
+                                <rect key="frame" x="0.0" y="0.0" width="383" height="528"/>
                                 <connections>
                                     <segue destination="0GP-rM-Hvu" kind="embed" id="taY-7m-sQh"/>
                                 </connections>
                             </containerView>
                             <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="juu-ng-v2N">
-                                <rect key="frame" x="0.0" y="583" width="375" height="84"/>
+                                <rect key="frame" x="0.0" y="528" width="383" height="84"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jiQ-IN-bzh">
-                                        <rect key="frame" x="20" y="20" width="335" height="44"/>
+                                        <rect key="frame" x="20" y="20" width="343" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="wlF-fo-JMp"/>
                                         </constraints>
@@ -1190,7 +1190,7 @@
                                         </connections>
                                     </button>
                                     <imageView hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="darkgrey-shadow" translatesAutoresizingMaskIntoConstraints="NO" id="cmz-zv-QBQ">
-                                        <rect key="frame" x="0.0" y="-10" width="375" height="10"/>
+                                        <rect key="frame" x="0.0" y="-10" width="383" height="10"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="P6k-Ic-btx"/>
                                         </constraints>
@@ -1235,16 +1235,16 @@
             <objects>
                 <tableViewController id="0GP-rM-Hvu" customClass="LoginEpilogueTableView" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="154" sectionHeaderHeight="28" sectionFooterHeight="28" id="TzF-S4-1lW">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="563"/>
+                        <rect key="frame" x="0.0" y="0.0" width="383" height="528"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.95294117647058818" green="0.96470588235294119" blue="0.97254901960784312" alpha="1" colorSpace="calibratedRGB"/>
                         <inset key="separatorInset" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="userInfo" rowHeight="148" id="rFk-m6-PzB" customClass="LoginEpilogueUserInfoCell" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="148"/>
+                                <rect key="frame" x="0.0" y="28" width="383" height="148"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rFk-m6-PzB" id="Be1-mM-Agr">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="148"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383" height="148"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xKq-ni-wZB" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -1323,10 +1323,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlogCell" rowHeight="52" id="Efm-ja-Y8C" customClass="LoginEpilogueBlogCell" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="176" width="375" height="52"/>
+                                <rect key="frame" x="0.0" y="176" width="383" height="52"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Efm-ja-Y8C" id="Xid-Yh-Kpa">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="52"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383" height="52"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Rtc-ao-Fl6">
@@ -1664,78 +1664,77 @@
                         <rect key="frame" x="0.0" y="0.0" width="383" height="676"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="245" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="QcA-UD-Exa" userLabel="Wrapper Stack View">
-                                <rect key="frame" x="0.0" y="64" width="383" height="612"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a59-c7-WBk">
+                                <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
-                                    <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" placeholderIntrinsicWidth="383" placeholderIntrinsicHeight="426" translatesAutoresizingMaskIntoConstraints="NO" id="a1t-zo-d5c">
-                                        <rect key="frame" x="0.0" y="0.0" width="383" height="426"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PIc-wF-cQF">
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="549"/>
                                         <subviews>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="example.wordpress.com" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZrT-CY-qD7" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="191" width="383" height="44"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
+                                            <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="a1t-zo-d5c">
+                                                <rect key="frame" x="0.0" y="194.5" width="391" height="122"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Enter the address of the WordPress site you'd like to connect." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-bF-n1P">
+                                                        <rect key="frame" x="20" y="0.0" width="351" height="38"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="example.wordpress.com" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZrT-CY-qD7" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="58" width="391" height="44"/>
+                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="A6G-yu-Aix"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="URL" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-url-field"/>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="handleSubmitForm" destination="anK-hg-K4j" eventType="primaryActionTriggered" id="9op-PL-dLy"/>
+                                                            <action selector="handleTextFieldDidChange:" destination="anK-hg-K4j" eventType="editingChanged" id="HdI-gj-hRv"/>
+                                                            <action selector="handleTextFieldDidChange:" destination="anK-hg-K4j" eventType="editingDidBegin" id="o3I-NR-Vk3"/>
+                                                            <outlet property="delegate" destination="anK-hg-K4j" id="LHf-xJ-KYE"/>
+                                                        </connections>
+                                                    </textField>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Up-9bc">
+                                                        <rect key="frame" x="20" y="122" width="351" height="0.0"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="A6G-yu-Aix"/>
-                                                    <constraint firstAttribute="width" constant="320" id="bh2-wA-dzz"/>
+                                                    <constraint firstAttribute="trailing" secondItem="SIW-Up-9bc" secondAttribute="trailing" constant="20" id="0Pd-gX-fOG"/>
+                                                    <constraint firstAttribute="trailing" secondItem="eFO-bF-n1P" secondAttribute="trailing" constant="20" id="0e8-ji-uHd"/>
+                                                    <constraint firstItem="SIW-Up-9bc" firstAttribute="leading" secondItem="a1t-zo-d5c" secondAttribute="leading" constant="20" id="33t-k3-3mR"/>
+                                                    <constraint firstItem="eFO-bF-n1P" firstAttribute="leading" secondItem="a1t-zo-d5c" secondAttribute="leading" constant="20" id="47h-v5-Mfv"/>
+                                                    <constraint firstItem="ZrT-CY-qD7" firstAttribute="leading" secondItem="a1t-zo-d5c" secondAttribute="leading" id="Be0-6x-vDK"/>
+                                                    <constraint firstItem="SIW-Up-9bc" firstAttribute="top" secondItem="ZrT-CY-qD7" secondAttribute="bottom" constant="20" id="HJf-Tb-1D8"/>
+                                                    <constraint firstAttribute="bottom" secondItem="SIW-Up-9bc" secondAttribute="bottom" id="StL-Lq-cRW"/>
+                                                    <constraint firstItem="ZrT-CY-qD7" firstAttribute="top" secondItem="eFO-bF-n1P" secondAttribute="bottom" constant="20" id="aLY-gB-aNq"/>
+                                                    <constraint firstItem="eFO-bF-n1P" firstAttribute="top" secondItem="a1t-zo-d5c" secondAttribute="top" id="fOJ-sm-UN0"/>
+                                                    <constraint firstAttribute="trailing" secondItem="ZrT-CY-qD7" secondAttribute="trailing" id="xKB-6s-tY8"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="URL" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-url-field"/>
-                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                </userDefinedRuntimeAttributes>
-                                                <variation key="default">
-                                                    <mask key="constraints">
-                                                        <exclude reference="bh2-wA-dzz"/>
-                                                    </mask>
-                                                </variation>
-                                                <variation key="heightClass=regular-widthClass=regular">
-                                                    <mask key="constraints">
-                                                        <include reference="bh2-wA-dzz"/>
-                                                    </mask>
-                                                </variation>
-                                                <connections>
-                                                    <action selector="handleSubmitForm" destination="anK-hg-K4j" eventType="primaryActionTriggered" id="9op-PL-dLy"/>
-                                                    <action selector="handleTextFieldDidChange:" destination="anK-hg-K4j" eventType="editingChanged" id="HdI-gj-hRv"/>
-                                                    <action selector="handleTextFieldDidChange:" destination="anK-hg-K4j" eventType="editingDidBegin" id="o3I-NR-Vk3"/>
-                                                    <outlet property="delegate" destination="anK-hg-K4j" id="LHf-xJ-KYE"/>
-                                                </connections>
-                                            </textField>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enter the address of the WordPress site you'd like to connect." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-bF-n1P">
-                                                <rect key="frame" x="20" y="133" width="343" height="38"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Up-9bc">
-                                                <rect key="frame" x="20" y="255" width="343" height="0.0"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            </view>
                                         </subviews>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="SIW-Up-9bc" secondAttribute="trailing" constant="20" id="0Pd-gX-fOG"/>
-                                            <constraint firstAttribute="trailing" secondItem="eFO-bF-n1P" secondAttribute="trailing" constant="20" id="0e8-ji-uHd"/>
-                                            <constraint firstItem="SIW-Up-9bc" firstAttribute="leading" secondItem="a1t-zo-d5c" secondAttribute="leading" constant="20" id="33t-k3-3mR"/>
-                                            <constraint firstItem="eFO-bF-n1P" firstAttribute="leading" secondItem="a1t-zo-d5c" secondAttribute="leading" constant="20" id="47h-v5-Mfv"/>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="5ey-80-9rh"/>
-                                            <constraint firstItem="ZrT-CY-qD7" firstAttribute="leading" secondItem="a1t-zo-d5c" secondAttribute="leading" id="Be0-6x-vDK"/>
-                                            <constraint firstItem="SIW-Up-9bc" firstAttribute="top" secondItem="ZrT-CY-qD7" secondAttribute="bottom" constant="20" id="HJf-Tb-1D8"/>
-                                            <constraint firstItem="ZrT-CY-qD7" firstAttribute="top" secondItem="eFO-bF-n1P" secondAttribute="bottom" constant="20" id="aLY-gB-aNq"/>
-                                            <constraint firstItem="ZrT-CY-qD7" firstAttribute="centerY" secondItem="a1t-zo-d5c" secondAttribute="centerY" id="jfb-bD-648"/>
-                                            <constraint firstAttribute="trailing" secondItem="ZrT-CY-qD7" secondAttribute="trailing" id="xKB-6s-tY8"/>
+                                            <constraint firstAttribute="trailing" secondItem="a1t-zo-d5c" secondAttribute="trailing" id="1PY-Jw-P0J"/>
+                                            <constraint firstItem="ZrT-CY-qD7" firstAttribute="centerY" secondItem="PIc-wF-cQF" secondAttribute="centerY" id="9ZA-SI-QXw"/>
+                                            <constraint firstItem="a1t-zo-d5c" firstAttribute="leading" secondItem="PIc-wF-cQF" secondAttribute="leading" id="Gsg-hb-SON"/>
                                         </constraints>
                                     </view>
-                                    <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="GKU-9C-CUT">
-                                        <rect key="frame" x="0.0" y="436" width="383" height="176"/>
+                                    <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="GKU-9C-CUT" userLabel="Footer">
+                                        <rect key="frame" x="0.0" y="549" width="391" height="63"/>
                                         <subviews>
-                                            <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="mlx-XY-MGX">
-                                                <rect key="frame" x="20" y="123" width="343" height="33"/>
+                                            <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mlx-XY-MGX">
+                                                <rect key="frame" x="20" y="10" width="351" height="33"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="roL-ID-k8n">
-                                                        <rect key="frame" x="0.0" y="1.5" width="307" height="30"/>
+                                                        <rect key="frame" x="0.0" y="1.5" width="250" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <state key="normal" title="Need help finding your site address?">
@@ -1746,7 +1745,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ltO-hW-mbe" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="307" y="0.0" width="36" height="33"/>
+                                                        <rect key="frame" x="315" y="0.0" width="36" height="33"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <state key="normal" title="Next">
@@ -1767,26 +1766,53 @@
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="mlx-XY-MGX" secondAttribute="trailing" constant="20" id="6vA-Fm-FcB"/>
                                             <constraint firstAttribute="bottom" secondItem="mlx-XY-MGX" secondAttribute="bottom" constant="20" id="6vW-rA-zhE"/>
-                                            <constraint firstItem="mlx-XY-MGX" firstAttribute="top" relation="greaterThanOrEqual" secondItem="GKU-9C-CUT" secondAttribute="top" priority="750" constant="10" id="E10-UM-cwY"/>
+                                            <constraint firstItem="mlx-XY-MGX" firstAttribute="top" secondItem="GKU-9C-CUT" secondAttribute="top" priority="750" constant="10" id="E10-UM-cwY"/>
                                             <constraint firstItem="mlx-XY-MGX" firstAttribute="leading" secondItem="GKU-9C-CUT" secondAttribute="leading" constant="20" id="OCg-Cl-3x5"/>
                                         </constraints>
                                     </view>
                                 </subviews>
-                            </stackView>
+                                <constraints>
+                                    <constraint firstItem="GKU-9C-CUT" firstAttribute="leading" secondItem="a59-c7-WBk" secondAttribute="leading" id="5Jh-Zd-1Ks"/>
+                                    <constraint firstAttribute="trailing" secondItem="PIc-wF-cQF" secondAttribute="trailing" id="77c-zg-8kc"/>
+                                    <constraint firstItem="PIc-wF-cQF" firstAttribute="leading" secondItem="a59-c7-WBk" secondAttribute="leading" id="IvI-xu-FTq"/>
+                                    <constraint firstAttribute="width" constant="383" id="M81-Xp-Ndj"/>
+                                    <constraint firstItem="PIc-wF-cQF" firstAttribute="top" secondItem="a59-c7-WBk" secondAttribute="top" id="cb9-Xe-IDv"/>
+                                    <constraint firstAttribute="bottom" secondItem="GKU-9C-CUT" secondAttribute="bottom" id="jkv-gL-LSx"/>
+                                    <constraint firstItem="GKU-9C-CUT" firstAttribute="top" secondItem="PIc-wF-cQF" secondAttribute="bottom" id="qPh-H7-G89"/>
+                                    <constraint firstAttribute="trailing" secondItem="GKU-9C-CUT" secondAttribute="trailing" id="zIX-Pb-Oxv"/>
+                                </constraints>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="M81-Xp-Ndj"/>
+                                    </mask>
+                                </variation>
+                                <variation key="heightClass=regular-widthClass=regular">
+                                    <mask key="constraints">
+                                        <include reference="M81-Xp-Ndj"/>
+                                    </mask>
+                                </variation>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="QcA-UD-Exa" firstAttribute="top" secondItem="pmp-Uj-4NW" secondAttribute="bottom" id="9X7-MZ-Ssf"/>
-                            <constraint firstItem="QcA-UD-Exa" firstAttribute="leading" secondItem="CvY-vN-fn9" secondAttribute="leading" id="W3t-US-RNS"/>
-                            <constraint firstItem="rYV-q2-blN" firstAttribute="top" secondItem="QcA-UD-Exa" secondAttribute="bottom" id="XBS-zC-Hmx"/>
-                            <constraint firstAttribute="trailing" secondItem="QcA-UD-Exa" secondAttribute="trailing" id="iTP-9P-d9h"/>
+                            <constraint firstItem="a59-c7-WBk" firstAttribute="centerX" secondItem="CvY-vN-fn9" secondAttribute="centerX" id="R8E-Gd-gVZ"/>
+                            <constraint firstItem="a59-c7-WBk" firstAttribute="leading" secondItem="CvY-vN-fn9" secondAttribute="leadingMargin" constant="-20" id="atB-bL-5qa"/>
+                            <constraint firstItem="a59-c7-WBk" firstAttribute="top" secondItem="pmp-Uj-4NW" secondAttribute="bottom" id="kCi-CC-wxN"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="a59-c7-WBk" secondAttribute="trailing" constant="-20" id="slk-Sa-O2b"/>
+                            <constraint firstItem="rYV-q2-blN" firstAttribute="top" secondItem="a59-c7-WBk" secondAttribute="bottom" id="tAJ-7d-k9u"/>
                         </constraints>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <exclude reference="atB-bL-5qa"/>
+                                <exclude reference="slk-Sa-O2b"/>
+                            </mask>
+                        </variation>
                     </view>
                     <navigationItem key="navigationItem" id="fMh-LG-dbq"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="383" height="676"/>
                     <connections>
-                        <outlet property="bottomContentConstraint" destination="XBS-zC-Hmx" id="z7W-Cv-cn8"/>
+                        <outlet property="bottomContentConstraint" destination="tAJ-7d-k9u" id="uH5-Q4-kG3"/>
                         <outlet property="errorLabel" destination="SIW-Up-9bc" id="rcO-eL-PuF"/>
                         <outlet property="instructionLabel" destination="eFO-bF-n1P" id="MVi-cw-csX"/>
                         <outlet property="siteAddressHelpButton" destination="roL-ID-k8n" id="QB2-ri-X5V"/>
@@ -2124,7 +2150,7 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="ySQ-EM-6JI"/>
-        <segue reference="gAE-di-Wyf"/>
         <segue reference="fWM-mD-lXg"/>
+        <segue reference="fA5-mb-vrv"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -110,7 +110,7 @@
         <scene sceneID="1BJ-CW-C88">
             <objects>
                 <navigationController id="Ck1-vY-O11" customClass="LoginNavigationController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="mKb-UO-KoA">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="mKb-UO-KoA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -135,22 +135,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ozJ-hT-OEw">
-                                <rect key="frame" x="0.0" y="64" width="383" height="612"/>
+                                <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
-                                        <rect key="frame" x="0.0" y="0.0" width="383" height="549"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="549"/>
                                         <subviews>
                                             <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ff9-jl-eKh">
-                                                <rect key="frame" x="0.0" y="194.5" width="383" height="122"/>
+                                                <rect key="frame" x="0.0" y="194.5" width="391" height="122"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
-                                                        <rect key="frame" x="20" y="0.0" width="343" height="38"/>
+                                                        <rect key="frame" x="20" y="0.0" width="351" height="38"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XXO-aV-keK" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="58" width="383" height="44"/>
+                                                        <rect key="frame" x="0.0" y="58" width="391" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
                                                         <constraints>
@@ -170,7 +170,7 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qqt-eq-gac">
-                                                        <rect key="frame" x="20" y="122" width="343" height="0.0"/>
+                                                        <rect key="frame" x="20" y="122" width="351" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" red="0.85098039215686272" green="0.30980392156862746" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -198,13 +198,13 @@
                                         </constraints>
                                     </view>
                                     <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="ecG-o1-wwE">
-                                        <rect key="frame" x="0.0" y="549" width="383" height="63"/>
+                                        <rect key="frame" x="0.0" y="549" width="391" height="63"/>
                                         <subviews>
                                             <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6i6-CG-3Tg">
-                                                <rect key="frame" x="20" y="10" width="343" height="33"/>
+                                                <rect key="frame" x="20" y="10" width="351" height="33"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Hn-ZK-h9k">
-                                                        <rect key="frame" x="0.0" y="1.5" width="299" height="30"/>
+                                                        <rect key="frame" x="0.0" y="1.5" width="307" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <state key="normal" title="Log into your site by entering your site address instead.">
@@ -215,7 +215,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="307" y="0.0" width="36" height="33"/>
+                                                        <rect key="frame" x="315" y="0.0" width="36" height="33"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <state key="normal" title="Next">
@@ -266,10 +266,10 @@
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="ozJ-hT-OEw" firstAttribute="top" secondItem="bn3-aC-RIM" secondAttribute="bottom" id="S6n-FZ-9Yc"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="ozJ-hT-OEw" secondAttribute="trailing" constant="-16" id="Uuo-bm-Be2"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="ozJ-hT-OEw" secondAttribute="trailing" constant="-20" id="Uuo-bm-Be2"/>
                             <constraint firstItem="ozJ-hT-OEw" firstAttribute="centerX" secondItem="e5n-Bf-JaL" secondAttribute="centerX" id="ZpP-No-8Mw"/>
                             <constraint firstItem="tip-gy-Hwr" firstAttribute="top" secondItem="ozJ-hT-OEw" secondAttribute="bottom" id="h6K-00-qtf"/>
-                            <constraint firstItem="ozJ-hT-OEw" firstAttribute="leading" secondItem="e5n-Bf-JaL" secondAttribute="leadingMargin" constant="-16" id="lqe-jU-dLs"/>
+                            <constraint firstItem="ozJ-hT-OEw" firstAttribute="leading" secondItem="e5n-Bf-JaL" secondAttribute="leadingMargin" constant="-20" id="lqe-jU-dLs"/>
                         </constraints>
                         <variation key="heightClass=regular-widthClass=regular">
                             <mask key="constraints">
@@ -539,102 +539,112 @@
                         <rect key="frame" x="0.0" y="0.0" width="383" height="676"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="9tM-uJ-hye" userLabel="Wrapper Stack View">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dSZ-FR-Cdo">
                                 <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Mjx-cz-sDG">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y8j-4r-VXw">
                                         <rect key="frame" x="0.0" y="0.0" width="391" height="538"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-BX-tKE" userLabel="Header Stack View">
-                                                <rect key="frame" x="20" y="133" width="351" height="72"/>
+                                            <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Mjx-cz-sDG">
+                                                <rect key="frame" x="0.0" y="133" width="391" height="200"/>
                                                 <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8z-Py-Err" customClass="SiteInfoHeaderView" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="0.0" width="351" height="50"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="50" placeholder="YES" id="NyW-2I-Z3P"/>
-                                                        </constraints>
-                                                    </view>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="m9N-GQ-6MI">
-                                                        <rect key="frame" x="0.0" y="50" width="351" height="22"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-BX-tKE" userLabel="Header Stack View">
+                                                        <rect key="frame" x="20" y="0.0" width="351" height="72"/>
                                                         <subviews>
-                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Dfh-U3-cvf">
-                                                                <rect key="frame" x="0.0" y="0.0" width="18" height="22"/>
-                                                            </imageView>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UL4-G6-7G6">
-                                                                <rect key="frame" x="26" y="0.0" width="325" height="22"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                                <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8z-Py-Err" customClass="SiteInfoHeaderView" customModule="WordPress" customModuleProvider="target">
+                                                                <rect key="frame" x="0.0" y="0.0" width="351" height="50"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="50" placeholder="YES" id="NyW-2I-Z3P"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="m9N-GQ-6MI">
+                                                                <rect key="frame" x="0.0" y="50" width="351" height="22"/>
+                                                                <subviews>
+                                                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Dfh-U3-cvf">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="18" height="22"/>
+                                                                    </imageView>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UL4-G6-7G6">
+                                                                        <rect key="frame" x="26" y="0.0" width="325" height="22"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                        <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
                                                         </subviews>
                                                     </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="tW0-In-DwC">
+                                                        <rect key="frame" x="0.0" y="92" width="391" height="88"/>
+                                                        <subviews>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ESh-DI-dtB" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                                <rect key="frame" x="0.0" y="0.0" width="391" height="44"/>
+                                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-username-field"/>
+                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="NO"/>
+                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                                </userDefinedRuntimeAttributes>
+                                                                <connections>
+                                                                    <action selector="handleTextFieldDidChange:" destination="SZS-o3-1P7" eventType="editingChanged" id="5b1-ZP-8Yq"/>
+                                                                    <outlet property="delegate" destination="SZS-o3-1P7" id="NfG-gH-Yct"/>
+                                                                </connections>
+                                                            </textField>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oi5-Kd-TEW" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                                <rect key="frame" x="0.0" y="44" width="391" height="44"/>
+                                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
+                                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
+                                                                </userDefinedRuntimeAttributes>
+                                                                <connections>
+                                                                    <action selector="handleTextFieldDidChange:" destination="SZS-o3-1P7" eventType="editingChanged" id="iSC-pZ-T1j"/>
+                                                                    <outlet property="delegate" destination="SZS-o3-1P7" id="4VW-gO-0pR"/>
+                                                                </connections>
+                                                            </textField>
+                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="88" id="F1M-fZ-NLz"/>
+                                                        </constraints>
+                                                    </stackView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dmn-nh-HTH">
+                                                        <rect key="frame" x="20" y="200" width="351" height="0.0"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
                                                 </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="tW0-In-DwC">
-                                                <rect key="frame" x="0.0" y="225" width="391" height="88"/>
-                                                <subviews>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ESh-DI-dtB" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="0.0" width="391" height="44"/>
-                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-username-field"/>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="NO"/>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="handleTextFieldDidChange:" destination="SZS-o3-1P7" eventType="editingChanged" id="5b1-ZP-8Yq"/>
-                                                            <outlet property="delegate" destination="SZS-o3-1P7" id="NfG-gH-Yct"/>
-                                                        </connections>
-                                                    </textField>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oi5-Kd-TEW" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="44" width="391" height="44"/>
-                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
-                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="handleTextFieldDidChange:" destination="SZS-o3-1P7" eventType="editingChanged" id="iSC-pZ-T1j"/>
-                                                            <outlet property="delegate" destination="SZS-o3-1P7" id="4VW-gO-0pR"/>
-                                                        </connections>
-                                                    </textField>
-                                                </subviews>
+                                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="88" id="F1M-fZ-NLz"/>
+                                                    <constraint firstItem="tW0-In-DwC" firstAttribute="leading" secondItem="Mjx-cz-sDG" secondAttribute="leading" id="03E-NW-xAt"/>
+                                                    <constraint firstAttribute="bottom" secondItem="Dmn-nh-HTH" secondAttribute="bottom" id="2rE-DB-PKt"/>
+                                                    <constraint firstItem="Dmn-nh-HTH" firstAttribute="top" secondItem="tW0-In-DwC" secondAttribute="bottom" constant="20" id="WvE-TC-l7z"/>
+                                                    <constraint firstItem="tW0-In-DwC" firstAttribute="top" secondItem="rFl-BX-tKE" secondAttribute="bottom" constant="20" id="bGJ-Uq-kxA"/>
+                                                    <constraint firstAttribute="trailing" secondItem="tW0-In-DwC" secondAttribute="trailing" id="cr8-vI-49m"/>
+                                                    <constraint firstItem="Dmn-nh-HTH" firstAttribute="leading" secondItem="Mjx-cz-sDG" secondAttribute="leading" constant="20" id="exr-hG-jE0"/>
+                                                    <constraint firstAttribute="trailing" secondItem="rFl-BX-tKE" secondAttribute="trailing" constant="20" id="fA6-Tn-cX4"/>
+                                                    <constraint firstAttribute="trailing" secondItem="Dmn-nh-HTH" secondAttribute="trailing" constant="20" id="fch-li-UDF"/>
+                                                    <constraint firstItem="rFl-BX-tKE" firstAttribute="top" secondItem="Mjx-cz-sDG" secondAttribute="top" id="jH7-bu-eF2"/>
+                                                    <constraint firstItem="rFl-BX-tKE" firstAttribute="leading" secondItem="Mjx-cz-sDG" secondAttribute="leading" constant="20" id="mht-aX-nWa"/>
                                                 </constraints>
-                                            </stackView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dmn-nh-HTH">
-                                                <rect key="frame" x="20" y="333" width="351" height="0.0"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            </view>
                                         </subviews>
-                                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstItem="tW0-In-DwC" firstAttribute="leading" secondItem="Mjx-cz-sDG" secondAttribute="leading" id="03E-NW-xAt"/>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="5h8-kM-ymL"/>
-                                            <constraint firstItem="tW0-In-DwC" firstAttribute="centerY" secondItem="Mjx-cz-sDG" secondAttribute="centerY" id="IGq-sy-bRJ"/>
-                                            <constraint firstItem="Dmn-nh-HTH" firstAttribute="top" secondItem="tW0-In-DwC" secondAttribute="bottom" constant="20" id="WvE-TC-l7z"/>
-                                            <constraint firstItem="tW0-In-DwC" firstAttribute="top" secondItem="rFl-BX-tKE" secondAttribute="bottom" constant="20" id="bGJ-Uq-kxA"/>
-                                            <constraint firstAttribute="trailing" secondItem="tW0-In-DwC" secondAttribute="trailing" id="cr8-vI-49m"/>
-                                            <constraint firstItem="Dmn-nh-HTH" firstAttribute="leading" secondItem="Mjx-cz-sDG" secondAttribute="leading" constant="20" id="exr-hG-jE0"/>
-                                            <constraint firstAttribute="trailing" secondItem="rFl-BX-tKE" secondAttribute="trailing" constant="20" id="fA6-Tn-cX4"/>
-                                            <constraint firstAttribute="trailing" secondItem="Dmn-nh-HTH" secondAttribute="trailing" constant="20" id="fch-li-UDF"/>
-                                            <constraint firstItem="rFl-BX-tKE" firstAttribute="leading" secondItem="Mjx-cz-sDG" secondAttribute="leading" constant="20" id="mht-aX-nWa"/>
+                                            <constraint firstItem="Mjx-cz-sDG" firstAttribute="leading" secondItem="y8j-4r-VXw" secondAttribute="leading" id="ijo-eO-0zW"/>
+                                            <constraint firstAttribute="trailing" secondItem="Mjx-cz-sDG" secondAttribute="trailing" id="jXU-Dw-NSV"/>
+                                            <constraint firstItem="tW0-In-DwC" firstAttribute="centerY" secondItem="y8j-4r-VXw" secondAttribute="centerY" id="mGk-PV-luu"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dRL-RD-U6n">
                                         <rect key="frame" x="0.0" y="538" width="391" height="74"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="zbk-h0-lpE">
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zbk-h0-lpE">
                                                 <rect key="frame" x="20" y="10" width="351" height="44"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gzk-TE-YfP">
@@ -669,25 +679,51 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstAttribute="bottom" secondItem="zbk-h0-lpE" secondAttribute="bottom" constant="20" id="Szt-FI-zE7"/>
-                                            <constraint firstAttribute="height" constant="74" id="jKW-gc-xHR"/>
                                             <constraint firstItem="zbk-h0-lpE" firstAttribute="leading" secondItem="dRL-RD-U6n" secondAttribute="leading" constant="20" id="sxH-7I-EtY"/>
                                             <constraint firstAttribute="trailing" secondItem="zbk-h0-lpE" secondAttribute="trailing" constant="20" id="vwI-nG-6xF"/>
                                             <constraint firstItem="zbk-h0-lpE" firstAttribute="top" secondItem="dRL-RD-U6n" secondAttribute="top" constant="10" id="ykz-4R-R7L"/>
                                         </constraints>
                                     </view>
                                 </subviews>
-                            </stackView>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="383" id="4XI-9Q-yp9"/>
+                                    <constraint firstItem="y8j-4r-VXw" firstAttribute="leading" secondItem="dSZ-FR-Cdo" secondAttribute="leading" id="WzD-WT-CPR"/>
+                                    <constraint firstItem="dRL-RD-U6n" firstAttribute="top" secondItem="y8j-4r-VXw" secondAttribute="bottom" id="YjR-Ea-c1g"/>
+                                    <constraint firstAttribute="trailing" secondItem="y8j-4r-VXw" secondAttribute="trailing" id="bQW-83-1aD"/>
+                                    <constraint firstItem="dRL-RD-U6n" firstAttribute="leading" secondItem="dSZ-FR-Cdo" secondAttribute="leading" id="fE8-GW-3b9"/>
+                                    <constraint firstItem="y8j-4r-VXw" firstAttribute="top" secondItem="dSZ-FR-Cdo" secondAttribute="top" id="la9-4O-imU"/>
+                                    <constraint firstAttribute="trailing" secondItem="dRL-RD-U6n" secondAttribute="trailing" id="snL-9q-BNH"/>
+                                    <constraint firstAttribute="bottom" secondItem="dRL-RD-U6n" secondAttribute="bottom" id="zGL-aj-JEv"/>
+                                </constraints>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="4XI-9Q-yp9"/>
+                                    </mask>
+                                </variation>
+                                <variation key="heightClass=regular-widthClass=regular">
+                                    <mask key="constraints">
+                                        <include reference="4XI-9Q-yp9"/>
+                                    </mask>
+                                </variation>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="9tM-uJ-hye" firstAttribute="top" secondItem="Yjk-Cc-Bxb" secondAttribute="bottom" id="2iQ-k5-nKi"/>
-                            <constraint firstItem="Ktl-It-Kmo" firstAttribute="top" secondItem="9tM-uJ-hye" secondAttribute="bottom" id="5dJ-k5-ZLd"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="9tM-uJ-hye" secondAttribute="trailing" constant="-20" id="kSK-M5-Th3"/>
-                            <constraint firstItem="9tM-uJ-hye" firstAttribute="leading" secondItem="HTO-Y8-god" secondAttribute="leadingMargin" constant="-20" id="tCJ-Hh-wJ8"/>
+                            <constraint firstItem="Ktl-It-Kmo" firstAttribute="top" secondItem="dSZ-FR-Cdo" secondAttribute="bottom" id="1qL-V5-NRd"/>
+                            <constraint firstItem="dSZ-FR-Cdo" firstAttribute="leading" secondItem="HTO-Y8-god" secondAttribute="leadingMargin" constant="-20" id="E8T-56-rvq"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="dSZ-FR-Cdo" secondAttribute="trailing" constant="-20" id="HRv-bN-Rg3"/>
+                            <constraint firstItem="dSZ-FR-Cdo" firstAttribute="centerX" secondItem="HTO-Y8-god" secondAttribute="centerX" id="coA-jN-kCz"/>
+                            <constraint firstItem="dSZ-FR-Cdo" firstAttribute="top" secondItem="Yjk-Cc-Bxb" secondAttribute="bottom" id="grg-bx-Iir"/>
                         </constraints>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <exclude reference="E8T-56-rvq"/>
+                                <exclude reference="HRv-bN-Rg3"/>
+                            </mask>
+                        </variation>
                     </view>
                     <connections>
-                        <outlet property="bottomContentConstraint" destination="5dJ-k5-ZLd" id="smR-FD-ynn"/>
+                        <outlet property="bottomContentConstraint" destination="1qL-V5-NRd" id="u34-Bi-1jY"/>
                         <outlet property="errorLabel" destination="Dmn-nh-HTH" id="MdY-kK-o4s"/>
                         <outlet property="forgotPasswordButton" destination="Gzk-TE-YfP" id="yzb-jL-iRE"/>
                         <outlet property="passwordField" destination="oi5-Kd-TEW" id="ONl-tn-LtT"/>
@@ -2089,6 +2125,6 @@
     <inferredMetricsTieBreakers>
         <segue reference="ySQ-EM-6JI"/>
         <segue reference="gAE-di-Wyf"/>
-        <segue reference="qLI-qX-rkG"/>
+        <segue reference="fWM-mD-lXg"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -714,16 +714,16 @@
                                 <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="ZWc-TJ-W9T">
-                                        <rect key="frame" x="0.0" y="0.0" width="391" height="612"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="343" placeholderIntrinsicHeight="48" text="Enter the password for your WordPress.com account." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBi-2N-RAh">
-                                                <rect key="frame" x="20" y="189.5" width="351" height="48"/>
+                                                <rect key="frame" x="20" y="172" width="351" height="48"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3be-99-g62">
-                                                <rect key="frame" x="0.0" y="269.5" width="391" height="72.5"/>
+                                                <rect key="frame" x="0.0" y="252" width="391" height="72.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xgi-ZQ-8YL">
                                                         <rect key="frame" x="20" y="0.0" width="351" height="20.5"/>
@@ -764,7 +764,7 @@
                                                 </constraints>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
-                                                <rect key="frame" x="20" y="362" width="351" height="18"/>
+                                                <rect key="frame" x="20" y="344.5" width="351" height="18"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -776,11 +776,11 @@
                                             <constraint firstItem="3be-99-g62" firstAttribute="leading" secondItem="ZWc-TJ-W9T" secondAttribute="leading" id="7nc-IA-WRQ"/>
                                             <constraint firstAttribute="trailing" secondItem="3be-99-g62" secondAttribute="trailing" id="J3T-Wn-sCt"/>
                                             <constraint firstAttribute="trailing" secondItem="bBi-2N-RAh" secondAttribute="trailing" constant="20" id="JR4-H1-jSu"/>
+                                            <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="centerY" secondItem="ZWc-TJ-W9T" secondAttribute="centerY" priority="900" constant="-12" id="Mvg-8n-vRh"/>
                                             <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="width" secondItem="bBi-2N-RAh" secondAttribute="width" id="TEB-A9-Hw8"/>
                                             <constraint firstItem="bBi-2N-RAh" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ZWc-TJ-W9T" secondAttribute="top" constant="20" id="UtP-9Q-0ZZ"/>
                                             <constraint firstItem="3be-99-g62" firstAttribute="top" secondItem="bBi-2N-RAh" secondAttribute="bottom" constant="32" id="Vta-qL-UfT"/>
                                             <constraint firstAttribute="trailing" secondItem="ZqY-I8-yWG" secondAttribute="trailing" constant="20" id="f3e-Y7-O2r"/>
-                                            <constraint firstItem="3be-99-g62" firstAttribute="centerY" secondItem="ZWc-TJ-W9T" secondAttribute="centerY" priority="900" id="g0V-37-vOa"/>
                                             <constraint firstItem="ZqY-I8-yWG" firstAttribute="leading" secondItem="ZWc-TJ-W9T" secondAttribute="leading" constant="20" id="ugU-fq-Kc8"/>
                                             <constraint firstItem="bBi-2N-RAh" firstAttribute="leading" secondItem="ZWc-TJ-W9T" secondAttribute="leading" constant="20" id="xca-YW-pid"/>
                                         </constraints>
@@ -823,11 +823,11 @@
                                     <constraint firstItem="ilv-iW-HgP" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" constant="20" id="0Zk-0j-bUt"/>
                                     <constraint firstAttribute="bottom" secondItem="ilv-iW-HgP" secondAttribute="bottom" constant="20" id="8xQ-I1-LZB"/>
                                     <constraint firstItem="ZWc-TJ-W9T" firstAttribute="top" secondItem="7OQ-0t-1zq" secondAttribute="top" id="Auv-Qn-vWa"/>
+                                    <constraint firstItem="ilv-iW-HgP" firstAttribute="top" secondItem="ZWc-TJ-W9T" secondAttribute="bottom" id="CvW-DU-wCv"/>
                                     <constraint firstItem="ZWc-TJ-W9T" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" id="Osp-Ar-qix"/>
                                     <constraint firstAttribute="width" constant="383" id="VgM-uK-kk3"/>
                                     <constraint firstAttribute="trailing" secondItem="ZWc-TJ-W9T" secondAttribute="trailing" id="p8c-n5-W3X"/>
                                     <constraint firstAttribute="trailing" secondItem="ilv-iW-HgP" secondAttribute="trailing" constant="20" id="sLX-Xa-ldK"/>
-                                    <constraint firstAttribute="bottom" secondItem="ZWc-TJ-W9T" secondAttribute="bottom" id="sSC-44-fTn"/>
                                 </constraints>
                                 <variation key="default">
                                     <mask key="constraints">
@@ -885,19 +885,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hTY-xb-H5h">
-                                <rect key="frame" x="0.0" y="64" width="383" height="612"/>
+                                <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DHF-bN-so0">
-                                        <rect key="frame" x="0.0" y="0.0" width="383" height="612"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Almost there" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h0i-9g-1E6">
-                                                <rect key="frame" x="20" y="246" width="343" height="18"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Almost there" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h0i-9g-1E6">
+                                                <rect key="frame" x="20" y="214" width="351" height="18"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Verification Code" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="A2K-lq-6XM" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="284" width="383" height="44"/>
+                                                <rect key="frame" x="0.0" y="252" width="391" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="Verification Code"/>
                                                 <constraints>
@@ -926,8 +926,8 @@
                                                     <outlet property="delegate" destination="bAd-Df-IzS" id="Bgq-yf-mas"/>
                                                 </connections>
                                             </textField>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zhF-jf-Wcv">
-                                                <rect key="frame" x="20" y="348" width="343" height="0.0"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zhF-jf-Wcv">
+                                                <rect key="frame" x="20" y="316" width="351" height="0.0"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.85098039215686272" green="0.30980392156862746" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -946,8 +946,8 @@
                                             <constraint firstItem="A2K-lq-6XM" firstAttribute="top" secondItem="h0i-9g-1E6" secondAttribute="bottom" constant="20" id="ycZ-Hd-5Z2"/>
                                         </constraints>
                                     </view>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="bottom" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="x1G-Lf-mra">
-                                        <rect key="frame" x="20" y="548" width="343" height="44"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="x1G-Lf-mra">
+                                        <rect key="frame" x="20" y="548" width="351" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="309-z3-fPx">
                                                 <rect key="frame" x="0.0" y="0.0" width="131" height="44"/>
@@ -964,7 +964,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="250" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6eO-V2-a64" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="296" y="0.0" width="47" height="44"/>
+                                                <rect key="frame" x="304" y="0.0" width="47" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="eoc-KU-71N"/>
                                                 </constraints>
@@ -988,19 +988,29 @@
                                     <constraint firstItem="DHF-bN-so0" firstAttribute="leading" secondItem="hTY-xb-H5h" secondAttribute="leading" id="3Og-Ew-r3y"/>
                                     <constraint firstItem="DHF-bN-so0" firstAttribute="top" secondItem="hTY-xb-H5h" secondAttribute="top" id="9hm-xn-6lZ"/>
                                     <constraint firstAttribute="bottom" secondItem="x1G-Lf-mra" secondAttribute="bottom" constant="20" id="XBv-Gg-JAY"/>
-                                    <constraint firstAttribute="bottom" secondItem="DHF-bN-so0" secondAttribute="bottom" id="blP-qB-Bvl"/>
+                                    <constraint firstItem="x1G-Lf-mra" firstAttribute="top" secondItem="DHF-bN-so0" secondAttribute="bottom" id="YdZ-5s-UBx"/>
                                     <constraint firstAttribute="width" constant="383" id="eWE-lA-7Kg"/>
                                     <constraint firstAttribute="trailing" secondItem="DHF-bN-so0" secondAttribute="trailing" id="pId-Zh-c89"/>
                                     <constraint firstItem="x1G-Lf-mra" firstAttribute="leading" secondItem="hTY-xb-H5h" secondAttribute="leading" constant="20" id="yEl-i3-fts"/>
                                 </constraints>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="eWE-lA-7Kg"/>
+                                    </mask>
+                                </variation>
+                                <variation key="heightClass=regular-widthClass=regular">
+                                    <mask key="constraints">
+                                        <include reference="eWE-lA-7Kg"/>
+                                    </mask>
+                                </variation>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="hTY-xb-H5h" secondAttribute="trailing" id="23h-QU-eyB"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="hTY-xb-H5h" secondAttribute="trailing" constant="-20" id="23h-QU-eyB"/>
                             <constraint firstItem="hTY-xb-H5h" firstAttribute="centerX" secondItem="cm5-76-st7" secondAttribute="centerX" id="PRb-I7-O07"/>
                             <constraint firstItem="hTY-xb-H5h" firstAttribute="top" secondItem="959-UQ-1Jm" secondAttribute="bottom" id="lqc-JK-kaQ"/>
-                            <constraint firstItem="hTY-xb-H5h" firstAttribute="leading" secondItem="cm5-76-st7" secondAttribute="leading" id="riV-3j-5QK"/>
+                            <constraint firstItem="hTY-xb-H5h" firstAttribute="leading" secondItem="cm5-76-st7" secondAttribute="leadingMargin" constant="-20" id="riV-3j-5QK"/>
                             <constraint firstItem="fG1-qw-2YS" firstAttribute="top" secondItem="hTY-xb-H5h" secondAttribute="bottom" id="tJ5-Do-kBC"/>
                         </constraints>
                         <variation key="heightClass=regular-widthClass=regular">
@@ -1073,20 +1083,20 @@
                         <viewControllerLayoutGuide type="bottom" id="pCc-dg-bxb"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="gJB-TV-Tpp">
-                        <rect key="frame" x="0.0" y="64" width="383" height="612"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Onf-X6-J5w">
-                                <rect key="frame" x="0.0" y="0.0" width="383" height="528"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="563"/>
                                 <connections>
                                     <segue destination="0GP-rM-Hvu" kind="embed" id="taY-7m-sQh"/>
                                 </connections>
                             </containerView>
                             <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="juu-ng-v2N">
-                                <rect key="frame" x="0.0" y="528" width="383" height="84"/>
+                                <rect key="frame" x="0.0" y="583" width="375" height="84"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jiQ-IN-bzh">
-                                        <rect key="frame" x="20" y="20" width="343" height="44"/>
+                                        <rect key="frame" x="20" y="20" width="335" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="wlF-fo-JMp"/>
                                         </constraints>
@@ -1103,7 +1113,7 @@
                                         </connections>
                                     </button>
                                     <imageView hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="darkgrey-shadow" translatesAutoresizingMaskIntoConstraints="NO" id="cmz-zv-QBQ">
-                                        <rect key="frame" x="0.0" y="-10" width="383" height="10"/>
+                                        <rect key="frame" x="0.0" y="-10" width="375" height="10"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="P6k-Ic-btx"/>
                                         </constraints>
@@ -1148,16 +1158,16 @@
             <objects>
                 <tableViewController id="0GP-rM-Hvu" customClass="LoginEpilogueTableView" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="154" sectionHeaderHeight="28" sectionFooterHeight="28" id="TzF-S4-1lW">
-                        <rect key="frame" x="0.0" y="0.0" width="383" height="528"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="563"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.95294117647058818" green="0.96470588235294119" blue="0.97254901960784312" alpha="1" colorSpace="calibratedRGB"/>
                         <inset key="separatorInset" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="userInfo" rowHeight="148" id="rFk-m6-PzB" customClass="LoginEpilogueUserInfoCell" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="383" height="148"/>
+                                <rect key="frame" x="0.0" y="28" width="375" height="148"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rFk-m6-PzB" id="Be1-mM-Agr">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="148"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="148"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xKq-ni-wZB" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -1236,10 +1246,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlogCell" rowHeight="52" id="Efm-ja-Y8C" customClass="LoginEpilogueBlogCell" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="176" width="383" height="52"/>
+                                <rect key="frame" x="0.0" y="176" width="375" height="52"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Efm-ja-Y8C" id="Xid-Yh-Kpa">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="52"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="52"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Rtc-ao-Fl6">
@@ -2067,8 +2077,8 @@
         <image name="login-magic-link" width="160" height="160"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="fWM-mD-lXg"/>
-        <segue reference="fA5-mb-vrv"/>
         <segue reference="0ao-yi-yZI"/>
+        <segue reference="qLI-qX-rkG"/>
+        <segue reference="lIb-sw-yM7"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Ck1-vY-O11">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -201,11 +201,11 @@
                                     <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="ecG-o1-wwE">
                                         <rect key="frame" x="0.0" y="436" width="383" height="176"/>
                                         <subviews>
-                                            <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="6i6-CG-3Tg">
+                                            <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6i6-CG-3Tg">
                                                 <rect key="frame" x="20" y="123" width="343" height="33"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Hn-ZK-h9k">
-                                                        <rect key="frame" x="0.0" y="1.5" width="307" height="30"/>
+                                                        <rect key="frame" x="0.0" y="1.5" width="299" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <state key="normal" title="Log into your site by entering your site address instead.">
@@ -215,7 +215,7 @@
                                                             <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="avL-c6-SBY"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
+                                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
                                                         <rect key="frame" x="307" y="0.0" width="36" height="33"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -2061,5 +2061,8 @@
         <image name="login-magic-link" width="160" height="160"/>
     </resources>
     <inferredMetricsTieBreakers>
+        <segue reference="ySQ-EM-6JI"/>
+        <segue reference="gAE-di-Wyf"/>
+        <segue reference="qLI-qX-rkG"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -526,7 +526,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-BX-tKE" userLabel="Header Stack View">
-                                                <rect key="frame" x="20" y="138" width="351" height="72"/>
+                                                <rect key="frame" x="20" y="160" width="351" height="72"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8z-Py-Err" customClass="SiteInfoHeaderView" customModule="WordPress" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="351" height="50"/>
@@ -551,7 +551,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="tW0-In-DwC">
-                                                <rect key="frame" x="0.0" y="230" width="391" height="88"/>
+                                                <rect key="frame" x="0.0" y="252" width="391" height="88"/>
                                                 <subviews>
                                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ESh-DI-dtB" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="391" height="44"/>
@@ -591,7 +591,7 @@
                                                 </constraints>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dmn-nh-HTH">
-                                                <rect key="frame" x="20" y="338" width="351" height="0.0"/>
+                                                <rect key="frame" x="20" y="360" width="351" height="0.0"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -602,7 +602,7 @@
                                             <constraint firstAttribute="trailing" secondItem="Dmn-nh-HTH" secondAttribute="trailing" constant="20" id="Fnr-1U-uRo"/>
                                             <constraint firstItem="tW0-In-DwC" firstAttribute="top" secondItem="rFl-BX-tKE" secondAttribute="bottom" constant="20" id="Mh1-XM-rZz"/>
                                             <constraint firstItem="tW0-In-DwC" firstAttribute="leading" secondItem="y8j-4r-VXw" secondAttribute="leading" id="UpW-cT-zMt"/>
-                                            <constraint firstItem="tW0-In-DwC" firstAttribute="centerY" secondItem="y8j-4r-VXw" secondAttribute="centerY" priority="900" id="bPH-5g-emV"/>
+                                            <constraint firstItem="ESh-DI-dtB" firstAttribute="centerY" secondItem="y8j-4r-VXw" secondAttribute="centerY" priority="900" id="akh-WO-ER7"/>
                                             <constraint firstItem="rFl-BX-tKE" firstAttribute="top" relation="greaterThanOrEqual" secondItem="y8j-4r-VXw" secondAttribute="top" constant="20" id="c4S-2w-Qws"/>
                                             <constraint firstItem="rFl-BX-tKE" firstAttribute="leading" secondItem="y8j-4r-VXw" secondAttribute="leading" constant="20" id="d1s-fn-y7S"/>
                                             <constraint firstItem="Dmn-nh-HTH" firstAttribute="leading" secondItem="y8j-4r-VXw" secondAttribute="leading" constant="20" id="fJq-9J-ZGR"/>
@@ -1073,20 +1073,20 @@
                         <viewControllerLayoutGuide type="bottom" id="pCc-dg-bxb"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="gJB-TV-Tpp">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="64" width="383" height="612"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Onf-X6-J5w">
-                                <rect key="frame" x="0.0" y="20" width="375" height="563"/>
+                                <rect key="frame" x="0.0" y="0.0" width="383" height="528"/>
                                 <connections>
                                     <segue destination="0GP-rM-Hvu" kind="embed" id="taY-7m-sQh"/>
                                 </connections>
                             </containerView>
                             <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="juu-ng-v2N">
-                                <rect key="frame" x="0.0" y="583" width="375" height="84"/>
+                                <rect key="frame" x="0.0" y="528" width="383" height="84"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jiQ-IN-bzh">
-                                        <rect key="frame" x="20" y="20" width="335" height="44"/>
+                                        <rect key="frame" x="20" y="20" width="343" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="wlF-fo-JMp"/>
                                         </constraints>
@@ -1103,7 +1103,7 @@
                                         </connections>
                                     </button>
                                     <imageView hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="darkgrey-shadow" translatesAutoresizingMaskIntoConstraints="NO" id="cmz-zv-QBQ">
-                                        <rect key="frame" x="0.0" y="-10" width="375" height="10"/>
+                                        <rect key="frame" x="0.0" y="-10" width="383" height="10"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="P6k-Ic-btx"/>
                                         </constraints>
@@ -1148,16 +1148,16 @@
             <objects>
                 <tableViewController id="0GP-rM-Hvu" customClass="LoginEpilogueTableView" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="154" sectionHeaderHeight="28" sectionFooterHeight="28" id="TzF-S4-1lW">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="563"/>
+                        <rect key="frame" x="0.0" y="0.0" width="383" height="528"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.95294117647058818" green="0.96470588235294119" blue="0.97254901960784312" alpha="1" colorSpace="calibratedRGB"/>
                         <inset key="separatorInset" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="userInfo" rowHeight="148" id="rFk-m6-PzB" customClass="LoginEpilogueUserInfoCell" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="148"/>
+                                <rect key="frame" x="0.0" y="28" width="383" height="148"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rFk-m6-PzB" id="Be1-mM-Agr">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="148"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383" height="148"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xKq-ni-wZB" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -1236,10 +1236,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlogCell" rowHeight="52" id="Efm-ja-Y8C" customClass="LoginEpilogueBlogCell" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="176" width="375" height="52"/>
+                                <rect key="frame" x="0.0" y="176" width="383" height="52"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Efm-ja-Y8C" id="Xid-Yh-Kpa">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="52"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383" height="52"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Rtc-ao-Fl6">
@@ -2067,8 +2067,8 @@
         <image name="login-magic-link" width="160" height="160"/>
     </resources>
     <inferredMetricsTieBreakers>
+        <segue reference="fWM-mD-lXg"/>
+        <segue reference="fA5-mb-vrv"/>
         <segue reference="0ao-yi-yZI"/>
-        <segue reference="qLI-qX-rkG"/>
-        <segue reference="7lv-19-h36"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -1459,23 +1459,23 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Mq6-n0-6iO">
-                                <rect key="frame" x="-4" y="189" width="391" height="258.5"/>
+                                <rect key="frame" x="36" y="189" width="311" height="258.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ukv-qo-ql4" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="145.5" y="0.0" width="100" height="100"/>
+                                        <rect key="frame" x="105.5" y="0.0" width="100" height="100"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="100" id="3wv-b7-gzu"/>
                                             <constraint firstAttribute="height" constant="100" id="aMT-Sa-KA3"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CmN-ir-1YK">
-                                        <rect key="frame" x="0.0" y="130" width="391" height="64.5"/>
+                                        <rect key="frame" x="0.0" y="130" width="311" height="64.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iIy-Sm-1r0" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="159.5" y="224.5" width="72" height="34"/>
+                                        <rect key="frame" x="119.5" y="224.5" width="72" height="34"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="GRI-y6-q3i"/>
                                         </constraints>
@@ -1520,12 +1520,12 @@
                         </subviews>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailingMargin" secondItem="Mq6-n0-6iO" secondAttribute="trailing" constant="-20" id="CoO-Ax-hqg"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="Mq6-n0-6iO" secondAttribute="trailing" constant="20" id="CoO-Ax-hqg"/>
                             <constraint firstItem="Mq6-n0-6iO" firstAttribute="centerX" secondItem="HnR-5a-suO" secondAttribute="centerX" id="H21-tP-R9E"/>
                             <constraint firstItem="h4a-j8-84P" firstAttribute="top" secondItem="B6x-b7-hU9" secondAttribute="bottom" priority="900" constant="20" id="asJ-6Y-anx"/>
                             <constraint firstItem="Mq6-n0-6iO" firstAttribute="centerY" secondItem="HnR-5a-suO" secondAttribute="centerY" constant="-20" id="gQ3-og-ak7"/>
                             <constraint firstItem="B6x-b7-hU9" firstAttribute="centerX" secondItem="HnR-5a-suO" secondAttribute="centerX" id="iMu-uo-e9U"/>
-                            <constraint firstItem="Mq6-n0-6iO" firstAttribute="leading" secondItem="HnR-5a-suO" secondAttribute="leadingMargin" constant="-20" id="rtb-lw-VMZ"/>
+                            <constraint firstItem="Mq6-n0-6iO" firstAttribute="leading" secondItem="HnR-5a-suO" secondAttribute="leadingMargin" constant="20" id="rtb-lw-VMZ"/>
                         </constraints>
                         <variation key="heightClass=regular-widthClass=regular">
                             <mask key="constraints">
@@ -1559,17 +1559,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="L3o-Cy-vXw">
-                                <rect key="frame" x="-4" y="159" width="391" height="318.5"/>
+                                <rect key="frame" x="36" y="148" width="311" height="340.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="login-magic-link" translatesAutoresizingMaskIntoConstraints="NO" id="upR-OL-iQF">
-                                        <rect key="frame" x="115.5" y="0.0" width="160" height="160"/>
+                                        <rect key="frame" x="75.5" y="0.0" width="160" height="160"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="160" id="CtE-yp-T3g"/>
                                             <constraint firstAttribute="width" constant="160" id="LVD-7T-c7k"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your magic link is on its way! Check your email on this device, and tap the link in the email you receive from WordPress.com" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pkM-xx-821">
-                                        <rect key="frame" x="8" y="190" width="375.5" height="64.5"/>
+                                        <rect key="frame" x="5" y="190" width="301.5" height="86.5"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="0nV-Yg-je4"/>
                                             <constraint firstAttribute="width" constant="320" id="2JY-7V-RVK"/>
@@ -1589,7 +1589,7 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Iy-9H-ykD" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="158" y="284.5" width="75" height="34"/>
+                                        <rect key="frame" x="118" y="306.5" width="75" height="34"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="tyz-kt-Arb"/>
                                         </constraints>
@@ -1633,11 +1633,11 @@
                         </subviews>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="L3o-Cy-vXw" firstAttribute="leading" secondItem="Xyo-MA-Ddd" secondAttribute="leadingMargin" constant="-20" id="EG6-tW-icm"/>
+                            <constraint firstItem="L3o-Cy-vXw" firstAttribute="leading" secondItem="Xyo-MA-Ddd" secondAttribute="leadingMargin" constant="20" id="EG6-tW-icm"/>
                             <constraint firstItem="b0O-LO-6ax" firstAttribute="centerX" secondItem="Xyo-MA-Ddd" secondAttribute="centerX" id="RM7-fX-URR"/>
                             <constraint firstItem="vKK-Mm-0yR" firstAttribute="top" secondItem="b0O-LO-6ax" secondAttribute="bottom" priority="900" constant="20" id="T3w-we-LXY"/>
                             <constraint firstItem="L3o-Cy-vXw" firstAttribute="centerY" secondItem="Xyo-MA-Ddd" secondAttribute="centerY" constant="-20" id="ece-WV-24S"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="L3o-Cy-vXw" secondAttribute="trailing" constant="-20" id="pS9-2a-bJD"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="L3o-Cy-vXw" secondAttribute="trailing" constant="20" id="pS9-2a-bJD"/>
                             <constraint firstItem="L3o-Cy-vXw" firstAttribute="centerX" secondItem="Xyo-MA-Ddd" secondAttribute="centerX" id="xII-A3-ICI"/>
                         </constraints>
                         <variation key="heightClass=regular-widthClass=regular">
@@ -2158,8 +2158,8 @@
         <image name="login-magic-link" width="160" height="160"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="ySQ-EM-6JI"/>
-        <segue reference="fWM-mD-lXg"/>
-        <segue reference="lIb-sw-yM7"/>
+        <segue reference="Jfl-Zm-PRR"/>
+        <segue reference="qLI-qX-rkG"/>
+        <segue reference="7ky-IR-Xbv"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -140,7 +140,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
                                         <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
                                                 <rect key="frame" x="20" y="194" width="351" height="38"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
@@ -2077,8 +2077,8 @@
         <image name="login-magic-link" width="160" height="160"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="0ao-yi-yZI"/>
+        <segue reference="gAE-di-Wyf"/>
+        <segue reference="ySQ-EM-6JI"/>
         <segue reference="qLI-qX-rkG"/>
-        <segue reference="lIb-sw-yM7"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -140,7 +140,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
                                         <rect key="frame" x="0.0" y="0.0" width="391" height="549"/>
                                         <subviews>
-                                            <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ff9-jl-eKh">
+                                            <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Ff9-jl-eKh">
                                                 <rect key="frame" x="0.0" y="194.5" width="391" height="122"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
@@ -192,9 +192,10 @@
                                             </view>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstItem="Ff9-jl-eKh" firstAttribute="top" relation="greaterThanOrEqual" secondItem="KAn-ug-oE6" secondAttribute="top" constant="20" id="EKx-vI-rSm"/>
                                             <constraint firstAttribute="trailing" secondItem="Ff9-jl-eKh" secondAttribute="trailing" id="Tbw-s4-sXV"/>
                                             <constraint firstItem="Ff9-jl-eKh" firstAttribute="leading" secondItem="KAn-ug-oE6" secondAttribute="leading" id="UlL-49-A8K"/>
-                                            <constraint firstItem="XXO-aV-keK" firstAttribute="centerY" secondItem="KAn-ug-oE6" secondAttribute="centerY" id="ftV-Sq-D3b"/>
+                                            <constraint firstItem="XXO-aV-keK" firstAttribute="centerY" secondItem="KAn-ug-oE6" secondAttribute="centerY" priority="900" id="ftV-Sq-D3b"/>
                                         </constraints>
                                     </view>
                                     <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="ecG-o1-wwE">
@@ -636,9 +637,10 @@
                                             </view>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstItem="Mjx-cz-sDG" firstAttribute="top" relation="greaterThanOrEqual" secondItem="y8j-4r-VXw" secondAttribute="top" constant="20" id="f4G-G5-w9e"/>
                                             <constraint firstItem="Mjx-cz-sDG" firstAttribute="leading" secondItem="y8j-4r-VXw" secondAttribute="leading" id="ijo-eO-0zW"/>
                                             <constraint firstAttribute="trailing" secondItem="Mjx-cz-sDG" secondAttribute="trailing" id="jXU-Dw-NSV"/>
-                                            <constraint firstItem="tW0-In-DwC" firstAttribute="centerY" secondItem="y8j-4r-VXw" secondAttribute="centerY" id="mGk-PV-luu"/>
+                                            <constraint firstItem="tW0-In-DwC" firstAttribute="centerY" secondItem="y8j-4r-VXw" secondAttribute="centerY" priority="900" id="mGk-PV-luu"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dRL-RD-U6n">
@@ -1685,7 +1687,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PIc-wF-cQF">
                                         <rect key="frame" x="0.0" y="0.0" width="391" height="549"/>
                                         <subviews>
-                                            <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="a1t-zo-d5c">
+                                            <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="a1t-zo-d5c">
                                                 <rect key="frame" x="0.0" y="194.5" width="391" height="122"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Enter the address of the WordPress site you'd like to connect." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-bF-n1P">
@@ -1738,7 +1740,8 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="a1t-zo-d5c" secondAttribute="trailing" id="1PY-Jw-P0J"/>
-                                            <constraint firstItem="ZrT-CY-qD7" firstAttribute="centerY" secondItem="PIc-wF-cQF" secondAttribute="centerY" id="9ZA-SI-QXw"/>
+                                            <constraint firstItem="ZrT-CY-qD7" firstAttribute="centerY" secondItem="PIc-wF-cQF" secondAttribute="centerY" priority="900" id="9ZA-SI-QXw"/>
+                                            <constraint firstItem="a1t-zo-d5c" firstAttribute="top" relation="greaterThanOrEqual" secondItem="PIc-wF-cQF" secondAttribute="top" constant="20" id="BA4-eI-gjp"/>
                                             <constraint firstItem="a1t-zo-d5c" firstAttribute="leading" secondItem="PIc-wF-cQF" secondAttribute="leading" id="Gsg-hb-SON"/>
                                         </constraints>
                                     </view>
@@ -2165,7 +2168,7 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="Jfl-Zm-PRR"/>
-        <segue reference="7lv-19-h36"/>
-        <segue reference="qLI-qX-rkG"/>
+        <segue reference="fWM-mD-lXg"/>
+        <segue reference="lIb-sw-yM7"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -1143,7 +1143,6 @@
                     </view>
                     <connections>
                         <outlet property="errorLabel" destination="Bnl-db-peA" id="vfV-dr-NBR"/>
-                        <outlet property="statusLabel" destination="Bnl-db-peA" id="ekO-Re-yc4"/>
                         <segue destination="Mwz-tq-5A8" kind="custom" identifier="showEpilogue" customClass="EpilogueSegue" customModule="WordPress" customModuleProvider="target" id="7ky-IR-Xbv"/>
                     </connections>
                 </viewController>
@@ -1160,20 +1159,20 @@
                         <viewControllerLayoutGuide type="bottom" id="pCc-dg-bxb"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="gJB-TV-Tpp">
-                        <rect key="frame" x="0.0" y="64" width="383" height="612"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Onf-X6-J5w">
-                                <rect key="frame" x="0.0" y="0.0" width="383" height="528"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="563"/>
                                 <connections>
                                     <segue destination="0GP-rM-Hvu" kind="embed" id="taY-7m-sQh"/>
                                 </connections>
                             </containerView>
                             <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="juu-ng-v2N">
-                                <rect key="frame" x="0.0" y="528" width="383" height="84"/>
+                                <rect key="frame" x="0.0" y="583" width="375" height="84"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jiQ-IN-bzh">
-                                        <rect key="frame" x="20" y="20" width="343" height="44"/>
+                                        <rect key="frame" x="20" y="20" width="335" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="wlF-fo-JMp"/>
                                         </constraints>
@@ -1190,7 +1189,7 @@
                                         </connections>
                                     </button>
                                     <imageView hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="darkgrey-shadow" translatesAutoresizingMaskIntoConstraints="NO" id="cmz-zv-QBQ">
-                                        <rect key="frame" x="0.0" y="-10" width="383" height="10"/>
+                                        <rect key="frame" x="0.0" y="-10" width="375" height="10"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="10" id="P6k-Ic-btx"/>
                                         </constraints>
@@ -1235,16 +1234,16 @@
             <objects>
                 <tableViewController id="0GP-rM-Hvu" customClass="LoginEpilogueTableView" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="154" sectionHeaderHeight="28" sectionFooterHeight="28" id="TzF-S4-1lW">
-                        <rect key="frame" x="0.0" y="0.0" width="383" height="528"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="563"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.95294117647058818" green="0.96470588235294119" blue="0.97254901960784312" alpha="1" colorSpace="calibratedRGB"/>
                         <inset key="separatorInset" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="userInfo" rowHeight="148" id="rFk-m6-PzB" customClass="LoginEpilogueUserInfoCell" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="383" height="148"/>
+                                <rect key="frame" x="0.0" y="28" width="375" height="148"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rFk-m6-PzB" id="Be1-mM-Agr">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="148"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="148"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xKq-ni-wZB" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -1323,10 +1322,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlogCell" rowHeight="52" id="Efm-ja-Y8C" customClass="LoginEpilogueBlogCell" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="176" width="383" height="52"/>
+                                <rect key="frame" x="0.0" y="176" width="375" height="52"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Efm-ja-Y8C" id="Xid-Yh-Kpa">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="52"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="52"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Rtc-ao-Fl6">
@@ -1578,29 +1577,18 @@
                         <rect key="frame" x="0.0" y="0.0" width="383" height="676"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b0O-LO-6ax">
-                                <rect key="frame" x="105.5" y="632" width="172" height="28"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                <state key="normal" title="Enter your password instead">
-                                    <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="handleUsePasswordTapped:" destination="GSd-vy-rpZ" eventType="touchUpInside" id="I1f-Mc-BbK"/>
-                                    <segue destination="lmD-c6-SLs" kind="show" id="Jfl-Zm-PRR"/>
-                                </connections>
-                            </button>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="L3o-Cy-vXw">
-                                <rect key="frame" x="18" y="159" width="347" height="318.5"/>
+                                <rect key="frame" x="-4" y="159" width="391" height="318.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="login-magic-link" translatesAutoresizingMaskIntoConstraints="NO" id="upR-OL-iQF">
-                                        <rect key="frame" x="93.5" y="0.0" width="160" height="160"/>
+                                        <rect key="frame" x="115.5" y="0.0" width="160" height="160"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="160" id="CtE-yp-T3g"/>
                                             <constraint firstAttribute="width" constant="160" id="LVD-7T-c7k"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your magic link is on its way! Check your email on this device, and tap the link in the email you receive from WordPress.com" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pkM-xx-821">
-                                        <rect key="frame" x="2.5" y="190" width="342.5" height="64.5"/>
+                                        <rect key="frame" x="8" y="190" width="375.5" height="64.5"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="0nV-Yg-je4"/>
                                             <constraint firstAttribute="width" constant="320" id="2JY-7V-RVK"/>
@@ -1620,7 +1608,7 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Iy-9H-ykD" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="136" y="284.5" width="75" height="34"/>
+                                        <rect key="frame" x="158" y="284.5" width="75" height="34"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="tyz-kt-Arb"/>
                                         </constraints>
@@ -1636,16 +1624,47 @@
                                         </connections>
                                     </button>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="383" id="lQv-V1-jm1"/>
+                                </constraints>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="lQv-V1-jm1"/>
+                                    </mask>
+                                </variation>
+                                <variation key="heightClass=regular-widthClass=regular">
+                                    <mask key="constraints">
+                                        <include reference="lQv-V1-jm1"/>
+                                    </mask>
+                                </variation>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b0O-LO-6ax">
+                                <rect key="frame" x="105.5" y="628" width="172" height="28"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <state key="normal" title="Enter your password instead">
+                                    <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="handleUsePasswordTapped:" destination="GSd-vy-rpZ" eventType="touchUpInside" id="I1f-Mc-BbK"/>
+                                    <segue destination="lmD-c6-SLs" kind="show" id="Jfl-Zm-PRR"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="L3o-Cy-vXw" firstAttribute="leading" secondItem="Xyo-MA-Ddd" secondAttribute="leading" constant="18" id="EG6-tW-icm"/>
+                            <constraint firstItem="L3o-Cy-vXw" firstAttribute="leading" secondItem="Xyo-MA-Ddd" secondAttribute="leadingMargin" constant="-20" id="EG6-tW-icm"/>
                             <constraint firstItem="b0O-LO-6ax" firstAttribute="centerX" secondItem="Xyo-MA-Ddd" secondAttribute="centerX" id="RM7-fX-URR"/>
-                            <constraint firstItem="vKK-Mm-0yR" firstAttribute="top" secondItem="b0O-LO-6ax" secondAttribute="bottom" priority="900" constant="16" id="T3w-we-LXY"/>
+                            <constraint firstItem="vKK-Mm-0yR" firstAttribute="top" secondItem="b0O-LO-6ax" secondAttribute="bottom" priority="900" constant="20" id="T3w-we-LXY"/>
                             <constraint firstItem="L3o-Cy-vXw" firstAttribute="centerY" secondItem="Xyo-MA-Ddd" secondAttribute="centerY" constant="-20" id="ece-WV-24S"/>
-                            <constraint firstAttribute="trailing" secondItem="L3o-Cy-vXw" secondAttribute="trailing" constant="18" id="pS9-2a-bJD"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="L3o-Cy-vXw" secondAttribute="trailing" constant="-20" id="pS9-2a-bJD"/>
+                            <constraint firstItem="L3o-Cy-vXw" firstAttribute="centerX" secondItem="Xyo-MA-Ddd" secondAttribute="centerX" id="xII-A3-ICI"/>
                         </constraints>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <exclude reference="EG6-tW-icm"/>
+                                <exclude reference="pS9-2a-bJD"/>
+                            </mask>
+                        </variation>
                     </view>
                     <connections>
                         <outlet property="label" destination="pkM-xx-821" id="nOS-5r-86h"/>
@@ -2154,8 +2173,8 @@
         <image name="login-magic-link" width="160" height="160"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="0ao-yi-yZI"/>
+        <segue reference="Jfl-Zm-PRR"/>
         <segue reference="fWM-mD-lXg"/>
-        <segue reference="fA5-mb-vrv"/>
+        <segue reference="7ky-IR-Xbv"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -138,10 +138,10 @@
                                 <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
-                                        <rect key="frame" x="0.0" y="0.0" width="391" height="538"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
                                         <subviews>
                                             <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Ff9-jl-eKh">
-                                                <rect key="frame" x="0.0" y="189" width="391" height="122"/>
+                                                <rect key="frame" x="0.0" y="194" width="391" height="122"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
                                                         <rect key="frame" x="20" y="0.0" width="351" height="38"/>
@@ -199,10 +199,10 @@
                                         </constraints>
                                     </view>
                                     <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="ecG-o1-wwE">
-                                        <rect key="frame" x="0.0" y="538" width="391" height="74"/>
+                                        <rect key="frame" x="0.0" y="548" width="391" height="64"/>
                                         <subviews>
                                             <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6i6-CG-3Tg">
-                                                <rect key="frame" x="20" y="10" width="351" height="44"/>
+                                                <rect key="frame" x="20" y="0.0" width="351" height="44"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Hn-ZK-h9k">
                                                         <rect key="frame" x="0.0" y="7" width="307" height="30"/>
@@ -240,7 +240,7 @@
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="6i6-CG-3Tg" secondAttribute="trailing" constant="20" id="Qnl-JG-4jT"/>
                                             <constraint firstAttribute="bottom" secondItem="6i6-CG-3Tg" secondAttribute="bottom" constant="20" id="UF0-73-Qz4"/>
-                                            <constraint firstItem="6i6-CG-3Tg" firstAttribute="top" secondItem="ecG-o1-wwE" secondAttribute="top" priority="750" constant="10" id="w2M-l2-itq"/>
+                                            <constraint firstItem="6i6-CG-3Tg" firstAttribute="top" secondItem="ecG-o1-wwE" secondAttribute="top" id="w2M-l2-itq"/>
                                             <constraint firstItem="6i6-CG-3Tg" firstAttribute="leading" secondItem="ecG-o1-wwE" secondAttribute="leading" constant="20" id="xv3-Qs-Otm"/>
                                         </constraints>
                                     </view>
@@ -547,10 +547,10 @@
                                 <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y8j-4r-VXw">
-                                        <rect key="frame" x="0.0" y="0.0" width="391" height="538"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Mjx-cz-sDG">
-                                                <rect key="frame" x="0.0" y="133" width="391" height="200"/>
+                                                <rect key="frame" x="0.0" y="158" width="391" height="200"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-BX-tKE" userLabel="Header Stack View">
                                                         <rect key="frame" x="20" y="0.0" width="351" height="72"/>
@@ -643,14 +643,14 @@
                                             <constraint firstItem="Mjx-cz-sDG" firstAttribute="top" relation="greaterThanOrEqual" secondItem="y8j-4r-VXw" secondAttribute="top" constant="20" id="f4G-G5-w9e"/>
                                             <constraint firstItem="Mjx-cz-sDG" firstAttribute="leading" secondItem="y8j-4r-VXw" secondAttribute="leading" id="ijo-eO-0zW"/>
                                             <constraint firstAttribute="trailing" secondItem="Mjx-cz-sDG" secondAttribute="trailing" id="jXU-Dw-NSV"/>
-                                            <constraint firstItem="tW0-In-DwC" firstAttribute="centerY" secondItem="y8j-4r-VXw" secondAttribute="centerY" priority="900" id="mGk-PV-luu"/>
+                                            <constraint firstItem="tW0-In-DwC" firstAttribute="centerY" secondItem="y8j-4r-VXw" secondAttribute="centerY" priority="900" constant="20" id="mGk-PV-luu"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dRL-RD-U6n">
-                                        <rect key="frame" x="0.0" y="538" width="391" height="74"/>
+                                        <rect key="frame" x="0.0" y="548" width="391" height="64"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zbk-h0-lpE">
-                                                <rect key="frame" x="20" y="10" width="351" height="44"/>
+                                                <rect key="frame" x="20" y="0.0" width="351" height="44"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gzk-TE-YfP">
                                                         <rect key="frame" x="0.0" y="7" width="141" height="30"/>
@@ -686,7 +686,7 @@
                                             <constraint firstAttribute="bottom" secondItem="zbk-h0-lpE" secondAttribute="bottom" constant="20" id="Szt-FI-zE7"/>
                                             <constraint firstItem="zbk-h0-lpE" firstAttribute="leading" secondItem="dRL-RD-U6n" secondAttribute="leading" constant="20" id="sxH-7I-EtY"/>
                                             <constraint firstAttribute="trailing" secondItem="zbk-h0-lpE" secondAttribute="trailing" constant="20" id="vwI-nG-6xF"/>
-                                            <constraint firstItem="zbk-h0-lpE" firstAttribute="top" secondItem="dRL-RD-U6n" secondAttribute="top" constant="10" id="ykz-4R-R7L"/>
+                                            <constraint firstItem="zbk-h0-lpE" firstAttribute="top" secondItem="dRL-RD-U6n" secondAttribute="top" id="ykz-4R-R7L"/>
                                         </constraints>
                                     </view>
                                 </subviews>
@@ -761,10 +761,10 @@
                                 <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="ZWc-TJ-W9T">
-                                        <rect key="frame" x="0.0" y="0.0" width="391" height="538"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="612"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="5SZ-KU-Ynv">
-                                                <rect key="frame" x="0.0" y="134.5" width="391" height="194.5"/>
+                                                <rect key="frame" x="0.0" y="190" width="391" height="190.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="343" placeholderIntrinsicHeight="48" text="Enter the password for your WordPress.com account." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBi-2N-RAh">
                                                         <rect key="frame" x="20" y="0.0" width="351" height="48"/>
@@ -772,76 +772,80 @@
                                                         <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xgi-ZQ-8YL">
-                                                        <rect key="frame" x="20" y="80" width="351" height="20.5"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3be-99-g62">
+                                                        <rect key="frame" x="0.0" y="80" width="391" height="72.5"/>
                                                         <subviews>
-                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="icon-username-field" translatesAutoresizingMaskIntoConstraints="NO" id="e88-X2-Rh2">
-                                                                <rect key="frame" x="0.0" y="1.5" width="18" height="18"/>
-                                                            </imageView>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="avo-E8-mvG">
-                                                                <rect key="frame" x="28" y="0.0" width="323" height="20.5"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                                <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xgi-ZQ-8YL">
+                                                                <rect key="frame" x="20" y="0.0" width="351" height="20.5"/>
+                                                                <subviews>
+                                                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="icon-username-field" translatesAutoresizingMaskIntoConstraints="NO" id="e88-X2-Rh2">
+                                                                        <rect key="frame" x="0.0" y="1.5" width="18" height="18"/>
+                                                                    </imageView>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="avo-E8-mvG">
+                                                                        <rect key="frame" x="28" y="0.0" width="323" height="20.5"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                                        <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                                <rect key="frame" x="0.0" y="28.5" width="391" height="44"/>
+                                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="Mzl-m2-DZ7"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
+                                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
+                                                                </userDefinedRuntimeAttributes>
+                                                                <connections>
+                                                                    <action selector="handleTextFieldDidChange:" destination="lmD-c6-SLs" eventType="editingChanged" id="TIx-xK-PLT"/>
+                                                                    <outlet property="delegate" destination="lmD-c6-SLs" id="8se-wA-BuN"/>
+                                                                </connections>
+                                                            </textField>
                                                         </subviews>
                                                     </stackView>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="112.5" width="391" height="44"/>
-                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="Mzl-m2-DZ7"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
-                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="handleTextFieldDidChange:" destination="lmD-c6-SLs" eventType="editingChanged" id="TIx-xK-PLT"/>
-                                                            <outlet property="delegate" destination="lmD-c6-SLs" id="8se-wA-BuN"/>
-                                                        </connections>
-                                                    </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
-                                                        <rect key="frame" x="20" y="176.5" width="351" height="18"/>
+                                                        <rect key="frame" x="20" y="172.5" width="351" height="18"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="BtS-3D-CIU" firstAttribute="top" secondItem="Xgi-ZQ-8YL" secondAttribute="bottom" constant="12" id="8nF-H3-80k"/>
                                                     <constraint firstAttribute="bottom" secondItem="ZqY-I8-yWG" secondAttribute="bottom" id="E59-0T-vN0"/>
                                                     <constraint firstItem="bBi-2N-RAh" firstAttribute="top" secondItem="5SZ-KU-Ynv" secondAttribute="top" id="EHy-LX-CBy"/>
-                                                    <constraint firstItem="BtS-3D-CIU" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" id="Giu-bS-8c8"/>
                                                     <constraint firstAttribute="trailing" secondItem="bBi-2N-RAh" secondAttribute="trailing" constant="20" id="I5y-9X-RL3"/>
-                                                    <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="top" secondItem="bBi-2N-RAh" secondAttribute="bottom" constant="32" id="PE2-OG-pet"/>
+                                                    <constraint firstItem="3be-99-g62" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" id="TDc-85-iYF"/>
                                                     <constraint firstAttribute="trailing" secondItem="ZqY-I8-yWG" secondAttribute="trailing" constant="20" id="TVX-LB-4r2"/>
                                                     <constraint firstItem="ZqY-I8-yWG" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" constant="20" id="Tsh-Is-9Js"/>
-                                                    <constraint firstItem="ZqY-I8-yWG" firstAttribute="top" secondItem="BtS-3D-CIU" secondAttribute="bottom" constant="20" id="Wgp-cW-ayk"/>
                                                     <constraint firstItem="bBi-2N-RAh" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" constant="20" id="ZlZ-A4-QRe"/>
-                                                    <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" constant="20" id="a3S-8S-rbw"/>
-                                                    <constraint firstAttribute="trailing" secondItem="Xgi-ZQ-8YL" secondAttribute="trailing" constant="20" id="rlz-ah-HUI"/>
-                                                    <constraint firstAttribute="trailing" secondItem="BtS-3D-CIU" secondAttribute="trailing" id="xsm-nd-1Vw"/>
+                                                    <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="width" secondItem="bBi-2N-RAh" secondAttribute="width" id="b4N-GW-28t"/>
+                                                    <constraint firstItem="3be-99-g62" firstAttribute="top" secondItem="bBi-2N-RAh" secondAttribute="bottom" constant="32" id="egR-P4-trY"/>
+                                                    <constraint firstItem="ZqY-I8-yWG" firstAttribute="top" secondItem="3be-99-g62" secondAttribute="bottom" constant="20" id="gWk-tT-iSi"/>
+                                                    <constraint firstAttribute="trailing" secondItem="3be-99-g62" secondAttribute="trailing" id="ydq-F8-Wn1"/>
+                                                    <constraint firstItem="BtS-3D-CIU" firstAttribute="width" secondItem="5SZ-KU-Ynv" secondAttribute="width" id="yh3-jw-LHU"/>
                                                 </constraints>
                                             </view>
                                         </subviews>
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="5SZ-KU-Ynv" secondAttribute="trailing" id="Ew5-wQ-FxQ"/>
-                                            <constraint firstItem="BtS-3D-CIU" firstAttribute="centerY" secondItem="ZWc-TJ-W9T" secondAttribute="centerY" priority="900" id="T4P-6t-YLe"/>
                                             <constraint firstItem="5SZ-KU-Ynv" firstAttribute="leading" secondItem="ZWc-TJ-W9T" secondAttribute="leading" id="aOG-h6-gAw"/>
+                                            <constraint firstItem="3be-99-g62" firstAttribute="centerY" secondItem="ZWc-TJ-W9T" secondAttribute="centerY" id="kq2-hl-9vu"/>
                                             <constraint firstItem="5SZ-KU-Ynv" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ZWc-TJ-W9T" secondAttribute="top" constant="20" id="zPw-QR-H0E"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nNi-en-Ou0">
-                                        <rect key="frame" x="0.0" y="538" width="391" height="74"/>
+                                        <rect key="frame" x="0.0" y="548" width="391" height="64"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ilv-iW-HgP">
-                                                <rect key="frame" x="20" y="10" width="351" height="44"/>
+                                                <rect key="frame" x="20" y="0.0" width="351" height="44"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0P1-6g-BI3">
                                                         <rect key="frame" x="0.0" y="7" width="141" height="30"/>
@@ -875,7 +879,7 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="ilv-iW-HgP" firstAttribute="leading" secondItem="nNi-en-Ou0" secondAttribute="leading" constant="20" id="6wo-mO-YhL"/>
-                                            <constraint firstItem="ilv-iW-HgP" firstAttribute="top" secondItem="nNi-en-Ou0" secondAttribute="top" constant="10" id="KgI-bu-hJ4"/>
+                                            <constraint firstItem="ilv-iW-HgP" firstAttribute="top" secondItem="nNi-en-Ou0" secondAttribute="top" id="KgI-bu-hJ4"/>
                                             <constraint firstAttribute="bottom" secondItem="ilv-iW-HgP" secondAttribute="bottom" constant="20" id="fJe-nZ-WbT"/>
                                             <constraint firstAttribute="trailing" secondItem="ilv-iW-HgP" secondAttribute="trailing" constant="20" id="qyx-Z0-cuI"/>
                                         </constraints>
@@ -888,9 +892,9 @@
                                     <constraint firstItem="ZWc-TJ-W9T" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" id="Osp-Ar-qix"/>
                                     <constraint firstAttribute="bottom" secondItem="nNi-en-Ou0" secondAttribute="bottom" id="Ugi-9r-MdP"/>
                                     <constraint firstAttribute="width" constant="383" id="VgM-uK-kk3"/>
-                                    <constraint firstItem="nNi-en-Ou0" firstAttribute="top" secondItem="ZWc-TJ-W9T" secondAttribute="bottom" id="Y7j-Wg-YEy"/>
                                     <constraint firstAttribute="trailing" secondItem="nNi-en-Ou0" secondAttribute="trailing" id="fUL-dk-71l"/>
                                     <constraint firstAttribute="trailing" secondItem="ZWc-TJ-W9T" secondAttribute="trailing" id="p8c-n5-W3X"/>
+                                    <constraint firstAttribute="bottom" secondItem="ZWc-TJ-W9T" secondAttribute="bottom" id="sSC-44-fTn"/>
                                 </constraints>
                                 <variation key="default">
                                     <mask key="constraints">
@@ -951,10 +955,10 @@
                                 <rect key="frame" x="0.0" y="64" width="383" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DHF-bN-so0">
-                                        <rect key="frame" x="0.0" y="0.0" width="383" height="538"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="383" height="612"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="L68-uO-e3A">
-                                                <rect key="frame" x="0.0" y="209" width="383" height="102"/>
+                                                <rect key="frame" x="0.0" y="246" width="383" height="102"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Almost there" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h0i-9g-1E6">
                                                         <rect key="frame" x="20" y="0.0" width="343" height="18"/>
@@ -1025,12 +1029,12 @@
                                         <rect key="frame" x="20" y="548" width="343" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="309-z3-fPx">
-                                                <rect key="frame" x="0.0" y="0.0" width="115" height="44"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="131" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="fzI-rH-0f8"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="tFG-e2-XN2"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <state key="normal" title="Send another code">
                                                     <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
@@ -1062,8 +1066,8 @@
                                     <constraint firstAttribute="trailing" secondItem="x1G-Lf-mra" secondAttribute="trailing" constant="20" id="37l-6r-mKG"/>
                                     <constraint firstItem="DHF-bN-so0" firstAttribute="leading" secondItem="hTY-xb-H5h" secondAttribute="leading" id="3Og-Ew-r3y"/>
                                     <constraint firstItem="DHF-bN-so0" firstAttribute="top" secondItem="hTY-xb-H5h" secondAttribute="top" id="9hm-xn-6lZ"/>
-                                    <constraint firstItem="x1G-Lf-mra" firstAttribute="top" secondItem="DHF-bN-so0" secondAttribute="bottom" constant="10" id="IsJ-Kk-Pdi"/>
                                     <constraint firstAttribute="bottom" secondItem="x1G-Lf-mra" secondAttribute="bottom" constant="20" id="XBv-Gg-JAY"/>
+                                    <constraint firstAttribute="bottom" secondItem="DHF-bN-so0" secondAttribute="bottom" id="blP-qB-Bvl"/>
                                     <constraint firstAttribute="width" constant="383" id="eWE-lA-7Kg"/>
                                     <constraint firstAttribute="trailing" secondItem="DHF-bN-so0" secondAttribute="trailing" id="pId-Zh-c89"/>
                                     <constraint firstItem="x1G-Lf-mra" firstAttribute="leading" secondItem="hTY-xb-H5h" secondAttribute="leading" constant="20" id="yEl-i3-fts"/>
@@ -1681,10 +1685,10 @@
                                 <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PIc-wF-cQF">
-                                        <rect key="frame" x="0.0" y="0.0" width="391" height="538"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
                                         <subviews>
                                             <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="a1t-zo-d5c">
-                                                <rect key="frame" x="0.0" y="189" width="391" height="122"/>
+                                                <rect key="frame" x="0.0" y="194" width="391" height="122"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Enter the address of the WordPress site you'd like to connect." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-bF-n1P">
                                                         <rect key="frame" x="20" y="0.0" width="351" height="38"/>
@@ -1742,10 +1746,10 @@
                                         </constraints>
                                     </view>
                                     <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="GKU-9C-CUT" userLabel="Footer">
-                                        <rect key="frame" x="0.0" y="538" width="391" height="74"/>
+                                        <rect key="frame" x="0.0" y="548" width="391" height="64"/>
                                         <subviews>
                                             <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mlx-XY-MGX">
-                                                <rect key="frame" x="20" y="10" width="351" height="44"/>
+                                                <rect key="frame" x="20" y="0.0" width="351" height="44"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="roL-ID-k8n">
                                                         <rect key="frame" x="0.0" y="7" width="250" height="30"/>
@@ -1783,7 +1787,7 @@
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="mlx-XY-MGX" secondAttribute="trailing" constant="20" id="6vA-Fm-FcB"/>
                                             <constraint firstAttribute="bottom" secondItem="mlx-XY-MGX" secondAttribute="bottom" constant="20" id="6vW-rA-zhE"/>
-                                            <constraint firstItem="mlx-XY-MGX" firstAttribute="top" secondItem="GKU-9C-CUT" secondAttribute="top" priority="750" constant="10" id="E10-UM-cwY"/>
+                                            <constraint firstItem="mlx-XY-MGX" firstAttribute="top" secondItem="GKU-9C-CUT" secondAttribute="top" id="E10-UM-cwY"/>
                                             <constraint firstItem="mlx-XY-MGX" firstAttribute="leading" secondItem="GKU-9C-CUT" secondAttribute="leading" constant="20" id="OCg-Cl-3x5"/>
                                         </constraints>
                                     </view>
@@ -2166,8 +2170,8 @@
         <image name="login-magic-link" width="160" height="160"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="Jfl-Zm-PRR"/>
+        <segue reference="ySQ-EM-6JI"/>
         <segue reference="qLI-qX-rkG"/>
-        <segue reference="7lv-19-h36"/>
+        <segue reference="lIb-sw-yM7"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -140,120 +140,96 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
                                         <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
                                         <subviews>
-                                            <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Ff9-jl-eKh">
-                                                <rect key="frame" x="0.0" y="194" width="391" height="122"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
-                                                        <rect key="frame" x="20" y="0.0" width="351" height="38"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XXO-aV-keK" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="58" width="391" height="44"/>
-                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="c8B-Ol-kY2"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-username-field"/>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="handleSubmitForm" destination="fwZ-QE-5et" eventType="primaryActionTriggered" id="8l9-uh-Gyz"/>
-                                                            <action selector="handleTextFieldDidChange:" destination="fwZ-QE-5et" eventType="editingChanged" id="LoF-5Q-Yw5"/>
-                                                            <action selector="handleTextFieldEditingDidBegin:" destination="fwZ-QE-5et" eventType="editingDidBegin" id="Ff8-SJ-F9U"/>
-                                                            <outlet property="delegate" destination="fwZ-QE-5et" id="Urv-t1-Fui"/>
-                                                        </connections>
-                                                    </textField>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qqt-eq-gac">
-                                                        <rect key="frame" x="20" y="122" width="351" height="0.0"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" red="0.85098039215686272" green="0.30980392156862746" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
+                                                <rect key="frame" x="20" y="194" width="351" height="38"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XXO-aV-keK" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="252" width="391" height="44"/>
+                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
                                                 <constraints>
-                                                    <constraint firstItem="Qqt-eq-gac" firstAttribute="leading" secondItem="Ff9-jl-eKh" secondAttribute="leading" constant="20" id="94O-1n-HFL"/>
-                                                    <constraint firstItem="XXO-aV-keK" firstAttribute="leading" secondItem="Ff9-jl-eKh" secondAttribute="leading" id="Aae-9P-bkG"/>
-                                                    <constraint firstItem="XXO-aV-keK" firstAttribute="top" secondItem="DKR-9c-zZQ" secondAttribute="bottom" constant="20" id="K5W-wi-lao"/>
-                                                    <constraint firstItem="DKR-9c-zZQ" firstAttribute="top" secondItem="Ff9-jl-eKh" secondAttribute="top" id="Khm-BS-EIo"/>
-                                                    <constraint firstItem="DKR-9c-zZQ" firstAttribute="leading" secondItem="Ff9-jl-eKh" secondAttribute="leading" constant="20" id="MWF-1s-IWK"/>
-                                                    <constraint firstAttribute="bottom" secondItem="Qqt-eq-gac" secondAttribute="bottom" id="PSy-Fj-BxD"/>
-                                                    <constraint firstAttribute="trailing" secondItem="Qqt-eq-gac" secondAttribute="trailing" constant="20" id="XEe-SR-4Um"/>
-                                                    <constraint firstItem="Qqt-eq-gac" firstAttribute="top" secondItem="XXO-aV-keK" secondAttribute="bottom" constant="20" id="ZOe-Fb-b0U"/>
-                                                    <constraint firstAttribute="trailing" secondItem="XXO-aV-keK" secondAttribute="trailing" id="i4f-1H-u1d"/>
-                                                    <constraint firstAttribute="trailing" secondItem="DKR-9c-zZQ" secondAttribute="trailing" constant="20" id="odG-1L-fnV"/>
+                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="c8B-Ol-kY2"/>
                                                 </constraints>
-                                            </view>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-username-field"/>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleSubmitForm" destination="fwZ-QE-5et" eventType="primaryActionTriggered" id="8l9-uh-Gyz"/>
+                                                    <action selector="handleTextFieldDidChange:" destination="fwZ-QE-5et" eventType="editingChanged" id="LoF-5Q-Yw5"/>
+                                                    <action selector="handleTextFieldEditingDidBegin:" destination="fwZ-QE-5et" eventType="editingDidBegin" id="Ff8-SJ-F9U"/>
+                                                    <outlet property="delegate" destination="fwZ-QE-5et" id="Urv-t1-Fui"/>
+                                                </connections>
+                                            </textField>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qqt-eq-gac">
+                                                <rect key="frame" x="20" y="316" width="351" height="0.0"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <color key="textColor" red="0.85098039215686272" green="0.30980392156862746" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstItem="Ff9-jl-eKh" firstAttribute="top" relation="greaterThanOrEqual" secondItem="KAn-ug-oE6" secondAttribute="top" constant="20" id="EKx-vI-rSm"/>
-                                            <constraint firstAttribute="trailing" secondItem="Ff9-jl-eKh" secondAttribute="trailing" id="Tbw-s4-sXV"/>
-                                            <constraint firstItem="Ff9-jl-eKh" firstAttribute="leading" secondItem="KAn-ug-oE6" secondAttribute="leading" id="UlL-49-A8K"/>
-                                            <constraint firstItem="XXO-aV-keK" firstAttribute="centerY" secondItem="KAn-ug-oE6" secondAttribute="centerY" priority="900" id="ftV-Sq-D3b"/>
+                                            <constraint firstItem="DKR-9c-zZQ" firstAttribute="leading" secondItem="KAn-ug-oE6" secondAttribute="leading" constant="20" id="7wu-3l-qUr"/>
+                                            <constraint firstItem="XXO-aV-keK" firstAttribute="top" secondItem="DKR-9c-zZQ" secondAttribute="bottom" constant="20" id="9oX-ka-j3I"/>
+                                            <constraint firstItem="DKR-9c-zZQ" firstAttribute="top" relation="greaterThanOrEqual" secondItem="KAn-ug-oE6" secondAttribute="top" constant="20" id="JJl-Bt-GIK"/>
+                                            <constraint firstItem="XXO-aV-keK" firstAttribute="leading" secondItem="KAn-ug-oE6" secondAttribute="leading" id="KvU-q6-a4w"/>
+                                            <constraint firstAttribute="trailing" secondItem="XXO-aV-keK" secondAttribute="trailing" id="MIQ-Zc-xTt"/>
+                                            <constraint firstItem="Qqt-eq-gac" firstAttribute="top" secondItem="XXO-aV-keK" secondAttribute="bottom" constant="20" id="RI6-Oc-Mzl"/>
+                                            <constraint firstItem="Qqt-eq-gac" firstAttribute="leading" secondItem="KAn-ug-oE6" secondAttribute="leading" constant="20" id="YNt-g8-nUN"/>
+                                            <constraint firstAttribute="trailing" secondItem="Qqt-eq-gac" secondAttribute="trailing" constant="20" id="bSc-Qd-t4P"/>
+                                            <constraint firstAttribute="trailing" secondItem="DKR-9c-zZQ" secondAttribute="trailing" constant="20" id="jye-BF-2wg"/>
+                                            <constraint firstItem="XXO-aV-keK" firstAttribute="centerY" secondItem="KAn-ug-oE6" secondAttribute="centerY" priority="900" id="wqM-E8-vHO"/>
                                         </constraints>
                                     </view>
-                                    <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="ecG-o1-wwE">
-                                        <rect key="frame" x="0.0" y="548" width="391" height="64"/>
+                                    <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6i6-CG-3Tg">
+                                        <rect key="frame" x="20" y="548" width="351" height="44"/>
                                         <subviews>
-                                            <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6i6-CG-3Tg">
-                                                <rect key="frame" x="20" y="0.0" width="351" height="44"/>
-                                                <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Hn-ZK-h9k">
-                                                        <rect key="frame" x="0.0" y="7" width="307" height="30"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <state key="normal" title="Log into your site by entering your site address instead.">
-                                                            <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </state>
-                                                        <connections>
-                                                            <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="avL-c6-SBY"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="315" y="0.0" width="36" height="44"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="44" id="PgU-lW-anB"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <state key="normal" title="Next">
-                                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </state>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="handleSubmitButtonTapped:" destination="fwZ-QE-5et" eventType="touchUpInside" id="bLs-uJ-s0q"/>
-                                                        </connections>
-                                                    </button>
-                                                </subviews>
-                                                <color key="backgroundColor" red="0.02390592004" green="1" blue="0.002390008849" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                            </stackView>
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Hn-ZK-h9k">
+                                                <rect key="frame" x="0.0" y="7" width="307" height="30"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <state key="normal" title="Log into your site by entering your site address instead.">
+                                                    <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="avL-c6-SBY"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="315" y="0.0" width="36" height="44"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="44" id="PgU-lW-anB"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <state key="normal" title="Next">
+                                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleSubmitButtonTapped:" destination="fwZ-QE-5et" eventType="touchUpInside" id="bLs-uJ-s0q"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="6i6-CG-3Tg" secondAttribute="trailing" constant="20" id="Qnl-JG-4jT"/>
-                                            <constraint firstAttribute="bottom" secondItem="6i6-CG-3Tg" secondAttribute="bottom" constant="20" id="UF0-73-Qz4"/>
-                                            <constraint firstItem="6i6-CG-3Tg" firstAttribute="top" secondItem="ecG-o1-wwE" secondAttribute="top" id="w2M-l2-itq"/>
-                                            <constraint firstItem="6i6-CG-3Tg" firstAttribute="leading" secondItem="ecG-o1-wwE" secondAttribute="leading" constant="20" id="xv3-Qs-Otm"/>
-                                        </constraints>
-                                    </view>
+                                        <color key="backgroundColor" red="0.02390592004" green="1" blue="0.002390008849" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                    </stackView>
                                 </subviews>
                                 <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="6i6-CG-3Tg" secondAttribute="bottom" constant="20" id="4nN-nX-mKq"/>
                                     <constraint firstItem="KAn-ug-oE6" firstAttribute="leading" secondItem="ozJ-hT-OEw" secondAttribute="leading" id="K1C-YL-EQU"/>
-                                    <constraint firstItem="ecG-o1-wwE" firstAttribute="leading" secondItem="ozJ-hT-OEw" secondAttribute="leading" id="KHv-G5-yi6"/>
+                                    <constraint firstItem="6i6-CG-3Tg" firstAttribute="leading" secondItem="ozJ-hT-OEw" secondAttribute="leading" constant="20" id="OV8-qk-BeQ"/>
                                     <constraint firstAttribute="trailing" secondItem="KAn-ug-oE6" secondAttribute="trailing" id="PPm-oa-8dA"/>
                                     <constraint firstAttribute="width" constant="383" id="RDo-Cc-ZDN"/>
-                                    <constraint firstAttribute="trailing" secondItem="ecG-o1-wwE" secondAttribute="trailing" id="Sqb-TN-g4l"/>
-                                    <constraint firstItem="ecG-o1-wwE" firstAttribute="top" secondItem="KAn-ug-oE6" secondAttribute="bottom" id="XCU-nJ-IcQ"/>
+                                    <constraint firstItem="6i6-CG-3Tg" firstAttribute="top" secondItem="KAn-ug-oE6" secondAttribute="bottom" id="elb-dj-BL1"/>
                                     <constraint firstItem="KAn-ug-oE6" firstAttribute="top" secondItem="ozJ-hT-OEw" secondAttribute="top" id="nCb-yc-mV0"/>
-                                    <constraint firstAttribute="bottom" secondItem="ecG-o1-wwE" secondAttribute="bottom" id="q51-LD-TZq"/>
+                                    <constraint firstAttribute="trailing" secondItem="6i6-CG-3Tg" secondAttribute="trailing" constant="20" id="niR-ZN-hgD"/>
                                 </constraints>
                                 <variation key="default">
                                     <mask key="constraints">
@@ -549,156 +525,133 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y8j-4r-VXw">
                                         <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Mjx-cz-sDG">
-                                                <rect key="frame" x="0.0" y="158" width="391" height="200"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-BX-tKE" userLabel="Header Stack View">
+                                                <rect key="frame" x="20" y="138" width="351" height="72"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="rFl-BX-tKE" userLabel="Header Stack View">
-                                                        <rect key="frame" x="20" y="0.0" width="351" height="72"/>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8z-Py-Err" customClass="SiteInfoHeaderView" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="351" height="50"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="50" placeholder="YES" id="NyW-2I-Z3P"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="m9N-GQ-6MI">
+                                                        <rect key="frame" x="0.0" y="50" width="351" height="22"/>
                                                         <subviews>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n8z-Py-Err" customClass="SiteInfoHeaderView" customModule="WordPress" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="351" height="50"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" constant="50" placeholder="YES" id="NyW-2I-Z3P"/>
-                                                                </constraints>
-                                                            </view>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="m9N-GQ-6MI">
-                                                                <rect key="frame" x="0.0" y="50" width="351" height="22"/>
-                                                                <subviews>
-                                                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Dfh-U3-cvf">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="18" height="22"/>
-                                                                    </imageView>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UL4-G6-7G6">
-                                                                        <rect key="frame" x="26" y="0.0" width="325" height="22"/>
-                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                                        <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
-                                                                        <nil key="highlightedColor"/>
-                                                                    </label>
-                                                                </subviews>
-                                                            </stackView>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" image="icon-url-field" translatesAutoresizingMaskIntoConstraints="NO" id="Dfh-U3-cvf">
+                                                                <rect key="frame" x="0.0" y="0.0" width="18" height="22"/>
+                                                            </imageView>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UL4-G6-7G6">
+                                                                <rect key="frame" x="26" y="0.0" width="325" height="22"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="tW0-In-DwC">
-                                                        <rect key="frame" x="0.0" y="92" width="391" height="88"/>
-                                                        <subviews>
-                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ESh-DI-dtB" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="391" height="44"/>
-                                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
-                                                                <userDefinedRuntimeAttributes>
-                                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-username-field"/>
-                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="NO"/>
-                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                                </userDefinedRuntimeAttributes>
-                                                                <connections>
-                                                                    <action selector="handleTextFieldDidChange:" destination="SZS-o3-1P7" eventType="editingChanged" id="5b1-ZP-8Yq"/>
-                                                                    <outlet property="delegate" destination="SZS-o3-1P7" id="NfG-gH-Yct"/>
-                                                                </connections>
-                                                            </textField>
-                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oi5-Kd-TEW" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="44" width="391" height="44"/>
-                                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
-                                                                <userDefinedRuntimeAttributes>
-                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
-                                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
-                                                                </userDefinedRuntimeAttributes>
-                                                                <connections>
-                                                                    <action selector="handleTextFieldDidChange:" destination="SZS-o3-1P7" eventType="editingChanged" id="iSC-pZ-T1j"/>
-                                                                    <outlet property="delegate" destination="SZS-o3-1P7" id="4VW-gO-0pR"/>
-                                                                </connections>
-                                                            </textField>
-                                                        </subviews>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="88" id="F1M-fZ-NLz"/>
-                                                        </constraints>
-                                                    </stackView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dmn-nh-HTH">
-                                                        <rect key="frame" x="20" y="200" width="351" height="0.0"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstItem="tW0-In-DwC" firstAttribute="leading" secondItem="Mjx-cz-sDG" secondAttribute="leading" id="03E-NW-xAt"/>
-                                                    <constraint firstAttribute="bottom" secondItem="Dmn-nh-HTH" secondAttribute="bottom" id="2rE-DB-PKt"/>
-                                                    <constraint firstItem="Dmn-nh-HTH" firstAttribute="top" secondItem="tW0-In-DwC" secondAttribute="bottom" constant="20" id="WvE-TC-l7z"/>
-                                                    <constraint firstItem="tW0-In-DwC" firstAttribute="top" secondItem="rFl-BX-tKE" secondAttribute="bottom" constant="20" id="bGJ-Uq-kxA"/>
-                                                    <constraint firstAttribute="trailing" secondItem="tW0-In-DwC" secondAttribute="trailing" id="cr8-vI-49m"/>
-                                                    <constraint firstItem="Dmn-nh-HTH" firstAttribute="leading" secondItem="Mjx-cz-sDG" secondAttribute="leading" constant="20" id="exr-hG-jE0"/>
-                                                    <constraint firstAttribute="trailing" secondItem="rFl-BX-tKE" secondAttribute="trailing" constant="20" id="fA6-Tn-cX4"/>
-                                                    <constraint firstAttribute="trailing" secondItem="Dmn-nh-HTH" secondAttribute="trailing" constant="20" id="fch-li-UDF"/>
-                                                    <constraint firstItem="rFl-BX-tKE" firstAttribute="top" secondItem="Mjx-cz-sDG" secondAttribute="top" id="jH7-bu-eF2"/>
-                                                    <constraint firstItem="rFl-BX-tKE" firstAttribute="leading" secondItem="Mjx-cz-sDG" secondAttribute="leading" constant="20" id="mht-aX-nWa"/>
-                                                </constraints>
-                                            </view>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstItem="Mjx-cz-sDG" firstAttribute="top" relation="greaterThanOrEqual" secondItem="y8j-4r-VXw" secondAttribute="top" constant="20" id="f4G-G5-w9e"/>
-                                            <constraint firstItem="Mjx-cz-sDG" firstAttribute="leading" secondItem="y8j-4r-VXw" secondAttribute="leading" id="ijo-eO-0zW"/>
-                                            <constraint firstAttribute="trailing" secondItem="Mjx-cz-sDG" secondAttribute="trailing" id="jXU-Dw-NSV"/>
-                                            <constraint firstItem="tW0-In-DwC" firstAttribute="centerY" secondItem="y8j-4r-VXw" secondAttribute="centerY" priority="900" constant="20" id="mGk-PV-luu"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dRL-RD-U6n">
-                                        <rect key="frame" x="0.0" y="548" width="391" height="64"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zbk-h0-lpE">
-                                                <rect key="frame" x="20" y="0.0" width="351" height="44"/>
-                                                <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gzk-TE-YfP">
-                                                        <rect key="frame" x="0.0" y="7" width="141" height="30"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <state key="normal" title="Lost your password?">
-                                                            <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="handleForgotPasswordButtonTapped:" destination="SZS-o3-1P7" eventType="touchUpInside" id="YFl-yy-9UR"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SBB-7Z-qWs" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="319" y="0.0" width="32" height="44"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="44" id="NKL-1C-mN4"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <state key="normal" title="Next">
-                                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </state>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="handleSubmitButtonTapped:" destination="SZS-o3-1P7" eventType="touchUpInside" id="9a6-DP-q7L"/>
-                                                        </connections>
-                                                    </button>
                                                 </subviews>
                                             </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="tW0-In-DwC">
+                                                <rect key="frame" x="0.0" y="230" width="391" height="88"/>
+                                                <subviews>
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ESh-DI-dtB" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="391" height="44"/>
+                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-username-field"/>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="NO"/>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="handleTextFieldDidChange:" destination="SZS-o3-1P7" eventType="editingChanged" id="5b1-ZP-8Yq"/>
+                                                            <outlet property="delegate" destination="SZS-o3-1P7" id="NfG-gH-Yct"/>
+                                                        </connections>
+                                                    </textField>
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oi5-Kd-TEW" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="44" width="391" height="44"/>
+                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="next" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
+                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="handleTextFieldDidChange:" destination="SZS-o3-1P7" eventType="editingChanged" id="iSC-pZ-T1j"/>
+                                                            <outlet property="delegate" destination="SZS-o3-1P7" id="4VW-gO-0pR"/>
+                                                        </connections>
+                                                    </textField>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="88" id="F1M-fZ-NLz"/>
+                                                </constraints>
+                                            </stackView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dmn-nh-HTH">
+                                                <rect key="frame" x="20" y="338" width="351" height="0.0"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="zbk-h0-lpE" secondAttribute="bottom" constant="20" id="Szt-FI-zE7"/>
-                                            <constraint firstItem="zbk-h0-lpE" firstAttribute="leading" secondItem="dRL-RD-U6n" secondAttribute="leading" constant="20" id="sxH-7I-EtY"/>
-                                            <constraint firstAttribute="trailing" secondItem="zbk-h0-lpE" secondAttribute="trailing" constant="20" id="vwI-nG-6xF"/>
-                                            <constraint firstItem="zbk-h0-lpE" firstAttribute="top" secondItem="dRL-RD-U6n" secondAttribute="top" id="ykz-4R-R7L"/>
+                                            <constraint firstAttribute="trailing" secondItem="tW0-In-DwC" secondAttribute="trailing" id="1GR-Jg-n98"/>
+                                            <constraint firstAttribute="trailing" secondItem="Dmn-nh-HTH" secondAttribute="trailing" constant="20" id="Fnr-1U-uRo"/>
+                                            <constraint firstItem="tW0-In-DwC" firstAttribute="top" secondItem="rFl-BX-tKE" secondAttribute="bottom" constant="20" id="Mh1-XM-rZz"/>
+                                            <constraint firstItem="tW0-In-DwC" firstAttribute="leading" secondItem="y8j-4r-VXw" secondAttribute="leading" id="UpW-cT-zMt"/>
+                                            <constraint firstItem="tW0-In-DwC" firstAttribute="centerY" secondItem="y8j-4r-VXw" secondAttribute="centerY" priority="900" id="bPH-5g-emV"/>
+                                            <constraint firstItem="rFl-BX-tKE" firstAttribute="top" relation="greaterThanOrEqual" secondItem="y8j-4r-VXw" secondAttribute="top" constant="20" id="c4S-2w-Qws"/>
+                                            <constraint firstItem="rFl-BX-tKE" firstAttribute="leading" secondItem="y8j-4r-VXw" secondAttribute="leading" constant="20" id="d1s-fn-y7S"/>
+                                            <constraint firstItem="Dmn-nh-HTH" firstAttribute="leading" secondItem="y8j-4r-VXw" secondAttribute="leading" constant="20" id="fJq-9J-ZGR"/>
+                                            <constraint firstItem="Dmn-nh-HTH" firstAttribute="top" secondItem="tW0-In-DwC" secondAttribute="bottom" constant="20" id="oo1-Lw-jbc"/>
+                                            <constraint firstAttribute="trailing" secondItem="rFl-BX-tKE" secondAttribute="trailing" constant="20" id="tl6-nI-UEm"/>
                                         </constraints>
                                     </view>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zbk-h0-lpE">
+                                        <rect key="frame" x="20" y="548" width="351" height="44"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gzk-TE-YfP">
+                                                <rect key="frame" x="0.0" y="7" width="141" height="30"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <state key="normal" title="Lost your password?">
+                                                    <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="handleForgotPasswordButtonTapped:" destination="SZS-o3-1P7" eventType="touchUpInside" id="YFl-yy-9UR"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SBB-7Z-qWs" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="319" y="0.0" width="32" height="44"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="44" id="NKL-1C-mN4"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <state key="normal" title="Next">
+                                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleSubmitButtonTapped:" destination="SZS-o3-1P7" eventType="touchUpInside" id="9a6-DP-q7L"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="383" id="4XI-9Q-yp9"/>
+                                    <constraint firstItem="zbk-h0-lpE" firstAttribute="leading" secondItem="dSZ-FR-Cdo" secondAttribute="leading" constant="20" id="GXn-FD-lNT"/>
+                                    <constraint firstItem="zbk-h0-lpE" firstAttribute="top" secondItem="y8j-4r-VXw" secondAttribute="bottom" id="NSN-ak-hPe"/>
+                                    <constraint firstAttribute="bottom" secondItem="zbk-h0-lpE" secondAttribute="bottom" constant="20" id="Sar-1e-T5P"/>
+                                    <constraint firstAttribute="trailing" secondItem="zbk-h0-lpE" secondAttribute="trailing" constant="20" id="UwF-dv-d2o"/>
                                     <constraint firstItem="y8j-4r-VXw" firstAttribute="leading" secondItem="dSZ-FR-Cdo" secondAttribute="leading" id="WzD-WT-CPR"/>
-                                    <constraint firstItem="dRL-RD-U6n" firstAttribute="top" secondItem="y8j-4r-VXw" secondAttribute="bottom" id="YjR-Ea-c1g"/>
                                     <constraint firstAttribute="trailing" secondItem="y8j-4r-VXw" secondAttribute="trailing" id="bQW-83-1aD"/>
-                                    <constraint firstItem="dRL-RD-U6n" firstAttribute="leading" secondItem="dSZ-FR-Cdo" secondAttribute="leading" id="fE8-GW-3b9"/>
                                     <constraint firstItem="y8j-4r-VXw" firstAttribute="top" secondItem="dSZ-FR-Cdo" secondAttribute="top" id="la9-4O-imU"/>
-                                    <constraint firstAttribute="trailing" secondItem="dRL-RD-U6n" secondAttribute="trailing" id="snL-9q-BNH"/>
-                                    <constraint firstAttribute="bottom" secondItem="dRL-RD-U6n" secondAttribute="bottom" id="zGL-aj-JEv"/>
                                 </constraints>
                                 <variation key="default">
                                     <mask key="constraints">
@@ -763,137 +716,117 @@
                                     <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="ZWc-TJ-W9T">
                                         <rect key="frame" x="0.0" y="0.0" width="391" height="612"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="5SZ-KU-Ynv">
-                                                <rect key="frame" x="0.0" y="190" width="391" height="190.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="343" placeholderIntrinsicHeight="48" text="Enter the password for your WordPress.com account." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBi-2N-RAh">
+                                                <rect key="frame" x="20" y="189.5" width="351" height="48"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3be-99-g62">
+                                                <rect key="frame" x="0.0" y="269.5" width="391" height="72.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="343" placeholderIntrinsicHeight="48" text="Enter the password for your WordPress.com account." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBi-2N-RAh">
-                                                        <rect key="frame" x="20" y="0.0" width="351" height="48"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="3be-99-g62">
-                                                        <rect key="frame" x="0.0" y="80" width="391" height="72.5"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xgi-ZQ-8YL">
+                                                        <rect key="frame" x="20" y="0.0" width="351" height="20.5"/>
                                                         <subviews>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xgi-ZQ-8YL">
-                                                                <rect key="frame" x="20" y="0.0" width="351" height="20.5"/>
-                                                                <subviews>
-                                                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="icon-username-field" translatesAutoresizingMaskIntoConstraints="NO" id="e88-X2-Rh2">
-                                                                        <rect key="frame" x="0.0" y="1.5" width="18" height="18"/>
-                                                                    </imageView>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="avo-E8-mvG">
-                                                                        <rect key="frame" x="28" y="0.0" width="323" height="20.5"/>
-                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                                        <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                                        <nil key="highlightedColor"/>
-                                                                    </label>
-                                                                </subviews>
-                                                            </stackView>
-                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="28.5" width="391" height="44"/>
-                                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="Mzl-m2-DZ7"/>
-                                                                </constraints>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
-                                                                <userDefinedRuntimeAttributes>
-                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
-                                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
-                                                                </userDefinedRuntimeAttributes>
-                                                                <connections>
-                                                                    <action selector="handleTextFieldDidChange:" destination="lmD-c6-SLs" eventType="editingChanged" id="TIx-xK-PLT"/>
-                                                                    <outlet property="delegate" destination="lmD-c6-SLs" id="8se-wA-BuN"/>
-                                                                </connections>
-                                                            </textField>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="icon-username-field" translatesAutoresizingMaskIntoConstraints="NO" id="e88-X2-Rh2">
+                                                                <rect key="frame" x="0.0" y="1.5" width="18" height="18"/>
+                                                            </imageView>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="avo-E8-mvG">
+                                                                <rect key="frame" x="28" y="0.0" width="323" height="20.5"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                                <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
                                                         </subviews>
                                                     </stackView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
-                                                        <rect key="frame" x="20" y="172.5" width="351" height="18"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="28.5" width="391" height="44"/>
+                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="Mzl-m2-DZ7"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
+                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="handleTextFieldDidChange:" destination="lmD-c6-SLs" eventType="editingChanged" id="TIx-xK-PLT"/>
+                                                            <outlet property="delegate" destination="lmD-c6-SLs" id="8se-wA-BuN"/>
+                                                        </connections>
+                                                    </textField>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstAttribute="bottom" secondItem="ZqY-I8-yWG" secondAttribute="bottom" id="E59-0T-vN0"/>
-                                                    <constraint firstItem="bBi-2N-RAh" firstAttribute="top" secondItem="5SZ-KU-Ynv" secondAttribute="top" id="EHy-LX-CBy"/>
-                                                    <constraint firstAttribute="trailing" secondItem="bBi-2N-RAh" secondAttribute="trailing" constant="20" id="I5y-9X-RL3"/>
-                                                    <constraint firstItem="3be-99-g62" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" id="TDc-85-iYF"/>
-                                                    <constraint firstAttribute="trailing" secondItem="ZqY-I8-yWG" secondAttribute="trailing" constant="20" id="TVX-LB-4r2"/>
-                                                    <constraint firstItem="ZqY-I8-yWG" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" constant="20" id="Tsh-Is-9Js"/>
-                                                    <constraint firstItem="bBi-2N-RAh" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" constant="20" id="ZlZ-A4-QRe"/>
-                                                    <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="width" secondItem="bBi-2N-RAh" secondAttribute="width" id="b4N-GW-28t"/>
-                                                    <constraint firstItem="3be-99-g62" firstAttribute="top" secondItem="bBi-2N-RAh" secondAttribute="bottom" constant="32" id="egR-P4-trY"/>
-                                                    <constraint firstItem="ZqY-I8-yWG" firstAttribute="top" secondItem="3be-99-g62" secondAttribute="bottom" constant="20" id="gWk-tT-iSi"/>
-                                                    <constraint firstAttribute="trailing" secondItem="3be-99-g62" secondAttribute="trailing" id="ydq-F8-Wn1"/>
-                                                    <constraint firstItem="BtS-3D-CIU" firstAttribute="width" secondItem="5SZ-KU-Ynv" secondAttribute="width" id="yh3-jw-LHU"/>
+                                                    <constraint firstItem="BtS-3D-CIU" firstAttribute="width" secondItem="3be-99-g62" secondAttribute="width" id="uoX-on-LUd"/>
                                                 </constraints>
-                                            </view>
+                                            </stackView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
+                                                <rect key="frame" x="20" y="362" width="351" height="18"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                         </subviews>
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="5SZ-KU-Ynv" secondAttribute="trailing" id="Ew5-wQ-FxQ"/>
-                                            <constraint firstItem="5SZ-KU-Ynv" firstAttribute="leading" secondItem="ZWc-TJ-W9T" secondAttribute="leading" id="aOG-h6-gAw"/>
-                                            <constraint firstItem="3be-99-g62" firstAttribute="centerY" secondItem="ZWc-TJ-W9T" secondAttribute="centerY" id="kq2-hl-9vu"/>
-                                            <constraint firstItem="5SZ-KU-Ynv" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ZWc-TJ-W9T" secondAttribute="top" constant="20" id="zPw-QR-H0E"/>
+                                            <constraint firstItem="ZqY-I8-yWG" firstAttribute="top" secondItem="3be-99-g62" secondAttribute="bottom" constant="20" id="3ZX-0F-JMv"/>
+                                            <constraint firstItem="3be-99-g62" firstAttribute="leading" secondItem="ZWc-TJ-W9T" secondAttribute="leading" id="7nc-IA-WRQ"/>
+                                            <constraint firstAttribute="trailing" secondItem="3be-99-g62" secondAttribute="trailing" id="J3T-Wn-sCt"/>
+                                            <constraint firstAttribute="trailing" secondItem="bBi-2N-RAh" secondAttribute="trailing" constant="20" id="JR4-H1-jSu"/>
+                                            <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="width" secondItem="bBi-2N-RAh" secondAttribute="width" id="TEB-A9-Hw8"/>
+                                            <constraint firstItem="bBi-2N-RAh" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ZWc-TJ-W9T" secondAttribute="top" constant="20" id="UtP-9Q-0ZZ"/>
+                                            <constraint firstItem="3be-99-g62" firstAttribute="top" secondItem="bBi-2N-RAh" secondAttribute="bottom" constant="32" id="Vta-qL-UfT"/>
+                                            <constraint firstAttribute="trailing" secondItem="ZqY-I8-yWG" secondAttribute="trailing" constant="20" id="f3e-Y7-O2r"/>
+                                            <constraint firstItem="3be-99-g62" firstAttribute="centerY" secondItem="ZWc-TJ-W9T" secondAttribute="centerY" priority="900" id="g0V-37-vOa"/>
+                                            <constraint firstItem="ZqY-I8-yWG" firstAttribute="leading" secondItem="ZWc-TJ-W9T" secondAttribute="leading" constant="20" id="ugU-fq-Kc8"/>
+                                            <constraint firstItem="bBi-2N-RAh" firstAttribute="leading" secondItem="ZWc-TJ-W9T" secondAttribute="leading" constant="20" id="xca-YW-pid"/>
                                         </constraints>
                                     </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nNi-en-Ou0">
-                                        <rect key="frame" x="0.0" y="548" width="391" height="64"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ilv-iW-HgP">
+                                        <rect key="frame" x="20" y="548" width="351" height="44"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ilv-iW-HgP">
-                                                <rect key="frame" x="20" y="0.0" width="351" height="44"/>
-                                                <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0P1-6g-BI3">
-                                                        <rect key="frame" x="0.0" y="7" width="141" height="30"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <state key="normal" title="Lost your password?">
-                                                            <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="handleForgotPasswordButtonTapped:" destination="lmD-c6-SLs" eventType="touchUpInside" id="q8s-z9-VIK"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E3x-LN-sUk" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="300" y="0.0" width="51" height="44"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="44" id="H3A-PM-OJr"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <state key="normal" title="SIGN IN">
-                                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </state>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="handleSubmitButtonTapped:" destination="lmD-c6-SLs" eventType="touchUpInside" id="hX6-w6-i2P"/>
-                                                        </connections>
-                                                    </button>
-                                                </subviews>
-                                            </stackView>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0P1-6g-BI3">
+                                                <rect key="frame" x="0.0" y="7" width="141" height="30"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <state key="normal" title="Lost your password?">
+                                                    <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="handleForgotPasswordButtonTapped:" destination="lmD-c6-SLs" eventType="touchUpInside" id="q8s-z9-VIK"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E3x-LN-sUk" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="300" y="0.0" width="51" height="44"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="44" id="H3A-PM-OJr"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <state key="normal" title="SIGN IN">
+                                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleSubmitButtonTapped:" destination="lmD-c6-SLs" eventType="touchUpInside" id="hX6-w6-i2P"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
-                                        <constraints>
-                                            <constraint firstItem="ilv-iW-HgP" firstAttribute="leading" secondItem="nNi-en-Ou0" secondAttribute="leading" constant="20" id="6wo-mO-YhL"/>
-                                            <constraint firstItem="ilv-iW-HgP" firstAttribute="top" secondItem="nNi-en-Ou0" secondAttribute="top" id="KgI-bu-hJ4"/>
-                                            <constraint firstAttribute="bottom" secondItem="ilv-iW-HgP" secondAttribute="bottom" constant="20" id="fJe-nZ-WbT"/>
-                                            <constraint firstAttribute="trailing" secondItem="ilv-iW-HgP" secondAttribute="trailing" constant="20" id="qyx-Z0-cuI"/>
-                                        </constraints>
-                                    </view>
+                                    </stackView>
                                 </subviews>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
+                                    <constraint firstItem="ilv-iW-HgP" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" constant="20" id="0Zk-0j-bUt"/>
+                                    <constraint firstAttribute="bottom" secondItem="ilv-iW-HgP" secondAttribute="bottom" constant="20" id="8xQ-I1-LZB"/>
                                     <constraint firstItem="ZWc-TJ-W9T" firstAttribute="top" secondItem="7OQ-0t-1zq" secondAttribute="top" id="Auv-Qn-vWa"/>
-                                    <constraint firstItem="nNi-en-Ou0" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" id="EOB-fH-k6I"/>
                                     <constraint firstItem="ZWc-TJ-W9T" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" id="Osp-Ar-qix"/>
-                                    <constraint firstAttribute="bottom" secondItem="nNi-en-Ou0" secondAttribute="bottom" id="Ugi-9r-MdP"/>
                                     <constraint firstAttribute="width" constant="383" id="VgM-uK-kk3"/>
-                                    <constraint firstAttribute="trailing" secondItem="nNi-en-Ou0" secondAttribute="trailing" id="fUL-dk-71l"/>
                                     <constraint firstAttribute="trailing" secondItem="ZWc-TJ-W9T" secondAttribute="trailing" id="p8c-n5-W3X"/>
+                                    <constraint firstAttribute="trailing" secondItem="ilv-iW-HgP" secondAttribute="trailing" constant="20" id="sLX-Xa-ldK"/>
                                     <constraint firstAttribute="bottom" secondItem="ZWc-TJ-W9T" secondAttribute="bottom" id="sSC-44-fTn"/>
                                 </constraints>
                                 <variation key="default">
@@ -957,72 +890,60 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DHF-bN-so0">
                                         <rect key="frame" x="0.0" y="0.0" width="383" height="612"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="L68-uO-e3A">
-                                                <rect key="frame" x="0.0" y="246" width="383" height="102"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Almost there" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h0i-9g-1E6">
-                                                        <rect key="frame" x="20" y="0.0" width="343" height="18"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Verification Code" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="A2K-lq-6XM" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="38" width="383" height="44"/>
-                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="Verification Code"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="320" id="Qxo-90-2Bb"/>
-                                                            <constraint firstAttribute="height" constant="44" id="k3e-tQ-PD7"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="NO"/>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <variation key="default">
-                                                            <mask key="constraints">
-                                                                <exclude reference="Qxo-90-2Bb"/>
-                                                            </mask>
-                                                        </variation>
-                                                        <variation key="heightClass=regular-widthClass=regular">
-                                                            <mask key="constraints">
-                                                                <include reference="Qxo-90-2Bb"/>
-                                                            </mask>
-                                                        </variation>
-                                                        <connections>
-                                                            <action selector="handleSubmitForm" destination="bAd-Df-IzS" eventType="primaryActionTriggered" id="2LU-aF-Jpd"/>
-                                                            <action selector="handleTextFieldDidChange:" destination="bAd-Df-IzS" eventType="editingChanged" id="Jxf-Ep-cSb"/>
-                                                            <outlet property="delegate" destination="bAd-Df-IzS" id="Bgq-yf-mas"/>
-                                                        </connections>
-                                                    </textField>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zhF-jf-Wcv">
-                                                        <rect key="frame" x="20" y="102" width="343" height="0.0"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" red="0.85098039215686272" green="0.30980392156862746" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Almost there" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h0i-9g-1E6">
+                                                <rect key="frame" x="20" y="246" width="343" height="18"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Verification Code" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="A2K-lq-6XM" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="284" width="383" height="44"/>
+                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="Verification Code"/>
                                                 <constraints>
-                                                    <constraint firstItem="h0i-9g-1E6" firstAttribute="leading" secondItem="L68-uO-e3A" secondAttribute="leading" constant="20" id="2Ky-91-95A"/>
-                                                    <constraint firstAttribute="bottom" secondItem="zhF-jf-Wcv" secondAttribute="bottom" id="DXx-CY-mSW"/>
-                                                    <constraint firstItem="A2K-lq-6XM" firstAttribute="leading" secondItem="L68-uO-e3A" secondAttribute="leading" id="E9j-hr-Wx1"/>
-                                                    <constraint firstItem="zhF-jf-Wcv" firstAttribute="top" secondItem="A2K-lq-6XM" secondAttribute="bottom" constant="20" id="GOz-e7-KSV"/>
-                                                    <constraint firstItem="h0i-9g-1E6" firstAttribute="top" secondItem="L68-uO-e3A" secondAttribute="top" id="KGz-1U-C6c"/>
-                                                    <constraint firstAttribute="trailing" secondItem="h0i-9g-1E6" secondAttribute="trailing" constant="20" id="WQ1-kM-YUc"/>
-                                                    <constraint firstAttribute="trailing" secondItem="A2K-lq-6XM" secondAttribute="trailing" id="Wm5-NI-VWk"/>
-                                                    <constraint firstItem="zhF-jf-Wcv" firstAttribute="leading" secondItem="L68-uO-e3A" secondAttribute="leading" constant="20" id="YeU-2C-adU"/>
-                                                    <constraint firstItem="A2K-lq-6XM" firstAttribute="top" secondItem="h0i-9g-1E6" secondAttribute="bottom" constant="20" id="i3k-6b-Ny2"/>
-                                                    <constraint firstAttribute="trailing" secondItem="zhF-jf-Wcv" secondAttribute="trailing" constant="20" id="nIE-8o-10y"/>
+                                                    <constraint firstAttribute="width" constant="320" id="Qxo-90-2Bb"/>
+                                                    <constraint firstAttribute="height" constant="44" id="k3e-tQ-PD7"/>
                                                 </constraints>
-                                            </view>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="NO"/>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <variation key="default">
+                                                    <mask key="constraints">
+                                                        <exclude reference="Qxo-90-2Bb"/>
+                                                    </mask>
+                                                </variation>
+                                                <variation key="heightClass=regular-widthClass=regular">
+                                                    <mask key="constraints">
+                                                        <include reference="Qxo-90-2Bb"/>
+                                                    </mask>
+                                                </variation>
+                                                <connections>
+                                                    <action selector="handleSubmitForm" destination="bAd-Df-IzS" eventType="primaryActionTriggered" id="2LU-aF-Jpd"/>
+                                                    <action selector="handleTextFieldDidChange:" destination="bAd-Df-IzS" eventType="editingChanged" id="Jxf-Ep-cSb"/>
+                                                    <outlet property="delegate" destination="bAd-Df-IzS" id="Bgq-yf-mas"/>
+                                                </connections>
+                                            </textField>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zhF-jf-Wcv">
+                                                <rect key="frame" x="20" y="348" width="343" height="0.0"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <color key="textColor" red="0.85098039215686272" green="0.30980392156862746" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstItem="A2K-lq-6XM" firstAttribute="centerY" secondItem="DHF-bN-so0" secondAttribute="centerY" priority="900" id="G4Z-Cy-WcX"/>
-                                            <constraint firstAttribute="trailing" secondItem="L68-uO-e3A" secondAttribute="trailing" id="Hff-vH-oD1"/>
-                                            <constraint firstItem="L68-uO-e3A" firstAttribute="leading" secondItem="DHF-bN-so0" secondAttribute="leading" id="OWq-rf-Ju0"/>
-                                            <constraint firstItem="L68-uO-e3A" firstAttribute="top" relation="greaterThanOrEqual" secondItem="DHF-bN-so0" secondAttribute="top" constant="20" id="ck3-pw-4E8"/>
+                                            <constraint firstItem="h0i-9g-1E6" firstAttribute="top" relation="greaterThanOrEqual" secondItem="DHF-bN-so0" secondAttribute="top" constant="20" id="8th-8P-oNw"/>
+                                            <constraint firstItem="h0i-9g-1E6" firstAttribute="leading" secondItem="DHF-bN-so0" secondAttribute="leading" constant="20" id="Aup-2U-fpb"/>
+                                            <constraint firstAttribute="trailing" secondItem="h0i-9g-1E6" secondAttribute="trailing" constant="20" id="BoT-2y-HxB"/>
+                                            <constraint firstItem="A2K-lq-6XM" firstAttribute="leading" secondItem="DHF-bN-so0" secondAttribute="leading" id="Vea-2w-ZPx"/>
+                                            <constraint firstItem="A2K-lq-6XM" firstAttribute="centerY" secondItem="DHF-bN-so0" secondAttribute="centerY" priority="900" id="eUR-3k-wkg"/>
+                                            <constraint firstAttribute="trailing" secondItem="A2K-lq-6XM" secondAttribute="trailing" id="frc-ct-lX1"/>
+                                            <constraint firstAttribute="trailing" secondItem="zhF-jf-Wcv" secondAttribute="trailing" constant="20" id="g0T-RU-xg3"/>
+                                            <constraint firstItem="zhF-jf-Wcv" firstAttribute="top" secondItem="A2K-lq-6XM" secondAttribute="bottom" constant="20" id="pch-pX-ZHu"/>
+                                            <constraint firstItem="zhF-jf-Wcv" firstAttribute="leading" secondItem="DHF-bN-so0" secondAttribute="leading" constant="20" id="w65-Uk-ab5"/>
+                                            <constraint firstItem="A2K-lq-6XM" firstAttribute="top" secondItem="h0i-9g-1E6" secondAttribute="bottom" constant="20" id="ycZ-Hd-5Z2"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="bottom" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="x1G-Lf-mra">
@@ -1687,120 +1608,96 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PIc-wF-cQF">
                                         <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
                                         <subviews>
-                                            <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="a1t-zo-d5c">
-                                                <rect key="frame" x="0.0" y="194" width="391" height="122"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Enter the address of the WordPress site you'd like to connect." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-bF-n1P">
-                                                        <rect key="frame" x="20" y="0.0" width="351" height="38"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="example.wordpress.com" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZrT-CY-qD7" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="58" width="391" height="44"/>
-                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="A6G-yu-Aix"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="URL" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-url-field"/>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="handleSubmitForm" destination="anK-hg-K4j" eventType="primaryActionTriggered" id="9op-PL-dLy"/>
-                                                            <action selector="handleTextFieldDidChange:" destination="anK-hg-K4j" eventType="editingChanged" id="HdI-gj-hRv"/>
-                                                            <action selector="handleTextFieldDidChange:" destination="anK-hg-K4j" eventType="editingDidBegin" id="o3I-NR-Vk3"/>
-                                                            <outlet property="delegate" destination="anK-hg-K4j" id="LHf-xJ-KYE"/>
-                                                        </connections>
-                                                    </textField>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Up-9bc">
-                                                        <rect key="frame" x="20" y="122" width="351" height="0.0"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Enter the address of the WordPress site you'd like to connect." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-bF-n1P">
+                                                <rect key="frame" x="20" y="194" width="351" height="38"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="example.wordpress.com" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZrT-CY-qD7" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="252" width="391" height="44"/>
+                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="trailing" secondItem="SIW-Up-9bc" secondAttribute="trailing" constant="20" id="0Pd-gX-fOG"/>
-                                                    <constraint firstAttribute="trailing" secondItem="eFO-bF-n1P" secondAttribute="trailing" constant="20" id="0e8-ji-uHd"/>
-                                                    <constraint firstItem="SIW-Up-9bc" firstAttribute="leading" secondItem="a1t-zo-d5c" secondAttribute="leading" constant="20" id="33t-k3-3mR"/>
-                                                    <constraint firstItem="eFO-bF-n1P" firstAttribute="leading" secondItem="a1t-zo-d5c" secondAttribute="leading" constant="20" id="47h-v5-Mfv"/>
-                                                    <constraint firstItem="ZrT-CY-qD7" firstAttribute="leading" secondItem="a1t-zo-d5c" secondAttribute="leading" id="Be0-6x-vDK"/>
-                                                    <constraint firstItem="SIW-Up-9bc" firstAttribute="top" secondItem="ZrT-CY-qD7" secondAttribute="bottom" constant="20" id="HJf-Tb-1D8"/>
-                                                    <constraint firstAttribute="bottom" secondItem="SIW-Up-9bc" secondAttribute="bottom" id="StL-Lq-cRW"/>
-                                                    <constraint firstItem="ZrT-CY-qD7" firstAttribute="top" secondItem="eFO-bF-n1P" secondAttribute="bottom" constant="20" id="aLY-gB-aNq"/>
-                                                    <constraint firstItem="eFO-bF-n1P" firstAttribute="top" secondItem="a1t-zo-d5c" secondAttribute="top" id="fOJ-sm-UN0"/>
-                                                    <constraint firstAttribute="trailing" secondItem="ZrT-CY-qD7" secondAttribute="trailing" id="xKB-6s-tY8"/>
+                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="A6G-yu-Aix"/>
                                                 </constraints>
-                                            </view>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="URL" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-url-field"/>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleSubmitForm" destination="anK-hg-K4j" eventType="primaryActionTriggered" id="9op-PL-dLy"/>
+                                                    <action selector="handleTextFieldDidChange:" destination="anK-hg-K4j" eventType="editingChanged" id="HdI-gj-hRv"/>
+                                                    <action selector="handleTextFieldDidChange:" destination="anK-hg-K4j" eventType="editingDidBegin" id="o3I-NR-Vk3"/>
+                                                    <outlet property="delegate" destination="anK-hg-K4j" id="LHf-xJ-KYE"/>
+                                                </connections>
+                                            </textField>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Up-9bc">
+                                                <rect key="frame" x="20" y="316" width="351" height="0.0"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="a1t-zo-d5c" secondAttribute="trailing" id="1PY-Jw-P0J"/>
-                                            <constraint firstItem="ZrT-CY-qD7" firstAttribute="centerY" secondItem="PIc-wF-cQF" secondAttribute="centerY" priority="900" id="9ZA-SI-QXw"/>
-                                            <constraint firstItem="a1t-zo-d5c" firstAttribute="top" relation="greaterThanOrEqual" secondItem="PIc-wF-cQF" secondAttribute="top" constant="20" id="BA4-eI-gjp"/>
-                                            <constraint firstItem="a1t-zo-d5c" firstAttribute="leading" secondItem="PIc-wF-cQF" secondAttribute="leading" id="Gsg-hb-SON"/>
+                                            <constraint firstItem="SIW-Up-9bc" firstAttribute="leading" secondItem="PIc-wF-cQF" secondAttribute="leading" constant="20" id="0tS-1w-zS9"/>
+                                            <constraint firstAttribute="trailing" secondItem="SIW-Up-9bc" secondAttribute="trailing" constant="20" id="5NZ-US-fyT"/>
+                                            <constraint firstItem="SIW-Up-9bc" firstAttribute="top" secondItem="ZrT-CY-qD7" secondAttribute="bottom" constant="20" id="CaE-Bk-bQW"/>
+                                            <constraint firstItem="ZrT-CY-qD7" firstAttribute="leading" secondItem="PIc-wF-cQF" secondAttribute="leading" id="HJe-BW-8s9"/>
+                                            <constraint firstItem="eFO-bF-n1P" firstAttribute="top" relation="greaterThanOrEqual" secondItem="PIc-wF-cQF" secondAttribute="top" constant="20" id="JPa-oE-J0z"/>
+                                            <constraint firstItem="ZrT-CY-qD7" firstAttribute="top" secondItem="eFO-bF-n1P" secondAttribute="bottom" constant="20" id="PCW-0h-eOf"/>
+                                            <constraint firstAttribute="trailing" secondItem="eFO-bF-n1P" secondAttribute="trailing" constant="20" id="VZw-e6-4cN"/>
+                                            <constraint firstItem="ZrT-CY-qD7" firstAttribute="centerY" secondItem="PIc-wF-cQF" secondAttribute="centerY" priority="900" id="eTI-5L-VeE"/>
+                                            <constraint firstItem="eFO-bF-n1P" firstAttribute="leading" secondItem="PIc-wF-cQF" secondAttribute="leading" constant="20" id="ffC-rd-dHn"/>
+                                            <constraint firstAttribute="trailing" secondItem="ZrT-CY-qD7" secondAttribute="trailing" id="vOF-yi-MPL"/>
                                         </constraints>
                                     </view>
-                                    <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="GKU-9C-CUT" userLabel="Footer">
-                                        <rect key="frame" x="0.0" y="548" width="391" height="64"/>
+                                    <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mlx-XY-MGX">
+                                        <rect key="frame" x="20" y="548" width="351" height="44"/>
                                         <subviews>
-                                            <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mlx-XY-MGX">
-                                                <rect key="frame" x="20" y="0.0" width="351" height="44"/>
-                                                <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="roL-ID-k8n">
-                                                        <rect key="frame" x="0.0" y="7" width="250" height="30"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <state key="normal" title="Need help finding your site address?">
-                                                            <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="handleSiteAddressHelpButtonTapped:" destination="anK-hg-K4j" eventType="touchUpInside" id="PXe-Yc-xaK"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ltO-hW-mbe" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="315" y="0.0" width="36" height="44"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="44" id="6c7-EA-1KF"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <state key="normal" title="Next">
-                                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </state>
-                                                        <userDefinedRuntimeAttributes>
-                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                                        </userDefinedRuntimeAttributes>
-                                                        <connections>
-                                                            <action selector="handleSubmitButtonTapped:" destination="anK-hg-K4j" eventType="touchUpInside" id="FmW-Ni-UiM"/>
-                                                        </connections>
-                                                    </button>
-                                                </subviews>
-                                                <color key="backgroundColor" red="0.02390592004" green="1" blue="0.002390008849" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                            </stackView>
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="roL-ID-k8n">
+                                                <rect key="frame" x="0.0" y="7" width="250" height="30"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <state key="normal" title="Need help finding your site address?">
+                                                    <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="handleSiteAddressHelpButtonTapped:" destination="anK-hg-K4j" eventType="touchUpInside" id="PXe-Yc-xaK"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ltO-hW-mbe" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="315" y="0.0" width="36" height="44"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="44" id="6c7-EA-1KF"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <state key="normal" title="Next">
+                                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="handleSubmitButtonTapped:" destination="anK-hg-K4j" eventType="touchUpInside" id="FmW-Ni-UiM"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="mlx-XY-MGX" secondAttribute="trailing" constant="20" id="6vA-Fm-FcB"/>
-                                            <constraint firstAttribute="bottom" secondItem="mlx-XY-MGX" secondAttribute="bottom" constant="20" id="6vW-rA-zhE"/>
-                                            <constraint firstItem="mlx-XY-MGX" firstAttribute="top" secondItem="GKU-9C-CUT" secondAttribute="top" id="E10-UM-cwY"/>
-                                            <constraint firstItem="mlx-XY-MGX" firstAttribute="leading" secondItem="GKU-9C-CUT" secondAttribute="leading" constant="20" id="OCg-Cl-3x5"/>
-                                        </constraints>
-                                    </view>
+                                        <color key="backgroundColor" red="0.02390592004" green="1" blue="0.002390008849" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                    </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="GKU-9C-CUT" firstAttribute="leading" secondItem="a59-c7-WBk" secondAttribute="leading" id="5Jh-Zd-1Ks"/>
                                     <constraint firstAttribute="trailing" secondItem="PIc-wF-cQF" secondAttribute="trailing" id="77c-zg-8kc"/>
                                     <constraint firstItem="PIc-wF-cQF" firstAttribute="leading" secondItem="a59-c7-WBk" secondAttribute="leading" id="IvI-xu-FTq"/>
+                                    <constraint firstAttribute="bottom" secondItem="mlx-XY-MGX" secondAttribute="bottom" constant="20" id="KZS-hN-8sw"/>
                                     <constraint firstAttribute="width" constant="383" id="M81-Xp-Ndj"/>
+                                    <constraint firstItem="mlx-XY-MGX" firstAttribute="leading" secondItem="a59-c7-WBk" secondAttribute="leading" constant="20" id="NNf-uc-zgc"/>
                                     <constraint firstItem="PIc-wF-cQF" firstAttribute="top" secondItem="a59-c7-WBk" secondAttribute="top" id="cb9-Xe-IDv"/>
-                                    <constraint firstAttribute="bottom" secondItem="GKU-9C-CUT" secondAttribute="bottom" id="jkv-gL-LSx"/>
-                                    <constraint firstItem="GKU-9C-CUT" firstAttribute="top" secondItem="PIc-wF-cQF" secondAttribute="bottom" id="qPh-H7-G89"/>
-                                    <constraint firstAttribute="trailing" secondItem="GKU-9C-CUT" secondAttribute="trailing" id="zIX-Pb-Oxv"/>
+                                    <constraint firstAttribute="trailing" secondItem="mlx-XY-MGX" secondAttribute="trailing" constant="20" id="hAI-09-g1p"/>
+                                    <constraint firstItem="mlx-XY-MGX" firstAttribute="top" secondItem="PIc-wF-cQF" secondAttribute="bottom" id="pNr-TP-P4M"/>
                                 </constraints>
                                 <variation key="default">
                                     <mask key="constraints">
@@ -2170,8 +2067,8 @@
         <image name="login-magic-link" width="160" height="160"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="ySQ-EM-6JI"/>
+        <segue reference="0ao-yi-yZI"/>
         <segue reference="qLI-qX-rkG"/>
-        <segue reference="lIb-sw-yM7"/>
+        <segue reference="7lv-19-h36"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -945,84 +945,84 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hTY-xb-H5h">
-                                <rect key="frame" x="0.0" y="44" width="383" height="632"/>
+                                <rect key="frame" x="0.0" y="64" width="383" height="612"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L68-uO-e3A">
-                                        <rect key="frame" x="0.0" y="158" width="383" height="136"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DHF-bN-so0">
+                                        <rect key="frame" x="0.0" y="0.0" width="383" height="538"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Almost there" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h0i-9g-1E6">
-                                                <rect key="frame" x="20" y="34" width="343" height="18"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Verification Code" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="A2K-lq-6XM" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="72" width="383" height="44"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="Verification Code"/>
+                                            <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="L68-uO-e3A">
+                                                <rect key="frame" x="0.0" y="209" width="383" height="102"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Almost there" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h0i-9g-1E6">
+                                                        <rect key="frame" x="20" y="0.0" width="343" height="18"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Verification Code" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="A2K-lq-6XM" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="38" width="383" height="44"/>
+                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="Verification Code"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="320" id="Qxo-90-2Bb"/>
+                                                            <constraint firstAttribute="height" constant="44" id="k3e-tQ-PD7"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="NO"/>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <variation key="default">
+                                                            <mask key="constraints">
+                                                                <exclude reference="Qxo-90-2Bb"/>
+                                                            </mask>
+                                                        </variation>
+                                                        <variation key="heightClass=regular-widthClass=regular">
+                                                            <mask key="constraints">
+                                                                <include reference="Qxo-90-2Bb"/>
+                                                            </mask>
+                                                        </variation>
+                                                        <connections>
+                                                            <action selector="handleSubmitForm" destination="bAd-Df-IzS" eventType="primaryActionTriggered" id="2LU-aF-Jpd"/>
+                                                            <action selector="handleTextFieldDidChange:" destination="bAd-Df-IzS" eventType="editingChanged" id="Jxf-Ep-cSb"/>
+                                                            <outlet property="delegate" destination="bAd-Df-IzS" id="Bgq-yf-mas"/>
+                                                        </connections>
+                                                    </textField>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zhF-jf-Wcv">
+                                                        <rect key="frame" x="20" y="102" width="343" height="0.0"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" red="0.85098039215686272" green="0.30980392156862746" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="320" id="Qxo-90-2Bb"/>
-                                                    <constraint firstAttribute="height" constant="44" id="k3e-tQ-PD7"/>
+                                                    <constraint firstItem="h0i-9g-1E6" firstAttribute="leading" secondItem="L68-uO-e3A" secondAttribute="leading" constant="20" id="2Ky-91-95A"/>
+                                                    <constraint firstAttribute="bottom" secondItem="zhF-jf-Wcv" secondAttribute="bottom" id="DXx-CY-mSW"/>
+                                                    <constraint firstItem="A2K-lq-6XM" firstAttribute="leading" secondItem="L68-uO-e3A" secondAttribute="leading" id="E9j-hr-Wx1"/>
+                                                    <constraint firstItem="zhF-jf-Wcv" firstAttribute="top" secondItem="A2K-lq-6XM" secondAttribute="bottom" constant="20" id="GOz-e7-KSV"/>
+                                                    <constraint firstItem="h0i-9g-1E6" firstAttribute="top" secondItem="L68-uO-e3A" secondAttribute="top" id="KGz-1U-C6c"/>
+                                                    <constraint firstAttribute="trailing" secondItem="h0i-9g-1E6" secondAttribute="trailing" constant="20" id="WQ1-kM-YUc"/>
+                                                    <constraint firstAttribute="trailing" secondItem="A2K-lq-6XM" secondAttribute="trailing" id="Wm5-NI-VWk"/>
+                                                    <constraint firstItem="zhF-jf-Wcv" firstAttribute="leading" secondItem="L68-uO-e3A" secondAttribute="leading" constant="20" id="YeU-2C-adU"/>
+                                                    <constraint firstItem="A2K-lq-6XM" firstAttribute="top" secondItem="h0i-9g-1E6" secondAttribute="bottom" constant="20" id="i3k-6b-Ny2"/>
+                                                    <constraint firstAttribute="trailing" secondItem="zhF-jf-Wcv" secondAttribute="trailing" constant="20" id="nIE-8o-10y"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="numberPad" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="NO"/>
-                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                </userDefinedRuntimeAttributes>
-                                                <variation key="default">
-                                                    <mask key="constraints">
-                                                        <exclude reference="Qxo-90-2Bb"/>
-                                                    </mask>
-                                                </variation>
-                                                <variation key="heightClass=regular-widthClass=regular">
-                                                    <mask key="constraints">
-                                                        <include reference="Qxo-90-2Bb"/>
-                                                    </mask>
-                                                </variation>
-                                                <connections>
-                                                    <action selector="handleSubmitForm" destination="bAd-Df-IzS" eventType="primaryActionTriggered" id="2LU-aF-Jpd"/>
-                                                    <action selector="handleTextFieldDidChange:" destination="bAd-Df-IzS" eventType="editingChanged" id="Jxf-Ep-cSb"/>
-                                                    <outlet property="delegate" destination="bAd-Df-IzS" id="Bgq-yf-mas"/>
-                                                </connections>
-                                            </textField>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zhF-jf-Wcv">
-                                                <rect key="frame" x="20" y="136" width="343" height="0.0"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" red="0.85098039215686272" green="0.30980392156862746" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            </view>
                                         </subviews>
-                                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstItem="h0i-9g-1E6" firstAttribute="leading" secondItem="L68-uO-e3A" secondAttribute="leading" constant="20" id="2Ky-91-95A"/>
-                                            <constraint firstAttribute="bottom" secondItem="zhF-jf-Wcv" secondAttribute="bottom" id="DXx-CY-mSW"/>
-                                            <constraint firstItem="A2K-lq-6XM" firstAttribute="leading" secondItem="L68-uO-e3A" secondAttribute="leading" id="E9j-hr-Wx1"/>
-                                            <constraint firstItem="zhF-jf-Wcv" firstAttribute="top" secondItem="A2K-lq-6XM" secondAttribute="bottom" constant="20" id="GOz-e7-KSV"/>
-                                            <constraint firstItem="A2K-lq-6XM" firstAttribute="top" secondItem="L68-uO-e3A" secondAttribute="top" constant="72" id="H1D-YU-X3n"/>
-                                            <constraint firstAttribute="trailing" secondItem="h0i-9g-1E6" secondAttribute="trailing" constant="20" id="WQ1-kM-YUc"/>
-                                            <constraint firstAttribute="trailing" secondItem="A2K-lq-6XM" secondAttribute="trailing" id="Wm5-NI-VWk"/>
-                                            <constraint firstItem="zhF-jf-Wcv" firstAttribute="leading" secondItem="L68-uO-e3A" secondAttribute="leading" constant="20" id="YeU-2C-adU"/>
-                                            <constraint firstItem="A2K-lq-6XM" firstAttribute="top" secondItem="h0i-9g-1E6" secondAttribute="bottom" constant="20" id="i3k-6b-Ny2"/>
-                                            <constraint firstAttribute="width" constant="320" id="mig-hQ-ky8"/>
-                                            <constraint firstAttribute="trailing" secondItem="zhF-jf-Wcv" secondAttribute="trailing" constant="20" id="nIE-8o-10y"/>
+                                            <constraint firstItem="A2K-lq-6XM" firstAttribute="centerY" secondItem="DHF-bN-so0" secondAttribute="centerY" priority="900" id="G4Z-Cy-WcX"/>
+                                            <constraint firstAttribute="trailing" secondItem="L68-uO-e3A" secondAttribute="trailing" id="Hff-vH-oD1"/>
+                                            <constraint firstItem="L68-uO-e3A" firstAttribute="leading" secondItem="DHF-bN-so0" secondAttribute="leading" id="OWq-rf-Ju0"/>
+                                            <constraint firstItem="L68-uO-e3A" firstAttribute="top" relation="greaterThanOrEqual" secondItem="DHF-bN-so0" secondAttribute="top" constant="20" id="ck3-pw-4E8"/>
                                         </constraints>
-                                        <variation key="default">
-                                            <mask key="constraints">
-                                                <exclude reference="mig-hQ-ky8"/>
-                                            </mask>
-                                        </variation>
-                                        <variation key="heightClass=regular-widthClass=regular">
-                                            <mask key="constraints">
-                                                <include reference="mig-hQ-ky8"/>
-                                            </mask>
-                                        </variation>
                                     </view>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="x1G-Lf-mra">
-                                        <rect key="frame" x="20" y="568" width="343" height="44"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="bottom" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="x1G-Lf-mra">
+                                        <rect key="frame" x="20" y="548" width="343" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="309-z3-fPx">
-                                                <rect key="frame" x="0.0" y="0.0" width="293" height="44"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="115" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="fzI-rH-0f8"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="tFG-e2-XN2"/>
@@ -1058,32 +1058,19 @@
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="x1G-Lf-mra" secondAttribute="trailing" constant="20" id="37l-6r-mKG"/>
-                                    <constraint firstItem="L68-uO-e3A" firstAttribute="centerX" secondItem="hTY-xb-H5h" secondAttribute="centerX" id="5w6-D7-NpW"/>
-                                    <constraint firstAttribute="trailing" secondItem="L68-uO-e3A" secondAttribute="trailing" id="LlH-nI-0ys"/>
-                                    <constraint firstItem="L68-uO-e3A" firstAttribute="leading" secondItem="hTY-xb-H5h" secondAttribute="leading" id="PEJ-fI-cb6"/>
+                                    <constraint firstItem="DHF-bN-so0" firstAttribute="leading" secondItem="hTY-xb-H5h" secondAttribute="leading" id="3Og-Ew-r3y"/>
+                                    <constraint firstItem="DHF-bN-so0" firstAttribute="top" secondItem="hTY-xb-H5h" secondAttribute="top" id="9hm-xn-6lZ"/>
+                                    <constraint firstItem="x1G-Lf-mra" firstAttribute="top" secondItem="DHF-bN-so0" secondAttribute="bottom" constant="10" id="IsJ-Kk-Pdi"/>
                                     <constraint firstAttribute="bottom" secondItem="x1G-Lf-mra" secondAttribute="bottom" constant="20" id="XBv-Gg-JAY"/>
-                                    <constraint firstItem="A2K-lq-6XM" firstAttribute="centerY" secondItem="hTY-xb-H5h" secondAttribute="centerY" priority="900" constant="-64" id="cMC-S2-j55"/>
-                                    <constraint firstItem="L68-uO-e3A" firstAttribute="top" relation="greaterThanOrEqual" secondItem="hTY-xb-H5h" secondAttribute="top" id="uxt-ER-8Hi"/>
+                                    <constraint firstAttribute="trailing" secondItem="DHF-bN-so0" secondAttribute="trailing" id="pId-Zh-c89"/>
                                     <constraint firstItem="x1G-Lf-mra" firstAttribute="leading" secondItem="hTY-xb-H5h" secondAttribute="leading" constant="20" id="yEl-i3-fts"/>
                                 </constraints>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="5w6-D7-NpW"/>
-                                    </mask>
-                                </variation>
-                                <variation key="heightClass=regular-widthClass=regular">
-                                    <mask key="constraints">
-                                        <include reference="5w6-D7-NpW"/>
-                                        <exclude reference="LlH-nI-0ys"/>
-                                        <exclude reference="PEJ-fI-cb6"/>
-                                    </mask>
-                                </variation>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="hTY-xb-H5h" secondAttribute="trailing" id="23h-QU-eyB"/>
-                            <constraint firstItem="hTY-xb-H5h" firstAttribute="top" secondItem="959-UQ-1Jm" secondAttribute="bottom" constant="-20" id="lqc-JK-kaQ"/>
+                            <constraint firstItem="hTY-xb-H5h" firstAttribute="top" secondItem="959-UQ-1Jm" secondAttribute="bottom" id="lqc-JK-kaQ"/>
                             <constraint firstItem="hTY-xb-H5h" firstAttribute="leading" secondItem="cm5-76-st7" secondAttribute="leading" id="riV-3j-5QK"/>
                             <constraint firstItem="fG1-qw-2YS" firstAttribute="top" secondItem="hTY-xb-H5h" secondAttribute="bottom" id="tJ5-Do-kBC"/>
                         </constraints>
@@ -1095,7 +1082,6 @@
                         <outlet property="sendCodeButton" destination="309-z3-fPx" id="ML8-O4-ZZs"/>
                         <outlet property="submitButton" destination="6eO-V2-a64" id="O2y-fh-zZd"/>
                         <outlet property="verificationCodeField" destination="A2K-lq-6XM" id="U35-Ci-hs6"/>
-                        <outlet property="verticalCenterConstraint" destination="cMC-S2-j55" id="FMH-Ok-y2a"/>
                         <segue destination="Mwz-tq-5A8" kind="custom" identifier="showEpilogue" customClass="EpilogueSegue" customModule="WordPress" customModuleProvider="target" id="lIb-sw-yM7"/>
                     </connections>
                 </viewController>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -138,10 +138,10 @@
                                 <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
-                                        <rect key="frame" x="0.0" y="0.0" width="391" height="549"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="538"/>
                                         <subviews>
                                             <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Ff9-jl-eKh">
-                                                <rect key="frame" x="0.0" y="194.5" width="391" height="122"/>
+                                                <rect key="frame" x="0.0" y="189" width="391" height="122"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
                                                         <rect key="frame" x="20" y="0.0" width="351" height="38"/>
@@ -199,13 +199,13 @@
                                         </constraints>
                                     </view>
                                     <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="ecG-o1-wwE">
-                                        <rect key="frame" x="0.0" y="549" width="391" height="63"/>
+                                        <rect key="frame" x="0.0" y="538" width="391" height="74"/>
                                         <subviews>
                                             <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6i6-CG-3Tg">
-                                                <rect key="frame" x="20" y="10" width="351" height="33"/>
+                                                <rect key="frame" x="20" y="10" width="351" height="44"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Hn-ZK-h9k">
-                                                        <rect key="frame" x="0.0" y="1.5" width="307" height="30"/>
+                                                        <rect key="frame" x="0.0" y="7" width="307" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <state key="normal" title="Log into your site by entering your site address instead.">
@@ -216,8 +216,11 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="315" y="0.0" width="36" height="33"/>
+                                                        <rect key="frame" x="315" y="0.0" width="36" height="44"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="44" id="PgU-lW-anB"/>
+                                                        </constraints>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <state key="normal" title="Next">
                                                             <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -758,10 +761,10 @@
                                 <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="ZWc-TJ-W9T">
-                                        <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="538"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="5SZ-KU-Ynv">
-                                                <rect key="frame" x="0.0" y="143.5" width="391" height="190.5"/>
+                                                <rect key="frame" x="0.0" y="138.5" width="391" height="190.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="343" placeholderIntrinsicHeight="48" text="Enter the password for your WordPress.com account." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBi-2N-RAh">
                                                         <rect key="frame" x="20" y="0.0" width="351" height="48"/>
@@ -835,13 +838,13 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nNi-en-Ou0">
-                                        <rect key="frame" x="20" y="548" width="351" height="64"/>
+                                        <rect key="frame" x="20" y="538" width="351" height="74"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ilv-iW-HgP">
-                                                <rect key="frame" x="20" y="10" width="311" height="34"/>
+                                                <rect key="frame" x="20" y="10" width="311" height="44"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0P1-6g-BI3">
-                                                        <rect key="frame" x="0.0" y="3" width="125" height="28"/>
+                                                        <rect key="frame" x="0.0" y="8" width="125" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Lost your password?">
                                                             <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -851,10 +854,10 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E3x-LN-sUk" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="260" y="0.0" width="51" height="34"/>
+                                                        <rect key="frame" x="260" y="0.0" width="51" height="44"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="H3A-PM-OJr"/>
+                                                            <constraint firstAttribute="height" constant="44" id="H3A-PM-OJr"/>
                                                         </constraints>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <state key="normal" title="SIGN IN">
@@ -1036,10 +1039,9 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="250" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6eO-V2-a64" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="293" y="10" width="50" height="34"/>
+                                                <rect key="frame" x="296" y="0.0" width="47" height="44"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="aiy-Qn-dDm"/>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="eoc-KU-71N"/>
+                                                    <constraint firstAttribute="height" constant="44" id="eoc-KU-71N"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <state key="normal" title="VERIFY">
@@ -1137,17 +1139,17 @@
                         <viewControllerLayoutGuide type="top" id="Vw0-RX-ERM"/>
                         <viewControllerLayoutGuide type="bottom" id="pCc-dg-bxb"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="gJB-TV-Tpp">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="gJB-TV-Tpp">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Onf-X6-J5w">
+                            <containerView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Onf-X6-J5w">
                                 <rect key="frame" x="0.0" y="20" width="375" height="563"/>
                                 <connections>
                                     <segue destination="0GP-rM-Hvu" kind="embed" id="taY-7m-sQh"/>
                                 </connections>
                             </containerView>
-                            <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="juu-ng-v2N">
+                            <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="juu-ng-v2N">
                                 <rect key="frame" x="0.0" y="583" width="375" height="84"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jiQ-IN-bzh">
@@ -1212,13 +1214,13 @@
         <scene sceneID="YcQ-wo-pmy">
             <objects>
                 <tableViewController id="0GP-rM-Hvu" customClass="LoginEpilogueTableView" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="154" sectionHeaderHeight="28" sectionFooterHeight="28" id="TzF-S4-1lW">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="154" sectionHeaderHeight="28" sectionFooterHeight="28" id="TzF-S4-1lW">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="563"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.95294117647058818" green="0.96470588235294119" blue="0.97254901960784312" alpha="1" colorSpace="calibratedRGB"/>
                         <inset key="separatorInset" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="userInfo" rowHeight="148" id="rFk-m6-PzB" customClass="LoginEpilogueUserInfoCell" customModule="WordPress" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="userInfo" rowHeight="148" id="rFk-m6-PzB" customClass="LoginEpilogueUserInfoCell" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="375" height="148"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rFk-m6-PzB" id="Be1-mM-Agr">
@@ -1300,7 +1302,7 @@
                                     <outlet property="usernameLabel" destination="ONy-ZJ-GTI" id="Gv8-6L-ylR"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlogCell" rowHeight="52" id="Efm-ja-Y8C" customClass="LoginEpilogueBlogCell" customModule="WordPress" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlogCell" rowHeight="52" id="Efm-ja-Y8C" customClass="LoginEpilogueBlogCell" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="176" width="375" height="52"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Efm-ja-Y8C" id="Xid-Yh-Kpa">
@@ -1671,10 +1673,10 @@
                                 <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PIc-wF-cQF">
-                                        <rect key="frame" x="0.0" y="0.0" width="391" height="549"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="538"/>
                                         <subviews>
                                             <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="a1t-zo-d5c">
-                                                <rect key="frame" x="0.0" y="194.5" width="391" height="122"/>
+                                                <rect key="frame" x="0.0" y="189" width="391" height="122"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Enter the address of the WordPress site you'd like to connect." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eFO-bF-n1P">
                                                         <rect key="frame" x="20" y="0.0" width="351" height="38"/>
@@ -1732,13 +1734,13 @@
                                         </constraints>
                                     </view>
                                     <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="GKU-9C-CUT" userLabel="Footer">
-                                        <rect key="frame" x="0.0" y="549" width="391" height="63"/>
+                                        <rect key="frame" x="0.0" y="538" width="391" height="74"/>
                                         <subviews>
                                             <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mlx-XY-MGX">
-                                                <rect key="frame" x="20" y="10" width="351" height="33"/>
+                                                <rect key="frame" x="20" y="10" width="351" height="44"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="roL-ID-k8n">
-                                                        <rect key="frame" x="0.0" y="1.5" width="250" height="30"/>
+                                                        <rect key="frame" x="0.0" y="7" width="250" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <state key="normal" title="Need help finding your site address?">
@@ -1749,8 +1751,11 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ltO-hW-mbe" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="315" y="0.0" width="36" height="33"/>
+                                                        <rect key="frame" x="315" y="0.0" width="36" height="44"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="44" id="6c7-EA-1KF"/>
+                                                        </constraints>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <state key="normal" title="Next">
                                                             <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2153,7 +2158,7 @@
         <image name="login-magic-link" width="160" height="160"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="Jfl-Zm-PRR"/>
+        <segue reference="ySQ-EM-6JI"/>
         <segue reference="fWM-mD-lXg"/>
         <segue reference="lIb-sw-yM7"/>
     </inferredMetricsTieBreakers>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -110,7 +110,7 @@
         <scene sceneID="1BJ-CW-C88">
             <objects>
                 <navigationController id="Ck1-vY-O11" customClass="LoginNavigationController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="mKb-UO-KoA">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="mKb-UO-KoA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -1478,48 +1478,24 @@
                         <rect key="frame" x="0.0" y="0.0" width="383" height="676"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B6x-b7-hU9">
-                                <rect key="frame" x="105.5" y="632" width="172" height="28"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                <state key="normal" title="Enter your password instead">
-                                    <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="handleUsePasswordTapped:" destination="Kvo-Y2-yhG" eventType="touchUpInside" id="T8m-o8-zic"/>
-                                    <segue destination="lmD-c6-SLs" kind="show" id="0ao-yi-yZI"/>
-                                </connections>
-                            </button>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Mq6-n0-6iO">
-                                <rect key="frame" x="20" y="189" width="343" height="258.5"/>
+                                <rect key="frame" x="-4" y="189" width="391" height="258.5"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ukv-qo-ql4" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="121.5" y="0.0" width="100" height="100"/>
+                                        <rect key="frame" x="145.5" y="0.0" width="100" height="100"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="100" id="3wv-b7-gzu"/>
                                             <constraint firstAttribute="height" constant="100" id="aMT-Sa-KA3"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CmN-ir-1YK">
-                                        <rect key="frame" x="0.0" y="130" width="343" height="64.5"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="320" id="cYD-Pv-crb"/>
-                                        </constraints>
+                                        <rect key="frame" x="0.0" y="130" width="391" height="64.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
-                                        <variation key="default">
-                                            <mask key="constraints">
-                                                <exclude reference="cYD-Pv-crb"/>
-                                            </mask>
-                                        </variation>
-                                        <variation key="heightClass=regular-widthClass=regular">
-                                            <mask key="constraints">
-                                                <include reference="cYD-Pv-crb"/>
-                                            </mask>
-                                        </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iIy-Sm-1r0" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="135.5" y="224.5" width="72" height="34"/>
+                                        <rect key="frame" x="159.5" y="224.5" width="72" height="34"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="GRI-y6-q3i"/>
                                         </constraints>
@@ -1537,17 +1513,46 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="CmN-ir-1YK" firstAttribute="width" secondItem="Mq6-n0-6iO" secondAttribute="width" id="Lcr-XS-PSo"/>
+                                    <constraint firstAttribute="width" constant="383" id="mgH-Q8-cJr"/>
                                 </constraints>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="mgH-Q8-cJr"/>
+                                    </mask>
+                                </variation>
+                                <variation key="heightClass=regular-widthClass=regular">
+                                    <mask key="constraints">
+                                        <include reference="mgH-Q8-cJr"/>
+                                    </mask>
+                                </variation>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B6x-b7-hU9">
+                                <rect key="frame" x="105.5" y="628" width="172" height="28"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <state key="normal" title="Enter your password instead">
+                                    <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="handleUsePasswordTapped:" destination="Kvo-Y2-yhG" eventType="touchUpInside" id="T8m-o8-zic"/>
+                                    <segue destination="lmD-c6-SLs" kind="show" id="0ao-yi-yZI"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="Mq6-n0-6iO" secondAttribute="trailing" constant="20" id="CoO-Ax-hqg"/>
-                            <constraint firstItem="h4a-j8-84P" firstAttribute="top" secondItem="B6x-b7-hU9" secondAttribute="bottom" priority="900" constant="16" id="asJ-6Y-anx"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="Mq6-n0-6iO" secondAttribute="trailing" constant="-20" id="CoO-Ax-hqg"/>
+                            <constraint firstItem="Mq6-n0-6iO" firstAttribute="centerX" secondItem="HnR-5a-suO" secondAttribute="centerX" id="H21-tP-R9E"/>
+                            <constraint firstItem="h4a-j8-84P" firstAttribute="top" secondItem="B6x-b7-hU9" secondAttribute="bottom" priority="900" constant="20" id="asJ-6Y-anx"/>
                             <constraint firstItem="Mq6-n0-6iO" firstAttribute="centerY" secondItem="HnR-5a-suO" secondAttribute="centerY" constant="-20" id="gQ3-og-ak7"/>
                             <constraint firstItem="B6x-b7-hU9" firstAttribute="centerX" secondItem="HnR-5a-suO" secondAttribute="centerX" id="iMu-uo-e9U"/>
-                            <constraint firstItem="Mq6-n0-6iO" firstAttribute="leading" secondItem="HnR-5a-suO" secondAttribute="leading" constant="20" id="rtb-lw-VMZ"/>
+                            <constraint firstItem="Mq6-n0-6iO" firstAttribute="leading" secondItem="HnR-5a-suO" secondAttribute="leadingMargin" constant="-20" id="rtb-lw-VMZ"/>
                         </constraints>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <exclude reference="CoO-Ax-hqg"/>
+                                <exclude reference="rtb-lw-VMZ"/>
+                            </mask>
+                        </variation>
                     </view>
                     <connections>
                         <outlet property="gravatarView" destination="Ukv-qo-ql4" id="8BJ-j2-Ci2"/>
@@ -2149,7 +2154,7 @@
         <image name="login-magic-link" width="160" height="160"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="ySQ-EM-6JI"/>
+        <segue reference="0ao-yi-yZI"/>
         <segue reference="fWM-mD-lXg"/>
         <segue reference="fA5-mb-vrv"/>
     </inferredMetricsTieBreakers>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -110,7 +110,7 @@
         <scene sceneID="1BJ-CW-C88">
             <objects>
                 <navigationController id="Ck1-vY-O11" customClass="LoginNavigationController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="mKb-UO-KoA">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="mKb-UO-KoA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -752,34 +752,94 @@
                         <rect key="frame" x="0.0" y="0.0" width="383" height="676"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7OQ-0t-1zq" userLabel="Wrapper View">
-                                <rect key="frame" x="0.0" y="44" width="383" height="632"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7OQ-0t-1zq">
+                                <rect key="frame" x="-4" y="64" width="391" height="612"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZWc-TJ-W9T" userLabel="Login Form Holder View">
-                                        <rect key="frame" x="0.0" y="0.0" width="383" height="426.5"/>
+                                    <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="ZWc-TJ-W9T">
+                                        <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="5SZ-KU-Ynv">
+                                                <rect key="frame" x="0.0" y="143.5" width="391" height="190.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="343" placeholderIntrinsicHeight="48" text="Enter the password for your WordPress.com account." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBi-2N-RAh">
+                                                        <rect key="frame" x="20" y="0.0" width="351" height="48"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xgi-ZQ-8YL">
+                                                        <rect key="frame" x="20" y="68" width="351" height="20.5"/>
+                                                        <subviews>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="icon-username-field" translatesAutoresizingMaskIntoConstraints="NO" id="e88-X2-Rh2">
+                                                                <rect key="frame" x="0.0" y="1.5" width="18" height="18"/>
+                                                            </imageView>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="avo-E8-mvG">
+                                                                <rect key="frame" x="28" y="0.0" width="323" height="20.5"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                                <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="108.5" width="391" height="44"/>
+                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="Mzl-m2-DZ7"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
+                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="handleTextFieldDidChange:" destination="lmD-c6-SLs" eventType="editingChanged" id="TIx-xK-PLT"/>
+                                                            <outlet property="delegate" destination="lmD-c6-SLs" id="8se-wA-BuN"/>
+                                                        </connections>
+                                                    </textField>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
+                                                        <rect key="frame" x="20" y="172.5" width="351" height="18"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="BtS-3D-CIU" firstAttribute="top" secondItem="Xgi-ZQ-8YL" secondAttribute="bottom" constant="20" id="8nF-H3-80k"/>
+                                                    <constraint firstAttribute="bottom" secondItem="ZqY-I8-yWG" secondAttribute="bottom" id="E59-0T-vN0"/>
+                                                    <constraint firstItem="bBi-2N-RAh" firstAttribute="top" secondItem="5SZ-KU-Ynv" secondAttribute="top" id="EHy-LX-CBy"/>
+                                                    <constraint firstItem="BtS-3D-CIU" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" id="Giu-bS-8c8"/>
+                                                    <constraint firstAttribute="trailing" secondItem="bBi-2N-RAh" secondAttribute="trailing" constant="20" id="I5y-9X-RL3"/>
+                                                    <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="top" secondItem="bBi-2N-RAh" secondAttribute="bottom" constant="20" id="PE2-OG-pet"/>
+                                                    <constraint firstAttribute="trailing" secondItem="ZqY-I8-yWG" secondAttribute="trailing" constant="20" id="TVX-LB-4r2"/>
+                                                    <constraint firstItem="ZqY-I8-yWG" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" constant="20" id="Tsh-Is-9Js"/>
+                                                    <constraint firstItem="ZqY-I8-yWG" firstAttribute="top" secondItem="BtS-3D-CIU" secondAttribute="bottom" constant="20" id="Wgp-cW-ayk"/>
+                                                    <constraint firstItem="bBi-2N-RAh" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" constant="20" id="ZlZ-A4-QRe"/>
+                                                    <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" constant="20" id="a3S-8S-rbw"/>
+                                                    <constraint firstAttribute="trailing" secondItem="Xgi-ZQ-8YL" secondAttribute="trailing" constant="20" id="rlz-ah-HUI"/>
+                                                    <constraint firstAttribute="trailing" secondItem="BtS-3D-CIU" secondAttribute="trailing" id="xsm-nd-1Vw"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="320" id="8EH-3z-HFm"/>
+                                            <constraint firstAttribute="trailing" secondItem="5SZ-KU-Ynv" secondAttribute="trailing" id="Ew5-wQ-FxQ"/>
+                                            <constraint firstItem="BtS-3D-CIU" firstAttribute="centerY" secondItem="ZWc-TJ-W9T" secondAttribute="centerY" priority="900" id="T4P-6t-YLe"/>
+                                            <constraint firstItem="5SZ-KU-Ynv" firstAttribute="leading" secondItem="ZWc-TJ-W9T" secondAttribute="leading" id="aOG-h6-gAw"/>
+                                            <constraint firstItem="5SZ-KU-Ynv" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ZWc-TJ-W9T" secondAttribute="top" constant="20" id="zPw-QR-H0E"/>
                                         </constraints>
-                                        <variation key="default">
-                                            <mask key="constraints">
-                                                <exclude reference="8EH-3z-HFm"/>
-                                            </mask>
-                                        </variation>
-                                        <variation key="heightClass=regular-widthClass=regular">
-                                            <mask key="constraints">
-                                                <include reference="8EH-3z-HFm"/>
-                                            </mask>
-                                        </variation>
                                     </view>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="ilv-iW-HgP">
-                                        <rect key="frame" x="20" y="578" width="343" height="34"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nNi-en-Ou0">
+                                        <rect key="frame" x="20" y="548" width="351" height="64"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="oua-LU-gvC">
-                                                <rect key="frame" x="0.0" y="6" width="292" height="28"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ilv-iW-HgP">
+                                                <rect key="frame" x="20" y="10" width="311" height="34"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0P1-6g-BI3">
-                                                        <rect key="frame" x="0.0" y="0.0" width="125" height="28"/>
+                                                        <rect key="frame" x="0.0" y="3" width="125" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Lost your password?">
                                                             <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -788,140 +848,71 @@
                                                             <action selector="handleForgotPasswordButtonTapped:" destination="lmD-c6-SLs" eventType="touchUpInside" id="q8s-z9-VIK"/>
                                                         </connections>
                                                     </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E3x-LN-sUk" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="260" y="0.0" width="51" height="34"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="H3A-PM-OJr"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <state key="normal" title="SIGN IN">
+                                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        </state>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="handleSubmitButtonTapped:" destination="lmD-c6-SLs" eventType="touchUpInside" id="hX6-w6-i2P"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
                                             </stackView>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E3x-LN-sUk" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="292" y="0.0" width="51" height="34"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="H3A-PM-OJr"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <state key="normal" title="SIGN IN">
-                                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </state>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                                </userDefinedRuntimeAttributes>
-                                                <connections>
-                                                    <action selector="handleSubmitButtonTapped:" destination="lmD-c6-SLs" eventType="touchUpInside" id="hX6-w6-i2P"/>
-                                                </connections>
-                                            </button>
                                         </subviews>
-                                    </stackView>
+                                        <constraints>
+                                            <constraint firstItem="ilv-iW-HgP" firstAttribute="leading" secondItem="nNi-en-Ou0" secondAttribute="leading" constant="20" id="6wo-mO-YhL"/>
+                                            <constraint firstItem="ilv-iW-HgP" firstAttribute="top" secondItem="nNi-en-Ou0" secondAttribute="top" constant="10" id="KgI-bu-hJ4"/>
+                                            <constraint firstAttribute="bottom" secondItem="ilv-iW-HgP" secondAttribute="bottom" constant="20" id="fJe-nZ-WbT"/>
+                                            <constraint firstAttribute="trailing" secondItem="ilv-iW-HgP" secondAttribute="trailing" constant="20" id="qyx-Z0-cuI"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="ilv-iW-HgP" secondAttribute="bottom" constant="20" id="3jk-VL-Jxm"/>
-                                    <constraint firstItem="ilv-iW-HgP" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" constant="20" id="MRn-ON-ojl"/>
-                                    <constraint firstItem="ZWc-TJ-W9T" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" id="P9q-Yk-vce"/>
-                                    <constraint firstAttribute="trailing" secondItem="ilv-iW-HgP" secondAttribute="trailing" constant="20" id="S20-aP-lKV"/>
-                                    <constraint firstItem="ZWc-TJ-W9T" firstAttribute="top" relation="greaterThanOrEqual" secondItem="7OQ-0t-1zq" secondAttribute="top" id="VLg-UB-2XP"/>
-                                    <constraint firstAttribute="trailing" secondItem="ZWc-TJ-W9T" secondAttribute="trailing" id="dKJ-Hw-hpF"/>
-                                    <constraint firstItem="ZWc-TJ-W9T" firstAttribute="centerX" secondItem="7OQ-0t-1zq" secondAttribute="centerX" id="jcM-uc-2PV"/>
+                                    <constraint firstItem="ZWc-TJ-W9T" firstAttribute="top" secondItem="7OQ-0t-1zq" secondAttribute="top" id="Auv-Qn-vWa"/>
+                                    <constraint firstItem="nNi-en-Ou0" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" constant="20" id="EOB-fH-k6I"/>
+                                    <constraint firstItem="ZWc-TJ-W9T" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" id="Osp-Ar-qix"/>
+                                    <constraint firstAttribute="bottom" secondItem="nNi-en-Ou0" secondAttribute="bottom" id="Ugi-9r-MdP"/>
+                                    <constraint firstAttribute="width" constant="383" id="VgM-uK-kk3"/>
+                                    <constraint firstItem="nNi-en-Ou0" firstAttribute="top" secondItem="ZWc-TJ-W9T" secondAttribute="bottom" id="Y7j-Wg-YEy"/>
+                                    <constraint firstAttribute="trailing" secondItem="nNi-en-Ou0" secondAttribute="trailing" constant="20" id="fUL-dk-71l"/>
+                                    <constraint firstAttribute="trailing" secondItem="ZWc-TJ-W9T" secondAttribute="trailing" id="p8c-n5-W3X"/>
                                 </constraints>
                                 <variation key="default">
                                     <mask key="constraints">
-                                        <exclude reference="jcM-uc-2PV"/>
+                                        <exclude reference="VgM-uK-kk3"/>
                                     </mask>
                                 </variation>
                                 <variation key="heightClass=regular-widthClass=regular">
                                     <mask key="constraints">
-                                        <exclude reference="P9q-Yk-vce"/>
-                                        <exclude reference="dKJ-Hw-hpF"/>
-                                        <include reference="jcM-uc-2PV"/>
+                                        <include reference="VgM-uK-kk3"/>
                                     </mask>
                                 </variation>
                             </view>
-                            <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Bli-Rb-X9m">
-                                <rect key="frame" x="0.0" y="225.5" width="383" height="194.5"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="343" placeholderIntrinsicHeight="48" text="Enter the password for your WordPress.com account." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBi-2N-RAh">
-                                        <rect key="frame" x="20" y="0.0" width="343" height="48"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="OvF-Iy-KJT"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                        <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ikm-O0-Gwu">
-                                        <rect key="frame" x="0.0" y="56" width="383" height="20"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="20" id="MCe-hi-fnd"/>
-                                        </constraints>
-                                    </view>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xgi-ZQ-8YL">
-                                        <rect key="frame" x="20" y="84" width="343" height="20.5"/>
-                                        <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="251" image="icon-username-field" translatesAutoresizingMaskIntoConstraints="NO" id="e88-X2-Rh2">
-                                                <rect key="frame" x="0.0" y="1.5" width="18" height="18"/>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="avo-E8-mvG">
-                                                <rect key="frame" x="28" y="0.0" width="315" height="20.5"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="112.5" width="383" height="44"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="Mzl-m2-DZ7"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES" secureTextEntry="YES"/>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showSecureTextEntryToggle" value="YES"/>
-                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-password-field"/>
-                                        </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <action selector="handleTextFieldDidChange:" destination="lmD-c6-SLs" eventType="editingChanged" id="TIx-xK-PLT"/>
-                                            <outlet property="delegate" destination="lmD-c6-SLs" id="8se-wA-BuN"/>
-                                        </connections>
-                                    </textField>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IFI-gc-uvn">
-                                        <rect key="frame" x="0.0" y="164.5" width="383" height="4"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="4" id="mjA-ul-41x"/>
-                                        </constraints>
-                                    </view>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
-                                        <rect key="frame" x="20" y="176.5" width="343" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="18" id="2xK-Aw-MVX"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                        <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstItem="bBi-2N-RAh" firstAttribute="width" secondItem="Xgi-ZQ-8YL" secondAttribute="width" id="3yb-zG-vHe"/>
-                                    <constraint firstItem="BtS-3D-CIU" firstAttribute="width" secondItem="Bli-Rb-X9m" secondAttribute="width" id="Nj7-Tr-hSq"/>
-                                    <constraint firstItem="ZqY-I8-yWG" firstAttribute="width" secondItem="Xgi-ZQ-8YL" secondAttribute="width" id="Pbz-jT-al6"/>
-                                    <constraint firstItem="ikm-O0-Gwu" firstAttribute="width" secondItem="Bli-Rb-X9m" secondAttribute="width" id="RE5-2t-F5L"/>
-                                    <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="width" secondItem="Bli-Rb-X9m" secondAttribute="width" constant="-40" id="bd8-gJ-cIB"/>
-                                    <constraint firstItem="IFI-gc-uvn" firstAttribute="width" secondItem="Bli-Rb-X9m" secondAttribute="width" id="vJu-6s-TYF"/>
-                                </constraints>
-                            </stackView>
                         </subviews>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="7OQ-0t-1zq" secondAttribute="trailing" id="1LF-21-aUE"/>
-                            <constraint firstItem="7OQ-0t-1zq" firstAttribute="leading" secondItem="tEh-Nj-xof" secondAttribute="leading" id="2v0-ee-Bno"/>
-                            <constraint firstItem="7OQ-0t-1zq" firstAttribute="top" secondItem="dAs-4b-ACP" secondAttribute="bottom" constant="-20" id="6Lb-n5-RrE"/>
-                            <constraint firstItem="Bli-Rb-X9m" firstAttribute="width" secondItem="tEh-Nj-xof" secondAttribute="width" id="As6-KN-DJf"/>
+                            <constraint firstItem="7OQ-0t-1zq" firstAttribute="centerX" secondItem="tEh-Nj-xof" secondAttribute="centerX" id="1g8-p2-jnJ"/>
+                            <constraint firstItem="7OQ-0t-1zq" firstAttribute="top" secondItem="dAs-4b-ACP" secondAttribute="bottom" id="6Lb-n5-RrE"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="7OQ-0t-1zq" secondAttribute="trailing" constant="-20" id="CHX-tt-x4p"/>
+                            <constraint firstItem="7OQ-0t-1zq" firstAttribute="leading" secondItem="tEh-Nj-xof" secondAttribute="leadingMargin" constant="-20" id="GcS-IL-8lA"/>
                             <constraint firstItem="kOH-fr-1L0" firstAttribute="top" secondItem="7OQ-0t-1zq" secondAttribute="bottom" priority="900" id="cuz-xK-BSJ"/>
-                            <constraint firstItem="Bli-Rb-X9m" firstAttribute="centerX" secondItem="tEh-Nj-xof" secondAttribute="centerX" id="i9z-jd-4DN"/>
-                            <constraint firstItem="BtS-3D-CIU" firstAttribute="centerY" secondItem="7OQ-0t-1zq" secondAttribute="centerY" id="sV1-hZ-O4b"/>
                         </constraints>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <exclude reference="CHX-tt-x4p"/>
+                                <exclude reference="GcS-IL-8lA"/>
+                            </mask>
+                        </variation>
                     </view>
                     <connections>
                         <outlet property="bottomContentConstraint" destination="cuz-xK-BSJ" id="fwY-mo-qJg"/>
@@ -2174,7 +2165,7 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="Jfl-Zm-PRR"/>
-        <segue reference="fWM-mD-lXg"/>
-        <segue reference="7ky-IR-Xbv"/>
+        <segue reference="7lv-19-h36"/>
+        <segue reference="qLI-qX-rkG"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -110,7 +110,7 @@
         <scene sceneID="1BJ-CW-C88">
             <objects>
                 <navigationController id="Ck1-vY-O11" customClass="LoginNavigationController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="mKb-UO-KoA">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="mKb-UO-KoA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1064,6 +1064,7 @@
                                     <constraint firstItem="DHF-bN-so0" firstAttribute="top" secondItem="hTY-xb-H5h" secondAttribute="top" id="9hm-xn-6lZ"/>
                                     <constraint firstItem="x1G-Lf-mra" firstAttribute="top" secondItem="DHF-bN-so0" secondAttribute="bottom" constant="10" id="IsJ-Kk-Pdi"/>
                                     <constraint firstAttribute="bottom" secondItem="x1G-Lf-mra" secondAttribute="bottom" constant="20" id="XBv-Gg-JAY"/>
+                                    <constraint firstAttribute="width" constant="383" id="eWE-lA-7Kg"/>
                                     <constraint firstAttribute="trailing" secondItem="DHF-bN-so0" secondAttribute="trailing" id="pId-Zh-c89"/>
                                     <constraint firstItem="x1G-Lf-mra" firstAttribute="leading" secondItem="hTY-xb-H5h" secondAttribute="leading" constant="20" id="yEl-i3-fts"/>
                                 </constraints>
@@ -1072,10 +1073,17 @@
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="hTY-xb-H5h" secondAttribute="trailing" id="23h-QU-eyB"/>
+                            <constraint firstItem="hTY-xb-H5h" firstAttribute="centerX" secondItem="cm5-76-st7" secondAttribute="centerX" id="PRb-I7-O07"/>
                             <constraint firstItem="hTY-xb-H5h" firstAttribute="top" secondItem="959-UQ-1Jm" secondAttribute="bottom" id="lqc-JK-kaQ"/>
                             <constraint firstItem="hTY-xb-H5h" firstAttribute="leading" secondItem="cm5-76-st7" secondAttribute="leading" id="riV-3j-5QK"/>
                             <constraint firstItem="fG1-qw-2YS" firstAttribute="top" secondItem="hTY-xb-H5h" secondAttribute="bottom" id="tJ5-Do-kBC"/>
                         </constraints>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <exclude reference="23h-QU-eyB"/>
+                                <exclude reference="riV-3j-5QK"/>
+                            </mask>
+                        </variation>
                     </view>
                     <connections>
                         <outlet property="bottomContentConstraint" destination="tJ5-Do-kBC" id="lfp-1Z-g7f"/>
@@ -1228,14 +1236,14 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xKq-ni-wZB" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                            <rect key="frame" x="157.5" y="20" width="60" height="60"/>
+                                            <rect key="frame" x="161.5" y="20" width="60" height="60"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="60" id="Omr-X8-XDl"/>
                                                 <constraint firstAttribute="width" constant="60" id="pI0-bo-l6s"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@username" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ONy-ZJ-GTI">
-                                            <rect key="frame" x="0.0" y="109.5" width="375" height="18"/>
+                                            <rect key="frame" x="0.0" y="109.5" width="383" height="18"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="18" id="UkN-Od-n0K"/>
                                             </constraints>
@@ -1244,21 +1252,21 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4RV-hS-DYN" userLabel="bottom hairline">
-                                            <rect key="frame" x="0.0" y="139.5" width="375" height="0.5"/>
+                                            <rect key="frame" x="0.0" y="139.5" width="383" height="0.5"/>
                                             <color key="backgroundColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.84313725490196079" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="0.5" id="A3O-Oh-nqx"/>
                                             </constraints>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3hv-UB-D9b" userLabel="top hairline">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="0.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="0.5"/>
                                             <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="0.5" id="gaI-rY-zWc"/>
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Men-mq-jKi">
-                                            <rect key="frame" x="20" y="89" width="335" height="20.5"/>
+                                            <rect key="frame" x="20" y="89" width="343" height="20.5"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="Z2K-dy-J3D"/>
                                             </constraints>
@@ -1267,7 +1275,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zfb-lS-v47" userLabel="bottom pad">
-                                            <rect key="frame" x="0.0" y="140" width="375" height="8"/>
+                                            <rect key="frame" x="0.0" y="140" width="383" height="8"/>
                                             <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="8" id="wB5-3u-5Pm"/>
@@ -2159,7 +2167,7 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="Jfl-Zm-PRR"/>
-        <segue reference="qLI-qX-rkG"/>
-        <segue reference="7ky-IR-Xbv"/>
+        <segue reference="fWM-mD-lXg"/>
+        <segue reference="lIb-sw-yM7"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -110,7 +110,7 @@
         <scene sceneID="1BJ-CW-C88">
             <objects>
                 <navigationController id="Ck1-vY-O11" customClass="LoginNavigationController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="mKb-UO-KoA">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="mKb-UO-KoA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -134,75 +134,74 @@
                         <rect key="frame" x="0.0" y="0.0" width="383" height="676"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="245" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ZBL-pW-jTv" userLabel="Wrapper Stack View">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ozJ-hT-OEw">
                                 <rect key="frame" x="0.0" y="64" width="383" height="612"/>
                                 <subviews>
-                                    <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" placeholderIntrinsicWidth="383" placeholderIntrinsicHeight="426" translatesAutoresizingMaskIntoConstraints="NO" id="Ff9-jl-eKh">
-                                        <rect key="frame" x="0.0" y="0.0" width="383" height="426"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
+                                        <rect key="frame" x="0.0" y="0.0" width="383" height="549"/>
                                         <subviews>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XXO-aV-keK" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="191" width="383" height="44"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
+                                            <view opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ff9-jl-eKh">
+                                                <rect key="frame" x="0.0" y="194.5" width="383" height="122"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
+                                                        <rect key="frame" x="20" y="0.0" width="343" height="38"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XXO-aV-keK" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="58" width="383" height="44"/>
+                                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="c8B-Ol-kY2"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-username-field"/>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="handleSubmitForm" destination="fwZ-QE-5et" eventType="primaryActionTriggered" id="8l9-uh-Gyz"/>
+                                                            <action selector="handleTextFieldDidChange:" destination="fwZ-QE-5et" eventType="editingChanged" id="LoF-5Q-Yw5"/>
+                                                            <action selector="handleTextFieldEditingDidBegin:" destination="fwZ-QE-5et" eventType="editingDidBegin" id="Ff8-SJ-F9U"/>
+                                                            <outlet property="delegate" destination="fwZ-QE-5et" id="Urv-t1-Fui"/>
+                                                        </connections>
+                                                    </textField>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qqt-eq-gac">
+                                                        <rect key="frame" x="20" y="122" width="343" height="0.0"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" red="0.85098039215686272" green="0.30980392156862746" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="320" id="7hw-mi-ba0"/>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="c8B-Ol-kY2"/>
+                                                    <constraint firstItem="Qqt-eq-gac" firstAttribute="leading" secondItem="Ff9-jl-eKh" secondAttribute="leading" constant="20" id="94O-1n-HFL"/>
+                                                    <constraint firstItem="XXO-aV-keK" firstAttribute="leading" secondItem="Ff9-jl-eKh" secondAttribute="leading" id="Aae-9P-bkG"/>
+                                                    <constraint firstItem="XXO-aV-keK" firstAttribute="top" secondItem="DKR-9c-zZQ" secondAttribute="bottom" constant="20" id="K5W-wi-lao"/>
+                                                    <constraint firstItem="DKR-9c-zZQ" firstAttribute="top" secondItem="Ff9-jl-eKh" secondAttribute="top" id="Khm-BS-EIo"/>
+                                                    <constraint firstItem="DKR-9c-zZQ" firstAttribute="leading" secondItem="Ff9-jl-eKh" secondAttribute="leading" constant="20" id="MWF-1s-IWK"/>
+                                                    <constraint firstAttribute="bottom" secondItem="Qqt-eq-gac" secondAttribute="bottom" id="PSy-Fj-BxD"/>
+                                                    <constraint firstAttribute="trailing" secondItem="Qqt-eq-gac" secondAttribute="trailing" constant="20" id="XEe-SR-4Um"/>
+                                                    <constraint firstItem="Qqt-eq-gac" firstAttribute="top" secondItem="XXO-aV-keK" secondAttribute="bottom" constant="20" id="ZOe-Fb-b0U"/>
+                                                    <constraint firstAttribute="trailing" secondItem="XXO-aV-keK" secondAttribute="trailing" id="i4f-1H-u1d"/>
+                                                    <constraint firstAttribute="trailing" secondItem="DKR-9c-zZQ" secondAttribute="trailing" constant="20" id="odG-1L-fnV"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next" enablesReturnKeyAutomatically="YES"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="image" keyPath="leftViewImage" value="icon-username-field"/>
-                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="showTopLineSeparator" value="YES"/>
-                                                </userDefinedRuntimeAttributes>
-                                                <variation key="default">
-                                                    <mask key="constraints">
-                                                        <exclude reference="7hw-mi-ba0"/>
-                                                    </mask>
-                                                </variation>
-                                                <variation key="heightClass=regular-widthClass=regular">
-                                                    <mask key="constraints">
-                                                        <include reference="7hw-mi-ba0"/>
-                                                    </mask>
-                                                </variation>
-                                                <connections>
-                                                    <action selector="handleSubmitForm" destination="fwZ-QE-5et" eventType="primaryActionTriggered" id="8l9-uh-Gyz"/>
-                                                    <action selector="handleTextFieldDidChange:" destination="fwZ-QE-5et" eventType="editingChanged" id="LoF-5Q-Yw5"/>
-                                                    <action selector="handleTextFieldEditingDidBegin:" destination="fwZ-QE-5et" eventType="editingDidBegin" id="Ff8-SJ-F9U"/>
-                                                    <outlet property="delegate" destination="fwZ-QE-5et" id="Urv-t1-Fui"/>
-                                                </connections>
-                                            </textField>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
-                                                <rect key="frame" x="20" y="133" width="343" height="38"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qqt-eq-gac">
-                                                <rect key="frame" x="20" y="255" width="343" height="0.0"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" red="0.85098039215686272" green="0.30980392156862746" blue="0.30980392156862746" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            </view>
                                         </subviews>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
-                                            <constraint firstItem="Qqt-eq-gac" firstAttribute="top" secondItem="XXO-aV-keK" secondAttribute="bottom" constant="20" id="7Mg-FL-RY2"/>
-                                            <constraint firstItem="Qqt-eq-gac" firstAttribute="leading" secondItem="Ff9-jl-eKh" secondAttribute="leading" constant="20" id="94O-1n-HFL"/>
-                                            <constraint firstItem="XXO-aV-keK" firstAttribute="leading" secondItem="Ff9-jl-eKh" secondAttribute="leading" id="Aae-9P-bkG"/>
-                                            <constraint firstItem="XXO-aV-keK" firstAttribute="top" secondItem="DKR-9c-zZQ" secondAttribute="bottom" constant="20" id="K5W-wi-lao"/>
-                                            <constraint firstItem="DKR-9c-zZQ" firstAttribute="leading" secondItem="Ff9-jl-eKh" secondAttribute="leading" constant="20" id="MWF-1s-IWK"/>
-                                            <constraint firstAttribute="trailing" secondItem="Qqt-eq-gac" secondAttribute="trailing" constant="20" id="XEe-SR-4Um"/>
-                                            <constraint firstItem="XXO-aV-keK" firstAttribute="centerY" secondItem="Ff9-jl-eKh" secondAttribute="centerY" id="g79-1R-Vzx"/>
-                                            <constraint firstAttribute="trailing" secondItem="XXO-aV-keK" secondAttribute="trailing" id="i4f-1H-u1d"/>
-                                            <constraint firstAttribute="trailing" secondItem="DKR-9c-zZQ" secondAttribute="trailing" constant="20" id="odG-1L-fnV"/>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="oki-wA-lL1"/>
+                                            <constraint firstAttribute="trailing" secondItem="Ff9-jl-eKh" secondAttribute="trailing" id="Tbw-s4-sXV"/>
+                                            <constraint firstItem="Ff9-jl-eKh" firstAttribute="leading" secondItem="KAn-ug-oE6" secondAttribute="leading" id="UlL-49-A8K"/>
+                                            <constraint firstItem="XXO-aV-keK" firstAttribute="centerY" secondItem="KAn-ug-oE6" secondAttribute="centerY" id="ftV-Sq-D3b"/>
                                         </constraints>
                                     </view>
                                     <view opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="ecG-o1-wwE">
-                                        <rect key="frame" x="0.0" y="436" width="383" height="176"/>
+                                        <rect key="frame" x="0.0" y="549" width="383" height="63"/>
                                         <subviews>
                                             <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6i6-CG-3Tg">
-                                                <rect key="frame" x="20" y="123" width="343" height="33"/>
+                                                <rect key="frame" x="20" y="10" width="343" height="33"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Hn-ZK-h9k">
                                                         <rect key="frame" x="0.0" y="1.5" width="299" height="30"/>
@@ -237,26 +236,53 @@
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="6i6-CG-3Tg" secondAttribute="trailing" constant="20" id="Qnl-JG-4jT"/>
                                             <constraint firstAttribute="bottom" secondItem="6i6-CG-3Tg" secondAttribute="bottom" constant="20" id="UF0-73-Qz4"/>
-                                            <constraint firstItem="6i6-CG-3Tg" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ecG-o1-wwE" secondAttribute="top" priority="750" constant="10" id="w2M-l2-itq"/>
+                                            <constraint firstItem="6i6-CG-3Tg" firstAttribute="top" secondItem="ecG-o1-wwE" secondAttribute="top" priority="750" constant="10" id="w2M-l2-itq"/>
                                             <constraint firstItem="6i6-CG-3Tg" firstAttribute="leading" secondItem="ecG-o1-wwE" secondAttribute="leading" constant="20" id="xv3-Qs-Otm"/>
                                         </constraints>
                                     </view>
                                 </subviews>
-                            </stackView>
+                                <constraints>
+                                    <constraint firstItem="KAn-ug-oE6" firstAttribute="leading" secondItem="ozJ-hT-OEw" secondAttribute="leading" id="K1C-YL-EQU"/>
+                                    <constraint firstItem="ecG-o1-wwE" firstAttribute="leading" secondItem="ozJ-hT-OEw" secondAttribute="leading" id="KHv-G5-yi6"/>
+                                    <constraint firstAttribute="trailing" secondItem="KAn-ug-oE6" secondAttribute="trailing" id="PPm-oa-8dA"/>
+                                    <constraint firstAttribute="width" constant="383" id="RDo-Cc-ZDN"/>
+                                    <constraint firstAttribute="trailing" secondItem="ecG-o1-wwE" secondAttribute="trailing" id="Sqb-TN-g4l"/>
+                                    <constraint firstItem="ecG-o1-wwE" firstAttribute="top" secondItem="KAn-ug-oE6" secondAttribute="bottom" id="XCU-nJ-IcQ"/>
+                                    <constraint firstItem="KAn-ug-oE6" firstAttribute="top" secondItem="ozJ-hT-OEw" secondAttribute="top" id="nCb-yc-mV0"/>
+                                    <constraint firstAttribute="bottom" secondItem="ecG-o1-wwE" secondAttribute="bottom" id="q51-LD-TZq"/>
+                                </constraints>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="RDo-Cc-ZDN"/>
+                                    </mask>
+                                </variation>
+                                <variation key="heightClass=regular-widthClass=regular">
+                                    <mask key="constraints">
+                                        <include reference="RDo-Cc-ZDN"/>
+                                    </mask>
+                                </variation>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="ZBL-pW-jTv" secondAttribute="trailing" id="7zD-MO-U4t"/>
-                            <constraint firstItem="ZBL-pW-jTv" firstAttribute="top" secondItem="bn3-aC-RIM" secondAttribute="bottom" id="AGv-aa-6ci"/>
-                            <constraint firstItem="ZBL-pW-jTv" firstAttribute="leading" secondItem="e5n-Bf-JaL" secondAttribute="leading" id="Zbk-NI-bPR"/>
-                            <constraint firstItem="tip-gy-Hwr" firstAttribute="top" secondItem="ZBL-pW-jTv" secondAttribute="bottom" id="ygR-XU-dv4"/>
+                            <constraint firstItem="ozJ-hT-OEw" firstAttribute="top" secondItem="bn3-aC-RIM" secondAttribute="bottom" id="S6n-FZ-9Yc"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="ozJ-hT-OEw" secondAttribute="trailing" constant="-16" id="Uuo-bm-Be2"/>
+                            <constraint firstItem="ozJ-hT-OEw" firstAttribute="centerX" secondItem="e5n-Bf-JaL" secondAttribute="centerX" id="ZpP-No-8Mw"/>
+                            <constraint firstItem="tip-gy-Hwr" firstAttribute="top" secondItem="ozJ-hT-OEw" secondAttribute="bottom" id="h6K-00-qtf"/>
+                            <constraint firstItem="ozJ-hT-OEw" firstAttribute="leading" secondItem="e5n-Bf-JaL" secondAttribute="leadingMargin" constant="-16" id="lqe-jU-dLs"/>
                         </constraints>
+                        <variation key="heightClass=regular-widthClass=regular">
+                            <mask key="constraints">
+                                <exclude reference="Uuo-bm-Be2"/>
+                                <exclude reference="lqe-jU-dLs"/>
+                            </mask>
+                        </variation>
                     </view>
                     <navigationItem key="navigationItem" id="Au9-gn-veI"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="383" height="676"/>
                     <connections>
-                        <outlet property="bottomContentConstraint" destination="ygR-XU-dv4" id="Htk-Pq-5Kc"/>
+                        <outlet property="bottomContentConstraint" destination="h6K-00-qtf" id="qRz-TA-WAC"/>
                         <outlet property="emailTextField" destination="XXO-aV-keK" id="GZQ-cn-hKd"/>
                         <outlet property="errorLabel" destination="Qqt-eq-gac" id="4mV-5J-TJ2"/>
                         <outlet property="instructionLabel" destination="DKR-9c-zZQ" id="2Rj-ad-hnL"/>

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -764,7 +764,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="391" height="538"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="5SZ-KU-Ynv">
-                                                <rect key="frame" x="0.0" y="138.5" width="391" height="190.5"/>
+                                                <rect key="frame" x="0.0" y="134.5" width="391" height="194.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" placeholderIntrinsicWidth="343" placeholderIntrinsicHeight="48" text="Enter the password for your WordPress.com account." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBi-2N-RAh">
                                                         <rect key="frame" x="20" y="0.0" width="351" height="48"/>
@@ -773,7 +773,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Xgi-ZQ-8YL">
-                                                        <rect key="frame" x="20" y="68" width="351" height="20.5"/>
+                                                        <rect key="frame" x="20" y="80" width="351" height="20.5"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="icon-username-field" translatesAutoresizingMaskIntoConstraints="NO" id="e88-X2-Rh2">
                                                                 <rect key="frame" x="0.0" y="1.5" width="18" height="18"/>
@@ -787,7 +787,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="108.5" width="391" height="44"/>
+                                                        <rect key="frame" x="0.0" y="112.5" width="391" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
                                                         <constraints>
@@ -806,19 +806,19 @@
                                                         </connections>
                                                     </textField>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
-                                                        <rect key="frame" x="20" y="172.5" width="351" height="18"/>
+                                                        <rect key="frame" x="20" y="176.5" width="351" height="18"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" red="0.85098039219999999" green="0.30980392159999998" blue="0.30980392159999998" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="BtS-3D-CIU" firstAttribute="top" secondItem="Xgi-ZQ-8YL" secondAttribute="bottom" constant="20" id="8nF-H3-80k"/>
+                                                    <constraint firstItem="BtS-3D-CIU" firstAttribute="top" secondItem="Xgi-ZQ-8YL" secondAttribute="bottom" constant="12" id="8nF-H3-80k"/>
                                                     <constraint firstAttribute="bottom" secondItem="ZqY-I8-yWG" secondAttribute="bottom" id="E59-0T-vN0"/>
                                                     <constraint firstItem="bBi-2N-RAh" firstAttribute="top" secondItem="5SZ-KU-Ynv" secondAttribute="top" id="EHy-LX-CBy"/>
                                                     <constraint firstItem="BtS-3D-CIU" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" id="Giu-bS-8c8"/>
                                                     <constraint firstAttribute="trailing" secondItem="bBi-2N-RAh" secondAttribute="trailing" constant="20" id="I5y-9X-RL3"/>
-                                                    <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="top" secondItem="bBi-2N-RAh" secondAttribute="bottom" constant="20" id="PE2-OG-pet"/>
+                                                    <constraint firstItem="Xgi-ZQ-8YL" firstAttribute="top" secondItem="bBi-2N-RAh" secondAttribute="bottom" constant="32" id="PE2-OG-pet"/>
                                                     <constraint firstAttribute="trailing" secondItem="ZqY-I8-yWG" secondAttribute="trailing" constant="20" id="TVX-LB-4r2"/>
                                                     <constraint firstItem="ZqY-I8-yWG" firstAttribute="leading" secondItem="5SZ-KU-Ynv" secondAttribute="leading" constant="20" id="Tsh-Is-9Js"/>
                                                     <constraint firstItem="ZqY-I8-yWG" firstAttribute="top" secondItem="BtS-3D-CIU" secondAttribute="bottom" constant="20" id="Wgp-cW-ayk"/>
@@ -838,14 +838,14 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nNi-en-Ou0">
-                                        <rect key="frame" x="20" y="538" width="351" height="74"/>
+                                        <rect key="frame" x="0.0" y="538" width="391" height="74"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ilv-iW-HgP">
-                                                <rect key="frame" x="20" y="10" width="311" height="44"/>
+                                                <rect key="frame" x="20" y="10" width="351" height="44"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0P1-6g-BI3">
-                                                        <rect key="frame" x="0.0" y="8" width="125" height="28"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                        <rect key="frame" x="0.0" y="7" width="141" height="30"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <state key="normal" title="Lost your password?">
                                                             <color key="titleColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         </state>
@@ -854,7 +854,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E3x-LN-sUk" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="260" y="0.0" width="51" height="44"/>
+                                                        <rect key="frame" x="300" y="0.0" width="51" height="44"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="submitButton"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="H3A-PM-OJr"/>
@@ -884,12 +884,12 @@
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="ZWc-TJ-W9T" firstAttribute="top" secondItem="7OQ-0t-1zq" secondAttribute="top" id="Auv-Qn-vWa"/>
-                                    <constraint firstItem="nNi-en-Ou0" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" constant="20" id="EOB-fH-k6I"/>
+                                    <constraint firstItem="nNi-en-Ou0" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" id="EOB-fH-k6I"/>
                                     <constraint firstItem="ZWc-TJ-W9T" firstAttribute="leading" secondItem="7OQ-0t-1zq" secondAttribute="leading" id="Osp-Ar-qix"/>
                                     <constraint firstAttribute="bottom" secondItem="nNi-en-Ou0" secondAttribute="bottom" id="Ugi-9r-MdP"/>
                                     <constraint firstAttribute="width" constant="383" id="VgM-uK-kk3"/>
                                     <constraint firstItem="nNi-en-Ou0" firstAttribute="top" secondItem="ZWc-TJ-W9T" secondAttribute="bottom" id="Y7j-Wg-YEy"/>
-                                    <constraint firstAttribute="trailing" secondItem="nNi-en-Ou0" secondAttribute="trailing" constant="20" id="fUL-dk-71l"/>
+                                    <constraint firstAttribute="trailing" secondItem="nNi-en-Ou0" secondAttribute="trailing" id="fUL-dk-71l"/>
                                     <constraint firstAttribute="trailing" secondItem="ZWc-TJ-W9T" secondAttribute="trailing" id="p8c-n5-W3X"/>
                                 </constraints>
                                 <variation key="default">
@@ -1236,14 +1236,14 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xKq-ni-wZB" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                            <rect key="frame" x="161.5" y="20" width="60" height="60"/>
+                                            <rect key="frame" x="157.5" y="20" width="60" height="60"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="60" id="Omr-X8-XDl"/>
                                                 <constraint firstAttribute="width" constant="60" id="pI0-bo-l6s"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@username" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ONy-ZJ-GTI">
-                                            <rect key="frame" x="0.0" y="109.5" width="383" height="18"/>
+                                            <rect key="frame" x="0.0" y="109.5" width="375" height="18"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="18" id="UkN-Od-n0K"/>
                                             </constraints>
@@ -1252,21 +1252,21 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4RV-hS-DYN" userLabel="bottom hairline">
-                                            <rect key="frame" x="0.0" y="139.5" width="383" height="0.5"/>
+                                            <rect key="frame" x="0.0" y="139.5" width="375" height="0.5"/>
                                             <color key="backgroundColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.84313725490196079" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="0.5" id="A3O-Oh-nqx"/>
                                             </constraints>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3hv-UB-D9b" userLabel="top hairline">
-                                            <rect key="frame" x="0.0" y="0.0" width="383" height="0.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="0.5"/>
                                             <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="0.5" id="gaI-rY-zWc"/>
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Men-mq-jKi">
-                                            <rect key="frame" x="20" y="89" width="343" height="20.5"/>
+                                            <rect key="frame" x="20" y="89" width="335" height="20.5"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="Z2K-dy-J3D"/>
                                             </constraints>
@@ -1275,7 +1275,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zfb-lS-v47" userLabel="bottom pad">
-                                            <rect key="frame" x="0.0" y="140" width="383" height="8"/>
+                                            <rect key="frame" x="0.0" y="140" width="375" height="8"/>
                                             <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="8" id="wB5-3u-5Pm"/>
@@ -2167,7 +2167,7 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="Jfl-Zm-PRR"/>
-        <segue reference="fWM-mD-lXg"/>
-        <segue reference="lIb-sw-yM7"/>
+        <segue reference="qLI-qX-rkG"/>
+        <segue reference="7lv-19-h36"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -36,6 +36,10 @@ class LoginEpilogueViewController: UIViewController {
         }
     }
 
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return UIDevice.isPad() ? .all : .portrait
+    }
+
     @IBAction func dismissEpilogue() {
         dismissBlock?(false)
         navigationController?.dismiss(animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/NUX/LoginPrologueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginPrologueViewController.swift
@@ -26,6 +26,10 @@ class LoginPrologueViewController: UIViewController {
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
     }
 
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return UIDevice.isPad() ? .all : .portrait
+    }
+
     // MARK: - Setup and Config
 
     func localizeControls() {


### PR DESCRIPTION
Refs #7272 

This PR includes updates to the login storyboard, adjusting the view hierarchy and constraints for presenting the login screens on an iPad.  Its also enforces portrait orientation on the prologue and epilogue screens.
- Screens on the iPad are limited to the same width as the iPhone 6s -- 383px.
- Constraints are adjusted so text fields are centered vertically in their parent view's container.  A top constraint is added to ensure the form does not get pushed above the top of the screen.  These changes remove the need for the `verticalCenterConstraint` used by the old sign-in vcs. 

Note: The epilogue remains full screen in this PR. Its stubbornly ignoring settings to follow readable content margins.  I'll sort that out in a follow up PR so as to not delay these changes. 

To test:
Test the login flow on both an iPad and iPhone.  Ensure that margins and placement are correct for both platforms. 

Needs review: @nheagy 

Examples:

![simulator screen shot jul 10 2017 1 57 29 pm](https://user-images.githubusercontent.com/1435271/28034921-523a0cdc-6578-11e7-87ab-fa545afe5e79.png)
![simulator screen shot jul 10 2017 1 57 38 pm](https://user-images.githubusercontent.com/1435271/28034933-557f0582-6578-11e7-8109-0d71a7048ac5.png)
![simulator screen shot jul 10 2017 2 01 03 pm](https://user-images.githubusercontent.com/1435271/28034934-5764d908-6578-11e7-86bd-26fa3058a6d8.png)
![simulator screen shot jul 10 2017 2 04 57 pm](https://user-images.githubusercontent.com/1435271/28035113-033a9a74-6579-11e7-8f93-907fa088dcf5.png)
![simulator screen shot jul 10 2017 2 09 53 pm](https://user-images.githubusercontent.com/1435271/28035264-afa09782-6579-11e7-81d7-3e9972113c64.png)

