### PR TITLE
RichContentFormatter: Sanitizer Fix

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -378,7 +378,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 {
     NSString *content = string;
     content = [RichContentFormatter removeTrailingBreakTags:content];
-    content = [RichContentFormatter formatContentString:content isPrivateStie:isPrivateSite];
+    content = [RichContentFormatter formatContentString:content isPrivateSite:isPrivateSite];
     return content;
 }
 

--- a/WordPressKit/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/WordPressKit/ReaderPostServiceRemote.m
@@ -754,7 +754,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
     NSString *content = [self stringOrEmptyString:[dict stringForKey:PostRESTKeyContent]];
     BOOL isPrivateSite = [self siteIsPrivateFromPostDictionary:dict];
 
-    return [RichContentFormatter formatContentString:content isPrivateStie:isPrivateSite];
+    return [RichContentFormatter formatContentString:content isPrivateSite:isPrivateSite];
 }
 
 /**

--- a/WordPressShared/WordPressShared/Core/Utility/RichContentFormatter.swift
+++ b/WordPressShared/WordPressShared/Core/Utility/RichContentFormatter.swift
@@ -209,11 +209,7 @@ import Foundation
             return string
         }
 
-        guard let window = UIApplication.shared.keyWindow else {
-            return string
-        }
-
-        let imageSize = window.frame.size
+        let imageSize = UIScreen.main.bounds.size
         let scale = UIScreen.main.scale
         let scaledSize = imageSize.applying(CGAffineTransform(scaleX: scale, y: scale))
 

--- a/WordPressShared/WordPressShared/Core/Utility/RichContentFormatter.swift
+++ b/WordPressShared/WordPressShared/Core/Utility/RichContentFormatter.swift
@@ -40,7 +40,7 @@ import Foundation
     ///
     /// - Returns: The formatted string.
     ///
-    public class func formatContentString(_ string: String, isPrivateStie isPrivate: Bool) -> String {
+    public class func formatContentString(_ string: String, isPrivateSite isPrivate: Bool) -> String {
         guard string.characters.count > 0 else {
             return string
         }


### PR DESCRIPTION
### Details:
In this PR we're swapping `UIApplication.shared.keyWindow` usage for `UIScreen.main`:

- We're **not** updating the threading scheme.
- Instead, we're switching over an API that doesn't piss off the Main Thread Sanitizer.
- We'll iterate... if the console warning gets back!

Closes #7861

### To test:
1. Launch the app in Xcode 9
2. Open the Reader and sync
3. Verify that no warning shows up in the console

Needs review: @aerych 
Thanks in advance sir!
