### PR TITLE
Issue/7846: SettingsTextViewController cell height

### DIFF
--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -81,6 +81,9 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
 
     self.shouldNotifyValue = YES;
 
+    // Don't auto-size rows
+    self.tableView.estimatedRowHeight = 0;
+
     [self startListeningTextfieldChanges];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 }


### PR DESCRIPTION
Fixes #7846 

In iOS 11, table cells default to being auto sizing. This was resulting in the text cell in `SettingsTextViewController` collapsing to fit its content exactly. We'd prefer the cell to be the default cell height (44pt), so we'll disable auto sizing for it.

To test:

* Navigate to Me > My Profile > First Name, and ensure the cell is the correct height.

Needs review: @jleandroperez 