### PR TITLE
Aztec 1.0.0 Beta Mark 9.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.19'
   pod 'WordPress-iOS-Editor', '1.9.3'
-  pod 'WordPress-Aztec-iOS', '=1.0.0-beta.9.1'
+  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ce83f604225df84e1cc93f0390217a79a8af5383'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.19'
   pod 'WordPress-iOS-Editor', '1.9.3'
-  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ce83f604225df84e1cc93f0390217a79a8af5383'
+  pod 'WordPress-Aztec-iOS', '=1.0.0-beta.9.2'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -93,7 +93,7 @@ PODS:
   - Starscream (2.1.0)
   - SVProgressHUD (2.1.2)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.9.1)
+  - WordPress-Aztec-iOS (1.0.0-beta.9.2)
   - WordPress-iOS-Editor (1.9.3):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
@@ -128,7 +128,7 @@ DEPENDENCIES:
   - Starscream (= 2.1.0)
   - SVProgressHUD (= 2.1.2)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (= 1.0.0-beta.9.1)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ce83f604225df84e1cc93f0390217a79a8af5383`)
   - WordPress-iOS-Editor (= 1.9.3)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.19)
@@ -138,6 +138,9 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
+  WordPress-Aztec-iOS:
+    :commit: ce83f604225df84e1cc93f0390217a79a8af5383
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -146,6 +149,9 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
+  WordPress-Aztec-iOS:
+    :commit: ce83f604225df84e1cc93f0390217a79a8af5383
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -177,12 +183,12 @@ SPEC CHECKSUMS:
   Starscream: 168fd64c345fb2dea71b0a869c482aeffcf866e4
   SVProgressHUD: c404a55d78acbeb7ebb78b76d3faf986475a6994
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 3ecf3ef7f3162fa67ef75771c0c00091704ef2c9
+  WordPress-Aztec-iOS: 10dfe6a07a0b356bd66ea2ba650cf1a7e7b8da43
   WordPress-iOS-Editor: ed02135d783ecb9aa4ee5e2462935432d464d461
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 771abfe3a334119a909ebe403188498e4a2b01e8
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: e18b82c32b735f3ddf2707dfd58a2ad3ed4ec2d6
+PODFILE CHECKSUM: 6a390aba8ae24644a5d96a306defb945f6408dee
 
 COCOAPODS: 1.2.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -128,7 +128,7 @@ DEPENDENCIES:
   - Starscream (= 2.1.0)
   - SVProgressHUD (= 2.1.2)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ce83f604225df84e1cc93f0390217a79a8af5383`)
+  - WordPress-Aztec-iOS (= 1.0.0-beta.9.2)
   - WordPress-iOS-Editor (= 1.9.3)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.19)
@@ -138,9 +138,6 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
-  WordPress-Aztec-iOS:
-    :commit: ce83f604225df84e1cc93f0390217a79a8af5383
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -149,9 +146,6 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
-  WordPress-Aztec-iOS:
-    :commit: ce83f604225df84e1cc93f0390217a79a8af5383
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -183,12 +177,12 @@ SPEC CHECKSUMS:
   Starscream: 168fd64c345fb2dea71b0a869c482aeffcf866e4
   SVProgressHUD: c404a55d78acbeb7ebb78b76d3faf986475a6994
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 10dfe6a07a0b356bd66ea2ba650cf1a7e7b8da43
+  WordPress-Aztec-iOS: 8046272c420f9287fa7cb76b99fca45fbb7f64da
   WordPress-iOS-Editor: ed02135d783ecb9aa4ee5e2462935432d464d461
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 771abfe3a334119a909ebe403188498e4a2b01e8
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 6a390aba8ae24644a5d96a306defb945f6408dee
+PODFILE CHECKSUM: 6952e6d78595e74fb8a5efa807e17fbfa20188ff
 
 COCOAPODS: 1.2.1

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -682,7 +682,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func getHTML() -> String {
-        var processedHTML = richTextView.getHTML()
+        var processedHTML = richTextView.getHTML(prettyPrint: true)
         for processor in htmlPostProcessors {
             processedHTML = processor.process(text: processedHTML)
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -682,7 +682,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func getHTML() -> String {
-        var processedHTML = richTextView.getHTML(prettyPrint: true)
+        var processedHTML = richTextView.getHTML()
         for processor in htmlPostProcessors {
             processedHTML = processor.process(text: processedHTML)
         }


### PR DESCRIPTION
### Details:
This PR integrates Aztec Bleeding Edge Release into WPiOS 8.2.

### To test:
Run a smoke test on the Aztec Editor. We're temporarily disabling the HTML prettifier (to be addressed in WPiOS 8.3).

Needs review: @diegoreymendez 

