### PR TITLE
Issue/7891 crash on multiple thumb insert

### DIFF
--- a/WordPress/Classes/Categories/Media+WPMediaAsset.m
+++ b/WordPress/Classes/Categories/Media+WPMediaAsset.m
@@ -10,6 +10,7 @@
 {
     NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
     MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:mainContext];
+    mediaService.concurrentThumbnailGeneration = YES;
     [mediaService thumbnailImageForMedia:self
                            preferredSize:size
                               completion:completionHandler];

--- a/WordPress/Classes/Services/MediaExportService.swift
+++ b/WordPress/Classes/Services/MediaExportService.swift
@@ -8,6 +8,12 @@ import CocoaLumberjack
 ///
 open class MediaExportService: LocalCoreDataService {
 
+    private static let defaultExportQueue: DispatchQueue = DispatchQueue(label: "org.wordpress.mediaExportService", autoreleaseFrequency: .workItem)
+
+    public lazy var exportQueue: DispatchQueue = {
+        return MediaExportService.defaultExportQueue
+    }()
+
     /// Constant for the ideal compression quality used when images are added to the Media Library.
     ///
     /// - Note: This value may or may not be honored, depending on the export implementation and underlying data.
@@ -30,7 +36,7 @@ open class MediaExportService: LocalCoreDataService {
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
     public func exportMediaWith(blog: Blog, asset: PHAsset, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
-        DispatchQueue.global(qos: .default).async {
+        exportQueue.async {
 
             let exporter = MediaAssetExporter()
             exporter.imageOptions = self.exporterImageOptions
@@ -47,7 +53,7 @@ open class MediaExportService: LocalCoreDataService {
                 }
             }, onError: { (error) in
                 self.handleExportError(error, errorHandler: onError)
-            })
+            })            
         }
     }
 
