### PR TITLE
Fix/credentials build warnings

### DIFF
--- a/WordPress/Credentials/ApiCredentials.m
+++ b/WordPress/Credentials/ApiCredentials.m
@@ -29,6 +29,14 @@
     return @"";
 }
 
++ (NSString *)googleLoginClientId {
+    return @"";
+}
+
++ (NSString *)googleLoginServerClientId {
+    return @"";
+}
+
 + (NSString *)helpshiftAPIKey {
     return  @"";
 }
@@ -38,6 +46,10 @@
 }
 
 + (NSString *)helpshiftAppId {
+    return @"";
+}
+
++ (NSString *)debuggingKey {
     return @"";
 }
 


### PR DESCRIPTION
The first build after cleaning will create some warnings about missing methods in `ApiCredentials.m`, which is just a placeholder that is replaced by a file generated by `gencredentials.rb`.

These changes silence those warnings.

To test:
- clean, then build
- look for warnings

Needs review: @elibud
