### PR TITLE
Make links have underlines and use mediumBlue color.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -43,6 +43,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         textView.formattingDelegate = self
         textView.textAttachmentDelegate = self
         textView.backgroundColor = Colors.aztecBackground
+        textView.linkTextAttributes = [NSUnderlineStyleAttributeName: NSNumber(value:NSUnderlineStyle.styleSingle.rawValue), NSForegroundColorAttributeName: Colors.aztecLinkColor]
 
         return textView
     }()
@@ -2800,6 +2801,7 @@ extension AztecPostViewController {
         static let mediaProgressOverlay = UIColor(white: 1, alpha: 0.6)
         static let mediaProgressBarBackground = WPStyleGuide.lightGrey()
         static let mediaProgressBarTrack = WPStyleGuide.wordPressBlue()
+        static let aztecLinkColor = WPStyleGuide.mediumBlue()
     }
 
     struct Fonts {


### PR DESCRIPTION
Fixes #7576 

To test:
 - Create or open text using Aztec
 - Insert link to post
 - Check if underline and medium blue styles are applied.


