### PR TITLE
Comment UnitTest that enable Helpshift while running tests.

### DIFF
--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Alpha.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Alpha.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -37,6 +38,11 @@
                BlueprintName = "WordPressTest"
                ReferencedContainer = "container:WordPress.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "PushNotificationsManagerTests/testHelpshiftNotificationIsProperlyHandled">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
             skipped = "NO">
@@ -85,6 +91,7 @@
       buildConfiguration = "Release-Alpha"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
@@ -52,6 +53,9 @@
                ReferencedContainer = "container:WordPress.xcodeproj">
             </BuildableReference>
             <SkippedTests>
+               <Test
+                  Identifier = "PushNotificationsManagerTests/testHelpshiftNotificationIsProperlyHandled">
+               </Test>
                <Test
                   Identifier = "RemoteTestCase">
                </Test>
@@ -109,6 +113,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/WordPress/WordPressTest/PushNotificationsManagerTests.m
+++ b/WordPress/WordPressTest/PushNotificationsManagerTests.m
@@ -84,22 +84,26 @@
     OCMVerify(mockManager);
 }
 
-- (void)testHelpshiftNotificationIsProperlyHandled
-{
-    NSDictionary *userInfo = @{ @"origin" : @"helpshift" };
-    [HelpshiftCore initializeWithProvider:[HelpshiftSupport sharedInstance]];
-    PushNotificationsManager *manager = [PushNotificationsManager new];
-    id mockManager = OCMPartialMock(manager);
-    
-    XCTAssertTrue([mockManager handleHelpshiftNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
-    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
-    XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
-    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
-    
-    OCMExpect([manager handleHelpshiftNotification:userInfo completionHandler:nil]);
-    [mockManager handleNotification:userInfo completionHandler:nil];
-    OCMVerify(mockManager);
-}
+/** HACK: Sergio Estevao (2017-10-02) Disabled this test to avoid Helpshift run during the execution of unit tests.
+    Helpshift version 6.2.0 has a bug that acccess one property of UIApplication on a background thread.
+    This cause the new Thread Guard on Xcode to detect access and stop execution of tests with a crash.
+ **/
+//- (void)testHelpshiftNotificationIsProperlyHandled
+//{
+//    NSDictionary *userInfo = @{ @"origin" : @"helpshift" };
+//    [HelpshiftCore initializeWithProvider:[HelpshiftSupport sharedInstance]];
+//    PushNotificationsManager *manager = [PushNotificationsManager new];
+//    id mockManager = OCMPartialMock(manager);
+//
+//    XCTAssertTrue([mockManager handleHelpshiftNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
+//    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
+//    XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
+//    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
+//
+//    OCMExpect([manager handleHelpshiftNotification:userInfo completionHandler:nil]);
+//    [mockManager handleNotification:userInfo completionHandler:nil];
+//    OCMVerify(mockManager);
+//}
 
 - (void)testAuthenticationNotificationIsProperlyHandled
 {

--- a/WordPress/WordPressTest/PushNotificationsManagerTests.m
+++ b/WordPress/WordPressTest/PushNotificationsManagerTests.m
@@ -84,26 +84,26 @@
     OCMVerify(mockManager);
 }
 
-/** HACK: Sergio Estevao (2017-10-02) Disabled this test to avoid Helpshift run during the execution of unit tests.
+/** HACK: Sergio Estevao (2017-10-02)Disabled this test to avoid Helpshift run during the execution of unit tests.
     Helpshift version 6.2.0 has a bug that acccess one property of UIApplication on a background thread.
     This cause the new Thread Guard on Xcode to detect access and stop execution of tests with a crash.
  **/
-//- (void)testHelpshiftNotificationIsProperlyHandled
-//{
-//    NSDictionary *userInfo = @{ @"origin" : @"helpshift" };
-//    [HelpshiftCore initializeWithProvider:[HelpshiftSupport sharedInstance]];
-//    PushNotificationsManager *manager = [PushNotificationsManager new];
-//    id mockManager = OCMPartialMock(manager);
-//
-//    XCTAssertTrue([mockManager handleHelpshiftNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
-//    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
-//    XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
-//    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
-//
-//    OCMExpect([manager handleHelpshiftNotification:userInfo completionHandler:nil]);
-//    [mockManager handleNotification:userInfo completionHandler:nil];
-//    OCMVerify(mockManager);
-//}
+- (void)testHelpshiftNotificationIsProperlyHandled
+{
+    NSDictionary *userInfo = @{ @"origin" : @"helpshift" };
+    [HelpshiftCore initializeWithProvider:[HelpshiftSupport sharedInstance]];
+    PushNotificationsManager *manager = [PushNotificationsManager new];
+    id mockManager = OCMPartialMock(manager);
+
+    XCTAssertTrue([mockManager handleHelpshiftNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
+    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
+    XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
+    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling Helpshift");
+
+    OCMExpect([manager handleHelpshiftNotification:userInfo completionHandler:nil]);
+    [mockManager handleNotification:userInfo completionHandler:nil];
+    OCMVerify(mockManager);
+}
 
 - (void)testAuthenticationNotificationIsProperlyHandled
 {


### PR DESCRIPTION
This PR stops the execution of Helpshift while running tests circumventing the background crash cause by Helpshift accessing an UIApplication property while on a background thread.

To test:
 - Run the Unit tests
 - Make sure all tests pass and no crash happens.
