### PR TITLE
Issue/7878 fix editor bars with long titles 8.5.2

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -221,20 +221,20 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     fileprivate lazy var moreButton: UIButton = {
         let image = Gridicon.iconOfType(.ellipsis)
-        let moreItem = UIButton(type: .system)
-        moreItem.setImage(image, for: .normal)
-        var frame = CGRect(origin: .zero, size: image.size)
-        moreItem.frame = frame
-        moreItem.accessibilityLabel = NSLocalizedString("More", comment: "Action button to display more available options")
-        moreItem.addTarget(self, action: #selector(moreWasPressed), for: .touchUpInside)
-        moreItem.setContentHuggingPriority(UILayoutPriorityRequired, for: .horizontal)
-        return moreItem
+        let button = UIButton(type: .system)
+        button.setImage(image, for: .normal)
+        button.frame = CGRect(origin: .zero, size: image.size)
+        button.accessibilityLabel = NSLocalizedString("More", comment: "Action button to display more available options")
+        button.addTarget(self, action: #selector(moreWasPressed), for: .touchUpInside)
+        button.setContentHuggingPriority(UILayoutPriorityRequired, for: .horizontal)
+        return button
     }()
+
+
     /// NavigationBar's More Button
     ///
     fileprivate lazy var moreBarButtonItem: UIBarButtonItem = {
         let moreItem = UIBarButtonItem(customView: self.moreButton)
-
         return moreItem
     }()
 
@@ -807,16 +807,17 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func resizeBlogPickerButton() {
-        // Ensure the BlogPicker gets it's maximum possible size
+        // On iOS 11 no resize is needed because the StackView on the navigation bar will do the work
         if #available(iOS 11, *) {
             return
-        } else {
-            blogPickerButton.sizeToFit()
-            // Cap the size, according to the current traits
-            var blogPickerSize = hasHorizontallyCompactView() ? Constants.blogPickerCompactSize : Constants.blogPickerRegularSize
-            blogPickerSize.width = min(blogPickerSize.width, blogPickerButton.frame.width)
-            blogPickerButton.frame.size = blogPickerSize
         }
+        // On iOS 10 and before we still need to manually resize the button.
+        // Ensure the BlogPicker gets it's maximum possible size
+        blogPickerButton.sizeToFit()
+        // Cap the size, according to the current traits
+        var blogPickerSize = hasHorizontallyCompactView() ? Constants.blogPickerCompactSize : Constants.blogPickerRegularSize
+        blogPickerSize.width = min(blogPickerSize.width, blogPickerButton.frame.width)
+        blogPickerButton.frame.size = blogPickerSize
     }
 
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3207,7 +3207,7 @@ extension AztecPostViewController {
     }
 
     struct Constants {
-        static let defaultMargin            = CGFloat(20)        
+        static let defaultMargin            = CGFloat(20)
         static let cancelButtonPadding      = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
         static let blogPickerCompactSize    = CGSize(width: 125, height: 30)
         static let blogPickerRegularSize    = CGSize(width: 300, height: 30)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -170,7 +170,6 @@ class AztecPostViewController: UIViewController, PostEditor {
     ///
     fileprivate lazy var separatorButtonItem: UIBarButtonItem = {
         let separator = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
-        separator.width = Constants.separatorButtonWidth
         return separator
     }()
 
@@ -3208,8 +3207,7 @@ extension AztecPostViewController {
     }
 
     struct Constants {
-        static let defaultMargin            = CGFloat(20)
-        static let separatorButtonWidth     = CGFloat(-12)
+        static let defaultMargin            = CGFloat(20)        
         static let cancelButtonPadding      = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
         static let blogPickerCompactSize    = CGSize(width: 125, height: 30)
         static let blogPickerRegularSize    = CGSize(width: 300, height: 30)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -202,20 +202,40 @@ class AztecPostViewController: UIViewController, PostEditor {
 
 
     /// Publish Button
-    fileprivate(set) lazy var publishButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(title: self.postEditorStateContext.publishButtonText, style: WPStyleGuide.barButtonStyleForDone(), target: self, action: #selector(publishButtonTapped(sender:)))
+    fileprivate(set) lazy var publishButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.addTarget(self, action: #selector(publishButtonTapped(sender:)), for: .touchUpInside)
+        button.setTitle(self.postEditorStateContext.publishButtonText, for: .normal)
+        button.sizeToFit()
         button.isEnabled = self.postEditorStateContext.isPublishButtonEnabled
+        button.setContentHuggingPriority(UILayoutPriorityRequired, for: .horizontal)
+        return button
+    }()
+
+    /// Publish Button
+    fileprivate(set) lazy var publishBarButtonItem: UIBarButtonItem = {
+        let button = UIBarButtonItem(customView: self.publishButton)
 
         return button
     }()
 
 
+    fileprivate lazy var moreButton: UIButton = {
+        let image = Gridicon.iconOfType(.ellipsis)
+        let moreItem = UIButton(type: .system)
+        moreItem.setImage(image, for: .normal)
+        var frame = CGRect(origin: .zero, size: image.size)
+        moreItem.frame = frame
+        moreItem.accessibilityLabel = NSLocalizedString("More", comment: "Action button to display more available options")
+        moreItem.addTarget(self, action: #selector(moreWasPressed), for: .touchUpInside)
+        moreItem.setContentHuggingPriority(UILayoutPriorityRequired, for: .horizontal)
+        return moreItem
+    }()
     /// NavigationBar's More Button
     ///
     fileprivate lazy var moreBarButtonItem: UIBarButtonItem = {
-        let image = Gridicon.iconOfType(.ellipsis)
-        let moreItem = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(moreWasPressed))
-        moreItem.accessibilityLabel = NSLocalizedString("More", comment: "Action button to display more available options")
+        let moreItem = UIBarButtonItem(customView: self.moreButton)
+
         return moreItem
     }()
 
@@ -226,7 +246,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         let cancelButton = WPStyleGuide.buttonForBar(with: Assets.closeButtonModalImage, target: self, selector: #selector(closeWasPressed))
         cancelButton.leftSpacing = Constants.cancelButtonPadding.left
         cancelButton.rightSpacing = Constants.cancelButtonPadding.right
-
+        cancelButton.setContentHuggingPriority(UILayoutPriorityRequired, for: .horizontal)
         return cancelButton
     }()
 
@@ -236,6 +256,10 @@ class AztecPostViewController: UIViewController, PostEditor {
     fileprivate lazy var blogPickerButton: WPBlogSelectorButton = {
         let button = WPBlogSelectorButton(frame: .zero, buttonStyle: .typeSingleLine)
         button.addTarget(self, action: #selector(blogPickerWasPressed), for: .touchUpInside)
+        if #available(iOS 11, *) {
+            button.translatesAutoresizingMaskIntoConstraints = false
+        }
+        button.setContentHuggingPriority(UILayoutPriorityDefaultLow, for: .horizontal)
         return button
     }()
 
@@ -245,6 +269,10 @@ class AztecPostViewController: UIViewController, PostEditor {
         let button = WPUploadStatusButton(frame: CGRect(origin: .zero, size: Constants.uploadingButtonSize))
         button.setTitle(NSLocalizedString("Media Uploading", comment: "Message to indicate progress of uploading media to server"), for: .normal)
         button.addTarget(self, action: #selector(displayCancelMediaUploads), for: .touchUpInside)
+        if #available(iOS 11, *) {
+            button.translatesAutoresizingMaskIntoConstraints = false
+        }
+        button.setContentHuggingPriority(UILayoutPriorityDefaultLow, for: .horizontal)
         return button
     }()
 
@@ -635,7 +663,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         navigationController?.navigationBar.isTranslucent = false
 
         navigationItem.leftBarButtonItems = [separatorButtonItem, closeBarButtonItem, blogPickerBarButtonItem]
-        navigationItem.rightBarButtonItems = [moreBarButtonItem, publishButton]
+        navigationItem.rightBarButtonItems = [moreBarButtonItem, publishBarButtonItem, separatorButtonItem]
     }
 
     func configureDismissButton() {
@@ -775,19 +803,21 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func reloadPublishButton() {
-        publishButton.title = postEditorStateContext.publishButtonText
+        publishButton.setTitle(postEditorStateContext.publishButtonText, for: .normal)
         publishButton.isEnabled = postEditorStateContext.isPublishButtonEnabled
     }
 
     func resizeBlogPickerButton() {
         // Ensure the BlogPicker gets it's maximum possible size
-        blogPickerButton.sizeToFit()
-
-        // Cap the size, according to the current traits
-        var blogPickerSize = hasHorizontallyCompactView() ? Constants.blogPickerCompactSize : Constants.blogPickerRegularSize
-        blogPickerSize.width = min(blogPickerSize.width, blogPickerButton.frame.width)
-
-        blogPickerButton.frame.size = blogPickerSize
+        if #available(iOS 11, *) {
+            return
+        } else {
+            blogPickerButton.sizeToFit()
+            // Cap the size, according to the current traits
+            var blogPickerSize = hasHorizontallyCompactView() ? Constants.blogPickerCompactSize : Constants.blogPickerRegularSize
+            blogPickerSize.width = min(blogPickerSize.width, blogPickerButton.frame.width)
+            blogPickerButton.frame.size = blogPickerSize
+        }
     }
 
 

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -1097,10 +1097,12 @@ MediaProgressCoordinatorDelegate
 
 - (void)refreshNavigationBarRightButtons:(BOOL)editingChanged
 {
+    UIBarButtonItem *fixedSeparator = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
     if ([self isEditing]) {
         if (editingChanged) {
             [self.navigationItem setRightBarButtonItems:@[self.moreBarButtonItem,
-                                                          self.saveBarButtonItem] animated:YES];
+                                                          self.saveBarButtonItem,
+                                                          fixedSeparator] animated:YES];
         } else {
             self.saveBarButtonItem.title = [self saveBarButtonItemTitle];
         }
@@ -1108,7 +1110,8 @@ MediaProgressCoordinatorDelegate
         self.saveBarButtonItem.enabled = [self.post canSave];
 	} else {
         NSMutableArray* rightBarButtons = [[NSMutableArray alloc] initWithArray:@[self.moreBarButtonItem,
-                                                                                  self.editBarButtonItem]];
+                                                                                  self.editBarButtonItem,
+                                                                                  fixedSeparator]];
 
 		[self.navigationItem setRightBarButtonItems:rightBarButtons animated:NO];
 	}
@@ -1261,14 +1264,18 @@ MediaProgressCoordinatorDelegate
         [button addTarget:self action:@selector(showBlogSelectorPrompt:) forControlEvents:UIControlEventTouchUpInside];
         _blogPickerButton = button;
     }
-    
-    // Update the width to the appropriate size for the horizontal size class
-    CGFloat titleButtonWidth = CompactTitleButtonWidth;
-    if (![self hasHorizontallyCompactView]) {
-        titleButtonWidth = RegularTitleButtonWidth;
+
+    if (@available(iOS 11, *)) {
+        _blogPickerButton.translatesAutoresizingMaskIntoConstraints = NO;
+    } else {
+        // Update the width to the appropriate size for the horizontal size class
+        CGFloat titleButtonWidth = CompactTitleButtonWidth;
+        if (![self hasHorizontallyCompactView]) {
+            titleButtonWidth = RegularTitleButtonWidth;
+        }
+        _blogPickerButton.frame = CGRectMake(_blogPickerButton.frame.origin.x, _blogPickerButton.frame.origin.y, titleButtonWidth, RegularTitleButtonHeight);
     }
-    _blogPickerButton.frame = CGRectMake(_blogPickerButton.frame.origin.x, _blogPickerButton.frame.origin.y, titleButtonWidth, RegularTitleButtonHeight);
-    
+    [_blogPickerButton setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis: UILayoutConstraintAxisHorizontal];
     return _blogPickerButton;
 }
 
@@ -1279,6 +1286,10 @@ MediaProgressCoordinatorDelegate
         [button setTitle:NSLocalizedString(@"Media Uploading", @"Message to indicate progress of uploading media to server") forState: UIControlStateNormal];
         [button addTarget:self action:@selector(showCancelMediaUploadPrompt) forControlEvents:UIControlEventTouchUpInside];
         _uploadStatusButton = [[UIBarButtonItem alloc] initWithCustomView:button];
+        if (@available(iOS 11, *)) {
+            button.translatesAutoresizingMaskIntoConstraints = NO;
+        }
+        [button setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis: UILayoutConstraintAxisHorizontal];
     }
     
     return _uploadStatusButton;


### PR DESCRIPTION
Fixes #7878 

This PR fixes the issues with long names of blogs by setting the `ContentHuggingPriority` on components of the navigation bar on iOS11. This keeps the structure and layout of the navigation bar the same has before and avoid the use of the title view.

<img width="882" alt="screen shot 2017-10-12 at 12 38 47" src="https://user-images.githubusercontent.com/651601/31494246-5d725750-af4a-11e7-9fc5-feda77946f28.png">
<img width="504" alt="screen shot 2017-10-12 at 12 38 43" src="https://user-images.githubusercontent.com/651601/31494247-5d931828-af4a-11e7-9f19-a475bf204888.png">


To test:  
 - Open the editor on a blog with a long name
 - Check that the navigation bar shows correctly and the blog name it's cropped correctly if needed.
 - Test on different devices (iPhone SE, iPhone 8+, iPad) and multitasking modes.
 - Test on iOS10 and iOS11

Thanks to @frosty for the nudge to the right direction.