### PR TITLE
AztecPostViewController: No longer dismissing upon draft update

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -866,7 +866,7 @@ extension AztecPostViewController {
     @IBAction func publishButtonTapped(sender: UIBarButtonItem) {
         trackPostSave(stat: postEditorStateContext.publishActionAnalyticsStat)
 
-        publishTapped(dismissWhenDone: true)
+        publishTapped(dismissWhenDone: postEditorStateContext.publishActionDismissesEditor)
     }
 
     @IBAction func secondaryPublishButtonTapped(dismissWhenDone: Bool = true) {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -283,8 +283,15 @@ public class PostEditorStateContext {
     }
 
     /// Returns the WPAnalyticsStat enum to be tracked when this post is published
+    ///
     var publishActionAnalyticsStat: WPAnalyticsStat {
         return editorState.action.publishActionAnalyticsStat
+    }
+
+    /// Indicates if the editor should be dismissed whenever the Publish Action is executed
+    ///
+    var publishActionDismissesEditor: Bool {
+        return editorState.action != .update
     }
 
     /// Should post-post be shown for the current editor when publishing has happened

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -288,7 +288,7 @@ public class PostEditorStateContext {
         return editorState.action.publishActionAnalyticsStat
     }
 
-    /// Indicates if the editor should be dismissed whenever the Publish Action is executed
+    /// Indicates if the editor should be dismissed when the publish button is tapped
     ///
     var publishActionDismissesEditor: Bool {
         return editorState.action != .update


### PR DESCRIPTION
Fixes #7441

### To test:
1. Launch WPiOS and enable Aztec
2. Edit a **Draft**
3. Verify that pressing the **Update** button won't dismiss the editor.

Needs review: @diegoreymendez 
Thanks in advance!
