### PR TITLE
Jetpack disconnect - development only implementation

### DIFF
--- a/WordPress/Classes/Services/BlogJetpackSettingsService.swift
+++ b/WordPress/Classes/Services/BlogJetpackSettingsService.swift
@@ -116,6 +116,23 @@ struct BlogJetpackSettingsService {
                                                        failure(error)
                                                    })
     }
+
+    func disconnectJetpackFromBlog(_ blog: Blog, success: @escaping () -> Void, failure: @escaping (Error?) -> Void) {
+        guard let remote = BlogJetpackSettingsServiceRemote(wordPressComRestApi: blog.wordPressComRestApi()),
+            let blogDotComId = blog.dotComID as? Int else {
+                failure(nil)
+                return
+        }
+
+        remote.disconnectJetpackFromSite(blogDotComId,
+                                         success: {
+                                            success()
+                                         },
+                                         failure: { (error) in
+                                            failure(error)
+                                         })
+    }
+
 }
 
 private extension BlogJetpackSettingsService {

--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -8,6 +8,7 @@ enum FeatureFlag: Int {
     case pluginManagement
     case jetpackThemesBrowsing
     case googleLogin
+    case jetpackDisconnect
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -23,6 +24,8 @@ enum FeatureFlag: Int {
         case .jetpackThemesBrowsing:
             return build(.a8cPrereleaseTesting, .a8cBranchTest, .localDeveloper)
         case .googleLogin:
+            return build(.localDeveloper)
+        case .jetpackDisconnect:
             return build(.localDeveloper)
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/JetpackConnectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackConnectionViewController.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+@objc
+protocol JetpackConnectionDelegate {
+    func jetpackDisconnectedForBlog(_ blog: Blog)
+}
+
+/// The purpose of this class is to manage the Jetpack Connection associated to a site.
+///
+open class JetpackConnectionViewController: UITableViewController {
+
+    // MARK: - Private Properties
+
+    fileprivate var blog: Blog!
+    fileprivate var service: BlogJetpackSettingsService!
+    fileprivate lazy var handler: ImmuTableViewHandler = {
+        return ImmuTableViewHandler(takeOver: self)
+    }()
+
+    // MARK: - Public Properties
+
+    var delegate: JetpackConnectionDelegate?
+
+    // MARK: - Initializer
+
+    public convenience init(blog: Blog) {
+        self.init(style: .grouped)
+        self.blog = blog
+        self.service = BlogJetpackSettingsService(managedObjectContext: blog.managedObjectContext!)
+    }
+
+    // MARK: - View Lifecycle
+
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        title = NSLocalizedString("Manage Connection", comment: "Title for the Jetpack Manage Connection Screen")
+        ImmuTable.registerRows([DestructiveButtonRow.self], tableView: tableView)
+        reloadViewModel()
+    }
+
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+    }
+
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+    }
+
+    // MARK: - Model
+
+    fileprivate func reloadViewModel() {
+        handler.viewModel = tableViewModel()
+    }
+
+    func tableViewModel() -> ImmuTable {
+        let disconnectRow = DestructiveButtonRow(title: NSLocalizedString("Disconnect from WordPress.com",
+                                                                          comment: "Disconnect from WordPress.com button"),
+                                                 action: self.disconnectJetpackTapped(),
+                                                 accessibilityIdentifier: "disconnectFromWordPress.comButton")
+        return ImmuTable(sections: [
+            ImmuTableSection(
+                headerText: "",
+                rows: [disconnectRow],
+                footerText: NSLocalizedString("Your site will no longer send data to WordPress.com and Jetpack features will stop working. You will lose access to the site on the app and you will have to re-add it with the site credentials.",
+                                              comment: "Explanatory text bellow the Disconnect from WordPress.com button")
+            )])
+    }
+
+    // MARK: - Row Handler
+
+    func disconnectJetpackTapped() -> ImmuTableAction {
+        return { [unowned self] row in
+            self.tableView.deselectSelectedRowWithAnimation(true)
+            let message = NSLocalizedString("Are you sure you want to disconnect Jetpack from the site?",
+                                            comment: "Message prompting the user to confirm that they want to disconnect Jetpack from the site.")
+
+            let alertController = UIAlertController(title: nil,
+                                                    message: message,
+                                                    preferredStyle: .alert)
+            alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: ""))
+            alertController.addDestructiveActionWithTitle(NSLocalizedString("Disconnect",
+                                                                            comment: "Title for button that disconnects Jetpack from the site"),
+                                                          handler: { action in
+                                                              self.disconnectJetpack()
+                                                          })
+            self.present(alertController, animated: true, completion: nil)
+        }
+    }
+
+    func disconnectJetpack() {
+        self.service.disconnectJetpackFromBlog(self.blog,
+                                               success: { [weak self] in
+                                                   if let blog = self?.blog {
+                                                       // Jetpack was successfully disconnected, lets hide the blog,
+                                                       // it should become unavailable the next time blogs are fetched
+                                                       let context = ContextManager.sharedInstance().mainContext
+                                                       let service = AccountService(managedObjectContext: context)
+                                                       service.setVisibility(false, forBlogs: [blog])
+                                                       try? context.save()
+                                                       self?.delegate?.jetpackDisconnectedForBlog(blog)
+                                                   } else {
+                                                       self?.dismiss()
+                                                   }
+                                               },
+                                               failure: { error in
+                                                   let errorTitle = NSLocalizedString("Error disconnecting Jetpack",
+                                                                                      comment: "Title of error dialog when disconnecting jetpack fails.")
+                                                   let errorMessage = NSLocalizedString("Please contact support for assistance.",
+                                                                                        comment: "Message displayed on an error alert to prompt the user to contact support")
+                                                   WPError.showAlert(withTitle: errorTitle, message: errorMessage, withSupportButton: true)
+                                                   DDLogError("Error disconnecting Jetpack: \(String(describing: error))")
+                                               })
+    }
+
+    func dismiss() {
+        if isModal() {
+            dismiss(animated: true, completion: nil)
+        } else {
+            navigationController?.popViewController(animated: true)
+        }
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -330,6 +330,7 @@
 		822D60B91F4CCC7A0016C46D /* BlogJetpackSettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822D60B81F4CCC7A0016C46D /* BlogJetpackSettingsService.swift */; };
 		82301B8F1E787420009C9C4E /* AppRatingUtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82301B8E1E787420009C9C4E /* AppRatingUtilityTests.swift */; };
 		8261B4CC1EA8E13700668298 /* SVProgressHUD+Dismiss.m in Sources */ = {isa = PBXBuildFile; fileRef = 8261B4CA1EA8E13700668298 /* SVProgressHUD+Dismiss.m */; };
