### PR TITLE
Uppercase strings with the locale to take into account language rules

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -78,7 +78,7 @@ open class DeleteSiteViewController: UITableViewController {
         sectionTwoColumnItems.forEach({ $0.textColor = WPStyleGuide.darkGrey() })
 
         sectionTwoHeader.text = NSLocalizedString("these items will be deleted:",
-                                                  comment: "Header of delete screen section listing things that will be deleted.").uppercased()
+                                                  comment: "Header of delete screen section listing things that will be deleted.").uppercased(with: Locale.current)
 
         sectionTwoColumnOneItem.text = NSLocalizedString("• Posts",
                                                          comment: "Item 1 of delete screen section listing things that will be deleted.")

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -78,7 +78,7 @@ open class DeleteSiteViewController: UITableViewController {
         sectionTwoColumnItems.forEach({ $0.textColor = WPStyleGuide.darkGrey() })
 
         sectionTwoHeader.text = NSLocalizedString("these items will be deleted:",
-                                                  comment: "Header of delete screen section listing things that will be deleted.").uppercased(with: Locale.current)
+                                                  comment: "Header of delete screen section listing things that will be deleted.").localizedUppercase()
 
         sectionTwoColumnOneItem.text = NSLocalizedString("• Posts",
                                                          comment: "Item 1 of delete screen section listing things that will be deleted.")

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -78,7 +78,7 @@ open class DeleteSiteViewController: UITableViewController {
         sectionTwoColumnItems.forEach({ $0.textColor = WPStyleGuide.darkGrey() })
 
         sectionTwoHeader.text = NSLocalizedString("these items will be deleted:",
-                                                  comment: "Header of delete screen section listing things that will be deleted.").localizedUppercase()
+                                                  comment: "Header of delete screen section listing things that will be deleted.").localizedUppercase
 
         sectionTwoColumnOneItem.text = NSLocalizedString("• Posts",
                                                          comment: "Item 1 of delete screen section listing things that will be deleted.")

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/TableViewHeaderDetailView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/TableViewHeaderDetailView.swift
@@ -9,7 +9,7 @@ open class TableViewHeaderDetailView: UITableViewHeaderFooterView {
     open var title: String = "" {
         didSet {
             if title != oldValue {
-                titleLabel.text = title.localizedUppercase()
+                titleLabel.text = title.localizedUppercase
                 setNeedsLayout()
             }
         }

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/TableViewHeaderDetailView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/TableViewHeaderDetailView.swift
@@ -9,7 +9,7 @@ open class TableViewHeaderDetailView: UITableViewHeaderFooterView {
     open var title: String = "" {
         didSet {
             if title != oldValue {
-                titleLabel.text = title.uppercased(with: Locale.current)
+                titleLabel.text = title.localizedUppercase()
                 setNeedsLayout()
             }
         }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
@@ -57,13 +57,13 @@ class LoginEpilogueTableView: UITableViewController {
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let sectionTitle: String
         if (section == 0) {
-            sectionTitle = NSLocalizedString("Logged In As", comment: "Header for user info, shown after loggin in").uppercased(with: Locale.current)
+            sectionTitle = NSLocalizedString("Logged In As", comment: "Header for user info, shown after loggin in").localizedUppercase()
         } else {
             switch blogCount {
             case .some(let count) where count > 1:
-                sectionTitle = NSLocalizedString("My Sites", comment: "Header for list of multiple sites, shown after loggin in").uppercased(with: Locale.current)
+                sectionTitle = NSLocalizedString("My Sites", comment: "Header for list of multiple sites, shown after loggin in").localizedUppercase()
             case .some(let count) where count == 1:
-                sectionTitle = NSLocalizedString("My Site", comment: "Header for a single site, shown after loggin in").uppercased(with: Locale.current)
+                sectionTitle = NSLocalizedString("My Site", comment: "Header for a single site, shown after loggin in").localizedUppercase()
             default:
                 sectionTitle = ""
             }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
@@ -57,13 +57,13 @@ class LoginEpilogueTableView: UITableViewController {
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let sectionTitle: String
         if (section == 0) {
-            sectionTitle = NSLocalizedString("Logged In As", comment: "Header for user info, shown after loggin in").localizedUppercase()
+            sectionTitle = NSLocalizedString("Logged In As", comment: "Header for user info, shown after loggin in").localizedUppercase
         } else {
             switch blogCount {
             case .some(let count) where count > 1:
-                sectionTitle = NSLocalizedString("My Sites", comment: "Header for list of multiple sites, shown after loggin in").localizedUppercase()
+                sectionTitle = NSLocalizedString("My Sites", comment: "Header for list of multiple sites, shown after loggin in").localizedUppercase
             case .some(let count) where count == 1:
-                sectionTitle = NSLocalizedString("My Site", comment: "Header for a single site, shown after loggin in").localizedUppercase()
+                sectionTitle = NSLocalizedString("My Site", comment: "Header for a single site, shown after loggin in").localizedUppercase
             default:
                 sectionTitle = ""
             }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
@@ -57,13 +57,13 @@ class LoginEpilogueTableView: UITableViewController {
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let sectionTitle: String
         if (section == 0) {
-            sectionTitle = NSLocalizedString("LOGGED IN AS", comment: "Header for user info, shown after loggin in").uppercased()
+            sectionTitle = NSLocalizedString("Logged In As", comment: "Header for user info, shown after loggin in").uppercased(with: Locale.current)
         } else {
             switch blogCount {
             case .some(let count) where count > 1:
-                sectionTitle = NSLocalizedString("MY SITES", comment: "Header for list of multiple sites, shown after loggin in").uppercased()
+                sectionTitle = NSLocalizedString("My Sites", comment: "Header for list of multiple sites, shown after loggin in").uppercased(with: Locale.current)
             case .some(let count) where count == 1:
-                sectionTitle = NSLocalizedString("MY SITE", comment: "Header for a single site, shown after loggin in").uppercased()
+                sectionTitle = NSLocalizedString("My Site", comment: "Header for a single site, shown after loggin in").uppercased(with: Locale.current)
             default:
                 sectionTitle = ""
             }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -380,7 +380,7 @@ extension NotificationDetailsViewController {
     func setupReplyTextView() {
         let replyTextView = ReplyTextView(width: view.frame.width)
         replyTextView.placeholder = NSLocalizedString("Write a reply…", comment: "Placeholder text for inline compose view")
-        replyTextView.replyText = NSLocalizedString("Reply", comment: "").localizedUppercase()
+        replyTextView.replyText = NSLocalizedString("Reply", comment: "").localizedUppercase
         replyTextView.accessibilityIdentifier = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
         replyTextView.delegate = self
         replyTextView.onReply = { [weak self] content in

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -380,7 +380,7 @@ extension NotificationDetailsViewController {
     func setupReplyTextView() {
         let replyTextView = ReplyTextView(width: view.frame.width)
         replyTextView.placeholder = NSLocalizedString("Write a reply…", comment: "Placeholder text for inline compose view")
-        replyTextView.replyText = NSLocalizedString("Reply", comment: "").uppercased()
+        replyTextView.replyText = NSLocalizedString("Reply", comment: "").uppercased(with: Locale.current)
         replyTextView.accessibilityIdentifier = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
         replyTextView.delegate = self
         replyTextView.onReply = { [weak self] content in

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -380,7 +380,7 @@ extension NotificationDetailsViewController {
     func setupReplyTextView() {
         let replyTextView = ReplyTextView(width: view.frame.width)
         replyTextView.placeholder = NSLocalizedString("Write a reply…", comment: "Placeholder text for inline compose view")
-        replyTextView.replyText = NSLocalizedString("Reply", comment: "").uppercased(with: Locale.current)
+        replyTextView.replyText = NSLocalizedString("Reply", comment: "").localizedUppercase()
         replyTextView.accessibilityIdentifier = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
         replyTextView.delegate = self
         replyTextView.onReply = { [weak self] content in

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
@@ -9,7 +9,7 @@ class NoteTableHeaderView: UIView {
     var title: String? {
         set {
             // For layout reasons, we need to ensure that the titleLabel uses an exact Paragraph Height!
-            let unwrappedTitle = newValue?.uppercased(with: Locale.current) ?? String()
+            let unwrappedTitle = newValue?.localizedUppercase() ?? String()
             let attributes = Style.sectionHeaderRegularStyle
             titleLabel.attributedText = NSAttributedString(string: unwrappedTitle, attributes: attributes)
             setNeedsLayout()

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
@@ -9,7 +9,7 @@ class NoteTableHeaderView: UIView {
     var title: String? {
         set {
             // For layout reasons, we need to ensure that the titleLabel uses an exact Paragraph Height!
-            let unwrappedTitle = newValue?.localizedUppercase() ?? String()
+            let unwrappedTitle = newValue?.localizedUppercase ?? String()
             let attributes = Style.sectionHeaderRegularStyle
             titleLabel.attributedText = NSAttributedString(string: unwrappedTitle, attributes: attributes)
             setNeedsLayout()

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -61,7 +61,7 @@ class PlanDetailViewController: UIViewController {
         let label = UILabel()
         label.font = WPFontManager.systemSemiBoldFont(ofSize: 13.0)
         label.textColor = WPStyleGuide.validGreen()
-        label.text = NSLocalizedString("Current Plan", comment: "").uppercased(with: Locale.current)
+        label.text = NSLocalizedString("Current Plan", comment: "").localizedUppercase()
         label.translatesAutoresizingMaskIntoConstraints = false
 
         // Wrapper view required for spacing to work out correctly, as the header stackview

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -61,7 +61,7 @@ class PlanDetailViewController: UIViewController {
         let label = UILabel()
         label.font = WPFontManager.systemSemiBoldFont(ofSize: 13.0)
         label.textColor = WPStyleGuide.validGreen()
-        label.text = NSLocalizedString("Current Plan", comment: "").localizedUppercase()
+        label.text = NSLocalizedString("Current Plan", comment: "").localizedUppercase
         label.translatesAutoresizingMaskIntoConstraints = false
 
         // Wrapper view required for spacing to work out correctly, as the header stackview

--- a/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
@@ -54,7 +54,7 @@ struct PlanListRow: ImmuTableRow {
                     NSFontAttributeName: WPFontManager.systemSemiBoldFont(ofSize: 11.0),
                     NSForegroundColorAttributeName: WPStyleGuide.validGreen()
                 ]
-                let currentPlan = NSLocalizedString("Current Plan", comment: "").localizedUppercase()
+                let currentPlan = NSLocalizedString("Current Plan", comment: "").localizedUppercase
                 let attributedCurrentPlan = NSAttributedString(string: currentPlan, attributes: currentPlanAttributes)
                 attributedTitle.append(attributedCurrentPlan)
             } else if !price.isEmpty {

--- a/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
@@ -54,7 +54,7 @@ struct PlanListRow: ImmuTableRow {
                     NSFontAttributeName: WPFontManager.systemSemiBoldFont(ofSize: 11.0),
                     NSForegroundColorAttributeName: WPStyleGuide.validGreen()
                 ]
-                let currentPlan = NSLocalizedString("Current Plan", comment: "").uppercased(with: Locale.current)
+                let currentPlan = NSLocalizedString("Current Plan", comment: "").localizedUppercase()
                 let attributedCurrentPlan = NSAttributedString(string: currentPlan, attributes: currentPlanAttributes)
                 attributedTitle.append(attributedCurrentPlan)
             } else if !price.isEmpty {


### PR DESCRIPTION
Fixes #7449 

This fixes a couple instances of using uppercased() without passing in the current locale. Some languages have different rules for what's considered uppercasing based upon the character set. I also eliminated the default string from being in uppercase to simplify translations (prevents a duplicate string).

To test:
1. Build and run.
2. Make sure values are uppercased in each of the view controllers. Testing uppercase logic might be hard so just making sure default behavior isn't changed is good.

Needs review: @nheagy 
