### PR TITLE
Fix heading width in fancy alert when no beta button is shown

### DIFF
--- a/WordPress/Classes/ViewRelated/System/FancyAlerts.storyboard
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F2073" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -68,14 +68,14 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JVE-OD-Ia7">
-                                                        <rect key="frame" x="0.0" y="162" width="315" height="1"/>
+                                                        <rect key="frame" x="0.0" y="162" width="334" height="1"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" priority="750" constant="1" id="lCv-jy-vNg"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rzT-7k-QCD" userLabel="Content Container">
-                                                        <rect key="frame" x="0.0" y="163" width="315" height="87"/>
+                                                        <rect key="frame" x="0.0" y="163" width="334" height="87"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="999" verticalHuggingPriority="999" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rH2-Nt-ZNa">
                                                                 <rect key="frame" x="71.5" y="16" width="46" height="30"/>
@@ -92,7 +92,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="30" baselineRelativeArrangement="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Er7-dR-3IB" userLabel="Content Stack View">
-                                                                <rect key="frame" x="20" y="20" width="294" height="73.5"/>
+                                                                <rect key="frame" x="20" y="20" width="294" height="47"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" horizontalCompressionResistancePriority="999" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cUO-4N-FhV">
                                                                         <rect key="frame" x="0.0" y="0.0" width="43.5" height="20.5"/>
@@ -101,13 +101,13 @@
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OPz-wQ-LdM">
-                                                                        <rect key="frame" x="0.0" y="31.5" width="37.5" height="15"/>
+                                                                        <rect key="frame" x="0.0" y="31.5" width="37.5" height="0.0"/>
                                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bwf-Ap-GLo">
-                                                                        <rect key="frame" x="0.0" y="43.5" width="46" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="40" width="46" height="7"/>
                                                                         <state key="normal" title="Button"/>
                                                                         <connections>
                                                                             <action selector="buttonTapped:" destination="ZA1-84-qnC" eventType="touchUpInside" id="3PW-eX-0Sw"/>
@@ -118,11 +118,11 @@
                                                         </subviews>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
+                                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cUO-4N-FhV" secondAttribute="trailing" constant="28" id="8Dt-2R-IOW"/>
                                                             <constraint firstItem="75Q-Jn-AFH" firstAttribute="firstBaseline" secondItem="cUO-4N-FhV" secondAttribute="firstBaseline" id="CuZ-hU-uES"/>
                                                             <constraint firstItem="75Q-Jn-AFH" firstAttribute="leading" secondItem="cUO-4N-FhV" secondAttribute="trailing" id="JAl-Yr-Eh3"/>
                                                             <constraint firstItem="Er7-dR-3IB" firstAttribute="top" secondItem="rzT-7k-QCD" secondAttribute="top" constant="20" id="Rxa-JT-XKl"/>
                                                             <constraint firstAttribute="trailing" secondItem="Er7-dR-3IB" secondAttribute="trailing" constant="20" id="aEb-Sn-pwu"/>
-                                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rH2-Nt-ZNa" secondAttribute="trailing" constant="20" id="jDZ-tY-mxR"/>
                                                             <constraint firstAttribute="bottom" secondItem="Er7-dR-3IB" secondAttribute="bottom" constant="20" id="nJT-ly-DDr"/>
                                                             <constraint firstItem="rH2-Nt-ZNa" firstAttribute="leading" secondItem="cUO-4N-FhV" secondAttribute="trailing" constant="8" id="o0I-ch-GMs"/>
                                                             <constraint firstItem="Er7-dR-3IB" firstAttribute="leading" secondItem="rzT-7k-QCD" secondAttribute="leading" constant="20" id="v3D-07-SBb"/>
@@ -130,7 +130,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLm-WS-1GK">
-                                                        <rect key="frame" x="0.0" y="250" width="315" height="49"/>
+                                                        <rect key="frame" x="0.0" y="250" width="334" height="49"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" priority="750" constant="1" id="T3v-yU-SxK"/>
@@ -221,7 +221,6 @@
                         <outlet property="moreInfoButton" destination="bwf-Ap-GLo" id="Z0W-pQ-eVj"/>
                         <outlet property="titleAccessoryButton" destination="rH2-Nt-ZNa" id="iCK-Op-GF7"/>
                         <outlet property="titleLabel" destination="cUO-4N-FhV" id="kjQ-N0-LhA"/>
-                        <outlet property="titleStackView" destination="ClB-4D-cxC" id="ZVb-go-Mmo"/>
                         <outlet property="topDividerView" destination="JVE-OD-Ia7" id="hhk-Ox-h6f"/>
                         <outlet property="wrapperView" destination="Zfy-Hg-zeP" id="g4f-8K-r32"/>
                         <outletCollection property="contentViews" destination="Krq-uR-e1t" collectionClass="NSMutableArray" id="hm4-hY-tCX"/>


### PR DESCRIPTION
Fixes #7548

The title now fill the space properly

![simulator screen shot jul 14 2017 2 13 29 pm](https://user-images.githubusercontent.com/517257/28229263-49ef6f52-689f-11e7-9406-529100e99ab5.png)

To test:
- ensure that the fancy alert titles look correct: site address, aztec beta

Needs review: @aerych 
