### PR TITLE
Turn on the new login experience for everyone

### DIFF
--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -12,7 +12,7 @@ enum FeatureFlag: Int {
         case .exampleFeature:
             return true
         case .newLogin:
-            return build(.localDeveloper, .a8cBranchTest)
+            return true
         case .newMediaExports:
             return build(.localDeveloper, .a8cBranchTest)
         }


### PR DESCRIPTION
Fixes #7272

Who do we want to see the new login process?

![everyone-gif-2](https://user-images.githubusercontent.com/517257/28229415-f19a5dfc-689f-11e7-8da3-18739dd32edd.gif)

To test:
- build a release build that wouldn't otherwise see the new login process

Needs review: @aerych 