### PR TITLE
Comment Actions: Fixed Font Size

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -378,6 +378,6 @@ private extension NoteBlockActionsTableViewCell {
 
     struct Constants {
         static let buttonSpacing = CGFloat(20)
-        static let buttonSpacingCompact = CGFloat(10)
+        static let buttonSpacingCompact = CGFloat(9)
     }
 }

--- a/WordPress/Classes/ViewRelated/Views/VerticallyStackedButton.m
+++ b/WordPress/Classes/ViewRelated/Views/VerticallyStackedButton.m
@@ -1,6 +1,9 @@
 #import "VerticallyStackedButton.h"
+#import <WordPressShared/WPFontManager.h>
+
 
 static const CGFloat ImageLabelSeparation = 2.f;
+static const CGFloat LabelFontSize = 11.f;
 
 @implementation VerticallyStackedButton
 
@@ -19,7 +22,7 @@ static const CGFloat ImageLabelSeparation = 2.f;
 - (void)layoutSubviews {
     [super layoutSubviews];
     
-    [self.titleLabel setFont:[WPStyleGuide labelFontNormal]];
+    [self.titleLabel setFont:[WPFontManager systemRegularFontOfSize:LabelFontSize]];
     
     CGSize imageSize    = self.imageView.image.size;
     CGSize maxTitleSize = CGSizeMake(CGRectGetWidth(self.frame), CGRectGetHeight(self.frame) - imageSize.height);

--- a/WordPress/Classes/ViewRelated/Views/VerticallyStackedButton.m
+++ b/WordPress/Classes/ViewRelated/Views/VerticallyStackedButton.m
@@ -4,11 +4,10 @@ static const CGFloat ImageLabelSeparation = 2.f;
 
 @implementation VerticallyStackedButton
 
-- (id)initWithFrame:(CGRect)frame {
+- (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
-    
     if (self) {
-        [self.titleLabel setLineBreakMode: NSLineBreakByTruncatingTail];
+        [self.titleLabel setLineBreakMode:NSLineBreakByTruncatingTail];
         [self setTitleColor:[WPStyleGuide newKidOnTheBlockBlue] forState:UIControlStateNormal];
         [self setTitleColor:[WPStyleGuide midnightBlue] forState:UIControlStateHighlighted];
         [self setTintColor:[WPStyleGuide newKidOnTheBlockBlue]];
@@ -23,9 +22,12 @@ static const CGFloat ImageLabelSeparation = 2.f;
     [self.titleLabel setFont:[WPStyleGuide labelFontNormal]];
     
     CGSize imageSize    = self.imageView.image.size;
-    CGSize maxTitleSize = CGSizeMake(CGRectGetWidth(self.frame), CGRectGetHeight(self.frame) - (imageSize.height));
+    CGSize maxTitleSize = CGSizeMake(CGRectGetWidth(self.frame), CGRectGetHeight(self.frame) - imageSize.height);
     CGSize titleSize    = [self.titleLabel sizeThatFits:maxTitleSize];
-    
+
+    // Prevent Overflowing the container's area
+    titleSize.width     = MIN(CGRectGetWidth(self.frame), titleSize.width);
+
     self.imageView.frame = CGRectIntegral(CGRectMake((CGRectGetWidth(self.frame) - imageSize.width) * 0.5f,
                                                      (CGRectGetHeight(self.frame) - (imageSize.height + titleSize.height)) * 0.5f,
                                                      imageSize.width,


### PR DESCRIPTION
### Details:
In this PR we're:
- Updating VerticallyStackedButton so that the titleLabel never overflows the container frame.
- Enforcing a fixed size for the Notification Comment's Actions.

I'm opting towards a fixed point size, since that's exactly what happens with the TabBar: each action has an icon, so it really does not make any sense to break the UI. Each action is recognizable always.

Fixes #7696 

### To test:
1. Enable Dynamic Typing a select a bigger font
2. Launch WPiOS
3. Open a Comment-Y Notification
4. Verify that Approving / Disapproving a comment doesn't cause the text to move
5. Verify that the font size remains fixed.

Needs review: @elibud 
Elisa, may i bug you with this one?

Thanks in advance!
