### PR TITLE
Issue/7816 Update New Post tab bar button for iOS 11

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -542,6 +542,7 @@ int ddLogLevel = DDLogLevelInfo;
 
     [[UITabBar appearance] setShadowImage:[UIImage imageWithColor:[UIColor colorWithRed:210.0/255.0 green:222.0/255.0 blue:230.0/255.0 alpha:1.0]]];
     [[UITabBar appearance] setTintColor:[WPStyleGuide newKidOnTheBlockBlue]];
+    [[UITabBar appearance] setUnselectedItemTintColor:[WPStyleGuide greyLighten10]];
 
     [[UINavigationBar appearance] setBackgroundImage:[WPStyleGuide navigationBarBackgroundImage] forBarMetrics:UIBarMetricsDefault];
     [[UINavigationBar appearance] setShadowImage:[WPStyleGuide navigationBarShadowImage]];


### PR DESCRIPTION
Fixes #7816. See the original issue for details of the problems we were having with the New Post button in iOS 11.

I've updated the logic so that we now show a different style in a couple of different situations, where the tab bar shows button icons and labels side-by-side instead of vertically stacked:

* Landscape on iPhone
* Portrait on iPad when the app is fullscreen
* Landscape on iPad if the app fills greater than 50% of the screen

It feels a bit of a hack detecting these specific cases, but I can't see any other way to determine how the bar is currently displaying. Here's how things look now:

![tab-buttons-1](https://user-images.githubusercontent.com/4780/30922907-6803967e-a3a2-11e7-98d8-ec515c19d319.png)

To test:

* On each type of device, test the tab bar in both orientations, and in different multitasking splits:
- [x] iPhone 8 landscape / portrait
- [x] iPhone 8 Plus landscape / portrait
- [x] iPhone X landscape / portrait
- [x] iPhone SE landscape / portrait
- [x] iPad landscape / portrait
- [x] iPad multitasking splits at each side in each orientation

Needs review: @elibud 

cc @mattmiklic does this look ok to you?