### PR TITLE
Issue/7844 Fix misplaced follow button

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.swift
@@ -11,10 +11,14 @@ class NoteBlockUserTableViewCell: NoteBlockTableViewCell {
 
     var isFollowEnabled: Bool {
         set {
-            btnFollow.isHidden = !newValue
+            if newValue {
+                innerStackView.addArrangedSubview(btnFollow)
+            } else {
+                btnFollow.removeFromSuperview()
+            }
         }
         get {
-            return !btnFollow.isHidden
+            return btnFollow.superview != nil
         }
     }
     var isFollowOn: Bool {
@@ -87,8 +91,9 @@ class NoteBlockUserTableViewCell: NoteBlockTableViewCell {
     fileprivate var gravatarURL: URL?
 
     // MARK: - IBOutlets
-    @IBOutlet fileprivate weak var nameLabel: UILabel!
-    @IBOutlet fileprivate weak var blogLabel: UILabel!
-    @IBOutlet fileprivate weak var btnFollow: UIButton!
-    @IBOutlet fileprivate weak var gravatarImageView: CircularImageView!
+    @IBOutlet fileprivate var nameLabel: UILabel!
+    @IBOutlet fileprivate var blogLabel: UILabel!
+    @IBOutlet fileprivate var btnFollow: UIButton!
+    @IBOutlet fileprivate var gravatarImageView: CircularImageView!
+    @IBOutlet fileprivate var innerStackView: UIStackView!
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.xib
@@ -107,6 +107,7 @@
                 <outlet property="blogLabel" destination="Lsp-ya-PNI" id="MU2-IP-ioj"/>
                 <outlet property="btnFollow" destination="7h0-qK-qQQ" id="mrP-k7-mXx"/>
                 <outlet property="gravatarImageView" destination="LYp-ge-5Fb" id="zlq-p2-dIB"/>
+                <outlet property="innerStackView" destination="ilL-3r-WNn" id="oHd-Sx-qs8"/>
                 <outlet property="nameLabel" destination="bBR-jy-KRp" id="qrk-bR-zkq"/>
             </connections>
             <point key="canvasLocation" x="15" y="115"/>


### PR DESCRIPTION
Fixes #7844 

In iOS 11, the Follow button in notifications can become misplaced when hidden. I couldn't work out exactly why it was being misplaced, as it seems to not be in the view hierarchy at this point. To fix it, we now explicitly remove the button from the view hierarchy entirely, and re-add it if necessary.

To test:

* See original issue for testing steps. Ensure the follow button isn't visible when it shouldn't be there.

Needs review: @jleandroperez 