### PR TITLE
AztecPostViewController: Removes unowned modifier

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -358,7 +358,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     /// Maintainer of state for editor - like for post button
     ///
-    fileprivate lazy var postEditorStateContext: PostEditorStateContext = { [unowned self] in
+    fileprivate lazy var postEditorStateContext: PostEditorStateContext = {
         return self.createEditorStateContext(for: self.post)
     }()
 


### PR DESCRIPTION
### Details:
As discussed [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/7765#discussion_r136657517), `unowned self` is no longer required in lazy properties.

In this PR we're just performing a minor cleanup.

Ref #7765

### To test:
Please verify that the unit tests pass.

Needs review: @diegoreymendez 
Thanks in advance!
