### PR TITLE
Implement wpautop and wpremovep in Swift.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.19'
   pod 'WordPress-iOS-Editor', '1.9.3'
-  pod 'WordPress-Aztec-iOS', '=1.0.0-beta.9.1'
+  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ce83f604225df84e1cc93f0390217a79a8af5383'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.19'
   pod 'WordPress-iOS-Editor', '1.9.3'
-  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ce83f604225df84e1cc93f0390217a79a8af5383'
+  pod 'WordPress-Aztec-iOS', '=1.0.0-beta.9.2'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -93,7 +93,7 @@ PODS:
   - Starscream (2.1.0)
   - SVProgressHUD (2.1.2)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.9.1)
+  - WordPress-Aztec-iOS (1.0.0-beta.9.2)
   - WordPress-iOS-Editor (1.9.3):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
@@ -128,7 +128,7 @@ DEPENDENCIES:
   - Starscream (= 2.1.0)
   - SVProgressHUD (= 2.1.2)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (= 1.0.0-beta.9.1)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ce83f604225df84e1cc93f0390217a79a8af5383`)
   - WordPress-iOS-Editor (= 1.9.3)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.19)
@@ -138,6 +138,9 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
+  WordPress-Aztec-iOS:
+    :commit: ce83f604225df84e1cc93f0390217a79a8af5383
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -146,6 +149,9 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
+  WordPress-Aztec-iOS:
+    :commit: ce83f604225df84e1cc93f0390217a79a8af5383
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -177,12 +183,12 @@ SPEC CHECKSUMS:
   Starscream: 168fd64c345fb2dea71b0a869c482aeffcf866e4
   SVProgressHUD: c404a55d78acbeb7ebb78b76d3faf986475a6994
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 3ecf3ef7f3162fa67ef75771c0c00091704ef2c9
+  WordPress-Aztec-iOS: 10dfe6a07a0b356bd66ea2ba650cf1a7e7b8da43
   WordPress-iOS-Editor: ed02135d783ecb9aa4ee5e2462935432d464d461
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 771abfe3a334119a909ebe403188498e4a2b01e8
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: e18b82c32b735f3ddf2707dfd58a2ad3ed4ec2d6
+PODFILE CHECKSUM: 6a390aba8ae24644a5d96a306defb945f6408dee
 
 COCOAPODS: 1.2.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -128,7 +128,7 @@ DEPENDENCIES:
   - Starscream (= 2.1.0)
   - SVProgressHUD (= 2.1.2)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ce83f604225df84e1cc93f0390217a79a8af5383`)
+  - WordPress-Aztec-iOS (= 1.0.0-beta.9.2)
   - WordPress-iOS-Editor (= 1.9.3)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.19)
@@ -138,9 +138,6 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
-  WordPress-Aztec-iOS:
-    :commit: ce83f604225df84e1cc93f0390217a79a8af5383
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -149,9 +146,6 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
-  WordPress-Aztec-iOS:
-    :commit: ce83f604225df84e1cc93f0390217a79a8af5383
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -183,12 +177,12 @@ SPEC CHECKSUMS:
   Starscream: 168fd64c345fb2dea71b0a869c482aeffcf866e4
   SVProgressHUD: c404a55d78acbeb7ebb78b76d3faf986475a6994
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 10dfe6a07a0b356bd66ea2ba650cf1a7e7b8da43
+  WordPress-Aztec-iOS: 8046272c420f9287fa7cb76b99fca45fbb7f64da
   WordPress-iOS-Editor: ed02135d783ecb9aa4ee5e2462935432d464d461
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 771abfe3a334119a909ebe403188498e4a2b01e8
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 6a390aba8ae24644a5d96a306defb945f6408dee
+PODFILE CHECKSUM: 6952e6d78595e74fb8a5efa807e17fbfa20188ff
 
 COCOAPODS: 1.2.1

