### PR TITLE
Integrates Processor changes in Aztec.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.19'
   pod 'WordPress-iOS-Editor', '1.9.4'
-  pod 'WordPress-Aztec-iOS', '=1.0.0-beta.10'
+  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '64edec362b5e671cf517fc28c712a3af578b5f8b'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'c9215c1c2c0136a8c2c6ef2ef6828fd37a4cfcab'
   pod 'WordPress-iOS-Editor', '1.9.4'
-  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '64edec362b5e671cf517fc28c712a3af578b5f8b'
+  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '97e76922eb2dbccdb8373cfc9d0cc36b40039e52'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile
+++ b/Podfile
@@ -52,7 +52,7 @@ target 'WordPress' do
   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.0'
   pod 'Gridicons', '0.10'
   pod 'NSURL+IDN', '0.3'
-  pod 'WPMediaPicker', '0.19'
+  pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'c9215c1c2c0136a8c2c6ef2ef6828fd37a4cfcab'
   pod 'WordPress-iOS-Editor', '1.9.4'
   pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '64edec362b5e671cf517fc28c712a3af578b5f8b'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -128,7 +128,7 @@ DEPENDENCIES:
   - Starscream (= 2.1.0)
   - SVProgressHUD (= 2.1.2)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (= 1.0.0-beta.10)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `64edec362b5e671cf517fc28c712a3af578b5f8b`)
   - WordPress-iOS-Editor (= 1.9.4)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.19)
@@ -138,6 +138,9 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
+  WordPress-Aztec-iOS:
+    :commit: 64edec362b5e671cf517fc28c712a3af578b5f8b
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -146,6 +149,9 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
+  WordPress-Aztec-iOS:
+    :commit: 64edec362b5e671cf517fc28c712a3af578b5f8b
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -177,12 +183,12 @@ SPEC CHECKSUMS:
   Starscream: 168fd64c345fb2dea71b0a869c482aeffcf866e4
   SVProgressHUD: c404a55d78acbeb7ebb78b76d3faf986475a6994
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 17a73f2b5b21b2dc102e392344f9d40b5f6b8676
+  WordPress-Aztec-iOS: c47f4c93a01944a603ddcde02811cfb3227d0a1b
   WordPress-iOS-Editor: 3792b28f6b139150b37363e450d3c8769137eaca
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 771abfe3a334119a909ebe403188498e4a2b01e8
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: ac0e612988413118b7051cd0c8c103388f64c7ff
+PODFILE CHECKSUM: 13de5bcc235ffe46a70cefd526dba69044838761
 
 COCOAPODS: 1.2.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -128,7 +128,7 @@ DEPENDENCIES:
   - Starscream (= 2.1.0)
   - SVProgressHUD (= 2.1.2)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `64edec362b5e671cf517fc28c712a3af578b5f8b`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `97e76922eb2dbccdb8373cfc9d0cc36b40039e52`)
   - WordPress-iOS-Editor (= 1.9.4)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `c9215c1c2c0136a8c2c6ef2ef6828fd37a4cfcab`)
@@ -139,7 +139,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
   WordPress-Aztec-iOS:
-    :commit: 64edec362b5e671cf517fc28c712a3af578b5f8b
+    :commit: 97e76922eb2dbccdb8373cfc9d0cc36b40039e52
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -153,7 +153,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
   WordPress-Aztec-iOS:
-    :commit: 64edec362b5e671cf517fc28c712a3af578b5f8b
+    :commit: 97e76922eb2dbccdb8373cfc9d0cc36b40039e52
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -195,6 +195,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 771abfe3a334119a909ebe403188498e4a2b01e8
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: ec1ed842426018aceafde9fa322ff07609835d88
+PODFILE CHECKSUM: e0b12b079be34ded3c1b97c7ffeb9ddef74d12b3
 
 COCOAPODS: 1.2.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -131,7 +131,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `64edec362b5e671cf517fc28c712a3af578b5f8b`)
   - WordPress-iOS-Editor (= 1.9.4)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
-  - WPMediaPicker (= 0.19)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `c9215c1c2c0136a8c2c6ef2ef6828fd37a4cfcab`)
   - wpxmlrpc (= 0.8.3)
 
 EXTERNAL SOURCES:
@@ -144,6 +144,9 @@ EXTERNAL SOURCES:
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
+  WPMediaPicker:
+    :commit: c9215c1c2c0136a8c2c6ef2ef6828fd37a4cfcab
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -155,6 +158,9 @@ CHECKOUT OPTIONS:
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
+  WPMediaPicker:
+    :commit: c9215c1c2c0136a8c2c6ef2ef6828fd37a4cfcab
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: e775a29310c65851e5a6cec1afc349ab4e334e47
@@ -189,6 +195,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 771abfe3a334119a909ebe403188498e4a2b01e8
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 13de5bcc235ffe46a70cefd526dba69044838761
+PODFILE CHECKSUM: ec1ed842426018aceafde9fa322ff07609835d88
 
 COCOAPODS: 1.2.1