+		827704F11F607C0E002E8A03 /* JetpackConnectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827704F01F607C0E002E8A03 /* JetpackConnectionViewController.swift */; };
 		8298F38F1EEF2B15008EB7F0 /* AppFeedbackPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8298F38E1EEF2B15008EB7F0 /* AppFeedbackPromptView.swift */; };
 		8298F3921EEF3BA7008EB7F0 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8298F3911EEF3BA7008EB7F0 /* StoreKit.framework */; };
 		82B85DF91EDDB807004FD510 /* SiteIconPickerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */; };
@@ -1500,6 +1501,7 @@
 		8261B4CA1EA8E13700668298 /* SVProgressHUD+Dismiss.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SVProgressHUD+Dismiss.m"; sourceTree = "<group>"; };
 		8261B4CB1EA8E13700668298 /* SVProgressHUD+Dismiss.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SVProgressHUD+Dismiss.h"; sourceTree = "<group>"; };
 		827482C81E966E32001A2B62 /* WordPress 58.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 58.xcdatamodel"; sourceTree = "<group>"; };
+		827704F01F607C0E002E8A03 /* JetpackConnectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackConnectionViewController.swift; sourceTree = "<group>"; };
 		8298F38E1EEF2B15008EB7F0 /* AppFeedbackPromptView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppFeedbackPromptView.swift; sourceTree = "<group>"; };
 		8298F3911EEF3BA7008EB7F0 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteIconPickerPresenter.swift; sourceTree = "<group>"; };
@@ -3823,6 +3825,7 @@
 				B54346951C6A707D0010B3AD /* LanguageViewController.swift */,
 				E1468DE61E794A4D0044D80F /* LanguageSelectorViewController.swift */,
 				B5AC00671BE3C4E100F8E7C3 /* DiscussionSettingsViewController.swift */,
