### PR TITLE
Disable Jetpack themes on AppStore builds

### DIFF
--- a/Scripts/fastlane/download_metadata.swift
+++ b/Scripts/fastlane/download_metadata.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 let glotPressSubtitleKey = "app_store_subtitle"
-let glotPressWhatsNewKey = "v8.4-whats-new"
+let glotPressWhatsNewKey = "standard-whats-new-1"
 let glotPressDescriptionKey = "app_store_desc"
 let glotPressKeywordsKey = "app_store_keywords"
 let baseFolder = "./metadata"

--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -6,6 +6,7 @@ enum FeatureFlag: Int {
     case newMediaExports
     case newInputMediaPicker
     case pluginManagement
+    case jetpackThemesBrowsing
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -18,6 +19,8 @@ enum FeatureFlag: Int {
             return build(.a8cPrereleaseTesting, .a8cBranchTest, .localDeveloper)
         case .pluginManagement:
             return build(.localDeveloper)
+        case .jetpackThemesBrowsing:
+            return build(.a8cPrereleaseTesting, .a8cBranchTest, .localDeveloper)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -456,7 +456,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
-    if ([self.blog supports:BlogFeatureThemeBrowsing]) {
+    BOOL enableThemesBrowsing = (self.blog.isHostedAtWPcom ||
+                                [Feature enabled:FeatureFlagJetpackThemesBrowsing]) &&
+                                [self.blog supports:BlogFeatureThemeBrowsing];
+    if (enableThemesBrowsing) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Themes", @"Themes option in the blog details")
                                                         image:[Gridicon iconOfType:GridiconTypeThemes]
                                                      callback:^{


### PR DESCRIPTION
We are disabling Jetpack themes until we fix https://github.com/wordpress-mobile/WordPress-iOS/issues/7758 and finish https://github.com/wordpress-mobile/WordPress-iOS/tree/feature/webviewcontroller-refactor

**To test:**
Check that theme browsing is still enabled on development builds but not on prod builds for Jetpack sites. Check that .com sites always have access to themes.

Needs review: @koke 