### PR TITLE
Media: Hide group selector for media library

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1753,7 +1753,7 @@ extension AztecPostViewController {
         case .device:
             picker.dataSource = devicePhotoLibraryDataSource
         case .mediaLibrary:
-            picker.startOnGroupSelector = false
+            picker.showGroupSelector = false
             picker.dataSource = mediaLibraryDataSource
         }
 


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/MediaPicker-iOS/issues/210

This PR updates the Media Library item on the new inline media picker's toolbar to bypass the group selector.

To test:

* Open Aztec
* Tap the + button
* Tap the (W) Media Library button
* Ensure that you're shown the full list of media library thumbnails, and that the left navigation button says Cancel, not Back.

Needs review: @SergioEstevao 