### PR TITLE
Login: Improve xmlrpc discovery failure tracking.

### DIFF
--- a/WordPress/Classes/Services/LoginFacade.m
+++ b/WordPress/Classes/Services/LoginFacade.m
@@ -93,6 +93,7 @@
     
     void (^guessXMLRPCURLFailure)(NSError *) = ^(NSError *error){        
         [WPAppAnalytics track:WPAnalyticsStatLoginFailedToGuessXMLRPC error:error];
+        [WPAppAnalytics track:WPAnalyticsStatLoginFailed error:error];
         [self.delegate displayRemoteError:error];
     };
     

--- a/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
@@ -152,6 +152,7 @@ class LoginSiteAddressViewController: LoginViewController, SigninKeyboardRespond
                 return
             }
             DDLogError(error.localizedDescription)
+            WPAppAnalytics.track(.loginFailedToGuessXMLRPC, error: error)
             WPAppAnalytics.track(.loginFailed, error: error)
             strongSelf.configureViewLoading(false)
 


### PR DESCRIPTION
While doing a bit of analytics research I noticed stats for xmlrpc discovery failures had plummeted. I suspect this is less due to the success of the new login flow and more to where the stat was being bumped.  This PR adds adds tracking for discovery failures to the site address vc as well as bumping regular failures via the "guess" failure callback in LoginFacade for consistency. 

Needs review: @nheagy could you take a quick peek? 