### PR TITLE
Issue/7940: Set explicit header / footer heights in CommentsViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -142,6 +142,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 {
     self.tableView.cellLayoutMarginsFollowReadableWidth = YES;
     self.tableView.accessibilityIdentifier  = @"Comments Table";
+
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     
     // Register the cells
@@ -228,6 +229,17 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     [self.navigationController pushViewController:vc animated:YES];
 }
 
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    // Override WPTableViewHandler's default of UITableViewAutomaticDimension,
+    // which results in 30pt tall headers on iOS 11
+    return 0;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+{
+    return 0;
+}
 
 #pragma mark - Comment Actions
 


### PR DESCRIPTION
Fixes #7940 

The same as #7847, we were seeing large grey section headers and footers in the CommentsViewController. It seems as though iOS 11 handles automatic headers and footers differently from iOS 10. To fix it, we're simply explicitly setting the header and footer heights to zero, instead of the `UITableViewAutomaticDimension` that `WPTableViewHandler` uses.

![comments-header-footer](https://user-images.githubusercontent.com/4780/31540263-1a5cc748-b003-11e7-914d-dee25d05a5b5.png)

To test:

* Open Site Details > Comments, and ensure there are no headers and footers.

Needs review: @jleandroperez would you mind?