### PR TITLE
Aztec: Vertical Offset Glitch

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2007,9 +2007,8 @@ extension AztecPostViewController {
             return
         }
 
-        richTextView.resignFirstResponder()
         richTextView.inputView = to
-        richTextView.becomeFirstResponder()
+        richTextView.reloadInputView()
     }
 
     fileprivate func trackFormatBarAnalytics(stat: WPAnalyticsStat, action: String? = nil, headingStyle: String? = nil) {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2008,7 +2008,7 @@ extension AztecPostViewController {
         }
 
         richTextView.inputView = to
-        richTextView.reloadInputView()
+        richTextView.reloadInputViews()
     }
 
     fileprivate func trackFormatBarAnalytics(stat: WPAnalyticsStat, action: String? = nil, headingStyle: String? = nil) {


### PR DESCRIPTION
### Details:
This is a backport of #7925 for WPiOS Mark 8.5.1.

Fixes #7923 
cc @diegoreymendez @elibud 

### To test:
1. Launch Aztec
2. Type enough text to cause vertical scrolling
3. Place the cursor at the bottom of the document
4. Press `H` / `List`'s format bar buttons

Verify that the vertical offset doesn't flicker at all.
