### PR TITLE
Issues/7272 update login error screen

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
+++ b/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
@@ -81,7 +81,6 @@ extension FancyAlertViewController {
         if error.domain != WPXMLRPCFaultErrorDomain && error.code != NSURLErrorBadURL {
             if HelpshiftUtils.isHelpshiftEnabled() {
                 return alertForGenericErrorMessageWithHelpshiftButton(message, loginFields: loginFields, sourceTag: sourceTag)
-
             } else {
                 return alertForGenericErrorMessage(message, sourceTag: sourceTag)
             }
@@ -97,9 +96,9 @@ extension FancyAlertViewController {
 
         if error.code == NSURLErrorBadURL {
             return alertForBadURLMessage(message)
-        } else {
-            return alertForGenericErrorMessage(message, sourceTag: sourceTag)
         }
+
+        return alertForGenericErrorMessage(message, sourceTag: sourceTag)
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
+++ b/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
@@ -189,11 +189,12 @@ extension FancyAlertViewController {
                 // Find the topmost view controller that we can present from
                 guard let appDelegate = UIApplication.shared.delegate,
                     let window = appDelegate.window,
-                    let viewController = window?.topmostPresentedViewController else { return }
+                    let viewController = window?.topmostPresentedViewController,
+                    let url = URL(string: "https://apps.wordpress.org/support/#faq-ios-3"),
+                    let webController = WPWebViewController(url: url)
+                    else { return }
 
-                let url = URL(string: "https://apps.wordpress.org/support/#faq-ios-3")!
-                let webController = WPWebViewController(url: url)
-                let navController = UINavigationController(rootViewController: webController!)
+                let navController = UINavigationController(rootViewController: webController)
                 viewController.present(navController, animated: true, completion: nil)
             }
         }

--- a/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
+++ b/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
@@ -1,21 +1,24 @@
 import UIKit
+import wpxmlrpc
 
 extension FancyAlertViewController {
-    static func siteAddressHelpController() -> FancyAlertViewController {
-        struct Strings {
-            static let titleText = NSLocalizedString("What's my site address?", comment: "Title of alert helping users understand their site address")
-            static let bodyText = NSLocalizedString("Your site address appears in the bar at the the top of the screen when you visit your site in Safari.", comment: "Body text of alert helping users understand their site address")
-            static let OK = NSLocalizedString("OK", comment: "Ok button for dismissing alert helping users understand their site address")
-            static let moreHelp = NSLocalizedString("Need more help?", comment: "Title of the more help button on alert helping users understand their site address")
-        }
+    struct Strings {
+        static let titleText = NSLocalizedString("What's my site address?", comment: "Title of alert helping users understand their site address")
+        static let bodyText = NSLocalizedString("Your site address appears in the bar at the the top of the screen when you visit your site in Safari.", comment: "Body text of alert helping users understand their site address")
+        static let OK = NSLocalizedString("OK", comment: "Ok button for dismissing alert helping users understand their site address")
+        static let moreHelp = NSLocalizedString("Need more help?", comment: "Title of the more help button on alert helping users understand their site address")
+    }
 
-        typealias Button = FancyAlertViewController.Config.ButtonConfig
+    typealias ButtonConfig = FancyAlertViewController.Config.ButtonConfig
 
-        let defaultButton = Button(Strings.OK) { controller in
+    private static func defaultButton() -> ButtonConfig {
+        return ButtonConfig(Strings.OK) { controller in
             controller.dismiss(animated: true, completion: nil)
         }
+    }
 
-        let moreHelpButton = Button(Strings.moreHelp) { controller in
+    static func siteAddressHelpController() -> FancyAlertViewController {
+        let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller in
             controller.dismiss(animated: true) {
                 // Find the topmost view controller that we can present from
                 guard let delegate = UIApplication.shared.delegate,
@@ -38,7 +41,7 @@ extension FancyAlertViewController {
                                                      bodyText: Strings.bodyText,
                                                      headerImage: image,
                                                      dividerPosition: .top,
-                                                     defaultButton: defaultButton,
+                                                     defaultButton: defaultButton(),
                                                      cancelButton: nil,
                                                      moreInfoButton: moreHelpButton,
                                                      titleAccessoryButton: nil,
@@ -47,4 +50,165 @@ extension FancyAlertViewController {
         let controller = FancyAlertViewController.controllerWithConfiguration(configuration: config)
         return controller
     }
+
+
+    // MARK: - Error Handling
+
+
+    /// Get an alert for the specified error message.
+    /// The view is configured differently depending on the kind of error.
+    ///
+    /// - Parameters:
+    ///     - error: An NSError instance
+    ///     - loginFields: A LoginFields instance.
+    ///     - sourceTag: The sourceTag that is the context of the error.
+    ///
+    /// - Returns: A FancyAlertViewController instance.
+    ///
+    static func alertForError(_ error: NSError, loginFields: LoginFields, sourceTag: SupportSourceTag) -> FancyAlertViewController {
+        var message = error.localizedDescription
+
+        DDLogError(message)
+
+        if sourceTag == .jetpackLogin && error.domain == WordPressAppErrorDomain && error.code == NSURLErrorBadURL {
+            if HelpshiftUtils.isHelpshiftEnabled() {
+                // TODO: Placeholder Jetpack login error message. Needs updating with final wording. 2017-06-15 Aerych.
+                message = NSLocalizedString("We're not able to connect to the Jetpack site at that URL.  Contact us for assistance.", comment: "Error message shown when having trouble connecting to a Jetpack site.")
+                return alertForGenericErrorMessageWithHelpshiftButton(message, loginFields: loginFields, sourceTag: sourceTag)
+            }
+        }
+
+        if error.domain != WPXMLRPCFaultErrorDomain && error.code != NSURLErrorBadURL {
+            if HelpshiftUtils.isHelpshiftEnabled() {
+                return alertForGenericErrorMessageWithHelpshiftButton(message, loginFields: loginFields, sourceTag: sourceTag)
+
+            } else {
+                return alertForGenericErrorMessage(message, sourceTag: sourceTag)
+            }
+        }
+
+        if error.code == 403 {
+            message = NSLocalizedString("Incorrect username or password. Please try entering your login details again.", comment: "An error message shown when a user signed in with incorrect credentials.")
+        }
+
+        if message.trim().characters.count == 0 {
+            message = NSLocalizedString("Log in failed. Please try again.", comment: "A generic error message for a failed log in.")
+        }
+
+        if error.code == NSURLErrorBadURL {
+            return alertForBadURLMessage(message)
+        } else {
+            return alertForGenericErrorMessage(message, sourceTag: sourceTag)
+        }
+    }
+
+
+    /// Shows a generic error message.
+    ///
+    /// - Parameter message: The error message to show.
+    ///
+    private static func alertForGenericErrorMessage(_ message: String, sourceTag: SupportSourceTag) -> FancyAlertViewController {
+        let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller in
+            controller.dismiss(animated: true) {
+                // Find the topmost view controller that we can present from
+                guard let appDelegate = UIApplication.shared.delegate,
+                    let window = appDelegate.window,
+                    let viewController = window?.topmostPresentedViewController else { return }
+
+                let supportController = SupportViewController()
+                supportController.sourceTag = sourceTag
+
+                let navController = UINavigationController(rootViewController: supportController)
+                navController.navigationBar.isTranslucent = false
+                navController.modalPresentationStyle = .formSheet
+
+                viewController.present(navController, animated: true, completion: nil)
+            }
+        }
+
+        let config = FancyAlertViewController.Config(titleText: "",
+                                                     bodyText: message,
+                                                     headerImage: nil,
+                                                     dividerPosition: .top,
+                                                     defaultButton: defaultButton(),
+                                                     cancelButton: nil,
+                                                     moreInfoButton: moreHelpButton,
+                                                     titleAccessoryButton: nil,
+                                                     dismissAction: nil)
+        return FancyAlertViewController.controllerWithConfiguration(configuration: config)
+    }
+
+
+    /// Shows a generic error message. The view
+    /// is configured so the user can open Helpshift for assistance.
+    ///
+    /// - Parameter message: The error message to show.
+    /// - Parameter sourceTag: tag of the source of the error
+    ///
+    private static func alertForGenericErrorMessageWithHelpshiftButton(_ message: String, loginFields: LoginFields, sourceTag: SupportSourceTag) -> FancyAlertViewController {
+        let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller in
+            controller.dismiss(animated: true) {
+                // Find the topmost view controller that we can present from
+                guard let appDelegate = UIApplication.shared.delegate,
+                    let window = appDelegate.window,
+                    let viewController = window?.topmostPresentedViewController else { return }
+
+                guard HelpshiftUtils.isHelpshiftEnabled() else { return }
+
+                let metaData: [String: AnyObject] = [
+                    "Source": "Failed login" as AnyObject,
+                    "Username": loginFields.username as AnyObject,
+                    "SiteURL": loginFields.siteUrl as AnyObject,
+                    HelpshiftSupportTagsKey: [sourceTag.rawValue]  as AnyObject
+                ]
+
+                HelpshiftSupport.showConversation(viewController, withOptions: [HelpshiftSupportCustomMetadataKey: metaData, "showSearchOnNewConversation": "YES"])
+                WPAppAnalytics.track(.supportOpenedHelpshiftScreen)
+            }
+        }
+
+        let config = FancyAlertViewController.Config(titleText: "",
+                                                     bodyText: message,
+                                                     headerImage: nil,
+                                                     dividerPosition: .top,
+                                                     defaultButton: defaultButton(),
+                                                     cancelButton: nil,
+                                                     moreInfoButton: moreHelpButton,
+                                                     titleAccessoryButton: nil,
+                                                     dismissAction: nil)
+        return FancyAlertViewController.controllerWithConfiguration(configuration: config)
+    }
+
+
+    /// Shows a WPWalkthroughOverlayView for a bad url error message.
+    ///
+    /// - Parameter message: The error message to show.
+    ///
+    private static func alertForBadURLMessage(_ message: String) -> FancyAlertViewController {
+        let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller in
+            controller.dismiss(animated: true) {
+                // Find the topmost view controller that we can present from
+                guard let appDelegate = UIApplication.shared.delegate,
+                    let window = appDelegate.window,
+                    let viewController = window?.topmostPresentedViewController else { return }
+
+                let url = URL(string: "https://apps.wordpress.org/support/#faq-ios-3")!
+                let webController = WPWebViewController(url: url)
+                let navController = UINavigationController(rootViewController: webController!)
+                viewController.present(navController, animated: true, completion: nil)
+            }
+        }
+
+        let config = FancyAlertViewController.Config(titleText: "",
+                                                     bodyText: message,
+                                                     headerImage: nil,
+                                                     dividerPosition: .top,
+                                                     defaultButton: defaultButton(),
+                                                     cancelButton: nil,
+                                                     moreInfoButton: moreHelpButton,
+                                                     titleAccessoryButton: nil,
+                                                     dismissAction: nil)
+        return FancyAlertViewController.controllerWithConfiguration(configuration: config)
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
@@ -263,13 +263,3 @@ class LoginSiteAddressViewController: LoginViewController, SigninKeyboardRespond
         keyboardWillHide(notification)
     }
 }
-
-extension LoginSiteAddressViewController: UIViewControllerTransitioningDelegate {
-    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
-        if presented is FancyAlertViewController {
-            return FancyAlertPresentationController(presentedViewController: presented, presenting: presenting)
-        }
-
-        return nil
-    }
-}

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
@@ -117,7 +117,11 @@ extension LoginViewController: SigninWPComSyncHandler, LoginFacadeDelegate {
             return
         }
 
-        displayError(error as NSError, sourceTag: sourceTag)
+        let presentingController = navigationController ?? self
+        let controller = FancyAlertViewController.alertForError(error as NSError, loginFields: loginFields, sourceTag: sourceTag)
+        controller.modalPresentationStyle = .custom
+        controller.transitioningDelegate = self
+        presentingController.present(controller, animated: true, completion: nil)
     }
 
     func needsMultifactorCode() {
@@ -136,5 +140,15 @@ extension LoginViewController: SigninWPComSyncHandler, LoginFacadeDelegate {
 
     func loginDismissal() {
         self.performSegue(withIdentifier: .showEpilogue, sender: self)
+    }
+}
+
+extension LoginViewController: UIViewControllerTransitioningDelegate {
+    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        if presented is FancyAlertViewController {
+            return FancyAlertPresentationController(presentedViewController: presented, presenting: presenting)
+        }
+
+        return nil
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
@@ -88,6 +88,14 @@ class LoginViewController: NUXAbstractViewController {
             destination.errorToPresent = source.errorToPresent
         }
     }
+
+    override func displayError(_ error: NSError, sourceTag: SupportSourceTag) {
+        let presentingController = navigationController ?? self
+        let controller = FancyAlertViewController.alertForError(error as NSError, loginFields: loginFields, sourceTag: sourceTag)
+        controller.modalPresentationStyle = .custom
+        controller.transitioningDelegate = self
+        presentingController.present(controller, animated: true, completion: nil)
+    }
 }
 
 extension LoginViewController: SigninWPComSyncHandler, LoginFacadeDelegate {
@@ -111,17 +119,14 @@ extension LoginViewController: SigninWPComSyncHandler, LoginFacadeDelegate {
     func displayRemoteError(_ error: Error!) {
         configureViewLoading(false)
 
-        guard (error as NSError).code != 403 else {
+        let err = error as NSError
+        guard err.code != 403 else {
             let message = NSLocalizedString("Whoops, something went wrong and we couldn't log you in. Please try again!", comment: "An error message shown when a wpcom user provides the wrong password.")
             displayError(message: message)
             return
         }
 
-        let presentingController = navigationController ?? self
-        let controller = FancyAlertViewController.alertForError(error as NSError, loginFields: loginFields, sourceTag: sourceTag)
-        controller.modalPresentationStyle = .custom
-        controller.transitioningDelegate = self
-        presentingController.present(controller, animated: true, completion: nil)
+        displayError(err, sourceTag: sourceTag)
     }
 
     func needsMultifactorCode() {


### PR DESCRIPTION
Refs #7272 

This PR switches the remote error handling from the modal SignupErrorViewController to the new FancyAlertViewController.
The error logic (decision branching) code has been ported more or less intact with a few exceptions:
- methods were renamed to better suit the alert controller. 
- the 405 check for XMLRPC errors has been dropped. Since XML-RPC is enabled by default in versions of WordPress the app supports we shouldn't see this error unless a user chooses to disable XML-RPC via a plugin.  Even if a user were to disable XML-RPC via a plugin the way it was being handled was incorrect.

To test:
To test the implementation, I opted to manually present errors using each option and confirm that the alerts are presented correctly, dismiss correctly and that the more button opens the FAQ, the Support vc, or Helpshift as appropriate. 

Needs review: @nheagy 

![simulator screen shot jul 14 2017 4 38 41 pm](https://user-images.githubusercontent.com/1435271/28231808-04649ac0-68b3-11e7-969d-3f50706736b4.png)
