### PR TITLE
Aztec: Accesibility Identifiers

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Extensions/Header+WordPress.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Extensions/Header+WordPress.swift
@@ -30,7 +30,7 @@ extension Header.HeaderType {
         }
     }
 
-    var accessibilityIdentifier: String {
+    var accessibilityLabel: String {
         switch self {
         case .none: return NSLocalizedString("Switches to the default Font Size", comment: "Accessibility Identifier for the Default Font Aztec Style.")
         case .h1: return NSLocalizedString("Switches to the Heading 1 font size", comment: "Accessibility Identifier for the H1 Aztec Style")

--- a/WordPress/Classes/ViewRelated/Aztec/Extensions/Header+WordPress.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Extensions/Header+WordPress.swift
@@ -30,6 +30,18 @@ extension Header.HeaderType {
         }
     }
 
+    var accessibilityIdentifier: String {
+        switch self {
+        case .none: return NSLocalizedString("Switches to the default Font Size", comment: "Accessibility Identifier for the Default Font Aztec Style.")
+        case .h1: return NSLocalizedString("Switches to the Heading 1 font size", comment: "Accessibility Identifier for the H1 Aztec Style")
+        case .h2: return NSLocalizedString("Switches to the Heading 2 font size", comment: "Accessibility Identifier for the H2 Aztec Style")
+        case .h3: return NSLocalizedString("Switches to the Heading 3 font size", comment: "Accessibility Identifier for the H3 Aztec Style")
+        case .h4: return NSLocalizedString("Switches to the Heading 4 font size", comment: "Accessibility Identifier for the H4 Aztec Style")
+        case .h5: return NSLocalizedString("Switches to the Heading 5 font size", comment: "Accessibility Identifier for the H5 Aztec Style")
+        case .h6: return NSLocalizedString("Switches to the Heading 6 font size", comment: "Accessibility Identifier for the H6 Aztec Style")
+        }
+    }
+
     var iconImage: UIImage? {
         switch self {
         case .none: return UIImage(color: .clear, havingSize: Gridicon.defaultSize)

--- a/WordPress/Classes/ViewRelated/Aztec/Extensions/TextList+WordPress.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Extensions/TextList+WordPress.swift
@@ -22,8 +22,8 @@ extension TextList.Style {
 
     var accessibilityIdentifier: String {
         switch self {
-        case .ordered: return NSLocalizedString("Toggles an Ordered List", comment: "Accessibility Identifier for the Aztec Ordered List Style.")
-        case .unordered: return NSLocalizedString("Toggles an Unordered List", comment: "Accessibility Identifier for the Aztec Unordered List Style")
+        case .ordered: return NSLocalizedString("Toggles the ordered list style", comment: "Accessibility Identifier for the Aztec Ordered List Style.")
+        case .unordered: return NSLocalizedString("Toggles the unordered list style", comment: "Accessibility Identifier for the Aztec Unordered List Style")
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Extensions/TextList+WordPress.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Extensions/TextList+WordPress.swift
@@ -20,7 +20,7 @@ extension TextList.Style {
         }
     }
 
-    var accessibilityIdentifier: String {
+    var accessibilityLabel: String {
         switch self {
         case .ordered: return NSLocalizedString("Toggles the ordered list style", comment: "Accessibility Identifier for the Aztec Ordered List Style.")
         case .unordered: return NSLocalizedString("Toggles the unordered list style", comment: "Accessibility Identifier for the Aztec Unordered List Style")

--- a/WordPress/Classes/ViewRelated/Aztec/Extensions/TextList+WordPress.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Extensions/TextList+WordPress.swift
@@ -20,6 +20,13 @@ extension TextList.Style {
         }
     }
 
+    var accessibilityIdentifier: String {
+        switch self {
+        case .ordered: return NSLocalizedString("Toggles an Ordered List", comment: "Accessibility Identifier for the Aztec Ordered List Style.")
+        case .unordered: return NSLocalizedString("Toggles an Unordered List", comment: "Accessibility Identifier for the Aztec Unordered List Style")
+        }
+    }
+
     var iconImage: UIImage? {
         return formattingIdentifier.iconImage
     }

--- a/WordPress/Classes/ViewRelated/Aztec/Options/OptionsTableView.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Options/OptionsTableView.swift
@@ -5,7 +5,7 @@ import UIKit
 struct OptionsTableViewOption: Equatable {
     let image: UIImage?
     let title: NSAttributedString
-    let accessibilityIdentifier: String?
+    let accessibilityLabel: String?
 
     // MARK: - Equatable
 
@@ -110,7 +110,7 @@ extension OptionsTableViewController {
         reuseCell.imageView?.image = option.image
 
         reuseCell.deselectedTintColor = cellDeselectedTintColor
-        reuseCell.accessibilityValue = option.accessibilityIdentifier
+        reuseCell.accessibilityLabel = option.accessibilityLabel
 
         let isSelected = indexPath.row == tableView.indexPathForSelectedRow?.row
         reuseCell.isSelected = isSelected

--- a/WordPress/Classes/ViewRelated/Aztec/Options/OptionsTableView.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Options/OptionsTableView.swift
@@ -5,6 +5,7 @@ import UIKit
 struct OptionsTableViewOption: Equatable {
     let image: UIImage?
     let title: NSAttributedString
+    let accessibilityIdentifier: String?
 
     // MARK: - Equatable
 
@@ -109,6 +110,7 @@ extension OptionsTableViewController {
         reuseCell.imageView?.image = option.image
 
         reuseCell.deselectedTintColor = cellDeselectedTintColor
+        reuseCell.accessibilityValue = option.accessibilityIdentifier
 
         let isSelected = indexPath.row == tableView.indexPathForSelectedRow?.row
         reuseCell.isSelected = isSelected

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1496,7 +1496,7 @@ extension AztecPostViewController {
             let title = NSAttributedString(string: listType.description, attributes: [:])
             return OptionsTableViewOption(image: listType.iconImage,
                                           title: title,
-                                          accessibilityIdentifier: listType.accessibilityIdentifier)
+                                          accessibilityLabel: listType.accessibilityLabel)
         }
 
         var index: Int? = nil
@@ -1840,7 +1840,7 @@ extension AztecPostViewController {
 
             return OptionsTableViewOption(image: headerType.iconImage,
                                           title: title,
-                                          accessibilityIdentifier: headerType.accessibilityIdentifier)
+                                          accessibilityLabel: headerType.accessibilityLabel)
         }
 
         let selectedIndex = Constants.headers.index(of: self.headerLevelForSelectedText())

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1492,8 +1492,11 @@ extension AztecPostViewController {
     }
 
     func toggleList(fromItem item: FormatBarItem) {
-        let listOptions = Constants.lists.map { (listType) -> OptionsTableViewOption in
-            return OptionsTableViewOption(image: listType.iconImage, title: NSAttributedString(string: listType.description, attributes: [:]))
+        let listOptions = Constants.lists.map { listType -> OptionsTableViewOption in
+            let title = NSAttributedString(string: listType.description, attributes: [:])
+            return OptionsTableViewOption(image: listType.iconImage,
+                                          title: title,
+                                          accessibilityIdentifier: listType.accessibilityIdentifier)
         }
 
         var index: Int? = nil
@@ -1827,11 +1830,17 @@ extension AztecPostViewController {
     func toggleHeader(fromItem item: FormatBarItem) {
         trackFormatBarAnalytics(stat: .editorTappedHeader)
 
-        let headerOptions = Constants.headers.map { (headerType) -> OptionsTableViewOption in
+        let headerOptions = Constants.headers.map { headerType -> OptionsTableViewOption in
+            let attributes = [
+                NSFontAttributeName: UIFont.systemFont(ofSize: headerType.fontSize),
+                NSForegroundColorAttributeName: WPStyleGuide.darkGrey()
+            ]
+
+            let title = NSAttributedString(string: headerType.description, attributes: attributes)
+
             return OptionsTableViewOption(image: headerType.iconImage,
-                                          title: NSAttributedString(string: headerType.description,
-                                                                    attributes:[NSFontAttributeName: UIFont.systemFont(ofSize: headerType.fontSize),
-                                                                                NSForegroundColorAttributeName: WPStyleGuide.darkGrey()]))
+                                          title: title,
+                                          accessibilityIdentifier: headerType.accessibilityIdentifier)
         }
 
         let selectedIndex = Constants.headers.index(of: self.headerLevelForSelectedText())


### PR DESCRIPTION
### Details:
In this PR we're adding accesibility identifiers over the Heading + List options.
Closes #7005

### To test:
1. Enable voice over in your device
2. Launch Aztec
3. Press the `Heading` button
4. Verify that all of the options have their accesibility details set
5. Press the `List` button
6. Verify that all of the options have their accesibility details set

Needs review: @diegoreymendez 

