### PR TITLE
Make sure that handling of notification is done on the main thread.

### DIFF
--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -112,21 +112,26 @@ open class WP3DTouchShortcutCreator: NSObject {
     }
 
     @objc fileprivate func createLoggedInShortcuts() {
-        var entireShortcutArray = loggedInShortcutArray()
-        var visibleShortcutArray = [UIApplicationShortcutItem]()
+        DispatchQueue.main.async {[weak self]() in
+            guard let strongSelf = self else {
+                return
+            }
+            var entireShortcutArray = strongSelf.loggedInShortcutArray()
+            var visibleShortcutArray = [UIApplicationShortcutItem]()
 
-        if hasWordPressComAccount() {
-            visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.notifications.rawValue])
+            if strongSelf.hasWordPressComAccount() {
+                visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.notifications.rawValue])
+            }
+
+            if strongSelf.doesCurrentBlogSupportStats() {
+                visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.stats.rawValue])
+            }
+
+            visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.newPhotoPost.rawValue])
+            visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.newPost.rawValue])
+
+            strongSelf.shortcutsProvider.shortcutItems = visibleShortcutArray
         }
-
-        if doesCurrentBlogSupportStats() {
-            visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.stats.rawValue])
-        }
-
-        visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.newPhotoPost.rawValue])
-        visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.newPost.rawValue])
-
-        shortcutsProvider.shortcutItems = visibleShortcutArray
     }
 
     fileprivate func clearShortcuts() {


### PR DESCRIPTION
While testing the app on Xcode 9 I noticed that we a crashes when trying to register the 3D Touch services. 

This PR changes the code to make sure the notifications that trigger the registration of 3DTouch are executed the main thread to avoid crashes.

To test:
 - Launch the app for the first time on a device with 3DTouch
 - Check that no crash happens when trying to register the 3DTouch events.


Needs review: @elibud  should I cherry pick this to the 8.5 release too?