### PR TITLE
Stop Hound for considering ruby files

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,4 @@
 swift:
     config_file: .swiftlint.yml
+ruby:
+  enabled: false


### PR DESCRIPTION
This PR will stop Hound from considering our ruby scripts.

This is hard to test (you'd have to push a fork of this branch with a change to a ruby script). Instead, perhaps just consider [the documentation](https://houndci.com/configuration#ruby)

Needs review: @koke

Thanks again, Jorge! 