### PR TITLE
Removing Aztec Beta References

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -245,7 +245,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         button.translatesAutoresizingMaskIntoConstraints = false
         WPStyleGuide.configureBetaButton(button)
 
-        button.setTitle(NSLocalizedString("Beta", comment: "Title for Beta tag button for the new Aztec editor"), for: .normal)
+        button.setTitle(NSLocalizedString("Feedback", comment: "Title for Feedback button for the new Aztec editor"), for: .normal)
         button.setContentHuggingPriority(UILayoutPriorityRequired, for: .horizontal)
         button.isEnabled = true
         button.addTarget(self, action: #selector(betaButtonTapped), for: .touchUpInside)

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -109,7 +109,7 @@ class AppSettingsViewController: UITableViewController {
         editorRows.append(visualEditor)
 
         let nativeEditor = CheckmarkRow(
-            title: NSLocalizedString("Beta", comment: "Option to enable the beta native editor (Aztec)"),
+            title: NSLocalizedString("Visual 2.0", comment: "Option to enable the beta native editor (Aztec)"),
             checked: (editor == .aztec),
             action: visualEditorChanged(editor: .aztec)
         )
@@ -453,7 +453,7 @@ fileprivate class AppSettingsEditorFooterView: UITableViewHeaderFooterView {
 
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .footnote)
-        label.text = NSLocalizedString("Editor beta release notes & bug reporting", comment: "Label for button linking to release notes and bug reporting help for the new beta Aztec editor")
+        label.text = NSLocalizedString("Editor release notes & bug reporting", comment: "Label for button linking to release notes and bug reporting help for the new beta Aztec editor")
         label.textColor = WPStyleGuide.greyDarken10()
         stackView.addArrangedSubview(label)
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -114,7 +114,7 @@ extension FancyAlertViewController {
     // Shown to users of the app who already have Aztec enabled
     static func existingTesterAztecAnnouncementController() -> FancyAlertViewController {
         struct Strings {
-            static let titleText = NSLocalizedString("New Editor in Public Beta!", comment: "Title of alert prompting users to try the new Aztec editor")
+            static let titleText = NSLocalizedString("New Editor!", comment: "Title of alert prompting users to try the new Aztec editor")
             static let bodyText = NSLocalizedString("The WordPress app's beautiful new editor is now in public beta. It looks like you already have it enabled, so you're all set!", comment: "Body text of alert informing existing testers that the new Aztec editor is now in public beta")
             static let whatsNew = NSLocalizedString("What's new?", comment: "Title of more info button on alert prompting users to try the new Aztec editor")
         }

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -37,7 +37,6 @@ extension FancyAlertViewController {
             static let tryIt = NSLocalizedString("Try It", comment: "Title of the primary button on alert prompting users to try the new Aztec editor")
             static let notNow = NSLocalizedString("Not Now", comment: "Title of the cancel button on alert prompting users to try the new Aztec editor")
             static let whatsNew = NSLocalizedString("What's new?", comment: "Title of more info button on alert prompting users to try the new Aztec editor")
-            static let beta = NSLocalizedString("Beta", comment: "Used to indicate a feature of the app currently in beta testing.")
         }
 
         typealias Button = FancyAlertViewController.Config.ButtonConfig
@@ -97,11 +96,6 @@ extension FancyAlertViewController {
             WPWebViewController.presentWhatsNewWebView(from: controller)
         })
 
-        let titleAccessoryButton = Button(Strings.beta, { controller in
-            WPAppAnalytics.track(.editorAztecBetaLink)
-            WPWebViewController.presentWhatsNewWebView(from: controller)
-        })
-
         let image = UIImage(named: "wp-illustration-hand-write")
 
         let config = FancyAlertViewController.Config(titleText: Strings.titleText,
@@ -111,7 +105,7 @@ extension FancyAlertViewController {
                                                      defaultButton: defaultButton,
                                                      cancelButton: cancelButton,
                                                      moreInfoButton: moreInfoButton,
-                                                     titleAccessoryButton: titleAccessoryButton,
+                                                     titleAccessoryButton: nil,
                                                      dismissAction: nil)
 
         return FancyAlertViewController.controllerWithConfiguration(configuration: config)
@@ -123,18 +117,12 @@ extension FancyAlertViewController {
             static let titleText = NSLocalizedString("New Editor in Public Beta!", comment: "Title of alert prompting users to try the new Aztec editor")
             static let bodyText = NSLocalizedString("The WordPress app's beautiful new editor is now in public beta. It looks like you already have it enabled, so you're all set!", comment: "Body text of alert informing existing testers that the new Aztec editor is now in public beta")
             static let whatsNew = NSLocalizedString("What's new?", comment: "Title of more info button on alert prompting users to try the new Aztec editor")
-            static let beta = NSLocalizedString("Beta", comment: "Used to indicate a feature of the app currently in beta testing.")
         }
 
         typealias Button = FancyAlertViewController.Config.ButtonConfig
 
         let moreInfoButton = Button(Strings.whatsNew, { controller in
             WPAppAnalytics.track(.editorAztecPromoLink)
-            WPWebViewController.presentWhatsNewWebView(from: controller)
-        })
-
-        let titleAccessoryButton = Button(Strings.beta, { controller in
-            WPAppAnalytics.track(.editorAztecBetaLink)
             WPWebViewController.presentWhatsNewWebView(from: controller)
         })
 
@@ -146,7 +134,7 @@ extension FancyAlertViewController {
                                                      dividerPosition: .bottom,
                                                      defaultButton: nil,
                                                      cancelButton: nil,
-                                                     moreInfoButton: moreInfoButton, titleAccessoryButton: titleAccessoryButton, dismissAction: nil)
+                                                     moreInfoButton: moreInfoButton, titleAccessoryButton: nil, dismissAction: nil)
 
         return FancyAlertViewController.controllerWithConfiguration(configuration: config)
     }
@@ -156,7 +144,6 @@ extension FancyAlertViewController {
             static let titleText = NSLocalizedString("New Editor Enabled!", comment: "Title of alert informing users that the new Aztec editor has been enabled")
             static let bodyText = NSLocalizedString("Thanks for trying it out! You can switch editor modes at any time in", comment: "Body text of alert informing users that the new Aztec editor has been enabled")
             static let appSettings = NSLocalizedString("Me > App Settings", comment: "Text for button telling user where to find the App Settings section of the app")
-            static let beta = NSLocalizedString("Beta", comment: "Used to indicate a feature of the app currently in beta testing.")
         }
 
         typealias Button = FancyAlertViewController.Config.ButtonConfig
@@ -167,18 +154,13 @@ extension FancyAlertViewController {
             })
         })
 
-        let titleAccessoryButton = Button(Strings.beta, { controller in
-            WPAppAnalytics.track(.editorAztecBetaLink)
-            WPWebViewController.presentWhatsNewWebView(from: controller)
-        })
-
         let image = UIImage(named: "wp-illustration-thank-you")
 
         return FancyAlertViewController.Config(titleText: Strings.titleText,
                                                bodyText: Strings.bodyText,
                                                headerImage: image,
                                                dividerPosition: .bottom,
-                                               defaultButton: nil, cancelButton: nil, moreInfoButton: moreInfoButton, titleAccessoryButton: titleAccessoryButton,
+                                               defaultButton: nil, cancelButton: nil, moreInfoButton: moreInfoButton, titleAccessoryButton: nil,
                                                dismissAction: {
                                                 WPTabBarController.sharedInstance().showPostTab(animated: true, toMedia: false)
         })


### PR DESCRIPTION
### Details:
Fixes #7734

### To test:
1. Perform a fresh install
2. Log into your dotcom account
3. Verify that the Aztec popup looks as expected
4. Switch to App Settings. Verify that the Aztec option looks as expected
5. Launch Aztec. Verify that the `Beta` button now reads `Feedback`.

Needs review: @elibud 
Thanks in advance!
