### PR TITLE
New media picker: open up feature flag for internal testers

### DIFF
--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -15,13 +15,10 @@ enum FeatureFlag: Int {
         case .newMediaExports:
             return build(.localDeveloper, .a8cBranchTest)
         case .newInputMediaPicker:
-            if build(.a8cBranchTest, .localDeveloper) {
-                return true
-            }
+            return build(.a8cPrereleaseTesting, .a8cBranchTest, .localDeveloper)
         case .pluginManagement:
             return build(.localDeveloper)
         }
-        return false
     }
 }
 


### PR DESCRIPTION
This PR opens up the new media picker for all internal testers.

We'll merge after https://github.com/wordpress-mobile/WordPress-iOS/pull/7727 is merged.

Needs review: @SergioEstevao 