--- a/WordPress/Classes/ViewRelated/Aztec/Extensions/VideoAttachment+WordPress.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Extensions/VideoAttachment+WordPress.swift
@@ -8,13 +8,13 @@ extension VideoAttachment {
 
     var videoPressID: String? {
         get {
-            return extraAttributes[VideoProcessor.videoPressHTMLAttribute]
+            return extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute]
         }
         set {
             if let nonNilValue = newValue {
-                extraAttributes[VideoProcessor.videoPressHTMLAttribute] = nonNilValue
+                extraAttributes[VideoShortcodeProcessor.videoPressHTMLAttribute] = nonNilValue
             } else {
-                extraAttributes.removeValue(forKey: VideoProcessor.videoPressHTMLAttribute)
+                extraAttributes.removeValue(forKey: VideoShortcodeProcessor.videoPressHTMLAttribute)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -20,164 +20,113 @@ class CalypsoProcessorIn: Processor {
             "|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary"
 
         // Normalize line breaks.
-//      text = text.replace( /\r\n|\r/g, '\n' );
         var output = text.replacingMatches(of: "\r\n|\r", with: "\n")
 
-//      if ( text.indexOf( '\n' ) === -1 ) {
         guard output.contains("\n") else {
-            // return text;
             return output
         }
 
         // Remove line breaks from <object>
-//      if ( text.indexOf( '<object' ) !== -1 ) {
         if output.contains("<object") {
-//          text = text.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
             output = output.replacingMatches(of: "<object[\\s\\S]+?<\\/object>", using: { (match, _) in
-//              return a.replace( /\n+/g, '' );
                 return match.replacingMatches(of: "\n+", with: "")
             })
         }
 
         // Remove line breaks from tags.
-//      text = text.replace( /<[^<>]+>/g, function( a ) {
         output = output.replacingMatches(of: "<[^<>]+>", using: { (match, _) in
-//          return a.replace( /[\n\t ]+/g, ' ' );
             return match.replacingMatches(of: "[\n\t ]+", with: " ")
         })
 
         // Preserve line breaks in <pre> and <script> tags.
-//      if ( text.indexOf( '<pre' ) !== -1 || text.indexOf( '<script' ) !== -1 ) {
         if output.contains("<pre") || output.contains("<script") {
-//          preserve_linebreaks = true;
             preserveLinebreaks = true
-//          text = text.replace( /<(pre|script)[^>]*>[\s\S]*?<\/\1>/g, function( a ) {
+
             output = output.replacingMatches(of: "<(pre|script)[^>]*>[\\s\\S]*?<\\/\\1>", using: { (match, _) in
-//              return a.replace( /\n/g, '<wp-line-break>' );
                 return match.replacingMatches(of: "\n", with: "<wp-line-break>")
             })
         }
 
-//      if ( text.indexOf( '<figcaption' ) !== -1 ) {
         if output.contains("<figcaption") {
-//          text = text.replace( /\s*(<figcaption[^>]*>)/g, '$1' );
             output = output.replacingMatches(of: "\\s*(<figcaption[^>]*>)", with: "$1")
-//          text = text.replace( /<\/figcaption>\s*/g, '</figcaption>' );
             output = output.replacingMatches(of: "</figcaption>\\s*", with: "</figcaption>")
         }
 
         // Keep <br> tags inside captions.
-//      if ( text.indexOf( '[caption' ) !== -1 ) {
         if output.contains("[caption") {
-//          preserveBR = true;
             preserveBR = true
 
-//          text = text.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
             output = output.replacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", using: { (match, _) in
-
-//              a = a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' );
                 var updated = match.replacingMatches(of: "<br([^>]*)>", with: "<wp-temp-br$1>")
 
-//              a = a.replace( /<[^<>]+>/g, function( b ) {
                 updated = updated.replacingMatches(of: "<[^<>]+>", using: { (match, _) in
-//                  return b.replace( /[\n\t ]+/, ' ' );
                     return match.replacingMatches(of: "[\n\t ]+", with: " ")
                 })
 
-//              return a.replace( /\s*\n\s*/g, '<wp-temp-br />' );
                 return updated.replacingMatches(of: "\\s*\n\\s*", with: "<wp-temp-br />")
             })
         }
 
-//      text = text + '\n\n';
         output = output + "\n\n"
-
-//      text = text.replace( /<br \/>\s*<br \/>/gi, '\n\n' );
         output = output.replacingMatches(of: "<br \\/>\\s*<br \\/>", with: "\n\n", options: .caseInsensitive)
 
         // Pad block tags with two line breaks.
-//    text = text.replace( new RegExp( '(<(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '\n\n$1' );
         output = output.replacingMatches(of: "(<(?:" + blocklist + ")(?: [^>]*)?>)", with: "\n\n$1", options: .caseInsensitive)
-//    text = text.replace( new RegExp( '(</(?:' + blocklist + ')>)', 'gi' ), '$1\n\n' );
         output = output.replacingMatches(of: "(</(?:" + blocklist + ")>)", with: "$1\n\n", options: .caseInsensitive)
-//    text = text.replace( /<hr( [^>]*)?>/gi, '<hr$1>\n\n' );
         output = output.replacingMatches(of: "<hr( [^>]*)?>", with: "<hr$1>\n\n", options: .caseInsensitive)
 
         // Remove white space chars around <option>.
-//    text = text.replace( /\s*<option/gi, '<option' );
         output = output.replacingMatches(of: "\\s*<option", with: "<option", options: .caseInsensitive)
-//    text = text.replace( /<\/option>\s*/gi, '</option>' );
         output = output.replacingMatches(of: "<\\/option>\\s*", with: "</option>", options: .caseInsensitive)
 
         // Normalize multiple line breaks and white space chars.
-//    text = text.replace( /\n\s*\n+/g, '\n\n' );
         output = output.replacingMatches(of: "\n\\s*\n+", with: "\n\n")
 
         // Convert two line breaks to a paragraph.
-//    text = text.replace( /([\s\S]+?)\n\n/g, '<p>$1</p>\n' );
         output = output.replacingMatches(of: "([\\s\\S]+?)\n\n", with: "<p>$1</p>\n")
 
         // Remove empty paragraphs.
-//    text = text.replace( /<p>\s*?<\/p>/gi, '');
         output = output.replacingMatches(of: "<p>\\s*?<\\/p>", with: "", options: .caseInsensitive)
 
         // Remove <p> tags that are around block tags.
-//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
         output = output.replacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
-//    text = text.replace( /<p>(<li.+?)<\/p>/gi, '$1');
         output = output.replacingMatches(of: "<p>(<li.+?)<\\/p>", with: "$1", options: .caseInsensitive)
 
         // Fix <p> in blockquotes.
-//    text = text.replace( /<p>\s*<blockquote([^>]*)>/gi, '<blockquote$1><p>');
         output = output.replacingMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$1><p>", options: .caseInsensitive)
-//    text = text.replace( /<\/blockquote>\s*<\/p>/gi, '</p></blockquote>');
         output = output.replacingMatches(of: "<\\/blockquote>\\s*<\\/p>", with: "</p></blockquote>", options: .caseInsensitive)
 
         // Remove <p> tags that are wrapped around block tags.
-//    text = text.replace( new RegExp( '<p>\\s*(</?(?:' + blocklist + ')(?: [^>]*)?>)', 'gi' ), '$1' );
         output = output.replacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$1", options: .caseInsensitive)
-//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')(?: [^>]*)?>)\\s*</p>', 'gi' ), '$1' );
         output = output.replacingMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
-//    text = text.replace( /(<br[^>]*>)\s*\n/gi, '$1' );
         output = output.replacingMatches(of: "(<br[^>]*>)\\s*\n", with: "$1", options: .caseInsensitive)
 
         // Add <br> tags.
-//    text = text.replace( /\s*\n/g, '<br />\n');
         output = output.replacingMatches(of: "\\s*\n", with: "<br />\n")
 
         // Remove <br> tags that are around block tags.
-//    text = text.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
         output = output.replacingMatches(of: "(</?(?:" + blocklist + ")[^>]*>)\\s*<br />", with: "$1", options: .caseInsensitive)
-//    text = text.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
         output = output.replacingMatches(of: "<br \\/>(\\s*<\\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)", with: "$1", options: .caseInsensitive)
 
         // Remove <p> and <br> around captions.
-//    text = text.replace( /(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi, '[caption$1[/caption]' );
         output = output.replacingMatches(of: "(?:<p>|<br ?\\/?>)*\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*(?:<\\/p>|<br ?\\/?>)*", with: "[caption$1[/caption]", options: .caseInsensitive)
 
         // Make sure there is <p> when there is </p> inside block tags that can contain other blocks.
-//    text = text.replace( /(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\/p>/g, function( a, b, c ) {
         output = output.replacingMatches(of: "(<(?:div|th|td|form|fieldset|dd)[^>]*>)(.*?)<\\/p>", using: { (match, submatches) in
-
-//        if ( c.match( /<p( [^>]*)?>/ ) ) {
             guard submatches.count < 2 || submatches[1].matches(regex: "<p( [^>]*)?>").count == 0 else {
-//            return a;
                 return match
             }
 
-//        return b + '<p>' + c + '</p>';
             return submatches[0] + "<p>" + submatches[1] + "</p>"
         })
 
         // Restore the line breaks in <pre> and <script> tags.
         if preserveLinebreaks {
-//            text = text.replace( /<wp-line-break>/g, '\n' );
             output = output.replacingOccurrences(of: "<wp-line-break>", with: "\n")
         }
 
         // Restore the <br> tags in captions.
         if preserveBR {
-//            text = text.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
             output = output.replacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$1>")
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -12,7 +12,7 @@ class CalypsoProcessorIn: Processor {
     /// https://github.com/WordPress/WordPress/blob/4e4df0e/wp-admin/js/editor.js#L309
     /// Current as of 2017/08/08
     ///
-    func process(text: String) -> String {
+    func process(_ text: String) -> String {
         var preserveLinebreaks = false
         var preserveBR = false
         let blocklist = "table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre" +

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -15,9 +15,7 @@ class CalypsoProcessorOut: Processor {
     ///
     func process(text: String) -> String {
 
-        // if ( ! html ) {
         guard text.characters.count > 0 else {
-            // return '';
             return ""
         }
 
@@ -33,178 +31,118 @@ class CalypsoProcessorOut: Processor {
 
         var output = text
 
-        //        // Protect script and style tags.
-        //        if ( html.indexOf( '<script' ) !== -1 || html.indexOf( '<style' ) !== -1 ) {
+        // Protect script and style tags.
         if output.contains("<script") || output.contains("<style") {
-            //            html = html.replace( /<(script|style)[^>]*>[\s\S]*?<\/\1>/g, function( match ) {
             output = output.replacingMatches(of: "<(script|style)[^>]*>[\\s\\S]*?<\\/\\1>", using: { (match, _) -> String in
-                //                preserve.push( match );
                 preserve.append(match)
 
-                //                return '<wp-preserve>';
                 return preserveMarker
             })
         }
 
-        //        // Protect pre tags.
-        //        if ( html.indexOf( '<pre' ) !== -1 ) {
+        // Protect pre tags.
         if output.contains("<pre") {
-            //            preserve_linebreaks = true;
             preserveLinebreaks = true
 
-            //            html = html.replace( /<pre[^>]*>[\s\S]+?<\/pre>/g, function( a ) {
             output = output.replacingMatches(of: "<pre[^>]*>[\\s\\S]+?<\\/pre>", using: { (match, _) -> String in
-                //                a = a.replace( /<br ?\/?>(\r\n|\n)?/g, '<wp-line-break>' );
                 var string = match.replacingMatches(of: "<br ?\\/?>(\r\n|\n)?", with: lineBreakMarker)
 
-                //                a = a.replace( /<\/?p( [^>]*)?>(\r\n|\n)?/g, '<wp-line-break>' );
                 string = string.replacingMatches(of: "<\\/?p( [^>]*)?>(\r\n|\n)?", with: lineBreakMarker)
 
-                //                return a.replace( /\r?\n/g, '<wp-line-break>' );
                 return string.replacingMatches(of: "\r?\n", with: lineBreakMarker)
             })
         }
 
-        //        // Remove line breaks but keep <br> tags inside image captions.
-        //        if ( html.indexOf( '[caption' ) !== -1 ) {
+        // Remove line breaks but keep <br> tags inside image captions.
         if output.contains("[caption") {
-            //            preserve_br = true;
             preserveBr = true
 
-            //            html = html.replace( /\[caption[\s\S]+?\[\/caption\]/g, function( a ) {
             output = output.replacingMatches(of: "\\[caption[\\s\\S]+?\\[\\/caption\\]", using: { (match, _) -> String in
-                //                return a.replace( /<br([^>]*)>/g, '<wp-temp-br$1>' ).replace( /[\r\n\t]+/, '' );
                 let string = match.replacingMatches(of: "<br([^>]*)>", with: "<wp-temp-br$1>")
                 return string.replacingMatches(of: "[\r\n\t]+", with: "")
             })
         }
 
-        //                // Normalize white space characters before and after block tags.
-        //                html = html.replace( new RegExp( '\\s*</(' + blocklist1 + ')>\\s*', 'g' ), '</$1>\n' );
+        // Normalize white space characters before and after block tags.
         output = output.replacingMatches(of: "\\s*</(\(blocklist1))>\\s*", with: "</$1>\n")
-
-        //                html = html.replace( new RegExp( '\\s*<((?:' + blocklist1 + ')(?: [^>]*)?)>', 'g' ), '\n<$1>' );
         output = output.replacingMatches(of: "\\s*<((?:" + blocklist1 + ")(?: [^>]*)?)>", with: "\n<$1>")
 
-        //                // Mark </p> if it has any attributes.
-        //                html = html.replace( /(<p [^>]+>.*?)<\/p>/g, '$1</p#>' );
+        // Mark </p> if it has any attributes.
         output = output.replacingMatches(of: "(<p [^>]+>.*?)<\\/p>", with: "$1</p#>")
 
-        //                // Preserve the first <p> inside a <div>.
-        //                html = html.replace( /<div( [^>]*)?>\s*<p>/gi, '<div$1>\n\n' );
+        // Preserve the first <p> inside a <div>.
         output = output.replacingMatches(of: "<div( [^>]*)?>\\s*<p>", with: "<div$1>\n\n", options: .caseInsensitive)
 
-        //                // Remove paragraph tags.
-        //                html = html.replace( /\s*<p>/gi, '' );
+        // Remove paragraph tags.
         output = output.replacingMatches(of: "\\s*<p>", with: "", options: .caseInsensitive)
-
-        //                html = html.replace( /\s*<\/p>\s*/gi, '\n\n' );
         output = output.replacingMatches(of: "\\s*<\\/p>\\s*", with: "\n\n", options: .caseInsensitive)
 
-        //                // Normalize white space chars and remove multiple line breaks.
-        //                html = html.replace( /\n[\s\u00a0]+\n/g, '\n\n' );
+        // Normalize white space chars and remove multiple line breaks.
         output = output.replacingMatches(of: "\n[\\s\\u00a0]+\n", with: "\n\n")
 
-        //                // Replace <br> tags with line breaks.
-        //                html = html.replace( /(\s*)<br ?\/?>\s*/gi, function( match, space ) {
+        // Replace <br> tags with line breaks.
         output = output.replacingMatches(of: "(\\s*)<br ?\\/?>\\s*", options: .caseInsensitive, using: { (match, ranges) -> String in
-
-            //                if ( space && space.indexOf( '\n' ) !== -1 ) {
             if ranges.count > 0 && ranges[0].contains("\n") {
-                //                return '\n\n';
                 return "\n\n"
             }
 
-            //                return '\n';
             return "\n"
         })
 
-        //                // Fix line breaks around <div>.
-        //                html = html.replace( /\s*<div/g, '\n<div' );
+        // Fix line breaks around <div>.
         output = output.replacingMatches(of: "\\s*<div", with: "\n<div")
-
-        //                html = html.replace( /<\/div>\s*/g, '</div>\n' );
         output = output.replacingMatches(of: "<\\/div>\\s*", with: "</div>\n")
 
-        //                // Fix line breaks around caption shortcodes.
-        //                html = html.replace( /\s*\[caption([^\[]+)\[\/caption\]\s*/gi, '\n\n[caption$1[/caption]\n\n' );
+        // Fix line breaks around caption shortcodes.
         output = output.replacingMatches(of: "\\s*\\[caption([^\\[]+)\\[\\/caption\\]\\s*", with: "\n\n[caption$1[/caption]\n\n")
-
-        //                html = html.replace( /caption\]\n\n+\[caption/g, 'caption]\n\n[caption' );
         output = output.replacingMatches(of: "caption\\]\n\n+\\[caption", with: "caption]\n\n[caption")
 
-        //                // Pad block elements tags with a line break.
-        //                html = html.replace( new RegExp('\\s*<((?:' + blocklist2 + ')(?: [^>]*)?)\\s*>', 'g' ), '\n<$1>' );
+        // Pad block elements tags with a line break.
         output = output.replacingMatches(of: "\\s*<((?:" + blocklist2 + ")(?: [^>]*)?)\\s*>", with: "\n<$1>")
-
-        //                html = html.replace( new RegExp('\\s*</(' + blocklist2 + ')>\\s*', 'g' ), '</$1>\n' );
         output = output.replacingMatches(of: "\\s*</(' + blocklist2 + ')>\\s*", with: "</$1>\n")
 
-        //                // Indent <li>, <dt> and <dd> tags.
-        //                html = html.replace( /<((li|dt|dd)[^>]*)>/g, ' \t<$1>' );
+        // Indent <li>, <dt> and <dd> tags.
         output = output.replacingMatches(of: "<((li|dt|dd)[^>]*)>", with: " \t<$1>")
 
-        //                // Fix line breaks around <select> and <option>.
-        //                if ( html.indexOf( '<option' ) !== -1 ) {
+        // Fix line breaks around <select> and <option>.
         if output.contains("<option") {
-            //                html = html.replace( /\s*<option/g, '\n<option' );
             output = output.replacingMatches(of: "\\s*<option", with: "\n<option")
-
-            //                html = html.replace( /\s*<\/select>/g, '\n</select>' );
             output = output.replacingMatches(of: "\\s*<\\/select>", with: "\n</select>")
         }
 
-        //                // Pad <hr> with two line breaks.
-        //                if ( html.indexOf( '<hr' ) !== -1 ) {
+        // Pad <hr> with two line breaks.
         if output.contains("<hr") {
-            //                html = html.replace( /\s*<hr( [^>]*)?>\s*/g, '\n\n<hr$1>\n\n' );
             output = output.replacingMatches(of: "\\s*<hr( [^>]*)?>\\s*", with: "\n\n<hr$1>\n\n")
         }
 
-        //                // Remove line breaks in <object> tags.
-        //                if ( html.indexOf( '<object' ) !== -1 ) {
+        // Remove line breaks in <object> tags.
         if output.contains("<object") {
-            //                html = html.replace( /<object[\s\S]+?<\/object>/g, function( a ) {
             output = output.replacingMatches(of: "<object[\\s\\S]+?<\\/object>", using: { (match, _) -> String in
-                //                return a.replace( /[\r\n]+/g, '' );
                 return match.replacingMatches(of: "[\r\n]+", with: "")
             })
         }
 
-        //                // Unmark special paragraph closing tags.
-        //                html = html.replace( /<\/p#>/g, '</p>\n' );
+        // Unmark special paragraph closing tags.
         output = output.replacingMatches(of: "<\\/p#>", with: "</p>\n")
 
-        //                // Pad remaining <p> tags whit a line break.
-        //                html = html.replace( /\s*(<p [^>]+>[\s\S]*?<\/p>)/g, '\n$1' );
+        // Pad remaining <p> tags whit a line break.
         output = output.replacingMatches(of: "\\s*(<p [^>]+>[\\s\\S]*?<\\/p>)", with: "\n$1")
 
-        //                // Trim.
-        //                html = html.replace( /^\s+/, '' );
+        // Trim.
         output = output.replacingMatches(of: "^\\s+", with: "")
-
-        //                html = html.replace( /[\s\u00a0]+$/, '' );
         output = output.replacingMatches(of: "[\\s\\u00a0]+$", with: "")
 
-        //                if ( preserve_linebreaks ) {
         if preserveLinebreaks {
-            //                html = html.replace( /<wp-line-break>/g, '\n' );
             output = output.replacingMatches(of: lineBreakMarker, with: "\n")
         }
 
-        //                if ( preserve_br ) {
         if preserveBr {
-            //                html = html.replace( /<wp-temp-br([^>]*)>/g, '<br$1>' );
             output = output.replacingMatches(of: "<wp-temp-br([^>]*)>", with: "<br$1>")
         }
 
-        //                // Restore preserved tags.
-        //                if ( preserve.length ) {
+        // Restore preserved tags.
         if preserve.count > 0 {
-            //                html = html.replace( /<wp-preserve>/g, function() {
             output = output.replacingMatches(of: preserveMarker, using: { (_, _) -> String in
-
-                // return preserve.shift();
                 return preserve.removeFirst()
             })
         }

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -13,7 +13,7 @@ class CalypsoProcessorOut: Processor {
     /// https://github.com/WordPress/WordPress/blob/4e4df0e/wp-admin/js/editor.js#L172
     /// Current as of 2017/08/08
     ///
-    func process(text: String) -> String {
+    func process(_ text: String) -> String {
 
         guard text.characters.count > 0 else {
             return ""

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/VideoShortcodeProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/VideoShortcodeProcessor.swift
@@ -25,11 +25,10 @@ public struct VideoShortcodeProcessor {
             if let height = shortcode.attributes.named["h"] {
                 html += "height=\(height) "
             }
-            
+
             html += "/>"
-            
+
             return html
-            
         })
         return videoPressProcessor
     }

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/VideoShortcodeProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/VideoShortcodeProcessor.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Aztec
 
-public struct VideoProcessor {
+public struct VideoShortcodeProcessor {
 
     static public var videoPressScheme = "videopress"
     static public var videoPressHTMLAttribute = "data-wpvideopress"

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/VideoShortcodeProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/VideoShortcodeProcessor.swift
@@ -10,21 +10,26 @@ public struct VideoShortcodeProcessor {
     ///
     static public var videoPressPreProcessor: Processor {
         let videoPressProcessor = ShortcodeProcessor(tag:"wpvideo", replacer: { (shortcode) in
-        var html = "<video "
-        if let src = shortcode.attributes.unamed.first {
+            var html = "<video "
+
+            let src = shortcode.attributes.unamed.first ?? ""
+
             html += "src=\"\(videoPressScheme)://\(src)\" "
             html += "data-wpvideopress=\"\(src)\" "
             html += "poster=\"\(videoPressScheme)://\(src)\" "
-        }
-        if let width = shortcode.attributes.named["w"] {
-            html += "width=\(width) "
-        }
-        if let height = shortcode.attributes.named["h"] {
-            html += "height=\(height) "
-        }
 
-        html += "/>"
-        return html
+            if let width = shortcode.attributes.named["w"] {
+                html += "width=\(width) "
+            }
+
+            if let height = shortcode.attributes.named["h"] {
+                html += "height=\(height) "
+            }
+            
+            html += "/>"
+            
+            return html
+            
         })
         return videoPressProcessor
     }

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/WordPressProcessors.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/WordPressProcessors.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+class WordPressProcessors {
+    
+}

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/WordPressProcessors.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/WordPressProcessors.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-class WordPressProcessors {
-    
-}

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -637,12 +637,12 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func registerHTMLProcessors() {
-        htmlPreProcessors.append(VideoProcessor.videoPressPreProcessor)
-        htmlPreProcessors.append(VideoProcessor.wordPressVideoPreProcessor)
+        htmlPreProcessors.append(VideoShortcodeProcessor.videoPressPreProcessor)
+        htmlPreProcessors.append(VideoShortcodeProcessor.wordPressVideoPreProcessor)
         htmlPreProcessors.append(CalypsoProcessorIn())
 
-        htmlPostProcessors.append(VideoProcessor.videoPressPostProcessor)
-        htmlPostProcessors.append(VideoProcessor.wordPressVideoPostProcessor)
+        htmlPostProcessors.append(VideoShortcodeProcessor.videoPressPostProcessor)
+        htmlPostProcessors.append(VideoShortcodeProcessor.wordPressVideoPostProcessor)
         htmlPostProcessors.append(CalypsoProcessorOut())
     }
 
@@ -2494,7 +2494,7 @@ extension AztecPostViewController {
         richTextView.textStorage.enumerateAttachments { (attachment, range) in
             if let videoAttachment = attachment as? VideoAttachment,
                let videoSrcURL = videoAttachment.srcURL,
-               videoSrcURL.scheme == VideoProcessor.videoPressScheme,
+               videoSrcURL.scheme == VideoShortcodeProcessor.videoPressScheme,
                let videoPressID = videoSrcURL.host {
                 // It's videoPress video so let's fetch the information for the video
                 let mediaService = MediaService(managedObjectContext:ContextManager.sharedInstance().mainContext)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -36,12 +36,12 @@ class AztecPostViewController: UIViewController, PostEditor {
     fileprivate(set) lazy var richTextView: Aztec.TextView = {
         let textView = Aztec.TextView(defaultFont: Fonts.regular, defaultMissingImage: Assets.defaultMissingImage)
 
-        textView.preProcessors =
+        textView.inputProcessor =
             PipelineProcessor([VideoShortcodeProcessor.videoPressPreProcessor,
                                VideoShortcodeProcessor.wordPressVideoPreProcessor,
                                CalypsoProcessorIn()])
 
-        textView.postProcessors =
+        textView.outputProcessor =
             PipelineProcessor([VideoShortcodeProcessor.videoPressPostProcessor,
                                VideoShortcodeProcessor.wordPressVideoPostProcessor,
                                CalypsoProcessorOut()])

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -915,7 +915,6 @@
 		F1049F331F39FCF9004DF0BB /* CalypsoProcessorOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */; };
 		F128C31C1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */; };
 		F1564E5B18946087009F8F97 /* NSStringHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */; };
-		F16D40BD1F4DB9D3006681BB /* WordPressProcessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16D40BC1F4DB9D3006681BB /* WordPressProcessors.swift */; };
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
@@ -2342,7 +2341,6 @@
 		F128C31A1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPNavigationMediaPickerViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
 		F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WPNavigationMediaPickerViewController+StatusBarStyle.m"; sourceTree = "<group>"; };
 		F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringHelpersTests.m; sourceTree = "<group>"; };
-		F16D40BC1F4DB9D3006681BB /* WordPressProcessors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressProcessors.swift; sourceTree = "<group>"; };
 		FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Themes.swift"; sourceTree = "<group>"; };
 		FA2D12891BCED0AD006F2A15 /* WordPress 40.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 40.xcdatamodel"; sourceTree = "<group>"; };
 		FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementService.swift; sourceTree = "<group>"; };
@@ -3879,7 +3877,6 @@
 				B50C0C551EF42A0000372C65 /* VideoShortcodeProcessor.swift */,
 				B5032DDC1F02B30B00D946DC /* CalypsoProcessorIn.swift */,
 				F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */,
-				F16D40BC1F4DB9D3006681BB /* WordPressProcessors.swift */,
 			);
 			path = Processors;
 			sourceTree = "<group>";
@@ -6456,7 +6453,6 @@
 				43D54D131DCAA070007F575F /* PostPostViewController.swift in Sources */,
 				B54E1DF41A0A7BBF00807537 /* NotificationMediaDownloader.swift in Sources */,
 				178EDE701C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift in Sources */,
-				F16D40BD1F4DB9D3006681BB /* WordPressProcessors.swift in Sources */,
 				E174F6E6172A73960004F23A /* WPAccount.m in Sources */,
 				E1718EA01CAD0800006F9E2D /* HockeyManager.m in Sources */,
 				FF619DD51C75246900903B65 /* CLPlacemark+Formatting.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -473,7 +473,7 @@
 		B50C0C511EF429E900372C65 /* HTMLAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C4E1EF429E900372C65 /* HTMLAttachmentRenderer.swift */; };
 		B50C0C521EF429E900372C65 /* MoreAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C4F1EF429E900372C65 /* MoreAttachmentRenderer.swift */; };
 		B50C0C561EF42A0000372C65 /* ShortcodeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C541EF42A0000372C65 /* ShortcodeProcessor.swift */; };
-		B50C0C571EF42A0000372C65 /* VideoProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C551EF42A0000372C65 /* VideoProcessor.swift */; };
+		B50C0C571EF42A0000372C65 /* VideoShortcodeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C551EF42A0000372C65 /* VideoShortcodeProcessor.swift */; };
 		B50C0C5A1EF42A2600372C65 /* MediaProgressCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C591EF42A2600372C65 /* MediaProgressCoordinator.swift */; };
 		B50C0C5E1EF42A4A00372C65 /* AztecAttachmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C5C1EF42A4A00372C65 /* AztecAttachmentViewController.swift */; };
 		B50C0C5F1EF42A4A00372C65 /* AztecPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C5D1EF42A4A00372C65 /* AztecPostViewController.swift */; };
@@ -915,6 +915,7 @@
 		F1049F331F39FCF9004DF0BB /* CalypsoProcessorOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */; };
 		F128C31C1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */; };
 		F1564E5B18946087009F8F97 /* NSStringHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */; };
+		F16D40BD1F4DB9D3006681BB /* WordPressProcessors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16D40BC1F4DB9D3006681BB /* WordPressProcessors.swift */; };
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
@@ -1749,7 +1750,7 @@
 		B50C0C4E1EF429E900372C65 /* HTMLAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B50C0C4F1EF429E900372C65 /* MoreAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoreAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B50C0C541EF42A0000372C65 /* ShortcodeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcodeProcessor.swift; sourceTree = "<group>"; };
-		B50C0C551EF42A0000372C65 /* VideoProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoProcessor.swift; sourceTree = "<group>"; };
+		B50C0C551EF42A0000372C65 /* VideoShortcodeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoShortcodeProcessor.swift; sourceTree = "<group>"; };
 		B50C0C591EF42A2600372C65 /* MediaProgressCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaProgressCoordinator.swift; sourceTree = "<group>"; };
 		B50C0C5C1EF42A4A00372C65 /* AztecAttachmentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecAttachmentViewController.swift; sourceTree = "<group>"; };
 		B50C0C5D1EF42A4A00372C65 /* AztecPostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AztecPostViewController.swift; sourceTree = "<group>"; };
@@ -2341,6 +2342,7 @@
 		F128C31A1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPNavigationMediaPickerViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
 		F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WPNavigationMediaPickerViewController+StatusBarStyle.m"; sourceTree = "<group>"; };
 		F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringHelpersTests.m; sourceTree = "<group>"; };
+		F16D40BC1F4DB9D3006681BB /* WordPressProcessors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressProcessors.swift; sourceTree = "<group>"; };
 		FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Themes.swift"; sourceTree = "<group>"; };
 		FA2D12891BCED0AD006F2A15 /* WordPress 40.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 40.xcdatamodel"; sourceTree = "<group>"; };
 		FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementService.swift; sourceTree = "<group>"; };
@@ -3874,9 +3876,10 @@
 			isa = PBXGroup;
 			children = (
 				B50C0C541EF42A0000372C65 /* ShortcodeProcessor.swift */,
-				B50C0C551EF42A0000372C65 /* VideoProcessor.swift */,
+				B50C0C551EF42A0000372C65 /* VideoShortcodeProcessor.swift */,
 				B5032DDC1F02B30B00D946DC /* CalypsoProcessorIn.swift */,
 				F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */,
+				F16D40BC1F4DB9D3006681BB /* WordPressProcessors.swift */,
 			);
 			path = Processors;
 			sourceTree = "<group>";
