### PR TITLE
Track event failing for theme activation

### DIFF
--- a/WordPress/Classes/Services/AccountService+SocialService.swift
+++ b/WordPress/Classes/Services/AccountService+SocialService.swift
@@ -10,7 +10,7 @@ extension AccountService {
     ///     - token The service's OpenID Connect (JWT) ID token for the user.
     ///     - success
     ///     - failure
-    func connectToSocialService(_ service: SocialServiceName, serviceIDToken token:String, success:@escaping (() -> Void), failure:@escaping ((NSError) -> Void)) {
+    func connectToSocialService(_ service: SocialServiceName, serviceIDToken token: String, success:@escaping (() -> Void), failure:@escaping ((NSError) -> Void)) {
         guard let api = defaultWordPressComAccount()?.wordPressComRestApi,
             let remote = AccountServiceRemoteREST(wordPressComRestApi: api) else {
                 fatalError("Failed to initialize a valid remote via the default WordPress.com account.")

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -795,7 +795,7 @@ public protocol ThemePresenter: class {
         _ = themeService.activate(theme,
             for: blog,
             success: { [weak self] (theme: Theme?) in
-                WPAppAnalytics.track(.themesChangedTheme, withProperties: ["themeId": theme?.themeId ?? ""], with: self?.blog)
+                WPAppAnalytics.track(.themesChangedTheme, withProperties: ["theme_id": theme?.themeId ?? ""], with: self?.blog)
 
                 self?.collectionView?.reloadData()
 


### PR DESCRIPTION
**Fixes** #7803 

**To test:**

1. Activate a theme on develop and check that you see a warning on the console when the event is sent to Tracks.
2. Check out this branch and check that the warning is gone.

Needs review: @frosty 