### PR TITLE
Respect order of roles

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -145,6 +145,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (nonatomic,   weak,  readonly, nullable) NSArray *sortedPostFormatNames;
 @property (nonatomic,   weak,  readonly, nullable) NSArray *sortedPostFormats;
 @property (nonatomic,   weak,  readonly, nullable) NSArray *sortedConnections;
+@property (nonatomic, readonly, nullable) NSArray<Role *> *sortedRoles;
 @property (nonatomic, strong,  readonly, nullable) WordPressOrgXMLRPCApi *xmlrpcApi;
 @property (nonatomic,   weak,  readonly, nullable) NSString       *version;
 @property (nonatomic, strong,  readonly, nullable) NSString       *authToken;

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -274,6 +274,11 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
     return [[self.connections allObjects] sortedArrayUsingDescriptors:sortDescriptors];
 }
 
+- (NSArray<Role *> *)sortedRoles
+{
+    return [self.roles sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"order" ascending:YES]]];
+}
+
 - (NSString *)defaultPostFormatText
 {
     return [self postFormatTextFromSlug:self.settings.defaultPostFormat];

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -53,7 +53,7 @@ class InvitePersonViewController: UITableViewController {
     /// Roles available for the current site
     ///
     fileprivate var availableRoles: [RemoteRole] {
-        let blogRoles = blog?.roles.map({ Array($0) }) ?? []
+        let blogRoles = blog?.sortedRoles ?? []
         var roles = [RemoteRole]()
         let inviteRole: RemoteRole
         if blog.isPrivate() {
@@ -61,8 +61,8 @@ class InvitePersonViewController: UITableViewController {
         } else {
             inviteRole = RemoteRole.follower
         }
-        roles.append(inviteRole)
         roles += blogRoles.map({ $0.toUnmanaged() })
+        roles.append(inviteRole)
         return roles
     }
 
@@ -387,11 +387,11 @@ private extension InvitePersonViewController {
     }
 
     func setupDefaultRole() {
-        guard let firstRole = availableRoles.first else {
+        guard let lastRole = availableRoles.last else {
             return
         }
 
-        role = firstRole
+        role = lastRole
     }
 }
 

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -194,7 +194,7 @@ final class PersonViewController: UITableViewController {
             return
         }
 
-        roleViewController.roles = blog.roles?.map({ $0.toUnmanaged() }) ?? []
+        roleViewController.roles = blog.sortedRoles?.map({ $0.toUnmanaged() }) ?? []
         roleViewController.selectedRole = person.role
         roleViewController.onChange = { [weak self] newRole in
             self?.updateUserRole(newRole)


### PR DESCRIPTION
We were storing the order, but then fetching the blog's roles unordered. This
adds a `sortedRoles` accessor so they appear in the right order.

Also moved the Follower role to the end of the list when inviting a user.

![simulator screen shot - iphone 7 - 2017-09-07 at 11 55 51](https://user-images.githubusercontent.com/8739/30157956-f2b66fba-93c3-11e7-9cff-261fe11d64a4.png)


Fixes #7682 

To test:

Ensure correct order of roles when editing a user and inviting a new user.

Needs review: @elibud 
