### PR TITLE
Aztec: Darkens format bar active color

### DIFF
--- a/WordPress/Classes/Extensions/WPStyleGuide+Aztec.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+Aztec.swift
@@ -4,7 +4,7 @@ import WordPressShared
 extension WPStyleGuide {
     static let aztecFormatBarInactiveColor = UIColor(hexString: "7B9AB1")
 
-    static let aztecFormatBarActiveColor = WPStyleGuide.wordPressBlue()
+    static let aztecFormatBarActiveColor = UIColor(hexString: "11181D")
 
     static let aztecFormatBarDisabledColor = WPStyleGuide.greyLighten20()
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/AztecEditor-iOS/issues/663

This PR fixes the above issue by darkening the color used for the active highlight in the format bar.

![formatbar-active](https://user-images.githubusercontent.com/4780/28775212-b456fde6-75e8-11e7-9ec2-1fb1ef5cfb32.png)

To test:

* Open Aztec
* Use the buttons on the format bar
* Check the highlight of the button matches the new color

Needs review: @elibud 
