### PR TITLE
Aztec: Fixing Undo for Image Updates

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -3,11 +3,6 @@ import UIKit
 import WordPressShared
 import Aztec
 
-protocol AztecAttachmentViewControllerDelegate: class {
-
-    func aztecAttachmentViewController(_ viewController: AztecAttachmentViewController, changedAttachment: ImageAttachment)
-
-}
 
 class AztecAttachmentViewController: UITableViewController {
 
@@ -23,9 +18,10 @@ class AztecAttachmentViewController: UITableViewController {
     var alignment = ImageAttachment.Alignment.none
     var size = ImageAttachment.Size.full
 
+    var onUpdate: ((ImageAttachment.Alignment, ImageAttachment.Size) -> Void)?
+
     fileprivate var handler: ImmuTableViewHandler!
 
-    weak var delegate: AztecAttachmentViewControllerDelegate?
 
     // MARK: - Initialization
 
@@ -167,11 +163,7 @@ class AztecAttachmentViewController: UITableViewController {
     }
 
     func handleDoneButtonTapped(sender: UIBarButtonItem) {
-        if let attachment = self.attachment {
-            attachment.alignment = alignment
-            attachment.size = size
-            delegate?.aztecAttachmentViewController(self, changedAttachment: attachment)
-        }
+        onUpdate?(alignment, size)
         dismiss(animated: true, completion: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2776,8 +2776,14 @@ extension AztecPostViewController {
 
     func displayDetails(forAttachment attachment: ImageAttachment) {
         let controller = AztecAttachmentViewController()
-        controller.delegate = self
         controller.attachment = attachment
+        controller.onUpdate = { [weak self] (alignment, size) in
+            self?.richTextView.edit(attachment) { updated in
+                updated.alignment = alignment
+                updated.size = size
+            }
+        }
+
         let navController = UINavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .formSheet
         present(navController, animated: true, completion: nil)
@@ -2808,20 +2814,6 @@ extension AztecPostViewController {
             return Gridicon.iconOfType(.video, withSize: imageSize)
         default:
             return Gridicon.iconOfType(.attachment, withSize: imageSize)
-        }
-    }
-}
-
-
-// AztecAttachmentViewController Delegate Conformance
-//
-extension AztecPostViewController: AztecAttachmentViewControllerDelegate {
-
-    func aztecAttachmentViewController(_ viewController: AztecAttachmentViewController, changedAttachment: ImageAttachment) {
-        richTextView.edit(changedAttachment) { attachment in
-            attachment.alignment = changedAttachment.alignment
-            attachment.size = changedAttachment.size
-            attachment.updateURL(changedAttachment.url)
         }
     }
 }


### PR DESCRIPTION
### Details:
In this PR we're fixing a regression we had in the Undo Mechanism, that affected, precisely, Image edits.

Fixes #7729

### To test:
1. Open a post for editing.
2. Insert an image.
3. Tap the image, tap again for options, select "Details."
4. Make changes to the web display settings for the image and tap "Done."
5. Shake the device to see undo options and revert the last change

As a result, the Image Edits should be undone.

Needs review: @diegoreymendez 
