### PR TITLE
Only share URL on WPWebViewController sharing

### DIFF
--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -313,19 +313,11 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
 - (IBAction)showLinkOptions
 {
     NSString *permaLink             = [self documentPermalink];
-    NSString *title                 = [self documentTitle];
     NSMutableArray *activityItems   = [NSMutableArray array];
     
-    if (title) {
-        [activityItems addObject:title];
-    }
-
     [activityItems addObject:[NSURL URLWithString:permaLink]];
     
     UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:activityItems applicationActivities:[WPActivityDefaults defaultActivities]];
-    if (title) {
-        [activityViewController setValue:title forKey:@"subject"];
-    }
     activityViewController.completionWithItemsHandler = ^(NSString *activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
         if (!completed) {
             return;


### PR DESCRIPTION
**Fixes** #6020 

The simplest fix, lets only share the URL when sharing from the `WPWebViewController` 

**To test:**

Go to a Reader Stream and click on Visit. Then tap on the share Icon, copy, and paste it somewhere. Verify that the title is not included. 

![heiwt7](https://user-images.githubusercontent.com/5558824/30168277-4b47deac-93bf-11e7-907c-3c7f08c77eb9.png) | ![ouynhk](https://user-images.githubusercontent.com/5558824/30168276-4b3e329e-93bf-11e7-9ac1-2a13bbfcea2c.png) 


Needs review: @koke 