### PR TITLE
Update Helpshift settings for showSearchOnNewConversation

### DIFF
--- a/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
@@ -5,10 +5,6 @@ import UIKit
 /// or a conversation) from anywhere in the app.
 ///
 @objc class HelpshiftPresenter: NSObject {
-    // Passed into options when displaying a Helpshift window, so that users are presented
-    // a list of possibly related FAQs with matching terms before posting a new conversation.
-    fileprivate static let HelpshiftShowsSearchOnNewConversationKey = "showSearchOnNewConversation"
-
 
     /// set the source of the presenter for tagging in Helpshift
     var sourceTag: SupportSourceTag?
@@ -105,11 +101,11 @@ import UIKit
             }
         }
 
-        let config: [AnyHashable: Any] = [HelpshiftSupportCustomMetadataKey: metaData,
-                HelpshiftPresenter.HelpshiftShowsSearchOnNewConversationKey: true]
+        let config: [AnyHashable: Any] = [HelpshiftSupportCustomMetadataKey: metaData]
 
         let builder = HelpshiftAPIConfigBuilder()
         builder.extraConfig = config
+        builder.showSearchOnNewConversation = true
 
         return builder.build()
     }


### PR DESCRIPTION
**Fixes** #7770 

It looks like at some point we missed an update on the API and ticket deflection has not been working for a while. This fix brings it back.

**To test:**

Me -> Help & Support -> Contact Us
Type something that would have a suggested answer, like "Delete post"
Send
You should be presented with suggested FAQ articles.

![simulator screen shot sep 1 2017 10 09 13](https://user-images.githubusercontent.com/5558824/29971173-ade65ed8-8efd-11e7-980b-3158879f9eda.png)

I'm targeting 8.4 since it's an extremely simple fix and it may help with ticket volume.

Needs review: @aerych 