### PR TITLE
AztecPostViewController: Fixing Options Dismissal

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -803,7 +803,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         }
 
         refreshInsets(forKeyboardFrame: keyboardFrame)
-        dismissOptionsViewControllerIfNecessary()
     }
 
     fileprivate func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {
@@ -1833,11 +1832,11 @@ extension AztecPostViewController : Aztec.FormatBarDelegate {
     // MARK: - Present Toolbar related VC
 
     fileprivate func dismissOptionsViewControllerIfNecessary() {
-        if let optionsViewController = optionsViewController,
-            presentedViewController == optionsViewController {
-            dismiss(animated: true, completion: nil)
-            self.optionsViewController = nil
+        guard optionsViewController != nil else {
+            return
         }
+
+        dismissOptionsViewController()
     }
 
     func showOptionsTableViewControllerWithOptions(_ options: [OptionsTableViewOption],


### PR DESCRIPTION
### Details:
Fixes #7698

### To test:
1. Launch Aztec
2. Press the List (OR) H button
3. Press the Bold button

As a result, the *regular* soft keyboard should show up onscreen. Please: test this one on iPad + iPhone.

Needs review: @diegoreymendez 