### PR TITLE
Login: Fixes an issue making the help button untappable.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
@@ -62,7 +62,6 @@ class LoginViewController: NUXAbstractViewController {
         helpButton.trailingAnchor.constraint(equalTo: customView.trailingAnchor).isActive = true
         helpButton.topAnchor.constraint(equalTo: customView.topAnchor).isActive = true
         helpButton.bottomAnchor.constraint(equalTo: customView.bottomAnchor).isActive = true
-        helpButton.centerYAnchor.constraint(equalTo: customView.centerYAnchor).isActive = true
 
         helpBadge = WPNUXHelpBadgeLabel()
         helpBadge.translatesAutoresizingMaskIntoConstraints = false

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
@@ -58,7 +58,10 @@ class LoginViewController: NUXAbstractViewController {
 
         customView.addSubview(helpButton)
         helpButton.translatesAutoresizingMaskIntoConstraints = false
+        helpButton.leadingAnchor.constraint(equalTo: customView.leadingAnchor).isActive = true
         helpButton.trailingAnchor.constraint(equalTo: customView.trailingAnchor).isActive = true
+        helpButton.topAnchor.constraint(equalTo: customView.topAnchor).isActive = true
+        helpButton.bottomAnchor.constraint(equalTo: customView.bottomAnchor).isActive = true
         helpButton.centerYAnchor.constraint(equalTo: customView.centerYAnchor).isActive = true
 
         helpBadge = WPNUXHelpBadgeLabel()


### PR DESCRIPTION
Props @nheagy for noticing the glitch.  The problem was the Help button was no longer responding to taps.   Some debugging showed that its parent view had 0,0 geometry so taps weren't being registered. If `clipToBounds` was set on the `customView` then the button would simply vanish.

Not too sure what could have changed, something in a private API or the internals of how UIButtonBarItems are laid out.   In any event, this PR fixes the problem by setting constraints to pin the sides of the button to the customView so it has proper geometry.

To test: 
- Launch the app.  
- Enter the Login flow and confirm you can tap on the help button. 
- Confirm the Help button's layout is correct.

Needs review: @nheagy 
cc @elibud 
