### PR TITLE
8.2: Cherry-pick PostPreviewGenerator retain cycle fix

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
@@ -8,7 +8,7 @@ protocol PostPreviewGeneratorDelegate {
 
 class PostPreviewGenerator: NSObject {
     let post: AbstractPost
-    var delegate: PostPreviewGeneratorDelegate?
+    weak var delegate: PostPreviewGeneratorDelegate?
 
     init(post: AbstractPost) {
         self.post = post


### PR DESCRIPTION
This PR cherry-picks the retain cycle fix for post preview from #7646. See the original PR for testing details.

Needs review: @elibud 