### PR TITLE
Issue/7513: Allow alert title to wrap to 2 lines

### DIFF
--- a/WordPress/Classes/ViewRelated/System/FancyAlerts.storyboard
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts.storyboard
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F2073" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -25,26 +26,27 @@
                                 <rect key="frame" x="0.0" y="141" width="375" height="385"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HFL-PH-DaB" userLabel="Padding">
-                                        <rect key="frame" x="0.0" y="0.0" width="30" height="385"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="20.5" height="385"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <constraints>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="5oK-qi-G6x"/>
+                                            <constraint firstAttribute="width" priority="999" constant="20" id="MZ4-M7-Cm5"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Zfy-Hg-zeP">
-                                        <rect key="frame" x="30" y="0.0" width="315" height="385"/>
+                                        <rect key="frame" x="20.5" y="0.0" width="334" height="385"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="hxn-lJ-Q8T">
-                                                <rect key="frame" x="0.0" y="0.0" width="315" height="385"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="334" height="385"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zUD-7D-1OQ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="315" height="162"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="334" height="162"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LSs-Y1-hBy">
-                                                                <rect key="frame" x="0.0" y="20" width="315" height="122"/>
+                                                                <rect key="frame" x="0.0" y="20" width="334" height="122"/>
                                                                 <subviews>
                                                                     <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Krq-uR-e1t">
-                                                                        <rect key="frame" x="20" y="20" width="275" height="82"/>
+                                                                        <rect key="frame" x="20" y="20" width="294" height="82"/>
                                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="82" placeholder="YES" id="qrZ-Uu-G6f"/>
@@ -69,37 +71,39 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rzT-7k-QCD" userLabel="Content Container">
-                                                        <rect key="frame" x="0.0" y="162" width="315" height="87"/>
+                                                        <rect key="frame" x="0.0" y="162" width="334" height="113.5"/>
                                                         <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="999" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH2-Nt-ZNa">
+                                                                <rect key="frame" x="71.5" y="16" width="46" height="30"/>
+                                                                <inset key="titleEdgeInsets" minX="0.0" minY="4" maxX="0.0" maxY="4"/>
+                                                                <state key="normal" title="Button"/>
+                                                                <connections>
+                                                                    <action selector="buttonTapped:" destination="ZA1-84-qnC" eventType="touchUpInside" id="Ob9-0T-1NU"/>
+                                                                </connections>
+                                                            </button>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" horizontalCompressionResistancePriority="999" verticalCompressionResistancePriority="1000" text=" " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="75Q-Jn-AFH" userLabel="Alignment Placeholder">
+                                                                <rect key="frame" x="63.5" y="20" width="4.5" height="20.5"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="30" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Er7-dR-3IB" userLabel="Content Stack View">
-                                                                <rect key="frame" x="20" y="20" width="275" height="47"/>
+                                                                <rect key="frame" x="20" y="20" width="294" height="73.5"/>
                                                                 <subviews>
-                                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ClB-4D-cxC">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="97.5" height="20.5"/>
-                                                                        <subviews>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cUO-4N-FhV">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="43.5" height="20.5"/>
-                                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                                                <nil key="textColor"/>
-                                                                                <nil key="highlightedColor"/>
-                                                                            </label>
-                                                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH2-Nt-ZNa">
-                                                                                <rect key="frame" x="51.5" y="0.0" width="46" height="20.5"/>
-                                                                                <state key="normal" title="Button"/>
-                                                                                <connections>
-                                                                                    <action selector="buttonTapped:" destination="ZA1-84-qnC" eventType="touchUpInside" id="Ob9-0T-1NU"/>
-                                                                                </connections>
-                                                                            </button>
-                                                                        </subviews>
-                                                                    </stackView>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" horizontalCompressionResistancePriority="999" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cUO-4N-FhV">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="43.5" height="20.5"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OPz-wQ-LdM">
-                                                                        <rect key="frame" x="0.0" y="22.5" width="37.5" height="0.0"/>
+                                                                        <rect key="frame" x="0.0" y="31.5" width="37.5" height="15"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bwf-Ap-GLo">
-                                                                        <rect key="frame" x="0.0" y="21.5" width="46" height="25.5"/>
+                                                                        <rect key="frame" x="0.0" y="43.5" width="46" height="30"/>
                                                                         <state key="normal" title="Button"/>
                                                                         <connections>
                                                                             <action selector="buttonTapped:" destination="ZA1-84-qnC" eventType="touchUpInside" id="3PW-eX-0Sw"/>
