### PR TITLE
Media: Remove new inline media picker feature flag

### DIFF
--- a/WordPress/Classes/Utility/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/FeatureFlag.swift
@@ -4,7 +4,6 @@
 enum FeatureFlag: Int {
     case exampleFeature
     case newMediaExports
-    case newInputMediaPicker
     case pluginManagement
     case jetpackThemesBrowsing
     case googleLogin
@@ -16,8 +15,6 @@ enum FeatureFlag: Int {
             return true
         case .newMediaExports:
             return build(.localDeveloper, .a8cBranchTest)
-        case .newInputMediaPicker:
-            return build(.a8cPrereleaseTesting, .a8cBranchTest, .localDeveloper)
         case .pluginManagement:
             return build(.localDeveloper)
         case .jetpackThemesBrowsing:

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1800,10 +1800,7 @@ extension AztecPostViewController {
 
     private func presentMediaPicker(fromButton button: UIButton, animated: Bool = true) {
         trackFormatBarAnalytics(stat: .editorTappedImage)
-        if !(FeatureFlag.newInputMediaPicker.enabled) {
-            presentMediaPickerFullScreen(animated: animated)
-            return
-        }
+
         let options = WPMediaPickerOptions()
         options.showMostRecentFirst = true
         options.filter = [WPMediaType.image, WPMediaType.video]


### PR DESCRIPTION
This PR removes the feature flag for the new inline media picker.

<img width="374" alt="screen shot 2017-09-25 at 15 16 13" src="https://user-images.githubusercontent.com/4780/30813138-82b4a00c-a204-11e7-85b5-fee7e13bebfe.png">

To test:

* Check the code
* Build and run the app, check that the inline media picker is present in Aztec

Needs review: @SergioEstevao  
