### PR TITLE
Issue/7860 insert medias alt field

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Extensions/ImageAttachment+WordPress.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Extensions/ImageAttachment+WordPress.swift
@@ -17,7 +17,7 @@ extension ImageAttachment {
             }
         }
     }
-    
+
     var width: Int? {
         get {
             guard let stringInt = extraAttributes["width"] else {

--- a/WordPress/Classes/ViewRelated/Aztec/Extensions/ImageAttachment+WordPress.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Extensions/ImageAttachment+WordPress.swift
@@ -5,6 +5,19 @@ import Aztec
 ///
 extension ImageAttachment {
 
+    var alt: String? {
+        get {
+            return extraAttributes["alt"]
+        }
+        set {
+            if let nonNilValue = newValue, newValue != "" {
+                extraAttributes["alt"] = nonNilValue
+            } else {
+                extraAttributes.removeValue(forKey: "alt")
+            }
+        }
+    }
+    
     var width: Int? {
         get {
             guard let stringInt = extraAttributes["width"] else {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -11,14 +11,16 @@ class AztecAttachmentViewController: UITableViewController {
             if let attachment = attachment {
                 alignment = attachment.alignment
                 size = attachment.size
+                alt = attachment.extraAttributes["alt"] ?? ""
             }
         }
     }
 
     var alignment = ImageAttachment.Alignment.none
     var size = ImageAttachment.Size.full
+    var alt = ""
 
-    var onUpdate: ((ImageAttachment.Alignment, ImageAttachment.Size) -> Void)?
+    var onUpdate: ((ImageAttachment.Alignment, ImageAttachment.Size, String) -> Void)?
 
     fileprivate var handler: ImmuTableViewHandler!
 
@@ -77,12 +79,18 @@ class AztecAttachmentViewController: UITableViewController {
             value: size.localizedString,
             action: displaySizeSelector)
 
+        let altRow = EditableTextRow(
+            title: NSLocalizedString("Alt Text", comment: "Image alt attribute."),
+            value: alt,
+            action: displayAltTextfield)
+
         return ImmuTable(sections: [
             ImmuTableSection(
                 headerText: displaySettingsHeader,
                 rows: [
                     alignmentRow,
                     sizeRow,
+                    altRow
                 ],
                 footerText: nil)
             ])
@@ -90,6 +98,27 @@ class AztecAttachmentViewController: UITableViewController {
 
 
     // MARK: - Actions
+    
+    private func displayAltTextfield(row: ImmuTableRow) {
+        let editableRow = row as! EditableTextRow
+        self.pushSettingsController(for: editableRow,
+                                    hint: NSLocalizedString("Image Description", comment: "Hint for image description on image settings."),
+                                    onValueChanged: { value in
+                                        self.alt = value
+                                        self.tableView.reloadData()
+        })
+    }
+    
+    private func pushSettingsController(for row: EditableTextRow, hint: String? = nil, onValueChanged: @escaping SettingsTextChanged) {
+        let title = row.title
+        let value = row.value
+        let controller = SettingsTextViewController(text: value, placeholder: "\(title)...", hint: hint)
+        
+        controller.title = title
+        controller.onValueChanged = onValueChanged
+        
+        navigationController?.pushViewController(controller, animated: true)
+    }
 
     func displayAlignmentSelector(row: ImmuTableRow) {
 
@@ -163,7 +192,7 @@ class AztecAttachmentViewController: UITableViewController {
     }
 
     func handleDoneButtonTapped(sender: UIBarButtonItem) {
-        onUpdate?(alignment, size)
+        onUpdate?(alignment, size, alt)
         dismiss(animated: true, completion: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -11,16 +11,16 @@ class AztecAttachmentViewController: UITableViewController {
             if let attachment = attachment {
                 alignment = attachment.alignment
                 size = attachment.size
-                alt = attachment.extraAttributes["alt"] ?? ""
+                alt = attachment.extraAttributes["alt"]
             }
         }
     }
 
     var alignment = ImageAttachment.Alignment.none
     var size = ImageAttachment.Size.full
-    var alt = ""
+    var alt: String?
 
-    var onUpdate: ((ImageAttachment.Alignment, ImageAttachment.Size, String) -> Void)?
+    var onUpdate: ((ImageAttachment.Alignment, ImageAttachment.Size, String?) -> Void)?
 
     fileprivate var handler: ImmuTableViewHandler!
 
@@ -81,7 +81,7 @@ class AztecAttachmentViewController: UITableViewController {
 
         let altRow = EditableTextRow(
             title: NSLocalizedString("Alt Text", comment: "Image alt attribute."),
-            value: alt,
+            value: alt ?? "",
             action: displayAltTextfield)
 
         return ImmuTable(sections: [

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -193,7 +193,12 @@ class AztecAttachmentViewController: UITableViewController {
     }
 
     func handleDoneButtonTapped(sender: UIBarButtonItem) {
-        onUpdate?(alignment, size, alt)
+        if let alt = alt, alt != "" {
+            onUpdate?(alignment, size, alt)
+        } else {
+            onUpdate?(alignment, size, nil)
+        }
+        
         dismiss(animated: true, completion: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -108,19 +108,6 @@ class AztecAttachmentViewController: UITableViewController {
         })
     }
 
-    private func pushSettingsController(for row: EditableTextRow,
-                                        hint: String? = nil,
-                                        onValueChanged: @escaping SettingsTextChanged) {
-        let title = row.title
-        let value = row.value
-        let controller = SettingsTextViewController(text: value, placeholder: "\(title)...", hint: hint)
-
-        controller.title = title
-        controller.onValueChanged = onValueChanged
-
-        navigationController?.pushViewController(controller, animated: true)
-    }
-
     func displayAlignmentSelector(row: ImmuTableRow) {
 
         let values: [ImageAttachment.Alignment] = [.left, .center, .right, .none]
@@ -193,13 +180,22 @@ class AztecAttachmentViewController: UITableViewController {
     }
 
     func handleDoneButtonTapped(sender: UIBarButtonItem) {
-        if let alt = alt, alt != "" {
-            onUpdate?(alignment, size, alt)
-        } else {
-            onUpdate?(alignment, size, nil)
-        }
-
+        let checkedAlt = alt == "" ? nil : alt
+        onUpdate?(alignment, size, checkedAlt)
         dismiss(animated: true, completion: nil)
+    }
+
+    private func pushSettingsController(for row: EditableTextRow,
+                                        hint: String? = nil,
+                                        onValueChanged: @escaping SettingsTextChanged) {
+        let title = row.title
+        let value = row.value
+        let controller = SettingsTextViewController(text: value, placeholder: "\(title)...", hint: hint)
+
+        controller.title = title
+        controller.onValueChanged = onValueChanged
+
+        navigationController?.pushViewController(controller, animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -101,15 +101,16 @@ class AztecAttachmentViewController: UITableViewController {
     
     private func displayAltTextfield(row: ImmuTableRow) {
         let editableRow = row as! EditableTextRow
-        self.pushSettingsController(for: editableRow,
-                                    hint: NSLocalizedString("Image Description", comment: "Hint for image description on image settings."),
-                                    onValueChanged: { value in
-                                        self.alt = value
-                                        self.tableView.reloadData()
+        let hint = NSLocalizedString("Image Description", comment: "Hint for image description on image settings.")
+        self.pushSettingsController(for: editableRow, hint: hint, onValueChanged: { value in
+            self.alt = value
+            self.tableView.reloadData()
         })
     }
     
-    private func pushSettingsController(for row: EditableTextRow, hint: String? = nil, onValueChanged: @escaping SettingsTextChanged) {
+    private func pushSettingsController(for row: EditableTextRow,
+                                        hint: String? = nil,
+                                        onValueChanged: @escaping SettingsTextChanged) {
         let title = row.title
         let value = row.value
         let controller = SettingsTextViewController(text: value, placeholder: "\(title)...", hint: hint)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -98,7 +98,7 @@ class AztecAttachmentViewController: UITableViewController {
 
 
     // MARK: - Actions
-    
+
     private func displayAltTextfield(row: ImmuTableRow) {
         let editableRow = row as! EditableTextRow
         let hint = NSLocalizedString("Image Description", comment: "Hint for image description on image settings.")
@@ -107,17 +107,17 @@ class AztecAttachmentViewController: UITableViewController {
             self.tableView.reloadData()
         })
     }
-    
+
     private func pushSettingsController(for row: EditableTextRow,
                                         hint: String? = nil,
                                         onValueChanged: @escaping SettingsTextChanged) {
         let title = row.title
         let value = row.value
         let controller = SettingsTextViewController(text: value, placeholder: "\(title)...", hint: hint)
-        
+
         controller.title = title
         controller.onValueChanged = onValueChanged
-        
+
         navigationController?.pushViewController(controller, animated: true)
     }
 
@@ -198,10 +198,9 @@ class AztecAttachmentViewController: UITableViewController {
         } else {
             onUpdate?(alignment, size, nil)
         }
-        
+
         dismiss(animated: true, completion: nil)
     }
-
 }
 
 extension ImageAttachment.Alignment {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -11,7 +11,7 @@ class AztecAttachmentViewController: UITableViewController {
             if let attachment = attachment {
                 alignment = attachment.alignment
                 size = attachment.size
-                alt = attachment.extraAttributes["alt"]
+                alt = attachment.alt
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -80,7 +80,7 @@ class AztecAttachmentViewController: UITableViewController {
             action: displaySizeSelector)
 
         let altRow = EditableTextRow(
-            title: NSLocalizedString("Alt Text", comment: "Image alt attribute."),
+            title: NSLocalizedString("Alt Text", comment: "Image alt attribute option title."),
             value: alt ?? "",
             action: displayAltTextfield)
 
@@ -101,7 +101,7 @@ class AztecAttachmentViewController: UITableViewController {
 
     private func displayAltTextfield(row: ImmuTableRow) {
         let editableRow = row as! EditableTextRow
-        let hint = NSLocalizedString("Image Description", comment: "Hint for image description on image settings.")
+        let hint = NSLocalizedString("Image Alt", comment: "Hint for image alt on image settings.")
         self.pushSettingsController(for: editableRow, hint: hint, onValueChanged: { value in
             self.alt = value
             self.tableView.reloadData()

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2975,7 +2975,9 @@ extension AztecPostViewController {
             self?.richTextView.edit(attachment) { updated in
                 updated.alignment = alignment
                 updated.size = size
-                updated.extraAttributes["alt"] = alt
+                if let alt = alt {
+                    updated.extraAttributes["alt"] = alt
+                }
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3001,15 +3001,18 @@ extension AztecPostViewController {
 
     func placeholderImage(for attachment: NSTextAttachment) -> UIImage {
         let imageSize = CGSize(width: 128, height: 128)
-
+        let icon: UIImage
         switch attachment {
         case _ as ImageAttachment:
-            return Gridicon.iconOfType(.image, withSize: imageSize)
+            icon = Gridicon.iconOfType(.image, withSize: imageSize)
         case _ as VideoAttachment:
-            return Gridicon.iconOfType(.video, withSize: imageSize)
+            icon = Gridicon.iconOfType(.video, withSize: imageSize)
         default:
-            return Gridicon.iconOfType(.attachment, withSize: imageSize)
+            icon = Gridicon.iconOfType(.attachment, withSize: imageSize)
         }
+        
+        icon.addAccessibilityForAttachment(attachment)
+        return icon
     }
 
     // [2017-08-30] We need to auto-close the input media picker when multitasking panes are resized - iOS
@@ -3255,6 +3258,17 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
             if formatBar.trailingItem != insertToolbarItem {
                 formatBar.trailingItem = insertToolbarItem
             }
+        }
+    }
+}
+
+// MARK - Accessibilty Helpers
+//
+extension UIImage {
+    func addAccessibilityForAttachment(_ attachment: NSTextAttachment) {
+        if let attachment = attachment as? ImageAttachment,
+            let accessibilityLabel = attachment.extraAttributes["alt"]  {
+            self.accessibilityLabel = accessibilityLabel
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2975,9 +2975,7 @@ extension AztecPostViewController {
             self?.richTextView.edit(attachment) { updated in
                 updated.alignment = alignment
                 updated.size = size
-                if let alt = alt {
-                    updated.extraAttributes["alt"] = alt
-                }
+                updated.extraAttributes["alt"] = alt
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3264,7 +3264,7 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
     }
 }
 
-// MARK - Accessibilty Helpers
+// MARK: - Accessibilty Helpers
 //
 extension UIImage {
     func addAccessibilityForAttachment(_ attachment: NSTextAttachment) {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2682,7 +2682,7 @@ extension AztecPostViewController {
         switch media.mediaType {
         case .image:
             let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange, sourceURL: remoteURL, placeHolderImage: Assets.defaultMissingImage)
-            attachment.extraAttributes["alt"] = media.alt
+            attachment.alt = media.alt
             WPAppAnalytics.track(.editorAddedPhotoViaWPMediaLibrary, withProperties: WPAppAnalytics.properties(for: media, mediaOrigin: selectedMediaOrigin), with: post)
         case .video:
             var posterURL: URL?
@@ -2975,7 +2975,7 @@ extension AztecPostViewController {
             self?.richTextView.edit(attachment) { updated in
                 updated.alignment = alignment
                 updated.size = size
-                updated.extraAttributes["alt"] = alt
+                updated.alt = alt
             }
         }
 
@@ -3262,12 +3262,12 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
     }
 }
 
-// MARK: - Accessibilty Helpers
+// MARK: - Accessibility Helpers
 //
 extension UIImage {
     func addAccessibilityForAttachment(_ attachment: NSTextAttachment) {
         if let attachment = attachment as? ImageAttachment,
-            let accessibilityLabel = attachment.extraAttributes["alt"] {
+            let accessibilityLabel = attachment.alt {
             self.accessibilityLabel = accessibilityLabel
         }
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2681,7 +2681,8 @@ extension AztecPostViewController {
         }
         switch media.mediaType {
         case .image:
-            let _ = richTextView.replaceWithImage(at: richTextView.selectedRange, sourceURL: remoteURL, placeHolderImage: Assets.defaultMissingImage)
+            let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange, sourceURL: remoteURL, placeHolderImage: Assets.defaultMissingImage)
+            attachment.extraAttributes["alt"] = media.alt
             WPAppAnalytics.track(.editorAddedPhotoViaWPMediaLibrary, withProperties: WPAppAnalytics.properties(for: media, mediaOrigin: selectedMediaOrigin), with: post)
         case .video:
             var posterURL: URL?
@@ -2970,10 +2971,11 @@ extension AztecPostViewController {
     func displayDetails(forAttachment attachment: ImageAttachment) {
         let controller = AztecAttachmentViewController()
         controller.attachment = attachment
-        controller.onUpdate = { [weak self] (alignment, size) in
+        controller.onUpdate = { [weak self] (alignment, size, alt) in
             self?.richTextView.edit(attachment) { updated in
                 updated.alignment = alignment
                 updated.size = size
+                updated.extraAttributes["alt"] = alt
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3012,7 +3012,7 @@ extension AztecPostViewController {
         default:
             icon = Gridicon.iconOfType(.attachment, withSize: imageSize)
         }
-        
+
         icon.addAccessibilityForAttachment(attachment)
         return icon
     }
@@ -3269,7 +3269,7 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
 extension UIImage {
     func addAccessibilityForAttachment(_ attachment: NSTextAttachment) {
         if let attachment = attachment as? ImageAttachment,
-            let accessibilityLabel = attachment.extraAttributes["alt"]  {
+            let accessibilityLabel = attachment.extraAttributes["alt"] {
             self.accessibilityLabel = accessibilityLabel
         }
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -938,6 +938,7 @@
 		F1564E5B18946087009F8F97 /* NSStringHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */; };
 		F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
 		F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
+		F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B43771F849F580089B817 /* PostAttachmentTests.swift */; };
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
@@ -2375,6 +2376,7 @@
 		F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringHelpersTests.m; sourceTree = "<group>"; };
 		F1D690141F828FF000200E30 /* BuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfiguration.swift; sourceTree = "<group>"; };
 		F1D690151F828FF000200E30 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
+		F18B43771F849F580089B817 /* PostAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAttachmentTests.swift; path = Posts/PostAttachmentTests.swift; sourceTree = "<group>"; };
 		F373612EEEEF10E500093FF3 /* Pods-WordPress.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressShareExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Themes.swift"; sourceTree = "<group>"; };
@@ -3109,6 +3111,7 @@
 			isa = PBXGroup;
 			children = (
 				59ECF87A1CB7061D00E68F25 /* PostSharingControllerTests.swift */,
+				F18B43771F849F580089B817 /* PostAttachmentTests.swift */,
 			);
 			name = Posts;
 			sourceTree = "<group>";
@@ -6854,6 +6857,7 @@
 				08F8CD311EBD2A960049D0C0 /* MediaImageExporterTests.swift in Sources */,
 				E1B921BC1C0ED5A3003EA3CB /* MediaSizeSliderCellTest.swift in Sources */,
 				0885A3671E837AFE00619B4D /* URLIncrementalFilenameTests.swift in Sources */,
+				F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */,
 				E1E4CE0D177439D100430844 /* WPAvatarSourceTest.m in Sources */,
 				B55F1AA21C107CE200FD04D4 /* BlogSettingsDiscussionTests.swift in Sources */,
 			);

--- a/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
+++ b/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
@@ -16,21 +16,21 @@ class MockAttachmentDelegate: TextViewAttachmentDelegate {
     func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
         success(UIImage())
     }
-    
+
     func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL {
         return URL(string: "http://someExampleImage.jpg")!
     }
-    
+
     func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage {
         return UIImage()
     }
-    
+
     func textView(_ textView: TextView, deletedAttachmentWith attachmentID: String) {
     }
-    
+
     func textView(_ textView: TextView, selected attachment: NSTextAttachment, atPosition position: CGPoint) {
     }
-    
+
     func textView(_ textView: TextView, deselected attachment: NSTextAttachment, atPosition position: CGPoint) {
     }
 }
@@ -39,7 +39,7 @@ class PostAttachmentTests: XCTestCase {
 
     private let richTextView = TextView(defaultFont: UIFont(), defaultMissingImage: UIImage())
     private let delegate = MockAttachmentDelegate()
-    
+
     override func setUp() {
         super.setUp()
         richTextView.textAttachmentDelegate = delegate
@@ -50,15 +50,14 @@ class PostAttachmentTests: XCTestCase {
         super.tearDown()
     }
 
-    func testIfAltValueWasAddedToImageAttachment()  {
+    func testIfAltValueWasAddedToImageAttachment() {
         richTextView.attributedText = NSAttributedString(string: "Image with alt: ")
         let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange,
                                                        sourceURL: URL(string: "someExampleImage.jpg")!,
                                                        placeHolderImage: UIImage())
-        
-        
+
         let expect = expectation(description: "Alt Value has been updated")
-        
+
         let controller = AztecAttachmentViewController()
         controller.attachment = attachment
         controller.alt = "alt"
@@ -71,22 +70,21 @@ class PostAttachmentTests: XCTestCase {
             }
         }
         controller.handleDoneButtonTapped(sender: UIBarButtonItem())
-        
+
         waitForExpectations(timeout: 1, handler: nil)
-        
+
         let html = richTextView.getHTML()
         XCTAssert(html == "<p>Image with alt: <img src=\"someExampleImage.jpg\" alt=\"alt\"></p>")
     }
 
-    func testIfAltValueWasLeftEmptyForImageAttachment()  {
+    func testIfAltValueWasLeftEmptyForImageAttachment() {
         richTextView.attributedText = NSAttributedString(string: "Image with alt: ")
         let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange,
                                                        sourceURL: URL(string: "someExampleImage.jpg")!,
                                                        placeHolderImage: UIImage())
-        
-        
+
         let expect = expectation(description: "AztecAttachmentViewController did finish updating")
-        
+
         let controller = AztecAttachmentViewController()
         controller.attachment = attachment
         controller.alt = ""
@@ -99,11 +97,10 @@ class PostAttachmentTests: XCTestCase {
             }
         }
         controller.handleDoneButtonTapped(sender: UIBarButtonItem())
-        
+
         waitForExpectations(timeout: 1, handler: nil)
-        
+
         let html = richTextView.getHTML()
         XCTAssert(html == "<p>Image with alt: <img src=\"someExampleImage.jpg\"></p>")
     }
 }
-

--- a/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
+++ b/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
@@ -29,24 +29,14 @@ class MockAttachmentDelegate: TextViewAttachmentDelegate {
 
 class PostAttachmentTests: XCTestCase {
 
-    private let richTextView = TextView(defaultFont: UIFont(), defaultMissingImage: UIImage())
-    private let delegate = MockAttachmentDelegate()
-
-    override func setUp() {
-        super.setUp()
-        richTextView.textAttachmentDelegate = delegate
-    }
-
-    override func tearDown() {
-        richTextView.textAttachmentDelegate = nil
-        super.tearDown()
-    }
-
     func testIfAltValueWasAddedToImageAttachment() {
         let prefixString = "Image with alt: "
         let imageName = "someExampleImage.jpg"
         let altValue = "additional alt"
 
+        let richTextView = TextView(defaultFont: UIFont(), defaultMissingImage: UIImage())
+        let delegate = MockAttachmentDelegate()
+        richTextView.textAttachmentDelegate = delegate
         richTextView.attributedText = NSAttributedString(string: prefixString)
         let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange,
                                                        sourceURL: URL(string: imageName)!,
@@ -57,8 +47,8 @@ class PostAttachmentTests: XCTestCase {
         let controller = AztecAttachmentViewController()
         controller.attachment = attachment
         controller.alt = altValue
-        controller.onUpdate = { [weak self] (_, _, alt) in
-            self?.richTextView.edit(attachment) { updated in
+        controller.onUpdate = { (_, _, alt) in
+        richTextView.edit(attachment) { updated in
                 if let alt = alt {
                     updated.alt = alt
                 }
@@ -78,6 +68,9 @@ class PostAttachmentTests: XCTestCase {
         let imageName = "someExampleImage.jpg"
         let altValue = ""
 
+        let richTextView = TextView(defaultFont: UIFont(), defaultMissingImage: UIImage())
+        let delegate = MockAttachmentDelegate()
+        richTextView.textAttachmentDelegate = delegate
         richTextView.attributedText = NSAttributedString(string: prefixString)
         let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange,
                                                        sourceURL: URL(string: imageName)!,
@@ -88,8 +81,8 @@ class PostAttachmentTests: XCTestCase {
         let controller = AztecAttachmentViewController()
         controller.attachment = attachment
         controller.alt = altValue
-        controller.onUpdate = { [weak self] (_, _, alt) in
-            self?.richTextView.edit(attachment) { updated in
+        controller.onUpdate = { (_, _, alt) in
+        richTextView.edit(attachment) { updated in
                 if let alt = alt {
                     updated.alt = alt
                 }

--- a/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
+++ b/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
@@ -1,0 +1,60 @@
+//
+//  PostAttachmentTests.swift
+//  WordPressTest
+//
+//  Created by Evangelos Sismanidis on 04.10.17.
+//  Copyright © 2017 WordPress. All rights reserved.
+//
+
+import XCTest
+import Aztec
+
+class MockAttachmentDelegate: TextViewAttachmentDelegate {
+
+    func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
+        success(UIImage())
+    }
+    
+    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL {
+        return URL(string: "http://someExampleImage.jpg")!
+    }
+    
+    func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage {
+        return UIImage()
+    }
+    
+    func textView(_ textView: TextView, deletedAttachmentWith attachmentID: String) {
+    }
+    
+    func textView(_ textView: TextView, selected attachment: NSTextAttachment, atPosition position: CGPoint) {
+    }
+    
+    func textView(_ textView: TextView, deselected attachment: NSTextAttachment, atPosition position: CGPoint) {
+    }
+}
+
+class PostAttachmentTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testIfAltValueWasAddedToImageAttachment() {
+        let richTextView = TextView(defaultFont: UIFont(), defaultMissingImage: UIImage())
+        let delegate = MockAttachmentDelegate()
+        richTextView.textAttachmentDelegate = delegate
+        richTextView.attributedText = NSAttributedString(string: "Image: ")
+        let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange,
+                                                       sourceURL: URL(string: "someExampleImage.jpg")!,
+                                                       placeHolderImage: UIImage())
+        attachment.extraAttributes["alt"] = "alt"
+        let html = richTextView.getHTML()
+        XCTAssert(html == "<p>Image: <img src=\"someExampleImage.jpg\" alt=\"alt\"></p>")
+    }
+    
+}
+

--- a/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
+++ b/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
@@ -43,16 +43,20 @@ class PostAttachmentTests: XCTestCase {
     }
 
     func testIfAltValueWasAddedToImageAttachment() {
-        richTextView.attributedText = NSAttributedString(string: "Image with alt: ")
+        let prefixString = "Image with alt: "
+        let imageName = "someExampleImage.jpg"
+        let altValue = "additional alt"
+
+        richTextView.attributedText = NSAttributedString(string: prefixString)
         let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange,
-                                                       sourceURL: URL(string: "someExampleImage.jpg")!,
+                                                       sourceURL: URL(string: imageName)!,
                                                        placeHolderImage: UIImage())
 
         let expect = expectation(description: "Alt Value has been updated")
 
         let controller = AztecAttachmentViewController()
         controller.attachment = attachment
-        controller.alt = "alt"
+        controller.alt = altValue
         controller.onUpdate = { [weak self] (_, _, alt) in
             self?.richTextView.edit(attachment) { updated in
                 if let alt = alt {
@@ -66,20 +70,24 @@ class PostAttachmentTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
 
         let html = richTextView.getHTML()
-        XCTAssert(html == "<p>Image with alt: <img src=\"someExampleImage.jpg\" alt=\"alt\"></p>")
+        XCTAssert(html == "<p>\(prefixString)<img src=\"\(imageName)\" alt=\"\(altValue)\"></p>")
     }
 
     func testIfAltValueWasLeftEmptyForImageAttachment() {
-        richTextView.attributedText = NSAttributedString(string: "Image with alt: ")
+        let prefixString = "Image without alt: "
+        let imageName = "someExampleImage.jpg"
+        let altValue = ""
+
+        richTextView.attributedText = NSAttributedString(string: prefixString)
         let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange,
-                                                       sourceURL: URL(string: "someExampleImage.jpg")!,
+                                                       sourceURL: URL(string: imageName)!,
                                                        placeHolderImage: UIImage())
 
         let expect = expectation(description: "AztecAttachmentViewController did finish updating")
 
         let controller = AztecAttachmentViewController()
         controller.attachment = attachment
-        controller.alt = ""
+        controller.alt = altValue
         controller.onUpdate = { [weak self] (_, _, alt) in
             self?.richTextView.edit(attachment) { updated in
                 if let alt = alt {
@@ -93,6 +101,6 @@ class PostAttachmentTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
 
         let html = richTextView.getHTML()
-        XCTAssert(html == "<p>Image with alt: <img src=\"someExampleImage.jpg\"></p>")
+        XCTAssert(html == "<p>\(prefixString)<img src=\"\(imageName)\"></p>")
     }
 }

--- a/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
+++ b/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
@@ -1,11 +1,3 @@
-//
-//  PostAttachmentTests.swift
-//  WordPressTest
-//
-//  Created by Evangelos Sismanidis on 04.10.17.
-//  Copyright © 2017 WordPress. All rights reserved.
-//
-
 import XCTest
 import Aztec
 

--- a/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
+++ b/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
@@ -60,7 +60,7 @@ class PostAttachmentTests: XCTestCase {
         controller.onUpdate = { [weak self] (_, _, alt) in
             self?.richTextView.edit(attachment) { updated in
                 if let alt = alt {
-                    updated.extraAttributes["alt"] = alt
+                    updated.alt = alt
                 }
                 expect.fulfill()
             }
@@ -91,7 +91,7 @@ class PostAttachmentTests: XCTestCase {
         controller.onUpdate = { [weak self] (_, _, alt) in
             self?.richTextView.edit(attachment) { updated in
                 if let alt = alt {
-                    updated.extraAttributes["alt"] = alt
+                    updated.alt = alt
                 }
                 expect.fulfill()
             }

--- a/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
+++ b/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
@@ -35,26 +35,27 @@ class MockAttachmentDelegate: TextViewAttachmentDelegate {
 
 class PostAttachmentTests: XCTestCase {
 
+    private let richTextView = TextView(defaultFont: UIFont(), defaultMissingImage: UIImage())
+    private let delegate = MockAttachmentDelegate()
+    
     override func setUp() {
         super.setUp()
+        richTextView.textAttachmentDelegate = delegate
     }
 
     override func tearDown() {
+        richTextView.textAttachmentDelegate = nil
         super.tearDown()
     }
 
     func testIfAltValueWasAddedToImageAttachment() {
-        let richTextView = TextView(defaultFont: UIFont(), defaultMissingImage: UIImage())
-        let delegate = MockAttachmentDelegate()
-        richTextView.textAttachmentDelegate = delegate
-        richTextView.attributedText = NSAttributedString(string: "Image: ")
+        richTextView.attributedText = NSAttributedString(string: "Image with alt: ")
         let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange,
                                                        sourceURL: URL(string: "someExampleImage.jpg")!,
                                                        placeHolderImage: UIImage())
         attachment.extraAttributes["alt"] = "alt"
         let html = richTextView.getHTML()
-        XCTAssert(html == "<p>Image: <img src=\"someExampleImage.jpg\" alt=\"alt\"></p>")
-    }
-    
+        XCTAssert(html == "<p>Image with alt: <img src=\"someExampleImage.jpg\" alt=\"alt\"></p>")
+    }    
 }
 


### PR DESCRIPTION
Fixes #7860

To test:

- check that the img tag's value can be loaded and is editable at the image details edit screen (tap on image to edit its details)
- check if after adding an image with an existing alt tag, the value appears in html img tag
- check if after adding an alt value to an image, the value appears in html img tag
- check that altering the alt value of an image. does not affect the alt value of an ImageAttachment
- check if the alt value (when it exists), is the one which is read when Voice over Accessibility feature is active

Needs review: @diegoreymendez @frosty 