@@ -110,27 +114,32 @@
                                                         </subviews>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
+                                                            <constraint firstItem="75Q-Jn-AFH" firstAttribute="firstBaseline" secondItem="cUO-4N-FhV" secondAttribute="firstBaseline" id="CuZ-hU-uES"/>
+                                                            <constraint firstItem="75Q-Jn-AFH" firstAttribute="leading" secondItem="cUO-4N-FhV" secondAttribute="trailing" id="JAl-Yr-Eh3"/>
                                                             <constraint firstItem="Er7-dR-3IB" firstAttribute="top" secondItem="rzT-7k-QCD" secondAttribute="top" constant="20" id="Rxa-JT-XKl"/>
                                                             <constraint firstAttribute="trailing" secondItem="Er7-dR-3IB" secondAttribute="trailing" constant="20" id="aEb-Sn-pwu"/>
+                                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rH2-Nt-ZNa" secondAttribute="trailing" constant="20" id="jDZ-tY-mxR"/>
                                                             <constraint firstAttribute="bottom" secondItem="Er7-dR-3IB" secondAttribute="bottom" constant="20" id="nJT-ly-DDr"/>
+                                                            <constraint firstItem="rH2-Nt-ZNa" firstAttribute="leading" secondItem="cUO-4N-FhV" secondAttribute="trailing" constant="8" id="o0I-ch-GMs"/>
                                                             <constraint firstItem="Er7-dR-3IB" firstAttribute="leading" secondItem="rzT-7k-QCD" secondAttribute="leading" constant="20" id="v3D-07-SBb"/>
+                                                            <constraint firstItem="rH2-Nt-ZNa" firstAttribute="centerY" secondItem="75Q-Jn-AFH" secondAttribute="centerY" id="xqs-mT-uoA"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLm-WS-1GK">
-                                                        <rect key="frame" x="0.0" y="249" width="315" height="50"/>
+                                                        <rect key="frame" x="0.0" y="275.5" width="334" height="23.5"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" priority="750" constant="1" id="T3v-yU-SxK"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fve-0t-icO">
-                                                        <rect key="frame" x="0.0" y="299" width="315" height="86"/>
+                                                        <rect key="frame" x="0.0" y="299" width="334" height="86"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Ut8-yb-neA" userLabel="Button Stack View">
-                                                                <rect key="frame" x="20" y="20" width="275" height="46"/>
+                                                                <rect key="frame" x="20" y="20" width="294" height="46"/>
                                                                 <subviews>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qlO-59-AKI" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="127.5" height="46"/>
+                                                                        <rect key="frame" x="0.0" y="0.0" width="137" height="46"/>
                                                                         <state key="normal" title="Not Now"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
@@ -140,7 +149,7 @@
                                                                         </connections>
                                                                     </button>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bju-kg-VqX" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                                        <rect key="frame" x="147.5" y="0.0" width="127.5" height="46"/>
+                                                                        <rect key="frame" x="157" y="0.0" width="137" height="46"/>
                                                                         <state key="normal" title="Try It"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
@@ -176,7 +185,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GWg-BX-CHE" userLabel="Padding">
-                                        <rect key="frame" x="345" y="0.0" width="30" height="385"/>
+                                        <rect key="frame" x="354.5" y="0.0" width="20.5" height="385"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     </view>
                                 </subviews>
