### PR TITLE
Consistently use WordPress blue for links on table footers

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/JetpackConnectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackConnectionViewController.swift
@@ -35,6 +35,7 @@ open class JetpackConnectionViewController: UITableViewController {
         super.viewDidLoad()
         title = NSLocalizedString("Manage Connection", comment: "Title for the Jetpack Manage Connection Screen")
         ImmuTable.registerRows([DestructiveButtonRow.self], tableView: tableView)
+        WPStyleGuide.configureColors(for: view, andTableView: tableView)
         reloadViewModel()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
@@ -42,6 +42,7 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
         title = NSLocalizedString("Security", comment: "Title for the Jetpack Security Settings Screen")
         ImmuTable.registerRows([SwitchRow.self], tableView: tableView)
         ImmuTable.registerRows([NavigationItemRow.self], tableView: tableView)
+        WPStyleGuide.configureColors(for: view, andTableView: tableView)
         reloadViewModel()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
@@ -161,8 +161,7 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
             footer.textLabel?.text = NSLocalizedString("Learn more...",
                                                        comment: "Jetpack Settings: WordPress.com Login WordPress login footer text")
             footer.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
-            WPStyleGuide.configureTableViewSectionFooter(footer)
-            footer.isUserInteractionEnabled = true
+            footer.textLabel?.isUserInteractionEnabled = true
 
             let tap = UITapGestureRecognizer(target: self, action: #selector(self.handleLearnMoreTap(_:)))
             footer.addGestureRecognizer(tap)

--- a/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
@@ -154,16 +154,16 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
 
     open override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         if section == JetpackSecuritySettingsViewController.wordPressLoginSection {
-            let footer = UITableViewHeaderFooterView.init(frame: CGRect(x: 0.0,
-                                                                        y: 0.0,
-                                                                        width: tableView.frame.width,
-                                                                        height: JetpackSecuritySettingsViewController.footerHeight))
+            let footer = UITableViewHeaderFooterView(frame: CGRect(x: 0.0,
+                                                                   y: 0.0,
+                                                                   width: tableView.frame.width,
+                                                                   height: JetpackSecuritySettingsViewController.footerHeight))
             footer.textLabel?.text = NSLocalizedString("Learn more...",
                                                        comment: "Jetpack Settings: WordPress.com Login WordPress login footer text")
             footer.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
             footer.textLabel?.isUserInteractionEnabled = true
 
-            let tap = UITapGestureRecognizer(target: self, action: #selector(self.handleLearnMoreTap(_:)))
+            let tap = UITapGestureRecognizer(target: self, action: #selector(handleLearnMoreTap(_:)))
             footer.addGestureRecognizer(tap)
             return footer
         }
@@ -287,7 +287,7 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
 
     // MARK: - Footer handler
 
-    func handleLearnMoreTap(_ sender: UITapGestureRecognizer) {
+    @objc fileprivate func handleLearnMoreTap(_ sender: UITapGestureRecognizer) {
         guard let url =  URL(string: JetpackSecuritySettingsViewController.learnMoreUrl) else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -165,16 +165,16 @@ class AppSettingsViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         if shouldShowEditorFooterForSection(section) {
-            let footer = UITableViewHeaderFooterView.init(frame: CGRect(x: 0.0,
-                                                                        y: 0.0,
-                                                                        width: tableView.frame.width,
-                                                                        height: AppSettingsViewController.aztecEditorFooterHeight))
+            let footer = UITableViewHeaderFooterView(frame: CGRect(x: 0.0,
+                                                                   y: 0.0,
+                                                                   width: tableView.frame.width,
+                                                                   height: AppSettingsViewController.aztecEditorFooterHeight))
             footer.textLabel?.text = NSLocalizedString("Editor release notes & bug reporting",
                                                        comment: "Label for button linking to release notes and bug reporting help for the new beta Aztec editor")
             footer.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
             footer.textLabel?.isUserInteractionEnabled = true
 
-            let tap = UITapGestureRecognizer(target: self, action: #selector(self.handleEditorFooterTap(_:)))
+            let tap = UITapGestureRecognizer(target: self, action: #selector(handleEditorFooterTap(_:)))
             footer.addGestureRecognizer(tap)
             return footer
         }
@@ -194,7 +194,7 @@ class AppSettingsViewController: UITableViewController {
         return section == Sections.editor.rawValue && EditorSettings().editor == .aztec
     }
 
-    func handleEditorFooterTap(_ sender: UITapGestureRecognizer) {
+    @objc fileprivate func handleEditorFooterTap(_ sender: UITapGestureRecognizer) {
         WPAppAnalytics.track(.editorAztecBetaLink)
         WPWebViewController.presentWhatsNewWebView(from: self)
     }

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -12,6 +12,7 @@ class AppSettingsViewController: UITableViewController {
     }
 
     fileprivate var handler: ImmuTableViewHandler!
+    fileprivate static let aztecEditorFooterHeight = CGFloat(34.0)
 
     // MARK: - Initialization
 
@@ -30,9 +31,6 @@ class AppSettingsViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        tableView.register(AppSettingsEditorFooterView.self,
-                           forHeaderFooterViewReuseIdentifier: AppSettingsEditorFooterView.reuseIdentifier)
 
         ImmuTable.registerRows([
             DestructiveButtonRow.self,
@@ -167,17 +165,18 @@ class AppSettingsViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         if shouldShowEditorFooterForSection(section) {
-            let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: AppSettingsEditorFooterView.reuseIdentifier) as! AppSettingsEditorFooterView
+            let footer = UITableViewHeaderFooterView.init(frame: CGRect(x: 0.0,
+                                                                        y: 0.0,
+                                                                        width: tableView.frame.width,
+                                                                        height: AppSettingsViewController.aztecEditorFooterHeight))
+            footer.textLabel?.text = NSLocalizedString("Editor release notes & bug reporting",
+                                                       comment: "Label for button linking to release notes and bug reporting help for the new beta Aztec editor")
+            footer.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
+            footer.textLabel?.isUserInteractionEnabled = true
 
-            view.tapBlock = { [weak self] in
-                WPAppAnalytics.track(.editorAztecBetaLink)
-
-                if let controller = self {
-                    WPWebViewController.presentWhatsNewWebView(from: controller)
-                }
-            }
-
-            return view
+            let tap = UITapGestureRecognizer(target: self, action: #selector(self.handleEditorFooterTap(_:)))
+            footer.addGestureRecognizer(tap)
+            return footer
         }
 
         return nil
@@ -185,7 +184,7 @@ class AppSettingsViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         if shouldShowEditorFooterForSection(section) {
-            return AppSettingsEditorFooterView.height
+            return AppSettingsViewController.aztecEditorFooterHeight
         }
 
         return UITableViewAutomaticDimension
@@ -193,6 +192,11 @@ class AppSettingsViewController: UITableViewController {
 
     private func shouldShowEditorFooterForSection(_ section: Int) -> Bool {
         return section == Sections.editor.rawValue && EditorSettings().editor == .aztec
+    }
+
+    func handleEditorFooterTap(_ sender: UITapGestureRecognizer) {
+        WPAppAnalytics.track(.editorAztecBetaLink)
+        WPWebViewController.presentWhatsNewWebView(from: self)
     }
 
     // MARK: - Media cache methods
@@ -394,50 +398,5 @@ fileprivate struct ImageSizingRow: ImmuTableRow {
         cell.selectionStyle = .none
 
         (cell.minValue, cell.maxValue) = MediaSettings().allowedImageSizeRange
-    }
-}
-
-fileprivate class AppSettingsEditorFooterView: UITableViewHeaderFooterView {
-    static let height: CGFloat = 38.0
-    static let reuseIdentifier = "AppSettingsEditorFooterView"
-    var tapBlock: (() -> Void)? = nil
-
-    override init(reuseIdentifier: String?) {
-        super.init(reuseIdentifier: reuseIdentifier)
-
-        let stackView = UIStackView()
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.alignment = .fill
-        stackView.distribution = .equalSpacing
-        stackView.axis = .horizontal
-
-        let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .footnote)
-        label.text = NSLocalizedString("Editor release notes & bug reporting", comment: "Label for button linking to release notes and bug reporting help for the new beta Aztec editor")
-        label.textColor = WPStyleGuide.greyDarken10()
-        stackView.addArrangedSubview(label)
-
-        let button = UIButton(type: .custom)
-        button.setImage(Gridicon.iconOfType(.infoOutline), for: .normal)
-        button.tintColor = WPStyleGuide.greyDarken10()
-        button.addTarget(self, action: #selector(footerButtonTapped), for: .touchUpInside)
-
-        contentView.addSubview(stackView)
-        stackView.addArrangedSubview(button)
-
-        NSLayoutConstraint.activate([
-            stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            stackView.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor)
-            ])
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    @IBAction private func footerButtonTapped() {
-        tapBlock?()
     }
 }

--- a/WordPressShared/WordPressShared/Core/Views/WPStyleGuide.m
+++ b/WordPressShared/WordPressShared/Core/Views/WPStyleGuide.m
@@ -391,7 +391,11 @@
 	if (![footer isKindOfClass:[UITableViewHeaderFooterView class]]) {
 		return;
 	}
-	footer.textLabel.textColor = [self greyDarken10];
+    if (footer.textLabel.userInteractionEnabled) {
+        footer.textLabel.textColor = [self wordPressBlue];
+    } else {
+        footer.textLabel.textColor = [self greyDarken10];
+    }
 }
 
 // TODO: Move to fetaure category


### PR DESCRIPTION
**Fixes** #7851 
And it also updates the AztecEditor footer to remove the info icon as agreed with @mattmiklic and to use WordPress blue in the link text.

**To test:**
Go to Jetpack Settings and check that the Learn More text is the correct color and that taping navigatest to the WebViewController.
Repeat for the Aztec editor feedback link on app settings.

![simulator screen shot - iphone 8 - 2017-09-27 at 11 27 30](https://user-images.githubusercontent.com/5558824/30919622-559a038a-a378-11e7-98f8-b30758f32eb3.png)![simulator screen shot - iphone 8 - 2017-09-27 at 11 27 37](https://user-images.githubusercontent.com/5558824/30919625-55d2acda-a378-11e7-8035-a055b4972419.png)

Needs review: @frosty 
