### PR TITLE
Fix lint issues for control_statement rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -128,3 +128,5 @@ whitelist_rules:
 
 # Rules configuration
 
+control_statement: 
+  severity: error 

--- a/WordPress/Classes/Extensions/NSURL+Exporters.swift
+++ b/WordPress/Classes/Extensions/NSURL+Exporters.swift
@@ -200,7 +200,7 @@ extension NSURL: ExportableAsset {
         get {
             if isImage {
                 return .image
-            } else if (isVideo) {
+            } else if isVideo {
                 return .video
             }
             return .document

--- a/WordPress/Classes/Extensions/PHAsset+Exporters.swift
+++ b/WordPress/Classes/Extensions/PHAsset+Exporters.swift
@@ -126,7 +126,7 @@ extension PHAsset: ExportableAsset {
             self.requestMetadataWithCompletionBlock({ (metadata) -> () in
                 do {
                     var attributesToRemove = [String]()
-                    if (stripGeoLocation) {
+                    if stripGeoLocation {
                         attributesToRemove.append(kCGImagePropertyGPSDictionary as String)
                     }
                     var exportMetadata = self.removeAttributes(attributesToRemove, fromMetadata: metadata)
@@ -276,7 +276,7 @@ extension PHAsset: ExportableAsset {
             options.isSynchronous = synchronous
             options.isNetworkAccessAllowed = true
             var requestedSize = targetSize
-            if (requestedSize == CGSize.zero) {
+            if requestedSize == CGSize.zero {
                 requestedSize = PHImageManagerMaximumSize
             }
 
@@ -311,7 +311,7 @@ extension PHAsset: ExportableAsset {
         get {
             if self.mediaType == .image {
                 return .image
-            } else if (self.mediaType == .video) {
+            } else if self.mediaType == .video {
                 /** HACK: Sergio Estevao (2015-11-09): We ignore allowsFileTypes for videos in WP.com
                  because we have an exception on the server for mobile that allows video uploads event
                  if videopress is not enabled.
@@ -361,13 +361,13 @@ extension PHAsset: ExportableAsset {
     func originalUTI() -> String? {
         let resources = PHAssetResource.assetResources(for: self)
         var types: [PHAssetResourceType.RawValue] = []
-        if (mediaType == PHAssetMediaType.image) {
+        if mediaType == PHAssetMediaType.image {
             types = [PHAssetResourceType.photo.rawValue]
-        } else if (mediaType == PHAssetMediaType.video) {
+        } else if mediaType == PHAssetMediaType.video {
             types = [PHAssetResourceType.video.rawValue]
         }
         for resource in resources {
-            if (types.contains(resource.type.rawValue) ) {
+            if types.contains(resource.type.rawValue) {
                 return resource.uniformTypeIdentifier
             }
         }
@@ -377,13 +377,13 @@ extension PHAsset: ExportableAsset {
     func originalFilename() -> String? {
         let resources = PHAssetResource.assetResources(for: self)
         var types: [PHAssetResourceType.RawValue] = []
-        if (mediaType == PHAssetMediaType.image) {
+        if mediaType == PHAssetMediaType.image {
             types = [PHAssetResourceType.photo.rawValue]
-        } else if (mediaType == PHAssetMediaType.video) {
+        } else if mediaType == PHAssetMediaType.video {
             types = [PHAssetResourceType.video.rawValue]
         }
         for resource in resources {
-            if (types.contains(resource.type.rawValue) ) {
+            if types.contains(resource.type.rawValue) {
                 return resource.originalFilename
             }
         }

--- a/WordPress/Classes/Extensions/UIImage+Exporters.swift
+++ b/WordPress/Classes/Extensions/UIImage+Exporters.swift
@@ -40,7 +40,7 @@ extension UIImage {
         }
         CGImageDestinationSetProperties(destination, properties as CFDictionary?)
         CGImageDestinationAddImage(destination, imageRef, finalMetadata as CFDictionary?)
-        if (!CGImageDestinationFinalize(destination)) {
+        if !CGImageDestinationFinalize(destination) {
             throw errorForCode(.failedToWrite,
                 failureReason: NSLocalizedString("Unable to write image to file", comment: "Error reason to display when the writing of a image to a file fails")
             )
@@ -84,7 +84,7 @@ extension UIImage: ExportableAsset {
                      successHandler: @escaping SuccessHandler,
                      errorHandler: @escaping ErrorHandler) {
         var finalImage = self
-        if (maximumResolution.width <= self.size.width || maximumResolution.height <= self.size.height) {
+        if maximumResolution.width <= self.size.width || maximumResolution.height <= self.size.height {
             finalImage = self.resizedImage(with: .scaleAspectFit, bounds: maximumResolution, interpolationQuality: .high)
         }
 

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -257,7 +257,7 @@ class Post: AbstractPost {
                 return true
             }
 
-            if (!NSDictionary(dictionary: disabledPublicizeConnections ?? [:])
+            if !NSDictionary(dictionary: disabledPublicizeConnections ?? [:]
                              .isEqual(to: originalPost.disabledPublicizeConnections ?? [:])) {
                 return true
             }

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -257,8 +257,8 @@ class Post: AbstractPost {
                 return true
             }
 
-            if !NSDictionary(dictionary: disabledPublicizeConnections ?? [:]
-                             .isEqual(to: originalPost.disabledPublicizeConnections ?? [:])) {
+            if !NSDictionary(dictionary: disabledPublicizeConnections ?? [:])
+                             .isEqual(to: originalPost.disabledPublicizeConnections ?? [:]) {
                 return true
             }
         }

--- a/WordPress/Classes/Services/Store.swift
+++ b/WordPress/Classes/Services/Store.swift
@@ -330,7 +330,7 @@ struct MockStore: Store {
             let products = products.flatMap({ $0 })
 
             let completion = {
-                if (self.succeeds) {
+                if self.succeeds {
                     success(products)
                 } else {
                     failure(ProductRequestError.missingProduct)

--- a/WordPress/Classes/Utility/Ratings/AppRatingsUtility.swift
+++ b/WordPress/Classes/Utility/Ratings/AppRatingsUtility.swift
@@ -55,7 +55,7 @@ class AppRatingUtility: NSObject {
         let trackingVersion = defaults.string(forKey: Key.currentVersion) ?? version
         defaults.set(version, forKey: Key.currentVersion)
 
-        if (trackingVersion == version) {
+        if trackingVersion == version {
             incrementUseCount()
         } else {
             let shouldSkipRating = shouldSkipRatingForCurrentVersion()

--- a/WordPress/Classes/ViewRelated/Aztec/Extensions/FormatBarItemProviders.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Extensions/FormatBarItemProviders.swift
@@ -12,7 +12,7 @@ protocol FormatBarItemProvider {
 //
 extension FormattingIdentifier: FormatBarItemProvider {
     var iconImage: UIImage {
-        switch(self) {
+        switch self {
         case .media:
             return Gridicon.iconOfType(.addOutline)
         case .p:
@@ -55,7 +55,7 @@ extension FormattingIdentifier: FormatBarItemProvider {
     }
 
     var accessibilityIdentifier: String {
-        switch(self) {
+        switch self {
         case .media:
             return "format_toolbar_insert_media"
         case .p:
@@ -98,7 +98,7 @@ extension FormattingIdentifier: FormatBarItemProvider {
     }
 
     var accessibilityLabel: String {
-        switch(self) {
+        switch self {
         case .media:
             return NSLocalizedString("Insert media", comment: "Accessibility label for insert media button on formatting toolbar.")
         case .p:
@@ -150,7 +150,7 @@ enum FormatBarMediaIdentifier: String {
 
 extension FormatBarMediaIdentifier: FormatBarItemProvider {
     var iconImage: UIImage {
-        switch (self) {
+        switch self {
         case .deviceLibrary:
             return Gridicon.iconOfType(.imageMultiple)
         case .camera:
@@ -163,7 +163,7 @@ extension FormatBarMediaIdentifier: FormatBarItemProvider {
     }
 
     var accessibilityIdentifier: String {
-        switch (self) {
+        switch self {
         case .deviceLibrary:
             return "format_toolbar_media_photo_library"
         case .camera:
@@ -176,7 +176,7 @@ extension FormatBarMediaIdentifier: FormatBarItemProvider {
     }
 
     var accessibilityLabel: String {
-        switch (self) {
+        switch self {
         case .deviceLibrary:
             return NSLocalizedString("Photo Library", comment: "Accessibility label for selecting an image or video from the device's photo library on formatting toolbar.")
         case .camera:

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -788,7 +788,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     private func setHTML(_ html: String, for mode: EditMode) {
-        switch(mode) {
+        switch mode {
         case .html:
             htmlTextView.text = html
         case .richText:
@@ -802,7 +802,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
         let html: String
 
-        switch (mode) {
+        switch mode {
         case .html:
             html = htmlTextView.text
         case .richText:
@@ -1640,7 +1640,7 @@ extension AztecPostViewController {
 
     func listTypeForSelectedText() -> TextList.Style? {
         var identifiers = [FormattingIdentifier]()
-        if (richTextView.selectedRange.length > 0) {
+        if richTextView.selectedRange.length > 0 {
             identifiers = richTextView.formatIdentifiersSpanningRange(richTextView.selectedRange)
         } else {
             identifiers = richTextView.formatIdentifiersForTypingAttributes()
@@ -1980,7 +1980,7 @@ extension AztecPostViewController {
 
     func headerLevelForSelectedText() -> Header.HeaderType {
         var identifiers = [FormattingIdentifier]()
-        if (richTextView.selectedRange.length > 0) {
+        if richTextView.selectedRange.length > 0 {
             identifiers = richTextView.formatIdentifiersSpanningRange(richTextView.selectedRange)
         } else {
             identifiers = richTextView.formatIdentifiersForTypingAttributes()
@@ -2505,7 +2505,7 @@ private extension AztecPostViewController {
             // On iOS 10, when the soft keyboard is visible, the keyboard's frame is within the dimensions of the screen.
             // However, when an external keyboard is present, the keyboard's frame is located offscreen. Test to see if
             // that is true and adjust the keyboard height as necessary.
-            if ((currentKeyboardFrame.origin.y + currentKeyboardFrame.height) > view.frame.height) {
+            if (currentKeyboardFrame.origin.y + currentKeyboardFrame.height) > view.frame.height {
                 keyboardHeight = (currentKeyboardFrame.maxY - view.frame.height)
             } else {
                 keyboardHeight = (currentKeyboardFrame.height - Constants.toolbarHeight)
@@ -2895,7 +2895,7 @@ extension AztecPostViewController {
                                            handler: { (action) in
                                             if attachment == self.currentSelectedAttachment {
                                                 self.currentSelectedAttachment = nil
-                                                if (attachment is ImageAttachment) {
+                                                if attachment is ImageAttachment {
                                                     attachment.overlayImage = nil
                                                 }
                                                 attachment.message = nil
@@ -2936,7 +2936,7 @@ extension AztecPostViewController {
                                                     //retry upload
                                                     if let media = self.mediaProgressCoordinator.object(forMediaID: mediaID) as? Media,
                                                         let attachment = self.richTextView.attachment(withId: mediaID) {
-                                                        if (attachment is ImageAttachment) {
+                                                        if attachment is ImageAttachment {
                                                             attachment.overlayImage = nil
                                                         }
                                                         attachment.message = nil

--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
@@ -102,7 +102,7 @@ open class AboutViewController: UITableViewController {
 
         cell!.textLabel?.text       = row.title
         cell!.detailTextLabel?.text = row.details ?? String()
-        if (row.handler != nil) {
+        if row.handler != nil {
             WPStyleGuide.configureTableViewActionCell(cell)
         } else {
             WPStyleGuide.configureTableViewCell(cell)

--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -215,7 +215,7 @@ extension Login2FAViewController {
 
         configureViewLoading(false)
         let err = error as NSError
-        if (err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidOneTimePassword.rawValue) {
+        if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidOneTimePassword.rawValue {
             // Invalid verification code.
             displayError(message: NSLocalizedString("Whoops, that's not a valid two-factor verification code. Double-check your code and try again!",
                                                     comment: "Error message shown when an incorrect two factor code is provided."))

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -262,7 +262,7 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
     ///                        to authenticate the user with the available credentails.  Default is `false`.
     ///
     func loginWithUsernamePassword(immediately: Bool = false) {
-        if (immediately) {
+        if immediately {
             validateFormAndLogin()
         } else {
             performSegue(withIdentifier: .showWPComLogin, sender: self)

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableView.swift
@@ -28,7 +28,7 @@ class LoginEpilogueTableView: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if (section == 0) {
+        if section == 0 {
             return 1
         } else {
             let count = blogDataSource.tableView(tableView, numberOfRowsInSection: section-1)
@@ -38,7 +38,7 @@ class LoginEpilogueTableView: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if (indexPath.section == 0) {
+        if indexPath.section == 0 {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "userInfo") as? LoginEpilogueUserInfoCell else {
                 fatalError("Failed to get a user info cell")
             }
@@ -56,7 +56,7 @@ class LoginEpilogueTableView: UITableViewController {
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let sectionTitle: String
-        if (section == 0) {
+        if section == 0 {
             sectionTitle = NSLocalizedString("Logged In As", comment: "Header for user info, shown after loggin in").localizedUppercase
         } else {
             switch blogCount {
@@ -78,7 +78,7 @@ class LoginEpilogueTableView: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        if (indexPath.section == 0) {
+        if indexPath.section == 0 {
             return 140.0
         } else {
             return 52.0

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -19,7 +19,7 @@ class LoginEpilogueViewController: UIViewController {
         var numberOfBlogs = 0
         if let info = epilogueUserInfo {
             tableViewController?.epilogueUserInfo = info
-            if (info.blog != nil) {
+            if info.blog != nil {
                 numberOfBlogs = 1
             }
         } else {

--- a/WordPress/Classes/ViewRelated/NUX/LoginSocialErrorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSocialErrorViewController.swift
@@ -52,7 +52,7 @@ class LoginSocialErrorViewController: UITableViewController, LoginWithLogoAndHel
         super.viewDidLoad()
 
         view.backgroundColor = WPStyleGuide.greyLighten30()
-        addHelpButtonToNavController()
+        _ = addHelpButtonToNavController()
         addWordPressLogoToNavController()
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginTextField.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginTextField.swift
@@ -4,7 +4,7 @@ import WordPressShared
 class LoginTextField: WPWalkthroughTextField {
 
     override func draw(_ rect: CGRect) {
-        if (showTopLineSeparator) {
+        if showTopLineSeparator {
             guard let context = UIGraphicsGetCurrentContext() else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/NUX/NUXSubmitButton.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXSubmitButton.swift
@@ -88,7 +88,7 @@ let NUXSubmitButtonDisabledAlpha = CGFloat(0.25)
         var titleColorNormal = UIColor.white
         var titleColorHighlighted = WPStyleGuide.lightBlue()
         var titleColorDisabled = UIColor(white: 1.0, alpha: NUXSubmitButtonDisabledAlpha)
-        if (isPrimary) {
+        if isPrimary {
             backgroundColor = UIColor.white
             titleColorNormal = WPStyleGuide.wordPressBlue()
             titleColorHighlighted = WPStyleGuide.darkBlue()

--- a/WordPress/Classes/ViewRelated/NUX/SigninKeyboardResponder.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninKeyboardResponder.swift
@@ -145,7 +145,7 @@ extension SigninKeyboardResponder where Self: NUXAbstractViewController {
         // If an external keyboard is connected, the ending keyboard frame's maxY
         // will exceed the height of the view controller's view.
         // In these cases, just adjust the height by the amount of the keyboard visible.
-        if (keyboardFrame.maxY > view.frame.height) {
+        if keyboardFrame.maxY > view.frame.height {
             return view.frame.height - keyboardFrame.minY
         }
         return keyboardFrame.height

--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -522,7 +522,7 @@ extension SignupViewController: UITextFieldDelegate {
         }
 
         // Disallow punctuation in username and site names
-        if (textField == usernameField || textField == siteURLField) {
+        if textField == usernameField || textField == siteURLField {
             if (string as NSString).rangeOfCharacter(from: nonAlphanumericCharacterSet).location != NSNotFound {
                 return false
             }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -350,7 +350,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         // The result is the cells do not show the correct layouts relative to superview margins.
         // HACK: kurzee, 2016-07-12
         // Use a generic cell in this situation and reload the table view once its back in a window.
-        if (tableView.window == nil) {
+        if tableView.window == nil {
             reloadTableViewBeforeAppearing = true
             return tableView.dequeueReusableCell(withIdentifier: abstractPostWindowlessCellIdenfitier)
         }

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -82,7 +82,7 @@ class EditPostViewController: UIViewController {
     }
 
     override func viewDidAppear(_ animated: Bool) {
-        if (!hasShownEditor) {
+        if !hasShownEditor {
             showEditor()
             hasShownEditor = true
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorSaveAction.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorSaveAction.swift
@@ -16,9 +16,9 @@ extension WPPostViewController {
     var currentSaveAction: PostEditorSaveAction {
         if let status = post.status,
             let originalStatus = post.original?.status, status != originalStatus || !post.hasRemote() {
-            if (post.isScheduled()) {
+            if post.isScheduled() {
                 return .schedule
-            } else if (status == .publish) {
+            } else if status == .publish {
                 return .post
             } else {
                 return .save

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -500,7 +500,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
     func cell(_ cell: UITableViewCell, handleTrashPost post: AbstractPost) {
         ReachabilityUtils.onAvailableInternetConnectionDo {
-            if (post.status == .trash) {
+            if post.status == .trash {
 
                 let cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
                 let deleteText = NSLocalizedString("Delete", comment: "Deletes post permanently")

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
@@ -142,12 +142,12 @@ private enum ReaderCardDiscoverAttribution: Int {
                 comment: "Used to attribute a post back to its original author and blog.  The '%@' characters are placholders for the author's name, and the author's blog repsectively.")
             str = String(format: pattern, authorName!, blogName!)
 
-        } else if (authorName != nil) {
+        } else if authorName != nil {
             let pattern = NSLocalizedString("Originally posted by %@",
                 comment: "Used to attribute a post back to its original author.  The '%@' characters are a placholder for the author's name.")
             str = String(format: pattern, authorName!)
 
-        } else if (blogName != nil) {
+        } else if blogName != nil {
             let pattern = NSLocalizedString("Originally posted on %@",
                 comment: "Used to attribute a post back to its original blog.  The '%@' characters are a placholder for the blog name.")
             str = String(format: pattern, blogName!)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -822,11 +822,11 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     }
 
     func setBarsHidden(_ hidden: Bool, animated: Bool = true) {
-        if (navigationController?.isNavigationBarHidden == hidden) {
+        if navigationController?.isNavigationBarHidden == hidden {
             return
         }
 
-        if (hidden) {
+        if hidden {
             // Hides the navbar and footer view
             navigationController?.setNavigationBarHidden(true, animated: animated)
             currentPreferredStatusBarStyle = .default

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -133,7 +133,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
             return
         }
 
-        if (isSyncing) {
+        if isSyncing {
             view.addSubview(loadingView)
             loadingView.centerInSuperview()
         } else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
@@ -52,7 +52,7 @@ open class ReaderGapMarkerCell: UITableViewCell {
         super.setHighlighted(highlighted, animated: animated)
         button.isHighlighted = highlighted
         button.backgroundColor = highlighted ? WPStyleGuide.gapMarkerButtonBackgroundColorHighlighted() : WPStyleGuide.gapMarkerButtonBackgroundColor()
-        if (highlighted) {
+        if highlighted {
             // Redraw the backgrounds when highlighted
             drawTearBackground()
             tearMaskView.backgroundColor = WPStyleGuide.greyLighten30()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -136,7 +136,7 @@ import WordPressShared
             stat = .readerTagLoaded
 
         }
-        if (stat != nil) {
+        if stat != nil {
             WPAnalytics.track(stat!, withProperties: properties)
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -123,7 +123,7 @@ import WordPressShared
         super.viewWillAppear(animated)
 
         // We shouldn't show a selection if our split view is collapsed
-        if (splitViewControllerIsHorizontallyCompact) {
+        if splitViewControllerIsHorizontallyCompact {
             animateDeselectionInteractively()
 
             restorableSelectedIndexPath = defaultIndexPath

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -70,7 +70,7 @@ open class ReaderPostMenu {
 
     fileprivate class func shouldShowBlockSiteMenuItemForPost(_ post: ReaderPost) -> Bool {
         if let topic = post.topic {
-            if (ReaderHelpers.isLoggedIn()) {
+            if ReaderHelpers.isLoggedIn() {
                 return ReaderHelpers.isTopicTag(topic) || ReaderHelpers.topicIsFreshlyPressed(topic)
             }
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -663,7 +663,7 @@ import WordPressShared
         guard let topic = readerTopic else {
             return false
         }
-        if (isLoggedIn) {
+        if isLoggedIn {
             return ReaderHelpers.isTopicTag(topic) || ReaderHelpers.topicIsFreshlyPressed(topic)
         }
         return false

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -530,9 +530,9 @@ public protocol ThemePresenter: class {
     // MARK: - WPContentSyncHelperDelegate
 
     func syncHelper(_ syncHelper: WPContentSyncHelper, syncContentWithUserInteraction userInteraction: Bool, success: ((_ hasMore: Bool) -> Void)?, failure: ((_ error: NSError) -> Void)?) {
-        if (syncHelper == themesSyncHelper) {
+        if syncHelper == themesSyncHelper {
             syncThemePage(1, success: success, failure: failure)
-        } else if (syncHelper == customThemesSyncHelper) {
+        } else if syncHelper == customThemesSyncHelper {
             syncCustomThemes(success: success, failure: failure)
         }
     }

--- a/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
+++ b/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
@@ -69,10 +69,10 @@ extension WPStyleGuide {
 
         public static func headerHeight(_ horizontallyCompact: Bool, includingSearchBar: Bool) -> CGFloat {
             var headerHeight = (currentBarSeparator * 2)
-            if (includingSearchBar) {
+            if includingSearchBar {
                 headerHeight += searchBarHeight
             }
-            if (horizontallyCompact) {
+            if horizontallyCompact {
                 headerHeight += (currentBarLineHeight * 2) + currentBarSeparator
             } else {
                 headerHeight += currentBarLineHeight

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
@@ -85,7 +85,7 @@ class WPRichTextEmbed: UIView, UIWebViewDelegate, WPRichTextMediaAttachment {
         }
 
         // embeds, unlike images, typically have no intrinsic content size that we can use to fall back on
-        if (fixedHeight > 0) {
+        if fixedHeight > 0 {
             return CGSize(width: CGFloat.greatestFiniteMagnitude, height: fixedHeight)
         }
 
@@ -97,7 +97,7 @@ class WPRichTextEmbed: UIView, UIWebViewDelegate, WPRichTextMediaAttachment {
     }
 
     func contentRatio() -> CGFloat {
-        if (fixedHeight > 0) {
+        if fixedHeight > 0 {
             return 0.0
         }
 
@@ -105,7 +105,7 @@ class WPRichTextEmbed: UIView, UIWebViewDelegate, WPRichTextMediaAttachment {
             return attachmentSize.width / attachmentSize.height
         }
 
-        if (!documentSize.equalTo(CGSize.zero)) {
+        if !documentSize.equalTo(CGSize.zero) {
             return documentSize.width / documentSize.height
         }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -18,6 +18,17 @@
 			name = OCLint;
 			productName = OCLint;
 		};
+		FFA8E22A1F94E3DE0002170F /* SwiftLint */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = FFA8E22F1F94E3DE0002170F /* Build configuration list for PBXAggregateTarget "SwiftLint" */;
+			buildPhases = (
+				FFA8E2301F94E3EF0002170F /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = SwiftLint;
+			productName = SwiftLint;
+		};
 		FFC3F6F41B0DBF0900EFC359 /* UpdatePlistPreprocessor */ = {
 			isa = PBXAggregateTarget;
 			buildConfigurationList = FFC3F6F51B0DBF1000EFC359 /* Build configuration list for PBXAggregateTarget "UpdatePlistPreprocessor" */;
@@ -5473,6 +5484,10 @@
 						LastSwiftMigration = 0800;
 						TestTargetID = 1D6058900D05DD3D006BFB54;
 					};
+					FFA8E22A1F94E3DE0002170F = {
+						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Automatic;
+					};
 					FFC3F6F41B0DBF0900EFC359 = {
 						CreatedOnToolsVersion = 6.3.1;
 						DevelopmentTeam = PZYM8XX95Q;
@@ -5537,6 +5552,7 @@
 				8511CFB51C607A7000B7CEED /* WordPressScreenshotGeneration */,
 				A2795807198819DE0031C6A3 /* OCLint */,
 				FFC3F6F41B0DBF0900EFC359 /* UpdatePlistPreprocessor */,
+				FFA8E22A1F94E3DE0002170F /* SwiftLint */,
 			);
 		};
 /* End PBXProject section */
@@ -6031,6 +6047,19 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension-resources.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		FFA8E2301F94E3EF0002170F /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\nrake lint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 		FFC3F6FA1B0DBF1E00EFC359 /* Update Plist Preprocessor file */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -8474,6 +8503,38 @@
 			};
 			name = "Release-Alpha";
 		};
+		FFA8E22B1F94E3DE0002170F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		FFA8E22C1F94E3DE0002170F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		FFA8E22D1F94E3DE0002170F /* Release-Internal */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Release-Internal";
+		};
+		FFA8E22E1F94E3DE0002170F /* Release-Alpha */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = "Release-Alpha";
+		};
 		FFC3F6F61B0DBF1000EFC359 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -8585,6 +8646,17 @@
 				FF2716971CAAC87B0006E2D4 /* Release */,
 				FF2716981CAAC87B0006E2D4 /* Release-Internal */,
 				FF2716991CAAC87B0006E2D4 /* Release-Alpha */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FFA8E22F1F94E3DE0002170F /* Build configuration list for PBXAggregateTarget "SwiftLint" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FFA8E22B1F94E3DE0002170F /* Debug */,
+				FFA8E22C1F94E3DE0002170F /* Release */,
+				FFA8E22D1F94E3DE0002170F /* Release-Internal */,
+				FFA8E22E1F94E3DE0002170F /* Release-Alpha */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/WordPress/WordPressUITests/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/XCTest+Extensions.swift
@@ -184,7 +184,7 @@ extension XCTestCase {
         passwordField.tap()
         passwordField.clearAndEnterText(text: password)
 
-        if (url != nil) {
+        if url != nil {
             urlField.tap()
             urlField.clearAndEnterText(text: url!)
         }

--- a/WordPress/WordPressUITests/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/XCTest+Extensions.swift
@@ -65,7 +65,7 @@ extension XCTestCase {
         let timeoutValue = timeout ?? 5
 
         waitForExpectations(timeout: TimeInterval(timeoutValue)) { (error) -> Void in
-            if (error != nil) {
+            if error != nil {
                 let message = "Failed to find \(element) after \(timeoutValue) seconds."
                 self.recordFailure(withDescription: message,
                                                   inFile: file, atLine: line, expected: true)
@@ -99,7 +99,7 @@ extension XCTestCase {
         emailOrUsernameTextField.typeText( username )
 
         let nextButton = app.buttons[ elementStringIDs.loginNextButton ]
-        if ( nextButton.exists ) {
+        if nextButton.exists {
             nextButton.tap()
         }
 
@@ -116,7 +116,7 @@ extension XCTestCase {
         emailOrUsernameTextField.typeText( username )
 
         let nextButton = app.buttons[ elementStringIDs.loginNextButton ]
-        if ( nextButton.exists ) {
+        if nextButton.exists {
             nextButton.tap()
         }
 
@@ -155,7 +155,7 @@ extension XCTestCase {
         waitForElementToAppear(element: removeButton)
         removeButton.tap()
 
-        if ( isIpad(app: app) ) {
+        if isIpad(app: app) {
             app.alerts.buttons.element(boundBy: 1).tap()
         } else {
             app.sheets.buttons.element(boundBy: 0).tap()
@@ -184,7 +184,7 @@ extension XCTestCase {
         passwordField.tap()
         passwordField.clearAndEnterText(text: password)
 
-        if ( url != nil ) {
+        if (url != nil) {
             urlField.tap()
             urlField.clearAndEnterText(text: url!)
         }


### PR DESCRIPTION
Related to this PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/7965

We found that the control_statement rules was only triggering a warning instead of an error.

Without error Hound doesn't trigger so this PR fix this and the current violations in the code.

To test:
 - Check if project build without errors.