@@ -59,7 +65,7 @@ open class MediaExportService: LocalCoreDataService {
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
     public func exportMediaWith(blog: Blog, image: UIImage, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
-        DispatchQueue.global(qos: .default).async {
+        exportQueue.async {
 
             let exporter = MediaImageExporter()
             exporter.options = self.exporterImageOptions
@@ -87,7 +93,7 @@ open class MediaExportService: LocalCoreDataService {
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
     public func exportMediaWith(blog: Blog, url: URL, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
-        DispatchQueue.global(qos: .default).async {
+        exportQueue.async {
 
             let exporter = MediaURLExporter()
             exporter.imageOptions = self.exporterImageOptions

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -9,6 +9,11 @@
 @interface MediaService : LocalCoreDataService
 
 /**
+ This property determines if multiple thumbnail generation will be done in parallel.
+ By default this value is NO.
+ */
+@property (nonatomic, assign) BOOL concurrentThumbnailGeneration;
+/**
  Create a media object using the url provided as the source of media.
 
  @param url a file url pointing to a file with the media data

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -22,6 +22,15 @@
 
 @implementation MediaService
 
+- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context
+{
+    self = [super initWithManagedObjectContext:context];
+    if (self) {
+        _concurrentThumbnailGeneration = NO;
+    }
+    return self;
+}
+
 #pragma mark - Creating media
 
 - (void)createMediaWithURL:(NSURL *)url
@@ -678,6 +687,9 @@
 {
     if (!_thumbnailService) {
         _thumbnailService = [[MediaThumbnailService alloc] initWithManagedObjectContext:self.managedObjectContext];
+        if (self.concurrentThumbnailGeneration) {
+            _thumbnailService.exportQueue = dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0);
+        }
     }
     return _thumbnailService;
 }

--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -13,6 +13,12 @@ class MediaThumbnailService: LocalCoreDataService {
     ///
     public typealias OnError = (Error) -> Void
 
+    private static let defaultExportQueue: DispatchQueue = DispatchQueue(label: "org.wordpress.mediaThumbnailService", autoreleaseFrequency: .workItem)
+
+    public lazy var exportQueue: DispatchQueue = {
+        return MediaThumbnailService.defaultExportQueue
+    }()
+
     /// Generate a URL to a thumbnail of the Media, if available.
     ///
     /// - Parameters:
@@ -64,7 +70,7 @@ class MediaThumbnailService: LocalCoreDataService {
                         onCompletion(nil)
                         return
                     }
-                    DispatchQueue.global(qos: .default).async {
+                    self.exportQueue.async {
                         exporter.exportThumbnail(forImage: image,
                                                  onCompletion: onThumbnailExport,
                                                  onError: onThumbnailExportError)
@@ -76,7 +82,7 @@ class MediaThumbnailService: LocalCoreDataService {
 
             // If the Media asset is available locally, export thumbnails from the local asset.
             if let localAssetURL = media.absoluteLocalURL, exporter.supportsThumbnailExport(forFile: localAssetURL) {
-                DispatchQueue.global(qos: .default).async {
+                self.exportQueue.async {
                     exporter.exportThumbnail(forFile: localAssetURL,
                                              onCompletion: onThumbnailExport,
                                              onError: onThumbnailExportError)
@@ -86,7 +92,7 @@ class MediaThumbnailService: LocalCoreDataService {
 
             // If the Media item is a video and has a remote video URL, try and export from the remote video URL.
             if media.mediaType == .video, let remoteURLStr = media.remoteURL, let videoURL = URL(string: remoteURLStr) {
-                DispatchQueue.global(qos: .default).async {
+                self.exportQueue.async {
                     exporter.exportThumbnail(forVideoURL: videoURL,
                                              onCompletion: onThumbnailExport,
                                              onError: { (error) in

--- a/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
@@ -93,6 +93,7 @@ class MediaAssetExporter: MediaExporter {
             options.deliveryMode = .highQualityFormat
             options.resizeMode = .exact
             options.isNetworkAccessAllowed = true
+            options.isSynchronous = true
 
             // Configure the targetSize for PHImageManager to resize to.
             let targetSize: CGSize

--- a/WordPress/Classes/Utility/Media/MediaImageExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaImageExporter.swift
@@ -174,7 +174,7 @@ class MediaImageExporter: MediaExporter {
             if let maximumImageSize = options.maximumImageSize {
                 writer.maximumSize = maximumImageSize as CFNumber
             }
-            writer.lossyCompressionQuality = options.imageCompressionQuality as CFNumber
+            writer.lossyCompressionQuality = options.imageCompressionQuality
             writer.nullifyGPSData = options.stripsGeoLocationIfNeeded
             let result = try writer.writeImageSource(source)
             onCompletion(MediaImageExport(url: url,
@@ -200,7 +200,7 @@ class MediaImageExporter: MediaExporter {
 
         /// The Compression quality used, defaults to 1.0 or full
         ///
-        var lossyCompressionQuality = 1.0 as CFNumber
+        var lossyCompressionQuality = 1.0
 
         /// Whether or not GPS data should be nullified.
         ///
@@ -236,7 +236,7 @@ class MediaImageExporter: MediaExporter {
             // Configure destination properties
             imageProperties[kCGImageDestinationLossyCompressionQuality] = lossyCompressionQuality
             // Configure orientation properties to default .up or 1
-            imageProperties[kCGImagePropertyOrientation] = CGImagePropertyOrientation.up
+            imageProperties[kCGImagePropertyOrientation] = Int(CGImagePropertyOrientation.up.rawValue) as CFNumber
             if var tiffProperties = imageProperties[kCGImagePropertyTIFFDictionary] as? [NSString: Any] {
                 // Remove TIFF orientation value
                 tiffProperties.removeValue(forKey: kCGImagePropertyTIFFOrientation)
@@ -296,6 +296,7 @@ class MediaImageExporter: MediaExporter {
             guard written == true else {
                 throw ImageExportError.imageSourceDestinationWriteFailed
             }
+
             // Return the result with any interesting properties.
             return WriteResultProperties(width: width,
                                          height: height)


### PR DESCRIPTION
Fixes #7891 

This PR adds serial queues for the execution for the image resize operation while exporting PHAssets and other media resources.

This avoid multiple exports to be executed at the same time and cause issues with memory pressure.

To test:
 - Check the ticket above for details how to reproduce.

