### PR TITLE
AztecPostViewController: Preventing vertical offset glitch

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2022,9 +2022,8 @@ extension AztecPostViewController {
             return
         }
 
-        richTextView.resignFirstResponder()
         richTextView.inputView = to
-        richTextView.becomeFirstResponder()
+        richTextView.reloadInputView()
     }
 
     fileprivate func trackFormatBarAnalytics(stat: WPAnalyticsStat, action: String? = nil, headingStyle: String? = nil) {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2023,7 +2023,7 @@ extension AztecPostViewController {
         }
 
         richTextView.inputView = to
-        richTextView.reloadInputView()
+        richTextView.reloadInputViews()
     }
 
     fileprivate func trackFormatBarAnalytics(stat: WPAnalyticsStat, action: String? = nil, headingStyle: String? = nil) {


### PR DESCRIPTION
### Details:
This PR prevents an undesired vertical scrolling glitch, when switching to a custom Input View (ie. Header Level picker).

Fixes #7923 
cc @diegoreymendez 

### To test:
1. Launch Aztec
2. Type enough text to cause vertical scrolling
3. Place the cursor at the bottom of the document
4. Press `H` / `List`'s format bar buttons

Verify that the vertical offset doesn't flicker at all.
