### PR TITLE
Add missing param to sync methods for ReaderCommentsViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -753,7 +753,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     } failure:failure];
 }
 
-- (void)syncContentEnded
+- (void)syncContentEnded:(WPContentSyncHelper *)syncHelper
 {
     [self.activityFooter stopAnimating];
     if ([self.tableViewHandler isScrolling]) {
@@ -763,7 +763,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     [self refreshTableViewAndNoResultsView];
 }
 
-- (void)syncContentFailed
+- (void)syncContentFailed:(WPContentSyncHelper *)syncHelper
 {
     self.failedToFetchComments = YES;
     [self.activityFooter stopAnimating];


### PR DESCRIPTION
**Fixes** #7686 

As part of https://github.com/wordpress-mobile/WordPress-iOS/pull/7672 I missed updating `ReaderCommentsViewController` to add the extra parameter and that's causing comments to hang on 8.3

**To test:**
1. Verify that you can replicate the hanging on release/8.3
2. Check out this branch and verify that comments load properly on reader

Needs review: @aerych 