### PR TITLE
Add source param when following sites

### DIFF
--- a/WordPressKit/WordPressKit/ReaderSiteServiceRemote.m
+++ b/WordPressKit/WordPressKit/ReaderSiteServiceRemote.m
@@ -6,6 +6,10 @@
 @import NSObject_SafeExpectations;
 @import WordPressShared;
 
+static NSString* const ReaderSiteServiceRemoteURLKey = @"url";
+static NSString* const ReaderSiteServiceRemoteSourceKey = @"source";
+static NSString* const ReaderSiteServiceRemoteSourceValue = @"ios";
+
 NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteErrorDomain";
 
 @implementation ReaderSiteServiceRemote
@@ -42,8 +46,10 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
     NSString *path = [NSString stringWithFormat:@"sites/%lu/follows/new", (unsigned long)siteID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
-    
-    [self.wordPressComRestApi POST:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+
+    NSDictionary *params = @{ReaderSiteServiceRemoteSourceKey: ReaderSiteServiceRemoteSourceValue};
+
+    [self.wordPressComRestApi POST:requestUrl parameters:params success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
             success();
         }
@@ -73,11 +79,12 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 
 - (void)followSiteAtURL:(NSString *)siteURL success:(void (^)())success failure:(void(^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"read/following/mine/new?url=%@", siteURL];
+    NSString *path = @"read/following/mine/new";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    NSDictionary *params = @{@"url": siteURL};
+    NSDictionary *params = @{ReaderSiteServiceRemoteURLKey: siteURL,
+                             ReaderSiteServiceRemoteSourceKey: ReaderSiteServiceRemoteSourceValue};
     [self.wordPressComRestApi POST:requestUrl parameters:params success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         NSDictionary *dict = (NSDictionary *)responseObject;
         BOOL subscribed = [[dict numberForKey:@"subscribed"] boolValue];
@@ -101,11 +108,11 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 
 - (void)unfollowSiteAtURL:(NSString *)siteURL success:(void (^)())success failure:(void(^)(NSError *error))failure
 {
-    NSString *path = [NSString stringWithFormat:@"read/following/mine/delete?url=%@", siteURL];
+    NSString *path = @"read/following/mine/delete";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    NSDictionary *params = @{@"url": siteURL};
+    NSDictionary *params = @{ReaderSiteServiceRemoteURLKey: siteURL};
     
     [self.wordPressComRestApi POST:requestUrl parameters:params success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         NSDictionary *dict = (NSDictionary *)responseObject;

--- a/WordPressKit/WordPressKitTests/ReaderSiteServiceRemoteTests.swift
+++ b/WordPressKit/WordPressKitTests/ReaderSiteServiceRemoteTests.swift
@@ -73,10 +73,13 @@ class ReaderSiteServiceRemoteTests: XCTestCase {
     func testFollowSiteAtURLPath() {
 
         let url = "http://www.wordpress.com"
-        let expectedPath = "v1.1/read/following/mine/new?url=\(url)"
+        let expectedPath = "v1.1/read/following/mine/new"
         readerSiteServiceRemote.followSite(atURL: url, success: nil, failure: nil)
         XCTAssertTrue(mockRemoteApi.postMethodCalled, "Wrong method")
         XCTAssertEqual(mockRemoteApi.URLStringPassedIn, expectedPath, "Wrong path")
+        let parameters: NSDictionary = mockRemoteApi.parametersPassedIn as! NSDictionary
+        XCTAssertEqual(parameters["url"] as! String?, url, "incorrect url parameter")
+        XCTAssertEqual(parameters["source"] as! String?, "ios", "incorrect source parameter")
     }
 
     func testFollowSiteAtURL() {
@@ -106,10 +109,12 @@ class ReaderSiteServiceRemoteTests: XCTestCase {
     func testUnfollowSiteAtURLPath() {
 
         let url = "http://www.wordpress.com"
-        let expectedPath = "v1.1/read/following/mine/delete?url=\(url)"
+        let expectedPath = "v1.1/read/following/mine/delete"
         readerSiteServiceRemote.unfollowSite(atURL: url, success: nil, failure: nil)
         XCTAssertTrue(mockRemoteApi.postMethodCalled, "Wrong method")
         XCTAssertEqual(mockRemoteApi.URLStringPassedIn, expectedPath, "Wrong path")
+        let parameters: NSDictionary = mockRemoteApi.parametersPassedIn as! NSDictionary
+        XCTAssertEqual(parameters["url"] as! String?, url, "incorrect url parameter")
     }
 
     func testUnfollowSiteAtURL() {

--- a/WordPressKit/WordPressKitTests/ReaderSiteServiceRemoteTests.swift
+++ b/WordPressKit/WordPressKitTests/ReaderSiteServiceRemoteTests.swift
@@ -38,6 +38,8 @@ class ReaderSiteServiceRemoteTests: XCTestCase {
         readerSiteServiceRemote.followSite(withID: 1, success: nil, failure: nil)
         XCTAssertTrue(mockRemoteApi.postMethodCalled, "Wrong method")
         XCTAssertEqual(mockRemoteApi.URLStringPassedIn, expectedPath, "Wrong path")
+        let parameters: NSDictionary = mockRemoteApi.parametersPassedIn as! NSDictionary
+        XCTAssertEqual(parameters["source"] as! String?, "ios", "incorrect source parameter")
     }
 
     func testFollowSiteWithID() {


### PR DESCRIPTION
**Fixes:** #6924 

**To test:**
Follow a site and verify that the source is correctly recorded via `read/following/mine/new` and `sites/SITE_ID/follows/new`
Also please verify that unfollowing works because I made a simple change there too.


Needs review: @aerych 