### PR TITLE
AztecPostViewController: Unsaved Changes Cleanup

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -887,23 +887,29 @@ extension AztecPostViewController {
     }
 
     func showPostHasChangesAlert() {
-        let alertController = UIAlertController(title: UnsavedChangesAlert.title, message: nil, preferredStyle: .actionSheet)
+        let title = NSLocalizedString("You have unsaved changes.", comment: "Title of message with options that shown when there are unsaved changes and the author is trying to move away from the post.")
+        let cancelTitle = NSLocalizedString("Keep Editing", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
+        let saveTitle = NSLocalizedString("Save Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
+        let updateTitle = NSLocalizedString("Update Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from an already published/saved post.")
+        let discardTitle = NSLocalizedString("Discard", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
+
+        let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
 
         // Button: Keep editing
-        alertController.addCancelActionWithTitle(UnsavedChangesAlert.cancelTitle)
+        alertController.addCancelActionWithTitle(cancelTitle)
 
         // Button: Save Draft/Update Draft
         if post.hasLocalChanges() {
             if !post.hasRemote() {
                 // The post is a local draft or an autosaved draft: Discard or Save
-                alertController.addDefaultActionWithTitle(UnsavedChangesAlert.saveTitle) { _ in
+                alertController.addDefaultActionWithTitle(saveTitle) { _ in
                     self.post.status = .draft
                     self.trackPostSave(stat: self.postEditorStateContext.publishActionAnalyticsStat)
                     self.publishTapped(dismissWhenDone: true)
                 }
             } else if post.status == .draft {
                 // The post was already a draft
-                alertController.addDefaultActionWithTitle(UnsavedChangesAlert.updateTitle) { _ in
+                alertController.addDefaultActionWithTitle(updateTitle) { _ in
                     self.trackPostSave(stat: self.postEditorStateContext.publishActionAnalyticsStat)
                     self.publishTapped(dismissWhenDone: true)
                 }
@@ -911,7 +917,7 @@ extension AztecPostViewController {
         }
 
         // Button: Discard
-        alertController.addDestructiveActionWithTitle(UnsavedChangesAlert.discardTitle) { _ in
+        alertController.addDestructiveActionWithTitle(discardTitle) { _ in
             self.discardChangesAndUpdateGUI()
         }
 
@@ -3173,13 +3179,5 @@ extension AztecPostViewController {
         static let message = NSLocalizedString("You are currently uploading media. This action will cancel uploads in progress.\n\nAre you sure?", comment: "This prompt is displayed when the user attempts to stop media uploads in the post editor.")
         static let acceptTitle  = NSLocalizedString("Yes", comment: "Yes")
         static let cancelTitle  = NSLocalizedString("Not Now", comment: "Nicer dialog answer for \"No\".")
-    }
-
-    struct UnsavedChangesAlert {
-        static let title = NSLocalizedString("You have unsaved changes.", comment: "Title of message with options that shown when there are unsaved changes and the author is trying to move away from the post.")
-        static let cancelTitle = NSLocalizedString("Keep Editing", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
-        static let saveTitle = NSLocalizedString("Save Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
-        static let updateTitle = NSLocalizedString("Update Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from an already published/saved post.")
-        static let discardTitle = NSLocalizedString("Discard", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -887,26 +887,23 @@ extension AztecPostViewController {
     }
 
     func showPostHasChangesAlert() {
-        let alertController = UIAlertController(
-            title: NSLocalizedString("You have unsaved changes.", comment: "Title of message with options that shown when there are unsaved changes and the author is trying to move away from the post."),
-            message: nil,
-            preferredStyle: .actionSheet)
+        let alertController = UIAlertController(title: UnsavedChangesAlert.title, message: nil, preferredStyle: .actionSheet)
 
         // Button: Keep editing
-        alertController.addCancelActionWithTitle(NSLocalizedString("Keep Editing", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post."))
+        alertController.addCancelActionWithTitle(UnsavedChangesAlert.cancelTitle)
 
         // Button: Save Draft/Update Draft
         if post.hasLocalChanges() {
             if !post.hasRemote() {
                 // The post is a local draft or an autosaved draft: Discard or Save
-                alertController.addDefaultActionWithTitle(NSLocalizedString("Save Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")) { _ in
+                alertController.addDefaultActionWithTitle(UnsavedChangesAlert.saveTitle) { _ in
                     self.post.status = .draft
                     self.trackPostSave(stat: self.postEditorStateContext.publishActionAnalyticsStat)
                     self.publishTapped(dismissWhenDone: true)
                 }
             } else if post.status == .draft {
                 // The post was already a draft
-                alertController.addDefaultActionWithTitle(NSLocalizedString("Update Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from an already published/saved post.")) { _ in
+                alertController.addDefaultActionWithTitle(UnsavedChangesAlert.updateTitle) { _ in
                     self.trackPostSave(stat: self.postEditorStateContext.publishActionAnalyticsStat)
                     self.publishTapped(dismissWhenDone: true)
                 }
@@ -914,7 +911,7 @@ extension AztecPostViewController {
         }
 
         // Button: Discard
-        alertController.addDestructiveActionWithTitle(NSLocalizedString("Discard", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")) { _ in
+        alertController.addDestructiveActionWithTitle(UnsavedChangesAlert.discardTitle) { _ in
             self.discardChangesAndUpdateGUI()
         }
 
@@ -3176,5 +3173,13 @@ extension AztecPostViewController {
         static let message = NSLocalizedString("You are currently uploading media. This action will cancel uploads in progress.\n\nAre you sure?", comment: "This prompt is displayed when the user attempts to stop media uploads in the post editor.")
         static let acceptTitle  = NSLocalizedString("Yes", comment: "Yes")
         static let cancelTitle  = NSLocalizedString("Not Now", comment: "Nicer dialog answer for \"No\".")
+    }
+
+    struct UnsavedChangesAlert {
+        static let title = NSLocalizedString("You have unsaved changes.", comment: "Title of message with options that shown when there are unsaved changes and the author is trying to move away from the post.")
+        static let cancelTitle = NSLocalizedString("Keep Editing", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
+        static let saveTitle = NSLocalizedString("Save Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
+        static let updateTitle = NSLocalizedString("Update Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from an already published/saved post.")
+        static let discardTitle = NSLocalizedString("Discard", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
     }
 }


### PR DESCRIPTION
### Details:
Minor cleanup PR: moving Strings to constants!

### To test:
1. Edit a new Post, and type something, so that it's not empty
2. Press the top left `x` button
3. Verify that `Save`/ `Updated` / `Discard` / `Keep Editing`  work as expected

Needs review: @diegoreymendez 
