### PR TITLE
Stop updating Jetpack settings one by one

### DIFF
--- a/WordPress/Classes/Services/BlogJetpackSettingsService.swift
+++ b/WordPress/Classes/Services/BlogJetpackSettingsService.swift
@@ -137,7 +137,7 @@ private extension BlogJetpackSettingsService {
     func jetpackSettingsRemote(_ settings: BlogSettings) -> RemoteBlogJetpackSettings {
         return RemoteBlogJetpackSettings(monitorEnabled: settings.jetpackMonitorEnabled,
                                          blockMaliciousLoginAttempts: settings.jetpackBlockMaliciousLoginAttempts,
-                                         loginWhiteListedIPAddresses: settings.jetpackLoginWhiteListedIPAddresses != nil ? settings.jetpackLoginWhiteListedIPAddresses! : Set<String>(),
+                                         loginWhiteListedIPAddresses: settings.jetpackLoginWhiteListedIPAddresses ?? Set<String>(),
                                          ssoEnabled: settings.jetpackSSOEnabled,
                                          ssoMatchAccountsByEmail: settings.jetpackSSOMatchAccountsByEmail,
                                          ssoRequireTwoStepAuthentication: settings.jetpackSSORequireTwoStepAuthentication)

--- a/WordPress/Classes/Services/BlogJetpackSettingsService.swift
+++ b/WordPress/Classes/Services/BlogJetpackSettingsService.swift
@@ -94,7 +94,7 @@ struct BlogJetpackSettingsService {
 
     }
 
-    func updateJetpackMonitorSettinsForBlog(_ blog: Blog, success: @escaping () -> Void, failure: @escaping (Error?) -> Void) {
+    func updateJetpackMonitorSettingsForBlog(_ blog: Blog, success: @escaping () -> Void, failure: @escaping (Error?) -> Void) {
         guard let remote = BlogJetpackSettingsServiceRemote(wordPressComRestApi: blog.wordPressComRestApi()),
             let blogDotComId = blog.dotComID as? Int,
             let blogSettings = blog.settings else {

--- a/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
@@ -188,22 +188,22 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
     fileprivate func sendNotificationsByEmailValueChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
             self.settings.jetpackMonitorEmailNotifications = newValue
-            self.service.updateJetpackMonitorSettinsForBlog(self.blog,
-                                                            success: {},
-                                                            failure: { [weak self] (_) in
-                                                                self?.refreshSettingsAfterSavingError()
-                                                            })
+            self.service.updateJetpackMonitorSettingsForBlog(self.blog,
+                                                             success: {},
+                                                             failure: { [weak self] (_) in
+                                                                 self?.refreshSettingsAfterSavingError()
+                                                             })
         }
     }
 
     fileprivate func sendPushNotificationsValueChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
             self.settings.jetpackMonitorPushNotifications = newValue
-            self.service.updateJetpackMonitorSettinsForBlog(self.blog,
-                                                            success: {},
-                                                            failure: { [weak self] (_) in
-                                                                self?.refreshSettingsAfterSavingError()
-                                                            })
+            self.service.updateJetpackMonitorSettingsForBlog(self.blog,
+                                                             success: {},
+                                                             failure: { [weak self] (_) in
+                                                                 self?.refreshSettingsAfterSavingError()
+                                                             })
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
@@ -176,10 +176,9 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
     fileprivate func jetpackMonitorEnabledValueChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
             self.settings.jetpackMonitorEnabled = newValue
+            self.reloadViewModel()
             self.service.updateJetpackSettingsForBlog(self.blog,
-                                                      success: { [weak self] in
-                                                          self?.reloadViewModel()
-                                                      },
+                                                      success: {},
                                                       failure: { [weak self] (_) in
                                                           self?.refreshSettingsAfterSavingError()
                                                       })
@@ -211,10 +210,9 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
     fileprivate func blockMaliciousLoginAttemptsValueChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
             self.settings.jetpackBlockMaliciousLoginAttempts = newValue
+            self.reloadViewModel()
             self.service.updateJetpackSettingsForBlog(self.blog,
-                                                      success: {[weak self] in
-                                                          self?.reloadViewModel()
-                                                      },
+                                                      success: {},
                                                       failure: { [weak self] (_) in
                                                           self?.refreshSettingsAfterSavingError()
                                                       })
@@ -257,10 +255,9 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
     fileprivate func ssoEnabledChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
             self.settings.jetpackSSOEnabled = newValue
+            self.reloadViewModel()
             self.service.updateJetpackSettingsForBlog(self.blog,
-                                                      success: { [weak self] in
-                                                          self?.reloadViewModel()
-                                                      },
+                                                      success: {},
                                                       failure: { [weak self] (_) in
                                                           self?.refreshSettingsAfterSavingError()
                                                       })

--- a/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
@@ -176,14 +176,13 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
     fileprivate func jetpackMonitorEnabledValueChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
             self.settings.jetpackMonitorEnabled = newValue
-            self.service.updateJetpackMonitorEnabledForBlog(self.blog,
-                                                            value: newValue,
-                                                            success: { [weak self] in
-                                                                self?.reloadViewModel()
-                                                            },
-                                                            failure: { [weak self] (_) in
-                                                                self?.refreshSettingsAfterSavingError()
-                                                            })
+            self.service.updateJetpackSettingsForBlog(self.blog,
+                                                      success: { [weak self] in
+                                                          self?.reloadViewModel()
+                                                      },
+                                                      failure: { [weak self] (_) in
+                                                          self?.refreshSettingsAfterSavingError()
+                                                      })
         }
     }
 
@@ -212,14 +211,13 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
     fileprivate func blockMaliciousLoginAttemptsValueChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
             self.settings.jetpackBlockMaliciousLoginAttempts = newValue
-            self.service.updateBlockMaliciousLoginAttemptsForBlog(self.blog,
-                                                                  value: newValue,
-                                                                  success: { [weak self] in
-                                                                      self?.reloadViewModel()
-                                                                  },
-                                                                  failure: { [weak self] (_) in
-                                                                      self?.refreshSettingsAfterSavingError()
-                                                                  })
+            self.service.updateJetpackSettingsForBlog(self.blog,
+                                                      success: {[weak self] in
+                                                          self?.reloadViewModel()
+                                                      },
+                                                      failure: { [weak self] (_) in
+                                                          self?.refreshSettingsAfterSavingError()
+                                                      })
         }
     }
 
