### PR TITLE
Updates MGSwipeTableCell pod to the latest version

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -42,7 +42,7 @@ target 'WordPress' do
   pod 'Crashlytics', '3.8.5'
   pod 'BuddyBuildSDK', '1.0.16', :configurations => ['Release-Alpha']
   pod 'FLAnimatedImage', '1.0.12'
-  pod 'MGSwipeTableCell', '1.5.6'
+  pod 'MGSwipeTableCell', '1.6.0'
   pod 'lottie-ios', '1.5.1'
   pod 'Starscream', '2.1.0'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -40,7 +40,7 @@ PODS:
     - HockeySDK/DefaultLib (= 4.1.6)
   - HockeySDK/DefaultLib (4.1.6)
   - lottie-ios (1.5.1)
-  - MGSwipeTableCell (1.5.6)
+  - MGSwipeTableCell (1.6.0)
   - MRProgress (0.8.3):
     - MRProgress/ActivityIndicator (= 0.8.3)
     - MRProgress/Blur (= 0.8.3)
@@ -115,7 +115,7 @@ DEPENDENCIES:
   - Gridicons (= 0.10)
   - HockeySDK (= 4.1.6)
   - lottie-ios (= 1.5.1)
-  - MGSwipeTableCell (= 1.5.6)
+  - MGSwipeTableCell (= 1.6.0)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.0.0)
   - NSObject-SafeExpectations (= 0.0.2)
@@ -165,7 +165,7 @@ SPEC CHECKSUMS:
   Gridicons: e661b35e7d4f0ca79e8b2a2072c0081b91b5d1e0
   HockeySDK: 95db557d54489a570dcdefae0d02f98eecc279a3
   lottie-ios: f680a7c4cb7a567ecf258fde0f967913aff111b8
-  MGSwipeTableCell: 616700eb0ffd1c611ba909066cb7fd739790a0a7
+  MGSwipeTableCell: 6e1994f1eb31c76e76f70a8bc39de3c42cf5cd38
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
   Nimble: 657d000e11df8aebe27cdaf9d244de7f30ed87f7
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
@@ -183,6 +183,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 771abfe3a334119a909ebe403188498e4a2b01e8
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: d2e571c6d68a818319e6a06b2897e986b9c723e6
+PODFILE CHECKSUM: c57be7a211c74d9e5122cdb8035b94737b1c76aa
 
 COCOAPODS: 1.2.1


### PR DESCRIPTION
Fixes #7679 

To test:
Test that the swipe actions: Mark as Read, Unapprove/Approve and Trash work correctly on notifications. Please test on IPhone and IPad, both orientations.

Needs review: @jleandroperez 
