### PR TITLE
Login: Adjust height for external keyboard.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninKeyboardResponder.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninKeyboardResponder.swift
@@ -144,9 +144,9 @@ extension SigninKeyboardResponder where Self: NUXAbstractViewController {
     func heightDeltaFromKeyboardFrame(_ keyboardFrame: CGRect) -> CGFloat {
         // If an external keyboard is connected, the ending keyboard frame's maxY
         // will exceed the height of the view controller's view.
-        // There is no need to adjust the view in this case so just return 0.0.
-        if (keyboardFrame.maxY > self.view.frame.height) {
-            return 0.0
+        // In these cases, just adjust the height by the amount of the keyboard visible.
+        if (keyboardFrame.maxY > view.frame.height) {
+            return view.frame.height - keyboardFrame.minY
         }
         return keyboardFrame.height
     }


### PR DESCRIPTION
Refs #7272 

To test:
Use the simulator setting for an external keyboard.
Put focus on a text field. 
Ensure the view adjusts for the height of the keyboard bar.
Toggle the soft keyboard.  Ensure the height continues to adjust for the full keyboard size.

Needs review: @elibud could I trouble you with this one? 

cc @nheagy 

Example:
![simulator screen shot jul 13 2017 4 54 13 pm](https://user-images.githubusercontent.com/1435271/28189612-41577636-67ec-11e7-9eca-7a7f04f3468a.png)
