### PR TITLE
Login: Replace the custom epilogue animation

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/EpilogueSegue.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueSegue.swift
@@ -1,59 +1,10 @@
 import UIKit
 
-protocol EpilogueAnimation {
-}
-
-/// Custom animation to allow presented views to appear to come from behind the presenter
-extension EpilogueAnimation where Self: UIStoryboardSegue {
-    func performEpilogue(completion: @escaping () -> Void) {
-        guard let containerView = source.view.superview else {
+class EpilogueSegue: UIStoryboardSegue {
+    override func perform() {
+        guard let navController = source.navigationController else {
             return
         }
-        let sourceVC = source
-        let destinationVC = destination
-        let duration = 0.35
-
-        var frame = sourceVC.view.frame
-        // Adjust for the height of the status bar which seems to be ignored during the transition.
-        let statusBarHeight = UIApplication.shared.statusBarFrame.height
-        frame.origin.y += statusBarHeight
-        frame.size.height -= statusBarHeight
-        destinationVC.view.frame = frame
-
-        containerView.addSubview(destinationVC.view)
-        containerView.addSubview(sourceVC.view)
-
-        // Force hide the navigation bar and perform a layout pass so frames
-        // are correct before starting the animation.
-        sourceVC.navigationController?.setNavigationBarHidden(true, animated: false)
-        sourceVC.navigationController?.view.layoutIfNeeded()
-
-        UIView.animate(withDuration: duration, delay: 0, options:.curveEaseInOut, animations: {
-            sourceVC.view.center.y += sourceVC.view.frame.size.height
-        }) { (finished) in
-            completion()
-        }
-    }
-}
-
-/// Presenting segue version of the EpilogueAnimation
-class EpilogueSegue: UIStoryboardSegue, EpilogueAnimation {
-    let duration = 0.35
-
-    override func perform() {
-        performEpilogue() {
-            self.destination.view.removeFromSuperview()
-            let navController = self.source.navigationController
-            navController?.setViewControllers([self.destination], animated: false)
-        }
-    }
-}
-
-/// Unwinding segue version of the EpilogueAnimation
-class EpilogueUnwindSegue: UIStoryboardSegue, EpilogueAnimation {
-    let duration = 0.35
-
-    override func perform() {
-        performEpilogue() {}
+        navController.setViewControllers([destination], animated: true)
     }
 }


### PR DESCRIPTION
This patch replaces the custom epilogue animation with a simpler left to right transition that also clears the navigation controller's history. A happy side effect is it resolves the issue @frosty reported in #7583 

@nheagy @mattmiklic and I discussed dropping the custom animation so I'm keen to kill two birds with one PR (as it were) as long as everyone's happy with the transition.

Fixes #7583 

To test: 
- Login to the app.
- Observe that the epilogue controller transitions from left to right like a regular view controller being pushed onto the stack. 
- Confirm there is no visual jump in the view similar to #7583 

Needs review: @nheagy @mattmiklic, what say you gentlemen? 

cc @frosty 