@@ -206,16 +215,15 @@
                         <outlet property="moreInfoButton" destination="bwf-Ap-GLo" id="Z0W-pQ-eVj"/>
                         <outlet property="titleAccessoryButton" destination="rH2-Nt-ZNa" id="iCK-Op-GF7"/>
                         <outlet property="titleLabel" destination="cUO-4N-FhV" id="kjQ-N0-LhA"/>
-                        <outlet property="titleStackView" destination="ClB-4D-cxC" id="ZVb-go-Mmo"/>
                         <outlet property="wrapperView" destination="Zfy-Hg-zeP" id="g4f-8K-r32"/>
                         <outletCollection property="contentViews" destination="Krq-uR-e1t" collectionClass="NSMutableArray" id="hm4-hY-tCX"/>
-                        <outletCollection property="contentViews" destination="cUO-4N-FhV" collectionClass="NSMutableArray" id="lxF-hF-DT2"/>
-                        <outletCollection property="contentViews" destination="rH2-Nt-ZNa" collectionClass="NSMutableArray" id="25P-UC-ydS"/>
                         <outletCollection property="contentViews" destination="bwf-Ap-GLo" collectionClass="NSMutableArray" id="cBb-bT-aqY"/>
                         <outletCollection property="contentViews" destination="OPz-wQ-LdM" collectionClass="NSMutableArray" id="0zK-gs-3AW"/>
                         <outletCollection property="contentViews" destination="qlO-59-AKI" collectionClass="NSMutableArray" id="ozm-xc-dyp"/>
                         <outletCollection property="contentViews" destination="Bju-kg-VqX" collectionClass="NSMutableArray" id="99z-dA-G0J"/>
                         <outletCollection property="contentViews" destination="SLm-WS-1GK" collectionClass="NSMutableArray" id="dan-Gt-bHk"/>
+                        <outletCollection property="contentViews" destination="cUO-4N-FhV" collectionClass="NSMutableArray" id="lxF-hF-DT2"/>
+                        <outletCollection property="contentViews" destination="rH2-Nt-ZNa" collectionClass="NSMutableArray" id="25P-UC-ydS"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KAC-em-Hbz" userLabel="First Responder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
Fixes #7513 

Fancy alert titles were truncating if they were too long and didn't fit. This PR updates the view structure slightly to allow wrapping to 2 lines. I had to use a slight hack...

The stack view containing the title label and the beta badge was previously using `centered` distribution (first baseline would result in the badge being too low down in comparison to the label). However, when I enabled multiple lines on the label, that meant the badge would be centered against the entire label rather than just the first line. This looked a little weird.

To get around this, I've done the following:

* Removed the title stack view. The title label now sits directly in the main content stack view.
* The beta button now sits in the main content container and uses manual constraints instead of being in a stack view.
* There's an extra invisible placeholder label next to the title label. This is pinned to the first baseline of the title label.
* The beta button's center Y is pinned to the center Y of the placeholder label. This has the effect of making the button always centered against the first line of text in the title label.
* The beta button is pinned between the trailing edge of the title label and the trailing edge of the container to give it the correct X position.

You can see the updated hierarchy here:

<img width="683" alt="alert-title" src="https://user-images.githubusercontent.com/4780/28068837-178eeebe-663f-11e7-8fa8-ad6416a701bc.png">

So it's a little bit of a hack with the extra label, but I couldn't see any other way to center against the first line of text.

And here's an 'after' shot now that the text wraps:

<img width="305" alt="screen shot 2017-07-11 at 13 37 12" src="https://user-images.githubusercontent.com/4780/28068759-cdebc1b0-663e-11e7-8564-3fffa0d26eea.png">

To test:

* To get the alert to re-show, it's easiest to modify `showAztecAnnouncement` in `BlogDetailsViewController` to always show the announcement
* To get the long title, go into Me > App Settings and ensure Aztec is enabled
* Build and run
* Visit blog details. You should see the alert, and see the text wrapping.
* Ensure it works on bigger and smaller screens, and that single lines still look ok too.

Needs review: @nheagy 