### PR TITLE
Make PostServiceType a proper enum in Swift

### DIFF
--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -11,10 +11,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NSString * PostServiceType;
 typedef void(^PostServiceSyncSuccess)(NSArray<AbstractPost *> * _Nullable posts);
 typedef void(^PostServiceSyncFailure)(NSError * _Nullable error);
 
+typedef NSString * PostServiceType NS_TYPED_ENUM;
 extern PostServiceType const PostServiceTypePost;
 extern PostServiceType const PostServiceTypePage;
 extern PostServiceType const PostServiceTypeAny;

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -150,7 +150,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     // MARK: - Sync Methods
 
     override internal func postTypeToSync() -> PostServiceType {
-        return PostServiceTypePage as PostServiceType
+        return .page
     }
 
     override internal func lastSyncDate() -> Date? {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -307,7 +307,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
     func propertiesForAnalytics() -> [String: AnyObject] {
         var properties = [String: AnyObject]()
 
-        properties["type"] = postTypeToSync()
+        properties["type"] = postTypeToSync().rawValue as AnyObject?
         properties["filter"] = filterSettings.currentPostListFilter().title as AnyObject?
 
         if let dotComID = blog.dotComID {
@@ -568,7 +568,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
     internal func postTypeToSync() -> PostServiceType {
         // Subclasses should override.
-        return PostServiceTypeAny as PostServiceType
+        return .any
     }
 
     func lastSyncDate() -> Date? {
@@ -593,7 +593,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         options.purgesLocalSync = true
 
         postService.syncPosts(
-            ofType: postTypeToSync() as String,
+            ofType: postTypeToSync(),
             with: options,
             for: blog,
             success: {[weak self] posts in
@@ -644,7 +644,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         options.offset = tableViewHandler.resultsController.fetchedObjects?.count as NSNumber!
 
         postService.syncPosts(
-            ofType: postTypeToSync() as String,
+            ofType: postTypeToSync(),
             with: options,
             for: blog,
             success: {[weak self] posts in
@@ -779,7 +779,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         options.search = searchText
 
         postService.syncPosts(
-            ofType: postTypeToSync() as String,
+            ofType: postTypeToSync(),
             with: options,
             for: blog,
             success: { [weak self] posts in

--- a/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
@@ -83,9 +83,9 @@ class PostListFilterSettings: NSObject {
 
     func keyForCurrentListStatusFilter() -> String {
         switch postType {
-        case PostServiceTypePage as String:
+        case .page:
             return type(of: self).currentPageListStatusFilterKey
-        case PostServiceTypePost as String:
+        case .post:
             return type(of: self).currentPageListStatusFilterKey
         default:
             return ""
@@ -120,7 +120,7 @@ class PostListFilterSettings: NSObject {
     // MARK: - Author-related methods
 
     func canFilterByAuthor() -> Bool {
-        if postType as String == PostServiceTypePost {
+        if postType == .post {
             return blog.isMultiAuthor && blog.userID != nil
         }
         return false
@@ -168,7 +168,7 @@ class PostListFilterSettings: NSObject {
     func propertiesForAnalytics() -> [String: AnyObject] {
         var properties = [String: AnyObject]()
 
-        properties["type"] = postType
+        properties["type"] = postType.rawValue as AnyObject?
         properties["filter"] = currentPostListFilter().title as AnyObject?
 
         if let dotComID = blog.dotComID {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -226,7 +226,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     // MARK: - Sync Methods
 
     override func postTypeToSync() -> PostServiceType {
-        return PostServiceTypePost as PostServiceType
+        return .post
     }
 
     override func lastSyncDate() -> Date? {
@@ -282,7 +282,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             predicates.append(basePredicate)
         }
 
-        let typePredicate = NSPredicate(format: "postType = %@", postTypeToSync())
+        let typePredicate = NSPredicate(format: "postType = %@", postTypeToSync().rawValue)
         predicates.append(typePredicate)
 
         let searchText = currentSearchTerm()


### PR DESCRIPTION
As mentioned in #7905, there was a remaining warning in `PostListFilterSettings`.

Objective-C was exporting `PostServiceType` as `NSString`, but the specific values were correctly bridged as `String`.

Adding `NS_TYPED_ENUM` makes it a normal Swift enum, and solves all the bridging issues.

cc: @elibud 
Needs review: @nheagy 
