### PR TITLE
Login: Restore updating selected blog when adding new blog to app.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
@@ -358,8 +358,6 @@ extension LoginSelfHostedViewController {
         displayLoginMessage("")
 
         BlogSyncFacade().syncBlog(withUsername: username, password: password, xmlrpc: xmlrpc, options: options) { [weak self] in
-            NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: SigninHelpers.WPSigninDidFinishNotification), object: nil)
-
             let context = ContextManager.sharedInstance().mainContext
             let service = BlogService(managedObjectContext: context)
             guard let blog = service.findBlog(withXmlrpc: xmlrpc, andUsername: username) else {
@@ -372,6 +370,8 @@ extension LoginSelfHostedViewController {
             }
 
             RecentSitesService().touch(blog: blog)
+            NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: SigninHelpers.WPSigninDidFinishNotification), object: nil)
+
             self?.blog = blog
             self?.fetchUserProfileInfo(blog: blog, completion: {
                 self?.showEpilogue()


### PR DESCRIPTION
This PR restores a behavior that was accidentally clobbered while implementing the new login flow (mea culpa).  When adding a new self-hosted blog to the app, that blog should (once again) become the selected blog under the My Sites tab. 

To test:
- Confirm the bug in the release/8.1 branch by adding a new self-hosted site while logged into wpcom. When the epilogue dismisses you most likely will not be looking at the blog you just entered unless it is the first one in the list.
- Switch to this branch.
- Be logged into wpcom. 
- Add a self-hosted site to the app. 
- When the login epilogue dismisses, confirm you are view the detail screen for the newly added blog.

Needs review: 
