### PR TITLE
Fixing Share Extension Path

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3608,8 +3608,7 @@
 				E1CE41641E8D101A000CF5A4 /* ShareExtractor.swift */,
 				E1AFA8C21E8E34230004A323 /* WordPressShare.js */,
 			);
-			name = WordPressShareExtension;
-			path = WordPressShare;
+			path = WordPressShareExtension;
 			sourceTree = "<group>";
 		};
 		937D9A0D19F837ED007B9D5F /* 22-23 */ = {


### PR DESCRIPTION
### Details:
I've noticed the **WordPressShareExtension** folder turns red in the project's tree. 
When we implemented the Share Extension, it was initially called `WordPressShare`. Apparently we've got a leftover from that rename.

In this PR we're fixing the Share Extension's path, so that the project is happy again.

<img width="272" alt="screen shot 2017-10-02 at 9 36 41 am" src="https://user-images.githubusercontent.com/1195260/31077771-287cb12c-a756-11e7-9c51-269ef55a225d.png">


### To test:
1. Build the project and verify nothing breaks
2. Make sure the unit tests pass

Needs review: @elibud 
Thanks in advance!

