### PR TITLE
Fancy Alerts: Fix title wrap issue

### DIFF
--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController.swift
@@ -85,8 +85,8 @@ class FancyAlertViewController: UIViewController {
     @IBOutlet private weak var headerImageViewBottomConstraint: NSLayoutConstraint!
     @IBOutlet private weak var headerImageViewWrapperBottomConstraint: NSLayoutConstraint?
     @IBOutlet private weak var buttonWrapperViewTopConstraint: NSLayoutConstraint?
+    @IBOutlet private var titleAccessoryButtonTrailingConstraint: NSLayoutConstraint!
 
-    @IBOutlet private weak var titleStackView: UIStackView!
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var bodyLabel: UILabel!
 
@@ -220,6 +220,10 @@ class FancyAlertViewController: UIViewController {
         update(moreInfoButton, with: configuration.moreInfoButton)
         update(titleAccessoryButton, with: configuration.titleAccessoryButton)
 
+        // If we have no title accessory button, we need to
+        // disable the trailing constraint to allow the title to flow correctly
+        titleAccessoryButtonTrailingConstraint.isActive = (configuration.titleAccessoryButton != nil)
+        
         // If both primary buttons are hidden, we'll hide the bottom area of the dialog
         buttonWrapperView.isHiddenInStackView = isButtonless
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController.swift
@@ -223,7 +223,7 @@ class FancyAlertViewController: UIViewController {
         // If we have no title accessory button, we need to
         // disable the trailing constraint to allow the title to flow correctly
         titleAccessoryButtonTrailingConstraint.isActive = (configuration.titleAccessoryButton != nil)
-        
+
         // If both primary buttons are hidden, we'll hide the bottom area of the dialog
         buttonWrapperView.isHiddenInStackView = isButtonless
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts.storyboard
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F2073" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ZA1-84-qnC">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -45,9 +45,12 @@
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LSs-Y1-hBy">
                                                                 <rect key="frame" x="0.0" y="20" width="334" height="122"/>
                                                                 <subviews>
-                                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Krq-uR-e1t">
-                                                                        <rect key="frame" x="20" y="20" width="275" height="82"/>
+                                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Krq-uR-e1t">
+                                                                        <rect key="frame" x="29.5" y="20" width="275" height="82"/>
                                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="width" constant="275" placeholder="YES" id="ILt-Uy-qzf"/>
+                                                                        </constraints>
                                                                     </imageView>
                                                                 </subviews>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts.storyboard
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts.storyboard
@@ -121,13 +121,13 @@
                                                         </subviews>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cUO-4N-FhV" secondAttribute="trailing" constant="28" id="8Dt-2R-IOW"/>
+                                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rH2-Nt-ZNa" secondAttribute="trailing" constant="20" id="A7y-8k-dtG"/>
                                                             <constraint firstItem="75Q-Jn-AFH" firstAttribute="firstBaseline" secondItem="cUO-4N-FhV" secondAttribute="firstBaseline" id="CuZ-hU-uES"/>
                                                             <constraint firstItem="75Q-Jn-AFH" firstAttribute="leading" secondItem="cUO-4N-FhV" secondAttribute="trailing" id="JAl-Yr-Eh3"/>
                                                             <constraint firstItem="Er7-dR-3IB" firstAttribute="top" secondItem="rzT-7k-QCD" secondAttribute="top" constant="20" id="Rxa-JT-XKl"/>
                                                             <constraint firstAttribute="trailing" secondItem="Er7-dR-3IB" secondAttribute="trailing" constant="20" id="aEb-Sn-pwu"/>
+                                                            <constraint firstItem="rH2-Nt-ZNa" firstAttribute="leading" secondItem="cUO-4N-FhV" secondAttribute="trailing" constant="8" id="iHd-gE-XBa"/>
                                                             <constraint firstAttribute="bottom" secondItem="Er7-dR-3IB" secondAttribute="bottom" constant="20" id="nJT-ly-DDr"/>
-                                                            <constraint firstItem="rH2-Nt-ZNa" firstAttribute="leading" secondItem="cUO-4N-FhV" secondAttribute="trailing" constant="8" id="o0I-ch-GMs"/>
                                                             <constraint firstItem="Er7-dR-3IB" firstAttribute="leading" secondItem="rzT-7k-QCD" secondAttribute="leading" constant="20" id="v3D-07-SBb"/>
                                                             <constraint firstItem="rH2-Nt-ZNa" firstAttribute="centerY" secondItem="75Q-Jn-AFH" secondAttribute="centerY" id="xqs-mT-uoA"/>
                                                         </constraints>
@@ -223,6 +223,7 @@
                         <outlet property="headerImageWrapperView" destination="zUD-7D-1OQ" id="oXI-vd-cPX"/>
                         <outlet property="moreInfoButton" destination="bwf-Ap-GLo" id="Z0W-pQ-eVj"/>
                         <outlet property="titleAccessoryButton" destination="rH2-Nt-ZNa" id="iCK-Op-GF7"/>
+                        <outlet property="titleAccessoryButtonTrailingConstraint" destination="A7y-8k-dtG" id="WVS-5E-dUP"/>
                         <outlet property="titleLabel" destination="cUO-4N-FhV" id="kjQ-N0-LhA"/>
                         <outlet property="topDividerView" destination="JVE-OD-Ia7" id="hhk-Ox-h6f"/>
                         <outlet property="wrapperView" destination="Zfy-Hg-zeP" id="g4f-8K-r32"/>


### PR DESCRIPTION
Fix #7548

This should fix the issues we were seeing with the title of the fancy alert view. I'm not 100% sure of the reasoning, but I was able to get the wrapping working correctly by selectively deactivating the trailing constraint for the title accessory button – I'm guessing it was causing the button to still take up space despite being hidden.

To test:

* Check the site address alert, and the aztec announcements. If you need to get the aztec announcement to return, the easiest way is to change `aztecAnnouncementWasDisplayed` in `FancyAlertViewController+AztecAnnouncement` to always return `false`.

Needs review: @aerych 