### PR TITLE
Post Preview: Fix retain cycle and dismiss on memory warning

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
@@ -8,7 +8,7 @@ protocol PostPreviewGeneratorDelegate {
 
 class PostPreviewGenerator: NSObject {
     let post: AbstractPost
-    var delegate: PostPreviewGeneratorDelegate?
+    weak var delegate: PostPreviewGeneratorDelegate?
 
     init(post: AbstractPost) {
         self.post = post

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -48,6 +48,13 @@
 {
     DDLogMethod();
     [super didReceiveMemoryWarning];
+
+    // If we get a memory warning, let's pop or dismiss
+    if ([self.navigationController.viewControllers count] > 1 && self.navigationController.topViewController == self) {
+        [self.navigationController popViewControllerAnimated:YES];
+    } else {
+        [self dismissPreview];
+    }
 }
 
 - (void)viewDidLoad

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -48,13 +48,6 @@
 {
     DDLogMethod();
     [super didReceiveMemoryWarning];
-
-    // If we get a memory warning, let's pop or dismiss
-    if ([self.navigationController.viewControllers count] > 1 && self.navigationController.topViewController == self) {
-        [self.navigationController popViewControllerAnimated:YES];
-    } else {
-        [self dismissPreview];
-    }
 }
 
 - (void)viewDidLoad


### PR DESCRIPTION
Hopefully this PR goes some way to fix #7279. There are two key changes:

1. The delegate of `PostPreviewGenerator` is now `weak`. Previously, this was causing a retain cycle, resulting in `PostPreviewViewController`s and generators staying in memory.
2. PostPreviewViewController is now dismissed in the event of a memory warning. There doesn't seem to be much we can do in this situation, and you'd hope it wouldn't occur that often. But in an attempt to prevent the app crashing, let's just dismiss instead.

To test:

* Build and run the app.
* From the Posts list, open and close post previews multiple times.
* With the post preview closed, open the Debug Memory Graph. You shouldn't see any instances of `PostPreviewViewController` or `PostPreviewGenerator` in memory.
* Also, in the simulator, trigger a memory warning whilst the post preview is open and check that it gets dismissed.

Needs review: @koke 