### PR TITLE
Ensure all posting activity loads

### DIFF
--- a/WordPressKit/WordPressKit/WPStatsServiceRemote.m
+++ b/WordPressKit/WordPressKit/WPStatsServiceRemote.m
@@ -1545,7 +1545,8 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
     };
     
     NSDictionary *parameters = @{@"startDate" : [self deviceLocalStringForDate:startDate],
-                                 @"endDate"   : [self deviceLocalStringForDate:endDate]};
+                                 @"endDate"   : [self deviceLocalStringForDate:endDate],
+                                 @"max"       : @3000};
     
     id failureHandler = ^(NSURLSessionDataTask *task, NSError *error) {
         if (completionHandler) {

--- a/WordPressKit/WordPressKitTests/WPStatsServiceRemoteTests.m
+++ b/WordPressKit/WordPressKitTests/WPStatsServiceRemoteTests.m
@@ -971,7 +971,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"testStreak completion"];
     
     [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
-        return [[request.URL absoluteString] hasPrefix:@"https://public-api.wordpress.com/rest/v1.1/sites/123456/stats/streak/?endDate=2016-01-28&startDate=2014-01-01"];
+        return [[request.URL absoluteString] hasPrefix:@"https://public-api.wordpress.com/rest/v1.1/sites/123456/stats/streak/?endDate=2016-01-28&max=3000&startDate=2014-01-01"];
     } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
         return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFile(@"stats-v1.1-streak.json", self.class) statusCode:200 headers:@{@"Content-Type" : @"application/json"}];
     }];


### PR DESCRIPTION
Sets the max parameter to 3000 like calypso

![posting-activity](https://user-images.githubusercontent.com/8739/31610065-f398b8ee-b276-11e7-98b6-3f16d1550696.png)


Fixes #7976 

To test:

Find a blog with over 1,000 posts in the past year, and ensure you can reproduce the bug in #7976.
Make sure the bug is fixed in this branch.

Needs review: @astralbodies 
