### PR TITLE
Stops removing empty newlines.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -79,14 +79,8 @@ class CalypsoProcessorIn: Processor {
         output = output.replacingMatches(of: "\\s*<option", with: "<option", options: .caseInsensitive)
         output = output.replacingMatches(of: "<\\/option>\\s*", with: "</option>", options: .caseInsensitive)
 
-        // Normalize multiple line breaks and white space chars.
-        output = output.replacingMatches(of: "\n\\s*\n+", with: "\n\n")
-
         // Convert two line breaks to a paragraph.
-        output = output.replacingMatches(of: "([\\s\\S]+?)\n\n", with: "<p>$1</p>\n")
-
-        // Remove empty paragraphs.
-        output = output.replacingMatches(of: "<p>\\s*?<\\/p>", with: "", options: .caseInsensitive)
+        output = output.replacingMatches(of: "([\\s\\S]*?)\n\n", with: "<p>$1</p>\n")
 
         // Remove <p> tags that are around block tags.
         output = output.replacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
@@ -95,11 +89,6 @@ class CalypsoProcessorIn: Processor {
         // Fix <p> in blockquotes.
         output = output.replacingMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$1><p>", options: .caseInsensitive)
         output = output.replacingMatches(of: "<\\/blockquote>\\s*<\\/p>", with: "</p></blockquote>", options: .caseInsensitive)
-
-        // Remove <p> tags that are wrapped around block tags.
-        output = output.replacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$1", options: .caseInsensitive)
-        output = output.replacingMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
-        output = output.replacingMatches(of: "(<br[^>]*>)\\s*\n", with: "$1", options: .caseInsensitive)
 
         // Add <br> tags.
         output = output.replacingMatches(of: "\\s*\n", with: "<br />\n")

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -77,9 +77,6 @@ class CalypsoProcessorOut: Processor {
         output = output.replacingMatches(of: "\\s*<p>", with: "", options: .caseInsensitive)
         output = output.replacingMatches(of: "\\s*<\\/p>\\s*", with: "\n\n", options: .caseInsensitive)
 
-        // Normalize white space chars and remove multiple line breaks.
-        output = output.replacingMatches(of: "\n[\\s\\u00a0]+\n", with: "\n\n")
-
         // Replace <br> tags with line breaks.
         output = output.replacingMatches(of: "(\\s*)<br ?\\/?>\\s*", options: .caseInsensitive, using: { (match, ranges) -> String in
             if ranges.count > 0 && ranges[0].contains("\n") {
@@ -147,7 +144,6 @@ class CalypsoProcessorOut: Processor {
             })
         }
 
-        //                return html;
         return output
     }
 }


### PR DESCRIPTION
Fixes #7920 

Makes sure newlines are not added or removed from WP posts, other than by the user editing the post.

### Testing:

**Test 1:**

1. Open any existing post.
2. Switch to HTML mode and back.
3. Make sure newlines stay consistent.

**Test 2:**

1. Create a new post
2. Make some changes.  Add many empty lines.
3. Save it.
4. Open it again and make sure newlines stay consistent.