### PR TITLE
Update font style and line height on reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -113,9 +113,9 @@ class WPRichContentView: UITextView {
         set {
             let str = newValue
             let style = "<style>" +
-                "body { font:-apple-system-subheadline; font-family: 'Noto Serif'; font-weight: normal; line-height:1.6875; color: #2e4453; }" +
+                "body { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; line-height:1.6; color: #2e4453; }" +
                 "blockquote { color:#4f748e; } " +
-                "em, i { font:-apple-system-subheadline; font-family: 'Noto Serif'; font-weight: normal; font-style: italic; } " +
+                "em, i { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; font-style: italic; line-height:1.6; } " +
                 "a { color: #0087be; text-decoration: none; } " +
                 "a:active { color: #005082; } " +
                 "</style>"


### PR DESCRIPTION
**Fixes** #7534 

**To test:**
Go to reader and visit one article, check that the font is bigger. 
Then you can change the accessibility values and check that that view adjust accordingly (go back and in again into the article).

**SETTINGS**
![accessibility](https://user-images.githubusercontent.com/5558824/28184776-19c7511e-67eb-11e7-9fa4-a3fbcca1980b.png)
**BEFORE:**
![before](https://user-images.githubusercontent.com/5558824/28184879-749c3c58-67eb-11e7-86f7-abf31ca01242.png)
**AFTER:**
![reader-1 6](https://user-images.githubusercontent.com/5558824/28184791-24567d12-67eb-11e7-9eb2-0864a24e138e.png)

Needs review: @aerych 