### PR TITLE
Integrates the latest from Aztec 1.0.0 Beta 12 into WP.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.22'
   pod 'WordPress-iOS-Editor', '1.9.5'
-pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '2fabd6570b54a1bd1ee1201b8f7a4799d8dac3da'
+pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'df435d396ff5a0a429c29f37cc93fc357c9f716d'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.22'
   pod 'WordPress-iOS-Editor', '1.9.5'
-  pod 'WordPress-Aztec-iOS', '=1.0.0-beta.11.1'
+pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '2fabd6570b54a1bd1ee1201b8f7a4799d8dac3da'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -93,7 +93,7 @@ PODS:
   - Starscream (2.1.1)
   - SVProgressHUD (2.2.1)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.11.1)
+  - WordPress-Aztec-iOS (1.0.0-beta.11)
   - WordPress-iOS-Editor (1.9.5):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
@@ -128,7 +128,7 @@ DEPENDENCIES:
   - Starscream (= 2.1.1)
   - SVProgressHUD (= 2.2.1)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (= 1.0.0-beta.11.1)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `2fabd6570b54a1bd1ee1201b8f7a4799d8dac3da`)
   - WordPress-iOS-Editor (= 1.9.5)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.22)
@@ -138,6 +138,9 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
+  WordPress-Aztec-iOS:
+    :commit: 2fabd6570b54a1bd1ee1201b8f7a4799d8dac3da
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -146,6 +149,9 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
+  WordPress-Aztec-iOS:
+    :commit: 2fabd6570b54a1bd1ee1201b8f7a4799d8dac3da
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -177,12 +183,12 @@ SPEC CHECKSUMS:
   Starscream: 142bd8ef24592d985daee9fa48c936070b85b15f
   SVProgressHUD: db27c54e6e18bc903341661fc9feb55e04905cc4
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 9f964a1530de9a7e10775ba136b6ebf9c7e31dca
+  WordPress-Aztec-iOS: afd9fae55729a5fbeda189d9b19660d16b0fc04c
   WordPress-iOS-Editor: be1de639b28b894789366b8380f26df30a8bb571
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 6be379b2f082af41c3ad62d5d3cab7ccc242a644
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 65548e8c0b110beaccca125185c061af6f0041f1
+PODFILE CHECKSUM: bb1eee790e85a3bdae3421ab95efc40aada5ce93
 
 COCOAPODS: 1.3.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -93,7 +93,7 @@ PODS:
   - Starscream (2.1.1)
   - SVProgressHUD (2.2.1)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.11)
+  - WordPress-Aztec-iOS (1.0.0-beta.11.1)
   - WordPress-iOS-Editor (1.9.5):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
@@ -128,7 +128,7 @@ DEPENDENCIES:
   - Starscream (= 2.1.1)
   - SVProgressHUD (= 2.2.1)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `2fabd6570b54a1bd1ee1201b8f7a4799d8dac3da`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `df435d396ff5a0a429c29f37cc93fc357c9f716d`)
   - WordPress-iOS-Editor (= 1.9.5)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.22)
@@ -139,7 +139,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
   WordPress-Aztec-iOS:
-    :commit: 2fabd6570b54a1bd1ee1201b8f7a4799d8dac3da
+    :commit: df435d396ff5a0a429c29f37cc93fc357c9f716d
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -150,7 +150,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
   WordPress-Aztec-iOS:
-    :commit: 2fabd6570b54a1bd1ee1201b8f7a4799d8dac3da
+    :commit: df435d396ff5a0a429c29f37cc93fc357c9f716d
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -183,12 +183,12 @@ SPEC CHECKSUMS:
   Starscream: 142bd8ef24592d985daee9fa48c936070b85b15f
   SVProgressHUD: db27c54e6e18bc903341661fc9feb55e04905cc4
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: afd9fae55729a5fbeda189d9b19660d16b0fc04c
+  WordPress-Aztec-iOS: 22aa2de71c48e32dbd16ce0d0900693b540908b9
   WordPress-iOS-Editor: be1de639b28b894789366b8380f26df30a8bb571
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 6be379b2f082af41c3ad62d5d3cab7ccc242a644
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: bb1eee790e85a3bdae3421ab95efc40aada5ce93
+PODFILE CHECKSUM: b330e4591b4ceaaf6eca7d1ee279b665d6a67c2d
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
Things to test:

- Our iOS 11 fixes (make sure the toolbar highlights appropriately and styles aren't lost).
- Make sure the layout looks right in both iPhone and iPad.

Known issues:

Moving the caret with the keyboard arrows to the last position in the document doesn't properly maintain the typing attributes.  This is [known](https://github.com/wordpress-mobile/AztecEditor-iOS/issues/760).