### PR TITLE
Aztec: Nextpage support

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Renderers/SpecialTagAttachmentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Renderers/SpecialTagAttachmentRenderer.swift
@@ -3,9 +3,9 @@ import UIKit
 import Aztec
 
 
-// MARK: - WordPressAttachmentRenderer. This render aims rendering WordPress specific tags.
+// MARK: - SpecialTagAttachmentRenderer. This render aims rendering WordPress specific tags.
 //
-final class WordPressAttachmentRenderer {
+final class SpecialTagAttachmentRenderer {
 
     /// Text Color
     ///
@@ -15,7 +15,7 @@ final class WordPressAttachmentRenderer {
 
 // MARK: - TextViewCommentsDelegate Methods
 //
-extension WordPressAttachmentRenderer: TextViewAttachmentImageProvider {
+extension SpecialTagAttachmentRenderer: TextViewAttachmentImageProvider {
 
     func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
         guard let commentAttachment = attachment as? CommentAttachment else {
@@ -73,7 +73,7 @@ extension WordPressAttachmentRenderer: TextViewAttachmentImageProvider {
 
 // MARK: - Constants
 //
-extension WordPressAttachmentRenderer {
+extension SpecialTagAttachmentRenderer {
 
     struct Constants {
         static let defaultDashCount = CGFloat(8.0)

--- a/WordPress/Classes/ViewRelated/Aztec/Renderers/WordPressAttachmentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Renderers/WordPressAttachmentRenderer.swift
@@ -3,7 +3,7 @@ import UIKit
 import Aztec
 
 
-// MARK: - WordPressAttachmentRenderer: This render is expected to only work with `<!--more-->` comments!
+// MARK: - WordPressAttachmentRenderer. This render aims rendering WordPress specific tags.
 //
 final class WordPressAttachmentRenderer {
 
@@ -18,8 +18,11 @@ final class WordPressAttachmentRenderer {
 extension WordPressAttachmentRenderer: TextViewAttachmentImageProvider {
 
     func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
-        let commentAttachment = attachment as? CommentAttachment
-        return commentAttachment?.text == Constants.defaultCommentText
+        guard let commentAttachment = attachment as? CommentAttachment else {
+            return false
+        }
+
+        return Tags.supported.contains(commentAttachment.text)
     }
 
     func textView(_ textView: TextView, imageFor attachment: NSTextAttachment, with size: CGSize) -> UIImage? {
@@ -76,6 +79,9 @@ extension WordPressAttachmentRenderer {
         static let defaultDashCount = CGFloat(8.0)
         static let defaultDashWidth = CGFloat(2.0)
         static let defaultHeight = CGFloat(44.0)
-        static let defaultCommentText = "more"
+    }
+
+    struct Tags {
+        static let supported = ["more", "nextpage"]
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Renderers/WordPressAttachmentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Renderers/WordPressAttachmentRenderer.swift
@@ -3,9 +3,9 @@ import UIKit
 import Aztec
 
 
-// MARK: - MoreAttachmentRenderer: This render is expected to only work with `<!--more-->` comments!
+// MARK: - WordPressAttachmentRenderer: This render is expected to only work with `<!--more-->` comments!
 //
-final class MoreAttachmentRenderer {
+final class WordPressAttachmentRenderer {
 
     /// Text Color
     ///
@@ -15,7 +15,7 @@ final class MoreAttachmentRenderer {
 
 // MARK: - TextViewCommentsDelegate Methods
 //
-extension MoreAttachmentRenderer: TextViewAttachmentImageProvider {
+extension WordPressAttachmentRenderer: TextViewAttachmentImageProvider {
 
     func textView(_ textView: TextView, shouldRender attachment: NSTextAttachment) -> Bool {
         let commentAttachment = attachment as? CommentAttachment
@@ -70,7 +70,7 @@ extension MoreAttachmentRenderer: TextViewAttachmentImageProvider {
 
 // MARK: - Constants
 //
-extension MoreAttachmentRenderer {
+extension WordPressAttachmentRenderer {
 
     struct Constants {
         static let defaultDashCount = CGFloat(8.0)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -674,7 +674,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     func registerAttachmentImageProviders() {
         let providers: [TextViewAttachmentImageProvider] = [
-            MoreAttachmentRenderer(),
+            WordPressAttachmentRenderer(),
             CommentAttachmentRenderer(font: Fonts.regular),
             HTMLAttachmentRenderer(font: Fonts.regular)
         ]

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -55,6 +55,11 @@ class AztecPostViewController: UIViewController, PostEditor {
         textView.backgroundColor = Colors.aztecBackground
         textView.linkTextAttributes = [NSUnderlineStyleAttributeName: NSNumber(value:NSUnderlineStyle.styleSingle.rawValue), NSForegroundColorAttributeName: Colors.aztecLinkColor]
         textView.textAlignment = .natural
+
+        if #available(iOS 11, *) {
+            textView.smartDashesType = .no
+        }
+
         return textView
     }()
 
@@ -94,6 +99,10 @@ class AztecPostViewController: UIViewController, PostEditor {
         textView.accessibilityIdentifier = "HTMLContentView"
         textView.autocorrectionType = .no
         textView.autocapitalizationType = .none
+
+        if #available(iOS 11, *) {
+            textView.smartDashesType = .no
+        }
 
         return textView
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -683,7 +683,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     func registerAttachmentImageProviders() {
         let providers: [TextViewAttachmentImageProvider] = [
-            WordPressAttachmentRenderer(),
+            SpecialTagAttachmentRenderer(),
             CommentAttachmentRenderer(font: Fonts.regular),
             HTMLAttachmentRenderer(font: Fonts.regular)
         ]

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -473,7 +473,7 @@
 		B504F5F51C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */; };
 		B50C0C501EF429E900372C65 /* CommentAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C4D1EF429E900372C65 /* CommentAttachmentRenderer.swift */; };
 		B50C0C511EF429E900372C65 /* HTMLAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C4E1EF429E900372C65 /* HTMLAttachmentRenderer.swift */; };
-		B50C0C521EF429E900372C65 /* WordPressAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C4F1EF429E900372C65 /* WordPressAttachmentRenderer.swift */; };
+		B50C0C521EF429E900372C65 /* SpecialTagAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C4F1EF429E900372C65 /* SpecialTagAttachmentRenderer.swift */; };
 		B50C0C561EF42A0000372C65 /* ShortcodeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C541EF42A0000372C65 /* ShortcodeProcessor.swift */; };
 		B50C0C571EF42A0000372C65 /* VideoShortcodeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C551EF42A0000372C65 /* VideoShortcodeProcessor.swift */; };
 		B50C0C5A1EF42A2600372C65 /* MediaProgressCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C591EF42A2600372C65 /* MediaProgressCoordinator.swift */; };
@@ -1750,7 +1750,7 @@
 		B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tracks+ShareExtension.swift"; sourceTree = SOURCE_ROOT; };
 		B50C0C4D1EF429E900372C65 /* CommentAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B50C0C4E1EF429E900372C65 /* HTMLAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachmentRenderer.swift; sourceTree = "<group>"; };
-		B50C0C4F1EF429E900372C65 /* WordPressAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressAttachmentRenderer.swift; sourceTree = "<group>"; };
+		B50C0C4F1EF429E900372C65 /* SpecialTagAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpecialTagAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B50C0C541EF42A0000372C65 /* ShortcodeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcodeProcessor.swift; sourceTree = "<group>"; };
 		B50C0C551EF42A0000372C65 /* VideoShortcodeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoShortcodeProcessor.swift; sourceTree = "<group>"; };
 		B50C0C591EF42A2600372C65 /* MediaProgressCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaProgressCoordinator.swift; sourceTree = "<group>"; };
@@ -3854,7 +3854,7 @@
 			children = (
 				B50C0C4D1EF429E900372C65 /* CommentAttachmentRenderer.swift */,
 				B50C0C4E1EF429E900372C65 /* HTMLAttachmentRenderer.swift */,
-				B50C0C4F1EF429E900372C65 /* WordPressAttachmentRenderer.swift */,
+				B50C0C4F1EF429E900372C65 /* SpecialTagAttachmentRenderer.swift */,
 			);
 			path = Renderers;
 			sourceTree = "<group>";
@@ -6461,7 +6461,7 @@
 				E2E7EB46185FB140004F5E72 /* WPBlogSelectorButton.m in Sources */,
 				85D239B21AE5A5FC0074768D /* WordPressComOAuthClientFacade.m in Sources */,
 				85D239B31AE5A5FC0074768D /* WordPressXMLRPCAPIFacade.m in Sources */,
-				B50C0C521EF429E900372C65 /* WordPressAttachmentRenderer.swift in Sources */,
+				B50C0C521EF429E900372C65 /* SpecialTagAttachmentRenderer.swift in Sources */,
 				E183BD7417621D87000B0822 /* WPCookie.m in Sources */,
 				43D2436D1EAFCE3C00D0C77B /* LoginSegueHandler.swift in Sources */,
 				08216FD41CDBF96000304BA7 /* MenuItemTypeSelectionView.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -473,7 +473,7 @@
 		B504F5F51C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */; };
 		B50C0C501EF429E900372C65 /* CommentAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C4D1EF429E900372C65 /* CommentAttachmentRenderer.swift */; };
 		B50C0C511EF429E900372C65 /* HTMLAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C4E1EF429E900372C65 /* HTMLAttachmentRenderer.swift */; };
-		B50C0C521EF429E900372C65 /* MoreAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C4F1EF429E900372C65 /* MoreAttachmentRenderer.swift */; };
+		B50C0C521EF429E900372C65 /* WordPressAttachmentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C4F1EF429E900372C65 /* WordPressAttachmentRenderer.swift */; };
 		B50C0C561EF42A0000372C65 /* ShortcodeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C541EF42A0000372C65 /* ShortcodeProcessor.swift */; };
 		B50C0C571EF42A0000372C65 /* VideoShortcodeProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C551EF42A0000372C65 /* VideoShortcodeProcessor.swift */; };
 		B50C0C5A1EF42A2600372C65 /* MediaProgressCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C591EF42A2600372C65 /* MediaProgressCoordinator.swift */; };
@@ -1750,7 +1750,7 @@
 		B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tracks+ShareExtension.swift"; sourceTree = SOURCE_ROOT; };
 		B50C0C4D1EF429E900372C65 /* CommentAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B50C0C4E1EF429E900372C65 /* HTMLAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLAttachmentRenderer.swift; sourceTree = "<group>"; };
-		B50C0C4F1EF429E900372C65 /* MoreAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoreAttachmentRenderer.swift; sourceTree = "<group>"; };
+		B50C0C4F1EF429E900372C65 /* WordPressAttachmentRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressAttachmentRenderer.swift; sourceTree = "<group>"; };
 		B50C0C541EF42A0000372C65 /* ShortcodeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcodeProcessor.swift; sourceTree = "<group>"; };
 		B50C0C551EF42A0000372C65 /* VideoShortcodeProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoShortcodeProcessor.swift; sourceTree = "<group>"; };
 		B50C0C591EF42A2600372C65 /* MediaProgressCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaProgressCoordinator.swift; sourceTree = "<group>"; };
@@ -2778,7 +2778,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				E1B34C091CCDFFCE00889709 /* Credentials */,
@@ -3854,7 +3854,7 @@
 			children = (
 				B50C0C4D1EF429E900372C65 /* CommentAttachmentRenderer.swift */,
 				B50C0C4E1EF429E900372C65 /* HTMLAttachmentRenderer.swift */,
-				B50C0C4F1EF429E900372C65 /* MoreAttachmentRenderer.swift */,
+				B50C0C4F1EF429E900372C65 /* WordPressAttachmentRenderer.swift */,
 			);
 			path = Renderers;
 			sourceTree = "<group>";
@@ -5484,7 +5484,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -5800,7 +5800,7 @@
 			inputPaths = (
 				"${SRCROOT}/../Pods/Target Support Files/Pods-WordPress/Pods-WordPress-resources.sh",
 				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
-				"$PODS_CONFIGURATION_BUILD_DIR/HockeySDK/HockeySDKResources.bundle",
+				$PODS_CONFIGURATION_BUILD_DIR/HockeySDK/HockeySDKResources.bundle,
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -6461,7 +6461,7 @@
 				E2E7EB46185FB140004F5E72 /* WPBlogSelectorButton.m in Sources */,
 				85D239B21AE5A5FC0074768D /* WordPressComOAuthClientFacade.m in Sources */,
 				85D239B31AE5A5FC0074768D /* WordPressXMLRPCAPIFacade.m in Sources */,
-				B50C0C521EF429E900372C65 /* MoreAttachmentRenderer.swift in Sources */,
+				B50C0C521EF429E900372C65 /* WordPressAttachmentRenderer.swift in Sources */,
 				E183BD7417621D87000B0822 /* WPCookie.m in Sources */,
 				43D2436D1EAFCE3C00D0C77B /* LoginSegueHandler.swift in Sources */,
 				08216FD41CDBF96000304BA7 /* MenuItemTypeSelectionView.m in Sources */,
@@ -7063,7 +7063,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 				WPCOM_SCHEME = wpdebug;
 			};
 			name = Debug;
@@ -7129,7 +7129,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 				WPCOM_SCHEME = wordpress;
 			};
 			name = Release;
@@ -7416,7 +7416,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_CONFIG = "$HOME/.wpcom_alpha_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_alpha_app_credentials;
 				WPCOM_SCHEME = wpalpha;
 			};
 			name = "Release-Alpha";
@@ -7844,7 +7844,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_CONFIG = "$HOME/.wpcom_internal_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_internal_app_credentials;
 				WPCOM_SCHEME = wpinternal;
 			};
 			name = "Release-Internal";

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   xcode:
-    version: 8.3
+    version: 9.0


### PR DESCRIPTION
### Details:
In this PR we're:

- Disabling smartDashes: iOS 11 UITextView feature that converts `--` into a single, longer dash, and miserably breaks our HTML editor.
- Renamed MoreAttachmentRenderer > WordPressAttachmentRenderer
- Added support to render the `nextpage` comment, the same way we render the `more` comment

[Related Aztec PR Here!](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/743)

Fixes #7894
Needs Review: @diegoreymendez 

### To test:
1. Launch the empty editor
2. Verify that inserting the `more` attachment works as expected
3. Switch to HTML mode
4. Type `<!--nextpage-->`
5. Switch to visual mode and verify everything looks as expected
