### PR TITLE
Update the editor pod to 1.9.4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ target 'WordPress' do
   pod 'Gridicons', '0.10'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.19'
-  pod 'WordPress-iOS-Editor', '1.9.3'
+  pod 'WordPress-iOS-Editor', '1.9.4'
   pod 'WordPress-Aztec-iOS', '=1.0.0-beta.10'
 
   target 'WordPressTest' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -94,7 +94,7 @@ PODS:
   - SVProgressHUD (2.1.2)
   - UIDeviceIdentifier (0.5.0)
   - WordPress-Aztec-iOS (1.0.0-beta.10)
-  - WordPress-iOS-Editor (1.9.3):
+  - WordPress-iOS-Editor (1.9.4):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
   - WordPressComKit (0.0.6):
@@ -129,7 +129,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.1.2)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (= 1.0.0-beta.10)
-  - WordPress-iOS-Editor (= 1.9.3)
+  - WordPress-iOS-Editor (= 1.9.4)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.19)
   - wpxmlrpc (= 0.8.3)
@@ -178,11 +178,11 @@ SPEC CHECKSUMS:
   SVProgressHUD: c404a55d78acbeb7ebb78b76d3faf986475a6994
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: 17a73f2b5b21b2dc102e392344f9d40b5f6b8676
-  WordPress-iOS-Editor: ed02135d783ecb9aa4ee5e2462935432d464d461
+  WordPress-iOS-Editor: 3792b28f6b139150b37363e450d3c8769137eaca
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 771abfe3a334119a909ebe403188498e4a2b01e8
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: c57be7a211c74d9e5122cdb8035b94737b1c76aa
+PODFILE CHECKSUM: ac0e612988413118b7051cd0c8c103388f64c7ff
 
 COCOAPODS: 1.2.1


### PR DESCRIPTION
Updates the editor pod to the latest version: `1.9.4`

**To Test:** Build and run the app. Using the visual (hybrid) editor, verify everything is working as expected.

Needs review: @elibud Thanks!!
