### PR TITLE
Revert "Stops removing empty paragraphs."

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -79,8 +79,14 @@ class CalypsoProcessorIn: Processor {
         output = output.replacingMatches(of: "\\s*<option", with: "<option", options: .caseInsensitive)
         output = output.replacingMatches(of: "<\\/option>\\s*", with: "</option>", options: .caseInsensitive)
 
+        // Normalize multiple line breaks and white space chars.
+        output = output.replacingMatches(of: "\n\\s*\n+", with: "\n\n")
+
         // Convert two line breaks to a paragraph.
-        output = output.replacingMatches(of: "([\\s\\S]*?)\n\n", with: "<p>$1</p>\n")
+        output = output.replacingMatches(of: "([\\s\\S]+?)\n\n", with: "<p>$1</p>\n")
+
+        // Remove empty paragraphs.
+        output = output.replacingMatches(of: "<p>\\s*?<\\/p>", with: "", options: .caseInsensitive)
 
         // Remove <p> tags that are around block tags.
         output = output.replacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
@@ -89,6 +95,11 @@ class CalypsoProcessorIn: Processor {
         // Fix <p> in blockquotes.
         output = output.replacingMatches(of: "<p>\\s*<blockquote([^>]*)>", with: "<blockquote$1><p>", options: .caseInsensitive)
         output = output.replacingMatches(of: "<\\/blockquote>\\s*<\\/p>", with: "</p></blockquote>", options: .caseInsensitive)
+
+        // Remove <p> tags that are wrapped around block tags.
+        output = output.replacingMatches(of: "<p>\\s*(</?(?:" + blocklist + ")(?: [^>]*)?>)", with: "$1", options: .caseInsensitive)
+        output = output.replacingMatches(of: "(</?(?:" + blocklist + ")(?: [^>]*)?>)\\s*</p>", with: "$1", options: .caseInsensitive)
+        output = output.replacingMatches(of: "(<br[^>]*>)\\s*\n", with: "$1", options: .caseInsensitive)
 
         // Add <br> tags.
         output = output.replacingMatches(of: "\\s*\n", with: "<br />\n")

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -77,6 +77,9 @@ class CalypsoProcessorOut: Processor {
         output = output.replacingMatches(of: "\\s*<p>", with: "", options: .caseInsensitive)
         output = output.replacingMatches(of: "\\s*<\\/p>\\s*", with: "\n\n", options: .caseInsensitive)
 
+        // Normalize white space chars and remove multiple line breaks.
+        output = output.replacingMatches(of: "\n[\\s\\u00a0]+\n", with: "\n\n")
+
         // Replace <br> tags with line breaks.
         output = output.replacingMatches(of: "(\\s*)<br ?\\/?>\\s*", options: .caseInsensitive, using: { (match, ranges) -> String in
             if ranges.count > 0 && ranges[0].contains("\n") {
@@ -144,6 +147,7 @@ class CalypsoProcessorOut: Processor {
             })
         }
 
+        //                return html;
         return output
     }
 }


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-iOS#7928 since it introduced other problems we need to resolve.

I'm removing the milestones from these PRs in order to avoid any confusion as to anything having changed (nothing was changed and they cancel out).