### PR TITLE
Reader: only copy the url when sharing

### DIFF
--- a/WordPress/Classes/Utility/WPWebViewController.h
+++ b/WordPress/Classes/Utility/WPWebViewController.h
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 
-
+@protocol LinkOptionsDelegate;
 
 #pragma mark - WPWebViewController
 
@@ -47,6 +47,16 @@
 @property (nonatomic, assign) BOOL addsWPComReferrer;
 
 /**
+ * @brief Optional, delegate to handle taps on the link options/right navigation button.
+ */
+@property (nonatomic, weak) id<LinkOptionsDelegate> linkOptionsDelegate;
+
+/**
+ * @brief Optional, dictionary to pass back to the delegate when the right navigation button is tapped.
+ */
+@property (nonatomic, strong) NSDictionary *linkOptionsParams;
+
+/**
  *	@brief		Dismiss modal presentation
  */
 - (IBAction)dismiss;
@@ -70,5 +80,23 @@
  */
 + (instancetype)webViewControllerWithURL:(NSURL *)url
                            optionsButton:(UIBarButtonItem *)button;
+
+@end
+
+/**
+ * @brief Delegate to handle taps on the top right navigation button.
+ */
+@protocol LinkOptionsDelegate
+
+/**
+ *	@brief      Method to be invoked when the user taps on the link options/right navigation button.
+ *
+ *	@param      viewController ViewController where the button resides.
+ *  @param      optionsButton Right navigation button item tapped
+ *  @param      optionsParams A dictionary containing previously set linkOptionsParams.
+ */
+- (void)linkOptionsTappedOnViewController:(UIViewController *)viewController
+                            optionsButton:(UIBarButtonItem *)optionsButton
+                                   params:(NSDictionary *)optionsParams;
 
 @end

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -312,6 +312,13 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
 
 - (IBAction)showLinkOptions
 {
+    if (self.linkOptionsDelegate) {
+        [self.linkOptionsDelegate linkOptionsTappedOnViewController:self
+                                                      optionsButton:self.optionsButton
+                                                             params:self.linkOptionsParams];
+        return;
+    }
+
     NSString *permaLink             = [self documentPermalink];
     NSString *title                 = [self documentTitle];
     NSMutableArray *activityItems   = [NSMutableArray array];

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -94,6 +94,16 @@ import SVProgressHUD
             inViewController: viewController)
     }
 
+    func shareReaderPost(_ post: ReaderPost, fromBarButtonItem anchorBarButtonItem: UIBarButtonItem, inViewController viewController: UIViewController) {
+
+        sharePost(
+            post.titleForDisplay(),
+            summary: post.contentPreviewForDisplay(),
+            link: post.permaLink,
+            fromBarButtonItem: anchorBarButtonItem,
+            inViewController: viewController)
+    }
+
     func shareURL(url: NSURL, fromRect rect: CGRect, inView view: UIView, inViewController viewController: UIViewController) {
         let controller = shareController("", summary: "", link: url.absoluteString)
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -741,6 +741,20 @@ import WordPressShared
         }
     }
 
+    /// Shares a post from another view controller with the share controller.
+    ///
+    /// - Parameters:
+    ///     - postID: Object ID for the post.
+    ///     - anchorBarButtonItem: The button item to present the sharing controller from.
+    ///     - viewController: The view controller to present the sharing controller in.
+    ///
+    fileprivate func sharePost(_ postID: NSManagedObjectID, inViewController viewController: UIViewController, fromBarButtonItem anchorBarButtonItem: UIBarButtonItem) {
+        if let post = self.postWithObjectID(postID) {
+            let sharingController = PostSharingController()
+
+            sharingController.shareReaderPost(post, fromBarButtonItem: anchorBarButtonItem, inViewController: viewController)
+        }
+    }
 
     /// Retrieves a post for the specified object ID from the display context.
     ///
@@ -801,6 +815,8 @@ import WordPressShared
 
         let controller = WPWebViewController(url: siteURL)
         controller?.addsWPComReferrer = true
+        controller?.linkOptionsDelegate = self
+        controller?.linkOptionsParams = ["objectID": post.objectID]
         let navController = UINavigationController(rootViewController: controller!)
         present(navController, animated: true, completion: nil)
     }
@@ -1580,6 +1596,19 @@ extension ReaderStreamViewController : ReaderPostCellDelegate {
     public func readerCellImageRequestAuthToken(_ cell: ReaderPostCardCell) -> String? {
         return imageRequestAuthToken
     }
+}
+
+// MARK: - LinkOptionsDelegate
+
+extension ReaderStreamViewController : LinkOptionsDelegate {
+
+    public func linkOptionsTapped(on viewController: UIViewController!, optionsButton: UIBarButtonItem!, params optionsParams: [AnyHashable : Any]!) {
+
+        if let postID = optionsParams["objectID"] as? NSManagedObjectID {
+            sharePost(postID, inViewController: viewController, fromBarButtonItem: optionsButton)
+        }
+    }
+
 }
 
 


### PR DESCRIPTION
**Fixes** #6020 

This PR presents a possible solution to the issue described in #6020 by adding the possibility of delegating the handling of the right navigation bar button on the `WPWebViewController` to the presenter. 

**To test:**

Go to a Reader Stream and click on Visit. Then tap on the share Icon, copy, and paste it somewhere. Verify that the title is not included. 

![heiwt7](https://user-images.githubusercontent.com/5558824/30168277-4b47deac-93bf-11e7-907c-3c7f08c77eb9.png) | ![ouynhk](https://user-images.githubusercontent.com/5558824/30168276-4b3e329e-93bf-11e7-9ac1-2a13bbfcea2c.png) 


Needs review: @aerych @koke 