### PR TITLE
Neutralizing Simulator Check

### DIFF
--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -12,13 +12,6 @@ final class InteractiveNotificationsManager: NSObject {
     ///
     static let shared = InteractiveNotificationsManager()
 
-
-    /// Returns the SharedApplication instance. This is meant for Unit Testing purposes.
-    ///
-    var sharedApplication: UIApplication {
-        return UIApplication.shared
-    }
-
     /// Returns the Core Data main context.
     ///
     var context: NSManagedObjectContext {
@@ -43,10 +36,6 @@ final class InteractiveNotificationsManager: NSObject {
     /// This method should be called once during the app initialization process.
     ///
     func registerForUserNotifications() {
-        if Device.is(.simulator) || Build.is(.a8cBranchTest) {
-            return
-        }
-
         let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.delegate = self
         notificationCenter.setNotificationCategories(supportedNotificationCategories())
@@ -58,10 +47,6 @@ final class InteractiveNotificationsManager: NSObject {
     /// Because of this, this should be called only when we know we will need to show notifications (for instance, after login).
     ///
     func requestAuthorization() {
-        if Device.is(.simulator) || Build.is(.a8cBranchTest) {
-            return
-        }
-
         let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.requestAuthorization(options: [.badge, .sound, .alert], completionHandler: { _ in })
     }

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -58,10 +58,6 @@ final public class PushNotificationsManager: NSObject {
     /// Registers the device for Remote Notifications: Badge + Sounds + Alerts
     ///
     func registerForRemoteNotifications() {
-        if WordPress.Device.is(.simulator) || Build.is(.a8cBranchTest) {
-            return
-        }
-
         sharedApplication.registerForRemoteNotifications()
     }
 


### PR DESCRIPTION
### Details:
In this PR we're neutralizing the **Push Notifications** guard we've got, preventing the registration from taking place, when running on the sim.

### To test:
1. Preform a fresh install on the Simulator. Verify it doesn't crash miserably.
2. Verify that the unit tests pass correctly.

Needs review: @diegoreymendez 
Thanks in advance!

