### PR TITLE
Aztec: Avoiding \n >> BR conversions within Lists

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessor.swift
@@ -121,6 +121,6 @@ private extension CalypsoProcessor {
 private extension CalypsoProcessor {
     struct Constants {
         static let escapedSnippetKey = "<calypso-escaped>"
-        static let preformattedTextRegex = "<(pre|script)[^>]*>[\\s\\S]+?</\\1>"
+        static let preformattedTextRegex = "<(pre|script|ul|ol)[^>]*>[\\s\\S]+?</\\1>"
     }
 }

--- a/WordPress/WordPressTest/Aztec/CalypsoProcessorTests.swift
+++ b/WordPress/WordPressTest/Aztec/CalypsoProcessorTests.swift
@@ -55,8 +55,6 @@ class CalypsoProcessorTests: XCTestCase {
         let input = "<pre>First\n\nSecond</pre><pre>Third\nFourth</pre><pre>Fifth\n\nSixth\n</pre>"
         let output = processor.process(text: input)
 
-        NSLog("Input: \(input)")
-        NSLog("Output: \(output)")
         XCTAssertEqual(output, input)
     }
 
@@ -66,8 +64,6 @@ class CalypsoProcessorTests: XCTestCase {
         let input = "<ol>\n<li>hello\nbye</li>\n<li><ol><li>WAT\nWAT</li></ol></li></ol>"
         let output = processor.process(text: input)
 
-        NSLog("Input: \(input)")
-        NSLog("Output: \(output)")
         XCTAssertEqual(output, input)
     }
 
@@ -75,6 +71,20 @@ class CalypsoProcessorTests: XCTestCase {
     ///
     func testUnorderedListsWithNestedEntitiesAreLeftUntouched() {
         let input = "<ul>\n<li>hello\nbye</li>\n<li><ul><li>WAT\nWAT</li></ul></li></ul>"
+        let output = processor.process(text: input)
+
+        XCTAssertEqual(output, input)
+    }
+
+    /// Verifies that Pre + UL + OL tags escaping algorithm is case insensitive, and it's 
+    /// contents are left untouched, even when in uppercase.
+    ///
+    func testSantizationIsCaseInsensitiveAndEscapedUppercaseTagsAreLeftUntouched() {
+        let input = "here<UL>\n<LI>hello\nbye</LI>\n" +
+            "<LI><UL><LI>WAT\nWAT</LI></UL></LI></UL>there" +
+            "<PRE>\n</PRE>testing" +
+            "<OL><LI>ORDERED\n</LI></OL>"
+
         let output = processor.process(text: input)
 
         NSLog("Input: \(input)")

--- a/WordPress/WordPressTest/Aztec/CalypsoProcessorTests.swift
+++ b/WordPress/WordPressTest/Aztec/CalypsoProcessorTests.swift
@@ -59,4 +59,26 @@ class CalypsoProcessorTests: XCTestCase {
         NSLog("Output: \(output)")
         XCTAssertEqual(output, input)
     }
+
+    /// Verifies that Ordered Lists (with nested levels) will keep their contents untouched.
+    ///
+    func testOrderedListsWithNestedEntitiesAreLeftUntouched() {
+        let input = "<ol>\n<li>hello\nbye</li>\n<li><ol><li>WAT\nWAT</li></ol></li></ol>"
+        let output = processor.process(text: input)
+
+        NSLog("Input: \(input)")
+        NSLog("Output: \(output)")
+        XCTAssertEqual(output, input)
+    }
+
+    /// Verifies that Unordered Lists (with nested levels) will keep their contents untouched.
+    ///
+    func testUnorderedListsWithNestedEntitiesAreLeftUntouched() {
+        let input = "<ul>\n<li>hello\nbye</li>\n<li><ul><li>WAT\nWAT</li></ul></li></ul>"
+        let output = processor.process(text: input)
+
+        NSLog("Input: \(input)")
+        NSLog("Output: \(output)")
+        XCTAssertEqual(output, input)
+    }
 }


### PR DESCRIPTION
### Details:
We needed to implement a pre-processor that converts `\n` characters into `<br>` (Ref. #7446).
Problem is: doing so within UL / OL has a bad bad side effect of adding extra bullets to lists.

In this PR we're escaping UL / OL's, and adding a few Unit Tests.

Fixes #7598

### To test:
1. Run the Unit Tests and verify the world is a happy green place
2. Add a post to your site that looks like:

  ```
Unordered List
<ul>
	<li>First Item</li>
	<li>Second Item</li>
	<li>Third Item</li>
	<li>Fourth Item</li>
</ul>
Ordered List
<ol>
	<li>First Item</li>
	<li>Second Item</li>
	<li>Third Item</li>
	<li>Fourth Item</li>
</ol>
  ```
3. Edit the post in Aztec and verify it doesn't look... odd?

Needs review: @astralbodies 
Thanks in advance sir!!