### PR TITLE
Login: Disconnect from Google so the user is always prompted.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -144,6 +144,10 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
     }
 
     func googleLoginTapped() {
+        // For paranoia, make sure a Google account is not already signed in / cached.
+        GIDSignIn.sharedInstance().disconnect()
+
+        // Configure all the things and sign in.
         GIDSignIn.sharedInstance().delegate = self
         GIDSignIn.sharedInstance().uiDelegate = self
         GIDSignIn.sharedInstance().clientID = ApiCredentials.googleLoginClientId()
@@ -380,6 +384,8 @@ extension LoginEmailViewController {
     func finishedLogin(withGoogleIDToken googleIDToken: String!, authToken: String!) {
         let username = loginFields.username
         syncWPCom(username, authToken: authToken, requiredMultifactor: false)
+        // Disconnect now that we're done with Google.
+        GIDSignIn.sharedInstance().disconnect()
     }
 
     func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo!) {


### PR DESCRIPTION
Make sure that an existing Google sign-in is disconnected so the user is always prompted to enter their Google credentials vs silently logging in with an already authenticated Google account.

Refs #7675 

To test:
Login via Google.
Log out of the app and then log back in via Google. 
Confirm that you are prompted for your Google credentials rather than silently authenticated to Google via an already signed in account. 

Needs review: @nheagy 