### PR TITLE
InteractiveNotificationsManager: Swift Cleanup

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -77,7 +77,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:accountInContext];
 
         [[PushNotificationsManager sharedInstance] registerForRemoteNotifications];
-        [[InteractiveNotificationsManager sharedInstance] requestAuthorization];
+        [[InteractiveNotificationsManager shared] requestAuthorization];
     };
     if ([NSThread isMainThread]) {
         // This is meant to help with testing account observers.
@@ -99,7 +99,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 {
     NSAssert([NSThread isMainThread], @"This method should only be called from the main thread");
 
-    [[PushNotificationsManager sharedInstance] unregisterDeviceToken];
+    [[PushNotificationsManager shared] unregisterDeviceToken];
 
     WPAccount *account = [self defaultWordPressComAccount];
     if (account) {

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -76,7 +76,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         NSManagedObject *accountInContext = [mainContext existingObjectWithID:accountID error:nil];
         [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:accountInContext];
 
-        [[PushNotificationsManager sharedInstance] registerForRemoteNotifications];
+        [[PushNotificationsManager shared] registerForRemoteNotifications];
         [[InteractiveNotificationsManager shared] requestAuthorization];
     };
     if ([NSThread isMainThread]) {

--- a/WordPress/Classes/Services/NotificationSettingsService.swift
+++ b/WordPress/Classes/Services/NotificationSettingsService.swift
@@ -267,6 +267,6 @@ open class NotificationSettingsService: LocalCoreDataService {
     }
 
     fileprivate var deviceId: String {
-        return PushNotificationsManager.sharedInstance.deviceId ?? String()
+        return PushNotificationsManager.shared.deviceId ?? String()
     }
 }

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -134,7 +134,7 @@ int ddLogLevel = DDLogLevelInfo;
 {
     DDLogVerbose(@"didFinishLaunchingWithOptions state: %d", application.applicationState);
 
-    [[InteractiveNotificationsManager sharedInstance] registerForUserNotifications];
+    [[InteractiveNotificationsManager shared] registerForUserNotifications];
     [self showWelcomeScreenIfNeededAnimated:NO];
     [self setupStoreKit];
     [self setupBuddyBuild];
@@ -415,7 +415,7 @@ int ddLogLevel = DDLogLevelInfo;
     // Push notifications
     // This is silent (the user is prompted) so we can do it on launch.
     // We'll ask for user notification permission after signin.
-    [[PushNotificationsManager sharedInstance] registerForRemoteNotifications];
+    [[PushNotificationsManager shared] registerForRemoteNotifications];
     
     // Deferred tasks to speed up app launch
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
@@ -434,26 +434,26 @@ int ddLogLevel = DDLogLevelInfo;
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-    [[PushNotificationsManager sharedInstance] registerDeviceToken:deviceToken];
+    [[PushNotificationsManager shared] registerDeviceToken:deviceToken];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
-    [[PushNotificationsManager sharedInstance] registrationDidFail:error];
+    [[PushNotificationsManager shared] registrationDidFail:error];
 }
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
 {
     DDLogMethod();
 
-    [[PushNotificationsManager sharedInstance] handleNotification:userInfo completionHandler:nil];
+    [[PushNotificationsManager shared] handleNotification:userInfo completionHandler:nil];
 }
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 {
     DDLogMethod();
 
-    [[PushNotificationsManager sharedInstance] handleNotification:userInfo completionHandler:completionHandler];
+    [[PushNotificationsManager shared] handleNotification:userInfo completionHandler:completionHandler];
 }
 
 #pragma mark - Background Refresh
@@ -762,7 +762,7 @@ int ddLogLevel = DDLogLevelInfo;
     DDLogInfo(@"OS:        %@ %@", device.systemName, device.systemVersion);
     DDLogInfo(@"Language:  %@", currentLanguage);
     DDLogInfo(@"UDID:      %@", device.wordPressIdentifier);
-    DDLogInfo(@"APN token: %@", [[PushNotificationsManager sharedInstance] deviceToken]);
+    DDLogInfo(@"APN token: %@", [[PushNotificationsManager shared] deviceToken]);
     DDLogInfo(@"Launch options: %@", launchOptions);
     NSString *verificationTag = @"";
     if (account.verificationStatus) {

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -107,10 +107,12 @@ final class InteractiveNotificationsManager: NSObject {
 
         return true
     }
+}
 
 
-    // MARK: - Private Helpers
-
+// MARK: - Private Helpers
+//
+private extension InteractiveNotificationsManager {
 
     /// Likes a comment and marks the associated notification as read
     ///
@@ -170,11 +172,6 @@ final class InteractiveNotificationsManager: NSObject {
     }
 
 
-
-
-    // MARK: - Private: UNNotification Helpers
-
-
     /// Returns a collection of *UNNotificationCategory* instances, for each one of the
     /// supported NoteCategoryDefinition enum case's.
     ///
@@ -184,8 +181,13 @@ final class InteractiveNotificationsManager: NSObject {
         let categories: [UNNotificationCategory] = NoteCategoryDefinition.allDefinitions.map({ $0.notificationCategory() })
         return Set(categories)
     }
+}
 
 
+
+// MARK: - Nested Types
+//
+private extension InteractiveNotificationsManager {
 
     /// Describes information about Custom Actions that WPiOS can perform, as a response to
     /// a Push Notification event.
@@ -208,7 +210,6 @@ final class InteractiveNotificationsManager: NSObject {
                 return [.commentReply, .commentLike]
             }
         }
-
 
         var identifier: String {
             return rawValue
@@ -293,6 +294,8 @@ final class InteractiveNotificationsManager: NSObject {
 }
 
 
+// MARK: - UNUserNotificationCenterDelegate Conformance
+//
 extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
 
     func userNotificationCenter(_ center: UNUserNotificationCenter,

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -2,12 +2,11 @@ import Foundation
 import CocoaLumberjack
 import UserNotifications
 
+
 /// In this class, we'll encapsulate all of the code related to UNNotificationCategory and
 /// UNNotificationAction instantiation, along with the required handlers.
 ///
-final public class InteractiveNotificationsManager: NSObject {
-    // MARK: - Public Properties
-
+final class InteractiveNotificationsManager: NSObject {
 
     /// Returns the shared InteractiveNotificationsManager instance.
     ///
@@ -38,14 +37,12 @@ final public class InteractiveNotificationsManager: NSObject {
        return NotificationSyncMediator()
     }
 
-    // MARK: - Public Methods
-
 
     /// Registers the device for User Notifications.
     ///
     /// This method should be called once during the app initialization process.
     ///
-    public func registerForUserNotifications() {
+    func registerForUserNotifications() {
         if sharedApplication.isRunningSimulator() || build(.a8cBranchTest) {
             return
         }
@@ -60,7 +57,7 @@ final public class InteractiveNotificationsManager: NSObject {
     /// The first time this method is called it will ask the user for permission to show notifications.
     /// Because of this, this should be called only when we know we will need to show notifications (for instance, after login).
     ///
-    public func requestAuthorization() {
+    func requestAuthorization() {
         if sharedApplication.isRunningSimulator() || build(.a8cBranchTest) {
             return
         }
@@ -78,7 +75,7 @@ final public class InteractiveNotificationsManager: NSObject {
     /// - Returns: True on success
     ///
     @discardableResult
-    public func handleAction(with identifier: String, userInfo: NSDictionary, responseText: String?) -> Bool {
+    func handleAction(with identifier: String, userInfo: NSDictionary, responseText: String?) -> Bool {
         guard AccountHelper.isDotcomAvailable(),
             let noteID = userInfo.object(forKey: "note_id") as? NSNumber,
             let siteID = userInfo.object(forKey: "blog_id") as? NSNumber,
@@ -121,7 +118,7 @@ final public class InteractiveNotificationsManager: NSObject {
     ///     - commentID: The comment identifier
     ///     - siteID: The site identifier
     ///
-    fileprivate func likeCommentWithCommentID(_ commentID: NSNumber, noteID: NSNumber, siteID: NSNumber) {
+    func likeCommentWithCommentID(_ commentID: NSNumber, noteID: NSNumber, siteID: NSNumber) {
         commentService.likeComment(withID: commentID, siteID: siteID, success: {
             self.notificationSyncMediator?.markAsReadAndSync(noteID.stringValue)
             DDLogInfo("Liked comment from push notification")
@@ -137,7 +134,7 @@ final public class InteractiveNotificationsManager: NSObject {
     ///     - commentID: The comment identifier
     ///     - siteID: The site identifier
     ///
-    fileprivate func approveCommentWithCommentID(_ commentID: NSNumber, noteID: NSNumber, siteID: NSNumber) {
+    func approveCommentWithCommentID(_ commentID: NSNumber, noteID: NSNumber, siteID: NSNumber) {
         commentService.approveComment(withID: commentID, siteID: siteID, success: {
             self.notificationSyncMediator?.markAsReadAndSync(noteID.stringValue)
             DDLogInfo("Successfully moderated comment from push notification")
@@ -151,7 +148,7 @@ final public class InteractiveNotificationsManager: NSObject {
     ///
     /// - Parameter noteID: The Notification's Identifier
     ///
-    fileprivate func showDetailsWithNoteID(_ noteId: NSNumber) {
+    func showDetailsWithNoteID(_ noteId: NSNumber) {
         WPTabBarController.sharedInstance().showNotificationsTabForNote(withID: noteId.stringValue)
     }
 
@@ -163,7 +160,7 @@ final public class InteractiveNotificationsManager: NSObject {
     ///     - siteID: The site identifier
     ///     - content: The text for the comment reply
     ///
-    fileprivate func replyToCommentWithCommentID(_ commentID: NSNumber, noteID: NSNumber, siteID: NSNumber, content: String) {
+    func replyToCommentWithCommentID(_ commentID: NSNumber, noteID: NSNumber, siteID: NSNumber, content: String) {
         commentService.replyToComment(withID: commentID, siteID: siteID, content: content, success: {
             self.notificationSyncMediator?.markAsReadAndSync(noteID.stringValue)
             DDLogInfo("Successfully replied comment from push notification")
@@ -183,7 +180,7 @@ final public class InteractiveNotificationsManager: NSObject {
     ///
     /// - Returns: A set of *UNNotificationCategory* instances.
     ///
-    private func supportedNotificationCategories() -> Set<UNNotificationCategory> {
+    func supportedNotificationCategories() -> Set<UNNotificationCategory> {
         let categories: [UNNotificationCategory] = NoteCategoryDefinition.allDefinitions.map({ $0.notificationCategory() })
         return Set(categories)
     }
@@ -298,7 +295,7 @@ final public class InteractiveNotificationsManager: NSObject {
 
 extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
 
-    public func userNotificationCenter(_ center: UNUserNotificationCenter,
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
                                        didReceive response: UNNotificationResponse,
                                        withCompletionHandler completionHandler: @escaping () -> Void) {
         let userInfo = response.notification.request.content.userInfo as NSDictionary

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -93,11 +93,11 @@ final class InteractiveNotificationsManager: NSObject {
         }
 
         switch action {
-        case .CommentApprove:
+        case .commentApprove:
             approveCommentWithCommentID(commentID, noteID: noteID, siteID: siteID)
-        case .CommentLike:
+        case .commentLike:
             likeCommentWithCommentID(commentID, noteID: noteID, siteID: siteID)
-        case .CommentReply:
+        case .commentReply:
             if let responseText = responseText {
                 replyToCommentWithCommentID(commentID, noteID: noteID, siteID: siteID, content: responseText)
             } else {
@@ -190,22 +190,22 @@ final class InteractiveNotificationsManager: NSObject {
     /// Describes information about Custom Actions that WPiOS can perform, as a response to
     /// a Push Notification event.
     ///
-    fileprivate enum NoteCategoryDefinition: String {
-        case CommentApprove         = "approve-comment"
-        case CommentLike            = "like-comment"
-        case CommentReply           = "replyto-comment"
-        case CommentReplyWithLike   = "replyto-like-comment"
+    enum NoteCategoryDefinition: String {
+        case commentApprove         = "approve-comment"
+        case commentLike            = "like-comment"
+        case commentReply           = "replyto-comment"
+        case commentReplyWithLike   = "replyto-like-comment"
 
         var actions: [NoteActionDefinition] {
             switch self {
-            case .CommentApprove:
-                return [.CommentApprove]
-            case .CommentLike:
-                return [.CommentLike]
-            case .CommentReply:
-                return [.CommentReply]
-            case .CommentReplyWithLike:
-                return [.CommentReply, .CommentLike]
+            case .commentApprove:
+                return [.commentApprove]
+            case .commentLike:
+                return [.commentLike]
+            case .commentReply:
+                return [.commentReply]
+            case .commentReplyWithLike:
+                return [.commentReply, .commentLike]
             }
         }
 
@@ -222,25 +222,25 @@ final class InteractiveNotificationsManager: NSObject {
                 options: [])
         }
 
-        static var allDefinitions = [CommentApprove, CommentLike, CommentReply, CommentReplyWithLike]
+        static var allDefinitions = [commentApprove, commentLike, commentReply, commentReplyWithLike]
     }
 
 
 
     /// Describes the custom actions that WPiOS can perform in response to a Push notification.
     ///
-    fileprivate enum NoteActionDefinition: String {
-        case CommentApprove = "COMMENT_MODERATE_APPROVE"
-        case CommentLike    = "COMMENT_LIKE"
-        case CommentReply   = "COMMENT_REPLY"
+    enum NoteActionDefinition: String {
+        case commentApprove = "COMMENT_MODERATE_APPROVE"
+        case commentLike    = "COMMENT_LIKE"
+        case commentReply   = "COMMENT_REPLY"
 
         var description: String {
             switch self {
-            case .CommentApprove:
+            case .commentApprove:
                 return NSLocalizedString("Approve", comment: "Approve comment (verb)")
-            case .CommentLike:
+            case .commentLike:
                 return NSLocalizedString("Like", comment: "Like (verb)")
-            case .CommentReply:
+            case .commentReply:
                 return NSLocalizedString("Reply", comment: "Reply to a comment (verb)")
             }
         }
@@ -277,7 +277,7 @@ final class InteractiveNotificationsManager: NSObject {
 
         func notificationAction() -> UNNotificationAction {
             switch self {
-            case .CommentReply:
+            case .commentReply:
                 return UNTextInputNotificationAction(identifier: identifier,
                                                      title: description,
                                                      options: notificationActionOptions,
@@ -288,7 +288,7 @@ final class InteractiveNotificationsManager: NSObject {
             }
         }
 
-        static var allDefinitions = [CommentApprove, CommentLike, CommentReply]
+        static var allDefinitions = [commentApprove, commentLike, commentReply]
     }
 }
 

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -10,7 +10,7 @@ final class InteractiveNotificationsManager: NSObject {
 
     /// Returns the shared InteractiveNotificationsManager instance.
     ///
-    static let sharedInstance = InteractiveNotificationsManager()
+    static let shared = InteractiveNotificationsManager()
 
 
     /// Returns the SharedApplication instance. This is meant for Unit Testing purposes.
@@ -319,7 +319,7 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
         //  -   Nuke `PushNotificationsManager`
         //
         //
-        PushNotificationsManager.sharedInstance.handleNotification(userInfo) { _ in
+        PushNotificationsManager.shared.handleNotification(userInfo) { _ in
             completionHandler()
         }
     }

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -14,7 +14,7 @@ final public class PushNotificationsManager: NSObject {
 
     /// Returns the shared PushNotificationsManager instance.
     ///
-    static let sharedInstance = PushNotificationsManager()
+    static let shared = PushNotificationsManager()
 
 
     /// Stores the Apple's Push Notifications Token

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -250,7 +250,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
     }
 
     func refreshPushAuthorizationStatus() {
-        PushNotificationsManager.sharedInstance.loadAuthorizationStatus { authorized in
+        PushNotificationsManager.shared.loadAuthorizationStatus { authorized in
             self.pushNotificationsAuthorized = authorized
         }
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -186,7 +186,7 @@ class NotificationSettingStreamsViewController: UITableViewController {
 
     // MARK: - Disabled Push Notifications Helpers
     func refreshPushAuthorizationStatus() {
-        PushNotificationsManager.sharedInstance.loadAuthorizationStatus { authorized in
+        PushNotificationsManager.shared.loadAuthorizationStatus { authorized in
             self.pushNotificationsAuthorized = authorized
         }
     }

--- a/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
@@ -62,7 +62,7 @@ import UIKit
         UserDefaults.standard.set(true, forKey: UserDefaultsHelpshiftWasUsed)
 
         PushNotificationsManager.sharedInstance.registerForRemoteNotifications()
-        InteractiveNotificationsManager.sharedInstance.requestAuthorization()
+        InteractiveNotificationsManager.shared.requestAuthorization()
 
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)

--- a/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Tools/HelpshiftPresenter.swift
@@ -61,7 +61,7 @@ import UIKit
     fileprivate func prepareToDisplayHelpshiftWindow(_ refreshUserDetails: Bool, completion: @escaping () -> Void) {
         UserDefaults.standard.set(true, forKey: UserDefaultsHelpshiftWasUsed)
 
-        PushNotificationsManager.sharedInstance.registerForRemoteNotifications()
+        PushNotificationsManager.shared.registerForRemoteNotifications()
         InteractiveNotificationsManager.shared.requestAuthorization()
 
         let context = ContextManager.sharedInstance().mainContext


### PR DESCRIPTION
### Details:
In this PR we're doing a bit of pending cleanup:

- Swift enums should go in lowercase
- Replaced fileprivate methods with private extensions
- Renamed **sharedInstance** > **shared** properties

Ref #6755

### To test:
**No logic** was modified in this PR. In order to test this one, please, verify that the unit tests run correctly.

Needs review: @koke 
Thanks in advance!

