### PR TITLE
Updates to Aztec v1.0.0-beta.12.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.22'
   pod 'WordPress-iOS-Editor', '1.9.5'
-pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'df435d396ff5a0a429c29f37cc93fc357c9f716d'
+  pod 'WordPress-Aztec-iOS', '=1.0.0-beta.12'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -93,7 +93,7 @@ PODS:
   - Starscream (2.1.1)
   - SVProgressHUD (2.2.1)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.11.1)
+  - WordPress-Aztec-iOS (1.0.0-beta.12)
   - WordPress-iOS-Editor (1.9.5):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
@@ -128,7 +128,7 @@ DEPENDENCIES:
   - Starscream (= 2.1.1)
   - SVProgressHUD (= 2.2.1)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `df435d396ff5a0a429c29f37cc93fc357c9f716d`)
+  - WordPress-Aztec-iOS (= 1.0.0-beta.12)
   - WordPress-iOS-Editor (= 1.9.5)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.22)
@@ -138,9 +138,6 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
-  WordPress-Aztec-iOS:
-    :commit: df435d396ff5a0a429c29f37cc93fc357c9f716d
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -149,9 +146,6 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.0
-  WordPress-Aztec-iOS:
-    :commit: df435d396ff5a0a429c29f37cc93fc357c9f716d
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -183,12 +177,12 @@ SPEC CHECKSUMS:
   Starscream: 142bd8ef24592d985daee9fa48c936070b85b15f
   SVProgressHUD: db27c54e6e18bc903341661fc9feb55e04905cc4
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 22aa2de71c48e32dbd16ce0d0900693b540908b9
+  WordPress-Aztec-iOS: d472d3af74219e0bd4e01d49500d1e32c3a8cbf4
   WordPress-iOS-Editor: be1de639b28b894789366b8380f26df30a8bb571
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 6be379b2f082af41c3ad62d5d3cab7ccc242a644
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: b330e4591b4ceaaf6eca7d1ee279b665d6a67c2d
+PODFILE CHECKSUM: 050f46f0c81c13479b73bf23433bbc6dadba0be5
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
Updates Aztec to v1.0.0-beta.12.

The changes were already tested in https://github.com/wordpress-mobile/WordPress-iOS/pull/7946.  This PR only versions those changes.

Make sure `pod install` works fine.  Make sure the unit tests work fine.