### PR TITLE
Issues/7637 track prologue paging

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -437,6 +437,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatLoginAutoFillCredentialsUpdated:
             eventName = @"login_autofill_credentials_updated";
             break;
+        case WPAnalyticsStatLoginProloguePaged:
+            eventName = @"login_prologue_paged";
+            break;
         case WPAnalyticsStatLoginPrologueViewed:
             eventName = @"login_prologue_viewed";
             break;

--- a/WordPress/Classes/ViewRelated/NUX/LoginProloguePageViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginProloguePageViewController.swift
@@ -51,7 +51,7 @@ class LoginProloguePageViewController: UIPageViewController {
 
         let direction: UIPageViewControllerNavigationDirection = sender.currentPage > currentIndex ? .forward : .reverse
         setViewControllers([pages[sender.currentPage]], direction: direction, animated: true)
-        WPAppAnalytics.track(WPAnalyticsStat.loginProloguePaged)
+        WPAppAnalytics.track(.loginProloguePaged)
     }
 
     fileprivate func animateBackground(for index: Int, duration: TimeInterval = 0.5) {
@@ -107,7 +107,7 @@ extension LoginProloguePageViewController: UIPageViewControllerDelegate {
             pageControl?.currentPage = index
             animateBackground(for: index, duration: 0.2)
         } else {
-            WPAppAnalytics.track(WPAnalyticsStat.loginProloguePaged)
+            WPAppAnalytics.track(.loginProloguePaged)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginProloguePageViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginProloguePageViewController.swift
@@ -94,6 +94,8 @@ extension LoginProloguePageViewController: UIPageViewControllerDelegate {
         if !completed {
             pageControl?.currentPage = index
             animateBackground(for: index, duration: 0.2)
+        } else {
+            WPAppAnalytics.track(WPAnalyticsStat.loginProloguePaged)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginProloguePageViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginProloguePageViewController.swift
@@ -51,6 +51,7 @@ class LoginProloguePageViewController: UIPageViewController {
 
         let direction: UIPageViewControllerNavigationDirection = sender.currentPage > currentIndex ? .forward : .reverse
         setViewControllers([pages[sender.currentPage]], direction: direction, animated: true)
+        WPAppAnalytics.track(WPAnalyticsStat.loginProloguePaged)
     }
 
     fileprivate func animateBackground(for index: Int, duration: TimeInterval = 0.5) {

--- a/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -84,6 +84,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatLoginMagicLinkRequested,
     WPAnalyticsStatLoginMagicLinkSucceeded,
     WPAnalyticsStatLoginPasswordFormViewed,
+    WPAnalyticsStatLoginProloguePaged,
     WPAnalyticsStatLoginPrologueViewed,
     WPAnalyticsStatLoginTwoFactorFormViewed,
     WPAnalyticsStatLoginURLFormViewed,


### PR DESCRIPTION
Fixes #7637 

To test:
Set a break point where the stat is being bumped.
Confirm that its bumped when navigating through the prologue screens.

Waiting for #7701 to merge, then we'll update this PR to bump the stat from the page control's event handler as well.

Needs review: @nheagy 
