### PR TITLE
Reader Comments: Display error when they fail to load

### DIFF
--- a/WordPress/Classes/Utility/WPContentSyncHelper.swift
+++ b/WordPress/Classes/Utility/WPContentSyncHelper.swift
@@ -56,7 +56,7 @@ class WPContentSyncHelper: NSObject {
         }, failure: {
             [weak self] (error: NSError) -> Void in
             if let weakSelf = self {
-                weakSelf.syncContentEnded()
+                weakSelf.syncContentEnded(error: true)
             }
         })
 


### PR DESCRIPTION
Fixes #3002 

To test:
1. Follow https://cupofjo.com
2. On the followed sites list, select A Cup of Jo
3. Navigate to the post list
4. Tap on the comments button for one of the posts
5. Verify that a message explaning that the comments could not be fetched is displayed

(this site has some JP configuration issues right now and that is why we can not fetch the comments)

Needs review: @aerych 
