### PR TITLE
Helpshift: Use `aztec-feedback` source for Aztec issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/SupportViewController.h
+++ b/WordPress/Classes/ViewRelated/Me/SupportViewController.h
@@ -7,6 +7,7 @@ extern SupportSourceTag const SupportSourceTagWPOrgLogin;
 extern SupportSourceTag const SupportSourceTagJetpackLogin;
 extern SupportSourceTag const SupportSourceTagGeneralLogin;
 extern SupportSourceTag const SupportSourceTagInAppFeedback;
+extern SupportSourceTag const SupportSourceTagAztecFeedback;
 
 @interface SupportViewController : UITableViewController
 @property (nonatomic, strong) SupportSourceTag sourceTag;

--- a/WordPress/Classes/ViewRelated/Me/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/SupportViewController.m
@@ -25,6 +25,7 @@ SupportSourceTag const SupportSourceTagWPOrgLogin = @"origin:wporg-login-screen"
 SupportSourceTag const SupportSourceTagJetpackLogin = @"origin:jetpack-login-screen";
 SupportSourceTag const SupportSourceTagGeneralLogin = @"origin:login-screen";
 SupportSourceTag const SupportSourceTagInAppFeedback = @"origin:in-app-feedback";
+SupportSourceTag const SupportSourceTagAztecFeedback = @"origin:aztec-feedback";
 
 static NSString *const WPSupportRestorationID = @"WPSupportRestorationID";
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -243,7 +243,7 @@ extension WPWebViewController {
         guard HelpshiftUtils.isHelpshiftEnabled() else { return }
 
         let presenter = HelpshiftPresenter()
-        presenter.sourceTag = SupportSourceTag.inAppFeedback
+        presenter.sourceTag = SupportSourceTag.aztecFeedback
         presenter.presentHelpshiftConversationWindowFromViewController(viewController,
                                                                        refreshUserDetails: true,
                                                                        completion:nil)


### PR DESCRIPTION
Fixes #7517 

This PR changes Helpshift instances created from the Aztec what's new UI to use the `origin:aztec-feedback` Helpshift tag instead of `origin:in-app-feedback`, so we can more easily differentiate Aztec specific issues.

To test:

* Build and run
* Go into Me > App Settings, enable Aztec (if it's not already) and tap the 'i' button in the footer of the editors section.
* Tap the bug icon in the top right of the what's new webview
* Post a bug to Helpshift, view it in Helpshift and check that it has the correct tag.

Needs review: @elibud 