### PR TITLE
AztecPostViewController: Crash Failsafe

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -625,7 +625,10 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func configureMediaProgressView(in navigationBar: UINavigationBar) {
-        assert(mediaProgressView.superview == nil)
+        guard mediaProgressView.superview == nil else {
+            return
+        }
+
         navigationBar.addSubview(mediaProgressView)
 
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -574,7 +574,8 @@ class AztecPostViewController: UIViewController, PostEditor {
             placeholderLabel.bottomAnchor.constraint(lessThanOrEqualTo: richTextView.bottomAnchor, constant: Constants.placeholderPadding.bottom)
             ])
 
-        if let navigationBar = navigationController?.navigationBar {
+
+        if let navigationBar = navigationController?.navigationBar, navigationBar.subviews.contains(mediaProgressView) {
             NSLayoutConstraint.activate([
                 mediaProgressView.leadingAnchor.constraint(equalTo: navigationBar.leadingAnchor),
                 mediaProgressView.widthAnchor.constraint(equalTo: navigationBar.widthAnchor),

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -476,6 +476,19 @@ class AztecPostViewController: UIViewController, PostEditor {
         dismissOptionsViewControllerIfNecessary()
     }
 
+    override func didMove(toParentViewController parent: UIViewController?) {
+        guard let navigationController = parent as? UINavigationController else {
+            return
+        }
+
+        guard !navigationController.navigationBar.subviews.contains(mediaProgressView) else {
+            return
+        }
+
+        navigationController.navigationBar.addSubview(mediaProgressView)
+        view.setNeedsUpdateConstraints()
+    }
+
 
     // MARK: - Title and Title placeholder position methods
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -584,15 +584,6 @@ class AztecPostViewController: UIViewController, PostEditor {
             textPlaceholderTopConstraint,
             placeholderLabel.bottomAnchor.constraint(lessThanOrEqualTo: richTextView.bottomAnchor, constant: Constants.placeholderPadding.bottom)
             ])
-
-
-        if let navigationBar = navigationController?.navigationBar, navigationBar.subviews.contains(mediaProgressView) {
-            NSLayoutConstraint.activate([
-                mediaProgressView.leadingAnchor.constraint(equalTo: navigationBar.leadingAnchor),
-                mediaProgressView.widthAnchor.constraint(equalTo: navigationBar.widthAnchor),
-                mediaProgressView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: -mediaProgressView.frame.height)
-                ])
-        }
     }
 
     private func configureDefaultProperties(for textView: UITextView, accessibilityLabel: String) {
@@ -634,7 +625,14 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func configureMediaProgressView(in navigationBar: UINavigationBar) {
+        assert(mediaProgressView.superview == nil)
         navigationBar.addSubview(mediaProgressView)
+
+        NSLayoutConstraint.activate([
+            mediaProgressView.leadingAnchor.constraint(equalTo: navigationBar.leadingAnchor),
+            mediaProgressView.widthAnchor.constraint(equalTo: navigationBar.widthAnchor),
+            mediaProgressView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: -mediaProgressView.frame.height)
+            ])
     }
 
     func registerAttachmentImageProviders() {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -326,6 +326,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         progressView.progressTintColor = Colors.progressTint
         progressView.trackTintColor = Colors.progressTrack
         progressView.translatesAutoresizingMaskIntoConstraints = false
+        progressView.isHidden = true
         return progressView
     }()
 
@@ -476,17 +477,14 @@ class AztecPostViewController: UIViewController, PostEditor {
         dismissOptionsViewControllerIfNecessary()
     }
 
-    override func didMove(toParentViewController parent: UIViewController?) {
+    override func willMove(toParentViewController parent: UIViewController?) {
+        super.willMove(toParentViewController: parent)
+
         guard let navigationController = parent as? UINavigationController else {
             return
         }
 
-        guard !navigationController.navigationBar.subviews.contains(mediaProgressView) else {
-            return
-        }
-
-        navigationController.navigationBar.addSubview(mediaProgressView)
-        view.setNeedsUpdateConstraints()
+        configureMediaProgressView(in: navigationController.navigationBar)
     }
 
 
@@ -633,9 +631,10 @@ class AztecPostViewController: UIViewController, PostEditor {
         view.addSubview(separatorView)
         view.addSubview(placeholderLabel)
         view.addSubview(betaButton)
+    }
 
-        mediaProgressView.isHidden = true
-        navigationController?.navigationBar.addSubview(mediaProgressView)
+    func configureMediaProgressView(in navigationBar: UINavigationBar) {
+        navigationBar.addSubview(mediaProgressView)
     }
 
     func registerAttachmentImageProviders() {


### PR DESCRIPTION
### Details:
I've (unsuccessfully) tried to reproduce the original crash in WPiOS 8.0 / 8.1 / 8.2 / 8.3 with the following steps:

1. Upload multiple assets
2. Ensure the mediaProgressView is onscreen
3. Send the app to BG
4. Stop Xcode
5. Relaunch WPiOS (trigger State Restoration)

If you set a BP in step (4), in AztecPostViewController's *updateViewConstraints* method, you'll get a trace that looks very similar to the one in the crashlog (Except, right, for the exception).

In this (super minor) PR, we're just adding a failsafe that would effectively prevent the exception condition.

Fixes #7607

### Testing:
Perform the steps detailed in the issue's description and ensure nothing breaks!

Needs review: @diegoreymendez 
