### PR TITLE
AztecPostViewController: Enabling spell check on the title field

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -117,6 +117,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         textView.textAlignment = .natural
         textView.isScrollEnabled = false
         textView.backgroundColor = .clear
+        textView.spellCheckingType = .default
 
         return textView
     }()


### PR DESCRIPTION
Fixes #6974

### To test:
1. Launch Aztec
2. Type `Helo` in the title field

Verify that the (incorrectly spelt) word gets underlined in red.

Needs review: @diegoreymendez 
Thanks!