@@ -6050,7 +6053,7 @@
 				FF54D4641D6F3FA900A0DC4D /* EditorSettings.swift in Sources */,
 				17D1C22D1EFB16C10076734A /* FancyAlertViewController.swift in Sources */,
 				E6D2E16C1B8B423B0000ED14 /* ReaderStreamHeader.swift in Sources */,
-				B50C0C571EF42A0000372C65 /* VideoProcessor.swift in Sources */,
+				B50C0C571EF42A0000372C65 /* VideoShortcodeProcessor.swift in Sources */,
 				B5F641B31E37C36700B7819F /* AdaptiveNavigationController.swift in Sources */,
 				080AAA691E7C63C3004DCD11 /* Media+HTML.m in Sources */,
 				E60646801CB3133000A3073F /* SigninEditingState.swift in Sources */,
@@ -6453,6 +6456,7 @@
 				43D54D131DCAA070007F575F /* PostPostViewController.swift in Sources */,
 				B54E1DF41A0A7BBF00807537 /* NotificationMediaDownloader.swift in Sources */,
 				178EDE701C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift in Sources */,
+				F16D40BD1F4DB9D3006681BB /* WordPressProcessors.swift in Sources */,
 				E174F6E6172A73960004F23A /* WPAccount.m in Sources */,
 				E1718EA01CAD0800006F9E2D /* HockeyManager.m in Sources */,
 				FF619DD51C75246900903B65 /* CLPlacemark+Formatting.swift in Sources */,

