### PR TITLE
Improve algorithm to migrate Jetpack sites

### DIFF
--- a/WordPress/WordPressTest/BlogJetpackTest.m
+++ b/WordPress/WordPressTest/BlogJetpackTest.m
@@ -39,7 +39,7 @@
                               @"readonly": @YES,
                               },
                       @"jetpack_client_id": @{
-                              @"value": @"1",
+                              @"value": @"3",
                               @"desc": @"stub",
                               @"readonly": @YES,
                               },
@@ -70,7 +70,7 @@
 }
 
 - (void)testJetpackSiteId {
-    XCTAssertEqualObjects(_blog.jetpack.siteID, @1);
+    XCTAssertEqualObjects(_blog.jetpack.siteID, @3);
 }
 
 - (void)testJetpackUsername {
@@ -172,8 +172,8 @@
     WPAccount *wpComAccount = [accountService createOrUpdateAccountWithUsername:@"user" authToken:@"token"];
 
     Blog *dotcomBlog = [blogService createBlogWithAccount:wpComAccount];
-    dotcomBlog.xmlrpc = @"http://dotcom1.wordpress.com/xmlrpc.php";
-    dotcomBlog.url = @"http://dotcom1.wordpress.com/";
+    dotcomBlog.xmlrpc = @"https://dotcom1.wordpress.com/xmlrpc.php";
+    dotcomBlog.url = @"https://dotcom1.wordpress.com/";
     dotcomBlog.dotComID = @1;
 
     Blog *jetpackLegacyBlog = [blogService createBlog];

--- a/WordPress/WordPressTest/Test Data/get-user-blogs_has-blog.json
+++ b/WordPress/WordPressTest/Test Data/get-user-blogs_has-blog.json
@@ -3,7 +3,7 @@
         "apikey":"eeeeeeeeeeee",
         "blog":[
                 {
-                "id":1,
+                "id":3,
                 "url":"http:\/\/test.blog\/"
                 },
                 {


### PR DESCRIPTION
The previous code was too strict and would only do an exact match on the
XML-RPC endpoint.

This one will use the stored wp.com blog ID when available, and will fall back
to the XML-RPC endpoint, doing a case insensitive match of both HTTP and HTTPS
variants.

This is also closer to the algorithm in the Android app.

Fixes #5911 

To test:

See steps in #5911 and #7339.

Needs review: @aerych 