### PR TITLE
ReaderComments: Override default header and footer height

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -888,6 +888,17 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     }
 }
 
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    // Override WPTableViewHandler's default of UITableViewAutomaticDimension,
+    // which results in 30pt tall headers on iOS 11
+    return 0;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+{
+    return 0;
+}
 
 #pragma mark - UIScrollView Delegate Methods
 


### PR DESCRIPTION
Fixes #7845. See original issue for screenshot.

On iOS 11, we were seeing large grey headers and footers in the reader comments section. This screen uses `WPTableViewHandler`, and it seems that the default header / footer height of `UITableViewAutomaticDimension` was producing ~30pt tall headers and footers. I've overridden this in the comments view controller itself to keep them at 0 height.

To test:

* View the comments for a post in the Reader, and ensure that the headers and footers no longer show.

Needs review: @elibud 