--- a/WordPress/WordPressTest/Aztec/CalypsoProcessorInTests.swift
+++ b/WordPress/WordPressTest/Aztec/CalypsoProcessorInTests.swift
@@ -13,7 +13,7 @@ class CalypsoProcessorInTests: XCTestCase {
     func testNewlinesAreConvertedIntoBreakElements() {
         let input = "\nNewline \n Another \n New \n Line \n Here"
         let expected = "<p>\nNewline<br />\n Another<br />\n New<br />\n Line<br />\n Here</p>\n"
-        let output = processor.process(text: input)
+        let output = processor.process(input)
 
         XCTAssertEqual(output, expected)
     }
@@ -23,7 +23,7 @@ class CalypsoProcessorInTests: XCTestCase {
     func testParagraphsAreConvertedIntoParagraphElements() {
         let input = "First paragraph\n Newline \n\nSecond Paragraph\n Newline \n Another line \n\n Third Paragraph"
         let expected = "<p>First paragraph<br />\n Newline </p>\n<p>Second Paragraph<br />\n Newline<br />\n Another line </p>\n<p> Third Paragraph</p>\n"
-        let output = processor.process(text: input)
+        let output = processor.process(input)
 
         XCTAssertEqual(output, expected)
     }
@@ -33,7 +33,7 @@ class CalypsoProcessorInTests: XCTestCase {
     func testPreformattedTextIsEffectivelyPreserved() {
         let input = "<pre class='123'>Something\nHere\n\nAnd\nHere</pre>"
         let expected = "<pre class=\'123\'>Something\nHere\n\nAnd\nHere</pre>\n"
-        let output = processor.process(text: input)
+        let output = processor.process(input)
 
         XCTAssertEqual(output, expected)
     }
@@ -44,7 +44,7 @@ class CalypsoProcessorInTests: XCTestCase {
         let pre = "<pre class='123'>Something\nHere\n\nAnd\nHere</pre>"
         let input = pre + " LALALA \n LALA \n\n LA"
         let expected = pre + "\n<p> LALALA<br />\n LALA </p>\n<p> LA</p>\n"
-        let output = processor.process(text: input)
+        let output = processor.process(input)
 
         XCTAssertEqual(output, expected)
     }
@@ -54,7 +54,7 @@ class CalypsoProcessorInTests: XCTestCase {
     func testMultiplePreformattedElementsAreLeftUntouched() {
         let input = "<pre>First\n\nSecond</pre><pre>Third\nFourth</pre><pre>Fifth\n\nSixth\n</pre>"
         let expected = "<pre>First\n\nSecond</pre>\n<pre>Third\nFourth</pre>\n<pre>Fifth\n\nSixth\n</pre>\n"
-        let output = processor.process(text: input)
+        let output = processor.process(input)
 
         XCTAssertEqual(output, expected)
     }
@@ -64,7 +64,7 @@ class CalypsoProcessorInTests: XCTestCase {
     func testOrderedListsWithNestedEntitiesAreLeftUntouched() {
         let input = "<ol>\n<li>hello\nbye</li>\n<li><ol><li>WAT\nWAT</li></ol></li></ol>"
         let expected = "<ol>\n<li>hello<br />\nbye</li>\n<li>\n<ol>\n<li>WAT<br />\nWAT</li>\n</ol>\n</li>\n</ol>\n"
-        let output = processor.process(text: input)
+        let output = processor.process(input)
 
         XCTAssertEqual(output, expected)
     }
@@ -74,7 +74,7 @@ class CalypsoProcessorInTests: XCTestCase {
     func testUnorderedListsWithNestedEntitiesAreLeftUntouched() {
         let input = "<ul>\n<li>hello\nbye</li>\n<li><ul><li>WAT\nWAT</li></ul></li></ul>"
         let expected = "<ul>\n<li>hello<br />\nbye</li>\n<li>\n<ul>\n<li>WAT<br />\nWAT</li>\n</ul>\n</li>\n</ul>\n"
-        let output = processor.process(text: input)
+        let output = processor.process(input)
 
         XCTAssertEqual(output, expected)
     }
@@ -93,7 +93,7 @@ class CalypsoProcessorInTests: XCTestCase {
             "<PRE>\n</PRE>\n<p>testing</p>\n" +
             "<OL>\n<LI>ORDERED\n</LI>\n</OL>\n"
 
-        let output = processor.process(text: input)
+        let output = processor.process(input)
         XCTAssertEqual(output, expected)
     }
 }

--- a/WordPress/WordPressTest/Aztec/VideoProcessorTests.swift
+++ b/WordPress/WordPressTest/Aztec/VideoProcessorTests.swift
@@ -12,30 +12,30 @@ class VideoProcessorTests: XCTestCase {
     }
 
     func testVideoPressPreProcessor() {
-        let shortcodeProcessor = VideoProcessor.videoPressPreProcessor
+        let shortcodeProcessor = VideoShortcodeProcessor.videoPressPreProcessor
         let sampleText = "Before Text[wpvideo OcobLTqC w=640 h=400 autoplay=true html5only=true] After Text"
-        let parsedText = shortcodeProcessor.process(text: sampleText)
+        let parsedText = shortcodeProcessor.process(sampleText)
         XCTAssertEqual(parsedText, "Before Text<video src=\"videopress://OcobLTqC\" data-wpvideopress=\"OcobLTqC\" poster=\"videopress://OcobLTqC\" width=640 height=400 /> After Text")
     }
 
     func testWordPressPreProcessor() {
-        let shortcodeProcessor = VideoProcessor.wordPressVideoPreProcessor
+        let shortcodeProcessor = VideoShortcodeProcessor.wordPressVideoPreProcessor
         let sampleText = "[video src=\"video-source.mp4\"]"
-        let parsedText = shortcodeProcessor.process(text: sampleText)
+        let parsedText = shortcodeProcessor.process(sampleText)
         XCTAssertEqual(parsedText, "<video src=\"video-source.mp4\" />")
     }
 
     func testVideoPressPostProcessor() {
-        let shortcodeProcessor = VideoProcessor.videoPressPostProcessor
+        let shortcodeProcessor = VideoShortcodeProcessor.videoPressPostProcessor
         let sampleText = "Before Text<video src=\"videopress://OcobLTqC\" data-wpvideopress=\"OcobLTqC\" width=640 height=400 /> After Text<video src=\"video-source.mp4\" />"
-        let parsedText = shortcodeProcessor.process(text: sampleText)
+        let parsedText = shortcodeProcessor.process(sampleText)
         XCTAssertEqual(parsedText, "Before Text[wpvideo OcobLTqC w=640 h=400 ] After Text<video src=\"video-source.mp4\" />")
     }
 
     func testWordPressPostProcessor() {
-        let shortcodeProcessor = VideoProcessor.wordPressVideoPostProcessor
+        let shortcodeProcessor = VideoShortcodeProcessor.wordPressVideoPostProcessor
         let sampleText = "<video src=\"video-source.mp4\" />"
-        let parsedText = shortcodeProcessor.process(text: sampleText)
+        let parsedText = shortcodeProcessor.process(sampleText)
         XCTAssertEqual(parsedText, "[video src=\"video-source.mp4\" ]")
     }
 


### PR DESCRIPTION
This PR:

- Integrates Aztec changes from https://github.com/wordpress-mobile/AztecEditor-iOS/pull/705.
- Adds a processor for `[caption]` shortcodes moving [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/7715) forward.  Still needs improvements in format coloring and alignment.
- Removes some old comments from the code.
- Fixes an issue that was converting certain `[wpvideo]` captions without a URL into `[video]` captions.

**How to test:**

Test that shortcodes still work fine.
Try with `[video]`, `[wpvideo]` and `[caption]`.

To avoid de-synchornization issues between Aztec's `develop` branch and WPiOS's `develop` branch, this will be merged simultaneously with the PR mentioned above.