--- a/WordPress/Classes/Extensions/String+Ranges.swift
+++ b/WordPress/Classes/Extensions/String+Ranges.swift
@@ -10,34 +10,4 @@ extension String {
     var foundationRangeOfEntireString: NSRange {
         return NSRange(location: 0, length: utf16.count)
     }
-
-    /// Returns the Substring contained by at specified NSRange
-    ///
-    func substring(with nsrange: NSRange) -> String? {
-        guard let range = nsrange.toRange() else {
-            return nil
-        }
-
-        let start = UTF16Index(range.lowerBound)
-        let end = UTF16Index(range.upperBound)
-
-        return String(utf16[start..<end])
-    }
-
-    /// Returns the Swift Range for the specified Foundation Range
-    ///
-    func range(from nsrange: NSRange) -> Range<Index>? {
-        guard let range = nsrange.toRange() else {
-            return nil
-        }
-
-        let utf16Start = UTF16Index(range.lowerBound)
-        let utf16End = UTF16Index(range.upperBound)
-
-        guard let start = Index(utf16Start, within: self), let end = Index(utf16End, within: self) else {
-            return nil
-        }
-
-        return start..<end
-    }
 }

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -7,7 +7,7 @@ extension String {
 
     /// Replaces all matches of a given RegEx, with a template String.
     ///
-    func replacingMatches(of regex: String, with template: String, options: NSRegularExpression.Options = []) -> String {
+    func stringByReplacingMatches(of regex: String, with template: String, options: NSRegularExpression.Options = []) -> String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)
@@ -47,7 +47,7 @@ extension String {
     ///
     /// - Returns: the new string.
     ///
-    func replacingMatches(of regex: String, with options: NSRegularExpression.Options = [], using block: (String) -> String) -> String {
+    func stringByReplacingMatches(of regex: String, with options: NSRegularExpression.Options = [], using block: (String) -> String) -> String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -11,11 +11,31 @@ extension String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)
+        let matches = regex.matches(in: self, options: [], range: fullRange)
 
-        return regex.stringByReplacingMatches(in: self,
-                                              options: [],
-                                              range: fullRange,
-                                              withTemplate: template)
+        var output = self
+
+        for match in matches.reversed() {
+
+            var finalTemplate = template
+
+            for captureGroupIndex in 1...9 {
+                let captureGroupMarker = "$\(captureGroupIndex)"
+
+                if finalTemplate.contains(captureGroupMarker) {
+
+                    let captureGroupRange = self.range(from: match.rangeAt(captureGroupIndex))
+                    let captureGroupText = self.substring(with: captureGroupRange)
+
+                    finalTemplate = finalTemplate.stringByReplacingMatches(of: captureGroupMarker, with: captureGroupText)
+                }
+            }
+
+            let matchRange = range(from: match.range)
+            output = output.replacingCharacters(in: matchRange, with: finalTemplate)
+        }
+
+        return output
     }
 
     /// Replaces all matches of a given RegEx using a provided block.

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+
+// MARK: - String: RegularExpression Helpers
+//
+extension String {
+
+    /// Replaces all matches of a given RegEx, with a template String.
+    ///
+    func replaceMatches(of regex: String, with template: String) -> String {
+        do {
+            let regex = try NSRegularExpression(pattern: regex, options: .caseInsensitive)
+            let range = NSRange(location: 0, length: characters.count)
+            return regex.stringByReplacingMatches(in: self,
+                                                  options: [],
+                                                  range: range,
+                                                  withTemplate: template)
+        } catch {
+            assertionFailure()
+        }
+
+        return self
+    }
+}

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -5,6 +5,13 @@ import Foundation
 //
 extension String {
 
+    func matches(regex: String, options: NSRegularExpression.Options = []) -> [NSTextCheckingResult] {
+        let regex = try! NSRegularExpression(pattern: regex, options: options)
+        let fullRange = NSRange(location: 0, length: characters.count)
+        
+        return regex.matches(in: self, options: [], range: fullRange)
+    }
+
     /// Replaces all matches of a given RegEx, with a template String.
     ///
     func stringByReplacingMatches(of regex: String, with template: String, options: NSRegularExpression.Options = []) -> String {

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -16,7 +16,7 @@ extension String {
     func matches(regex: String, options: NSRegularExpression.Options = []) -> [NSTextCheckingResult] {
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)
-        
+
         return regex.matches(in: self, options: [], range: fullRange)
     }
 

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -7,9 +7,9 @@ extension String {
 
     /// Replaces all matches of a given RegEx, with a template String.
     ///
-    func replaceMatches(of regex: String, with template: String) -> String {
+    func replaceMatches(of regex: String, with template: String, options: NSRegularExpression.Options) -> String {
         do {
-            let regex = try NSRegularExpression(pattern: regex, options: .caseInsensitive)
+            let regex = try NSRegularExpression(pattern: regex, options: options)
             let range = NSRange(location: 0, length: characters.count)
             return regex.stringByReplacingMatches(in: self,
                                                   options: [],

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -5,6 +5,14 @@ import Foundation
 //
 extension String {
 
+    /// Find all matches of the specified regex.
+    ///
+    /// - Parameters:
+    ///     - regex: the regex to use.
+    ///     - options: the regex options.
+    ///
+    /// - Returns: the requested matches.
+    ///
     func matches(regex: String, options: NSRegularExpression.Options = []) -> [NSTextCheckingResult] {
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)
@@ -14,12 +22,19 @@ extension String {
 
     /// Replaces all matches of a given RegEx, with a template String.
     ///
-    func stringByReplacingMatches(of regex: String, with template: String, options: NSRegularExpression.Options = []) -> String {
+    /// - Parameters:
+    ///     - regex: the regex to use.
+    ///     - template: the template string to use for the replacement.
+    ///     - options: the regex options.
+    ///
+    /// - Returns: a new string after replacing all matches with the specified template.
+    ///
+    func replacingMatches(of regex: String, with template: String, options: NSRegularExpression.Options = []) -> String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)
 
-        return regex.stringByReplacingMatches(in: self,
+        return regex.replacingMatches(in: self,
                                               options: [],
                                               range: fullRange,
                                               withTemplate: template)
@@ -34,7 +49,7 @@ extension String {
     ///
     /// - Returns: the new string.
     ///
-    func stringByReplacingMatches(of regex: String, options: NSRegularExpression.Options = [], using block: (String, [String]) -> String) -> String {
+    func replacingMatches(of regex: String, options: NSRegularExpression.Options = [], using block: (String, [String]) -> String) -> String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -11,31 +11,11 @@ extension String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)
-        let matches = regex.matches(in: self, options: [], range: fullRange)
 
-        var output = self
-
-        for match in matches.reversed() {
-
-            var finalTemplate = template
-
-            for captureGroupIndex in 1...9 {
-                let captureGroupMarker = "$\(captureGroupIndex)"
-
-                if finalTemplate.contains(captureGroupMarker) {
-
-                    let captureGroupRange = self.range(from: match.rangeAt(captureGroupIndex))
-                    let captureGroupText = self.substring(with: captureGroupRange)
-
-                    finalTemplate = finalTemplate.stringByReplacingMatches(of: captureGroupMarker, with: captureGroupText)
-                }
-            }
-
-            let matchRange = range(from: match.range)
-            output = output.replacingCharacters(in: matchRange, with: finalTemplate)
-        }
-
-        return output
+        return regex.stringByReplacingMatches(in: self,
+                                              options: [],
+                                              range: fullRange,
+                                              withTemplate: template)
     }
 
     /// Replaces all matches of a given RegEx using a provided block.

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -7,7 +7,7 @@ extension String {
 
     /// Replaces all matches of a given RegEx, with a template String.
     ///
-    func stringByReplacingMatches(of regex: String, with template: String, options: NSRegularExpression.Options = []) -> String {
+    func replacingMatches(of regex: String, with template: String, options: NSRegularExpression.Options = []) -> String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)
@@ -47,7 +47,7 @@ extension String {
     ///
     /// - Returns: the new string.
     ///
-    func stringByReplacingMatches(of regex: String, with options: NSRegularExpression.Options = [], using block: (String) -> String) -> String {
+    func replacingMatches(of regex: String, with options: NSRegularExpression.Options = [], using block: (String) -> String) -> String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -34,7 +34,7 @@ extension String {
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)
 
-        return regex.replacingMatches(in: self,
+        return regex.stringByReplacingMatches(in: self,
                                               options: [],
                                               range: fullRange,
                                               withTemplate: template)

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -7,18 +7,40 @@ extension String {
 
     /// Replaces all matches of a given RegEx, with a template String.
     ///
-    func replaceMatches(of regex: String, with template: String, options: NSRegularExpression.Options) -> String {
-        do {
-            let regex = try NSRegularExpression(pattern: regex, options: options)
-            let range = NSRange(location: 0, length: characters.count)
-            return regex.stringByReplacingMatches(in: self,
-                                                  options: [],
-                                                  range: range,
-                                                  withTemplate: template)
-        } catch {
-            assertionFailure()
+    func replaceMatches(of regex: String, with template: String, options: NSRegularExpression.Options = []) -> String {
+
+        let regex = try! NSRegularExpression(pattern: regex, options: options)
+        let fullRange = NSRange(location: 0, length: characters.count)
+
+        return regex.stringByReplacingMatches(in: self,
+                                              options: [],
+                                              range: fullRange,
+                                              withTemplate: template)
+    }
+
+    /// Replaces all matches of a given RegEx using a provided block.
+    ///
+    /// - Parameters:
+    ///     - regex: the regex to use for pattern matching.
+    ///     - options: the regex options.
+    ///     - block: the block that will be used for the replacement logic.
+    ///
+    /// - Returns: the new string.
+    ///
+    func replaceMatches(of regex: String, with options: NSRegularExpression.Options = [], using block: (String) -> String) -> String {
+
+        let regex = try! NSRegularExpression(pattern: regex, options: options)
+        let fullRange = NSRange(location: 0, length: characters.count)
+        let matches = regex.matches(in: self, options: [], range: fullRange)
+        var newString = self
+
+        for match in matches.reversed() {
+            let matchRange = range(from: match.range)
+            let matchString = substring(with: matchRange)
+
+            newString.replaceSubrange(matchRange, with: block(matchString))
         }
 
-        return self
+        return newString
     }
 }

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -27,7 +27,7 @@ extension String {
     ///
     /// - Returns: the new string.
     ///
-    func stringByReplacingMatches(of regex: String, with options: NSRegularExpression.Options = [], using block: (String, [String]) -> String) -> String {
+    func stringByReplacingMatches(of regex: String, options: NSRegularExpression.Options = [], using block: (String, [String]) -> String) -> String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -27,7 +27,7 @@ extension String {
     ///
     /// - Returns: the new string.
     ///
-    func stringByReplacingMatches(of regex: String, with options: NSRegularExpression.Options = [], using block: (String) -> String) -> String {
+    func stringByReplacingMatches(of regex: String, with options: NSRegularExpression.Options = [], using block: (String, [String]) -> String) -> String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
         let fullRange = NSRange(location: 0, length: characters.count)
@@ -38,7 +38,16 @@ extension String {
             let matchRange = range(from: match.range)
             let matchString = substring(with: matchRange)
 
-            newString.replaceSubrange(matchRange, with: block(matchString))
+            var submatchStrings = [String]()
+
+            for submatchIndex in 0 ..< match.numberOfRanges {
+                let submatchRange = self.range(from: match.rangeAt(submatchIndex))
+                let submatchString = self.substring(with: submatchRange)
+
+                submatchStrings.append(submatchString)
+            }
+
+            newString.replaceSubrange(matchRange, with: block(matchString, submatchStrings))
         }
 
         return newString

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -91,21 +91,21 @@ class CalypsoProcessorIn: Processor {
         output = output + "\n\n"
 
 //      text = text.replace( /<br \/>\s*<br \/>/gi, '\n\n' );
-        output = output.stringByReplacingMatches(of: "<br \\/>\\s*<br \\/>", with: "\n\n")
+        output = output.stringByReplacingMatches(of: "<br \\/>\\s*<br \\/>", with: "\n\n", options: .caseInsensitive)
 
         // Pad block tags with two line breaks.
 //    text = text.replace( new RegExp( '(<(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '\n\n$1' );
-        output = output.stringByReplacingMatches(of: "(<(?:" + blocklist + ")(?: [^>]*)?>)", with: "\n\n$1")
+        output = output.stringByReplacingMatches(of: "(<(?:" + blocklist + ")(?: [^>]*)?>)", with: "\n\n$1", options: .caseInsensitive)
 //    text = text.replace( new RegExp( '(</(?:' + blocklist + ')>)', 'gi' ), '$1\n\n' );
-        output = output.stringByReplacingMatches(of: "(</(?:" + blocklist + ")>)", with: "$1\n\n")
+        output = output.stringByReplacingMatches(of: "(</(?:" + blocklist + ")>)", with: "$1\n\n", options: .caseInsensitive)
 //    text = text.replace( /<hr( [^>]*)?>/gi, '<hr$1>\n\n' );
-        output = output.stringByReplacingMatches(of: "<hr( [^>]*)?>", with: "<hr$1>\n\n")
+        output = output.stringByReplacingMatches(of: "<hr( [^>]*)?>", with: "<hr$1>\n\n", options: .caseInsensitive)
 
         // Remove white space chars around <option>.
 //    text = text.replace( /\s*<option/gi, '<option' );
-        output = output.stringByReplacingMatches(of: "\\s*<option", with: "<option")
+        output = output.stringByReplacingMatches(of: "\\s*<option", with: "<option", options: .caseInsensitive)
 //    text = text.replace( /<\/option>\s*/gi, '</option>' );
-        output = output.stringByReplacingMatches(of: "<\\/option>\\s*", with: "</option>")
+        output = output.stringByReplacingMatches(of: "<\\/option>\\s*", with: "</option>", options: .caseInsensitive)
 
         // Normalize multiple line breaks and white space chars.
 //    text = text.replace( /\n\s*\n+/g, '\n\n' );
@@ -117,27 +117,27 @@ class CalypsoProcessorIn: Processor {
 
         // Remove empty paragraphs.
 //    text = text.replace( /<p>\s*?<\/p>/gi, '');
-        output = output.stringByReplacingMatches(of: "<p>\\s*?<\\/p>", with: "")
+        output = output.stringByReplacingMatches(of: "<p>\\s*?<\\/p>", with: "", options: .caseInsensitive)
 
         // Remove <p> tags that are around block tags.
 //    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1")
+        output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
 //    text = text.replace( /<p>(<li.+?)<\/p>/gi, '$1');
-        output = output.stringByReplacingMatches(of: "<p>(<li.+?)<\\/p>", with: "$1")
+        output = output.stringByReplacingMatches(of: "<p>(<li.+?)<\\/p>", with: "$1", options: .caseInsensitive)
 
         // Fix <p> in blockquotes.
 //    text = text.replace( /<p>\s*<blockquote([^>]*)>/gi, '<blockquote$1><p>');
-        output = output.stringByReplacingMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$1><p>")
+        output = output.stringByReplacingMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$1><p>", options: .caseInsensitive)
 //    text = text.replace( /<\/blockquote>\s*<\/p>/gi, '</p></blockquote>');
-        output = output.stringByReplacingMatches(of: "<\\/blockquote>\\s*<\\/p>", with: "</p></blockquote>")
+        output = output.stringByReplacingMatches(of: "<\\/blockquote>\\s*<\\/p>", with: "</p></blockquote>", options: .caseInsensitive)
 
         // Remove <p> tags that are wrapped around block tags.
 //    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$1")
+        output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$1", options: .caseInsensitive)
 //    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1")
+        output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
 //    text = text.replace( /(<br[^>]*>)\s*\n/gi, '$1' );
-        output = output.stringByReplacingMatches(of: "(<br[^>]*>)\\s*\n", with: "$1")
+        output = output.stringByReplacingMatches(of: "(<br[^>]*>)\\s*\n", with: "$1", options: .caseInsensitive)
 
         // Add <br> tags.
 //    text = text.replace( /\s*\n/g, '<br />\n');
@@ -145,13 +145,13 @@ class CalypsoProcessorIn: Processor {
 
         // Remove <br> tags that are around block tags.
 //    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")[^>]*>)\\s*<br />", with: "$1")
+        output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")[^>]*>)\\s*<br />", with: "$1", options: .caseInsensitive)
 //    text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
-        output = output.stringByReplacingMatches(of: "<br \\/>(\\s*<\\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)", with: "$1")
+        output = output.stringByReplacingMatches(of: "<br \\/>(\\s*<\\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)", with: "$1", options: .caseInsensitive)
 
         // Remove <p> and <br> around captions.
 //    text = text.replace( /(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi, '[caption$1[/caption]' );
-        output = output.stringByReplacingMatches(of: "(?:<p>|<br ?\\/?>)*\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*(?:<\\/p>|<br ?\\/?>)*", with: "[caption$1[/caption]")
+        output = output.stringByReplacingMatches(of: "(?:<p>|<br ?\\/?>)*\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*(?:<\\/p>|<br ?\\/?>)*", with: "[caption$1[/caption]", options: .caseInsensitive)
 
         // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
 //    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -71,13 +71,13 @@ class CalypsoProcessorIn: Processor {
             preserve_br = true
 
 //          text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", with: [], using: { (match, _) in
+            output = output.stringByReplacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", using: { (match, _) in
 
 //              a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
                 var updated = match.stringByReplacingMatches(of: "<br([^>]*)>", with: "<wp-temp-br$1>")
 
 //              a = a.replace( /<[^<>]+>/g, function( b ) {
-                updated = updated.stringByReplacingMatches(of: "<[^<>]+>", with: [], using: { (match, _) in
+                updated = updated.stringByReplacingMatches(of: "<[^<>]+>", using: { (match, _) in
 //                  return b.replace( /[\n\t ]+/, ' ' );
                     return match.stringByReplacingMatches(of: "[\n\t ]+", with: " ")
                 })
@@ -155,7 +155,7 @@ class CalypsoProcessorIn: Processor {
 
         // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
 //    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
-        output = output.stringByReplacingMatches(of: "(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\\/p>", with: [], using: { (match, _) in
+        output = output.stringByReplacingMatches(of: "(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\\/p>", using: { (match, _) in
 //    text = text.replace( //g, function( a, b, c ) {
 //        if ( c.match( /<p( [^>]*)?>/ ) ) {
 //            return a;

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -23,6 +23,7 @@ class CalypsoProcessorIn: Processor {
 
 //      if ( text.indexOf( '\n' ) === -1 ) {
         guard output.contains("\n") else {
+            // return text;
             return output
         }
 
@@ -30,7 +31,7 @@ class CalypsoProcessorIn: Processor {
 //      if ( text.indexOf( '<object' ) !== -1 ) {
         if output.contains("<object") {
 //          text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "<object[\\s\\S]+?<\\/object>", with: [], using: { match in
+            output = output.stringByReplacingMatches(of: "<object[\\s\\S]+?<\\/object>", using: { match in
 //              return a.replace( /\n+/g, '' );
                 return match.stringByReplacingMatches(of: "\n+", with: "")
             })
@@ -38,7 +39,7 @@ class CalypsoProcessorIn: Processor {
 
         // Remove line breaks from tags.
 //      text = text.replace( /<[^<>]+>/g, function( a ) {
-        output = output.stringByReplacingMatches(of: "<[^<>]+>", with: [], using: { match in
+        output = output.stringByReplacingMatches(of: "<[^<>]+>", using: { match in
 //          return a.replace( /[\n\t ]+/g, ' ' );
             return match.stringByReplacingMatches(of: "[\n\t ]+", with: " ")
         })
@@ -49,7 +50,7 @@ class CalypsoProcessorIn: Processor {
 //          preserve_linebreaks = true;
             preserve_linebreaks = true
 //          text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "<(pre|script)[^>]*>[\\s\\S]*?<\\/\\1>", with: [], using: { match in
+            output = output.stringByReplacingMatches(of: "<(pre|script)[^>]*>[\\s\\S]*?<\\/\\1>", using: { match in
 //              return a.replace( /\n/g, '<wp-line-break>' );
                 return match.stringByReplacingMatches(of: "\n", with: "<wp-line-break>")
             })

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -22,240 +22,165 @@ class CalypsoProcessorIn: Processor {
             "|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary"
 
         // Normalize line breaks.
+//      text = text.replace( /\r\n|\r/g, '\n' );
         var output = text.stringByReplacingMatches(of: "\r\n|\r", with: "\n")
 
+//      if ( text.indexOf( '\n' ) === -1 ) {
         guard output.contains("\n") else {
             return output
         }
 
         // Remove line breaks from <object>
+//      if ( text.indexOf( '<object' ) !== -1 ) {
         if output.contains("<object") {
+//          text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
             output = output.stringByReplacingMatches(of: "<object[\\s\\S]+?<\\/object>", with: [], using: { match in
+//              return a.replace( /\n+/g, '' );
                 return match.stringByReplacingMatches(of: "\n+", with: "")
             })
         }
 
         // Remove line breaks from tags.
+//      text = text.replace( /<[^<>]+>/g, function( a ) {
         output = output.stringByReplacingMatches(of: "<[^<>]+>", with: [], using: { match in
+//          return a.replace( /[\n\t ]+/g, ' ' );
             return match.stringByReplacingMatches(of: "[\n\t ]+", with: " ")
         })
 
         // Preserve line breaks in <pre> and <script> tags.
+//      if ( text.indexOf( '<pre' ) !== -1 || text.indexOf( '<script' ) !== -1 ) {
         if output.contains("<pre") || output.contains("<script") {
+//          preserve_linebreaks = true;
             preserve_linebreaks = true
+//          text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
             output = output.stringByReplacingMatches(of: "<(pre|script)[^>]*>[\\s\\S]*?<\\/\\1>", with: [], using: { match in
+//              return a.replace( /\n/g, '<wp-line-break>' );
                 return match.stringByReplacingMatches(of: "\n", with: "<wp-line-break>")
             })
         }
 
+//      if ( text.indexOf( '<figcaption' ) !== -1 ) {
         if output.contains("<figcaption") {
+//          text = text.replace( /\s*(<figcaption[^>]*>)/g, '$1' );
             output = output.stringByReplacingMatches(of: "\\s*(<figcaption[^>]*>)", with: "$0")
+//          text = text.replace( /<\/figcaption>\s*/g, '</figcaption>' );
             output = output.stringByReplacingMatches(of: "</figcaption>\\s*", with: "</figcaption>")
         }
 
         // Keep <br> tags inside captions.
+//      if ( text.indexOf( '[caption' ) !== -1 ) {
         if output.contains("[caption") {
+//          preserve_br = true;
             preserve_br = true
 
-//        text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
-//            a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
-//
-//            a = a.replace( /<[^<>]+>/g, function( b ) {
-//                return b.replace( /[\n\t ]+/, ' ' );
-//            });
-//
-//            return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
-//        });
+//          text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
+            output = output.stringByReplacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", with: [], using: { match in
+
+//              a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
+                var updated = match.stringByReplacingMatches(of: "<br([^>]*)>", with: "<wp-temp-br$0>")
+
+//              a = a.replace( /<[^<>]+>/g, function( b ) {
+                updated = updated.stringByReplacingMatches(of: "<[^<>]+>", with: [], using: { match in
+//                  return b.replace( /[\n\t ]+/, ' ' );
+                    return match.stringByReplacingMatches(of: "[\n\t ]+", with: " ")
+                })
+
+//              return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
+                return updated.stringByReplacingMatches(of: "\\s*\n\\s*", with: "<wp-temp-br />")
+            })
         }
 
+//      text = text + '\n\n';
         output = output + "\n\n"
+
+//      text = text.replace( /<br \/>\s*<br \/>/gi, '\n\n' );
         output = output.stringByReplacingMatches(of: "<br \\/>\\s*<br \\/>", with: "\n\n")
 
         // Pad block tags with two line breaks.
+//    text = text.replace( new RegExp( '(<(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '\n\n$1' );
         output = output.stringByReplacingMatches(of: "(<(?:" + blocklist + ")(?: [^>]*)?>)", with: "\n\n$0")
+//    text = text.replace( new RegExp( '(</(?:' + blocklist + ')>)', 'gi' ), '$1\n\n' );
         output = output.stringByReplacingMatches(of: "(</(?:" + blocklist + ")>)", with: "$0\n\n")
+//    text = text.replace( /<hr( [^>]*)?>/gi, '<hr$1>\n\n' );
         output = output.stringByReplacingMatches(of: "<hr( [^>]*)?>", with: "<hr$0>\n\n")
 
         // Remove white space chars around <option>.
+//    text = text.replace( /\s*<option/gi, '<option' );
         output = output.stringByReplacingMatches(of: "\\s*<option", with: "<option")
+//    text = text.replace( /<\/option>\s*/gi, '</option>' );
         output = output.stringByReplacingMatches(of: "</option>\\s*", with: "</option>")
 
         // Normalize multiple line breaks and white space chars.
+//    text = text.replace( /\n\s*\n+/g, '\n\n' );
         output = output.stringByReplacingMatches(of: "\n\\s*\n+", with: "\n\n")
 
         // Convert two line breaks to a paragraph.
+//    text = text.replace( /([\s\S]+?)\n\n/g, '<p>$1</p>\n' );
         output = output.stringByReplacingMatches(of: "([\\s\\S]+?)\n\n", with: "<p>$0</p>\n")
 
         // Remove empty paragraphs.
+//    text = text.replace( /<p>\s*?<\/p>/gi, '');
         output = output.stringByReplacingMatches(of: "<p>\\s*?</p>", with: "")
 
         // Remove <p> tags that are around block tags.
+//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
         output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$0")
+//    text = text.replace( /<p>(<li.+?)<\/p>/gi, '$1');
         output = output.stringByReplacingMatches(of: "<p>(<li.+?)<\\/p>", with: "$0")
 
         // Fix <p> in blockquotes.
+//    text = text.replace( /<p>\s*<blockquote([^>]*)>/gi, '<blockquote$1><p>');
         output = output.stringByReplacingMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$0><p>")
+//    text = text.replace( /<\/blockquote>\s*<\/p>/gi, '</p></blockquote>');
         output = output.stringByReplacingMatches(of: "<\\/blockquote>\\s*<\\/p>", with: "</p></blockquote>")
 
         // Remove <p> tags that are wrapped around block tags.
+//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '$1' );
         output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$0")
+//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
         output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$0")
-
+//    text = text.replace( /(<br[^>]*>)\s*\n/gi, '$1' );
         output = output.stringByReplacingMatches(of: "(<br[^>]*>)\\s*\n", with: "$0")
 
         // Add <br> tags.
+//    text = text.replace( /\s*\n/g, '<br />\n');
         output = output.stringByReplacingMatches(of: "\\s*\n", with: "<br />\n")
 
         // Remove <br> tags that are around block tags.
+//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
         output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")[^>]*>)\\s*<br />", with: "$0")
+//    text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
         output = output.stringByReplacingMatches(of: "<br />(\\s*<\\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)", with: "$0")
 
         // Remove <p> and <br> around captions.
+//    text = text.replace( /(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi, '[caption$1[/caption]' );
         output = output.stringByReplacingMatches(of: "(?:<p>|<br ?\\/?>)*\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*(?:<\\/p>|<br ?\\/?>)*", with: "[caption$0[/caption]")
 
-//    // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
+        // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
 //    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
+        output = output.stringByReplacingMatches(of: "(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\\/p>", with: [], using: { match in
+//    text = text.replace( //g, function( a, b, c ) {
 //        if ( c.match( /<p( [^>]*)?>/ ) ) {
 //            return a;
 //        }
-//        
+//
 //        return b + '<p>' + c + '</p>';
 //    });
+            return match
+        })
 
         // Restore the line breaks in <pre> and <script> tags.
         if preserve_linebreaks {
+//            text = text.replace( /<wp-line-break>/g, '\n' );
             output = output.replacingOccurrences(of: "<wp-line-break>", with: "\n")
         }
         
         // Restore the <br> tags in captions.
         if preserve_br {
+//            text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
             output = output.stringByReplacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$0>")
         }
         
         return text
     }
 }
-
-
-
-
-//function autop( text ) {
-//    var preserve_linebreaks = false,
-//        preserve_br = false,
-//		blocklist = 'table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre' +
-//            '|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section' +
-//            '|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary';
-//
-//    // Normalize line breaks.
-//    text = text.replace( /\r\n|\r/g, '\n' );
-//
-//    if ( text.indexOf( '\n' ) === -1 ) {
-//        return text;
-//    }
-//
-//    // Remove line breaks from <object>.
-//    if ( text.indexOf( '<object' ) !== -1 ) {
-//        text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
-//            return a.replace( /\n+/g, '' );
-//        });
-//    }
-//
-//    // Remove line breaks from tags.
-//    text = text.replace( /<[^<>]+>/g, function( a ) {
-//        return a.replace( /[\n\t ]+/g, ' ' );
-//    });
-//
-//    // Preserve line breaks in <pre> and <script> tags.
-//    if ( text.indexOf( '<pre' ) !== -1 || text.indexOf( '<script' ) !== -1 ) {
-//        preserve_linebreaks = true;
-//        text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
-//            return a.replace( /\n/g, '<wp-line-break>' );
-//        });
-//    }
-//
-//    if ( text.indexOf( '<figcaption' ) !== -1 ) {
-//        text = text.replace( /\s*(<figcaption[^>]*>)/g, '$1' );
-//        text = text.replace( /<\/figcaption>\s*/g, '</figcaption>' );
-//    }
-//
-//    // Keep <br> tags inside captions.
-//    if ( text.indexOf( '[caption' ) !== -1 ) {
-//        preserve_br = true;
-//
-//        text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
-//            a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
-//
-//            a = a.replace( /<[^<>]+>/g, function( b ) {
-//                return b.replace( /[\n\t ]+/, ' ' );
-//            });
-//
-//            return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
-//        });
-//    }
-//
-//    text = text + '\n\n';
-//    text = text.replace( /<br \/>\s*<br \/>/gi, '\n\n' );
-//
-//    // Pad block tags with two line breaks.
-//    text = text.replace( new RegExp( '(<(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '\n\n$1' );
-//    text = text.replace( new RegExp( '(</(?:' + blocklist + ')>)', 'gi' ), '$1\n\n' );
-//    text = text.replace( /<hr( [^>]*)?>/gi, '<hr$1>\n\n' );
-//
-//    // Remove white space chars around <option>.
-//    text = text.replace( /\s*<option/gi, '<option' );
-//    text = text.replace( /<\/option>\s*/gi, '</option>' );
-//
-//    // Normalize multiple line breaks and white space chars.
-//    text = text.replace( /\n\s*\n+/g, '\n\n' );
-//
-//    // Convert two line breaks to a paragraph.
-//    text = text.replace( /([\s\S]+?)\n\n/g, '<p>$1</p>\n' );
-//
-//    // Remove empty paragraphs.
-//    text = text.replace( /<p>\s*?<\/p>/gi, '');
-//
-//    // Remove <p> tags that are around block tags.
-//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
-//    text = text.replace( /<p>(<li.+?)<\/p>/gi, '$1');
-//
-//    // Fix <p> in blockquotes.
-//    text = text.replace( /<p>\s*<blockquote([^>]*)>/gi, '<blockquote$1><p>');
-//    text = text.replace( /<\/blockquote>\s*<\/p>/gi, '</p></blockquote>');
-//
-//    // Remove <p> tags that are wrapped around block tags.
-//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '$1' );
-//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
-//
-//    text = text.replace( /(<br[^>]*>)\s*\n/gi, '$1' );
-//
-//    // Add <br> tags.
-//    text = text.replace( /\s*\n/g, '<br />\n');
-//
-//    // Remove <br> tags that are around block tags.
-//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
-//    text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
-//
-//    // Remove <p> and <br> around captions.
-//    text = text.replace( /(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi, '[caption$1[/caption]' );
-//    
-//    // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
-//    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
-//        if ( c.match( /<p( [^>]*)?>/ ) ) {
-//            return a;
-//        }
-//        
-//        return b + '<p>' + c + '</p>';
-//    });
-//    
-//    // Restore the line breaks in <pre> and <script> tags.
-//    if ( preserve_linebreaks ) {
-//            text = text.replace( /<wp-line-break>/g, '\n' );
-//    }
-//    
-//    // Restore the <br> tags in captions.
-//    if ( preserve_br ) {
-//            text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
-//    }
-//    
-//    return text;
-//}

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -31,7 +31,7 @@ class CalypsoProcessorIn: Processor {
 //      if ( text.indexOf( '<object' ) !== -1 ) {
         if output.contains("<object") {
 //          text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "<object[\\s\\S]+?<\\/object>", using: { match in
+            output = output.stringByReplacingMatches(of: "<object[\\s\\S]+?<\\/object>", using: { (match, _) in
 //              return a.replace( /\n+/g, '' );
                 return match.stringByReplacingMatches(of: "\n+", with: "")
             })
@@ -39,7 +39,7 @@ class CalypsoProcessorIn: Processor {
 
         // Remove line breaks from tags.
 //      text = text.replace( /<[^<>]+>/g, function( a ) {
-        output = output.stringByReplacingMatches(of: "<[^<>]+>", using: { match in
+        output = output.stringByReplacingMatches(of: "<[^<>]+>", using: { (match, _) in
 //          return a.replace( /[\n\t ]+/g, ' ' );
             return match.stringByReplacingMatches(of: "[\n\t ]+", with: " ")
         })
@@ -50,7 +50,7 @@ class CalypsoProcessorIn: Processor {
 //          preserve_linebreaks = true;
             preserve_linebreaks = true
 //          text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "<(pre|script)[^>]*>[\\s\\S]*?<\\/\\1>", using: { match in
+            output = output.stringByReplacingMatches(of: "<(pre|script)[^>]*>[\\s\\S]*?<\\/\\1>", using: { (match, _) in
 //              return a.replace( /\n/g, '<wp-line-break>' );
                 return match.stringByReplacingMatches(of: "\n", with: "<wp-line-break>")
             })
@@ -71,13 +71,13 @@ class CalypsoProcessorIn: Processor {
             preserve_br = true
 
 //          text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", with: [], using: { match in
+            output = output.stringByReplacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", with: [], using: { (match, _) in
 
 //              a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
                 var updated = match.stringByReplacingMatches(of: "<br([^>]*)>", with: "<wp-temp-br$1>")
 
 //              a = a.replace( /<[^<>]+>/g, function( b ) {
-                updated = updated.stringByReplacingMatches(of: "<[^<>]+>", with: [], using: { match in
+                updated = updated.stringByReplacingMatches(of: "<[^<>]+>", with: [], using: { (match, _) in
 //                  return b.replace( /[\n\t ]+/, ' ' );
                     return match.stringByReplacingMatches(of: "[\n\t ]+", with: " ")
                 })
@@ -155,7 +155,7 @@ class CalypsoProcessorIn: Processor {
 
         // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
 //    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
-        output = output.stringByReplacingMatches(of: "(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\\/p>", with: [], using: { match in
+        output = output.stringByReplacingMatches(of: "(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\\/p>", with: [], using: { (match, _) in
 //    text = text.replace( //g, function( a, b, c ) {
 //        if ( c.match( /<p( [^>]*)?>/ ) ) {
 //            return a;

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -11,10 +11,6 @@ class CalypsoProcessorIn: Processor {
     /// Ref. https://github.com/WordPress/WordPress/blob/4e4df0e/wp-admin/js/editor.js#L309
     ///
     func process(text: String) -> String {
-// - Reventar el `/` inicial
-// - Duplicar los `\`
-// - Reventar el `/g` final
-
         var preserve_linebreaks = false
         var preserve_br = false
         let blocklist = "table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre" +
@@ -62,7 +58,7 @@ class CalypsoProcessorIn: Processor {
 //      if ( text.indexOf( '<figcaption' ) !== -1 ) {
         if output.contains("<figcaption") {
 //          text = text.replace( /\s*(<figcaption[^>]*>)/g, '$1' );
-            output = output.stringByReplacingMatches(of: "\\s*(<figcaption[^>]*>)", with: "$0")
+            output = output.stringByReplacingMatches(of: "\\s*(<figcaption[^>]*>)", with: "$1")
 //          text = text.replace( /<\/figcaption>\s*/g, '</figcaption>' );
             output = output.stringByReplacingMatches(of: "</figcaption>\\s*", with: "</figcaption>")
         }
@@ -77,7 +73,7 @@ class CalypsoProcessorIn: Processor {
             output = output.stringByReplacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", with: [], using: { match in
 
 //              a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
-                var updated = match.stringByReplacingMatches(of: "<br([^>]*)>", with: "<wp-temp-br$0>")
+                var updated = match.stringByReplacingMatches(of: "<br([^>]*)>", with: "<wp-temp-br$1>")
 
 //              a = a.replace( /<[^<>]+>/g, function( b ) {
                 updated = updated.stringByReplacingMatches(of: "<[^<>]+>", with: [], using: { match in
@@ -98,17 +94,17 @@ class CalypsoProcessorIn: Processor {
 
         // Pad block tags with two line breaks.
 //    text = text.replace( new RegExp( '(<(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '\n\n$1' );
-        output = output.stringByReplacingMatches(of: "(<(?:" + blocklist + ")(?: [^>]*)?>)", with: "\n\n$0")
+        output = output.stringByReplacingMatches(of: "(<(?:" + blocklist + ")(?: [^>]*)?>)", with: "\n\n$1")
 //    text = text.replace( new RegExp( '(</(?:' + blocklist + ')>)', 'gi' ), '$1\n\n' );
-        output = output.stringByReplacingMatches(of: "(</(?:" + blocklist + ")>)", with: "$0\n\n")
+        output = output.stringByReplacingMatches(of: "(</(?:" + blocklist + ")>)", with: "$1\n\n")
 //    text = text.replace( /<hr( [^>]*)?>/gi, '<hr$1>\n\n' );
-        output = output.stringByReplacingMatches(of: "<hr( [^>]*)?>", with: "<hr$0>\n\n")
+        output = output.stringByReplacingMatches(of: "<hr( [^>]*)?>", with: "<hr$1>\n\n")
 
         // Remove white space chars around <option>.
 //    text = text.replace( /\s*<option/gi, '<option' );
         output = output.stringByReplacingMatches(of: "\\s*<option", with: "<option")
 //    text = text.replace( /<\/option>\s*/gi, '</option>' );
-        output = output.stringByReplacingMatches(of: "</option>\\s*", with: "</option>")
+        output = output.stringByReplacingMatches(of: "<\\/option>\\s*", with: "</option>")
 
         // Normalize multiple line breaks and white space chars.
 //    text = text.replace( /\n\s*\n+/g, '\n\n' );
@@ -116,31 +112,31 @@ class CalypsoProcessorIn: Processor {
 
         // Convert two line breaks to a paragraph.
 //    text = text.replace( /([\s\S]+?)\n\n/g, '<p>$1</p>\n' );
-        output = output.stringByReplacingMatches(of: "([\\s\\S]+?)\n\n", with: "<p>$0</p>\n")
+        output = output.stringByReplacingMatches(of: "([\\s\\S]+?)\n\n", with: "<p>$1</p>\n")
 
         // Remove empty paragraphs.
 //    text = text.replace( /<p>\s*?<\/p>/gi, '');
-        output = output.stringByReplacingMatches(of: "<p>\\s*?</p>", with: "")
+        output = output.stringByReplacingMatches(of: "<p>\\s*?<\\/p>", with: "")
 
         // Remove <p> tags that are around block tags.
 //    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$0")
+        output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1")
 //    text = text.replace( /<p>(<li.+?)<\/p>/gi, '$1');
-        output = output.stringByReplacingMatches(of: "<p>(<li.+?)<\\/p>", with: "$0")
+        output = output.stringByReplacingMatches(of: "<p>(<li.+?)<\\/p>", with: "$1")
 
         // Fix <p> in blockquotes.
 //    text = text.replace( /<p>\s*<blockquote([^>]*)>/gi, '<blockquote$1><p>');
-        output = output.stringByReplacingMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$0><p>")
+        output = output.stringByReplacingMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$1><p>")
 //    text = text.replace( /<\/blockquote>\s*<\/p>/gi, '</p></blockquote>');
         output = output.stringByReplacingMatches(of: "<\\/blockquote>\\s*<\\/p>", with: "</p></blockquote>")
 
         // Remove <p> tags that are wrapped around block tags.
 //    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$0")
+        output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$1")
 //    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$0")
+        output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1")
 //    text = text.replace( /(<br[^>]*>)\s*\n/gi, '$1' );
-        output = output.stringByReplacingMatches(of: "(<br[^>]*>)\\s*\n", with: "$0")
+        output = output.stringByReplacingMatches(of: "(<br[^>]*>)\\s*\n", with: "$1")
 
         // Add <br> tags.
 //    text = text.replace( /\s*\n/g, '<br />\n');
@@ -148,13 +144,13 @@ class CalypsoProcessorIn: Processor {
 
         // Remove <br> tags that are around block tags.
 //    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")[^>]*>)\\s*<br />", with: "$0")
+        output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")[^>]*>)\\s*<br />", with: "$1")
 //    text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
-        output = output.stringByReplacingMatches(of: "<br />(\\s*<\\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)", with: "$0")
+        output = output.stringByReplacingMatches(of: "<br \\/>(\\s*<\\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)", with: "$1")
 
         // Remove <p> and <br> around captions.
 //    text = text.replace( /(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi, '[caption$1[/caption]' );
-        output = output.stringByReplacingMatches(of: "(?:<p>|<br ?\\/?>)*\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*(?:<\\/p>|<br ?\\/?>)*", with: "[caption$0[/caption]")
+        output = output.stringByReplacingMatches(of: "(?:<p>|<br ?\\/?>)*\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*(?:<\\/p>|<br ?\\/?>)*", with: "[caption$1[/caption]")
 
         // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
 //    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
@@ -178,9 +174,9 @@ class CalypsoProcessorIn: Processor {
         // Restore the <br> tags in captions.
         if preserve_br {
 //            text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
-            output = output.stringByReplacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$0>")
+            output = output.stringByReplacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$1>")
         }
         
-        return text
+        return output
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -8,7 +8,9 @@ class CalypsoProcessorIn: Processor {
 
     /// Converts a Calypso-Generated string into Valid HTML that can actually be edited by Aztec.
     ///
-    /// Ref. https://github.com/WordPress/WordPress/blob/4e4df0e/wp-admin/js/editor.js#L309
+    /// This method was a direct migration from:
+    /// https://github.com/WordPress/WordPress/blob/4e4df0e/wp-admin/js/editor.js#L309
+    /// Current as of 2017/08/08
     ///
     func process(text: String) -> String {
         var preserveLinebreaks = false

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -2,9 +2,9 @@ import Foundation
 import Aztec
 
 
-// MARK: - CalypsoProcessor
+// MARK: - CalypsoProcessorIn
 //
-class CalypsoProcessor: Processor {
+class CalypsoProcessorIn: Processor {
 
     /// Converts a Calypso-Generated string into Valid HTML that can actually be edited by Aztec.
     ///
@@ -21,7 +21,7 @@ class CalypsoProcessor: Processor {
 
 // MARK: - Calypso Escaping Helpers
 //
-private extension CalypsoProcessor {
+private extension CalypsoProcessorIn {
 
     /// Escapes Preformatted HTML Elements, and returns a touple containing the 'Original Pre Snippets'
     /// and the actual escaped string.
@@ -62,7 +62,7 @@ private extension CalypsoProcessor {
 
 // MARK: - Tag Generation Helpers
 //
-private extension CalypsoProcessor {
+private extension CalypsoProcessorIn {
 
     /// Encapsulates all of the paragraphs (split by '\n\n') into the HTML P Element
     ///
@@ -87,7 +87,7 @@ private extension CalypsoProcessor {
 
 // MARK: - Regex Helpers
 //
-private extension CalypsoProcessor {
+private extension CalypsoProcessorIn {
 
     /// Returns the collection of Swift Ranges pointing towards all of the "<PRE | <SCRIPT" snippets
     ///
@@ -118,7 +118,7 @@ private extension CalypsoProcessor {
 
 // MARK: - Private Helpers
 //
-private extension CalypsoProcessor {
+private extension CalypsoProcessorIn {
     struct Constants {
         static let escapedSnippetKey = "<calypso-escaped>"
         static let preformattedTextRegex = "<(pre|script|ul|ol)[^>]*>[\\s\\S]+?</\\1>"

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -11,8 +11,8 @@ class CalypsoProcessorIn: Processor {
     /// Ref. https://github.com/WordPress/WordPress/blob/4e4df0e/wp-admin/js/editor.js#L309
     ///
     func process(text: String) -> String {
-        var preserve_linebreaks = false
-        var preserve_br = false
+        var preserveLinebreaks = false
+        var preserveBR = false
         let blocklist = "table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre" +
             "|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section" +
             "|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary"
@@ -48,7 +48,7 @@ class CalypsoProcessorIn: Processor {
 //      if ( text.indexOf( '<pre' ) !== -1 || text.indexOf( '<script' ) !== -1 ) {
         if output.contains("<pre") || output.contains("<script") {
 //          preserve_linebreaks = true;
-            preserve_linebreaks = true
+            preserveLinebreaks = true
 //          text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
             output = output.replacingMatches(of: "<(pre|script)[^>]*>[\\s\\S]*?<\\/\\1>", using: { (match, _) in
 //              return a.replace( /\n/g, '<wp-line-break>' );
@@ -67,8 +67,8 @@ class CalypsoProcessorIn: Processor {
         // Keep <br> tags inside captions.
 //      if ( text.indexOf( '[caption' ) !== -1 ) {
         if output.contains("[caption") {
-//          preserve_br = true;
-            preserve_br = true
+//          preserveBR = true;
+            preserveBR = true
 
 //          text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
             output = output.replacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", using: { (match, _) in
@@ -168,13 +168,13 @@ class CalypsoProcessorIn: Processor {
         })
 
         // Restore the line breaks in <pre> and <script> tags.
-        if preserve_linebreaks {
+        if preserveLinebreaks {
 //            text = text.replace( /<wp-line-break>/g, '\n' );
             output = output.replacingOccurrences(of: "<wp-line-break>", with: "\n")
         }
 
         // Restore the <br> tags in captions.
-        if preserve_br {
+        if preserveBR {
 //            text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
             output = output.replacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$1>")
         }

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -155,15 +155,16 @@ class CalypsoProcessorIn: Processor {
 
         // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
 //    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
-        output = output.stringByReplacingMatches(of: "(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\\/p>", using: { (match, _) in
-//    text = text.replace( //g, function( a, b, c ) {
+        output = output.stringByReplacingMatches(of: "(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\\/p>", using: { (match, submatches) in
+
 //        if ( c.match( /<p( [^>]*)?>/ ) ) {
+            guard submatches.count < 2 || submatches[1].matches(regex: "<p( [^>]*)?>").count == 0 else {
 //            return a;
-//        }
-//
+                return match
+            }
+
 //        return b + '<p>' + c + '</p>';
-//    });
-            return match
+            return submatches[0] + "<p>" + submatches[1] + "</p>"
         })
 
         // Restore the line breaks in <pre> and <script> tags.

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -180,7 +180,7 @@ class CalypsoProcessorIn: Processor {
 //            text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
             output = output.replacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$1>")
         }
-        
+
         return output
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -8,119 +8,254 @@ class CalypsoProcessorIn: Processor {
 
     /// Converts a Calypso-Generated string into Valid HTML that can actually be edited by Aztec.
     ///
+    /// Ref. https://github.com/WordPress/WordPress/blob/4e4df0e/wp-admin/js/editor.js#L309
+    ///
     func process(text: String) -> String {
-        let (substrings, escaped) = escapePreformattedText(in: text)
-        let paragraphs = encapsulateParagraphs(in: escaped)
-        let linebreaks = replaceLineBreaks(in: paragraphs)
-        let unescaped = unescapePreformattedText(in: linebreaks, using: substrings)
+// - Reventar el `/` inicial
+// - Duplicar los `\`
+// - Reventar el `/g` final
 
-        return unescaped
-    }
-}
+        var preserve_linebreaks = false
+        var preserve_br = false
+        let blocklist = "table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre" +
+            "|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section" +
+            "|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary"
 
+        // Normalize line breaks.
+        var output = text.replaceMatches(of: "\r\n|\r", with: "\n")
 
-// MARK: - Calypso Escaping Helpers
+        guard output.contains("\n") else {
+            return output
+        }
+
+        // Remove line breaks from <object>
+        if output.contains("<object") {
+//        text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
+//            return a.replace( /\n+/g, '' );
+//        });
+        }
+
+        // Remove line breaks from tags.
+//    text = text.replace( /<[^<>]+>/g, function( a ) {
+//        return a.replace( /[\n\t ]+/g, ' ' );
+//    });
+
+        // Preserve line breaks in <pre> and <script> tags.
+        if output.contains("<pre") || output.contains("<script") {
+            preserve_linebreaks = true
+//        text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
+//            return a.replace( /\n/g, '<wp-line-break>' );
+//        });
+        }
+
+        if output.contains("<figcaption") {
+            output = output.replaceMatches(of: "\\s*(<figcaption[^>]*>)", with: "$0")
+            output = output.replaceMatches(of: "</figcaption>\\s*", with: "</figcaption>")
+        }
+
+        // Keep <br> tags inside captions.
+        if output.contains("[caption") {
+            preserve_br = true
+
+//        text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
+//            a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
 //
-private extension CalypsoProcessorIn {
-
-    /// Escapes Preformatted HTML Elements, and returns a touple containing the 'Original Pre Snippets'
-    /// and the actual escaped string.
-    ///
-    func escapePreformattedText(in string: String) -> ([String], String) {
-        var substrings = [String]()
-        var escaped = string
-
-        for range in preformattedTextRanges(in: string).reversed() {
-            let substring = string.substring(with: range)
-            escaped.replaceSubrange(range, with: Constants.escapedSnippetKey)
-            substrings.append(substring)
-        }
-
-        return (substrings, escaped)
-    }
-
-
-    /// Unescapes Preformatted Text HTML Elements, given a escaped string, and a collection of all of the 
-    /// 'Pristine' Pre Element's contents.
-    ///
-    func unescapePreformattedText(in string: String, using substrings: [String]) -> String {
-        var stack = Array(substrings.reversed())
-        var output = string
-
-        for range in escapedRanges(in: string).reversed() {
-            guard let replacement = stack.popLast() else {
-                break
-            }
-
-            output.replaceSubrange(range, with: replacement)
-        }
-
-        return output
-    }
-}
-
-
-// MARK: - Tag Generation Helpers
+//            a = a.replace( /<[^<>]+>/g, function( b ) {
+//                return b.replace( /[\n\t ]+/, ' ' );
+//            });
 //
-private extension CalypsoProcessorIn {
-
-    /// Encapsulates all of the paragraphs (split by '\n\n') into the HTML P Element
-    ///
-    func encapsulateParagraphs(in string: String) -> String {
-        let paragraphs = string.components(separatedBy: "\n\n")
-        guard paragraphs.count > 1 else {
-            return string
+//            return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
+//        });
         }
 
-        return paragraphs.reduce("") { (result, paragraph) in
-            return result + "<p>" + paragraph + "</p>"
-        }
-    }
+        output = output + "\n\n"
+        output = output.replaceMatches(of: "<br \\/>\\s*<br \\/>", with: "\n\n")
 
-    /// Replaces all of the Line Breaks with the HTML Element <br>
-    ///
-    func replaceLineBreaks(in string: String) -> String {
-        return string.replacingOccurrences(of: "\n", with: "<br>")
+        // Pad block tags with two line breaks.
+        output = output.replaceMatches(of: "(<(?:" + blocklist + ")(?: [^>]*)?>)", with: "\n\n$0")
+        output = output.replaceMatches(of: "(</(?:" + blocklist + ")>)", with: "$0\n\n")
+        output = output.replaceMatches(of: "<hr( [^>]*)?>", with: "<hr$0>\n\n")
+
+        // Remove white space chars around <option>.
+        output = output.replaceMatches(of: "\\s*<option", with: "<option")
+        output = output.replaceMatches(of: "</option>\\s*", with: "</option>")
+
+        // Normalize multiple line breaks and white space chars.
+        output = output.replaceMatches(of: "\n\\s*\n+", with: "\n\n")
+
+        // Convert two line breaks to a paragraph.
+        output = output.replaceMatches(of: "([\\s\\S]+?)\n\n", with: "<p>$0</p>\n")
+
+        // Remove empty paragraphs.
+        output = output.replaceMatches(of: "<p>\\s*?</p>", with: "")
+
+        // Remove <p> tags that are around block tags.
+        output = output.replaceMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$0")
+        output = output.replaceMatches(of: "<p>(<li.+?)<\\/p>", with: "$0")
+
+        // Fix <p> in blockquotes.
+        output = output.replaceMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$0><p>")
+        output = output.replaceMatches(of: "<\\/blockquote>\\s*<\\/p>", with: "</p></blockquote>")
+
+        // Remove <p> tags that are wrapped around block tags.
+        output = output.replaceMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$0")
+        output = output.replaceMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$0")
+
+        output = output.replaceMatches(of: "(<br[^>]*>)\\s*\n", with: "$0")
+
+        // Add <br> tags.
+        output = output.replaceMatches(of: "\\s*\n", with: "<br />\n")
+
+        // Remove <br> tags that are around block tags.
+        output = output.replaceMatches(of: "(</?(?:" + blocklist + ")[^>]*>)\\s*<br />", with: "$0")
+        output = output.replaceMatches(of: "<br />(\\s*<\\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)", with: "$0")
+
+        // Remove <p> and <br> around captions.
+        output = output.replaceMatches(of: "(?:<p>|<br ?\\/?>)*\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*(?:<\\/p>|<br ?\\/?>)*", with: "[caption$0[/caption]")
+
+//    // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
+//    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
+//        if ( c.match( /<p( [^>]*)?>/ ) ) {
+//            return a;
+//        }
+//        
+//        return b + '<p>' + c + '</p>';
+//    });
+
+        // Restore the line breaks in <pre> and <script> tags.
+        if preserve_linebreaks {
+            output = output.replacingOccurrences(of: "<wp-line-break>", with: "\n")
+        }
+        
+        // Restore the <br> tags in captions.
+        if preserve_br {
+            output = output.replaceMatches(of: "<wp-temp-br([^>]*)>", with: "<br$0>")
+        }
+        
+        return text
     }
 }
 
 
-// MARK: - Regex Helpers
+
+
+//function autop( text ) {
+//    var preserve_linebreaks = false,
+//        preserve_br = false,
+//		blocklist = 'table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre' +
+//            '|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section' +
+//            '|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary';
 //
-private extension CalypsoProcessorIn {
-
-    /// Returns the collection of Swift Ranges pointing towards all of the "<PRE | <SCRIPT" snippets
-    ///
-    func preformattedTextRanges(in text: String) -> [Range<String.Index>] {
-        return rangesOfSubstrings(matching: Constants.preformattedTextRegex, in: text)
-    }
-
-    /// Returns the collection of Swift Ranges pointing towards all of the the Calypso-Escaped Snippets
-    ///
-    func escapedRanges(in text: String) -> [Range<String.Index>] {
-        return rangesOfSubstrings(matching: Constants.escapedSnippetKey, in: text)
-    }
-
-    /// Returns the collection of Swift Ranges of all of the Pattern matches, in the specified String.
-    ///
-    private func rangesOfSubstrings(matching pattern: String, in text: String) -> [Range<String.Index>] {
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
-            return []
-        }
-
-        let matches = regex.matches(in: text, options: [], range: text.foundationRangeOfEntireString)
-        let ranges = matches.flatMap { text.range(from: $0.range) }
-
-        return ranges
-    }
-}
-
-
-// MARK: - Private Helpers
+//    // Normalize line breaks.
+//    text = text.replace( /\r\n|\r/g, '\n' );
 //
-private extension CalypsoProcessorIn {
-    struct Constants {
-        static let escapedSnippetKey = "<calypso-escaped>"
-        static let preformattedTextRegex = "<(pre|script|ul|ol)[^>]*>[\\s\\S]+?</\\1>"
-    }
-}
+//    if ( text.indexOf( '\n' ) === -1 ) {
+//        return text;
+//    }
+//
+//    // Remove line breaks from <object>.
+//    if ( text.indexOf( '<object' ) !== -1 ) {
+//        text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
+//            return a.replace( /\n+/g, '' );
+//        });
+//    }
+//
+//    // Remove line breaks from tags.
+//    text = text.replace( /<[^<>]+>/g, function( a ) {
+//        return a.replace( /[\n\t ]+/g, ' ' );
+//    });
+//
+//    // Preserve line breaks in <pre> and <script> tags.
+//    if ( text.indexOf( '<pre' ) !== -1 || text.indexOf( '<script' ) !== -1 ) {
+//        preserve_linebreaks = true;
+//        text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
+//            return a.replace( /\n/g, '<wp-line-break>' );
+//        });
+//    }
+//
+//    if ( text.indexOf( '<figcaption' ) !== -1 ) {
+//        text = text.replace( /\s*(<figcaption[^>]*>)/g, '$1' );
+//        text = text.replace( /<\/figcaption>\s*/g, '</figcaption>' );
+//    }
+//
+//    // Keep <br> tags inside captions.
+//    if ( text.indexOf( '[caption' ) !== -1 ) {
+//        preserve_br = true;
+//
+//        text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
+//            a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
+//
+//            a = a.replace( /<[^<>]+>/g, function( b ) {
+//                return b.replace( /[\n\t ]+/, ' ' );
+//            });
+//
+//            return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
+//        });
+//    }
+//
+//    text = text + '\n\n';
+//    text = text.replace( /<br \/>\s*<br \/>/gi, '\n\n' );
+//
+//    // Pad block tags with two line breaks.
+//    text = text.replace( new RegExp( '(<(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '\n\n$1' );
+//    text = text.replace( new RegExp( '(</(?:' + blocklist + ')>)', 'gi' ), '$1\n\n' );
+//    text = text.replace( /<hr( [^>]*)?>/gi, '<hr$1>\n\n' );
+//
+//    // Remove white space chars around <option>.
+//    text = text.replace( /\s*<option/gi, '<option' );
+//    text = text.replace( /<\/option>\s*/gi, '</option>' );
+//
+//    // Normalize multiple line breaks and white space chars.
+//    text = text.replace( /\n\s*\n+/g, '\n\n' );
+//
+//    // Convert two line breaks to a paragraph.
+//    text = text.replace( /([\s\S]+?)\n\n/g, '<p>$1</p>\n' );
+//
+//    // Remove empty paragraphs.
+//    text = text.replace( /<p>\s*?<\/p>/gi, '');
+//
+//    // Remove <p> tags that are around block tags.
+//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
+//    text = text.replace( /<p>(<li.+?)<\/p>/gi, '$1');
+//
+//    // Fix <p> in blockquotes.
+//    text = text.replace( /<p>\s*<blockquote([^>]*)>/gi, '<blockquote$1><p>');
+//    text = text.replace( /<\/blockquote>\s*<\/p>/gi, '</p></blockquote>');
+//
+//    // Remove <p> tags that are wrapped around block tags.
+//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '$1' );
+//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
+//
+//    text = text.replace( /(<br[^>]*>)\s*\n/gi, '$1' );
+//
+//    // Add <br> tags.
+//    text = text.replace( /\s*\n/g, '<br />\n');
+//
+//    // Remove <br> tags that are around block tags.
+//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
+//    text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
+//
+//    // Remove <p> and <br> around captions.
+//    text = text.replace( /(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi, '[caption$1[/caption]' );
+//    
+//    // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
+//    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
+//        if ( c.match( /<p( [^>]*)?>/ ) ) {
+//            return a;
+//        }
+//        
+//        return b + '<p>' + c + '</p>';
+//    });
+//    
+//    // Restore the line breaks in <pre> and <script> tags.
+//    if ( preserve_linebreaks ) {
+//            text = text.replace( /<wp-line-break>/g, '\n' );
+//    }
+//    
+//    // Restore the <br> tags in captions.
+//    if ( preserve_br ) {
+//            text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
+//    }
+//    
+//    return text;
+//}

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -30,22 +30,22 @@ class CalypsoProcessorIn: Processor {
 
         // Remove line breaks from <object>
         if output.contains("<object") {
-//        text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
-//            return a.replace( /\n+/g, '' );
-//        });
+            output = output.stringByReplacingMatches(of: "<object[\\s\\S]+?<\\/object>", with: [], using: { match in
+                return match.stringByReplacingMatches(of: "\n+", with: "")
+            })
         }
 
         // Remove line breaks from tags.
-//    text = text.replace( /<[^<>]+>/g, function( a ) {
-//        return a.replace( /[\n\t ]+/g, ' ' );
-//    });
+        output = output.stringByReplacingMatches(of: "<[^<>]+>", with: [], using: { match in
+            return match.stringByReplacingMatches(of: "[\n\t ]+", with: " ")
+        })
 
         // Preserve line breaks in <pre> and <script> tags.
         if output.contains("<pre") || output.contains("<script") {
             preserve_linebreaks = true
-//        text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
-//            return a.replace( /\n/g, '<wp-line-break>' );
-//        });
+            output = output.stringByReplacingMatches(of: "<(pre|script)[^>]*>[\\s\\S]*?<\\/\\1>", with: [], using: { match in
+                return match.stringByReplacingMatches(of: "\n", with: "<wp-line-break>")
+            })
         }
 
         if output.contains("<figcaption") {

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -19,7 +19,7 @@ class CalypsoProcessorIn: Processor {
 
         // Normalize line breaks.
 //      text = text.replace( /\r\n|\r/g, '\n' );
-        var output = text.stringByReplacingMatches(of: "\r\n|\r", with: "\n")
+        var output = text.replacingMatches(of: "\r\n|\r", with: "\n")
 
 //      if ( text.indexOf( '\n' ) === -1 ) {
         guard output.contains("\n") else {
@@ -31,17 +31,17 @@ class CalypsoProcessorIn: Processor {
 //      if ( text.indexOf( '<object' ) !== -1 ) {
         if output.contains("<object") {
 //          text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "<object[\\s\\S]+?<\\/object>", using: { (match, _) in
+            output = output.replacingMatches(of: "<object[\\s\\S]+?<\\/object>", using: { (match, _) in
 //              return a.replace( /\n+/g, '' );
-                return match.stringByReplacingMatches(of: "\n+", with: "")
+                return match.replacingMatches(of: "\n+", with: "")
             })
         }
 
         // Remove line breaks from tags.
 //      text = text.replace( /<[^<>]+>/g, function( a ) {
-        output = output.stringByReplacingMatches(of: "<[^<>]+>", using: { (match, _) in
+        output = output.replacingMatches(of: "<[^<>]+>", using: { (match, _) in
 //          return a.replace( /[\n\t ]+/g, ' ' );
-            return match.stringByReplacingMatches(of: "[\n\t ]+", with: " ")
+            return match.replacingMatches(of: "[\n\t ]+", with: " ")
         })
 
         // Preserve line breaks in <pre> and <script> tags.
@@ -50,18 +50,18 @@ class CalypsoProcessorIn: Processor {
 //          preserve_linebreaks = true;
             preserve_linebreaks = true
 //          text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "<(pre|script)[^>]*>[\\s\\S]*?<\\/\\1>", using: { (match, _) in
+            output = output.replacingMatches(of: "<(pre|script)[^>]*>[\\s\\S]*?<\\/\\1>", using: { (match, _) in
 //              return a.replace( /\n/g, '<wp-line-break>' );
-                return match.stringByReplacingMatches(of: "\n", with: "<wp-line-break>")
+                return match.replacingMatches(of: "\n", with: "<wp-line-break>")
             })
         }
 
 //      if ( text.indexOf( '<figcaption' ) !== -1 ) {
         if output.contains("<figcaption") {
 //          text = text.replace( /\s*(<figcaption[^>]*>)/g, '$1' );
-            output = output.stringByReplacingMatches(of: "\\s*(<figcaption[^>]*>)", with: "$1")
+            output = output.replacingMatches(of: "\\s*(<figcaption[^>]*>)", with: "$1")
 //          text = text.replace( /<\/figcaption>\s*/g, '</figcaption>' );
-            output = output.stringByReplacingMatches(of: "</figcaption>\\s*", with: "</figcaption>")
+            output = output.replacingMatches(of: "</figcaption>\\s*", with: "</figcaption>")
         }
 
         // Keep <br> tags inside captions.
@@ -71,19 +71,19 @@ class CalypsoProcessorIn: Processor {
             preserve_br = true
 
 //          text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", using: { (match, _) in
+            output = output.replacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", using: { (match, _) in
 
 //              a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
-                var updated = match.stringByReplacingMatches(of: "<br([^>]*)>", with: "<wp-temp-br$1>")
+                var updated = match.replacingMatches(of: "<br([^>]*)>", with: "<wp-temp-br$1>")
 
 //              a = a.replace( /<[^<>]+>/g, function( b ) {
-                updated = updated.stringByReplacingMatches(of: "<[^<>]+>", using: { (match, _) in
+                updated = updated.replacingMatches(of: "<[^<>]+>", using: { (match, _) in
 //                  return b.replace( /[\n\t ]+/, ' ' );
-                    return match.stringByReplacingMatches(of: "[\n\t ]+", with: " ")
+                    return match.replacingMatches(of: "[\n\t ]+", with: " ")
                 })
 
 //              return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
-                return updated.stringByReplacingMatches(of: "\\s*\n\\s*", with: "<wp-temp-br />")
+                return updated.replacingMatches(of: "\\s*\n\\s*", with: "<wp-temp-br />")
             })
         }
 
@@ -91,71 +91,71 @@ class CalypsoProcessorIn: Processor {
         output = output + "\n\n"
 
 //      text = text.replace( /<br \/>\s*<br \/>/gi, '\n\n' );
-        output = output.stringByReplacingMatches(of: "<br \\/>\\s*<br \\/>", with: "\n\n", options: .caseInsensitive)
+        output = output.replacingMatches(of: "<br \\/>\\s*<br \\/>", with: "\n\n", options: .caseInsensitive)
 
         // Pad block tags with two line breaks.
 //    text = text.replace( new RegExp( '(<(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '\n\n$1' );
-        output = output.stringByReplacingMatches(of: "(<(?:" + blocklist + ")(?: [^>]*)?>)", with: "\n\n$1", options: .caseInsensitive)
+        output = output.replacingMatches(of: "(<(?:" + blocklist + ")(?: [^>]*)?>)", with: "\n\n$1", options: .caseInsensitive)
 //    text = text.replace( new RegExp( '(</(?:' + blocklist + ')>)', 'gi' ), '$1\n\n' );
-        output = output.stringByReplacingMatches(of: "(</(?:" + blocklist + ")>)", with: "$1\n\n", options: .caseInsensitive)
+        output = output.replacingMatches(of: "(</(?:" + blocklist + ")>)", with: "$1\n\n", options: .caseInsensitive)
 //    text = text.replace( /<hr( [^>]*)?>/gi, '<hr$1>\n\n' );
-        output = output.stringByReplacingMatches(of: "<hr( [^>]*)?>", with: "<hr$1>\n\n", options: .caseInsensitive)
+        output = output.replacingMatches(of: "<hr( [^>]*)?>", with: "<hr$1>\n\n", options: .caseInsensitive)
 
         // Remove white space chars around <option>.
 //    text = text.replace( /\s*<option/gi, '<option' );
-        output = output.stringByReplacingMatches(of: "\\s*<option", with: "<option", options: .caseInsensitive)
+        output = output.replacingMatches(of: "\\s*<option", with: "<option", options: .caseInsensitive)
 //    text = text.replace( /<\/option>\s*/gi, '</option>' );
-        output = output.stringByReplacingMatches(of: "<\\/option>\\s*", with: "</option>", options: .caseInsensitive)
+        output = output.replacingMatches(of: "<\\/option>\\s*", with: "</option>", options: .caseInsensitive)
 
         // Normalize multiple line breaks and white space chars.
 //    text = text.replace( /\n\s*\n+/g, '\n\n' );
-        output = output.stringByReplacingMatches(of: "\n\\s*\n+", with: "\n\n")
+        output = output.replacingMatches(of: "\n\\s*\n+", with: "\n\n")
 
         // Convert two line breaks to a paragraph.
 //    text = text.replace( /([\s\S]+?)\n\n/g, '<p>$1</p>\n' );
-        output = output.stringByReplacingMatches(of: "([\\s\\S]+?)\n\n", with: "<p>$1</p>\n")
+        output = output.replacingMatches(of: "([\\s\\S]+?)\n\n", with: "<p>$1</p>\n")
 
         // Remove empty paragraphs.
 //    text = text.replace( /<p>\s*?<\/p>/gi, '');
-        output = output.stringByReplacingMatches(of: "<p>\\s*?<\\/p>", with: "", options: .caseInsensitive)
+        output = output.replacingMatches(of: "<p>\\s*?<\\/p>", with: "", options: .caseInsensitive)
 
         // Remove <p> tags that are around block tags.
 //    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
+        output = output.replacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
 //    text = text.replace( /<p>(<li.+?)<\/p>/gi, '$1');
-        output = output.stringByReplacingMatches(of: "<p>(<li.+?)<\\/p>", with: "$1", options: .caseInsensitive)
+        output = output.replacingMatches(of: "<p>(<li.+?)<\\/p>", with: "$1", options: .caseInsensitive)
 
         // Fix <p> in blockquotes.
 //    text = text.replace( /<p>\s*<blockquote([^>]*)>/gi, '<blockquote$1><p>');
-        output = output.stringByReplacingMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$1><p>", options: .caseInsensitive)
+        output = output.replacingMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$1><p>", options: .caseInsensitive)
 //    text = text.replace( /<\/blockquote>\s*<\/p>/gi, '</p></blockquote>');
-        output = output.stringByReplacingMatches(of: "<\\/blockquote>\\s*<\\/p>", with: "</p></blockquote>", options: .caseInsensitive)
+        output = output.replacingMatches(of: "<\\/blockquote>\\s*<\\/p>", with: "</p></blockquote>", options: .caseInsensitive)
 
         // Remove <p> tags that are wrapped around block tags.
 //    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$1", options: .caseInsensitive)
+        output = output.replacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$1", options: .caseInsensitive)
 //    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
+        output = output.replacingMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
 //    text = text.replace( /(<br[^>]*>)\s*\n/gi, '$1' );
-        output = output.stringByReplacingMatches(of: "(<br[^>]*>)\\s*\n", with: "$1", options: .caseInsensitive)
+        output = output.replacingMatches(of: "(<br[^>]*>)\\s*\n", with: "$1", options: .caseInsensitive)
 
         // Add <br> tags.
 //    text = text.replace( /\s*\n/g, '<br />\n');
-        output = output.stringByReplacingMatches(of: "\\s*\n", with: "<br />\n")
+        output = output.replacingMatches(of: "\\s*\n", with: "<br />\n")
 
         // Remove <br> tags that are around block tags.
 //    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
-        output = output.stringByReplacingMatches(of: "(</?(?:" + blocklist + ")[^>]*>)\\s*<br />", with: "$1", options: .caseInsensitive)
+        output = output.replacingMatches(of: "(</?(?:" + blocklist + ")[^>]*>)\\s*<br />", with: "$1", options: .caseInsensitive)
 //    text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
-        output = output.stringByReplacingMatches(of: "<br \\/>(\\s*<\\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)", with: "$1", options: .caseInsensitive)
+        output = output.replacingMatches(of: "<br \\/>(\\s*<\\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)", with: "$1", options: .caseInsensitive)
 
         // Remove <p> and <br> around captions.
 //    text = text.replace( /(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi, '[caption$1[/caption]' );
-        output = output.stringByReplacingMatches(of: "(?:<p>|<br ?\\/?>)*\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*(?:<\\/p>|<br ?\\/?>)*", with: "[caption$1[/caption]", options: .caseInsensitive)
+        output = output.replacingMatches(of: "(?:<p>|<br ?\\/?>)*\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*(?:<\\/p>|<br ?\\/?>)*", with: "[caption$1[/caption]", options: .caseInsensitive)
 
         // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
 //    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
-        output = output.stringByReplacingMatches(of: "(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\\/p>", using: { (match, submatches) in
+        output = output.replacingMatches(of: "(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\\/p>", using: { (match, submatches) in
 
 //        if ( c.match( /<p( [^>]*)?>/ ) ) {
             guard submatches.count < 2 || submatches[1].matches(regex: "<p( [^>]*)?>").count == 0 else {
@@ -176,7 +176,7 @@ class CalypsoProcessorIn: Processor {
         // Restore the <br> tags in captions.
         if preserve_br {
 //            text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
-            output = output.stringByReplacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$1>")
+            output = output.replacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$1>")
         }
         
         return output

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -172,7 +172,7 @@ class CalypsoProcessorIn: Processor {
 //            text = text.replace( /<wp-line-break>/g, '\n' );
             output = output.replacingOccurrences(of: "<wp-line-break>", with: "\n")
         }
-        
+
         // Restore the <br> tags in captions.
         if preserve_br {
 //            text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -34,8 +34,8 @@ class CalypsoProcessorOut: Processor {
 
         //        // Protect script and style tags.
         //        if ( html.indexOf( '<script' ) !== -1 || html.indexOf( '<style' ) !== -1 ) {
-        if output.range(of: "<script") != nil && output.range(of: "<style") != nil {
-        //            html = html.replace( /<(script|style)[^>]*>[\s\S]*?<\/\1>/g, function( match ) {
+        if output.contains("<script") || output.contains("<style") {
+            //            html = html.replace( /<(script|style)[^>]*>[\s\S]*?<\/\1>/g, function( match ) {
             output = output.stringByReplacingMatches(of: "<(script|style)[^>]*>[\\s\\S]*?<\\/\\1>", using: { (match, _) -> String in
                 //                preserve.push( match );
                 preserve.append(match)
@@ -47,7 +47,7 @@ class CalypsoProcessorOut: Processor {
 
         //        // Protect pre tags.
         //        if ( html.indexOf( '<pre' ) !== -1 ) {
-        if output.range(of: "<pre") != nil {
+        if output.contains("<pre") {
             //            preserve_linebreaks = true;
             preserveLinebreaks = true
 
@@ -66,7 +66,7 @@ class CalypsoProcessorOut: Processor {
 
         //        // Remove line breaks but keep <br> tags inside image captions.
         //        if ( html.indexOf( '[caption' ) !== -1 ) {
-        if output.range(of: "[caption") != nil {
+        if output.contains("[caption") {
             //            preserve_br = true;
             preserveBr = true
 
@@ -118,41 +118,58 @@ class CalypsoProcessorOut: Processor {
             return "\n"
         })
 
+        //                // Fix line breaks around <div>.
+        //                html = html.replace( /\s*<div/g, '\n<div' );
+        output = output.stringByReplacingMatches(of: "\\s*<div", with: "\n<div")
 
-//
-//                // Fix line breaks around <div>.
-//                html = html.replace( /\s*<div/g, '\n<div' );
-//                html = html.replace( /<\/div>\s*/g, '</div>\n' );
-//
-//                // Fix line breaks around caption shortcodes.
-//                html = html.replace( /\s*\[caption([^\[]+)\[\/caption\]\s*/gi, '\n\n[caption$1[/caption]\n\n' );
-//                html = html.replace( /caption\]\n\n+\[caption/g, 'caption]\n\n[caption' );
-//
-//                // Pad block elements tags with a line break.
-//                html = html.replace( new RegExp('\\s*<((?:' + blocklist2 + ')(?: [^>]*)?)\\s*>', 'g' ), '\n<$1>' );
-//                html = html.replace( new RegExp('\\s*</(' + blocklist2 + ')>\\s*', 'g' ), '</$1>\n' );
-//
-//                // Indent <li>, <dt> and <dd> tags.
-//                html = html.replace( /<((li|dt|dd)[^>]*)>/g, ' \t<$1>' );
-//
-//                // Fix line breaks around <select> and <option>.
-//                if ( html.indexOf( '<option' ) !== -1 ) {
-//                html = html.replace( /\s*<option/g, '\n<option' );
-//                html = html.replace( /\s*<\/select>/g, '\n</select>' );
-//                }
-//
-//                // Pad <hr> with two line breaks.
-//                if ( html.indexOf( '<hr' ) !== -1 ) {
-//                html = html.replace( /\s*<hr( [^>]*)?>\s*/g, '\n\n<hr$1>\n\n' );
-//                }
-//                
-//                // Remove line breaks in <object> tags.
-//                if ( html.indexOf( '<object' ) !== -1 ) {
-//                html = html.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
-//                return a.replace( /[\r\n]+/g, '' );
-//                });
-//                }
-//                
+        //                html = html.replace( /<\/div>\s*/g, '</div>\n' );
+        output = output.stringByReplacingMatches(of: "<\\/div>\\s*", with: "</div>\n")
+
+        //                // Fix line breaks around caption shortcodes.
+        //                html = html.replace( /\s*\[caption([^\[]+)\[\/caption\]\s*/gi, '\n\n[caption$1[/caption]\n\n' );
+        output = output.stringByReplacingMatches(of: "\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*", with: "\n\n[caption$1[/caption]\n\n")
+
+        //                html = html.replace( /caption\]\n\n+\[caption/g, 'caption]\n\n[caption' );
+        output = output.stringByReplacingMatches(of: "caption\\]\n\n+\\[caption", with: "caption]\n\n[caption")
+
+        //                // Pad block elements tags with a line break.
+        //                html = html.replace( new RegExp('\\s*<((?:' + blocklist2 + ')(?: [^>]*)?)\\s*>', 'g' ), '\n<$1>' );
+        output = output.stringByReplacingMatches(of: "\\s*<((?:" + blocklist2 + ")(?: [^>]*)?)\\s*>", with: "\n<$1>")
+
+        //                html = html.replace( new RegExp('\\s*</(' + blocklist2 + ')>\\s*', 'g' ), '</$1>\n' );
+        output = output.stringByReplacingMatches(of: "\\s*</(' + blocklist2 + ')>\\s*", with: "</$1>\n")
+
+        //                // Indent <li>, <dt> and <dd> tags.
+        //                html = html.replace( /<((li|dt|dd)[^>]*)>/g, ' \t<$1>' );
+        output = output.stringByReplacingMatches(of: "<((li|dt|dd)[^>]*)>", with: " \t<$1>")
+
+        //                // Fix line breaks around <select> and <option>.
+        //                if ( html.indexOf( '<option' ) !== -1 ) {
+        if output.contains("<option") {
+            //                html = html.replace( /\s*<option/g, '\n<option' );
+            output = output.stringByReplacingMatches(of: "\\s*<option", with: "\n<option")
+
+            //                html = html.replace( /\s*<\/select>/g, '\n</select>' );
+            output = output.stringByReplacingMatches(of: "\\s*<\\/select>", with: "\n</select>")
+        }
+
+        //                // Pad <hr> with two line breaks.
+        //                if ( html.indexOf( '<hr' ) !== -1 ) {
+        if output.contains("<hr") {
+            //                html = html.replace( /\s*<hr( [^>]*)?>\s*/g, '\n\n<hr$1>\n\n' );
+            output = output.stringByReplacingMatches(of: "\\s*<hr( [^>]*)?>\\s*", with: "\n\n<hr$1>\n\n")
+        }
+
+        //                // Remove line breaks in <object> tags.
+        //                if ( html.indexOf( '<object' ) !== -1 ) {
+        if output.contains("<object") {
+            //                html = html.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
+            output = output.stringByReplacingMatches(of: "<object[\\s\\S]+?<\\/object>", using: { (match, _) -> String in
+                //                return a.replace( /[\r\n]+/g, '' );
+                return match.stringByReplacingMatches(of: "[\r\n]+", with: "")
+            })
+        }
+
 //                // Unmark special paragraph closing tags.
 //                html = html.replace( /<\/p#>/g, '</p>\n' );
 //                

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -37,7 +37,7 @@ class CalypsoProcessorOut: Processor {
         //        if ( html.indexOf( '<script' ) !== -1 || html.indexOf( '<style' ) !== -1 ) {
         if output.contains("<script") || output.contains("<style") {
             //            html = html.replace( /<(script|style)[^>]*>[\s\S]*?<\/\1>/g, function( match ) {
-            output = output.stringByReplacingMatches(of: "<(script|style)[^>]*>[\\s\\S]*?<\\/\\1>", using: { (match, _) -> String in
+            output = output.replacingMatches(of: "<(script|style)[^>]*>[\\s\\S]*?<\\/\\1>", using: { (match, _) -> String in
                 //                preserve.push( match );
                 preserve.append(match)
 
@@ -53,15 +53,15 @@ class CalypsoProcessorOut: Processor {
             preserveLinebreaks = true
 
             //            html = html.replace( /<pre[^>]*>[\s\S]+?<\/pre>/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "<pre[^>]*>[\\s\\S]+?<\\/pre>", using: { (match, _) -> String in
+            output = output.replacingMatches(of: "<pre[^>]*>[\\s\\S]+?<\\/pre>", using: { (match, _) -> String in
                 //                a = a.replace( /<br ?\/?>(\r\n|\n)?/g, '<wp-line-break>' );
-                var string = match.stringByReplacingMatches(of: "<br ?\\/?>(\r\n|\n)?", with: lineBreakMarker)
+                var string = match.replacingMatches(of: "<br ?\\/?>(\r\n|\n)?", with: lineBreakMarker)
 
                 //                a = a.replace( /<\/?p( [^>]*)?>(\r\n|\n)?/g, '<wp-line-break>' );
-                string = string.stringByReplacingMatches(of: "<\\/?p( [^>]*)?>(\r\n|\n)?", with: lineBreakMarker)
+                string = string.replacingMatches(of: "<\\/?p( [^>]*)?>(\r\n|\n)?", with: lineBreakMarker)
 
                 //                return a.replace( /\r?\n/g, '<wp-line-break>' );
-                return string.stringByReplacingMatches(of: "\r?\n", with: lineBreakMarker)
+                return string.replacingMatches(of: "\r?\n", with: lineBreakMarker)
             })
         }
 
@@ -72,42 +72,42 @@ class CalypsoProcessorOut: Processor {
             preserveBr = true
 
             //            html = html.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", using: { (match, _) -> String in
+            output = output.replacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", using: { (match, _) -> String in
                 //                return a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' ).replace( /[\r\n\t]+/, '' );
-                let string = match.stringByReplacingMatches(of: "<br([^>]*)>", with: "<wp-temp-br$1>")
-                return string.stringByReplacingMatches(of: "[\r\n\t]+", with: "")
+                let string = match.replacingMatches(of: "<br([^>]*)>", with: "<wp-temp-br$1>")
+                return string.replacingMatches(of: "[\r\n\t]+", with: "")
             })
         }
 
         //                // Normalize white space characters before and after block tags.
         //                html = html.replace( new RegExp( '\\s*</(' + blocklist1 + ')>\\s*', 'g' ), '</$1>\n' );
-        output = output.stringByReplacingMatches(of: "\\s*</(\(blocklist1))>\\s*", with: "</$1>\n")
+        output = output.replacingMatches(of: "\\s*</(\(blocklist1))>\\s*", with: "</$1>\n")
 
         //                html = html.replace( new RegExp( '\\s*<((?:' + blocklist1 + ')(?: [^>]*)?)>', 'g' ), '\n<$1>' );
-        output = output.stringByReplacingMatches(of: "\\s*<((?:" + blocklist1 + ")(?: [^>]*)?)>", with: "\n<$1>")
+        output = output.replacingMatches(of: "\\s*<((?:" + blocklist1 + ")(?: [^>]*)?)>", with: "\n<$1>")
 
         //                // Mark </p> if it has any attributes.
         //                html = html.replace( /(<p [^>]+>.*?)<\/p>/g, '$1</p#>' );
-        output = output.stringByReplacingMatches(of: "(<p [^>]+>.*?)<\\/p>", with: "$1</p#>")
+        output = output.replacingMatches(of: "(<p [^>]+>.*?)<\\/p>", with: "$1</p#>")
 
         //                // Preserve the first <p> inside a <div>.
         //                html = html.replace( /<div( [^>]*)?>\s*<p>/gi, '<div$1>\n\n' );
-        output = output.stringByReplacingMatches(of: "<div( [^>]*)?>\\s*<p>", with: "<div$1>\n\n", options: .caseInsensitive)
+        output = output.replacingMatches(of: "<div( [^>]*)?>\\s*<p>", with: "<div$1>\n\n", options: .caseInsensitive)
 
         //                // Remove paragraph tags.
         //                html = html.replace( /\s*<p>/gi, '' );
-        output = output.stringByReplacingMatches(of: "\\s*<p>", with: "", options: .caseInsensitive)
+        output = output.replacingMatches(of: "\\s*<p>", with: "", options: .caseInsensitive)
 
         //                html = html.replace( /\s*<\/p>\s*/gi, '\n\n' );
-        output = output.stringByReplacingMatches(of: "\\s*<\\/p>\\s*", with: "\n\n", options: .caseInsensitive)
+        output = output.replacingMatches(of: "\\s*<\\/p>\\s*", with: "\n\n", options: .caseInsensitive)
 
         //                // Normalize white space chars and remove multiple line breaks.
         //                html = html.replace( /\n[\s\u00a0]+\n/g, '\n\n' );
-        output = output.stringByReplacingMatches(of: "\n[\\s\\u00a0]+\n", with: "\n\n")
+        output = output.replacingMatches(of: "\n[\\s\\u00a0]+\n", with: "\n\n")
 
         //                // Replace <br> tags with line breaks.
         //                html = html.replace( /(\s*)<br ?\/?>\s*/gi, function( match, space ) {
-        output = output.stringByReplacingMatches(of: "(\\s*)<br ?\\/?>\\s*", options: .caseInsensitive, using: { (match, ranges) -> String in
+        output = output.replacingMatches(of: "(\\s*)<br ?\\/?>\\s*", options: .caseInsensitive, using: { (match, ranges) -> String in
 
             //                if ( space && space.indexOf( '\n' ) !== -1 ) {
             if ranges.count > 0 && ranges[0].contains("\n") {
@@ -121,88 +121,88 @@ class CalypsoProcessorOut: Processor {
 
         //                // Fix line breaks around <div>.
         //                html = html.replace( /\s*<div/g, '\n<div' );
-        output = output.stringByReplacingMatches(of: "\\s*<div", with: "\n<div")
+        output = output.replacingMatches(of: "\\s*<div", with: "\n<div")
 
         //                html = html.replace( /<\/div>\s*/g, '</div>\n' );
-        output = output.stringByReplacingMatches(of: "<\\/div>\\s*", with: "</div>\n")
+        output = output.replacingMatches(of: "<\\/div>\\s*", with: "</div>\n")
 
         //                // Fix line breaks around caption shortcodes.
         //                html = html.replace( /\s*\[caption([^\[]+)\[\/caption\]\s*/gi, '\n\n[caption$1[/caption]\n\n' );
-        output = output.stringByReplacingMatches(of: "\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*", with: "\n\n[caption$1[/caption]\n\n")
+        output = output.replacingMatches(of: "\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*", with: "\n\n[caption$1[/caption]\n\n")
 
         //                html = html.replace( /caption\]\n\n+\[caption/g, 'caption]\n\n[caption' );
-        output = output.stringByReplacingMatches(of: "caption\\]\n\n+\\[caption", with: "caption]\n\n[caption")
+        output = output.replacingMatches(of: "caption\\]\n\n+\\[caption", with: "caption]\n\n[caption")
 
         //                // Pad block elements tags with a line break.
         //                html = html.replace( new RegExp('\\s*<((?:' + blocklist2 + ')(?: [^>]*)?)\\s*>', 'g' ), '\n<$1>' );
-        output = output.stringByReplacingMatches(of: "\\s*<((?:" + blocklist2 + ")(?: [^>]*)?)\\s*>", with: "\n<$1>")
+        output = output.replacingMatches(of: "\\s*<((?:" + blocklist2 + ")(?: [^>]*)?)\\s*>", with: "\n<$1>")
 
         //                html = html.replace( new RegExp('\\s*</(' + blocklist2 + ')>\\s*', 'g' ), '</$1>\n' );
-        output = output.stringByReplacingMatches(of: "\\s*</(' + blocklist2 + ')>\\s*", with: "</$1>\n")
+        output = output.replacingMatches(of: "\\s*</(' + blocklist2 + ')>\\s*", with: "</$1>\n")
 
         //                // Indent <li>, <dt> and <dd> tags.
         //                html = html.replace( /<((li|dt|dd)[^>]*)>/g, ' \t<$1>' );
-        output = output.stringByReplacingMatches(of: "<((li|dt|dd)[^>]*)>", with: " \t<$1>")
+        output = output.replacingMatches(of: "<((li|dt|dd)[^>]*)>", with: " \t<$1>")
 
         //                // Fix line breaks around <select> and <option>.
         //                if ( html.indexOf( '<option' ) !== -1 ) {
         if output.contains("<option") {
             //                html = html.replace( /\s*<option/g, '\n<option' );
-            output = output.stringByReplacingMatches(of: "\\s*<option", with: "\n<option")
+            output = output.replacingMatches(of: "\\s*<option", with: "\n<option")
 
             //                html = html.replace( /\s*<\/select>/g, '\n</select>' );
-            output = output.stringByReplacingMatches(of: "\\s*<\\/select>", with: "\n</select>")
+            output = output.replacingMatches(of: "\\s*<\\/select>", with: "\n</select>")
         }
 
         //                // Pad <hr> with two line breaks.
         //                if ( html.indexOf( '<hr' ) !== -1 ) {
         if output.contains("<hr") {
             //                html = html.replace( /\s*<hr( [^>]*)?>\s*/g, '\n\n<hr$1>\n\n' );
-            output = output.stringByReplacingMatches(of: "\\s*<hr( [^>]*)?>\\s*", with: "\n\n<hr$1>\n\n")
+            output = output.replacingMatches(of: "\\s*<hr( [^>]*)?>\\s*", with: "\n\n<hr$1>\n\n")
         }
 
         //                // Remove line breaks in <object> tags.
         //                if ( html.indexOf( '<object' ) !== -1 ) {
         if output.contains("<object") {
             //                html = html.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
-            output = output.stringByReplacingMatches(of: "<object[\\s\\S]+?<\\/object>", using: { (match, _) -> String in
+            output = output.replacingMatches(of: "<object[\\s\\S]+?<\\/object>", using: { (match, _) -> String in
                 //                return a.replace( /[\r\n]+/g, '' );
-                return match.stringByReplacingMatches(of: "[\r\n]+", with: "")
+                return match.replacingMatches(of: "[\r\n]+", with: "")
             })
         }
 
         //                // Unmark special paragraph closing tags.
         //                html = html.replace( /<\/p#>/g, '</p>\n' );
-        output = output.stringByReplacingMatches(of: "<\\/p#>", with: "</p>\n")
+        output = output.replacingMatches(of: "<\\/p#>", with: "</p>\n")
 
         //                // Pad remaining <p> tags whit a line break.
         //                html = html.replace( /\s*(<p [^>]+>[\s\S]*?<\/p>)/g, '\n$1' );
-        output = output.stringByReplacingMatches(of: "\\s*(<p [^>]+>[\\s\\S]*?<\\/p>)", with: "\n$1")
+        output = output.replacingMatches(of: "\\s*(<p [^>]+>[\\s\\S]*?<\\/p>)", with: "\n$1")
 
         //                // Trim.
         //                html = html.replace( /^\s+/, '' );
-        output = output.stringByReplacingMatches(of: "^\\s+", with: "")
+        output = output.replacingMatches(of: "^\\s+", with: "")
 
         //                html = html.replace( /[\s\u00a0]+$/, '' );
-        output = output.stringByReplacingMatches(of: "[\\s\\u00a0]+$", with: "")
+        output = output.replacingMatches(of: "[\\s\\u00a0]+$", with: "")
 
         //                if ( preserve_linebreaks ) {
         if preserveLinebreaks {
             //                html = html.replace( /<wp-line-break>/g, '\n' );
-            output = output.stringByReplacingMatches(of: lineBreakMarker, with: "\n")
+            output = output.replacingMatches(of: lineBreakMarker, with: "\n")
         }
 
         //                if ( preserve_br ) {
         if preserveBr {
             //                html = html.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
-            output = output.stringByReplacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$1>")
+            output = output.replacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$1>")
         }
 
         //                // Restore preserved tags.
         //                if ( preserve.length ) {
         if preserve.count > 0 {
             //                html = html.replace( /<wp-preserve>/g, function() {
-            output = output.stringByReplacingMatches(of: preserveMarker, using: { (_, _) -> String in
+            output = output.replacingMatches(of: preserveMarker, using: { (_, _) -> String in
                 return preserve.removeFirst()
             })
         }

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -203,6 +203,8 @@ class CalypsoProcessorOut: Processor {
         if preserve.count > 0 {
             //                html = html.replace( /<wp-preserve>/g, function() {
             output = output.replacingMatches(of: preserveMarker, using: { (_, _) -> String in
+
+                // return preserve.shift();
                 return preserve.removeFirst()
             })
         }

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -91,14 +91,14 @@ class CalypsoProcessorOut: Processor {
 
         //                // Preserve the first <p> inside a <div>.
         //                html = html.replace( /<div( [^>]*)?>\s*<p>/gi, '<div$1>\n\n' );
-        output = output.stringByReplacingMatches(of: "<div( [^>]*)?>\\s*<p>", with: "<div$1>\n\n")
+        output = output.stringByReplacingMatches(of: "<div( [^>]*)?>\\s*<p>", with: "<div$1>\n\n", options: .caseInsensitive)
 
         //                // Remove paragraph tags.
         //                html = html.replace( /\s*<p>/gi, '' );
-        output = output.stringByReplacingMatches(of: "\\s*<p>", with: "")
+        output = output.stringByReplacingMatches(of: "\\s*<p>", with: "", options: .caseInsensitive)
 
         //                html = html.replace( /\s*<\/p>\s*/gi, '\n\n' );
-        output = output.stringByReplacingMatches(of: "\\s*<\\/p>\\s*", with: "\n\n")
+        output = output.stringByReplacingMatches(of: "\\s*<\\/p>\\s*", with: "\n\n", options: .caseInsensitive)
 
         //                // Normalize white space chars and remove multiple line breaks.
         //                html = html.replace( /\n[\s\u00a0]+\n/g, '\n\n' );
@@ -106,7 +106,7 @@ class CalypsoProcessorOut: Processor {
 
         //                // Replace <br> tags with line breaks.
         //                html = html.replace( /(\s*)<br ?\/?>\s*/gi, function( match, space ) {
-        output = output.stringByReplacingMatches(of: "(\\s*)<br ?\\/?>\\s*", using: { (match, ranges) -> String in
+        output = output.stringByReplacingMatches(of: "(\\s*)<br ?\\/?>\\s*", options: .caseInsensitive, using: { (match, ranges) -> String in
 
             //                if ( space && space.indexOf( '\n' ) !== -1 ) {
             if ranges.count > 0 && ranges[0].contains("\n") {
@@ -170,157 +170,44 @@ class CalypsoProcessorOut: Processor {
             })
         }
 
-//                // Unmark special paragraph closing tags.
-//                html = html.replace( /<\/p#>/g, '</p>\n' );
-//                
-//                // Pad remaining <p> tags whit a line break.
-//                html = html.replace( /\s*(<p [^>]+>[\s\S]*?<\/p>)/g, '\n$1' );
-//                
-//                // Trim.
-//                html = html.replace( /^\s+/, '' );
-//                html = html.replace( /[\s\u00a0]+$/, '' );
-//                
-//                if ( preserve_linebreaks ) {
-//                html = html.replace( /<wp-line-break>/g, '\n' );
-//                }
-//                
-//                if ( preserve_br ) {
-//                html = html.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
-//                }
-//                
-//                // Restore preserved tags.
-//                if ( preserve.length ) {
-//                html = html.replace( /<wp-preserve>/g, function() {
-//                return preserve.shift();
-//                } );
-//                }
-//                
-//                return html;
+        //                // Unmark special paragraph closing tags.
+        //                html = html.replace( /<\/p#>/g, '</p>\n' );
+        output = output.stringByReplacingMatches(of: "<\\/p#>", with: "</p>\n")
 
+        //                // Pad remaining <p> tags whit a line break.
+        //                html = html.replace( /\s*(<p [^>]+>[\s\S]*?<\/p>)/g, '\n$1' );
+        output = output.stringByReplacingMatches(of: "\\s*(<p [^>]+>[\\s\\S]*?<\\/p>)", with: "\n$1")
+
+        //                // Trim.
+        //                html = html.replace( /^\s+/, '' );
+        output = output.stringByReplacingMatches(of: "^\\s+", with: "")
+
+        //                html = html.replace( /[\s\u00a0]+$/, '' );
+        output = output.stringByReplacingMatches(of: "[\\s\\u00a0]+$", with: "")
+
+        //                if ( preserve_linebreaks ) {
+        if preserveLinebreaks {
+            //                html = html.replace( /<wp-line-break>/g, '\n' );
+            output = output.stringByReplacingMatches(of: lineBreakMarker, with: "\n")
+        }
+
+        //                if ( preserve_br ) {
+        if preserveBr {
+            //                html = html.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
+            output = output.stringByReplacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$1>")
+        }
+
+        //                // Restore preserved tags.
+        //                if ( preserve.length ) {
+        if preserve.count > 0 {
+            //                html = html.replace( /<wp-preserve>/g, function() {
+            output = output.stringByReplacingMatches(of: "<wp-preserve>", using: { (_, _) -> String in
+                return preserve[0]
+            })
+        }
+
+        //                return html;
         return output
     }
 }
 
-
-
-
-//function autop( text ) {
-//    var preserve_linebreaks = false,
-//        preserve_br = false,
-//		blocklist = 'table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre' +
-//            '|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section' +
-//            '|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary';
-//
-//    // Normalize line breaks.
-//    text = text.replace( /\r\n|\r/g, '\n' );
-//
-//    if ( text.indexOf( '\n' ) === -1 ) {
-//        return text;
-//    }
-//
-//    // Remove line breaks from <object>.
-//    if ( text.indexOf( '<object' ) !== -1 ) {
-//        text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
-//            return a.replace( /\n+/g, '' );
-//        });
-//    }
-//
-//    // Remove line breaks from tags.
-//    text = text.replace( /<[^<>]+>/g, function( a ) {
-//        return a.replace( /[\n\t ]+/g, ' ' );
-//    });
-//
-//    // Preserve line breaks in <pre> and <script> tags.
-//    if ( text.indexOf( '<pre' ) !== -1 || text.indexOf( '<script' ) !== -1 ) {
-//        preserve_linebreaks = true;
-//        text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
-//            return a.replace( /\n/g, '<wp-line-break>' );
-//        });
-//    }
-//
-//    if ( text.indexOf( '<figcaption' ) !== -1 ) {
-//        text = text.replace( /\s*(<figcaption[^>]*>)/g, '$1' );
-//        text = text.replace( /<\/figcaption>\s*/g, '</figcaption>' );
-//    }
-//
-//    // Keep <br> tags inside captions.
-//    if ( text.indexOf( '[caption' ) !== -1 ) {
-//        preserve_br = true;
-//
-//        text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
-//            a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
-//
-//            a = a.replace( /<[^<>]+>/g, function( b ) {
-//                return b.replace( /[\n\t ]+/, ' ' );
-//            });
-//
-//            return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
-//        });
-//    }
-//
-//    text = text + '\n\n';
-//    text = text.replace( /<br \/>\s*<br \/>/gi, '\n\n' );
-//
-//    // Pad block tags with two line breaks.
-//    text = text.replace( new RegExp( '(<(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '\n\n$1' );
-//    text = text.replace( new RegExp( '(</(?:' + blocklist + ')>)', 'gi' ), '$1\n\n' );
-//    text = text.replace( /<hr( [^>]*)?>/gi, '<hr$1>\n\n' );
-//
-//    // Remove white space chars around <option>.
-//    text = text.replace( /\s*<option/gi, '<option' );
-//    text = text.replace( /<\/option>\s*/gi, '</option>' );
-//
-//    // Normalize multiple line breaks and white space chars.
-//    text = text.replace( /\n\s*\n+/g, '\n\n' );
-//
-//    // Convert two line breaks to a paragraph.
-//    text = text.replace( /([\s\S]+?)\n\n/g, '<p>$1</p>\n' );
-//
-//    // Remove empty paragraphs.
-//    text = text.replace( /<p>\s*?<\/p>/gi, '');
-//
-//    // Remove <p> tags that are around block tags.
-//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
-//    text = text.replace( /<p>(<li.+?)<\/p>/gi, '$1');
-//
-//    // Fix <p> in blockquotes.
-//    text = text.replace( /<p>\s*<blockquote([^>]*)>/gi, '<blockquote$1><p>');
-//    text = text.replace( /<\/blockquote>\s*<\/p>/gi, '</p></blockquote>');
-//
-//    // Remove <p> tags that are wrapped around block tags.
-//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '$1' );
-//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
-//
-//    text = text.replace( /(<br[^>]*>)\s*\n/gi, '$1' );
-//
-//    // Add <br> tags.
-//    text = text.replace( /\s*\n/g, '<br />\n');
-//
-//    // Remove <br> tags that are around block tags.
-//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
-//    text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
-//
-//    // Remove <p> and <br> around captions.
-//    text = text.replace( /(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi, '[caption$1[/caption]' );
-//    
-//    // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
-//    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
-//        if ( c.match( /<p( [^>]*)?>/ ) ) {
-//            return a;
-//        }
-//        
-//        return b + '<p>' + c + '</p>';
-//    });
-//    
-//    // Restore the line breaks in <pre> and <script> tags.
-//    if ( preserve_linebreaks ) {
-//            text = text.replace( /<wp-line-break>/g, '\n' );
-//    }
-//    
-//    // Restore the <br> tags in captions.
-//    if ( preserve_br ) {
-//            text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
-//    }
-//    
-//    return text;
-//}

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -213,4 +213,3 @@ class CalypsoProcessorOut: Processor {
         return output
     }
 }
-

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -202,7 +202,7 @@ class CalypsoProcessorOut: Processor {
         if preserve.count > 0 {
             //                html = html.replace( /<wp-preserve>/g, function() {
             output = output.stringByReplacingMatches(of: "<wp-preserve>", using: { (_, _) -> String in
-                return preserve[0]
+                return preserve.removeFirst()
             })
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -1,0 +1,261 @@
+import Foundation
+import Aztec
+
+
+// MARK: - CalypsoProcessorIn
+//
+class CalypsoProcessorOut: Processor {
+
+    /// Converts a Calypso-Generated string into Valid HTML that can actually be edited by Aztec.
+    ///
+    /// Ref. https://github.com/WordPress/WordPress/blob/4e4df0e/wp-admin/js/editor.js#L309
+    ///
+    func process(text: String) -> String {
+// - Reventar el `/` inicial
+// - Duplicar los `\`
+// - Reventar el `/g` final
+
+        var preserve_linebreaks = false
+        var preserve_br = false
+        let blocklist = "table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre" +
+            "|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section" +
+            "|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary"
+
+        // Normalize line breaks.
+        var output = text.replaceMatches(of: "\r\n|\r", with: "\n")
+
+        guard output.contains("\n") else {
+            return output
+        }
+
+        // Remove line breaks from <object>
+        if output.contains("<object") {
+//        text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
+//            return a.replace( /\n+/g, '' );
+//        });
+        }
+
+        // Remove line breaks from tags.
+//    text = text.replace( /<[^<>]+>/g, function( a ) {
+//        return a.replace( /[\n\t ]+/g, ' ' );
+//    });
+
+        // Preserve line breaks in <pre> and <script> tags.
+        if output.contains("<pre") || output.contains("<script") {
+            preserve_linebreaks = true
+//        text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
+//            return a.replace( /\n/g, '<wp-line-break>' );
+//        });
+        }
+
+        if output.contains("<figcaption") {
+            output = output.replaceMatches(of: "\\s*(<figcaption[^>]*>)", with: "$0")
+            output = output.replaceMatches(of: "</figcaption>\\s*", with: "</figcaption>")
+        }
+
+        // Keep <br> tags inside captions.
+        if output.contains("[caption") {
+            preserve_br = true
+
+//        text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
+//            a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
+//
+//            a = a.replace( /<[^<>]+>/g, function( b ) {
+//                return b.replace( /[\n\t ]+/, ' ' );
+//            });
+//
+//            return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
+//        });
+        }
+
+        output = output + "\n\n"
+        output = output.replaceMatches(of: "<br \\/>\\s*<br \\/>", with: "\n\n")
+
+        // Pad block tags with two line breaks.
+        output = output.replaceMatches(of: "(<(?:" + blocklist + ")(?: [^>]*)?>)", with: "\n\n$0")
+        output = output.replaceMatches(of: "(</(?:" + blocklist + ")>)", with: "$0\n\n")
+        output = output.replaceMatches(of: "<hr( [^>]*)?>", with: "<hr$0>\n\n")
+
+        // Remove white space chars around <option>.
+        output = output.replaceMatches(of: "\\s*<option", with: "<option")
+        output = output.replaceMatches(of: "</option>\\s*", with: "</option>")
+
+        // Normalize multiple line breaks and white space chars.
+        output = output.replaceMatches(of: "\n\\s*\n+", with: "\n\n")
+
+        // Convert two line breaks to a paragraph.
+        output = output.replaceMatches(of: "([\\s\\S]+?)\n\n", with: "<p>$0</p>\n")
+
+        // Remove empty paragraphs.
+        output = output.replaceMatches(of: "<p>\\s*?</p>", with: "")
+
+        // Remove <p> tags that are around block tags.
+        output = output.replaceMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$0")
+        output = output.replaceMatches(of: "<p>(<li.+?)<\\/p>", with: "$0")
+
+        // Fix <p> in blockquotes.
+        output = output.replaceMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$0><p>")
+        output = output.replaceMatches(of: "<\\/blockquote>\\s*<\\/p>", with: "</p></blockquote>")
+
+        // Remove <p> tags that are wrapped around block tags.
+        output = output.replaceMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$0")
+        output = output.replaceMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$0")
+
+        output = output.replaceMatches(of: "(<br[^>]*>)\\s*\n", with: "$0")
+
+        // Add <br> tags.
+        output = output.replaceMatches(of: "\\s*\n", with: "<br />\n")
+
+        // Remove <br> tags that are around block tags.
+        output = output.replaceMatches(of: "(</?(?:" + blocklist + ")[^>]*>)\\s*<br />", with: "$0")
+        output = output.replaceMatches(of: "<br />(\\s*<\\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)", with: "$0")
+
+        // Remove <p> and <br> around captions.
+        output = output.replaceMatches(of: "(?:<p>|<br ?\\/?>)*\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*(?:<\\/p>|<br ?\\/?>)*", with: "[caption$0[/caption]")
+
+//    // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
+//    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
+//        if ( c.match( /<p( [^>]*)?>/ ) ) {
+//            return a;
+//        }
+//        
+//        return b + '<p>' + c + '</p>';
+//    });
+
+        // Restore the line breaks in <pre> and <script> tags.
+        if preserve_linebreaks {
+            output = output.replacingOccurrences(of: "<wp-line-break>", with: "\n")
+        }
+        
+        // Restore the <br> tags in captions.
+        if preserve_br {
+            output = output.replaceMatches(of: "<wp-temp-br([^>]*)>", with: "<br$0>")
+        }
+        
+        return text
+    }
+}
+
+
+
+
+//function autop( text ) {
+//    var preserve_linebreaks = false,
+//        preserve_br = false,
+//		blocklist = 'table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre' +
+//            '|form|map|area|blockquote|address|math|style|p|h[1-6]|hr|fieldset|legend|section' +
+//            '|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary';
+//
+//    // Normalize line breaks.
+//    text = text.replace( /\r\n|\r/g, '\n' );
+//
+//    if ( text.indexOf( '\n' ) === -1 ) {
+//        return text;
+//    }
+//
+//    // Remove line breaks from <object>.
+//    if ( text.indexOf( '<object' ) !== -1 ) {
+//        text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
+//            return a.replace( /\n+/g, '' );
+//        });
+//    }
+//
+//    // Remove line breaks from tags.
+//    text = text.replace( /<[^<>]+>/g, function( a ) {
+//        return a.replace( /[\n\t ]+/g, ' ' );
+//    });
+//
+//    // Preserve line breaks in <pre> and <script> tags.
+//    if ( text.indexOf( '<pre' ) !== -1 || text.indexOf( '<script' ) !== -1 ) {
+//        preserve_linebreaks = true;
+//        text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
+//            return a.replace( /\n/g, '<wp-line-break>' );
+//        });
+//    }
+//
+//    if ( text.indexOf( '<figcaption' ) !== -1 ) {
+//        text = text.replace( /\s*(<figcaption[^>]*>)/g, '$1' );
+//        text = text.replace( /<\/figcaption>\s*/g, '</figcaption>' );
+//    }
+//
+//    // Keep <br> tags inside captions.
+//    if ( text.indexOf( '[caption' ) !== -1 ) {
+//        preserve_br = true;
+//
+//        text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
+//            a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
+//
+//            a = a.replace( /<[^<>]+>/g, function( b ) {
+//                return b.replace( /[\n\t ]+/, ' ' );
+//            });
+//
+//            return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
+//        });
+//    }
+//
+//    text = text + '\n\n';
+//    text = text.replace( /<br \/>\s*<br \/>/gi, '\n\n' );
+//
+//    // Pad block tags with two line breaks.
+//    text = text.replace( new RegExp( '(<(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '\n\n$1' );
+//    text = text.replace( new RegExp( '(</(?:' + blocklist + ')>)', 'gi' ), '$1\n\n' );
+//    text = text.replace( /<hr( [^>]*)?>/gi, '<hr$1>\n\n' );
+//
+//    // Remove white space chars around <option>.
+//    text = text.replace( /\s*<option/gi, '<option' );
+//    text = text.replace( /<\/option>\s*/gi, '</option>' );
+//
+//    // Normalize multiple line breaks and white space chars.
+//    text = text.replace( /\n\s*\n+/g, '\n\n' );
+//
+//    // Convert two line breaks to a paragraph.
+//    text = text.replace( /([\s\S]+?)\n\n/g, '<p>$1</p>\n' );
+//
+//    // Remove empty paragraphs.
+//    text = text.replace( /<p>\s*?<\/p>/gi, '');
+//
+//    // Remove <p> tags that are around block tags.
+//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
+//    text = text.replace( /<p>(<li.+?)<\/p>/gi, '$1');
+//
+//    // Fix <p> in blockquotes.
+//    text = text.replace( /<p>\s*<blockquote([^>]*)>/gi, '<blockquote$1><p>');
+//    text = text.replace( /<\/blockquote>\s*<\/p>/gi, '</p></blockquote>');
+//
+//    // Remove <p> tags that are wrapped around block tags.
+//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '$1' );
+//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
+//
+//    text = text.replace( /(<br[^>]*>)\s*\n/gi, '$1' );
+//
+//    // Add <br> tags.
+//    text = text.replace( /\s*\n/g, '<br />\n');
+//
+//    // Remove <br> tags that are around block tags.
+//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
+//    text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
+//
+//    // Remove <p> and <br> around captions.
+//    text = text.replace( /(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi, '[caption$1[/caption]' );
+//    
+//    // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
+//    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
+//        if ( c.match( /<p( [^>]*)?>/ ) ) {
+//            return a;
+//        }
+//        
+//        return b + '<p>' + c + '</p>';
+//    });
+//    
+//    // Restore the line breaks in <pre> and <script> tags.
+//    if ( preserve_linebreaks ) {
+//            text = text.replace( /<wp-line-break>/g, '\n' );
+//    }
+//    
+//    // Restore the <br> tags in captions.
+//    if ( preserve_br ) {
+//            text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
+//    }
+//    
+//    return text;
+//}

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -22,6 +22,7 @@ class CalypsoProcessorOut: Processor {
         }
 
         let lineBreakMarker = "<wp-line-break>"
+        let preserveMarker = "<wp-preserve>"
 
         var preserveLinebreaks = false
         var preserveBr = false
@@ -41,7 +42,7 @@ class CalypsoProcessorOut: Processor {
                 preserve.append(match)
 
                 //                return '<wp-preserve>';
-                return "<wp-preserve>"
+                return preserveMarker
             })
         }
 
@@ -201,7 +202,7 @@ class CalypsoProcessorOut: Processor {
         //                if ( preserve.length ) {
         if preserve.count > 0 {
             //                html = html.replace( /<wp-preserve>/g, function() {
-            output = output.stringByReplacingMatches(of: "<wp-preserve>", using: { (_, _) -> String in
+            output = output.stringByReplacingMatches(of: preserveMarker, using: { (_, _) -> String in
                 return preserve.removeFirst()
             })
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -682,7 +682,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func getHTML() -> String {
-        var processedHTML = richTextView.getHTML()
+        var processedHTML = richTextView.getHTML(prettyPrint: true)
         for processor in htmlPostProcessors {
             processedHTML = processor.process(text: processedHTML)
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -628,7 +628,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     func registerHTMLProcessors() {
         htmlPreProcessors.append(VideoProcessor.videoPressPreProcessor)
         htmlPreProcessors.append(VideoProcessor.wordPressVideoPreProcessor)
-        htmlPreProcessors.append(CalypsoProcessor())
+        htmlPreProcessors.append(CalypsoProcessorIn())
 
         htmlPostProcessors.append(VideoProcessor.videoPressPostProcessor)
         htmlPostProcessors.append(VideoProcessor.wordPressVideoPostProcessor)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -682,7 +682,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func getHTML() -> String {
-        var processedHTML = richTextView.getHTML(prettyPrint: true)
+        var processedHTML = richTextView.getHTML()
         for processor in htmlPostProcessors {
             processedHTML = processor.process(text: processedHTML)
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -632,6 +632,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
         htmlPostProcessors.append(VideoProcessor.videoPressPostProcessor)
         htmlPostProcessors.append(VideoProcessor.wordPressVideoPostProcessor)
+        htmlPostProcessors.append(CalypsoProcessorOut())
     }
 
     func startListeningToNotifications() {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -253,17 +253,28 @@ class AztecPostViewController: UIViewController, PostEditor {
         return button
     }()
 
-
     /// Active Editor's Mode
     ///
     fileprivate(set) var mode = EditionMode.richText {
+        willSet {
+            switch mode {
+            case .html:
+                richTextView.setHTML(getHTML())
+            case .richText:
+                htmlTextView.text = getHTML()
+            }
+        }
+
         didSet {
             switch mode {
             case .html:
-                switchToHTML()
+                htmlTextView.becomeFirstResponder()
             case .richText:
-                switchToRichText()
+                richTextView.becomeFirstResponder()
             }
+
+            refreshEditorVisibility()
+            refreshPlaceholderVisibility()
         }
     }
 
@@ -674,20 +685,38 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func setHTML(_ html: String) {
-        var processedHTML = html
-        for processor in htmlPreProcessors {
-            processedHTML = processor.process(text: processedHTML)
+        switch(mode) {
+        case .html:
+            htmlTextView.text = html
+        case .richText:
+            var processedHTML = html
+
+            for processor in htmlPreProcessors {
+                processedHTML = processor.process(text: processedHTML)
+            }
+
+            richTextView.setHTML(processedHTML)
+
+            self.processVideoPressAttachments()
         }
-        richTextView.setHTML(processedHTML)
-        self.processVideoPressAttachments()
     }
 
     func getHTML() -> String {
-        var processedHTML = richTextView.getHTML()
-        for processor in htmlPostProcessors {
-            processedHTML = processor.process(text: processedHTML)
+
+        var html: String
+
+        switch (mode) {
+        case .html:
+            html = htmlTextView.text
+        case .richText:
+            html = richTextView.getHTML()
         }
-        return processedHTML
+
+        for processor in htmlPostProcessors {
+            html = processor.process(text: html)
+        }
+
+        return html
     }
 
     func reloadEditorContents() {
@@ -1329,26 +1358,6 @@ extension AztecPostViewController {
         }
     }
 
-    fileprivate func switchToHTML() {
-        stopEditing()
-
-        htmlTextView.text = getHTML()
-        htmlTextView.becomeFirstResponder()
-
-        refreshEditorVisibility()
-        refreshPlaceholderVisibility()
-    }
-
-    fileprivate func switchToRichText() {
-        stopEditing()
-
-        setHTML(htmlTextView.text)
-        richTextView.becomeFirstResponder()
-
-        refreshEditorVisibility()
-        refreshPlaceholderVisibility()
-    }
-
     func refreshEditorVisibility() {
         let isRichEnabled = mode == .richText
 
@@ -1755,6 +1764,7 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
 
         trackFormatBarAnalytics(stat: .editorTappedHTML)
         formatBar.overflowToolbar(expand: true)
+
         mode.toggle()
     }
 
@@ -2158,12 +2168,7 @@ private extension AztecPostViewController {
 
     func mapUIContentToPostAndSave() {
         post.postTitle = titleTextField.text
-        // TODO: This may not be super performant; Instrument and improve if needed and remove this TODO
-        if richTextView.isHidden {
-            post.content = htmlTextView.text
-        } else {
-            post.content = getHTML()
-        }
+        post.content = getHTML()
 
         ContextManager.sharedInstance().save(post.managedObjectContext!)
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -519,6 +519,7 @@
 		B54346961C6A707D0010B3AD /* LanguageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54346951C6A707D0010B3AD /* LanguageViewController.swift */; };
 		B54866CA1A0D7042004AC79D /* NSAttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54866C91A0D7042004AC79D /* NSAttributedString+Helpers.swift */; };
 		B549BA681CF7447E0086C608 /* InvitePersonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B549BA671CF7447E0086C608 /* InvitePersonViewController.swift */; };
+		B54C02241F38F50100574572 /* String+RegEx.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54C02231F38F50100574572 /* String+RegEx.swift */; };
 		B54E1DF01A0A7BAA00807537 /* ReplyBezierView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54E1DED1A0A7BAA00807537 /* ReplyBezierView.swift */; };
 		B54E1DF11A0A7BAA00807537 /* ReplyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54E1DEE1A0A7BAA00807537 /* ReplyTextView.swift */; };
 		B54E1DF21A0A7BAA00807537 /* ReplyTextView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B54E1DEF1A0A7BAA00807537 /* ReplyTextView.xib */; };
@@ -1799,6 +1800,7 @@
 		B54810F61AA656B40081B54D /* WordPress 28.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 28.xcdatamodel"; sourceTree = "<group>"; };
 		B54866C91A0D7042004AC79D /* NSAttributedString+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "NSAttributedString+Helpers.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		B549BA671CF7447E0086C608 /* InvitePersonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InvitePersonViewController.swift; sourceTree = "<group>"; };
+		B54C02231F38F50100574572 /* String+RegEx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+RegEx.swift"; sourceTree = "<group>"; };
 		B54E1DED1A0A7BAA00807537 /* ReplyBezierView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReplyBezierView.swift; sourceTree = "<group>"; };
 		B54E1DEE1A0A7BAA00807537 /* ReplyTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReplyTextView.swift; sourceTree = "<group>"; };
 		B54E1DEF1A0A7BAA00807537 /* ReplyTextView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReplyTextView.xib; sourceTree = "<group>"; };
@@ -4141,6 +4143,7 @@
 				E1CFC1561E0AC8FF001DF9E9 /* Pattern.swift */,
 				E1AB5A061E0BF17500574B4E /* Array.swift */,
 				B55FFCF91F034F1A0070812C /* String+Ranges.swift */,
+				B54C02231F38F50100574572 /* String+RegEx.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -6396,6 +6399,7 @@
 				8298F38F1EEF2B15008EB7F0 /* AppFeedbackPromptView.swift in Sources */,
 				E1823E6C1E42231C00C19F53 /* UIEdgeInsets.swift in Sources */,
 				5D18FE9F1AFBB17400EFEED0 /* RestorePageTableViewCell.m in Sources */,
+				B54C02241F38F50100574572 /* String+RegEx.swift in Sources */,
 				43D2AE441EF704A70009387E /* LoginProloguePromoViewController.swift in Sources */,
 				FFB1FA9E1BF0EB840090C761 /* UIImage+Exporters.swift in Sources */,
 				E6B84DD51F01BDAA00B1B686 /* SiteInfoHeaderView.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -915,6 +915,7 @@
 		E6F058021C1A122B008000F9 /* ReaderPostMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F058011C1A122B008000F9 /* ReaderPostMenu.swift */; };
 		E6F66D421E00966000F875A5 /* UIImage+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F66D411E00966000F875A5 /* UIImage+Rotation.swift */; };
 		E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */; };
+		F1049F331F39FCF9004DF0BB /* CalypsoProcessorOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */; };
 		F128C31C1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */; };
 		F1564E5B18946087009F8F97 /* NSStringHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */; };
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
@@ -2341,6 +2342,7 @@
 		E6F058011C1A122B008000F9 /* ReaderPostMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostMenu.swift; sourceTree = "<group>"; };
 		E6F66D411E00966000F875A5 /* UIImage+Rotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Rotation.swift"; sourceTree = "<group>"; };
 		E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarProfile.swift; sourceTree = "<group>"; };
+		F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalypsoProcessorOut.swift; sourceTree = "<group>"; };
 		F128C31A1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPNavigationMediaPickerViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
 		F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WPNavigationMediaPickerViewController+StatusBarStyle.m"; sourceTree = "<group>"; };
 		F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringHelpersTests.m; sourceTree = "<group>"; };
@@ -3877,6 +3879,7 @@
 				B50C0C541EF42A0000372C65 /* ShortcodeProcessor.swift */,
 				B50C0C551EF42A0000372C65 /* VideoProcessor.swift */,
 				B5032DDC1F02B30B00D946DC /* CalypsoProcessorIn.swift */,
+				F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */,
 			);
 			path = Processors;
 			sourceTree = "<group>";
@@ -6176,6 +6179,7 @@
 				B50C0C5E1EF42A4A00372C65 /* AztecAttachmentViewController.swift in Sources */,
 				43FB3F411EBD215C00FC8A62 /* LoginEpilogueBlogCell.swift in Sources */,
 				E19B17B01E5C69A5007517C6 /* NSManagedObject.swift in Sources */,
+				F1049F331F39FCF9004DF0BB /* CalypsoProcessorOut.swift in Sources */,
 				E15644EF1CE0E53B00D96E64 /* PlanListViewModel.swift in Sources */,
 				93C1147F18EC5DD500DAC95C /* AccountService.m in Sources */,
 				FF945F701B28242300FB8AC4 /* MediaLibraryPickerDataSource.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -462,7 +462,7 @@
 		B50248B71C96FF8400AFBDED /* UIImageView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50248B31C96FF8400AFBDED /* UIImageView+Extensions.swift */; };
 		B50248C21C96FFCC00AFBDED /* WordPressShare-Lumberjack.m in Sources */ = {isa = PBXBuildFile; fileRef = B50248BC1C96FFCC00AFBDED /* WordPressShare-Lumberjack.m */; };
 		B50248C71C96FFE800AFBDED /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B50248C51C96FFE800AFBDED /* MainInterface.storyboard */; };
-		B5032DDD1F02B30B00D946DC /* CalypsoProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5032DDC1F02B30B00D946DC /* CalypsoProcessor.swift */; };
+		B5032DDD1F02B30B00D946DC /* CalypsoProcessorIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5032DDC1F02B30B00D946DC /* CalypsoProcessorIn.swift */; };
 		B50421E71B680839008EEA82 /* NoteUndoOverlayView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B50421E61B680839008EEA82 /* NoteUndoOverlayView.xib */; };
 		B50421E91B68170F008EEA82 /* NoteUndoOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50421E81B68170F008EEA82 /* NoteUndoOverlayView.swift */; };
 		B504F5F51C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */; };
@@ -536,7 +536,7 @@
 		B55F1AA21C107CE200FD04D4 /* BlogSettingsDiscussionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55F1AA11C107CE200FD04D4 /* BlogSettingsDiscussionTests.swift */; };
 		B55F1AA81C10936600FD04D4 /* BlogSettings+Discussion.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55F1AA71C10936600FD04D4 /* BlogSettings+Discussion.swift */; };
 		B55FFCFA1F034F1A0070812C /* String+Ranges.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FFCF91F034F1A0070812C /* String+Ranges.swift */; };
-		B55FFCFC1F0350700070812C /* CalypsoProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FFCFB1F0350700070812C /* CalypsoProcessorTests.swift */; };
+		B55FFCFC1F0350700070812C /* CalypsoProcessorInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FFCFB1F0350700070812C /* CalypsoProcessorInTests.swift */; };
 		B5623E901C7D060100CC29EA /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85ED988717DFA00000090D0B /* Images.xcassets */; };
 		B56695B01D411EEB007E342F /* KeyboardDismissHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56695AF1D411EEB007E342F /* KeyboardDismissHelper.swift */; };
 		B566EC751B83867800278395 /* NSMutableAttributedStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B566EC741B83867800278395 /* NSMutableAttributedStringTests.swift */; };
@@ -1738,7 +1738,7 @@
 		B50248BD1C96FFCC00AFBDED /* WordPressShare.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = WordPressShare.entitlements; path = WordPressShareExtension/WordPressShare.entitlements; sourceTree = SOURCE_ROOT; };
 		B50248BE1C96FFCC00AFBDED /* WordPressSharePrefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WordPressSharePrefix.pch; path = WordPressShareExtension/WordPressSharePrefix.pch; sourceTree = SOURCE_ROOT; };
 		B50248C61C96FFE800AFBDED /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = MainInterface.storyboard; sourceTree = "<group>"; };
-		B5032DDC1F02B30B00D946DC /* CalypsoProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalypsoProcessor.swift; sourceTree = "<group>"; };
+		B5032DDC1F02B30B00D946DC /* CalypsoProcessorIn.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalypsoProcessorIn.swift; sourceTree = "<group>"; };
 		B50421E61B680839008EEA82 /* NoteUndoOverlayView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NoteUndoOverlayView.xib; sourceTree = "<group>"; };
 		B50421E81B68170F008EEA82 /* NoteUndoOverlayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoteUndoOverlayView.swift; sourceTree = "<group>"; };
 		B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tracks+ShareExtension.swift"; sourceTree = SOURCE_ROOT; };
@@ -1818,7 +1818,7 @@
 		B55F1AA11C107CE200FD04D4 /* BlogSettingsDiscussionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlogSettingsDiscussionTests.swift; sourceTree = "<group>"; };
 		B55F1AA71C10936600FD04D4 /* BlogSettings+Discussion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BlogSettings+Discussion.swift"; sourceTree = "<group>"; };
 		B55FFCF91F034F1A0070812C /* String+Ranges.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Ranges.swift"; sourceTree = "<group>"; };
-		B55FFCFB1F0350700070812C /* CalypsoProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CalypsoProcessorTests.swift; path = Aztec/CalypsoProcessorTests.swift; sourceTree = "<group>"; };
+		B55FFCFB1F0350700070812C /* CalypsoProcessorInTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CalypsoProcessorInTests.swift; path = Aztec/CalypsoProcessorInTests.swift; sourceTree = "<group>"; };
 		B56695AF1D411EEB007E342F /* KeyboardDismissHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardDismissHelper.swift; sourceTree = "<group>"; };
 		B566DE701BFE46D9002B9DBB /* WordPress 41.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 41.xcdatamodel"; sourceTree = "<group>"; };
 		B566EC741B83867800278395 /* NSMutableAttributedStringTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringTests.swift; sourceTree = "<group>"; };
@@ -3874,7 +3874,7 @@
 			children = (
 				B50C0C541EF42A0000372C65 /* ShortcodeProcessor.swift */,
 				B50C0C551EF42A0000372C65 /* VideoProcessor.swift */,
-				B5032DDC1F02B30B00D946DC /* CalypsoProcessor.swift */,
+				B5032DDC1F02B30B00D946DC /* CalypsoProcessorIn.swift */,
 			);
 			path = Processors;
 			sourceTree = "<group>";
@@ -5174,7 +5174,7 @@
 			children = (
 				FF7691671EE06D1C00713F4B /* VideoProcessorTests.swift */,
 				FF8032651EE9E22200861F28 /* MediaProgressCoordinatorTests.swift */,
-				B55FFCFB1F0350700070812C /* CalypsoProcessorTests.swift */,
+				B55FFCFB1F0350700070812C /* CalypsoProcessorInTests.swift */,
 			);
 			name = Aztec;
 			sourceTree = "<group>";
@@ -6330,7 +6330,7 @@
 				174122051EFDCBBF00AFA901 /* FancyAlertPresentationController.swift in Sources */,
 				E61084C11B9B47BA008050C5 /* ReaderSiteTopic.swift in Sources */,
 				5DAE40AD19EC70930011A0AE /* ReaderPostHeaderView.m in Sources */,
-				B5032DDD1F02B30B00D946DC /* CalypsoProcessor.swift in Sources */,
+				B5032DDD1F02B30B00D946DC /* CalypsoProcessorIn.swift in Sources */,
 				E6C448571CB091AA00458157 /* SigninKeyboardResponder.swift in Sources */,
 				74BB6F1A19AE7B9400FB7829 /* WPLegacyEditPageViewController.m in Sources */,
 				B580E4791AEA91000091A094 /* UIViewController+Helpers.swift in Sources */,
@@ -6638,7 +6638,7 @@
 				931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */,
 				B5882C471D5297D1008E0EAA /* NotificationTests.swift in Sources */,
 				E15618FD16DB8677006532C4 /* UIKitTestHelper.m in Sources */,
-				B55FFCFC1F0350700070812C /* CalypsoProcessorTests.swift in Sources */,
+				B55FFCFC1F0350700070812C /* CalypsoProcessorInTests.swift in Sources */,
 				B532ACD31DC3AE1200FFFA57 /* OHHTTPStubs+Helpers.swift in Sources */,
 				5960967F1CF7959300848496 /* PostTests.swift in Sources */,
 				E124CE721C86D27100F7BA99 /* StoreTests.swift in Sources */,

--- a/WordPress/WordPressTest/Aztec/CalypsoProcessorInTests.swift
+++ b/WordPress/WordPressTest/Aztec/CalypsoProcessorInTests.swift
@@ -2,11 +2,11 @@ import XCTest
 @testable import WordPress
 
 
-// MARK: - CalypsoProcessorTests
+// MARK: - CalypsoProcessorInTests
 //
-class CalypsoProcessorTests: XCTestCase {
+class CalypsoProcessorInTests: XCTestCase {
 
-    let processor = CalypsoProcessor()
+    let processor = CalypsoProcessorIn()
 
     /// Verifies that newlines get replaced with Line Break Elements
     ///

--- a/WordPress/WordPressTest/Aztec/CalypsoProcessorInTests.swift
+++ b/WordPress/WordPressTest/Aztec/CalypsoProcessorInTests.swift
@@ -12,18 +12,17 @@ class CalypsoProcessorInTests: XCTestCase {
     ///
     func testNewlinesAreConvertedIntoBreakElements() {
         let input = "\nNewline \n Another \n New \n Line \n Here"
-        let expected = "<br>Newline <br> Another <br> New <br> Line <br> Here"
+        let expected = "<p>\nNewline<br />\n Another<br />\n New<br />\n Line<br />\n Here</p>\n"
         let output = processor.process(text: input)
 
         XCTAssertEqual(output, expected)
     }
 
-    /// Verifies that paragraphs, separated by two consecutive newlines, are effectively wrapped into the
-    /// HTML Paragraph Element.
+    /// Verifies that paragraphs, separated by two consecutive newlines, are effectively wrapped into the     /// HTML Paragraph Element.
     ///
     func testParagraphsAreConvertedIntoParagraphElements() {
         let input = "First paragraph\n Newline \n\nSecond Paragraph\n Newline \n Another line \n\n Third Paragraph"
-        let expected = "<p>First paragraph<br> Newline </p><p>Second Paragraph<br> Newline <br> Another line </p><p> Third Paragraph</p>"
+        let expected = "<p>First paragraph<br />\n Newline </p>\n<p>Second Paragraph<br />\n Newline<br />\n Another line </p>\n<p> Third Paragraph</p>\n"
         let output = processor.process(text: input)
 
         XCTAssertEqual(output, expected)
@@ -33,9 +32,10 @@ class CalypsoProcessorInTests: XCTestCase {
     ///
     func testPreformattedTextIsEffectivelyPreserved() {
         let input = "<pre class='123'>Something\nHere\n\nAnd\nHere</pre>"
+        let expected = "<pre class=\'123\'>Something\nHere\n\nAnd\nHere</pre>\n"
         let output = processor.process(text: input)
 
-        XCTAssertEqual(output, input)
+        XCTAssertEqual(output, expected)
     }
 
     /// Verifies that any text surrounding a Pre Element gets it's newlines mapped to HTML Elements
@@ -43,7 +43,7 @@ class CalypsoProcessorInTests: XCTestCase {
     func testTextSurroundingPreformattedElementIsEffectivelyConverted() {
         let pre = "<pre class='123'>Something\nHere\n\nAnd\nHere</pre>"
         let input = pre + " LALALA \n LALA \n\n LA"
-        let expected = "<p>" + pre + " LALALA <br> LALA </p><p> LA</p>"
+        let expected = pre + "\n<p> LALALA<br />\n LALA </p>\n<p> LA</p>\n"
         let output = processor.process(text: input)
 
         XCTAssertEqual(output, expected)
@@ -53,27 +53,30 @@ class CalypsoProcessorInTests: XCTestCase {
     ///
     func testMultiplePreformattedElementsAreLeftUntouched() {
         let input = "<pre>First\n\nSecond</pre><pre>Third\nFourth</pre><pre>Fifth\n\nSixth\n</pre>"
+        let expected = "<pre>First\n\nSecond</pre>\n<pre>Third\nFourth</pre>\n<pre>Fifth\n\nSixth\n</pre>\n"
         let output = processor.process(text: input)
 
-        XCTAssertEqual(output, input)
+        XCTAssertEqual(output, expected)
     }
 
     /// Verifies that Ordered Lists (with nested levels) will keep their contents untouched.
     ///
     func testOrderedListsWithNestedEntitiesAreLeftUntouched() {
         let input = "<ol>\n<li>hello\nbye</li>\n<li><ol><li>WAT\nWAT</li></ol></li></ol>"
+        let expected = "<ol>\n<li>hello<br />\nbye</li>\n<li>\n<ol>\n<li>WAT<br />\nWAT</li>\n</ol>\n</li>\n</ol>\n"
         let output = processor.process(text: input)
 
-        XCTAssertEqual(output, input)
+        XCTAssertEqual(output, expected)
     }
 
     /// Verifies that Unordered Lists (with nested levels) will keep their contents untouched.
     ///
     func testUnorderedListsWithNestedEntitiesAreLeftUntouched() {
         let input = "<ul>\n<li>hello\nbye</li>\n<li><ul><li>WAT\nWAT</li></ul></li></ul>"
+        let expected = "<ul>\n<li>hello<br />\nbye</li>\n<li>\n<ul>\n<li>WAT<br />\nWAT</li>\n</ul>\n</li>\n</ul>\n"
         let output = processor.process(text: input)
 
-        XCTAssertEqual(output, input)
+        XCTAssertEqual(output, expected)
     }
 
     /// Verifies that Pre + UL + OL tags escaping algorithm is case insensitive, and it's 
@@ -85,10 +88,12 @@ class CalypsoProcessorInTests: XCTestCase {
             "<PRE>\n</PRE>testing" +
             "<OL><LI>ORDERED\n</LI></OL>"
 
-        let output = processor.process(text: input)
+        let expected = "<p>here</p>\n<UL>\n<LI>hello<br />\nbye</LI>\n" +
+            "<LI>\n<UL>\n<LI>WAT<br />\nWAT</LI>\n</UL>\n</LI>\n</UL>\n<p>there</p>\n" +
+            "<PRE>\n</PRE>\n<p>testing</p>\n" +
+            "<OL>\n<LI>ORDERED\n</LI>\n</OL>\n"
 
-        NSLog("Input: \(input)")
-        NSLog("Output: \(output)")
-        XCTAssertEqual(output, input)
+        let output = processor.process(text: input)
+        XCTAssertEqual(output, expected)
     }
 }


### PR DESCRIPTION
### Description:

Fixes #7671 by migrating `autop` and `removep` to Swift, and processing the post content with it.

### Details:

- Adds support methods to make the migration more straightforward.
- Migrates `autop` and `removep` to Swift.
- The reference code can be found [here](https://github.com/WordPress/WordPress/blob/4e4df0e/wp-admin/js/editor.js#L309) and [here](https://github.com/WordPress/WordPress/blob/4e4df0e/wp-admin/js/editor.js#L172).

### How to review the code:

We've left comments for each line of code we migrated.  Make sure all lines have been properly migrated.

These comments will be removed once the PR is approved, but were left in there to make the review process easier.

### How to test:

**Test 1:**

Run the unit tests.  Make sure they all pass.

**Test 2:**

Create a post in Calypso with some content in more than 1 paragraph.  You can also use shift + enter in lists.
Switch to HTML mode and keep the content on screen.
Do the exact same thing in Aztec and make sure the output HTML is the same.
