### PR TITLE
Push Notification Manager: registration crash

### DIFF
--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -104,9 +104,11 @@ final public class PushNotificationsManager: NSObject {
     /// - Note: Helpshift will also be initialized. The token will be persisted across App Sessions.
     ///
     func registerDeviceToken(_ tokenData: Data) {
-        // We want to register Helpshift regardless so that way if a user isn't logged in
-        // they can still get push notifications that we replied to their support ticket.
-        HelpshiftCore.registerDeviceToken(tokenData)
+        if HelpshiftUtils.isHelpshiftEnabled() {
+            // We want to register Helpshift regardless so that way if a user isn't logged in
+            // they can still get push notifications that we replied to their support ticket.
+            HelpshiftCore.registerDeviceToken(tokenData)
+        }
 
         // Don't bother registering for WordPress anything if the user isn't logged in
         guard AccountHelper.isDotcomAvailable() else {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -376,7 +376,7 @@ extension LoginEmailViewController: GIDSignInDelegate {
 
         let alert = UIAlertController(title: "Login Success", message: "Google login succeeded. Actual wpcom account login yet to be implemented.", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Ok. Thanks.", style: .default, handler: { [weak self] (action) in
-            self?.dismiss(animated: true){}
+            self?.dismiss(animated: true) {}
         }))
         present(alert, animated: true)
     }


### PR DESCRIPTION
Fixes #7873.

A couple of folks who are new to the project and don't have the Helpshift API key in their credential files have seen a crash when the app attempts to register a device token with Helpshift. Not sure if this is a regression, but this PR puts a quick check in place before making the call to `registerDeviceToken`.

To test:

* Ensure the device token is registered correctly when it should be, and the app doesn't crash when there's no Helpshift key present.

Needs review: @astralbodies it looks like you touched this most recently – would you mind?