### PR TITLE
Login: For paranioa, make sure buttons won't show an ellipsis.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -86,6 +86,7 @@ class Login2FAViewController: LoginViewController, SigninKeyboardResponder {
 
         sendCodeButton.setTitle(NSLocalizedString("Text me a code instead", comment: "Button title"),
                                 for: .normal)
+        sendCodeButton.titleLabel?.numberOfLines = 0
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginLinkMailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginLinkMailViewController.swift
@@ -49,6 +49,7 @@ class LoginLinkMailViewController: LoginViewController {
         let usePasswordTitle = NSLocalizedString("Enter your password instead.", comment: "Title of a button on the magic link screen.")
         usePasswordButton?.setTitle(usePasswordTitle, for: UIControlState())
         usePasswordButton?.setTitle(usePasswordTitle, for: .highlighted)
+        usePasswordButton?.titleLabel?.numberOfLines = 0
     }
 
     // let the storyboard's style stay

--- a/WordPress/Classes/ViewRelated/NUX/LoginLinkRequestViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginLinkRequestViewController.swift
@@ -63,6 +63,7 @@ class LoginLinkRequestViewController: LoginViewController {
         let usePasswordTitle = NSLocalizedString("Enter your password instead.", comment: "Title of a button. ")
         usePasswordButton?.setTitle(usePasswordTitle, for: UIControlState())
         usePasswordButton?.setTitle(usePasswordTitle, for: .highlighted)
+        usePasswordButton?.titleLabel?.numberOfLines = 0
     }
 
     func configureLoading(_ animating: Bool) {

--- a/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
@@ -98,6 +98,7 @@ class LoginSelfHostedViewController: LoginViewController, SigninKeyboardResponde
         let forgotPasswordTitle = NSLocalizedString("Lost your password?", comment: "Title of a button. ")
         forgotPasswordButton.setTitle(forgotPasswordTitle, for: UIControlState())
         forgotPasswordButton.setTitle(forgotPasswordTitle, for: .highlighted)
+        forgotPasswordButton.titleLabel?.numberOfLines = 0
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginWPComViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginWPComViewController.swift
@@ -121,6 +121,7 @@ class LoginWPComViewController: LoginViewController, SigninKeyboardResponder {
         let forgotPasswordTitle = NSLocalizedString("Lost your password?", comment: "Title of a button. ")
         forgotPasswordButton?.setTitle(forgotPasswordTitle, for: UIControlState())
         forgotPasswordButton?.setTitle(forgotPasswordTitle, for: .highlighted)
+        forgotPasswordButton?.titleLabel?.numberOfLines = 0
     }
 
     // let the storyboard's style stay


### PR DESCRIPTION
Refs #7272 

This patch allows a button's title text to wrap rather than show an ellipsis in the event the button's text is too long to show on a single line. 

To test:
For a robust test, change the button titles to something rather long then run the app and ensure the text wraps. 

Needs review: @jleandroperez Could I trouble you for a review since you spotted this issue in an earlier iteration?  
