### PR TITLE
Issues/login fixes

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -121,9 +121,11 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 
     [_stackView addArrangedSubview:imageView];
 
+    NSLayoutConstraint *heightConstraint = [imageView.heightAnchor constraintEqualToConstant:BlogDetailHeaderViewBlavatarSize];
+    heightConstraint.priority = 999;
     [NSLayoutConstraint activateConstraints:@[
                                               [imageView.widthAnchor constraintEqualToConstant:BlogDetailHeaderViewBlavatarSize],
-                                              [imageView.heightAnchor constraintEqualToConstant:BlogDetailHeaderViewBlavatarSize]
+                                              heightConstraint
                                               ]];
     _blavatarImageView = imageView;
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
@@ -21,6 +21,14 @@ class LoginSelfHostedViewController: LoginViewController, SigninKeyboardResponde
         }
     }
 
+    override var loginFields: LoginFields {
+        didSet {
+            // Clear the username & password (if any) from LoginFields
+            loginFields.username = ""
+            loginFields.password = ""
+        }
+    }
+
     var gravatarProfile: GravatarProfile?
     var userProfile: UserProfile?
     var blog: Blog?

--- a/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
@@ -15,8 +15,9 @@ class LoginSiteAddressViewController: LoginViewController, SigninKeyboardRespond
 
     override var loginFields: LoginFields {
         didSet {
-            // Clear the username & password (if any) from LoginFields
+            // Clear the site url and site info (if any) from LoginFields
             loginFields.siteUrl = ""
+            loginFields.siteInfo = nil
         }
     }
 
@@ -184,7 +185,6 @@ class LoginSiteAddressViewController: LoginViewController, SigninKeyboardRespond
 
 
     func fetchSiteInfo() {
-        loginFields.siteInfo = nil
         let baseSiteUrl = SigninHelpers.baseSiteURL(string: loginFields.siteUrl) as NSString
         if let siteAddress = baseSiteUrl.components(separatedBy: "://").last {
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
@@ -13,6 +13,14 @@ class LoginSiteAddressViewController: LoginViewController, SigninKeyboardRespond
     }
 
 
+    override var loginFields: LoginFields {
+        didSet {
+            // Clear the username & password (if any) from LoginFields
+            loginFields.siteUrl = ""
+        }
+    }
+
+
     // MARK: - Lifecycle
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
@@ -176,6 +176,7 @@ class LoginSiteAddressViewController: LoginViewController, SigninKeyboardRespond
 
 
     func fetchSiteInfo() {
+        loginFields.siteInfo = nil
         let baseSiteUrl = SigninHelpers.baseSiteURL(string: loginFields.siteUrl) as NSString
         if let siteAddress = baseSiteUrl.components(separatedBy: "://").last {
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginWPComViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginWPComViewController.swift
@@ -18,6 +18,14 @@ class LoginWPComViewController: LoginViewController, SigninKeyboardResponder {
         }
     }
 
+    override var loginFields: LoginFields {
+        didSet {
+            // Clear the password (if any) from LoginFields.
+            loginFields.password = ""
+        }
+    }
+
+
     // MARK: - Lifecycle Methods
 
 
@@ -55,6 +63,7 @@ class LoginWPComViewController: LoginViewController, SigninKeyboardResponder {
         super.viewWillDisappear(animated)
         unregisterForKeyboardEvents()
     }
+
 
     // MARK: Setup and Configuration
 

--- a/WordPress/Classes/ViewRelated/NUX/WPStyleGuide+NUX.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WPStyleGuide+NUX.swift
@@ -39,7 +39,8 @@ extension WPStyleGuide {
         let onePasswordButton = UIButton(type: .custom)
         onePasswordButton.setImage(UIImage(named: "onepassword-wp-button"), for: UIControlState())
         onePasswordButton.sizeToFit()
-        onePasswordButton.setContentHuggingPriority(1000, for: .horizontal)
+        onePasswordButton.setContentHuggingPriority(UILayoutPriorityRequired, for: .horizontal)
+        onePasswordButton.setContentCompressionResistancePriority(UILayoutPriorityRequired, for: .horizontal)
 
         stack.addArrangedSubview(onePasswordButton)
 


### PR DESCRIPTION
This PR addresses a few issues identified by @rachelmcr while testing the new login flow.
Fixes #7557 as well.

To test:
- Ensure that the 1Password button on the LoginWPComViewController does not appear squashed when appearing beside a very long email address.  The email address should be truncated with an ending ellipsis.
- Test the steps in #7557 and confirm that the password field is empty.
- Perform similar tests on the LoginSiteAddressViewController and LoginSelfHostedViewController and ensure that they do not continue to show previously entered values after tapping the back button and relaunching the controller.   Note that the fields *should* continue to show previously entered data when tapping back to one of the above view controllers from a view controller that followed it (e.g. If you tap back from the 2fa controller the LoginWPComViewController should still have its password field populated.)
- Make sure there is no breaking constraint warning on the LoginSelfHostedViewController after entering the url for a private wpcom site in the LoginSiteAddressController. 

Needs review: @frosty would you be game to review this one? 
