### PR TITLE
PushAuthentication: Swift Update(s)

### DIFF
--- a/WordPress/Classes/Utility/PushAuthenticationManager.swift
+++ b/WordPress/Classes/Utility/PushAuthenticationManager.swift
@@ -154,7 +154,7 @@ private extension PushAuthenticationManager {
 //
 private extension PushAuthenticationManager {
 
-    struct Settings {
+    enum Settings {
         static let initialRetryCount = 0
         static let maximumRetryCount = 3
         static let minimumRemainingExpirationTime = TimeInterval(5)

--- a/WordPress/Classes/Utility/PushAuthenticationManager.swift
+++ b/WordPress/Classes/Utility/PushAuthenticationManager.swift
@@ -8,13 +8,18 @@ import WordPressShared
 /// authorizing access by means of a mobile device that's already authenticated.
 /// By doing so, WordPress.com backend will send a Push Notification, which is meant to be handled by this specific class.
 ///
-    // MARK: - Public Methods
-    //
-    open var alertControllerProxy = UIAlertControllerProxy()
-    open let pushAuthenticationService: PushAuthenticationService
 class PushAuthenticationManager {
 
-    override convenience init() {
+    /// AlertController Proxy
+    ///
+    var alertControllerProxy = UIAlertControllerProxy()
+
+    /// PushAuth Service
+    ///
+    fileprivate let pushAuthenticationService: PushAuthenticationService
+
+
+    convenience init() {
         let context = ContextManager.sharedInstance().mainContext
         let service = PushAuthenticationService(managedObjectContext: context)
         self.init(pushAuthenticationService: service)
@@ -22,7 +27,6 @@ class PushAuthenticationManager {
 
     public init(pushAuthenticationService: PushAuthenticationService) {
         self.pushAuthenticationService = pushAuthenticationService
-        super.init()
     }
 
 
@@ -87,7 +91,7 @@ private extension PushAuthenticationManager {
             return
         }
 
-        self.pushAuthenticationService.authorizeLogin(token) { success in
+        pushAuthenticationService.authorizeLogin(token) { success in
             if !success {
                 self.authorizeLogin(token, retryCount: (retryCount + 1))
             }
@@ -136,9 +140,9 @@ private extension PushAuthenticationManager {
         let acceptButtonTitle   = NSLocalizedString("Approve", comment: "Approve action. Verb")
 
         alertControllerProxy.show(withTitle: title,
-                                           message: message,
-                                           cancelButtonTitle: cancelButtonTitle,
-                                           otherButtonTitles: [acceptButtonTitle]) { (theAlertController, buttonIndex) in
+                                  message: message,
+                                  cancelButtonTitle: cancelButtonTitle,
+                                  otherButtonTitles: [acceptButtonTitle]) { (theAlertController, buttonIndex) in
             let approved = theAlertController?.actions[buttonIndex].style != .cancel
             completion(approved)
         }

--- a/WordPress/Classes/Utility/PushAuthenticationManager.swift
+++ b/WordPress/Classes/Utility/PushAuthenticationManager.swift
@@ -38,7 +38,7 @@ class PushAuthenticationManager {
     ///
     /// - Returns: True if the notification should be handled by this class
     ///
-    func isPushAuthenticationNotification(_ userInfo: NSDictionary?) -> Bool {
+    func isAuthenticationNotification(_ userInfo: NSDictionary?) -> Bool {
         let noteType = userInfo?["type"] as? String
         return noteType == Settings.pushAuthenticationNoteType
     }
@@ -51,8 +51,8 @@ class PushAuthenticationManager {
     ///
     /// - Parameter userInfo: Is the Notification's payload.
     ///
-    func handlePushAuthenticationNotification(_ userInfo: NSDictionary?) {
-        guard isNotificationExpired(userInfo) == false else {
+    func handleAuthenticationNotification(_ userInfo: NSDictionary?) {
+        guard isAuthenticationNotificationExpired(userInfo) == false else {
             showLoginExpiredAlert()
             WPAnalytics.track(.pushAuthenticationExpired)
             return
@@ -103,7 +103,7 @@ private extension PushAuthenticationManager {
     ///
     /// - Parameter userInfo: Is the Notification's payload.
     ///
-    func isNotificationExpired(_ userInfo: NSDictionary?) -> Bool {
+    func isAuthenticationNotificationExpired(_ userInfo: NSDictionary?) -> Bool {
         guard let rawExpiration = userInfo?["expires"] as? TimeInterval else {
             return false
         }

--- a/WordPress/Classes/Utility/PushAuthenticationManager.swift
+++ b/WordPress/Classes/Utility/PushAuthenticationManager.swift
@@ -47,9 +47,8 @@ class PushAuthenticationManager {
     ///
     /// - Parameter userInfo: Is the Notification's payload.
     ///
-        // Expired: Display a message!
-        if isNotificationExpired(userInfo) {
     func handlePushAuthenticationNotification(_ userInfo: NSDictionary?) {
+        guard isNotificationExpired(userInfo) == false else {
             showLoginExpiredAlert()
             WPAnalytics.track(.pushAuthenticationExpired)
             return
@@ -100,9 +99,8 @@ private extension PushAuthenticationManager {
     ///
     /// - Parameter userInfo: Is the Notification's payload.
     ///
-        let rawExpiration = userInfo?["expires"] as? TimeInterval
-        if rawExpiration == nil {
     func isNotificationExpired(_ userInfo: NSDictionary?) -> Bool {
+        guard let rawExpiration = userInfo?["expires"] as? TimeInterval else {
             return false
         }
 

--- a/WordPress/Classes/Utility/PushAuthenticationManager.swift
+++ b/WordPress/Classes/Utility/PushAuthenticationManager.swift
@@ -8,11 +8,11 @@ import WordPressShared
 /// authorizing access by means of a mobile device that's already authenticated.
 /// By doing so, WordPress.com backend will send a Push Notification, which is meant to be handled by this specific class.
 ///
-@objc open class PushAuthenticationManager: NSObject {
     // MARK: - Public Methods
     //
     open var alertControllerProxy = UIAlertControllerProxy()
     open let pushAuthenticationService: PushAuthenticationService
+class PushAuthenticationManager {
 
     override convenience init() {
         let context = ContextManager.sharedInstance().mainContext
@@ -34,12 +34,12 @@ import WordPressShared
     ///
     /// - Returns: True if the notification should be handled by this class
     ///
-    open func isPushAuthenticationNotification(_ userInfo: NSDictionary?) -> Bool {
         if let unwrappedNoteType = userInfo?["type"] as? String {
             return unwrappedNoteType == pushAuthenticationNoteType
         }
 
         return false
+    func isPushAuthenticationNotification(_ userInfo: NSDictionary?) -> Bool {
     }
 
     /// Will display a popup requesting for permission to verify a WordPress.com login attempt.
@@ -50,9 +50,9 @@ import WordPressShared
     ///
     /// - Parameter userInfo: Is the Notification's payload.
     ///
-    open func handlePushAuthenticationNotification(_ userInfo: NSDictionary?) {
         // Expired: Display a message!
         if isNotificationExpired(userInfo) {
+    func handlePushAuthenticationNotification(_ userInfo: NSDictionary?) {
             showLoginExpiredAlert()
             WPAnalytics.track(.pushAuthenticationExpired)
             return
@@ -75,9 +75,9 @@ import WordPressShared
     }
 
 
-
-    // MARK: - Private Helpers
-    //
+// MARK: - Private Helpers
+//
+private extension PushAuthenticationManager {
 
     /// Authorizes a WordPress.com login attempt.
     ///
@@ -85,8 +85,8 @@ import WordPressShared
     ///     - token: The login request token received in the Push Notification itself.
     ///     - retryCount: The number of retries that have taken place.
     ///
-    fileprivate func authorizeLogin(_ token: String, retryCount: Int) {
         if retryCount == maximumRetryCount {
+    func authorizeLogin(_ token: String, retryCount: Int) {
             WPAnalytics.track(.pushAuthenticationFailed)
             return
         }
@@ -103,9 +103,9 @@ import WordPressShared
     ///
     /// - Parameter userInfo: Is the Notification's payload.
     ///
-    fileprivate func isNotificationExpired(_ userInfo: NSDictionary?) -> Bool {
         let rawExpiration = userInfo?["expires"] as? TimeInterval
         if rawExpiration == nil {
+    func isNotificationExpired(_ userInfo: NSDictionary?) -> Bool {
             return false
         }
 
@@ -116,7 +116,7 @@ import WordPressShared
 
     /// Displays an AlertView indicating that a Login Request has expired.
     ///
-    fileprivate func showLoginExpiredAlert() {
+    func showLoginExpiredAlert() {
         let title               = NSLocalizedString("Login Request Expired", comment: "Login Request Expired")
         let message             = NSLocalizedString("The login request has expired. Log in to WordPress.com to try again.",
                                                     comment: "WordPress.com Push Authentication Expired message")
@@ -135,7 +135,7 @@ import WordPressShared
     ///     - message: The message to be displayed.
     ///     - completion: A closure that receives a parameter, indicating whether the login attempt was confirmed or not.
     ///
-    fileprivate func showLoginVerificationAlert(_ message: String, completion: @escaping ((_ approved: Bool) -> ())) {
+    func showLoginVerificationAlert(_ message: String, completion: @escaping ((_ approved: Bool) -> ())) {
         let title               = NSLocalizedString("Verify Log In", comment: "Push Authentication Alert Title")
         let cancelButtonTitle   = NSLocalizedString("Ignore", comment: "Ignore action. Verb")
         let acceptButtonTitle   = NSLocalizedString("Approve", comment: "Approve action. Verb")
@@ -148,7 +148,12 @@ import WordPressShared
             completion(approved)
         }
     }
+}
 
+
+// MARK: - Private Internal Constants
+//
+private extension PushAuthenticationManager {
 
     // MARK: - Private Internal Constants
     fileprivate let initialRetryCount                   = 0

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -262,12 +262,12 @@ final public class PushNotificationsManager: NSObject {
         // notifications when in BG mode. Still, we don't wanna relay that BG notification!
         //
         let authenticationManager = PushAuthenticationManager()
-        guard authenticationManager.isPushAuthenticationNotification(userInfo) else {
+        guard authenticationManager.isAuthenticationNotification(userInfo) else {
             return false
         }
 
         if applicationState != .background {
-            authenticationManager.handlePushAuthenticationNotification(userInfo)
+            authenticationManager.handleAuthenticationNotification(userInfo)
         }
 
         completionHandler?(.newData)

--- a/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import WordPress
+@testable import WordPress
 import WordPressShared
 
 class PushAuthenticationManagerTests: XCTestCase {

--- a/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
@@ -56,69 +56,69 @@ class PushAuthenticationManagerTests: XCTestCase {
     }
 
     func testIsPushAuthenticationNotificationReturnsTrueWhenPassedTheCorrectPushAuthenticationNoteType() {
-        let result = pushAuthenticationManager!.isPushAuthenticationNotification(["type": "push_auth"])
+        let result = pushAuthenticationManager!.isAuthenticationNotification(["type": "push_auth"])
 
         XCTAssertTrue(result, "Should be true when the type is 'push_auth'")
     }
 
     func testIsPushAuthenticationNotificationReturnsFalseWhenPassedIncorrectPushAuthenticationNoteType() {
-        let result = pushAuthenticationManager!.isPushAuthenticationNotification(["type": "not_push"])
+        let result = pushAuthenticationManager!.isAuthenticationNotification(["type": "not_push"])
 
         XCTAssertFalse(result, "Should be false when the type is not 'push_auth'")
     }
 
-    func expiredPushNotificationDictionary() -> NSDictionary {
+    var expiredAuthenticationDictionary: NSDictionary {
        return ["expires": TimeInterval(3)]
     }
 
-    func validPushAuthenticationDictionary() -> NSMutableDictionary {
+    var validAuthenticationDictionary: NSMutableDictionary {
         return ["push_auth_token": "token", "aps": [ "alert": "an alert"]]
     }
 
     func testHandlePushAuthenticationNotificationShowsTheLoginExpiredAlertIfNotificationHasExpired() {
-        pushAuthenticationManager!.handlePushAuthenticationNotification(expiredPushNotificationDictionary())
+        pushAuthenticationManager!.handleAuthenticationNotification(expiredAuthenticationDictionary)
 
         XCTAssertTrue(mockAlertControllerProxy.showWithTitleCalled, "Should show the login expired alert if the notification has expired")
         XCTAssertEqual(mockAlertControllerProxy.titlePassedIn, NSLocalizedString("Login Request Expired", comment: ""), "")
     }
 
     func testHandlePushAuthenticationNotificationDoesNotShowTheLoginExpiredAlertIfNotificationHasNotExpired() {
-        pushAuthenticationManager!.handlePushAuthenticationNotification([:])
+        pushAuthenticationManager!.handleAuthenticationNotification([:])
 
         XCTAssertFalse(mockAlertControllerProxy.showWithTitleCalled, "Should not show the login expired alert if the notification hasn't expired")
     }
 
     func testHandlePushAuthenticationNotificationWithBlankTokenDoesNotShowLoginVerificationAlert() {
-        let pushNotificationDictionary = validPushAuthenticationDictionary()
+        let pushNotificationDictionary = validAuthenticationDictionary
         pushNotificationDictionary.removeObject(forKey: "push_auth_token")
 
-        pushAuthenticationManager!.handlePushAuthenticationNotification(pushNotificationDictionary)
+        pushAuthenticationManager!.handleAuthenticationNotification(pushNotificationDictionary)
 
         XCTAssertFalse(mockAlertControllerProxy.showWithTitleCalled, "Should not show the login verification")
     }
 
     func testHandlePushAuthenticationNotificationWithBlankMessageDoesNotShowLoginVerificationAlert() {
-        pushAuthenticationManager!.handlePushAuthenticationNotification(["push_auth_token": "token"])
+        pushAuthenticationManager!.handleAuthenticationNotification(["push_auth_token": "token"])
 
         XCTAssertFalse(mockAlertControllerProxy.showWithTitleCalled, "Should not show the login verification")
     }
 
     func testHandlePushAuthenticationNotificationWithValidDataShouldShowLoginVerification() {
-        pushAuthenticationManager!.handlePushAuthenticationNotification(validPushAuthenticationDictionary())
+        pushAuthenticationManager!.handleAuthenticationNotification(validAuthenticationDictionary)
 
         XCTAssertTrue(mockAlertControllerProxy.showWithTitleCalled, "Should show the login verification")
         XCTAssertEqual(mockAlertControllerProxy.titlePassedIn, NSLocalizedString("Verify Log In", comment: ""), "")
     }
 
     func testHandlePushAuthenticationNotificationShouldAttemptToAuthorizeTheLoginIfTheUserIndicatesTheyWantTo() {
-        pushAuthenticationManager!.handlePushAuthenticationNotification(validPushAuthenticationDictionary())
+        pushAuthenticationManager!.handleAuthenticationNotification(validAuthenticationDictionary)
         mockAlertControllerProxy.tapBlockPassedIn?(approvalAlertController, 1)
 
         XCTAssertTrue(mockPushAuthenticationService.authorizedLoginCalled, "Should have attempted to authorize the login")
     }
 
     func testHandlePushAuthenticationNotificationWhenAttemptingToLoginShouldAttemptToRetryTheLoginIfItFailed() {
-        pushAuthenticationManager!.handlePushAuthenticationNotification(validPushAuthenticationDictionary())
+        pushAuthenticationManager!.handleAuthenticationNotification(validAuthenticationDictionary)
         mockAlertControllerProxy.tapBlockPassedIn?(approvalAlertController, 1)
         mockPushAuthenticationService.completionBlockPassedIn?(false)
 
@@ -126,7 +126,7 @@ class PushAuthenticationManagerTests: XCTestCase {
     }
 
     func testHandlePushAuthenticationNotificationShouldNotAttemptToAuthorizeTheLoginIfTheUserIndicatesTheyDontWantTo() {
-        pushAuthenticationManager!.handlePushAuthenticationNotification(validPushAuthenticationDictionary())
+        pushAuthenticationManager!.handleAuthenticationNotification(validAuthenticationDictionary)
         mockAlertControllerProxy.tapBlockPassedIn?(approvalAlertController, 0)
 
         XCTAssertFalse(mockPushAuthenticationService.authorizedLoginCalled, "Should not have attempted to authorize the login")


### PR DESCRIPTION
### Details:
As part of a Notifications refactor (merging a couple helpers!), we're updating few things around. Starting off with PushAuthenticationManager:

- Switched **if** statements over to guard
- Corrected method visibility
- Nuked NSObject inheritance
- Minor touches here and there

Ref #6755

### To test:
No logic has been updated in this PR (other than if getting replaced by guard). In order to test, please, verify that the unit tests don't break.

Needs review: @frosty 
Sir, may i bug you with yet another review?

Thanks!!
