### PR TITLE
Issue/7878 fix blog picker with long titles

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -490,7 +490,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         super.viewWillTransition(to: size, with: coordinator)
 
         coordinator.animate(alongsideTransition: { _ in
-            self.resizeBlogPickerButton()
             self.updateTitleHeight()
         })
 
@@ -717,8 +716,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     func refreshInterface() {
         reloadBlogPickerButton()
-        reloadEditorContents()
-        resizeBlogPickerButton()
+        reloadEditorContents()        
         reloadPublishButton()
         refreshNavigationBar()
     }
@@ -787,18 +785,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         publishButton.title = postEditorStateContext.publishButtonText
         publishButton.isEnabled = postEditorStateContext.isPublishButtonEnabled
     }
-
-    func resizeBlogPickerButton() {
-//        // Ensure the BlogPicker gets it's maximum possible size
-//        blogPickerButton.sizeToFit()
-//
-//        // Cap the size, according to the current traits
-//        var blogPickerSize = hasHorizontallyCompactView() ? Constants.blogPickerCompactSize : Constants.blogPickerRegularSize
-//        blogPickerSize.width = min(blogPickerSize.width, blogPickerButton.frame.width)
-//
-//        blogPickerButton.frame.size = blogPickerSize
-    }
-
 
     // MARK: - Keyboard Handling
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -192,15 +192,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         return cancelItem
     }()
 
