### PR TITLE
Don't set default account on Jetpack login

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
@@ -534,7 +534,6 @@ extension JetpackLoginViewController : LoginFacadeDelegate {
     func finishedLogin(withUsername username: String!, authToken: String!, requiredMultifactorCode: Bool) {
         let accountFacade = AccountServiceFacade()
         let account = accountFacade.createOrUpdateWordPressComAccount(withUsername: username, authToken: authToken)
-        accountFacade.setDefaultWordPressComAccount(account)
         BlogSyncFacade().syncBlogs(for: account, success: { [weak self] in
             accountFacade.updateUserDetails(for: account, success: { [weak self] in
                 guard let strongSelf = self else {


### PR DESCRIPTION
The account service already sets the default account if there's not one already. We don't want to force it.

Fixes #7590

To test:

- Sign in to wp.com account A, confirm it's set as the default in "Me", and all the blogs are synced in "My Sites"
- Add a self hosted site connected to account B
- Go to stats and enter the password for B
- Confirm the "Me" tab still shows the account A, and all the blogs for A are still in "My Sites".

Needs review: @bummytime 