### PR TITLE
Issue/7817: Reader insets on iPhone X

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -233,6 +233,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         Applies the default styles to the cell's subviews
     */
     fileprivate func applyStyles() {
+        backgroundColor = WPStyleGuide.greyLighten30()
         contentView.backgroundColor = WPStyleGuide.greyLighten30()
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = 1.0


### PR DESCRIPTION
Fixes #7817.

The Reader stream on iPhone X shows white insets on the left and right when in landscape. I fixed this by simply applying the same background colour as the content view to the cell itself.

![reader-insets-ix](https://user-images.githubusercontent.com/4780/30717658-81aa9f32-9f15-11e7-8e67-3330199ad9ce.png)

To test:

* Ensure the reader stream background looks correct on the iPhone X and other devices (including iPad).

Needs review: @aerych 