-
-    /// NavigationBar's Blog Picker Button
-    ///
-    fileprivate lazy var blogPickerBarButtonItem: UIBarButtonItem = {
-        let pickerItem = UIBarButtonItem(customView: self.blogPickerButton)
-        pickerItem.accessibilityLabel = NSLocalizedString("Switch Blog", comment: "Action button to switch the blog to which you'll be posting")
-        return pickerItem
-    }()
-
     /// Media Uploading Status Button
     ///
     fileprivate lazy var mediaUploadingBarButtonItem: UIBarButtonItem = {
@@ -649,8 +640,9 @@ class AztecPostViewController: UIViewController, PostEditor {
     func configureNavigationBar() {
         navigationController?.navigationBar.isTranslucent = false
 
-        navigationItem.leftBarButtonItems = [separatorButtonItem, closeBarButtonItem, blogPickerBarButtonItem]
-        navigationItem.rightBarButtonItems = [moreBarButtonItem, publishButton]
+        navigationItem.leftBarButtonItems = [separatorButtonItem, closeBarButtonItem]
+        navigationItem.rightBarButtonItems = [separatorButtonItem, moreBarButtonItem, publishButton]
+        navigationItem.titleView = blogPickerButton
     }
 
     func configureDismissButton() {
@@ -734,8 +726,10 @@ class AztecPostViewController: UIViewController, PostEditor {
     func refreshNavigationBar() {
         if postEditorStateContext.isUploadingMedia {
             navigationItem.leftBarButtonItems = [separatorButtonItem, closeBarButtonItem, mediaUploadingBarButtonItem]
+            navigationItem.titleView = nil
         } else {
-            navigationItem.leftBarButtonItems = [separatorButtonItem, closeBarButtonItem, blogPickerBarButtonItem]
+            navigationItem.leftBarButtonItems = [separatorButtonItem, closeBarButtonItem]
+            navigationItem.titleView = blogPickerButton
         }
     }
 
@@ -795,14 +789,14 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func resizeBlogPickerButton() {
-        // Ensure the BlogPicker gets it's maximum possible size
-        blogPickerButton.sizeToFit()
-
-        // Cap the size, according to the current traits
-        var blogPickerSize = hasHorizontallyCompactView() ? Constants.blogPickerCompactSize : Constants.blogPickerRegularSize
-        blogPickerSize.width = min(blogPickerSize.width, blogPickerButton.frame.width)
-
-        blogPickerButton.frame.size = blogPickerSize
+//        // Ensure the BlogPicker gets it's maximum possible size
+//        blogPickerButton.sizeToFit()
+//
+//        // Cap the size, according to the current traits
+//        var blogPickerSize = hasHorizontallyCompactView() ? Constants.blogPickerCompactSize : Constants.blogPickerRegularSize
+//        blogPickerSize.width = min(blogPickerSize.width, blogPickerButton.frame.width)
+//
+//        blogPickerButton.frame.size = blogPickerSize
     }
 
 
@@ -3203,7 +3197,7 @@ extension AztecPostViewController {
 
     struct Constants {
         static let defaultMargin            = CGFloat(20)
-        static let separatorButtonWidth     = CGFloat(-12)
+        static let separatorButtonWidth     = CGFloat(1)
         static let cancelButtonPadding      = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
         static let blogPickerCompactSize    = CGSize(width: 125, height: 30)
         static let blogPickerRegularSize    = CGSize(width: 300, height: 30)

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -81,7 +81,7 @@ UIDocumentPickerDelegate
 
 #pragma mark - Misc properties
 @property (nonatomic, strong) UIButton *blogPickerButton;
-@property (nonatomic, strong) UIBarButtonItem *uploadStatusButton;
+@property (nonatomic, strong) UIButton *uploadStatusButton;
 @property (nonatomic) CGPoint scrollOffsetRestorePoint;
 @property (nonatomic) BOOL isOpenedDirectlyForEditing;
 @property (nonatomic) CGRect keyboardRect;
@@ -97,7 +97,7 @@ UIDocumentPickerDelegate
 @property (nonatomic, strong) UIAlertController *mediaSourceAlertController;
 
 #pragma mark - Bar Button Items
-@property (nonatomic, strong) UIBarButtonItem *secondaryLeftUIBarButtonItem;
+@property (nonatomic, strong) UIButton *activeTitleButton;
 @property (nonatomic, strong) UIBarButtonItem *negativeSeparator;
 @property (nonatomic, strong) UIBarButtonItem *cancelXButton;
 @property (nonatomic, strong) UIBarButtonItem *cancelChevronButton;
@@ -1132,12 +1132,12 @@ UIDocumentPickerDelegate
 {
     [self refreshNavigationBarLeftButtons:editingChanged];
     [self refreshNavigationBarRightButtons:editingChanged];
+    self.navigationItem.titleView = self.activeTitleButton;
     [self refreshMediaProgress];
 }
 
 - (void)refreshNavigationBarLeftButtons:(BOOL)editingChanged
 {
-    UIBarButtonItem *secondaryleftHandButton = self.secondaryLeftUIBarButtonItem;
     NSArray* leftBarButtons;
 
     if ([self isModal]) {
@@ -1145,7 +1145,7 @@ UIDocumentPickerDelegate
     } else {
         self.currentCancelButton = self.cancelChevronButton;
     }
-    leftBarButtons = @[self.negativeSeparator, self.currentCancelButton, secondaryleftHandButton];
+    leftBarButtons = @[self.negativeSeparator, self.currentCancelButton];
     
     if (![leftBarButtons isEqualToArray:self.navigationItem.leftBarButtonItems]) {
         [self.navigationItem setLeftBarButtonItems:nil];
@@ -1277,12 +1277,12 @@ UIDocumentPickerDelegate
     return _saveBarButtonItem;
 }
 
-- (UIBarButtonItem *)secondaryLeftUIBarButtonItem
+- (UIButton *)activeTitleButton
 {
-    UIBarButtonItem *aUIButtonBarItem;
+    UIButton *aButton;
     
     if ([self isMediaUploading]) {
-        aUIButtonBarItem = self.uploadStatusButton;
+        aButton = self.uploadStatusButton;
     } else {
         WPBlogSelectorButton *blogButton = (WPBlogSelectorButton*)self.blogPickerButton;
         NSString *blogName = self.post.blog.settings.name;
@@ -1304,11 +1304,11 @@ UIDocumentPickerDelegate
         } else {
             blogButton.buttonMode = WPBlogSelectorButtonMultipleSite;
         }
-        aUIButtonBarItem = [[UIBarButtonItem alloc] initWithCustomView:blogButton];
+        aButton = blogButton;
     }
     
-    _secondaryLeftUIBarButtonItem = aUIButtonBarItem;
-    return _secondaryLeftUIBarButtonItem;
+    _activeTitleButton = aButton;
+    return _activeTitleButton;
 }
 
 - (UIButton *)blogPickerButton
@@ -1330,13 +1330,13 @@ UIDocumentPickerDelegate
     return _blogPickerButton;
 }
 
-- (UIBarButtonItem *)uploadStatusButton
+- (UIButton *)uploadStatusButton
 {
     if (!_uploadStatusButton) {
         UIButton *button = [[WPUploadStatusButton alloc] initWithFrame:CGRectMake(0.0f, 0.0f, CompactTitleButtonWidth , RegularTitleButtonHeight)];
         [button setTitle:NSLocalizedString(@"Media Uploading", @"Message to indicate progress of uploading media to server") forState: UIControlStateNormal];
         [button addTarget:self action:@selector(showCancelMediaUploadPrompt) forControlEvents:UIControlEventTouchUpInside];
-        _uploadStatusButton = [[UIBarButtonItem alloc] initWithCustomView:button];
+        _uploadStatusButton = button;
     }
     
     return _uploadStatusButton;

--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
@@ -1,15 +1,20 @@
 #import "WPBlogSelectorButton.h"
 
+@interface WPBlogSelectorButton()
+    @property (nonatomic, strong) UIImage *selectorImage;
+@end
+
 @implementation WPBlogSelectorButton
 
 + (instancetype)buttonWithFrame:(CGRect)frame buttonStyle:(WPBlogSelectorButtonStyle)buttonStyle
 {
-    WPBlogSelectorButton *button = [WPBlogSelectorButton buttonWithType:UIButtonTypeSystem];
+    WPBlogSelectorButton *button = [WPBlogSelectorButton buttonWithType:UIButtonTypeCustom];
     button.buttonStyle = buttonStyle;
     button.frame = frame;
     button.titleLabel.textColor = [UIColor whiteColor];
     button.titleLabel.adjustsFontSizeToFitWidth = NO;
-    [button setImage:[UIImage imageNamed:@"icon-nav-chevron"] forState:UIControlStateNormal];
+    button.selectorImage = [UIImage imageNamed:@"icon-nav-chevron"];
+    [button setImage:button.selectorImage forState:UIControlStateNormal];
     [button setAccessibilityHint:NSLocalizedString(@"Tap to select which blog to post to", @"This is the blog picker in the editor")];
     
     switch (button.buttonStyle) {
@@ -38,12 +43,18 @@
     [super layoutSubviews];
     self.titleLabel.frame = [self titleRectForContentRect:self.bounds];
     self.imageView.frame = [self imageRectForContentRect:self.bounds];
+    self.imageView.hidden = NO;
 }
 
 - (CGRect)imageRectForContentRect:(CGRect)contentRect
 {
     CGRect frame = [super imageRectForContentRect:contentRect];
-    frame.origin.x = CGRectGetMaxX([self titleRectForContentRect:contentRect]) + self.imageEdgeInsets.left;
+    CGRect titleContentRect = [self titleRectForContentRect:contentRect];
+    frame.origin.x = CGRectGetMaxX(titleContentRect) + self.imageEdgeInsets.left;
+    CGSize imageSize = self.selectorImage.size;
+    frame.origin.y = CGRectGetMidY(titleContentRect) - (imageSize.height / 2);
+    frame.size.height = imageSize.height;
+    frame.size.width = imageSize.width;
     return frame;
 }
 
@@ -60,7 +71,7 @@
             frame.origin.x = CGRectGetMidX(contentRect) - CGRectGetWidth(frame) / 2.0;
             break;
     }
-    
+
     return frame;
 }
 
@@ -71,10 +82,11 @@
         UIGraphicsBeginImageContextWithOptions(CGSizeMake(15, 15), NO, 0.0);
         UIImage *blankFillerImage = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
-        [self setImage:blankFillerImage forState:UIControlStateNormal];
+        self.selectorImage = blankFillerImage;
     } else {
-        [self setImage:[UIImage imageNamed:@"icon-nav-chevron"] forState:UIControlStateNormal];
+        self.selectorImage = [UIImage imageNamed:@"icon-nav-chevron"];
     }
+    [self setImage:self.selectorImage forState:UIControlStateNormal];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
@@ -8,7 +8,7 @@
 
 + (instancetype)buttonWithFrame:(CGRect)frame buttonStyle:(WPBlogSelectorButtonStyle)buttonStyle
 {
-    WPBlogSelectorButton *button = [WPBlogSelectorButton buttonWithType:UIButtonTypeCustom];
+    WPBlogSelectorButton *button = [WPBlogSelectorButton buttonWithType:UIButtonTypeSystem];
     button.buttonStyle = buttonStyle;
     button.frame = frame;
     button.titleLabel.textColor = [UIColor whiteColor];
@@ -23,7 +23,7 @@
             button.titleLabel.textAlignment = NSTextAlignmentLeft;
             button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
             button.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-            [button setImageEdgeInsets:UIEdgeInsetsMake(0, 4, 0, 0)];
+            [button setImageEdgeInsets:UIEdgeInsetsMake(0, 0, 0, 0)];
             break;
         case WPBlogSelectorButtonTypeStacked:
         default:


### PR DESCRIPTION
Fixes #7878 

So in iOS 11 the code for UINavigationBar navigationItem looks it was changed and we now see overlap of titles over the other buttons on the navigation bar.

In order to solve this I moved the blog selector button to the titleView of the navigation bar. This look to solve the overlapping issues, but it changes the design of this screens. Now we have the blog picker on the centre of the navigation bar if there is a site.

<img width="716" alt="screen shot 2017-10-10 at 14 42 23" src="https://user-images.githubusercontent.com/651601/31411047-5394564a-ae08-11e7-9a5d-ff95b98d1cf2.png">
<img width="545" alt="screen shot 2017-10-10 at 14 43 00" src="https://user-images.githubusercontent.com/651601/31411048-53ad1310-ae08-11e7-8b00-796447888d37.png">
<img width="504" alt="screen shot 2017-10-10 at 14 43 30" src="https://user-images.githubusercontent.com/651601/31411049-53c427e4-ae08-11e7-915f-524b0dc6f8d6.png">

To test:
 - Open the app
 - Select a blog with a long title
 - Create a Post
 - Check with the different orientations to see if title is not overlapping other buttons on the navigation bar.
 - Test on phones and tablets on different orientations and multitask modes. Also test in iOS10 and iOS11.

Needs review: @folletto do you mind to have a look to see if design wise this is ok.