### PR TITLE
Signup: Restores bumping the create-account-initiated stat.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -51,6 +51,12 @@ import WordPressShared
 
     // MARK: - Lifecycle Methods
 
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+
+        WPAppAnalytics.track(.createAccountInitiated)
+    }
+
 
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
This PR restores bumping the `createAccountInititated` stat which was previously being bumped in the old `SignupEmailViewController`, but was overlooked in the new login flow.

To test:
- Set a break point where the stat is bumped. 
- Launch the app, log out completely if needed, and tap the option to create an account. 
- Confirm the stat is bumped.

Needs review: @