+				827704F01F607C0E002E8A03 /* JetpackConnectionViewController.swift */,
 				822D60B01F4C747E0016C46D /* JetpackSecuritySettingsViewController.swift */,
 				FF42584E1BA092EE00580C68 /* RelatedPostsSettingsViewController.h */,
 				FF42584F1BA092EE00580C68 /* RelatedPostsSettingsViewController.m */,
@@ -6597,6 +6600,7 @@
 				E1EBC36F1C118EA500F638E0 /* ImmuTable.swift in Sources */,
 				B59B18751CC7FB8D0055EB7C /* PersonViewController.swift in Sources */,
 				E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */,
+				827704F11F607C0E002E8A03 /* JetpackConnectionViewController.swift in Sources */,
 				5D839AAB187F0D8000811F4A /* PostGeolocationCell.m in Sources */,
 				5D732F971AE84E3C00CD89E7 /* PostListFooterView.m in Sources */,
 				A2DC5B1A1953451B009584C3 /* WPNUXHelpBadgeLabel.m in Sources */,

--- a/WordPressKit/WordPressKit/BlogJetpackSettingsServiceRemote.swift
+++ b/WordPressKit/WordPressKit/BlogJetpackSettingsServiceRemote.swift
@@ -75,7 +75,7 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(path!,
                                  parameters: parameters,
                                  success: {
-                                    _, _ in
+                                    _ in
                                     success()
                                  }, failure: {
                                     error, _ in
@@ -94,7 +94,7 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(path!,
                                  parameters: parameters,
                                  success: {
-                                    _, _ in
+                                    _ in
                                     success()
                                  }, failure: {
                                     error, _ in
@@ -111,7 +111,7 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(path!,
                                  parameters: nil,
                                  success: {
-                                     _, _ in
+                                     _ in
                                      success()
                                  }, failure: {
                                      error, _ in

--- a/WordPressKit/WordPressKit/BlogJetpackSettingsServiceRemote.swift
+++ b/WordPressKit/WordPressKit/BlogJetpackSettingsServiceRemote.swift
@@ -99,6 +99,23 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
                                  }, failure: {
                                     error, _ in
                                     failure(error)
+                                })
+    }
+
+    /// Disconnects Jetpack from a site
+    ///
+    public func disconnectJetpackFromSite(_ siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+        let endpoint = "jetpack-blogs/\(siteID)/mine/delete"
+        let path = self.path(forEndpoint: endpoint, with: .version_1_1)
+
+        wordPressComRestApi.POST(path!,
+                                 parameters: nil,
+                                 success: {
+                                     _, _ in
+                                     success()
+                                 }, failure: {
+                                     error, _ in
+                                     failure(error)
                                  })
     }
 


### PR DESCRIPTION
**Fixes** #7473
This is a development only implementation for Jetpack disconnect. The feature as will be rolled out to users will have very a different UI, with strong confirmation dialogs, in line with Calypso.
I'm implementing this now so we can test the remote call and also have an easy way to disconnect while we work on the rest of the Jetpack experience.
Please note that this is feature flagged and will only be available for development builds.

**To test:**
1. Select a Jetpack site
2. Settings
3. Manage Connection
4. Disconnect from WordPress.com
5. Verify on the web that Jetpack was disconnected

![jetpacksitedisconnect](https://user-images.githubusercontent.com/5558824/30748365-7676ff4a-9f86-11e7-968e-3a6ab3aa92ed.gif)

Needs review: @koke 
cc: @mattmiklic 