### PR TITLE
Check if response to request is a proper dictionary before returning.

### DIFF
--- a/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.h
+++ b/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.h
@@ -11,7 +11,7 @@ extern NSString *const XMLRPCOriginalErrorKey;
 - (void)getBlogOptionsWithEndpoint:(NSURL *)xmlrpc
                          username:(NSString *)username
                          password:(NSString *)password
-                          success:(void (^)(id options))success
+                          success:(void (^)(NSDictionary *options))success
                           failure:(void (^)(NSError *error))failure;
 
 @end

--- a/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
+++ b/WordPress/Classes/Services/WordPressXMLRPCAPIFacade.m
@@ -51,15 +51,22 @@ NSString *const XMLRPCOriginalErrorKey = @"XMLRPCOriginalErrorKey";
 - (void)getBlogOptionsWithEndpoint:(NSURL *)xmlrpc
                          username:(NSString *)username
                          password:(NSString *)password
-                          success:(void (^)(id options))success
+                          success:(void (^)(NSDictionary *options))success
                           failure:(void (^)(NSError *error))failure;
 {
     
     WordPressOrgXMLRPCApi *api = [[WordPressOrgXMLRPCApi alloc] initWithEndpoint:xmlrpc userAgent:[WPUserAgent wordPressUserAgent]];
     [api checkCredentials:username password:password success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         dispatch_async(dispatch_get_main_queue(), ^{
+            if (![responseObject isKindOfClass:[NSDictionary class]]) {
+                if (failure) {
+                    NSError *error = [NSError errorWithDomain:WordPressOrgXMLRPCApiErrorDomain code:WordPressOrgXMLRPCApiErrorResponseSerializationFailed userInfo:nil];
+                    failure(error);
+                }
+                return;
+            }
             if (success) {
-                success(responseObject);
+                success((NSDictionary *)responseObject);
             }
         });
 


### PR DESCRIPTION
Fixes #7779 

To test:
 - Start the app
 - Add a self-hosted site with the following url: [REDACTED]
 - Insert any user and password combination
 - Check that app doesn't crash.

Needs review: @koke 