@@ -242,12 +240,15 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
                 guard let blog = self?.blog else {
                     return
                 }
-                self?.service.updateWhiteListedIPAddressesForBlog(blog,
-                                                                  value: updated,
-                                                                  success: {},
-                                                                  failure: { [weak self] (_) in
-                                                                      self?.refreshSettingsAfterSavingError()
-                                                                  })
+                self?.service.updateJetpackSettingsForBlog(blog,
+                                                           success: { [weak self] in
+                                                               // viewWillAppear will trigger a refresh, maybe before
+                                                               // the new IPs are saved, so lets refresh again here
+                                                               self?.refreshSettings()
+                                                           },
+                                                           failure: { [weak self] (_) in
+                                                               self?.refreshSettingsAfterSavingError()
+                                                           })
             }
             self.navigationController?.pushViewController(settingsViewController, animated: true)
         }
@@ -256,38 +257,35 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
     fileprivate func ssoEnabledChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
             self.settings.jetpackSSOEnabled = newValue
-            self.service.updateSSOEnabledForBlog(self.blog,
-                                                 value: newValue,
-                                                 success: { [weak self] in
-                                                     self?.reloadViewModel()
-                                                 },
-                                                 failure: { [weak self] (_) in
-                                                     self?.refreshSettingsAfterSavingError()
-                                                 })
+            self.service.updateJetpackSettingsForBlog(self.blog,
+                                                      success: { [weak self] in
+                                                          self?.reloadViewModel()
+                                                      },
+                                                      failure: { [weak self] (_) in
+                                                          self?.refreshSettingsAfterSavingError()
+                                                      })
         }
     }
 
     fileprivate func matchAccountsUsingEmailChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
             self.settings.jetpackSSOMatchAccountsByEmail = newValue
-            self.service.updateSSOMatchAccountsByEmailForBlog(self.blog,
-                                                              value: newValue,
-                                                              success: {},
-                                                              failure: { [weak self] (_) in
-                                                                  self?.refreshSettingsAfterSavingError()
-                                                              })
+            self.service.updateJetpackSettingsForBlog(self.blog,
+                                                      success: {},
+                                                      failure: { [weak self] (_) in
+                                                          self?.refreshSettingsAfterSavingError()
+                                                      })
         }
     }
 
     fileprivate func requireTwoStepAuthenticationChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
             self.settings.jetpackSSORequireTwoStepAuthentication = newValue
-            self.service.updateSSORequireTwoStepAuthenticationForBlog(self.blog,
-                                                                      value: newValue,
-                                                                      success: {},
-                                                                      failure: { [weak self] (_) in
-                                                                          self?.refreshSettingsAfterSavingError()
-                                                                      })
+            self.service.updateJetpackSettingsForBlog(self.blog,
+                                                      success: {},
+                                                      failure: { [weak self] (_) in
+                                                          self?.refreshSettingsAfterSavingError()
+                                                      })
         }
     }
 

--- a/WordPressKit/WordPressKit/RemoteBlogJetpackSettings.swift
+++ b/WordPressKit/WordPressKit/RemoteBlogJetpackSettings.swift
@@ -28,4 +28,17 @@ public struct RemoteBlogJetpackSettings {
     ///
     public let ssoRequireTwoStepAuthentication: Bool
 
+    public init(monitorEnabled: Bool,
+                blockMaliciousLoginAttempts: Bool,
+                loginWhiteListedIPAddresses: Set<String>,
+                ssoEnabled: Bool,
+                ssoMatchAccountsByEmail: Bool,
+                ssoRequireTwoStepAuthentication: Bool) {
+        self.monitorEnabled = monitorEnabled
+        self.blockMaliciousLoginAttempts = blockMaliciousLoginAttempts
+        self.loginWhiteListedIPAddresses = loginWhiteListedIPAddresses
+        self.ssoEnabled = ssoEnabled
+        self.ssoMatchAccountsByEmail = ssoMatchAccountsByEmail
+        self.ssoRequireTwoStepAuthentication = ssoRequireTwoStepAuthentication
+    }
 }


### PR DESCRIPTION
**Fixes** #7783 

**To test:**

Same as https://github.com/wordpress-mobile/WordPress-iOS/pull/7724 please check that all these work:

- [x] Monitor uptime 
- [x] Send notifications via email
- [x] Send push notifications
- [x] Block malicious login attempts
- [x] Whitelisted IP addresses
- [x] Allow WordPress.com login
- [x] Match accounts using email
- [x] Require two-step authentication
- [x] Learn more link

Needs review: @koke 