### PR TITLE
Mark note as read when navigating with arrows

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -89,6 +89,7 @@ class NotificationDetailsViewController: UIViewController {
             }
 
             refreshInterface()
+            markAsReadIfNeeded()
         }
     }
 


### PR DESCRIPTION
**Fixes** #7741 

**To test:**

Go to a notification before or after an unread one. 
Navigate with the arrows to the unread note. 
Go back to the list, check that the notification is marked as read.

Needs review: @jleandroperez 
